### PR TITLE
Remove unused functions getUrlRewriteInformation & getUrlRewriteInformations

### DIFF
--- a/classes/CMS.php
+++ b/classes/CMS.php
@@ -312,22 +312,6 @@ class CMSCore extends ObjectModel
 
     /**
      * @param int $idCms
-     *
-     * @return array|false|mysqli_result|PDOStatement|resource|null
-     */
-    public static function getUrlRewriteInformations($idCms)
-    {
-        $sql = 'SELECT l.`id_lang`, c.`link_rewrite`
-				FROM `' . _DB_PREFIX_ . 'cms_lang` AS c
-				LEFT JOIN  `' . _DB_PREFIX_ . 'lang` AS l ON c.`id_lang` = l.`id_lang`
-				WHERE c.`id_cms` = ' . (int) $idCms . '
-				AND l.`active` = 1';
-
-        return Db::getInstance()->executeS($sql);
-    }
-
-    /**
-     * @param int $idCms
      * @param int|null $idLang
      * @param int|null $idShop
      *

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -674,17 +674,4 @@ class CMSCategoryCore extends ObjectModel
     {
         return Db::getInstance()->getValue('SELECT MAX(position)+1 FROM `' . _DB_PREFIX_ . 'cms_category` WHERE `id_parent` = ' . (int) $id_category_parent);
     }
-
-    public static function getUrlRewriteInformations($id_category)
-    {
-        $sql = '
-		SELECT l.`id_lang`, c.`link_rewrite`
-		FROM `' . _DB_PREFIX_ . 'cms_category_lang` AS c
-		LEFT JOIN  `' . _DB_PREFIX_ . 'lang` AS l ON c.`id_lang` = l.`id_lang`
-		WHERE c.`id_cms_category` = ' . (int) $id_category . '
-		AND l.`active` = 1';
-        $arr_return = Db::getInstance()->executeS($sql);
-
-        return $arr_return;
-    }
 }

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1931,27 +1931,6 @@ class CategoryCore extends ObjectModel
     }
 
     /**
-     * Get URL Rewrite information.
-     *
-     * @param int $idCategory
-     *
-     * @return array|false|mysqli_result|PDOStatement|resource|null
-     *
-     * @since 1.7.0
-     */
-    public static function getUrlRewriteInformation($idCategory)
-    {
-        $sql = new DbQuery();
-        $sql->select('l.`id_lang`, cl.`link_rewrite`');
-        $sql->from('category_link', 'cl');
-        $sql->leftJoin('lang', 'l', 'cl.`id_lang` = l.`id_lang`');
-        $sql->where('cl.`id_category` = ' . (int) $idCategory);
-        $sql->where('l.`active` = 1');
-
-        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
-    }
-
-    /**
      * Return `nleft` and `nright` fields for a given category.
      *
      * @param int $id

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -6784,25 +6784,6 @@ class ProductCore extends ObjectModel
     }
 
     /**
-     * @param int $id_product Product identifier
-     *
-     * @return array
-     */
-    public static function getUrlRewriteInformations($id_product)
-    {
-        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
-            SELECT pl.`id_lang`, pl.`link_rewrite`, p.`ean13`, cl.`link_rewrite` AS category_rewrite
-            FROM `' . _DB_PREFIX_ . 'product` p
-            LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl ON (p.`id_product` = pl.`id_product`' . Shop::addSqlRestrictionOnLang('pl') . ')
-            ' . Shop::addSqlAssociation('product', 'p') . '
-            LEFT JOIN `' . _DB_PREFIX_ . 'lang` l ON (pl.`id_lang` = l.`id_lang`)
-            LEFT JOIN `' . _DB_PREFIX_ . 'category_lang` cl ON (cl.`id_category` = product_shop.`id_category_default`  AND cl.`id_lang` = pl.`id_lang`' . Shop::addSqlRestrictionOnLang('cl') . ')
-            WHERE p.`id_product` = ' . (int) $id_product . '
-            AND l.`active` = 1
-        ');
-    }
-
-    /**
      * @return int TaxRulesGroup identifier
      */
     public function getIdTaxRulesGroup()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed two functions that aren't used anymore in the project: [getUrlRewriteInformation](https://github.com/search?q=org%3APrestaShop+getUrlRewriteInformation%28&type=code) & [getUrlRewriteInformations](https://github.com/search?q=org%3APrestaShop+getUrlRewriteInformations%28&type=code). These were related to the blocklanguages module ([see here](https://github.com/search?q=repo%3APrestaShop%2FPrestaShop-1.4%20getUrlRewriteInformations%28&type=code))
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes - the functions have been removed
| Deprecations?     | no
| How to test?      | Nothing to test - there are no references to the removed functions anywhere in the project
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA

## Removed functions

* CMS::getUrlRewriteInformations()
* CMSCategory::getUrlRewriteInformations()
* Category::getUrlRewriteInformation()
* Product::getUrlRewriteInformations()