### PR TITLE
Translation app URL, refresh and selection issues

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/translations/router/index.ts
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/router/index.ts
@@ -26,7 +26,7 @@ import {createRouter, createWebHistory} from 'vue-router';
 import Overview from '@app/pages/translations/components/app.vue';
 
 export default createRouter({
-  history: createWebHistory(`${window.data.baseUrl}/translations`),
+  history: createWebHistory(),
   routes: [
     {
       path: '/',

--- a/admin-dev/themes/new-theme/js/pages/translation-settings/FormFieldToggle.ts
+++ b/admin-dev/themes/new-theme/js/pages/translation-settings/FormFieldToggle.ts
@@ -75,7 +75,7 @@ export default class FormFieldToggle {
       this.toggleEmailFields.bind(this),
     );
 
-    this.toggleFields();
+    $(window).on('load', this.toggleFields.bind(this));
   }
 
   /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | This PR fix translation app router to avoid url problem, and fix also translation settings form on page load.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #31115 
| Fixed ticket?     | Fixes #31115 
| Related PRs       | 
| Sponsor company   | 
