### PR TITLE
Hide vouchers with no available quantities

### DIFF
--- a/controllers/front/DiscountController.php
+++ b/controllers/front/DiscountController.php
@@ -74,6 +74,10 @@ class DiscountControllerCore extends FrontController
                 continue;
             }
 
+            if ($voucher['quantity'] === 0 || $voucher['quantity_for_user'] === 0) {
+                continue;
+            }
+
             $cart_rule = $this->buildCartRuleFromVoucher($voucher);
             $cart_rules[$key] = $cart_rule;
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x
| Description?      | This PR prevents vouchers to appear in the user account if they are not available to use. Either the total quantity is none or the user's available quantity is none.
| Type?             | bug fix 
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | First Case : <br><ul><li>Create a valid cart rule with a discount code , enable "Highlight"</li><li> Set the "Total available" quantity to 0 in "Conditions" tab. </li><li> Login as a customer, check the Voucher section, the unusable rule will not be there anymore.</li></ul>Second Case: <br><ul><li>Create a valid cart rule with a discount code , enable "Highlight" </li><li> Set the "Total available" quantity to an amount ( not 0 ) and the "User available uses" to 0 in "Conditions" tab. </li><li> Login as a customer, check the Voucher section, the unusable rule will not be there anymore.</li></ul>
| Fixed ticket?     | Fixes #31871 
| Related PRs       | N/A
| Sponsor company   | N/A
