### PR TITLE
Autowire grid definitions

### DIFF
--- a/src/Adapter/Form/ChoiceProvider/ShopNameByIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/ShopNameByIdChoiceProvider.php
@@ -32,7 +32,7 @@ use Shop;
 /**
  * Provides shop names by name => id value pairs
  */
-final class ShopNameByIdChoiceProvider implements FormChoiceProviderInterface
+class ShopNameByIdChoiceProvider implements FormChoiceProviderInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Core/Grid/Action/Row/AccessibilityChecker/PrintDeliverySlipAccessibilityChecker.php
+++ b/src/Core/Grid/Action/Row/AccessibilityChecker/PrintDeliverySlipAccessibilityChecker.php
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker;
 /**
  * Checks if print delivery slip option can be visible in order list.
  */
-final class PrintDeliverySlipAccessibilityChecker implements AccessibilityCheckerInterface
+class PrintDeliverySlipAccessibilityChecker implements AccessibilityCheckerInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Core/Grid/Action/Row/AccessibilityChecker/PrintInvoiceAccessibilityChecker.php
+++ b/src/Core/Grid/Action/Row/AccessibilityChecker/PrintInvoiceAccessibilityChecker.php
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker;
 /**
  * Checks if print invoice option can be visible in order list.
  */
-final class PrintInvoiceAccessibilityChecker implements AccessibilityCheckerInterface
+class PrintInvoiceAccessibilityChecker implements AccessibilityCheckerInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Core/Grid/Definition/Factory/AbstractGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AbstractGridDefinitionFactory.php
@@ -55,8 +55,9 @@ abstract class AbstractGridDefinitionFactory implements GridDefinitionFactoryInt
     /**
      * @param HookDispatcherInterface $hookDispatcher
      */
