### PR TITLE
Fix: Setting DNI mandatory after address creation launches an exception during checkout

### DIFF
--- a/classes/AddressChecksumCore.php
+++ b/classes/AddressChecksumCore.php
@@ -45,7 +45,13 @@ class AddressChecksumCore implements ChecksumInterface
         }
 
         $uniqId = '';
-        $fields = $address->getFields();
+
+        try {
+            $fields = $address->getFields();
+        } catch (Exception $e) {
+            return sha1('Invalid address');
+        }
+
         foreach ($fields as $name => $value) {
             $uniqId .= $value . self::SEPARATOR;
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.1.x
| Description?      | If for a country there is the mandatory CF field and try to make an order (in the front-office) with an address that has the DNI empty field, the system shows an error that I attach.
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #31668
| Sponsor company   | Codencode snc 