### PR TITLE
Avoid html being escaped in translation in the alert box

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2094,6 +2094,7 @@ class AdminControllerCore extends Controller
                 $this->trans(
                     'Have you checked your [1][2]abandoned carts[/2][/1]?[3]Your next order could be hiding there!',
                         [
+                            '_raw' => true,
                             '[1]' => '<strong>',
                             '[/1]' => '</strong>',
                             '[2]' => '<a href="' . $this->context->link->getAdminLink('AdminCarts', true, [], ['action' => 'filterOnlyAbandonedCarts']) . '">',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Prevent HTML from being escaped in the "Now new order" message in the alert section
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install PrestaShop, click the alerts icon at the top right, see message
| Fixed ticket?     | Fixes #32216
| Related PRs       | ~
| Sponsor company   | PrestaShop SA

Before:

![](https://uce3c51474f5287a52cd2743e4d7.previews.dropboxusercontent.com/p/thumb/AB7eT5UAKKPNtpfR1DYhNcD7S4j8dSLbWhjrI3t1lOyRN-wzPMq2lQJz0HgphsDve6l0sxeqbLPqMP4xplIyPQpVobV9mpRPcUadFWcQduwTsdsDvAscwdjjJDIfkMgNga5F8AVCV1FnQn_GZkrDueel1srD-_BV4Orhmw5AA06WC4aga86F15hcjOQp8HVPnshDdOqs0Mo_p9sSqlPa10UCflPCPlVBvgFqoBq1XzLsfJG7lvShnbvdFL8kZuIA1ZRNR7baHCVqRZAaW8t-F8ICXvz-b-r8e6XzSlEDml2t_KDyn_d0kVXaaCFJuCmBF5pEIOkKnO5oOWlh6Sk_fWXzcGYGP5iWJBTsjzVNaVecieV8zP8VhA4Uxp3IHFLppNmKsmJYQqBUpFf3ptJiO6o8/p.png)

After:

<img width="416" alt="Screenshot 2023-04-20 at 11 36 15" src="https://user-images.githubusercontent.com/1009343/233325365-f78b34e5-0b7a-4776-99c4-5823a9a9d38c.png">