-    public function __construct(HookDispatcherInterface $hookDispatcher)
-    {
+    public function __construct(
+        HookDispatcherInterface $hookDispatcher
+    ) {
         $this->hookDispatcher = $hookDispatcher;
     }
 

--- a/src/Core/Grid/Definition/Factory/AbstractGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AbstractGridDefinitionFactory.php
@@ -37,28 +37,34 @@ use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinition;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollectionInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
-use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class AbstractGridDefinitionFactory implements grid definition creation.
  */
 abstract class AbstractGridDefinitionFactory implements GridDefinitionFactoryInterface
 {
-    use TranslatorAwareTrait;
-
     /**
      * @var HookDispatcherInterface
      */
     protected $hookDispatcher;
 
     /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    /**
      * @param HookDispatcherInterface $hookDispatcher
+     * @param TranslatorInterface $translator
      */
     public function __construct(
-        HookDispatcherInterface $hookDispatcher
+        HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator
     ) {
         $this->hookDispatcher = $hookDispatcher;
+        $this->translator = $translator;
     }
 
     /**
@@ -146,5 +152,13 @@ abstract class AbstractGridDefinitionFactory implements GridDefinitionFactoryInt
     protected function getFilters()
     {
         return new FilterCollection();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function trans($id, array $options, $domain)
+    {
+        return $this->translator->trans($id, $options, $domain);
     }
 }

--- a/src/Core/Grid/Definition/Factory/AttachmentGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttachmentGridDefinitionFactory.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Defines attachments list grid
@@ -55,9 +56,11 @@ final class AttachmentGridDefinitionFactory extends AbstractFilterableGridDefini
     /**
      * @param HookDispatcherInterface $hookDispatcher
      */
-    public function __construct(HookDispatcherInterface $hookDispatcher)
-    {
-        parent::__construct($hookDispatcher);
+    public function __construct(
+        HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator
+    ) {
+        parent::__construct($hookDispatcher, $translator);
     }
 
     /**

--- a/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
@@ -47,6 +47,7 @@ use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Defines grid for attributes group > attributes list
@@ -74,10 +75,11 @@ final class AttributeGridDefinitionFactory extends AbstractFilterableGridDefinit
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         $attributeGroupId,
         AttributeGroupViewDataProviderInterface $attributeGroupViewDataProvider
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->attributeGroupId = $attributeGroupId;
         $this->attributeGroupViewDataProvider = $attributeGroupViewDataProvider;
     }

--- a/src/Core/Grid/Definition/Factory/AuthorizedApplicationGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AuthorizedApplicationGridDefinitionFactory.php
@@ -44,6 +44,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\LinkColumn;
 final class AuthorizedApplicationGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
     use DeleteActionTrait;
+
     public const GRID_ID = 'authorized_application';
 
     /**

--- a/src/Core/Grid/Definition/Factory/CartRuleGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CartRuleGridDefinitionFactory.php
@@ -48,6 +48,7 @@ use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class responsible for providing columns, filters, actions for cart price rule list.
@@ -66,9 +67,10 @@ final class CartRuleGridDefinitionFactory extends AbstractGridDefinitionFactory 
 
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         string $contextDateFormat
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->contextDateFormat = $contextDateFormat;
     }
 

--- a/src/Core/Grid/Definition/Factory/CatalogPriceRuleGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CatalogPriceRuleGridDefinitionFactory.php
@@ -45,6 +45,7 @@ use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class responsible for providing columns, filters, actions for catalog price rule list.
@@ -54,9 +55,10 @@ final class CatalogPriceRuleGridDefinitionFactory extends AbstractGridDefinition
     public const GRID_ID = 'catalog_price_rule';
 
     public function __construct(
-        HookDispatcherInterface $hookDispatcher
+        HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
     }
 
     /**

--- a/src/Core/Grid/Definition/Factory/CategoryGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CategoryGridDefinitionFactory.php
@@ -53,6 +53,7 @@ use PrestaShop\PrestaShop\Core\Multistore\MultistoreContextCheckerInterface;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class CategoryGridDefinitionFactory builds Grid definition for Categories listing.
@@ -78,10 +79,11 @@ final class CategoryGridDefinitionFactory extends AbstractFilterableGridDefiniti
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         MultistoreContextCheckerInterface $multistoreContextChecker,
         AccessibilityCheckerInterface $categoryForViewAccessibilityChecker
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->categoryForViewAccessibilityChecker = $categoryForViewAccessibilityChecker;
         $this->multistoreContextChecker = $multistoreContextChecker;
     }

--- a/src/Core/Grid/Definition/Factory/CmsPageCategoryDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageCategoryDefinitionFactory.php
@@ -48,6 +48,7 @@ use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class CmsPageCategoryDefinitionFactory builds Grid definition for Cms page category listing.
@@ -82,11 +83,12 @@ final class CmsPageCategoryDefinitionFactory extends AbstractFilterableGridDefin
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         RequestStack $requestStack,
         MultistoreContextCheckerInterface $multistoreContextChecker,
         $isMultiStoreFeatureUsed
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->setCmsPageCategoryParentId($requestStack);
 
         $this->multistoreContextChecker = $multistoreContextChecker;

--- a/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
@@ -49,6 +49,7 @@ use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class responsible for providing columns, filters, actions for cms page list.
@@ -82,12 +83,13 @@ class CmsPageDefinitionFactory extends AbstractGridDefinitionFactory
 
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         CommandBusInterface $queryBus,
         RequestStack $requestStack,
         MultistoreContextCheckerInterface $multistoreContextChecker,
         $isMultiStoreFeatureUsed
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
 
         $this->queryBus = $queryBus;
 

--- a/src/Core/Grid/Definition/Factory/CreditSlipGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CreditSlipGridDefinitionFactory.php
@@ -39,6 +39,7 @@ use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Defines grid for credit slip listing
@@ -56,9 +57,12 @@ final class CreditSlipGridDefinitionFactory extends AbstractGridDefinitionFactor
      * @param HookDispatcherInterface $hookDispatcher
      * @param string $dateFormat The format in which date column values should be shown
      */
-    public function __construct(HookDispatcherInterface $hookDispatcher, $dateFormat)
-    {
-        parent::__construct($hookDispatcher);
+    public function __construct(
+        HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
+        $dateFormat
+    ) {
+        parent::__construct($hookDispatcher, $translator);
         $this->dateFormat = $dateFormat;
     }
 

--- a/src/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactory.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class CustomerAddressGridDefinitionFactory defines customer's addresses grid structure.
@@ -51,9 +52,12 @@ final class CustomerAddressGridDefinitionFactory extends AbstractGridDefinitionF
      */
     private $backUrl;
 
-    public function __construct(HookDispatcherInterface $hookDispatcher, ?Request $currentRequest)
-    {
-        parent::__construct($hookDispatcher);
+    public function __construct(
+        HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
+        ?Request $currentRequest
+    ) {
+        parent::__construct($hookDispatcher, $translator);
         $this->backUrl = $currentRequest ? $currentRequest->getUri() : '';
     }
 

--- a/src/Core/Grid/Definition/Factory/CustomerBoughtProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerBoughtProductGridDefinitionFactory.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\LinkColumn;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class CustomerBoughtProductGridDefinitionFactory defines customer's bought products grid structure.
@@ -55,9 +56,10 @@ final class CustomerBoughtProductGridDefinitionFactory extends AbstractGridDefin
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         $contextDateFormat
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->contextDateFormat = $contextDateFormat;
     }
 

--- a/src/Core/Grid/Definition/Factory/CustomerCartGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerCartGridDefinitionFactory.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class CustomerCartGridDefinitionFactory defines customer's cart grid structure.
@@ -57,9 +58,10 @@ final class CustomerCartGridDefinitionFactory extends AbstractGridDefinitionFact
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         $contextDateFormat
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->contextDateFormat = $contextDateFormat;
     }
 

--- a/src/Core/Grid/Definition/Factory/CustomerGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerGridDefinitionFactory.php
@@ -52,6 +52,7 @@ use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class CustomerGridDefinitionFactory defines customers grid structure.
@@ -89,12 +90,13 @@ final class CustomerGridDefinitionFactory extends AbstractGridDefinitionFactory
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         $isB2bFeatureEnabled,
         $isMultistoreFeatureEnabled,
         string $contextDateFormat,
         bool $isGroupsFeatureEnabled = true
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->isB2bFeatureEnabled = $isB2bFeatureEnabled;
         $this->isMultistoreFeatureEnabled = $isMultistoreFeatureEnabled;
         $this->contextDateFormat = $contextDateFormat;

--- a/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\HtmlColumn;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class CustomerOrderGridDefinitionFactory defines customer's order grid structure.
@@ -58,9 +59,10 @@ final class CustomerOrderGridDefinitionFactory extends AbstractGridDefinitionFac
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         $contextDateFormat
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->contextDateFormat = $contextDateFormat;
     }
 

--- a/src/Core/Grid/Definition/Factory/CustomerThreadGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerThreadGridDefinitionFactory.php
@@ -54,6 +54,7 @@ use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class CustomerThreadGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
@@ -79,11 +80,12 @@ class CustomerThreadGridDefinitionFactory extends AbstractGridDefinitionFactory
 
     public function __construct(
         HookDispatcherInterface $hookDispatcher = null,
+        TranslatorInterface $translator,
         ContactTypeChoiceProvider $contactTypeProvider,
         FormChoiceProviderInterface $shopNameByIdChoiceProvider,
         CustomerThreadStatusesChoiceProvider $customerThreadStatusesChoiceProvider
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->contactTypeProvider = $contactTypeProvider;
         $this->shopNameByIdChoiceProvider = $shopNameByIdChoiceProvider;
         $this->customerThreadStatusesChoiceProvider = $customerThreadStatusesChoiceProvider;

--- a/src/Core/Grid/Definition/Factory/CustomerThreadGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerThreadGridDefinitionFactory.php
@@ -28,7 +28,8 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
-use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerThreadStatusesChoiceProvider;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollectionInterface;
@@ -62,7 +63,7 @@ class CustomerThreadGridDefinitionFactory extends AbstractGridDefinitionFactory
     public const GRID_ID = 'customer_thread';
 
     /**
-     * @var FormChoiceProviderInterface
+     * @var ContactTypeChoiceProvider
      */
     private $contactTypeProvider;
 
@@ -72,15 +73,15 @@ class CustomerThreadGridDefinitionFactory extends AbstractGridDefinitionFactory
     private $shopNameByIdChoiceProvider;
 
     /**
-     * @var ConfigurableFormChoiceProviderInterface
+     * @var CustomerThreadStatusesChoiceProvider
      */
     private $customerThreadStatusesChoiceProvider;
 
     public function __construct(
         HookDispatcherInterface $hookDispatcher = null,
-        FormChoiceProviderInterface $contactTypeProvider,
+        ContactTypeChoiceProvider $contactTypeProvider,
         FormChoiceProviderInterface $shopNameByIdChoiceProvider,
-        ConfigurableFormChoiceProviderInterface $customerThreadStatusesChoiceProvider
+        CustomerThreadStatusesChoiceProvider $customerThreadStatusesChoiceProvider
     ) {
         parent::__construct($hookDispatcher);
         $this->contactTypeProvider = $contactTypeProvider;

--- a/src/Core/Grid/Definition/Factory/CustomerViewedProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerViewedProductGridDefinitionFactory.php
@@ -33,11 +33,12 @@ use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\LinkColumn;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class CustomerViewedProductGridDefinitionFactory defines customer's viewed products grid structure.
  */
-final class CustomerViewedProductGridDefinitionFactory extends AbstractGridDefinitionFactory
+class CustomerViewedProductGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
     use DeleteActionTrait;
 
@@ -54,9 +55,10 @@ final class CustomerViewedProductGridDefinitionFactory extends AbstractGridDefin
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         $contextDateFormat
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->contextDateFormat = $contextDateFormat;
     }
 

--- a/src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
-use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageByIdChoiceProvider;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
@@ -55,17 +55,17 @@ final class EmailLogsDefinitionFactory extends AbstractGridDefinitionFactory
     public const GRID_ID = 'email_logs';
 
     /**
-     * @var ConfigurableFormChoiceProviderInterface
+     * @var LanguageByIdChoiceProvider
      */
     private $languageChoiceProvider;
 
     /**
      * @param HookDispatcherInterface $hookDispatcher
-     * @param ConfigurableFormChoiceProviderInterface $languageChoiceProvider
+     * @param LanguageByIdChoiceProvider $languageChoiceProvider
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
-        ConfigurableFormChoiceProviderInterface $languageChoiceProvider
+        LanguageByIdChoiceProvider $languageChoiceProvider
     ) {
         parent::__construct($hookDispatcher);
         $this->languageChoiceProvider = $languageChoiceProvider;

--- a/src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php
@@ -43,6 +43,7 @@ use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class EmailLogsDefinitionFactory is responsible for creating email logs definition.
@@ -65,9 +66,10 @@ final class EmailLogsDefinitionFactory extends AbstractGridDefinitionFactory
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         LanguageByIdChoiceProvider $languageChoiceProvider
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->languageChoiceProvider = $languageChoiceProvider;
     }
 

--- a/src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php
@@ -42,6 +42,7 @@ use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\LogSeverityChoiceType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class LogGridDefinitionFactory is responsible for creating new instance of Log grid definition.
@@ -57,9 +58,10 @@ final class LogGridDefinitionFactory extends AbstractGridDefinitionFactory
 
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         string $contextDateFormat
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->contextDateFormat = $contextDateFormat;
     }
 

--- a/src/Core/Grid/Definition/Factory/OrderGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/OrderGridDefinitionFactory.php
@@ -28,12 +28,14 @@ namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderStateByIdChoiceProvider;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\ButtonBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\ModalFormSubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\AccessibilityCheckerInterface;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\PrintDeliverySlipAccessibilityChecker;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\PrintInvoiceAccessibilityChecker;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\LinkGridAction;
@@ -61,7 +63,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 /**
  * Creates definition for Orders grid
  */
-final class OrderGridDefinitionFactory extends AbstractFilterableGridDefinitionFactory
+class OrderGridDefinitionFactory extends AbstractFilterableGridDefinitionFactory
 {
     public const GRID_ID = 'order';
 
@@ -76,11 +78,6 @@ final class OrderGridDefinitionFactory extends AbstractFilterableGridDefinitionF
     private $orderCountriesChoiceProvider;
 
     /**
-     * @var FormChoiceProviderInterface
-     */
-    private $orderStatusesChoiceProvider;
-
-    /**
      * @var string
      */
     private $contextDateFormat;
@@ -89,18 +86,19 @@ final class OrderGridDefinitionFactory extends AbstractFilterableGridDefinitionF
      * @var FeatureInterface
      */
     private $multistoreFeature;
+
     /**
-     * @var FormChoiceProviderInterface
+     * @var OrderStateByIdChoiceProvider
      */
     private $orderStatesChoiceProvider;
 
     /**
-     * @var AccessibilityCheckerInterface
+     * @var PrintInvoiceAccessibilityChecker
      */
     private $printInvoiceAccessibilityChecker;
 
     /**
-     * @var AccessibilityCheckerInterface
+     * @var PrintDeliverySlipAccessibilityChecker
      */
     private $printDeliverySlipAccessibilityChecker;
 
@@ -108,29 +106,26 @@ final class OrderGridDefinitionFactory extends AbstractFilterableGridDefinitionF
      * @param HookDispatcherInterface $dispatcher
      * @param ConfigurationInterface $configuration
      * @param FormChoiceProviderInterface $orderCountriesChoiceProvider
-     * @param FormChoiceProviderInterface $orderStatusesChoiceProvider
      * @param string $contextDateFormat
      * @param FeatureInterface $multistoreFeature
-     * @param AccessibilityCheckerInterface $printInvoiceAccessibilityChecker
-     * @param AccessibilityCheckerInterface $printDeliverySlipAccessibilityChecker
-     * @param FormChoiceProviderInterface $orderStatesChoiceProvider
+     * @param PrintInvoiceAccessibilityChecker $printInvoiceAccessibilityChecker
+     * @param PrintDeliverySlipAccessibilityChecker $printDeliverySlipAccessibilityChecker
+     * @param OrderStateByIdChoiceProvider $orderStatesChoiceProvider
      */
     public function __construct(
         HookDispatcherInterface $dispatcher,
         ConfigurationInterface $configuration,
         FormChoiceProviderInterface $orderCountriesChoiceProvider,
-        FormChoiceProviderInterface $orderStatusesChoiceProvider,
         $contextDateFormat,
         FeatureInterface $multistoreFeature,
-        AccessibilityCheckerInterface $printInvoiceAccessibilityChecker,
-        AccessibilityCheckerInterface $printDeliverySlipAccessibilityChecker,
-        FormChoiceProviderInterface $orderStatesChoiceProvider
+        PrintInvoiceAccessibilityChecker $printInvoiceAccessibilityChecker,
+        PrintDeliverySlipAccessibilityChecker $printDeliverySlipAccessibilityChecker,
+        OrderStateByIdChoiceProvider $orderStatesChoiceProvider
     ) {
         parent::__construct($dispatcher);
 
         $this->configuration = $configuration;
         $this->orderCountriesChoiceProvider = $orderCountriesChoiceProvider;
-        $this->orderStatusesChoiceProvider = $orderStatusesChoiceProvider;
         $this->contextDateFormat = $contextDateFormat;
         $this->multistoreFeature = $multistoreFeature;
         $this->printInvoiceAccessibilityChecker = $printInvoiceAccessibilityChecker;
@@ -344,7 +339,7 @@ final class OrderGridDefinitionFactory extends AbstractFilterableGridDefinitionF
             ->add((new Filter('osname', ChoiceType::class))
             ->setTypeOptions([
                 'required' => false,
-                'choices' => $this->orderStatusesChoiceProvider->getChoices(),
+                'choices' => $this->orderStatesChoiceProvider->getChoices(),
                 'translation_domain' => false,
             ])
             ->setAssociatedColumn('osname')

--- a/src/Core/Grid/Definition/Factory/OrderGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/OrderGridDefinitionFactory.php
@@ -59,6 +59,7 @@ use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Creates definition for Orders grid
@@ -114,6 +115,7 @@ class OrderGridDefinitionFactory extends AbstractFilterableGridDefinitionFactory
      */
     public function __construct(
         HookDispatcherInterface $dispatcher,
+        TranslatorInterface $translator,
         ConfigurationInterface $configuration,
         FormChoiceProviderInterface $orderCountriesChoiceProvider,
         $contextDateFormat,
@@ -122,7 +124,7 @@ class OrderGridDefinitionFactory extends AbstractFilterableGridDefinitionFactory
         PrintDeliverySlipAccessibilityChecker $printDeliverySlipAccessibilityChecker,
         OrderStateByIdChoiceProvider $orderStatesChoiceProvider
     ) {
-        parent::__construct($dispatcher);
+        parent::__construct($dispatcher, $translator);
 
         $this->configuration = $configuration;
         $this->orderCountriesChoiceProvider = $orderCountriesChoiceProvider;

--- a/src/Core/Grid/Definition/Factory/OrderReturnStatesGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/OrderReturnStatesGridDefinitionFactory.php
@@ -30,7 +30,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\AccessibilityCheckerInterface;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteOrderReturnStatesAccessibilityChecker;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
@@ -58,13 +58,13 @@ final class OrderReturnStatesGridDefinitionFactory extends AbstractGridDefinitio
     public const GRID_ID = 'order_return_states';
 
     /**
-     * @var AccessibilityCheckerInterface
+     * @var DeleteOrderReturnStatesAccessibilityChecker
      */
     protected $deleteOrderReturnStatesAccessibilityChecker;
 
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
-        AccessibilityCheckerInterface $deleteOrderReturnStatesAccessibilityChecker
+        DeleteOrderReturnStatesAccessibilityChecker $deleteOrderReturnStatesAccessibilityChecker
     ) {
         parent::__construct($hookDispatcher);
 

--- a/src/Core/Grid/Definition/Factory/OrderReturnStatesGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/OrderReturnStatesGridDefinitionFactory.php
@@ -46,6 +46,7 @@ use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class OrderReturnStatesGridDefinitionFactory defines return_states grid structure.
@@ -64,9 +65,10 @@ final class OrderReturnStatesGridDefinitionFactory extends AbstractGridDefinitio
 
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         DeleteOrderReturnStatesAccessibilityChecker $deleteOrderReturnStatesAccessibilityChecker
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
 
         $this->deleteOrderReturnStatesAccessibilityChecker = $deleteOrderReturnStatesAccessibilityChecker;
     }

--- a/src/Core/Grid/Definition/Factory/OrderStatesGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/OrderStatesGridDefinitionFactory.php
@@ -48,6 +48,7 @@ use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class OrderStatesGridDefinitionFactory defines order_states grid structure.
@@ -66,9 +67,10 @@ final class OrderStatesGridDefinitionFactory extends AbstractGridDefinitionFacto
 
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         DeleteOrderStatesAccessibilityChecker $deleteOrderStatesAccessibilityChecker
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
 
         $this->deleteOrderStatesAccessibilityChecker = $deleteOrderStatesAccessibilityChecker;
     }

--- a/src/Core/Grid/Definition/Factory/OrderStatesGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/OrderStatesGridDefinitionFactory.php
@@ -30,7 +30,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\AccessibilityCheckerInterface;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteOrderStatesAccessibilityChecker;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
@@ -60,13 +60,13 @@ final class OrderStatesGridDefinitionFactory extends AbstractGridDefinitionFacto
     public const GRID_ID = 'order_states';
 
     /**
-     * @var AccessibilityCheckerInterface
+     * @var DeleteOrderStatesAccessibilityChecker
      */
     protected $deleteOrderStatesAccessibilityChecker;
 
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
-        AccessibilityCheckerInterface $deleteOrderStatesAccessibilityChecker
+        DeleteOrderStatesAccessibilityChecker $deleteOrderStatesAccessibilityChecker
     ) {
         parent::__construct($hookDispatcher);
 

--- a/src/Core/Grid/Definition/Factory/OutstandingGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/OutstandingGridDefinitionFactory.php
@@ -44,6 +44,7 @@ use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Risk;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Created definition for Outstanding grid.
@@ -75,11 +76,12 @@ final class OutstandingGridDefinitionFactory extends AbstractGridDefinitionFacto
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         ConfigurationInterface $configuration,
         int $languageId,
         string $contextDateFormat
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
 
         $this->configuration = $configuration;
         $this->contextDateFormat = $contextDateFormat;

--- a/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
@@ -34,7 +34,8 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\AjaxBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\ModalOptions;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\AccessibilityCheckerInterface;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\ProductMultipleShopsAssociatedAccessibilityChecker;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\ProductSingleShopAssociatedAccessibilityChecker;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
@@ -92,12 +93,12 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
     private $formFactory;
 
     /**
-     * @var AccessibilityCheckerInterface
+     * @var ProductSingleShopAssociatedAccessibilityChecker
      */
     private $singleShopChecker;
 
     /**
-     * @var AccessibilityCheckerInterface
+     * @var ProductMultipleShopsAssociatedAccessibilityChecker
      */
     private $multipleShopsChecker;
 
@@ -107,8 +108,8 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
         FeatureInterface $multistoreFeature,
         ShopConstraintContextInterface $shopConstraintContext,
         FormFactoryInterface $formFactory,
-        AccessibilityCheckerInterface $singleShopChecker,
-        AccessibilityCheckerInterface $multipleShopsChecker
+        ProductSingleShopAssociatedAccessibilityChecker $singleShopChecker,
+        ProductMultipleShopsAssociatedAccessibilityChecker $multipleShopsChecker
     ) {
         parent::__construct($hookDispatcher);
         $this->configuration = $configuration;

--- a/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
@@ -62,6 +62,7 @@ use PrestaShopBundle\Form\Admin\Type\ShopSelectorType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Defines products grid name, its columns, actions, bulk actions and filters.
@@ -104,6 +105,7 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
 
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         ConfigurationInterface $configuration,
         FeatureInterface $multistoreFeature,
         ShopConstraintContextInterface $shopConstraintContext,
@@ -111,7 +113,7 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
         ProductSingleShopAssociatedAccessibilityChecker $singleShopChecker,
         ProductMultipleShopsAssociatedAccessibilityChecker $multipleShopsChecker
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->configuration = $configuration;
         $this->multistoreFeature = $multistoreFeature;
         $this->shopConstraintContext = $shopConstraintContext;

--- a/src/Core/Grid/Definition/Factory/ProductLightGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProductLightGridDefinitionFactory.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Grid\Action\ViewOptionsCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\LinkColumn;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ProductLightGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
@@ -51,9 +52,10 @@ class ProductLightGridDefinitionFactory extends AbstractGridDefinitionFactory
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         ConfigurationInterface $configuration
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->configuration = $configuration;
     }
 

--- a/src/Core/Grid/Definition/Factory/Security/Session/CustomerGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/Security/Session/CustomerGridDefinitionFactory.php
@@ -50,6 +50,7 @@ use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class CustomerGridDefinitionFactory responsible for creating Customer sessions grid definition.
@@ -66,9 +67,10 @@ final class CustomerGridDefinitionFactory extends AbstractGridDefinitionFactory
 
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         string $contextDateFormat
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->contextDateFormat = $contextDateFormat;
     }
 

--- a/src/Core/Grid/Definition/Factory/Security/Session/EmployeeGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/Security/Session/EmployeeGridDefinitionFactory.php
@@ -50,6 +50,7 @@ use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class EmployeeGridDefinitionFactory responsible for creating Employee grid definition.
@@ -66,9 +67,10 @@ final class EmployeeGridDefinitionFactory extends AbstractGridDefinitionFactory
 
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         string $contextDateFormat
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->contextDateFormat = $contextDateFormat;
     }
 

--- a/src/Core/Grid/Definition/Factory/StateGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/StateGridDefinitionFactory.php
@@ -56,7 +56,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * State grid definition
  */
-final class StateGridDefinitionFactory extends AbstractGridDefinitionFactory
+class StateGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
     use BulkDeleteActionTrait;
     use DeleteActionTrait;

--- a/src/Core/Grid/Definition/Factory/TitleGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/TitleGridDefinitionFactory.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
-use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GenderChoiceProvider;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
@@ -59,12 +59,14 @@ class TitleGridDefinitionFactory extends AbstractGridDefinitionFactory
     public const GRID_ID = 'title';
 
     /**
-     * @var FormChoiceProviderInterface
+     * @var GenderChoiceProvider
      */
     private $genderChoiceProvider;
 
-    public function __construct(HookDispatcherInterface $hookDispatcher, FormChoiceProviderInterface $genderChoiceProvider)
-    {
+    public function __construct(
+        HookDispatcherInterface $hookDispatcher,
+        GenderChoiceProvider $genderChoiceProvider
+    ) {
         parent::__construct($hookDispatcher);
         $this->genderChoiceProvider = $genderChoiceProvider;
     }

--- a/src/Core/Grid/Definition/Factory/TitleGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/TitleGridDefinitionFactory.php
@@ -47,6 +47,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class TitleGridDefinitionFactory creates definition for title grid.
@@ -65,9 +66,10 @@ class TitleGridDefinitionFactory extends AbstractGridDefinitionFactory
 
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
+        TranslatorInterface $translator,
         GenderChoiceProvider $genderChoiceProvider
     ) {
-        parent::__construct($hookDispatcher);
+        parent::__construct($hookDispatcher, $translator);
         $this->genderChoiceProvider = $genderChoiceProvider;
     }
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -134,8 +134,9 @@ services:
       - '@prestashop.adapter.multistore_feature'
       - '@prestashop.core.form.choice_provider.invoice_model_by_name'
 
-  prestashop.adapter.data_provider.language:
-    class: 'PrestaShop\PrestaShop\Adapter\Language\LanguageDataProvider'
+  PrestaShop\PrestaShop\Adapter\Language\LanguageDataProvider:
+    autowire: true
+    public: false
 
   prestashop.adapter.language.activator:
     class: 'PrestaShop\PrestaShop\Adapter\Language\LanguageActivator'
@@ -293,3 +294,8 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+
+  # deprecated services
+  prestashop.adapter.data_provider.language:
+    alias: PrestaShop\PrestaShop\Adapter\Language\LanguageDataProvider
+    deprecated: ~

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -2,10 +2,9 @@ services:
   _defaults:
     public: true
 
-  prestashop.core.form.choice_provider.language_by_id:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageByIdChoiceProvider'
-    arguments:
-      - '@prestashop.adapter.data_provider.language'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageByIdChoiceProvider:
+    autowire: true
+    public: false
 
   prestashop.core.form.choice_provider.all_languages:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageChoiceProvider'
@@ -56,13 +55,12 @@ services:
       - '@prestashop.adapter.data_provider.carrier'
       - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
 
-  prestashop.core.form.choice_provider.order_state_by_id:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderStateByIdChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderStateByIdChoiceProvider:
+    autowire: true
+    public: false
     arguments:
-      - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
-      - '@prestashop.adapter.data_provider.order_state'
-      - '@PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator'
-      - '@translator'
+      $languageId: '@=service("prestashop.adapter.legacy.context").getLanguage().id'
+      $orderStateDataProvider: '@prestashop.adapter.data_provider.order_state'
 
   prestashop.core.form.choice_provider.invoice_model_by_name:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\InvoiceModelByNameChoiceProvider'
@@ -296,20 +294,18 @@ services:
     arguments:
       - '@translator'
 
-  prestashop.core.form.choice_provider.gender_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GenderChoiceProvider'
-    arguments:
-      - '@translator'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GenderChoiceProvider:
+    autowire: true
+    public: false
 
-  prestashop.core.form.choice_provider.contact_type_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider:
+    autowire: true
     arguments:
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
+      $langId: '@=service("prestashop.adapter.legacy.context").getContext().language.id'
 
-  prestashop.core.form.choice_provider.customer_thread_statuses_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerThreadStatusesChoiceProvider'
-    arguments:
-      - '@translator'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerThreadStatusesChoiceProvider:
+    autowire: true
+    public: false
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ReductionTypeChoiceProvider:
     autowire: true
@@ -341,4 +337,24 @@ services:
   prestashop.core.form.choice_provider.tax_inclusion:
     alias: PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TaxInclusionChoiceProvider
     public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.language_by_id:
+    alias: PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageByIdChoiceProvider
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.order_state_by_id:
+    alias: PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderStateByIdChoiceProvider
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.gender_choice_provider:
+    alias: PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GenderChoiceProvider
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.contact_type_choice_provider:
+    alias: PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.customer_thread_statuses_choice_provider:
+    alias: PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerThreadStatusesChoiceProvider
     deprecated: ~

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/accessibility_checker.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/accessibility_checker.yml
@@ -1,28 +1,35 @@
 services:
   _defaults:
-    public: true
+    autowire: true
+    public: false
 
   prestashop.core.grid.action.row.accessibility_checker.delete_profile:
+    autowire: false
+    public: true
     class: 'PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteProfileAccessibilityChecker'
     arguments:
       - '@=service("prestashop.adapter.legacy.configuration").get("_PS_ADMIN_PROFILE_")'
 
+  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\PrintInvoiceAccessibilityChecker: ~
+  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\PrintDeliverySlipAccessibilityChecker: ~
+  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteOrderReturnStatesAccessibilityChecker: ~
+  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteOrderStatesAccessibilityChecker: ~
+  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\ProductSingleShopAssociatedAccessibilityChecker: ~
+  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\ProductMultipleShopsAssociatedAccessibilityChecker: ~
+
+  # deprecated services
   prestashop.core.grid.action.row.accessibility_checker.print_invoice:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\PrintInvoiceAccessibilityChecker'
+    alias: PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\PrintInvoiceAccessibilityChecker
+    deprecated: ~
 
   prestashop.core.grid.action.row.accessibility_checker.print_delivery_slip:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\PrintDeliverySlipAccessibilityChecker'
-
-  prestashop.core.grid.action.row.accessibility_checker.delete_order_return_states:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteOrderReturnStatesAccessibilityChecker'
+    alias: PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\PrintDeliverySlipAccessibilityChecker
+    deprecated: ~
 
   prestashop.core.grid.action.row.accessibility_checker.delete_order_states:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteOrderStatesAccessibilityChecker'
+    alias: PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteOrderStatesAccessibilityChecker
+    deprecated: ~
 
-  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\ProductSingleShopAssociatedAccessibilityChecker:
-    autowire: true
-    public: false
-
-  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\ProductMultipleShopsAssociatedAccessibilityChecker:
-    autowire: true
-    public: false
+  prestashop.core.grid.action.row.accessibility_checker.delete_order_return_states:
+    alias: PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteOrderReturnStatesAccessibilityChecker
+    deprecated: ~

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/accessibility_checker.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/accessibility_checker.yml
@@ -20,16 +20,20 @@ services:
   # deprecated services
   prestashop.core.grid.action.row.accessibility_checker.print_invoice:
     alias: PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\PrintInvoiceAccessibilityChecker
+    public: true
     deprecated: ~
 
   prestashop.core.grid.action.row.accessibility_checker.print_delivery_slip:
     alias: PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\PrintDeliverySlipAccessibilityChecker
+    public: true
     deprecated: ~
 
   prestashop.core.grid.action.row.accessibility_checker.delete_order_states:
     alias: PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteOrderStatesAccessibilityChecker
+    public: true
     deprecated: ~
 
   prestashop.core.grid.action.row.accessibility_checker.delete_order_return_states:
     alias: PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteOrderReturnStatesAccessibilityChecker
+    public: true
     deprecated: ~

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/accessibility_checker.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/accessibility_checker.yml
@@ -3,19 +3,13 @@ services:
     autowire: true
     public: false
 
-  prestashop.core.grid.action.row.accessibility_checker.delete_profile:
-    autowire: false
-    public: true
-    class: 'PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteProfileAccessibilityChecker'
-    arguments:
-      - '@=service("prestashop.adapter.legacy.configuration").get("_PS_ADMIN_PROFILE_")'
+  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\:
+    resource: "%kernel.root_dir%/../src/Core/Grid/Action/Row/AccessibilityChecker/*"
 
-  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\PrintInvoiceAccessibilityChecker: ~
-  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\PrintDeliverySlipAccessibilityChecker: ~
-  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteOrderReturnStatesAccessibilityChecker: ~
-  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteOrderStatesAccessibilityChecker: ~
-  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\ProductSingleShopAssociatedAccessibilityChecker: ~
-  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\ProductMultipleShopsAssociatedAccessibilityChecker: ~
+  # @todo: couldn't find usages of this service. Probably ProfileGridDefinition is missing it in delete actions.
+  PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteProfileAccessibilityChecker:
+    arguments:
+      $superAdminProfileId: '@=service("prestashop.adapter.legacy.configuration").get("_PS_ADMIN_PROFILE_")'
 
   # deprecated services
   prestashop.core.grid.action.row.accessibility_checker.print_invoice:
@@ -37,3 +31,7 @@ services:
     alias: PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteOrderReturnStatesAccessibilityChecker
     public: true
     deprecated: ~
+
+  prestashop.core.grid.action.row.accessibility_checker.delete_profile:
+    alias: PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteProfileAccessibilityChecker
+    public: true

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -1,5 +1,6 @@
 services:
   _defaults:
+    # most of grid definition factories must remain public to be accessed by CommonController:searchGridAction
     public: true
     autowire: true
     bind:
@@ -7,56 +8,6 @@ services:
 
   PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory:
     abstract: true
-    calls:
-      - [ setTranslator, [ '@translator' ] ]
-
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LogGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\EmailLogsDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\RequestSqlGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\BackupDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\WebserviceKeyDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\MetaGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\EmployeeGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ContactGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerDiscountGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerCartGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerOrderGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerBoughtProductGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerViewedProductGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LanguageGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CurrencyGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\SupplierGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProfileGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerAddressGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\EmptyCategoryGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\NoQtyProductWithCombinationGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\NoQtyProductWithoutCombinationGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\DisabledProductGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutImageGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutDescriptionGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutPriceGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CartRuleGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CatalogPriceRuleGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderMessageGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttachmentGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttributeGroupGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\MerchandiseReturnGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxRulesGroupGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AddressGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderStatesGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerGroupsGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderReturnStatesGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CarrierGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ZoneGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CountryGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\SearchEngineGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductLightGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Security\Session\EmployeeGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Security\Session\CustomerGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\StateGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TitleGridDefinitionFactory: ~
 
   PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductShopsGridDefinitionFactory:
     arguments:
@@ -112,15 +63,58 @@ services:
     arguments:
       $shopNameByIdChoiceProvider: '@prestashop.adapter.form.choice_provider.shop_name_by_id'
 
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LogGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\EmailLogsDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\RequestSqlGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\BackupDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\WebserviceKeyDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\MetaGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\EmployeeGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ContactGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerDiscountGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerCartGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerOrderGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerBoughtProductGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerViewedProductGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LanguageGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CurrencyGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\SupplierGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProfileGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerAddressGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\EmptyCategoryGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\NoQtyProductWithCombinationGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\NoQtyProductWithoutCombinationGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\DisabledProductGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutImageGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutDescriptionGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutPriceGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CartRuleGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CatalogPriceRuleGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderMessageGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttachmentGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttributeGroupGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\MerchandiseReturnGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxRulesGroupGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AddressGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderStatesGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerGroupsGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderReturnStatesGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CarrierGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ZoneGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CountryGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\SearchEngineGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductLightGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Security\Session\EmployeeGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Security\Session\CustomerGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\StateGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TitleGridDefinitionFactory: ~
   PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AuthorizedApplicationGridDefinitionFactory: ~
   PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxRuleGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AliasGridDefinitionFactory:
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\FeatureGridDefinitionFactory:
-    # must remain public to be accessed by CommonController:searchGridAction
-    public: true
-
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\StoreGridDefinitionFactory:
-    public: true
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AliasGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\FeatureGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\StoreGridDefinitionFactory: ~
 
   # deprecated services
   prestashop.core.grid.definition.factory.abstract_grid_definition:
@@ -270,7 +264,6 @@ services:
   prestashop.core.grid.definition.factory.order_message:
     alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderMessageGridDefinitionFactory
     deprecated: ~
-    public: true
 
   prestashop.core.grid.definition.factory.attachment:
     alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttachmentGridDefinitionFactory

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -6,6 +6,9 @@ services:
     bind:
       $contextDateFormat: '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
 
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\:
+    resource: "%kernel.root_dir%/../src/Core/Grid/Definition/Factory/*"
+
   PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory:
     abstract: true
 
@@ -62,59 +65,6 @@ services:
   PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerThreadGridDefinitionFactory:
     arguments:
       $shopNameByIdChoiceProvider: '@prestashop.adapter.form.choice_provider.shop_name_by_id'
-
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LogGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\EmailLogsDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\RequestSqlGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\BackupDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\WebserviceKeyDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\MetaGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\EmployeeGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ContactGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerDiscountGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerCartGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerOrderGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerBoughtProductGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerViewedProductGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LanguageGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CurrencyGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\SupplierGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProfileGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerAddressGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\EmptyCategoryGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\NoQtyProductWithCombinationGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\NoQtyProductWithoutCombinationGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\DisabledProductGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutImageGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutDescriptionGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutPriceGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CartRuleGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CatalogPriceRuleGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderMessageGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttachmentGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttributeGroupGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\MerchandiseReturnGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxRulesGroupGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AddressGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderStatesGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerGroupsGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderReturnStatesGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CarrierGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ZoneGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CountryGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\SearchEngineGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductLightGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Security\Session\EmployeeGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Security\Session\CustomerGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\StateGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TitleGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AuthorizedApplicationGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxRuleGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AliasGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\FeatureGridDefinitionFactory: ~
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\StoreGridDefinitionFactory: ~
 
   # deprecated services
   prestashop.core.grid.definition.factory.abstract_grid_definition:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -1,416 +1,365 @@
 services:
   _defaults:
     public: true
+    autowire: true
+    bind:
+      $contextDateFormat: '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
 
-  prestashop.core.grid.definition.factory.abstract_grid_definition:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory'
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory:
     abstract: true
-    arguments:
-      - '@prestashop.core.hook.dispatcher'
     calls:
       - [ setTranslator, [ '@translator' ] ]
 
-  prestashop.core.grid.definition.factory.logs:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LogGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LogGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\EmailLogsDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\RequestSqlGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\BackupDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\WebserviceKeyDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\MetaGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\EmployeeGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ContactGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerDiscountGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerCartGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerOrderGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerBoughtProductGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerViewedProductGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LanguageGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CurrencyGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\SupplierGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProfileGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerAddressGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\EmptyCategoryGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\NoQtyProductWithCombinationGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\NoQtyProductWithoutCombinationGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\DisabledProductGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutImageGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutDescriptionGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutPriceGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CartRuleGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CatalogPriceRuleGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderMessageGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttachmentGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttributeGroupGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\MerchandiseReturnGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxRulesGroupGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AddressGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderStatesGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerGroupsGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderReturnStatesGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CarrierGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ZoneGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CountryGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\SearchEngineGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductLightGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Security\Session\EmployeeGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Security\Session\CustomerGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\StateGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TitleGridDefinitionFactory: ~
+
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductShopsGridDefinitionFactory:
     arguments:
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
+      $multistoreFeature: '@PrestaShop\PrestaShop\Adapter\Feature\MultistoreFeature'
 
-  prestashop.core.grid.definition.factory.email_logs:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\EmailLogsDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CategoryGridDefinitionFactory:
     arguments:
-      - '@prestashop.core.form.choice_provider.language_by_id'
+      $categoryForViewAccessibilityChecker: '@prestashop.adapter.grid.action.row.accessibility_checker.category_for_view'
 
-  prestashop.core.grid.definition.factory.request_sql:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\RequestSqlGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.backup:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\BackupDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.webservice_key:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\WebserviceKeyDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.meta:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\MetaGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.category:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CategoryGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerGridDefinitionFactory:
     arguments:
-      - '@prestashop.adapter.shop.context'
-      - '@prestashop.adapter.grid.action.row.accessibility_checker.category_for_view'
-    public: true
+      $isB2bFeatureEnabled: '@=service("prestashop.core.b2b.b2b_feature").isActive()'
+      $isMultistoreFeatureEnabled: '@=service("prestashop.adapter.multistore_feature").isActive()'
+      $isGroupsFeatureEnabled: '@=service("prestashop.adapter.feature.group_feature").isActive()'
 
-  prestashop.core.grid.definition.factory.employee:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\EmployeeGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.contacts:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ContactGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.customer:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerAddressGridDefinitionFactory:
     arguments:
-      - '@=service("prestashop.core.b2b.b2b_feature").isActive()'
-      - '@=service("prestashop.adapter.multistore_feature").isActive()'
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
-      - '@=service("prestashop.adapter.feature.group_feature").isActive()'
-    public: true
+      $currentRequest: '@=service("request_stack").getCurrentRequest()'
 
-  prestashop.core.grid.definition.factory.customer.discount:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerDiscountGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.customer.address:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerAddressGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CmsPageCategoryDefinitionFactory:
     arguments:
-      - '@=service("request_stack").getCurrentRequest()'
-    public: true
+      $requestStack: '@request_stack'
+      $isMultiStoreFeatureUsed: '@=service("prestashop.adapter.multistore_feature").isUsed()'
 
-  prestashop.core.grid.definition.factory.customer.cart:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerCartGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CmsPageDefinitionFactory:
     arguments:
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
-    public: true
+      $requestStack: '@request_stack'
+      $isMultiStoreFeatureUsed: '@=service("prestashop.adapter.multistore_feature").isUsed()'
 
-  prestashop.core.grid.definition.factory.customer.order:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerOrderGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderGridDefinitionFactory:
     arguments:
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
-    public: true
+      $orderCountriesChoiceProvider: '@prestashop.adapter.form.choice_provider.order_countries'
+      $multistoreFeature: '@prestashop.adapter.feature.multistore'
 
-  prestashop.core.grid.definition.factory.customer.bought_product:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerBoughtProductGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttributeGridDefinitionFactory:
     arguments:
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
-    public: true
+      $attributeGroupId: '@=service("request_stack").getCurrentRequest().attributes.getInt("attributeGroupId")'
+      $attributeGroupViewDataProvider: '@PrestaShop\PrestaShop\Adapter\AttributeGroup\AttributeGroupViewDataProvider'
 
-  prestashop.core.grid.definition.factory.customer.viewed_product:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerViewedProductGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CreditSlipGridDefinitionFactory:
     arguments:
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
-    public: true
+      $dateFormat: '@=service("prestashop.adapter.legacy.context").getLanguage().date_format_lite'
 
-  prestashop.core.grid.definition.factory.language:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LanguageGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.currency:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CurrencyGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.supplier:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\SupplierGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.profile:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProfileGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.cms_page_category:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CmsPageCategoryDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OutstandingGridDefinitionFactory:
     arguments:
-      - '@request_stack'
-      - '@prestashop.adapter.shop.context'
-      - '@=service("prestashop.adapter.multistore_feature").isUsed()'
-    public: true
+      $languageId: "@=service('prestashop.adapter.legacy.context').getContext().language.id"
 
-  prestashop.core.grid.definition.factory.tax:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.manufacturer:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.manufacturer_address:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerAddressGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.cms_page:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CmsPageDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductGridDefinitionFactory:
     arguments:
-      - '@prestashop.core.query_bus'
-      - '@request_stack'
-      - '@prestashop.adapter.shop.context'
-      - '@=service("prestashop.adapter.multistore_feature").isUsed()'
-    public: true
+      $multistoreFeature: '@PrestaShop\PrestaShop\Adapter\Feature\MultistoreFeature'
 
-  prestashop.core.grid.definition.factory.monitoring.empty_category:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\EmptyCategoryGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerThreadGridDefinitionFactory:
     arguments:
-      - '@prestashop.adapter.grid.action.row.accessibility_checker.category_for_view'
-    public: true
+      $shopNameByIdChoiceProvider: '@prestashop.adapter.form.choice_provider.shop_name_by_id'
 
-  prestashop.core.grid.definition.factory.monitoring.no_qty_product_with_combination:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\NoQtyProductWithCombinationGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.monitoring.no_qty_product_without_combination:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\NoQtyProductWithoutCombinationGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.monitoring.disabled_product:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\DisabledProductGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.monitoring.product_without_image:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutImageGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.monitoring.product_without_description:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutDescriptionGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.monitoring.product_without_price:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutPriceGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.order:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    arguments:
-      - '@prestashop.adapter.legacy.configuration'
-      - '@prestashop.adapter.form.choice_provider.order_countries'
-      - '@prestashop.core.form.choice_provider.order_state_by_id'
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
-      - '@prestashop.adapter.feature.multistore'
-      - '@prestashop.core.grid.action.row.accessibility_checker.print_invoice'
-      - '@prestashop.core.grid.action.row.accessibility_checker.print_delivery_slip'
-      - '@prestashop.core.form.choice_provider.order_state_by_id'
-    public: true
-
-  prestashop.core.grid.definition.factory.cart_rule:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CartRuleGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-    arguments:
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
-
-  prestashop.core.grid.definition.factory.catalog_price_rule:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CatalogPriceRuleGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    arguments:
-      - '@request_stack'
-      - '@prestashop.adapter.shop.context'
-      - '@=service("prestashop.adapter.multistore_feature").isUsed()'
-    public: true
-
-  prestashop.core.grid.definition.factory.order_message:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderMessageGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.attachment:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttachmentGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.attribute:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttributeGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    arguments:
-      - '@=service("request_stack").getCurrentRequest().attributes.getInt("attributeGroupId")'
-      - '@PrestaShop\PrestaShop\Adapter\AttributeGroup\AttributeGroupViewDataProvider'
-    public: true
-
-  prestashop.core.grid.definition.factory.attribute_group:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttributeGroupGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.merchandise_return:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\MerchandiseReturnGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.tax_rules_group:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxRulesGroupGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.address:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AddressGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.credit_slip:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CreditSlipGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    arguments:
-      - '@=service("prestashop.adapter.legacy.context").getLanguage().date_format_lite'
-    public: true
-
-  prestashop.core.grid.definition.factory.order_states:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderStatesGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    arguments:
-      - '@prestashop.core.grid.action.row.accessibility_checker.delete_order_states'
-    public: true
-
-  prestashop.core.grid.definition.factory.order_return_states:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderReturnStatesGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    arguments:
-      - '@prestashop.core.grid.action.row.accessibility_checker.delete_order_return_states'
-    public: true
-
-  prestashop.core.grid.definition.factory.outstanding:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OutstandingGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    arguments:
-      - '@prestashop.adapter.legacy.configuration'
-      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
-    public: true
-
-  prestashop.core.grid.definition.factory.carrier:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CarrierGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.zone:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ZoneGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.country:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CountryGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.search_engines:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\SearchEngineGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  prestashop.core.grid.definition.factory.product:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    arguments:
-      - '@prestashop.adapter.legacy.configuration'
-      - '@PrestaShop\PrestaShop\Adapter\Feature\MultistoreFeature'
-      - '@prestashop.adapter.shop.context'
-      - '@form.factory'
-      - '@PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\ProductSingleShopAssociatedAccessibilityChecker'
-      - '@PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\ProductMultipleShopsAssociatedAccessibilityChecker'
-    public: true
-
-  prestashop.core.grid.definition.factory.product.shops:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductShopsGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.product'
-    public: true
-
-  prestashop.core.grid.definition.factory.product_light:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductLightGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    arguments:
-      - '@prestashop.adapter.legacy.configuration'
-    public: true
-
-  prestashop.core.grid.definition.factory.security.session.employee:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Security\Session\EmployeeGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    arguments:
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
-    public: true
-
-  prestashop.core.grid.definition.factory.security.session.customer:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Security\Session\CustomerGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    arguments:
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
-    public: true
-
-  prestashop.core.grid.definition.factory.state:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\StateGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    arguments:
-      - "@=service('router').generate('admin_common_reset_search', {'controller': 'state', 'action': 'index'})"
-      - "@=service('router').generate('admin_states_index')"
-    public: true
-
-  prestashop.core.grid.definition.factory.title:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TitleGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    arguments:
-      - '@prestashop.core.form.choice_provider.gender_choice_provider'
-    public: true
-
-  prestashop.core.grid.definition.factory.customer_thread:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerThreadGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    arguments:
-      - '@prestashop.core.form.choice_provider.contact_type_choice_provider'
-      - '@prestashop.adapter.form.choice_provider.shop_name_by_id'
-      - '@prestashop.core.form.choice_provider.customer_thread_statuses_choice_provider'
-    public: true
-
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AuthorizedApplicationGridDefinitionFactory:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AuthorizedApplicationGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: false
-    autowire: true
-
-  prestashop.core.grid.definition.factory.customer_groups:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerGroupsGridDefinitionFactory'
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: true
-
-  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxRuleGridDefinitionFactory:
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: false
-    autowire: true
-
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AuthorizedApplicationGridDefinitionFactory: ~
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxRuleGridDefinitionFactory: ~
   PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AliasGridDefinitionFactory:
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    public: false
-    autowire: true
-
   PrestaShop\PrestaShop\Core\Grid\Definition\Factory\FeatureGridDefinitionFactory:
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
-    autowire: true
     # must remain public to be accessed by CommonController:searchGridAction
     public: true
 
   PrestaShop\PrestaShop\Core\Grid\Definition\Factory\StoreGridDefinitionFactory:
-    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
     public: true
-    autowire: true
+
+  # deprecated services
+  prestashop.core.grid.definition.factory.abstract_grid_definition:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.logs:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LogGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.email_logs:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\EmailLogsDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.request_sql:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\RequestSqlGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.backup:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\BackupDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.webservice_key:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\WebserviceKeyDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.meta:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\MetaGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.category:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CategoryGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.employee:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\EmployeeGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.contacts:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ContactGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.customer:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.customer.discount:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerDiscountGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.customer.address:
+    class: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerAddressGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.customer.cart:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerCartGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.customer.order:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerOrderGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.customer.bought_product:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerBoughtProductGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.customer.viewed_product:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerViewedProductGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.language:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LanguageGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.currency:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CurrencyGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.supplier:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\SupplierGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.profile:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProfileGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.cms_page_category:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CmsPageCategoryDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.tax:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.manufacturer:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.manufacturer_address:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ManufacturerAddressGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.cms_page:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CmsPageDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.monitoring.empty_category:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\EmptyCategoryGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.monitoring.no_qty_product_with_combination:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\NoQtyProductWithCombinationGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.monitoring.no_qty_product_without_combination:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\NoQtyProductWithoutCombinationGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.monitoring.disabled_product:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\DisabledProductGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.monitoring.product_without_image:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutImageGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.monitoring.product_without_description:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutDescriptionGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.monitoring.product_without_price:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring\ProductWithoutPriceGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.order:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.cart_rule:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CartRuleGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.catalog_price_rule:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CatalogPriceRuleGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.order_message:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderMessageGridDefinitionFactory
+    deprecated: ~
+    public: true
+
+  prestashop.core.grid.definition.factory.attachment:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttachmentGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.attribute:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttributeGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.attribute_group:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AttributeGroupGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.merchandise_return:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\MerchandiseReturnGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.tax_rules_group:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TaxRulesGroupGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.address:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AddressGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.credit_slip:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CreditSlipGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.order_states:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderStatesGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.customer_groups:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerGroupsGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.order_return_states:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderReturnStatesGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.outstanding:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OutstandingGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.carrier:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CarrierGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.zone:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ZoneGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.country:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CountryGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.search_engines:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\SearchEngineGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.product:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.product.shops:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductShopsGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.product_light:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductLightGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.security.session.employee:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Security\Session\EmployeeGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.security.session.customer:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Security\Session\CustomerGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.state:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\StateGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.title:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\TitleGridDefinitionFactory
+    deprecated: ~
+
+  prestashop.core.grid.definition.factory.customer_thread:
+    alias: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerThreadGridDefinitionFactory
+    deprecated: ~

--- a/tests/Unit/Core/Grid/Definition/Factory/AbstractGridDefinitionFactoryTest.php
+++ b/tests/Unit/Core/Grid/Definition/Factory/AbstractGridDefinitionFactoryTest.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\ColumnInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinitionInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class AbstractGridDefinitionFactoryTest extends TestCase
 {
@@ -51,7 +52,10 @@ class AbstractGridDefinitionFactoryTest extends TestCase
             )
         ;
 
-        $definitionFactory = $this->getMockForAbstractClass(AbstractGridDefinitionFactory::class, [$hookDispatcherMock]);
+        $definitionFactory = $this->getMockForAbstractClass(
+            AbstractGridDefinitionFactory::class,
+            [$hookDispatcherMock, $this->mockTranslator()]
+        );
 
         $definitionFactory
             ->expects($this->once())
@@ -95,5 +99,16 @@ class AbstractGridDefinitionFactoryTest extends TestCase
             ->willReturn($id);
 
         return $column;
+    }
+
+    private function mockTranslator(): TranslatorInterface
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator
+            ->method('trans')
+            ->willReturnArgument(0)
+        ;
+
+        return $translator;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Autowires all BO migrated grids and replaced their service ids by FQCN and related services.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | All the migrated grids in BO needs to be checked (only open the grid page and if it is not resulting in fatal error that means it is ok)
| Fixed ticket?     | ADR https://github.com/PrestaShop/ADR/blob/master/0003-use-of-autowiring.md (not sure if there is a dedicated issue for this)
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).

**Deprecations**
all the current BO lists that was defined in grid_definition_factory,yml are now autowired and their service ids are replaced to FQCN -  :warning: **so all the previous service ids are deprecated** :warning: . As well as following services (now you should use the related FQCN instead):
- prestashop.adapter.data_provider.language
- prestashop.core.grid.action.row.accessibility_checker.print_invoice
- prestashop.core.grid.action.row.accessibility_checker.print_delivery_slip
- prestashop.core.grid.action.row.accessibility_checker.delete_order_return_states
- prestashop.core.grid.action.row.accessibility_checker.delete_order_states
- prestashop.core.grid.action.row.accessibility_checker.delete_order_return_states