### PR TITLE
Nightly : Fix forgotten environment variable `PS_ENABLE_SSL`

### DIFF
--- a/.github/workflows/cron_nightly_tests_reusable.yml
+++ b/.github/workflows/cron_nightly_tests_reusable.yml
@@ -97,6 +97,7 @@ jobs:
       PS_LANGUAGE: 'en'
       PS_INSTALL_AUTO: 1
       PS_DEV_MODE: 0
+      PS_ENABLE_SSL: ${{ matrix.BRANCH == '8.0.x' && '0' || '1' }}
       DB_SERVER: 'mysql'
       DB_NAME: 'prestashop'
       DB_PREFIX: 'tst_'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Nightly : Fix forgotten environment variable `PS_ENABLE_SSL` : The variable is useful for Docker to build SSL Apache :feather: parts. 
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | N/A
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp
