### PR TITLE
Inherit `AbstractType` instead of `ChoiceType`

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/ManufacturerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/ManufacturerType.php
@@ -30,11 +30,12 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product\Description;
 
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\NoManufacturerId;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ManufacturerType extends ChoiceType
+class ManufacturerType extends AbstractType
 {
     private const MANUFACTURER_MIN_RESULTS_FOR_SEARCH = 7;
 
@@ -56,17 +57,20 @@ class ManufacturerType extends ChoiceType
         TranslatorInterface $translator,
         FormChoiceProviderInterface $manufacturerChoiceProvider
     ) {
-        parent::__construct();
         $this->translator = $translator;
         $this->manufacturerChoiceProvider = $manufacturerChoiceProvider;
+    }
+
+    public function getParent(): string
+    {
+        return ChoiceType::class;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
-        parent::configureOptions($resolver);
         $manufacturers = $this->manufacturerChoiceProvider->getChoices();
         $choices = array_merge([
             $this->trans('No brand', 'Admin.Catalog.Feature') => NoManufacturerId::NO_MANUFACTURER_ID,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductTypeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductTypeType.php
@@ -31,10 +31,11 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceAttributeProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ProductTypeType extends ChoiceType
+class ProductTypeType extends AbstractType
 {
     /**
      * @var FormChoiceProviderInterface|FormChoiceAttributeProviderInterface
@@ -47,20 +48,27 @@ class ProductTypeType extends ChoiceType
     public function __construct(
         $formChoiceProvider
     ) {
-        parent::__construct();
         $this->formChoiceProvider = $formChoiceProvider;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function getParent(): string
     {
-        parent::configureOptions($resolver);
+        return ChoiceType::class;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
         $resolver->setDefaults([
             'choices' => $this->formChoiceProvider->getChoices(),
             'choice_attr' => $this->formChoiceProvider->getChoicesAttributes(),
             'required' => true,
             'label' => false,
             'empty_data' => ProductType::TYPE_STANDARD,
-            'block_prefix' => 'product_type',
         ]);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'product_type';
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Type/CurrencyChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CurrencyChoiceType.php
@@ -28,10 +28,11 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class CurrencyChoiceType extends ChoiceType
+class CurrencyChoiceType extends AbstractType
 {
     /**
      * @var CurrencyByIdChoiceProvider
@@ -41,8 +42,12 @@ class CurrencyChoiceType extends ChoiceType
     public function __construct(
         CurrencyByIdChoiceProvider $currencyByIdChoiceProvider
     ) {
-        parent::__construct();
         $this->currencyByIdChoiceProvider = $currencyByIdChoiceProvider;
+    }
+
+    public function getParent(): string
+    {
+        return ChoiceType::class;
     }
 
     /**
@@ -50,8 +55,6 @@ class CurrencyChoiceType extends ChoiceType
      */
     public function configureOptions(OptionsResolver $resolver): void
     {
-        parent::configureOptions($resolver);
-
         $resolver->setDefaults([
             'choices' => $this->currencyByIdChoiceProvider->getChoices(),
             'choice_attr' => $this->currencyByIdChoiceProvider->getChoicesAttributes(),

--- a/src/PrestaShopBundle/Form/Admin/Type/ShippingInclusionChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ShippingInclusionChoiceType.php
@@ -28,10 +28,11 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ShippingInclusionChoiceProvider;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ShippingInclusionChoiceType extends ChoiceType
+class ShippingInclusionChoiceType extends AbstractType
 {
     /**
      * @var ShippingInclusionChoiceProvider
@@ -41,8 +42,12 @@ class ShippingInclusionChoiceType extends ChoiceType
     public function __construct(
         ShippingInclusionChoiceProvider $shippingInclusionChoiceProvider
     ) {
-        parent::__construct();
         $this->shippingInclusionChoiceProvider = $shippingInclusionChoiceProvider;
+    }
+
+    public function getParent(): string
+    {
+        return ChoiceType::class;
     }
 
     /**
@@ -50,8 +55,6 @@ class ShippingInclusionChoiceType extends ChoiceType
      */
     public function configureOptions(OptionsResolver $resolver): void
     {
-        parent::configureOptions($resolver);
-
         $resolver->setDefaults([
             'label' => false,
             'choices' => $this->shippingInclusionChoiceProvider->getChoices(),

--- a/src/PrestaShopBundle/Form/Admin/Type/ShopSelectorType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ShopSelectorType.php
@@ -31,6 +31,7 @@ namespace PrestaShopBundle\Form\Admin\Type;
 use PrestaShopBundle\Entity\Repository\ShopRepository;
 use PrestaShopBundle\Entity\Shop;
 use PrestaShopBundle\Entity\ShopGroup;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -41,7 +42,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * This form type is used to select one or multiple shops, it is used with the
  */
-class ShopSelectorType extends ChoiceType
+class ShopSelectorType extends AbstractType
 {
     /**
      * @var ShopRepository
@@ -63,33 +64,40 @@ class ShopSelectorType extends ChoiceType
         array $shopGroups,
         ?int $contextShopId
     ) {
-        parent::__construct();
         $this->shopRepository = $shopRepository;
         $this->shopGroups = $shopGroups;
         $this->contextShopId = $contextShopId;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function getParent(): string
     {
-        parent::configureOptions($resolver);
+        return ChoiceType::class;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
         $resolver->setDefaults([
             'multiple' => false,
             'choices' => $this->getShopChoices(),
             'choice_label' => 'name',
             'choice_value' => 'id',
-            'block_prefix' => 'shop_selector',
             'label' => false,
             'form_theme' => '@PrestaShop/Admin/TwigTemplateForm/multishop.html.twig',
         ]);
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function getBlockPrefix(): string
+    {
+        return 'shop_selector';
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
         $view->vars['contextShopId'] = $this->contextShopId;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder->addModelTransformer(new CallbackTransformer(

--- a/src/PrestaShopBundle/Form/Admin/Type/TaxInclusionChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TaxInclusionChoiceType.php
@@ -28,10 +28,11 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TaxInclusionChoiceProvider;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class TaxInclusionChoiceType extends ChoiceType
+class TaxInclusionChoiceType extends AbstractType
 {
     /**
      * @var TaxInclusionChoiceProvider
@@ -41,8 +42,12 @@ class TaxInclusionChoiceType extends ChoiceType
     public function __construct(
         TaxInclusionChoiceProvider $shippingInclusionChoiceProvider
     ) {
-        parent::__construct();
         $this->taxInclusionChoiceProvider = $shippingInclusionChoiceProvider;
+    }
+
+    public function getParent(): string
+    {
+        return ChoiceType::class;
     }
 
     /**
@@ -50,8 +55,6 @@ class TaxInclusionChoiceType extends ChoiceType
      */
     public function configureOptions(OptionsResolver $resolver): void
     {
-        parent::configureOptions($resolver);
-
         $resolver->setDefaults([
             'label' => false,
             'choices' => $this->taxInclusionChoiceProvider->getChoices(),


### PR DESCRIPTION
Signed-off-by: Fabien Papet <fabien.papet@gmail.com>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Extending form types should be done with `getParent` and not with PHP extend
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Currency selection, should still work as intended