### PR TITLE
Use `CurrencyChoiceType` on all form types

### DIFF
--- a/src/Core/Form/ChoiceProvider/CurrencyByIdChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/CurrencyByIdChoiceProvider.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
-use PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider;
+use PrestaShop\PrestaShop\Core\Currency\CurrencyDataProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceAttributeProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 
@@ -36,14 +36,14 @@ use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 final class CurrencyByIdChoiceProvider implements FormChoiceProviderInterface, FormChoiceAttributeProviderInterface
 {
     /**
-     * @var CurrencyDataProvider
+     * @var CurrencyDataProviderInterface
      */
     private $currencyDataProvider;
 
     /**
-     * @param CurrencyDataProvider $currencyDataProvider
+     * @param CurrencyDataProviderInterface $currencyDataProvider
      */
-    public function __construct(CurrencyDataProvider $currencyDataProvider)
+    public function __construct(CurrencyDataProviderInterface $currencyDataProvider)
     {
         $this->currencyDataProvider = $currencyDataProvider;
     }
@@ -53,7 +53,7 @@ final class CurrencyByIdChoiceProvider implements FormChoiceProviderInterface, F
      *
      * @return array
      */
-    public function getChoices()
+    public function getChoices(): array
     {
         $currencies = $this->getCurrencies();
         $choices = [];
@@ -66,7 +66,7 @@ final class CurrencyByIdChoiceProvider implements FormChoiceProviderInterface, F
         return $choices;
     }
 
-    public function getChoicesAttributes()
+    public function getChoicesAttributes(): array
     {
         $currencies = $this->getCurrencies();
         $choicesAttributes = [];

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -82,6 +82,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductSearchEmptyPhrase
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\FoundProduct;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\QuerySorting;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider;
 use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Order\OrderSiblingProviderInterface;
@@ -249,7 +250,7 @@ class OrderController extends FrameworkBundleAdminController
                 'shop_id' => $shopContextChecker->getContextShopID(),
             ]
         );
-        $currencies = $this->get('prestashop.core.form.choice_provider.currency_by_id')->getChoices();
+        $currencies = $this->get(CurrencyByIdChoiceProvider::class)->getChoices();
 
         $configuration = $this->getConfiguration();
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Improve\International\Localization;
 
+use PrestaShopBundle\Form\Admin\Type\CurrencyChoiceType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -51,17 +52,11 @@ class LocalizationConfigurationType extends TranslatorAwareType
     /**
      * @var array
      */
-    private $currencyChoices;
-
-    /**
-     * @var array
-     */
     private $timezoneChoices;
 
     /**
      * @param array $languageChoices
      * @param array $countryChoices
-     * @param array $currencyChoices
      * @param array $timezoneChoices
      */
     public function __construct(
@@ -69,13 +64,11 @@ class LocalizationConfigurationType extends TranslatorAwareType
         array $locales,
         array $languageChoices,
         array $countryChoices,
-        array $currencyChoices,
         array $timezoneChoices
     ) {
         parent::__construct($translator, $locales);
         $this->languageChoices = $languageChoices;
         $this->countryChoices = $countryChoices;
-        $this->currencyChoices = $currencyChoices;
         $this->timezoneChoices = $timezoneChoices;
     }
 
@@ -138,9 +131,7 @@ class LocalizationConfigurationType extends TranslatorAwareType
                 ),
             ]
             )
