### PR TITLE
Remove isFeatureActive from CartRule

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -464,7 +464,7 @@ class CartCore extends ObjectModel
         $virtual_context->cart = $this;
 
         // If the cart has not been saved, then there can't be any cart rule applied
-        if (!CartRule::isFeatureActive() || !$this->id) {
+        if (!$this->id) {
             return [];
         }
         if ($autoAdd) {
@@ -576,9 +576,6 @@ class CartCore extends ObjectModel
      */
     public function getDiscountsCustomer($id_cart_rule)
     {
-        if (!CartRule::isFeatureActive()) {
-            return 0;
-        }
         $cache_id = 'Cart::getDiscountsCustomer_' . (int) $this->id . '-' . (int) $id_cart_rule;
         if (!Cache::isStored($cache_id)) {
             $result = (int) Db::getInstance()->getValue('
@@ -2032,11 +2029,6 @@ class CartCore extends ObjectModel
         }
 
         // EARLY RETURNS
-
-        // if cart rules are not used
-        if ($type == Cart::ONLY_DISCOUNTS && !CartRule::isFeatureActive()) {
-            return 0;
-        }
         // no shipping cost if is a cart with only virtuals products
         $virtual = $this->isVirtualCart();
         if ($virtual && $type == Cart::ONLY_SHIPPING) {

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -184,8 +184,6 @@ class CartRuleCore extends ObjectModel
             return false;
         }
 
-        Configuration::updateGlobalValue('PS_CART_RULE_FEATURE_ACTIVE', '1');
-
         return true;
     }
 
@@ -211,11 +209,6 @@ class CartRuleCore extends ObjectModel
             return false;
         }
 
-        Configuration::updateGlobalValue(
-            'PS_CART_RULE_FEATURE_ACTIVE',
-            CartRule::isCurrentlyUsed($this->def['table'], true)
-        );
-
         return true;
     }
 
@@ -231,11 +224,6 @@ class CartRuleCore extends ObjectModel
         if (!parent::delete()) {
             return false;
         }
-
-        Configuration::updateGlobalValue(
-            'PS_CART_RULE_FEATURE_ACTIVE',
-            CartRule::isCurrentlyUsed($this->def['table'], true)
-        );
 
         $r = Db::getInstance()->delete('cart_cart_rule', '`id_cart_rule` = ' . (int) $this->id);
         $r &= Db::getInstance()->delete('cart_rule_carrier', '`id_cart_rule` = ' . (int) $this->id);
@@ -388,7 +376,7 @@ class CartRuleCore extends ObjectModel
         $free_shipping_only = false,
         $highlight_only = false
     ) {
-        if (!CartRule::isFeatureActive() || !CartRule::haveCartRuleToday($id_customer)) {
+        if (!CartRule::haveCartRuleToday($id_customer)) {
             return [];
         }
 
@@ -594,10 +582,6 @@ class CartRuleCore extends ObjectModel
      */
     public static function cartRuleExists($code)
     {
-        if (!CartRule::isFeatureActive()) {
-            return false;
-        }
-
         return (bool) Db::getInstance()->getValue('
 		SELECT `id_cart_rule`
 		FROM `' . _DB_PREFIX_ . 'cart_rule`
@@ -684,9 +668,6 @@ class CartRuleCore extends ObjectModel
      */
     public function checkValidity(Context $context, $alreadyInCart = false, $display_error = true, $check_carrier = true, $useOrderPrices = false)
     {
-        if (!CartRule::isFeatureActive()) {
-            return false;
-        }
         $cart = $context->cart;
 
         // All these checks are necessary when you add the cart rule the first time, so when it's not in cart yet
@@ -1161,10 +1142,6 @@ class CartRuleCore extends ObjectModel
      */
     public function getContextualValue($use_tax, Context $context = null, $filter = null, $package = null, $use_cache = true)
     {
-        if (!CartRule::isFeatureActive()) {
-            return 0;
-        }
-
         // set base price that will be used for percent reductions
         if (!empty($context->virtualTotalTaxIncluded) && !empty($context->virtualTotalTaxExcluded)) {
             $basePriceForPercentReduction = $use_tax ? $context->virtualTotalTaxIncluded : $context->virtualTotalTaxExcluded;
@@ -1653,7 +1630,7 @@ class CartRuleCore extends ObjectModel
         if ($context === null) {
             $context = Context::getContext();
         }
-        if (!CartRule::isFeatureActive() || !Validate::isLoadedObject($context->cart)) {
+        if (!Validate::isLoadedObject($context->cart)) {
             return;
         }
 
@@ -1730,7 +1707,7 @@ class CartRuleCore extends ObjectModel
         if (!$context) {
             $context = Context::getContext();
         }
-        if (!CartRule::isFeatureActive() || !Validate::isLoadedObject($context->cart)) {
+        if (!Validate::isLoadedObject($context->cart)) {
             return [];
         }
 
@@ -1747,6 +1724,8 @@ class CartRuleCore extends ObjectModel
     }
 
     /**
+     * @deprecated Since 9.0.0 - not used anymore, it's active all the time.
+     *
      * Check if the CartRule feature is active
      * It becomes active after adding the first CartRule to the store.
      *
@@ -1754,9 +1733,7 @@ class CartRuleCore extends ObjectModel
      */
     public static function isFeatureActive()
     {
-        $is_feature_active = (bool) Configuration::get('PS_CART_RULE_FEATURE_ACTIVE');
-
-        return $is_feature_active;
+        return true;
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1597,7 +1597,7 @@ class FrontControllerCore extends Controller
                     ? $this->getTranslator()->trans('Unit price', [], 'Shop.Theme.Catalog')
                     : $this->getTranslator()->trans('Unit discount', [], 'Shop.Theme.Catalog'),
             ],
-            'voucher_enabled' => (int) CartRule::isFeatureActive(),
+            'voucher_enabled' => 1,
             'return_enabled' => (int) Configuration::get('PS_ORDER_RETURN'),
             'number_of_days_for_return' => (int) Configuration::get('PS_ORDER_RETURN_NB_DAYS'),
             'password_policy' => [

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -244,7 +244,7 @@ class CartControllerCore extends FrontController
                 $this->processChangeProductInCart();
             } elseif (Tools::getIsset('delete')) {
                 $this->processDeleteProductInCart();
-            } elseif (CartRule::isFeatureActive()) {
+            } else {
                 if (Tools::getIsset('addDiscount')) {
                     if (!($code = trim(Tools::getValue('discount_name')))) {
                         $this->errors[] = $this->trans(

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -431,9 +431,6 @@
   <configuration id="PS_CUSTOMIZATION_FEATURE_ACTIVE" name="PS_CUSTOMIZATION_FEATURE_ACTIVE">
     <value>1</value>
   </configuration>
-  <configuration id="PS_CART_RULE_FEATURE_ACTIVE" name="PS_CART_RULE_FEATURE_ACTIVE">
-    <value>0</value>
-  </configuration>
   <configuration id="PS_PACK_FEATURE_ACTIVE" name="PS_PACK_FEATURE_ACTIVE">
     <value>0</value>
   </configuration>

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -613,7 +613,7 @@ class CartPresenter implements PresenterInterface
         }
 
         return [
-            'allowed' => (int) CartRule::isFeatureActive(),
+            'allowed' => 1,
             'added' => $vouchers,
         ];
     }

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -93,10 +93,6 @@ class CartRuleCalculator
         $cartRule = $cartRuleData->getCartRule();
         $cart = $this->calculator->getCart();
 
-        if (!\CartRule::isFeatureActive()) {
-            return;
-        }
-
         // Free shipping on selected carriers
         if ($cartRule->free_shipping && $withFreeShipping) {
             $initialShippingFees = $this->calculator->getFees()->getInitialShippingFees();

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/add_cartrule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/add_cartrule.feature
@@ -11,7 +11,6 @@ Feature: Add cart rule in cart
   @bo-add-cart-rule
   Scenario: No product in cart should give a not valid cart rule insertion
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" has a discount code "foo1"
     Then I should have 0 different products in my cart
@@ -23,7 +22,6 @@ Feature: Add cart rule in cart
   @bo-add-cart-rule
   Scenario: 1 product in cart, cart rule is inserted correctly
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" has a discount code "foo1"
@@ -37,7 +35,6 @@ Feature: Add cart rule in cart
   @bo-add-cart-rule
   Scenario: 1 product in cart, cart rules are inserted correctly
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" has a discount code "foo1"
@@ -55,7 +52,6 @@ Feature: Add cart rule in cart
   @bo-add-cart-rule
   Scenario: 1 product in cart, double cart rule not inserted
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule1" has a discount code "foo1"
@@ -71,7 +67,6 @@ Feature: Add cart rule in cart
   @bo-add-cart-rule
   Scenario: 1 product in cart, cart rule giving gift, and global cart rule should be inserted without error
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
     Given there is a cart rule named "cartrule1" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
@@ -91,7 +86,6 @@ Feature: Add cart rule in cart
   @bo-add-cart-rule
   Scenario: 1 product in cart, cart rule giving gift out of stock, and global cart rule should be inserted without error (test PR #8361)
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product4" with a price of 35.567 and 1000 items in stock
     Given product "product4" is out of stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/usage_limit_per_user.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/usage_limit_per_user.feature
@@ -9,7 +9,6 @@ Feature: A cart rule's usage limit per user is detected
     And there is customer "testCustomer" with email "pub@prestashop.com"
     And customer "testCustomer" has address in "US" country
     And I am logged in as "test@prestashop.com" employee
-    And shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     And the module "dummy_payment" is installed
     And there is a cart rule named "limitedCartRule" that applies an amount discount of 1.0 with priority 1, quantity of 2 and quantity per user 1
     And cart rule "limitedCartRule" has a discount code "foo1"

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_mono.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_mono.feature
@@ -5,7 +5,6 @@ Feature: Cart rule (amount) calculation with one cart rule
 
   Scenario: Empty cart, one cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a cart rule named "cartrule4" that applies an amount discount of 5.0 with priority 4, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule4" has a discount code "foo4"
     Then I should have 0 different products in my cart
@@ -15,7 +14,6 @@ Feature: Cart rule (amount) calculation with one cart rule
 
   Scenario: one product in cart, quantity 1, one 5€ global cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule4" that applies an amount discount of 5.0 with priority 4, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule4" has a discount code "foo4"
@@ -26,7 +24,6 @@ Feature: Cart rule (amount) calculation with one cart rule
 
   Scenario: one product in cart, quantity 1, one 500€ global cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule5" that applies an amount discount of 500.0 with priority 5, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule5" has a discount code "foo5"
@@ -37,7 +34,6 @@ Feature: Cart rule (amount) calculation with one cart rule
 
   Scenario: one product in cart, quantity 3, one 5€ global cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule4" that applies an amount discount of 5.0 with priority 4, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule4" has a discount code "foo4"
@@ -48,7 +44,6 @@ Feature: Cart rule (amount) calculation with one cart rule
 
   Scenario: 3 products in cart, several quantities, one 5€ global cartRule (reduced product at first place)
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
@@ -63,7 +58,6 @@ Feature: Cart rule (amount) calculation with one cart rule
 
   Scenario: 3 products in cart, several quantities, one 5€ global cartRule (reduced product at second place)
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
@@ -78,7 +72,6 @@ Feature: Cart rule (amount) calculation with one cart rule
 
   Scenario: 3 products in cart, several quantities, one 500€ global cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_mono_virtual.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_mono_virtual.feature
@@ -5,7 +5,6 @@ Feature: Cart rule (amount) calculation with one cart rule
 
   Scenario: 4 products in cart, one is virtual, several quantities, one 5€ global voucher
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
@@ -24,7 +23,6 @@ Feature: Cart rule (amount) calculation with one cart rule
 
   Scenario: Only virtual product in my cart, one 5€ global voucher
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product8" with a price of 12.345 and 1000 items in stock
     Given product "product8" is virtual
     Given there is a cart rule named "cartrule4" that applies an amount discount of 5.0 with priority 4, quantity of 1000 and quantity per user 1000

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_multiple.feature
@@ -5,7 +5,6 @@ Feature: Cart rule (amount) calculation with multiple cart rules
 
   Scenario: Empty cart, 2 cartRules
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a cart rule named "cartrule4" that applies an amount discount of 5.0 with priority 4, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule4" has a discount code "foo4"
     Given there is a cart rule named "cartrule6" that applies an amount discount of 10.0 with priority 6, quantity of 1000 and quantity per user 1000
@@ -18,7 +17,6 @@ Feature: Cart rule (amount) calculation with multiple cart rules
 
   Scenario: one product in cart, quantity 1, one 5€ global cartRule, one 10€ global cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule4" that applies an amount discount of 5.0 with priority 4, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule4" has a discount code "foo4"
@@ -32,7 +30,6 @@ Feature: Cart rule (amount) calculation with multiple cart rules
 
   Scenario: one product in cart, quantity 3, one 5€ global cartRule, one 10€ global cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule4" that applies an amount discount of 5.0 with priority 4, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule4" has a discount code "foo4"
@@ -46,7 +43,6 @@ Feature: Cart rule (amount) calculation with multiple cart rules
 
   Scenario: 3 products in cart, several quantities, one 5€ global cartRule (reduced product at first place)
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
@@ -65,7 +61,6 @@ Feature: Cart rule (amount) calculation with multiple cart rules
   Scenario: One product in my cart, one cart rule for free shipping and one for free gift
     Given I have an empty default cart
     Given there is a category named "Awesome"
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product8" with a price of 12.345 and 1000 items in stock
     Given product "product8" is in category "Awesome"
     Given there is a cart rule named "cartrule-free-shipping" that applies an amount discount of 0.0 with priority 1, quantity of 1 and quantity per user 1
@@ -80,7 +75,6 @@ Feature: Cart rule (amount) calculation with multiple cart rules
 
   Scenario: One product in my cart, one 10€ global cartRule, 2 free gifts global cartRules
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
@@ -97,7 +91,6 @@ Feature: Cart rule (amount) calculation with multiple cart rules
 
   Scenario: One product in my cart, one 30€ global cartRule (which is superior to the product bought), 2 free gifts global cartRules
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
@@ -114,7 +107,6 @@ Feature: Cart rule (amount) calculation with multiple cart rules
 
   Scenario: One product in my cart, one 30€ global cartRule (which is superior to the product bought) with free shipping, 2 free gifts global cartRules
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_specific.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_specific.feature
@@ -5,7 +5,6 @@ Feature: Cart rule (amount) calculation with one cart rule restricted to one pro
 
   Scenario: Empty cart, one cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule8" that applies an amount discount of 5.0 with priority 8, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule8" is restricted to product "product2"
@@ -17,7 +16,6 @@ Feature: Cart rule (amount) calculation with one cart rule restricted to one pro
 
   Scenario: one product in cart, quantity 1, one specific 5€ cartRule on product2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule8" that applies an amount discount of 5.0 with priority 8, quantity of 1000 and quantity per user 1000
@@ -30,7 +28,6 @@ Feature: Cart rule (amount) calculation with one cart rule restricted to one pro
 
   Scenario: one product in cart, quantity 3, one specific 5€ cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule8" that applies an amount discount of 5.0 with priority 8, quantity of 1000 and quantity per user 1000
@@ -43,7 +40,6 @@ Feature: Cart rule (amount) calculation with one cart rule restricted to one pro
 
   Scenario: 3 products in cart, several quantities, one specific 5€ cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
@@ -59,7 +55,6 @@ Feature: Cart rule (amount) calculation with one cart rule restricted to one pro
 
   Scenario: 3 products in cart, several quantities, one specific 500€ cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/cheapest_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/cheapest_product.feature
@@ -5,7 +5,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to cheape
 
   Scenario: Empty cart, one 50% cartRule on cheapest product
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule10" is restricted to cheapest product
@@ -17,7 +16,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to cheape
 
   Scenario: one product in cart, quantity 1, one 50% cartRule on cheapest product
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule10" is restricted to cheapest product
@@ -29,7 +27,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to cheape
 
   Scenario: multiple products in cart, several quantities, one 50% cartRule on cheapest product
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
@@ -45,7 +42,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to cheape
 
   Scenario: multiple products in cart, several quantities, one 50% cartRule on cheapest product excluding already discounted
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
@@ -62,7 +58,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to cheape
 
   Scenario: multiple products in cart, several quantities, one 50% cartRule on cheapest product excluding already discounted, cheapest product is already discounted
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given product "product1" has a specific price named "specificPrice1" with an amount discount of 3.0
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/ecotax.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/ecotax.feature
@@ -15,8 +15,7 @@ Feature: Cart rule (percent) calculation with one cart rule
     And shop configuration for "PS_USE_ECOTAX" is set to 1
 
   Scenario:
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
-    And there is a tax named "tax4Percent" and rate 4.0%
+    Given there is a tax named "tax4Percent" and rate 4.0%
     And there is a tax rule named "taxRule4Percent" in country "country1" where tax "tax4Percent" is applied
     And I have an empty default cart
     ## Set Product
@@ -37,8 +36,7 @@ Feature: Cart rule (percent) calculation with one cart rule
     And my cart total should be 5.000 tax excluded
 
   Scenario:
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
-    And there is a tax named "tax4Percent" and rate 4.0%
+    Given there is a tax named "tax4Percent" and rate 4.0%
     And there is a tax rule named "taxRule4Percent" in country "country1" where tax "tax4Percent" is applied
     And I have an empty default cart
     ## Set Product
@@ -61,8 +59,7 @@ Feature: Cart rule (percent) calculation with one cart rule
     Then I should have a voucher named "cartRuleFiftyPercent" with 6.2 of discount
 
   Scenario:
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
-    And there is a tax named "tax4Percent" and rate 4.0%
+    Given there is a tax named "tax4Percent" and rate 4.0%
     And there is a tax rule named "taxRule4Percent" in country "country1" where tax "tax4Percent" is applied
     And Ecotax belongs to tax group "taxRule4Percent"
     And I have an empty default cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/exclude_discounted_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/exclude_discounted_product.feature
@@ -5,7 +5,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to not al
 
   Scenario: multiple products in cart, several quantities, one 50% cartRule excluding already discounted
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given product "product1" has a specific price named "specificPrice1" with an amount discount of 3.0
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
@@ -23,7 +22,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to not al
 
   Scenario: multiple products in cart, several quantities, one 50% cartRule on selected product excluding already discounted
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given product "product1" has a specific price named "specificPrice1" with an amount discount of 3.0
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/free_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/free_shipping.feature
@@ -5,7 +5,6 @@ Feature: Cart rule (amount) calculation with one cart rule offering free shippin
 
   Scenario: One product in cart, one cartRule offering only free shipping
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule4" that applies no discount with priority 4, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule4" offers free shipping
@@ -17,7 +16,6 @@ Feature: Cart rule (amount) calculation with one cart rule offering free shippin
 
   Scenario: One product in cart, one cartRule offering free shipping AND 5€ discount
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule4" that applies an amount discount of 5.0 with priority 4, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule4" offers free shipping
@@ -29,7 +27,6 @@ Feature: Cart rule (amount) calculation with one cart rule offering free shippin
 
   Scenario: One product in cart, four different cartRules offering free shipping
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule5" that applies an amount discount of 5.0 with priority 4, quantity of 100 and quantity per user 10
     Given there is a cart rule named "cartrule6" that applies no discount with priority 5, quantity of 100 and quantity per user 10

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
@@ -5,7 +5,6 @@ Feature: Cart calculation with cart rules giving gift
 
   Scenario: 1 product in cart (out of stock), 1 cart rule give it as a gift, offering a gift (out of stock) and a global 10% discount
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product4" with a price of 35.567 and 1000 items in stock
     Given product "product4" is out of stock
     Given there is a cart rule named "cartrule13" that applies a percent discount of 10.0% with priority 13, quantity of 1000 and quantity per user 1000
@@ -20,7 +19,6 @@ Feature: Cart calculation with cart rules giving gift
 
   Scenario: 2 products in cart, one cart rule offering a gift (out of stock) and a global 10% discount
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product4" with a price of 35.567 and 1000 items in stock
     Given product "product4" is out of stock
@@ -37,7 +35,6 @@ Feature: Cart calculation with cart rules giving gift
 
   Scenario: 3 products in cart, one cart rule offering a gift and a global 10% discount
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product4" with a price of 35.567 and 1000 items in stock
     Given there is a cart rule named "cartrule13" that applies a percent discount of 10.0% with priority 13, quantity of 1000 and quantity per user 1000
@@ -55,7 +52,6 @@ Feature: Cart calculation with cart rules giving gift
     but does not apply to already discounted products
 
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     And product "product1" has a specific price named "discount" with a discount of 20.00 percent
     Given there is a product in the catalog named "product2" with a price of 11.00 and 1000 items in stock
@@ -75,7 +71,6 @@ Feature: Cart calculation with cart rules giving gift
 
   Scenario: 1 product in my cart, one cart rule offering the same product and a global 50% discount
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product_1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product_2" with a price of 35.567 and 1000 items in stock
     Given there is a cart rule named "cartrule14" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
@@ -98,7 +93,6 @@ Feature: Cart calculation with cart rules giving gift
 
   Scenario: 1 product in my cart, 2 same cart rules offering the same product as gift
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product_1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product_2" with a price of 35.567 and 1000 items in stock
     Given there is a cart rule named "cartrule16" that applies no discount with priority 1, quantity of 1000 and quantity per user 1000
@@ -123,7 +117,6 @@ Feature: Cart calculation with cart rules giving gift
 
   Scenario: 2 products in cart, one cart rule offering a gift (in stock) and a global 10% discount
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
     Given there is a product in the catalog named "product4" with a price of 35.567 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/mixed.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/mixed.feature
@@ -5,7 +5,6 @@ Feature: Cart rule (mixed) calculation with multiple cart rules
 
   Scenario: Empty cart, 2 mixed cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a cart rule named "cartrule2" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule2" has a discount code "foo2"
     Given there is a cart rule named "cartrule4" that applies an amount discount of 5.0 with priority 4, quantity of 1000 and quantity per user 1000
@@ -18,7 +17,6 @@ Feature: Cart rule (mixed) calculation with multiple cart rules
 
   Scenario: one product in cart, quantity 1, one 50% global cartRule, one 5€ global cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule2" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule2" has a discount code "foo2"
@@ -32,7 +30,6 @@ Feature: Cart rule (mixed) calculation with multiple cart rules
 
   Scenario: one product in cart, quantity 1, one 50% global cartRule, one 500€ global cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule2" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule2" has a discount code "foo2"
@@ -46,7 +43,6 @@ Feature: Cart rule (mixed) calculation with multiple cart rules
 
   Scenario: one product in cart, quantity 3, one 5€ global cartRule, one 50% global cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule4" that applies an amount discount of 5.0 with priority 4, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule4" has a discount code "foo4"
@@ -61,7 +57,6 @@ Feature: Cart rule (mixed) calculation with multiple cart rules
 
   Scenario: one product in cart, quantity 3, one 500€ global cartRule, one 50% global cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule5" that applies an amount discount of 500.0 with priority 5, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule5" has a discount code "foo5"
@@ -75,7 +70,6 @@ Feature: Cart rule (mixed) calculation with multiple cart rules
 
   Scenario: 3 products with several quantities in cart, one 5€ global cartRule, one 50% global cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/mixed_specific.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/mixed_specific.feature
@@ -5,7 +5,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules restricted to 
 
   Scenario: Empty cart, 2 cartRules
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule10" is restricted to product "product2"
@@ -21,7 +20,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules restricted to 
 
   Scenario: one product in cart, quantity 1, specific 5€ cartRule on product #2, specific 50% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
@@ -38,7 +36,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules restricted to 
 
   Scenario: one product in cart, quantity 3, specific 5€ cartRule on product #2, specific 50% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
@@ -55,7 +52,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules restricted to 
 
   Scenario: one product #2 in cart, quantity 3, specific 5€ cartRule on product #2, specific 50% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule10" is restricted to product "product2"
@@ -72,7 +68,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules restricted to 
 
   Scenario: 3 products in cart, several quantities, specific 5€ cartRule on product #2, specific 50% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
@@ -93,7 +88,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules restricted to 
 
   Scenario: 2 products in cart, one is out of stock, specific 5€ cartRule on product #2, specific 50% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_mono.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_mono.feature
@@ -5,7 +5,6 @@ Feature: Cart rule (percent) calculation with one cart rule
 
   Scenario: Empty cart, one cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a cart rule named "cartrule2" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule2" has a discount code "foo2"
     Then I should have 0 different products in my cart
@@ -15,7 +14,6 @@ Feature: Cart rule (percent) calculation with one cart rule
 
   Scenario: one product in cart, quantity 1, one 50% global cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule2" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule2" has a discount code "foo2"
@@ -26,7 +24,6 @@ Feature: Cart rule (percent) calculation with one cart rule
 
   Scenario: one product in cart, quantity 3, one 50% global cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule2" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule2" has a discount code "foo2"
@@ -37,7 +34,6 @@ Feature: Cart rule (percent) calculation with one cart rule
 
   Scenario: 3 products in cart, several quantities, one 5€ global cartRule (reduced product at first place)
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_multiple.feature
@@ -8,7 +8,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules
 
   Scenario: Empty cart, 2 cartRules
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a cart rule named "cartrule2" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule2" has a discount code "foo2"
     Given there is a cart rule named "cartrule3" that applies a percent discount of 10.0% with priority 3, quantity of 1000 and quantity per user 1000
@@ -24,7 +23,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules
 
   Scenario: one product in cart, quantity 1, 2x % global cartRules
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule2" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule2" has a discount code "foo2"
@@ -42,7 +40,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules
 
   Scenario: one product in cart, quantity 3, one 50% global cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a cart rule named "cartrule2" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule2" has a discount code "foo2"
@@ -58,7 +55,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules
 
   Scenario: 3 products in cart, several quantities, 2x % global cartRules
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock
@@ -80,7 +76,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules
 
   Scenario: one product in cart, one cart rule free shipping, one cart rule 10%
     Given I have an empty default cart
-    And shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     And there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     And there is a cart rule named "freeshipping" that applies no discount with priority 1, quantity of 1000 and quantity per user 1000
     And cart rule "freeshipping" offers free shipping

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_no_code_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_no_code_multiple.feature
@@ -5,7 +5,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules without code
 
   Scenario: 3 products in cart, several quantities, 2x % global cartRules
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_specific.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_specific.feature
@@ -5,7 +5,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to one pr
 
   Scenario: Empty cart, one cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule10" is restricted to product "product2"
@@ -17,7 +16,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to one pr
 
   Scenario: one product in cart, quantity 1, one specific 50% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
@@ -30,7 +28,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to one pr
 
   Scenario: one product in cart, quantity 3, one specific 50% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
@@ -43,7 +40,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to one pr
 
   Scenario: one product #2 in cart, quantity 3, one specific 50% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule10" is restricted to product "product2"
@@ -55,7 +51,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to one pr
 
   Scenario: 3 products in cart, several quantities, one specific 50% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_specific_mono.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_specific_mono.feature
@@ -5,7 +5,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to one pr
 
   Scenario: Empty cart, one cartRule
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule10" is restricted to product "product2"
@@ -17,7 +16,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to one pr
 
   Scenario: one product in cart, quantity 1, one specific 50% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
@@ -30,7 +28,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to one pr
 
   Scenario: one product in cart, quantity 3, one specific 50% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
@@ -43,7 +40,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to one pr
 
   Scenario: one product #2 in cart, quantity 3, one specific 50% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule10" is restricted to product "product2"
@@ -55,7 +51,6 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to one pr
 
   Scenario: 3 products in cart, several quantities, one specific 50% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_specific_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_specific_multiple.feature
@@ -5,7 +5,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules restricted to 
 
   Scenario: Empty cart, 2 cartRules
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule10" is restricted to product "product2"
@@ -21,7 +20,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules restricted to 
 
   Scenario: one product in cart, quantity 1, specific 50% cartRule on product #2, specific 10% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
@@ -38,7 +36,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules restricted to 
 
   Scenario: one product in cart, quantity 3, specific 50% cartRule on product #2, specific 10% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
@@ -55,7 +52,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules restricted to 
 
   Scenario: one product #2 in cart, quantity 3, specific 50% cartRule on product #2, specific 10% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a cart rule named "cartrule10" that applies a percent discount of 50.0% with priority 10, quantity of 1000 and quantity per user 1000
     Given cart rule "cartrule10" is restricted to product "product2"
@@ -72,7 +68,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules restricted to 
 
   Scenario: 3 products in cart, several quantities, specific 50% cartRule on product #2, specific 10% cartRule on product #2
     Given I have an empty default cart
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     Given there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock
     Given there is a product in the catalog named "product3" with a price of 31.188 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
@@ -269,8 +269,7 @@ Feature: Cancel Order Product from Back Office (BO)
       | total_paid_real          | 0.00   |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
-    And there is a product in the catalog named "Test Product Cart Rule On Select Product" with a price of 15.0 and 100 items in stock
+    Given there is a product in the catalog named "Test Product Cart Rule On Select Product" with a price of 15.0 and 100 items in stock
     And there is a cart rule named "CartRuleAmountOnSelectedProduct" that applies an amount discount of 500.0 with priority 1, quantity of 100 and quantity per user 100
     And cart rule "CartRuleAmountOnSelectedProduct" has no discount code
     And cart rule "CartRuleAmountOnSelectedProduct" is restricted to product "Test Product Cart Rule On Select Product"
@@ -337,8 +336,7 @@ Feature: Cancel Order Product from Back Office (BO)
       | total_paid_real          | 0.00   |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
-    And there is a product in the catalog named "Test Product Cart Rule On Order" with a price of 15.0 and 100 items in stock
+    Given there is a product in the catalog named "Test Product Cart Rule On Order" with a price of 15.0 and 100 items in stock
     Given there is a cart rule named "CartRuleAmountOnWholeOrder" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     And cart rule "CartRuleAmountOnWholeOrder" is applied on every order
     When I add products to order "bo_order_cancel_product" with new invoice and the following products details:

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
@@ -40,8 +40,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
-    And there is a product in the catalog named "Test Product Cart Rule On Select Product" with a price of 15.0 and 100 items in stock
+    Given there is a product in the catalog named "Test Product Cart Rule On Select Product" with a price of 15.0 and 100 items in stock
     And there is a cart rule named "CartRuleAmountOnSelectedProduct" that applies an amount discount of 500.0 with priority 1, quantity of 100 and quantity per user 100
     And cart rule "CartRuleAmountOnSelectedProduct" has no discount code
     And cart rule "CartRuleAmountOnSelectedProduct" is restricted to product "Test Product Cart Rule On Select Product"
@@ -96,8 +95,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
-    And there is a product in the catalog named "Test Product Cart Rule On Select Product" with a price of 15.0 and 100 items in stock
+    Given there is a product in the catalog named "Test Product Cart Rule On Select Product" with a price of 15.0 and 100 items in stock
     And there is a cart rule named "CartRuleAmountOnSelectedProduct" that applies an amount discount of 500.0 with priority 1, quantity of 100 and quantity per user 100
     And cart rule "CartRuleAmountOnSelectedProduct" has no discount code
     And cart rule "CartRuleAmountOnSelectedProduct" is restricted to product "Test Product Cart Rule On Select Product"
@@ -175,8 +173,7 @@ Feature: Order from Back Office (BO)
 #      | total_paid_real          | 0.0    |
 #      | total_shipping_tax_excl  | 7.0    |
 #      | total_shipping_tax_incl  | 7.42   |
-#    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
-#    And there is a product in the catalog named "Test Product Cart Rule On Select Product" with a price of 15.0 and 100 items in stock
+#    Given there is a product in the catalog named "Test Product Cart Rule On Select Product" with a price of 15.0 and 100 items in stock
 #    And there is a cart rule named "CartRuleAmountOnSelectedProduct" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
 #    And cart rule "CartRuleAmountOnSelectedProduct" has no discount code
 #    And cart rule "CartRuleAmountOnSelectedProduct" is restricted to product "Test Product Cart Rule On Select Product"
@@ -240,8 +237,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
-    And there is a product in the catalog named "Test Product Cart Rule On Order" with a price of 15.0 and 100 items in stock
+    Given there is a product in the catalog named "Test Product Cart Rule On Order" with a price of 15.0 and 100 items in stock
     Given there is a cart rule named "CartRuleAmountOnWholeOrder" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     And cart rule "CartRuleAmountOnWholeOrder" is applied on every order
     When I add products to order "bo_order1" with new invoice and the following products details:
@@ -296,8 +292,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
-    And there is a product in the catalog named "Test Product Cart Rule On Order" with a price of 15.0 and 100 items in stock
+    Given there is a product in the catalog named "Test Product Cart Rule On Order" with a price of 15.0 and 100 items in stock
     Given there is a cart rule named "CartRuleAmountOnEveryOrder" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     And cart rule "CartRuleAmountOnEveryOrder" is applied on every order
     When I add products to order "bo_order1" with new invoice and the following products details:
@@ -368,8 +363,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
-    And there is a product in the catalog named "Test Product With Percent Discount" with a price of 350.00 and 100 items in stock
+    Given there is a product in the catalog named "Test Product With Percent Discount" with a price of 350.00 and 100 items in stock
     Given there is a cart rule named "CartRulePercentForSpecificProduct" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     And cart rule "CartRulePercentForSpecificProduct" is restricted to product "Test Product With Percent Discount"
     When I add products to order "bo_order1" with new invoice and the following products details:
@@ -442,8 +436,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
-    And there is a product in the catalog named "Test Product With Percent Discount" with a price of 350.00 and 100 items in stock
+    Given there is a product in the catalog named "Test Product With Percent Discount" with a price of 350.00 and 100 items in stock
     Given there is a cart rule named "CartRulePercentForSpecificProduct" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     And cart rule "CartRulePercentForSpecificProduct" is restricted to product "Test Product With Percent Discount"
     When I add products to order "bo_order1" with new invoice and the following products details:
@@ -517,8 +510,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
-    And there is a product in the catalog named "Test Product With Percent Discount" with a price of 350.00 and 100 items in stock
+    Given there is a product in the catalog named "Test Product With Percent Discount" with a price of 350.00 and 100 items in stock
     Given there is a cart rule named "CartRulePercentForSpecificProduct" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     And cart rule "CartRulePercentForSpecificProduct" is restricted to product "Test Product With Percent Discount"
     When I add products to order "bo_order1" with new invoice and the following products details:
@@ -607,7 +599,6 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     When I add discount to order "bo_order1" with following details:
       | name      | discount five-percent |
       | type      | percent               |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_fixed_product_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_fixed_product_prices.feature
@@ -18,7 +18,6 @@ Feature: Order from Back Office (BO)
     And a carrier "default_carrier" with name "My carrier" exists
     And a carrier "price_carrier" with name "My cheap carrier" exists
     And I enable carrier "price_carrier"
-    And shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     And there is a product in the catalog named "Test Changing Product" with a price of 10.0 and 100 items in stock
     And the available stock for product "Test Changing Product" should be 100
     And I create an empty cart "dummy_cart" for customer "testCustomer"

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_gift_cart_rule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_gift_cart_rule.feature
@@ -15,7 +15,6 @@ Feature: Order from Back Office (BO)
     And I am logged in as "test@prestashop.com" employee
     And there is customer "testCustomer" with email "pub@prestashop.com"
     And customer "testCustomer" has address in "US" country
-    And shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     And there is a product in the catalog named "Test Product Gifted" with a price of 15.0 and 100 items in stock
     And the available stock for product "Test Product Gifted" should be 100
     And I create an empty cart "dummy_cart" for customer "testCustomer"

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_invoices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_invoices.feature
@@ -398,7 +398,6 @@ Feature: Order from Back Office (BO)
 #      | shipping_cost_tax_incl | 14.84 |
 
   Scenario: I add products in two different invoices, a product has automatic discount when I move it to an order the discount is also moved
-    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     Given there is a cart rule named "CartRulePercentForSpecificProduct" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
     And cart rule "CartRulePercentForSpecificProduct" is restricted to product "Test Product B"
     When I generate invoice for "bo_order1" order

--- a/tests/Integration/Classes/CartTest.php
+++ b/tests/Integration/Classes/CartTest.php
@@ -319,7 +319,6 @@ class CartTest extends TestCase
         // Pre-existing cart rules might mess up our test
         Db::getInstance()->execute('UPDATE ' . _DB_PREFIX_ . 'cart_rule SET active = 0');
         // Something might have disabled CartRules :)
-        Configuration::set('PS_CART_RULE_FEATURE_ACTIVE', true);
         Configuration::set('PS_GROUP_FEATURE_ACTIVE', true);
         Configuration::set('PS_ATCP_SHIPWRAP', false);
     }

--- a/tests/Integration/Utility/CartOld.php
+++ b/tests/Integration/Utility/CartOld.php
@@ -101,11 +101,6 @@ class CartOld extends Cart
 
         $with_shipping = in_array($type, [Cart::BOTH, Cart::ONLY_SHIPPING]);
 
-        // if cart rules are not used
-        if ($type == Cart::ONLY_DISCOUNTS && !CartRule::isFeatureActive()) {
-            return 0;
-        }
-
         // no shipping cost if is a cart with only virtuals products
         $virtual = $this->isVirtualCart();
         if ($virtual && $type == Cart::ONLY_SHIPPING) {
@@ -252,7 +247,7 @@ class CartOld extends Cart
 
         $order_total_discount = 0;
         $order_shipping_discount = 0;
-        if (!in_array($type, [Cart::ONLY_SHIPPING, Cart::ONLY_PRODUCTS]) && CartRule::isFeatureActive()) {
+        if (!in_array($type, [Cart::ONLY_SHIPPING, Cart::ONLY_PRODUCTS])) {
             $cart_rules = $this->getTotalCalculationCartRules($type, $with_shipping);
 
             $package = [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | refacto
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     | yes
| How to test?      | See that cart rules work the same way and average load time on a clean store is not slower.
| Fixed ticket?     | -
| Related PRs       | 
| Sponsor company   | 

### Description
- There is a configuration value called `PS_CART_RULE_FEATURE_ACTIVE`. This value is updated each time a CartRule is saved, depending if at least one cart rule exists.
- Some checks for this are spread on multiple places over the core and just a bit complicate things.
- This value has a tiny performance benefit only on a completely clean store that does not have one single cart rule. Is there some shop like this?
- On all other stores, it only adds one configuration value to load and some method calls.

### Performance test for product page on empty shop
- Queries - before 283, after 290
- Average load time - before 224 ms, after 224 ms