### PR TITLE
Fix quantity check when there a customization in cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1363,7 +1363,6 @@ class CartCore extends ObjectModel
      */
     public function getProductQuantity($idProduct, $idProductAttribute = 0, $idCustomization = 0, $idAddressDelivery = 0)
     {
-        $productIsPack = Pack::isPack($idProduct);
         $defaultPackStockType = Configuration::get('PS_PACK_STOCK_TYPE');
         $packStockTypesAllowed = [
             Pack::STOCK_TYPE_PRODUCTS_ONLY,

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1561,19 +1561,12 @@ class CartCore extends ObjectModel
         $cartProductQuantity = $this->getProductQuantity(
             $id_product,
             $id_product_attribute,
-            false,
-            (int) $id_address_delivery
-        );
-
-        $customizationQuantity = $this->getProductQuantity(
-            $id_product,
-            $id_product_attribute,
             (int) $id_customization,
             (int) $id_address_delivery
         );
 
         /* Update quantity if product already exist */
-        if (!empty($customizationQuantity['quantity'])) {
+        if (!empty($cartProductQuantity['quantity'])) {
             $productQuantity = Product::getQuantity($id_product, $id_product_attribute, null, $this, false);
             $availableOutOfStock = Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($product->id));
 
@@ -1593,7 +1586,7 @@ class CartCore extends ObjectModel
                 $updateQuantity = '- ' . $quantity;
 
                 if ($cartFirstLevelProductQuantity['quantity'] <= 1
-                    || $customizationQuantity['quantity'] - $quantity <= 0
+                    || $cartProductQuantity['quantity'] - $quantity <= 0
                 ) {
                     return $this->deleteProduct((int) $id_product, (int) $id_product_attribute, (int) $id_customization, (int) $id_address_delivery, $preserveGiftRemoval, $useOrderPrices);
                 }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1355,7 +1355,7 @@ class CartCore extends ObjectModel
      *
      * @param int $idProduct Product ID
      * @param int $idProductAttribute ProductAttribute ID
-     * @param int $idCustomization Customization ID
+     * @param int|bool $idCustomization Customization ID
      * @param int $idAddressDelivery Delivery Address ID
      *
      * @return array quantity index     : number of product in cart without counting those of pack in cart

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1369,6 +1369,7 @@ class CartCore extends ObjectModel
             Pack::STOCK_TYPE_PACK_BOTH,
         ];
         $packStockTypesDefaultSupported = (int) in_array($defaultPackStockType, $packStockTypesAllowed);
+        // We need to SUM up cp.`quantity` because multiple rows could be returned when id_customization filtering is skipped.
         $firstUnionSql = 'SELECT SUM(cp.`quantity`) as first_level_quantity, 0 as pack_quantity
           FROM `' . _DB_PREFIX_ . 'cart_product` cp';
         $secondUnionSql = 'SELECT 0 as first_level_quantity, SUM(cp.`quantity` * p.`quantity`) as pack_quantity

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1386,6 +1386,8 @@ class CartCore extends ObjectModel
             $firstUnionSql .= $customizationJoin;
             $secondUnionSql .= $customizationJoin;
         }
+        // Ignore customizations if $idCustomization is set to false
+        // This is necessary to get products with or without customizations
         $commonWhere = '
             WHERE cp.`id_product_attribute` = ' . (int) $idProductAttribute . '
               ' . ($idCustomization !== false ? ' AND cp.`id_customization` = ' . (int) $idCustomization : '') . '

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1615,7 +1615,7 @@ class CartCore extends ObjectModel
 
             // Quantity for product pack
             if (Pack::isPack($id_product)) {
-                $result2['quantity'] = Pack::getQuantity($id_product, $id_product_attribute, null, $this);
+                $result2['quantity'] = Pack::getQuantity($id_product, $id_product_attribute, null, $this, false);
             }
 
             if (isset($result2['out_of_stock']) && !Product::isAvailableWhenOutOfStock((int) $result2['out_of_stock']) && !$skipAvailabilityCheckOutOfStock) {
@@ -4066,7 +4066,7 @@ class CartCore extends ObjectModel
                     $product['id_product_attribute'],
                     null,
                     $this,
-                    $product['id_customization']
+                    false
                 );
                 if ($productQuantity < 0) {
                     return $returnProductOnFailure ? $product : false;
@@ -4994,7 +4994,7 @@ class CartCore extends ObjectModel
                 $idProductAttribute,
                 null,
                 $this,
-                $product['id_customization']
+                false
             );
 
             if ($productQuantity < 0 && !$availableOutOfStock) {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1413,7 +1413,7 @@ class CartCore extends ObjectModel
             COALESCE(SUM(first_level_quantity), 0) as quantity
           FROM (' . $firstUnionSql . ' UNION ' . $secondUnionSql . ') as q';
 
-        return Db::getInstance()->getRow($parentSql, false);
+        return Db::getInstance()->getRow($parentSql);
     }
 
     /**

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -237,7 +237,7 @@ class PackCore extends Product
      * @param int|null $idProductAttribute Product attribute id (optional)
      * @param bool|null $cacheIsPack
      * @param CartCore|null $cart
-     * @param int|null $idCustomization Product customization id (optional)
+     * @param int|null|bool $idCustomization Product customization id (optional)
      *
      * @return int
      *

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -219,7 +219,7 @@ class PackCore extends Product
         $idProduct = (int) $idProduct;
         $wantedQuantity = (int) $wantedQuantity;
         $product = new Product($idProduct, false);
-        $packQuantity = self::getQuantity($idProduct, null, null, $cart);
+        $packQuantity = self::getQuantity($idProduct, null, null, $cart, false);
 
         if ($product->isAvailableWhenOutOfStock($product->out_of_stock)) {
             return true;
@@ -237,7 +237,7 @@ class PackCore extends Product
      * @param int|null $idProductAttribute Product attribute id (optional)
      * @param bool|null $cacheIsPack
      * @param CartCore|null $cart
-     * @param int|null|bool $idCustomization Product customization id (optional)
+     * @param bool|int|null $idCustomization Product customization id (optional)
      *
      * @return int
      *

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4308,7 +4308,7 @@ class ProductCore extends ObjectModel
      * @param int|null $idProductAttribute Product attribute id (optional)
      * @param bool|null $cacheIsPack
      * @param CartCore|null $cart
-     * @param int|null|bool $idCustomization Product customization id (optional)
+     * @param int|bool|null $idCustomization Product customization id (optional)
      *
      * @return int Available quantities
      */

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5750,7 +5750,8 @@ class ProductCore extends ObjectModel
                 (int) $row['id_product'],
                 $id_product_attribute,
                 isset($row['cache_is_pack']) ? $row['cache_is_pack'] : null,
-                $context->cart
+                $context->cart,
+                false
             );
 
             $row['available_date'] = Product::getAvailableDate(

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4308,7 +4308,7 @@ class ProductCore extends ObjectModel
      * @param int|null $idProductAttribute Product attribute id (optional)
      * @param bool|null $cacheIsPack
      * @param CartCore|null $cart
-     * @param int|null $idCustomization Product customization id (optional)
+     * @param int|null|bool $idCustomization Product customization id (optional)
      *
      * @return int Available quantities
      */

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5739,7 +5739,8 @@ class ProductCore extends ObjectModel
             (int) $row['id_product'],
             0,
             isset($row['cache_is_pack']) ? $row['cache_is_pack'] : null,
-            $context->cart
+            $context->cart,
+            false
         );
 
         $row['quantity_all_versions'] = $row['quantity'];

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -603,7 +603,7 @@ class CartControllerCore extends FrontController
             $this->id_product_attribute,
             null,
             $this->context->cart,
-            $this->customization_id
+            false
         );
 
         return $productQuantityAvailableAfterCartItemsHaveBeenRemovedFromStock < 0;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes related to customization quantity checks
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Add a product with customization then another without. The total quantity in cart that is checked against the available stock must be the total of the product and the separate quantities of the customized and the normal product. See #32233
| Fixed ticket?     | Fixes #32233
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/32292
| Sponsor company   | --