-            ->add('default_currency', ChoiceType::class, [
-                'choices' => $this->currencyChoices,
-                'choice_translation_domain' => false,
+            ->add('default_currency', CurrencyChoiceType::class, [
                 'label' => $this->trans(
                     'Default currency',
                     'Admin.International.Feature'
@@ -151,8 +142,6 @@ class LocalizationConfigurationType extends TranslatorAwareType
                 ),
                 'attr' => [
                     'data-warning-message' => 'Before changing the default currency, we strongly recommend that you enable maintenance mode. Indeed, any change on the default currency requires a manual adjustment of the price of each product and its combinations.',
-                    'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => 'select2',
                 ],
             ])
             ->add('timezone', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryType.php
@@ -31,7 +31,7 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Locations;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
-use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShopBundle\Form\Admin\Type\CurrencyChoiceType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
@@ -55,11 +55,6 @@ class CountryType extends AbstractType
     protected $isMultistoreEnabled;
 
     /**
-     * @var FormChoiceProviderInterface
-     */
-    protected $currencyChoiceProvider;
-
-    /**
      * @var ConfigurableFormChoiceProviderInterface
      */
     protected $zoneChoiceProvider;
@@ -70,12 +65,10 @@ class CountryType extends AbstractType
     public function __construct(
         TranslatorInterface $translator,
         bool $isMultistoreEnabled,
-        FormChoiceProviderInterface $currencyChoiceProvider,
         ConfigurableFormChoiceProviderInterface $zoneChoiceProvider
     ) {
         $this->translator = $translator;
         $this->isMultistoreEnabled = $isMultistoreEnabled;
-        $this->currencyChoiceProvider = $currencyChoiceProvider;
         $this->zoneChoiceProvider = $zoneChoiceProvider;
     }
 
@@ -119,10 +112,9 @@ class CountryType extends AbstractType
                 'required' => true,
                 'label' => $this->translator->trans('Call prefix', [], 'Admin.International.Feature'),
             ])
-            ->add('default_currency', ChoiceType::class, [
+            ->add('default_currency', CurrencyChoiceType::class, [
                 'required' => false,
                 'label' => $this->translator->trans('Default currency', [], 'Admin.International.Feature'),
-                'choices' => $this->currencyChoiceProvider->getChoices(),
                 'placeholder' => $this->translator->trans('Default store currency', [], 'Admin.International.Feature'),
             ])
             ->add('zone', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentModulePreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentModulePreferencesType.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Improve\Payment\Preferences;
 
 use PrestaShop\PrestaShop\Adapter\Country\CountryDataProvider;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialMultipleChoiceTableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -55,17 +56,16 @@ class PaymentModulePreferencesType extends TranslatorAwareType
     /**
      * @var array
      */
-    private $currencyChoices;
-
-    /**
-     * @var array
-     */
     private $paymentModules;
 
     /**
      * @var CountryDataProvider
      */
     private $countryDataProvider;
+    /**
+     * @var CurrencyByIdChoiceProvider
+     */
+    private $currencyChoicesProvider;
 
     /**
      * @param TranslatorInterface $translator
@@ -74,7 +74,7 @@ class PaymentModulePreferencesType extends TranslatorAwareType
      * @param array $countryChoices
      * @param array $groupChoices
      * @param array $carrierChoices
-     * @param array $currencyChoices
+     * @param CurrencyByIdChoiceProvider $currencyChoicesProvider
      * @param CountryDataProvider $countryDataProvider
      */
     public function __construct(
@@ -84,7 +84,7 @@ class PaymentModulePreferencesType extends TranslatorAwareType
         array $countryChoices,
         array $groupChoices,
         array $carrierChoices,
-        array $currencyChoices,
+        CurrencyByIdChoiceProvider $currencyChoicesProvider,
         CountryDataProvider $countryDataProvider
     ) {
         parent::__construct($translator, $locales);
@@ -92,9 +92,9 @@ class PaymentModulePreferencesType extends TranslatorAwareType
         $this->countryChoices = $countryChoices;
         $this->groupChoices = $groupChoices;
         $this->carrierChoices = $carrierChoices;
-        $this->currencyChoices = $currencyChoices;
         $this->paymentModules = $this->sortPaymentModules($paymentModules);
         $this->countryDataProvider = $countryDataProvider;
+        $this->currencyChoicesProvider = $currencyChoicesProvider;
     }
 
     /**
@@ -143,13 +143,10 @@ class PaymentModulePreferencesType extends TranslatorAwareType
 
             if ('radio' === $moduleInstance->currencies_mode) {
                 $allowMultipleCurrencies = false;
-                $currencyChoices = array_merge(
-                    $this->currencyChoices,
-                    $this->getAdditionalCurrencyChoices()
-                );
+                $currencyChoices = $this->getCurrencyChoices();
             } else {
                 $allowMultipleCurrencies = true;
-                $currencyChoices = $this->currencyChoices;
+                $currencyChoices = $this->currencyChoicesProvider->getChoices();
             }
 
             $choices[] = [
@@ -242,7 +239,7 @@ class PaymentModulePreferencesType extends TranslatorAwareType
     private function getCurrencyChoices()
     {
         return array_merge(
-            $this->currencyChoices,
+            $this->currencyChoicesProvider->getChoices(),
             $this->getAdditionalCurrencyChoices()
         );
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/CatalogPriceRule/CatalogPriceRuleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CatalogPriceRule/CatalogPriceRuleType.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DateRange;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\Reduction;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Reduction as ReductionVO;
+use PrestaShopBundle\Form\Admin\Type\CurrencyChoiceType;
 use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\PriceReductionType;
 use Symfony\Component\Form\AbstractType;
@@ -59,16 +60,6 @@ class CatalogPriceRuleType extends AbstractType
     /**
      * @var array
      */
-    private $currencyByIdChoices;
-
-    /**
-     * @var array
-     */
-    private $currencyByIdChoicesAttributes;
-
-    /**
-     * @var array
-     */
     private $countryByIdChoices;
 
     /**
@@ -82,37 +73,24 @@ class CatalogPriceRuleType extends AbstractType
     private $shopByIdChoices;
 
     /**
-     * @var string
-     */
-    private $defaultCurrencySymbol;
-
-    /**
      * @param TranslatorInterface $translator
      * @param bool $isMultiShopEnabled
-     * @param array $currencyByIdChoices
      * @param array $countryByIdChoices
      * @param array $groupByIdChoices
      * @param array $shopByIdChoices
-     * @param array $currencyByIdChoicesAttributes
      */
     public function __construct(
         TranslatorInterface $translator,
         bool $isMultiShopEnabled,
-        array $currencyByIdChoices,
         array $countryByIdChoices,
         array $groupByIdChoices,
-        array $shopByIdChoices,
-        array $currencyByIdChoicesAttributes,
-        string $defaultCurrencySymbol
+        array $shopByIdChoices
     ) {
         $this->translator = $translator;
         $this->isMultiShopEnabled = $isMultiShopEnabled;
-        $this->currencyByIdChoices = $currencyByIdChoices;
-        $this->currencyByIdChoicesAttributes = $currencyByIdChoicesAttributes;
         $this->countryByIdChoices = $countryByIdChoices;
         $this->groupByIdChoices = $groupByIdChoices;
         $this->shopByIdChoices = $shopByIdChoices;
-        $this->defaultCurrencySymbol = $defaultCurrencySymbol;
     }
 
     /**
@@ -126,14 +104,8 @@ class CatalogPriceRuleType extends AbstractType
                     new CleanHtml(),
                 ],
             ])
-            ->add('id_currency', ChoiceType::class, [
-                'required' => false,
-                'placeholder' => false,
-                'choices' => $this->getModifiedCurrencyChoices(),
-                'choice_attr' => $this->currencyByIdChoicesAttributes,
-                'attr' => [
-                    'data-default-currency-symbol' => $this->defaultCurrencySymbol,
-                ],
+            ->add('id_currency', CurrencyChoiceType::class, [
+                'add_all_currencies_option' => true,
             ])
             ->add('id_country', ChoiceType::class, [
                 'required' => false,
@@ -212,19 +184,6 @@ class CatalogPriceRuleType extends AbstractType
                 'choices' => $this->shopByIdChoices,
             ]);
         }
-    }
-
-    /**
-     * Prepends 'All currencies' option with id of 0 to currency choices
-     *
-     * @return array
-     */
-    private function getModifiedCurrencyChoices(): array
-    {
-        return array_merge(
-            [$this->translator->trans('All currencies', [], 'Admin.Global') => 0],
-            $this->currencyByIdChoices
-        );
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductSupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductSupplierType.php
@@ -33,10 +33,9 @@ use PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Reference;
-use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShopBundle\Form\Admin\Type\CurrencyChoiceType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use PrestaShopBundle\Form\FormCloner;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -51,11 +50,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ProductSupplierType extends TranslatorAwareType
 {
-    /**
-     * @var FormChoiceProviderInterface
-     */
-    private $currencyByIdChoiceProvider;
-
     /**
      * @var string
      */
@@ -74,19 +68,18 @@ class ProductSupplierType extends TranslatorAwareType
     /**
      * @param TranslatorInterface $translator
      * @param array $locales
-     * @param FormChoiceProviderInterface $currencyByIdChoiceProvider
      * @param string $defaultCurrencyIsoCode
+     * @param CurrencyRepository $currencyRepository
+     * @param FormCloner $formCloner
      */
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        FormChoiceProviderInterface $currencyByIdChoiceProvider,
         string $defaultCurrencyIsoCode,
         CurrencyRepository $currencyRepository,
         FormCloner $formCloner
     ) {
         parent::__construct($translator, $locales);
-        $this->currencyByIdChoiceProvider = $currencyByIdChoiceProvider;
         $this->defaultCurrencyIsoCode = $defaultCurrencyIsoCode;
         $this->currencyRepository = $currencyRepository;
         $this->formCloner = $formCloner;
@@ -129,12 +122,10 @@ class ProductSupplierType extends TranslatorAwareType
                 ],
                 'default_empty_data' => 0.0,
             ])
-            ->add('currency_id', ChoiceType::class, [
+            ->add('currency_id', CurrencyChoiceType::class, [
                 'label' => $this->trans('Currency', 'Admin.Global'),
-                'required' => false,
                 // placeholder false is important to avoid empty option in select input despite required being false
                 'placeholder' => false,
-                'choices' => $this->currencyByIdChoiceProvider->getChoices(),
             ])
         ;
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/ApplicableGroupsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/ApplicableGroupsType.php
@@ -28,8 +28,8 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Pricing;
 
-use PrestaShop\PrestaShop\Core\Form\FormChoiceAttributeProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShopBundle\Form\Admin\Type\CurrencyChoiceType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -38,11 +38,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ApplicableGroupsType extends TranslatorAwareType
 {
-    /**
-     * @var FormChoiceProviderInterface|FormChoiceAttributeProviderInterface
-     */
-    protected $currencyByIdChoiceProvider;
-
     /**
      * @var FormChoiceProviderInterface
      */
@@ -59,11 +54,6 @@ class ApplicableGroupsType extends TranslatorAwareType
     protected $shopByIdChoiceProvider;
 
     /**
-     * @var string
-     */
-    protected $defaultCurrencySymbol;
-
-    /**
      * @var bool
      */
     protected $isMultiShopEnabled;
@@ -76,29 +66,22 @@ class ApplicableGroupsType extends TranslatorAwareType
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        $currencyByIdChoiceProvider,
         FormChoiceProviderInterface $countryByIdChoiceProvider,
         FormChoiceProviderInterface $groupByIdChoiceProvider,
         FormChoiceProviderInterface $shopByIdChoiceProvider,
-        string $defaultCurrencySymbol,
         bool $isMultiShopEnabled,
         int $contextShopId
     ) {
         parent::__construct($translator, $locales);
-        $this->currencyByIdChoiceProvider = $currencyByIdChoiceProvider;
         $this->countryByIdChoiceProvider = $countryByIdChoiceProvider;
         $this->groupByIdChoiceProvider = $groupByIdChoiceProvider;
         $this->shopByIdChoiceProvider = $shopByIdChoiceProvider;
-        $this->defaultCurrencySymbol = $defaultCurrencySymbol;
         $this->isMultiShopEnabled = $isMultiShopEnabled;
         $this->contextShopId = $contextShopId;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $currencies = array_merge([
-            $this->trans('All currencies', 'Admin.Global') => 0,
-        ], $this->currencyByIdChoiceProvider->getChoices());
         $countries = array_merge([
             $this->trans('All countries', 'Admin.Global') => 0,
         ], $this->countryByIdChoiceProvider->getChoices());
@@ -107,15 +90,8 @@ class ApplicableGroupsType extends TranslatorAwareType
         ], $this->groupByIdChoiceProvider->getChoices());
 
         $builder
-            ->add('currency_id', ChoiceType::class, [
-                'label' => false,
-                'placeholder' => false,
-                'choices' => $currencies,
-                'choice_attr' => $this->currencyByIdChoiceProvider->getChoicesAttributes(),
-                'required' => false,
-                'attr' => [
-                    'data-default-currency-symbol' => $this->defaultCurrencySymbol,
-                ],
+            ->add('currency_id', CurrencyChoiceType::class, [
+                'add_all_currencies_option' => true,
             ])
             ->add('country_id', ChoiceType::class, [
                 'label' => false,

--- a/src/PrestaShopBundle/Form/Admin/Type/CurrencyChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CurrencyChoiceType.php
@@ -77,6 +77,14 @@ class CurrencyChoiceType extends AbstractType
             return $currencies;
         });
 
+        $resolver->addNormalizer('attr', function (Options $options, array $attr) {
+            $attr['data-default-currency-symbol'] = $this->currencyDataProvider->getDefaultCurrencySymbol();
+            $attr['data-minimumResultsForSearch'] = '7';
+            $attr['data-toggle'] = 'select2';
+
+            return $attr;
+        });
+
         $resolver->setDefaults([
             'required' => false,
             'add_all_currencies_option' => false,
@@ -85,11 +93,6 @@ class CurrencyChoiceType extends AbstractType
             'choice_attr' => $this->currencyByIdChoiceProvider->getChoicesAttributes(),
             'label' => 'Currency',
             'placeholder' => false,
-            'attr' => [
-                'data-default-currency-symbol' => $this->currencyDataProvider->getDefaultCurrencySymbol(),
-                'data-minimumResultsForSearch' => '7',
-                'data-toggle' => 'select2',
-            ],
         ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Type/CurrencyChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CurrencyChoiceType.php
@@ -27,9 +27,11 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
+use PrestaShop\PrestaShop\Core\Currency\CurrencyDataProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CurrencyChoiceType extends AbstractType
@@ -38,11 +40,17 @@ class CurrencyChoiceType extends AbstractType
      * @var CurrencyByIdChoiceProvider
      */
     private $currencyByIdChoiceProvider;
+    /**
+     * @var CurrencyDataProviderInterface
+     */
+    private $currencyDataProvider;
 
     public function __construct(
+        CurrencyDataProviderInterface $currencyDataProvider,
         CurrencyByIdChoiceProvider $currencyByIdChoiceProvider
     ) {
         $this->currencyByIdChoiceProvider = $currencyByIdChoiceProvider;
+        $this->currencyDataProvider = $currencyDataProvider;
     }
 
     public function getParent(): string
@@ -55,10 +63,30 @@ class CurrencyChoiceType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver): void
     {
+        $resolver->addNormalizer('choices', function (Options $options) {
+            $currencies = $this->currencyByIdChoiceProvider->getChoices();
+
+            if ($options['add_all_currencies_option']) {
+                return array_merge(
+                    ['All currencies' => 0],
+                    $currencies
+                );
+            }
+
+            return $currencies;
+        });
+
         $resolver->setDefaults([
-            'choices' => $this->currencyByIdChoiceProvider->getChoices(),
+            'required' => false,
+            'add_all_currencies_option' => false,
+            'choice_translation_domain' => false,
+            'choices' => [],
             'choice_attr' => $this->currencyByIdChoiceProvider->getChoicesAttributes(),
-            'label' => false,
+            'label' => 'Currency',
+            'placeholder' => false,
+            'attr' => [
+                'data-default-currency-symbol' => $this->currencyDataProvider->getDefaultCurrencySymbol(),
+            ],
         ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Type/CurrencyChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CurrencyChoiceType.php
@@ -40,6 +40,7 @@ class CurrencyChoiceType extends AbstractType
      * @var CurrencyByIdChoiceProvider
      */
     private $currencyByIdChoiceProvider;
+
     /**
      * @var CurrencyDataProviderInterface
      */
@@ -86,6 +87,8 @@ class CurrencyChoiceType extends AbstractType
             'placeholder' => false,
             'attr' => [
                 'data-default-currency-symbol' => $this->currencyDataProvider->getDefaultCurrencySymbol(),
+                'data-minimumResultsForSearch' => '7',
+                'data-toggle' => 'select2',
             ],
         ]);
     }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -36,7 +36,6 @@ services:
       $isSingleShopContext: '@=service("prestashop.adapter.shop.context").isShopContext()'
       $categoryDataProvider: '@prestashop.adapter.data_provider.category'
       $ecoTaxGroupId: "@=service('prestashop.adapter.legacy.configuration').getInt('PS_ECOTAX_TAX_RULES_GROUP_ID')"
-      $defaultCurrencySymbol: '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrency().symbol'
       $router: '@router'
       $isCombinationsUsed: '@=service("prestashop.adapter.combination_feature").isUsed()'
       $availableLocales: "@=service('prestashop.adapter.legacy.context').getAvailableLanguages()"
@@ -207,7 +206,6 @@ services:
     arguments:
       $languageChoices: '@=service("prestashop.core.form.choice_provider.language_by_id").getChoices()'
       $countryChoices: '@=service("prestashop.core.form.choice_provider.country_by_id").getChoices()'
-      $currencyChoices: '@=service("prestashop.core.form.choice_provider.currency_by_id").getChoices()'
       $timezoneChoices: '@=service("prestashop.core.form.choice_provider.timezone_by_name").getChoices()'
 
   PrestaShopBundle\Form\Admin\Improve\International\Localization\ImportLocalizationPackType:
@@ -228,7 +226,7 @@ services:
       $countryChoices: '@=service("prestashop.core.form.choice_provider.country_by_id").getChoices()'
       $groupChoices: '@=service("prestashop.core.form.choice_provider.group_by_id").getChoices()'
       $carrierChoices: '@=service("prestashop.core.form.choice_provider.carrier_by_reference_id").getChoices()'
-      $currencyChoices: '@=service("prestashop.core.form.choice_provider.currency_by_id").getChoices()'
+      $currencyChoices: '@=service("PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider").getChoices()'
       $countryDataProvider: '@prestashop.adapter.data_provider.country'
 
   PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Email\EmailConfigurationType:
@@ -431,11 +429,9 @@ services:
 
   PrestaShopBundle\Form\Admin\Sell\CatalogPriceRule\CatalogPriceRuleType:
     arguments:
-      $currencyByIdChoices: '@=service("prestashop.core.form.choice_provider.currency_by_id").getChoices()'
       $countryByIdChoices: '@=service("prestashop.core.form.choice_provider.country_by_id").getChoices()'
       $groupByIdChoices: '@=service("prestashop.core.form.choice_provider.group_by_id").getChoices()'
       $shopByIdChoices: '@=service("prestashop.adapter.form.choice_provider.shop_name_by_id").getChoices()'
-      $currencyByIdChoicesAttributes: '@=service("prestashop.core.form.choice_provider.currency_by_id").getChoicesAttributes()'
 
   PrestaShopBundle\Form\Admin\Type\PriceReductionType:
     arguments:
@@ -473,7 +469,7 @@ services:
 
   PrestaShopBundle\Form\Admin\Sell\Order\ChangeOrderCurrencyType:
     arguments:
-      $currencyChoiceProvider: '@prestashop.core.form.choice_provider.currency_by_id'
+      $currencyChoiceProvider: '@PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider'
 
   PrestaShopBundle\Form\Admin\Improve\Design\MailTheme\TranslateMailsBodyType:
   PrestaShopBundle\Form\Admin\Sell\Order\UpdateOrderShippingType:
@@ -616,7 +612,6 @@ services:
 
   PrestaShopBundle\Form\Admin\Sell\Product\Pricing\ApplicableGroupsType:
     arguments:
-      $currencyByIdChoiceProvider: '@prestashop.core.form.choice_provider.currency_by_id'
       $countryByIdChoiceProvider: '@prestashop.core.form.choice_provider.country_by_id'
       $groupByIdChoiceProvider: '@prestashop.core.form.choice_provider.group_by_id'
       $shopByIdChoiceProvider: '@prestashop.adapter.form.choice_provider.shop_name_by_id'
@@ -652,7 +647,6 @@ services:
 
   PrestaShopBundle\Form\Admin\Sell\Product\Options\ProductSupplierType:
     arguments:
-      $currencyByIdChoiceProvider: '@prestashop.core.form.choice_provider.currency_by_id'
       $defaultCurrencyIsoCode: "@=service('prestashop.adapter.legacy.context').getContext().currency.iso_code"
 
   PrestaShopBundle\Form\Admin\Sell\Product\ExtraModulesType:
@@ -718,7 +712,6 @@ services:
   PrestaShopBundle\Form\Admin\Improve\International\Locations\ZoneType:
   PrestaShopBundle\Form\Admin\Improve\International\Locations\CountryType:
     arguments:
-      $currencyChoiceProvider: '@prestashop.core.form.choice_provider.currency_by_id'
       $zoneChoiceProvider: '@prestashop.core.form.choice_provider.zone_by_id'
 
   PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\FeatureFlag\FeatureFlagListType:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -226,7 +226,6 @@ services:
       $countryChoices: '@=service("prestashop.core.form.choice_provider.country_by_id").getChoices()'
       $groupChoices: '@=service("prestashop.core.form.choice_provider.group_by_id").getChoices()'
       $carrierChoices: '@=service("prestashop.core.form.choice_provider.carrier_by_reference_id").getChoices()'
-      $currencyChoices: '@=service("PrestaShop\\PrestaShop\\Core\\Form\\ChoiceProvider\\CurrencyByIdChoiceProvider").getChoices()'
       $countryDataProvider: '@prestashop.adapter.data_provider.country'
 
   PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Email\EmailConfigurationType:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -226,7 +226,7 @@ services:
       $countryChoices: '@=service("prestashop.core.form.choice_provider.country_by_id").getChoices()'
       $groupChoices: '@=service("prestashop.core.form.choice_provider.group_by_id").getChoices()'
       $carrierChoices: '@=service("prestashop.core.form.choice_provider.carrier_by_reference_id").getChoices()'
-      $currencyChoices: '@=service("PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider").getChoices()'
+      $currencyChoices: '@=service("PrestaShop\\PrestaShop\\Core\\Form\\ChoiceProvider\\CurrencyByIdChoiceProvider").getChoices()'
       $countryDataProvider: '@prestashop.adapter.data_provider.country'
 
   PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Email\EmailConfigurationType:

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -327,9 +327,10 @@ services:
     autowire: true
     public: false
 
+  # Should be public as used in some controllers
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider:
     autowire: true
-    public: false
+    public: true
 
   # deprecated services
   prestashop.core.form.choice_provider.currency_by_id:


### PR DESCRIPTION
Signed-off-by: Fabien Papet <fabien.papet@gmail.com>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Update code maximise form type reusability
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | All currency selections should work as they used to.
