### PR TITLE
Fix css for search dropdown in combination generator

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/combination/generator/CombinationGenerator.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/combination/generator/CombinationGenerator.vue
@@ -28,6 +28,7 @@
       v-if="isModalShown"
       :modal-title="$t('modal.title')"
       :confirmation="true"
+      :close-on-click-outside="false"
       @close="closeModal"
     >
       <template #body>

--- a/admin-dev/themes/new-theme/js/vue/components/Modal.vue
+++ b/admin-dev/themes/new-theme/js/vue/components/Modal.vue
@@ -34,7 +34,7 @@
             class="modal-content"
             aria-labelledby="modalTitle"
             aria-describedby="modalDescription"
-            v-click-outside="close"
+            v-click-outside="clickOutsideClose"
           >
             <header
               class="modal-header"
@@ -118,6 +118,11 @@
       ClickOutside,
     },
     props: {
+      closeOnClickOutside: {
+        type: Boolean,
+        required: false,
+        default: true,
+      },
       confirmation: {
         type: Boolean,
         required: false,
@@ -153,6 +158,11 @@
       },
     },
     methods: {
+      clickOutsideClose(): void {
+        if (this.closeOnClickOutside) {
+          this.$emit('close');
+        }
+      },
       close(): void {
         this.$emit('close');
       },

--- a/admin-dev/themes/new-theme/scss/components/_entity_search.scss
+++ b/admin-dev/themes/new-theme/scss/components/_entity_search.scss
@@ -3,7 +3,7 @@ ul.entities-list {
 }
 
 .entity-search-widget {
-  @import '_twitter_typeahead.scss';
+  @import "twitter_typeahead";
 
   .entities-list {
     max-width: 100%;

--- a/admin-dev/themes/new-theme/scss/components/_entity_search.scss
+++ b/admin-dev/themes/new-theme/scss/components/_entity_search.scss
@@ -3,28 +3,7 @@ ul.entities-list {
 }
 
 .entity-search-widget {
-  .twitter-typeahead {
-    .tt-menu {
-      width: 100%;
-      max-height: 19.5rem;
-      padding: 0.3125rem 0;
-      overflow: auto;
-      background: $white;
-      border: 1px solid $gray-medium;
-    }
-
-    .tt-suggestion {
-      padding: 0.3125rem 0.625rem;
-      color: $gray-medium;
-      cursor: pointer;
-
-      &:hover,
-      &.tt-cursor {
-        color: $white;
-        background-color: $primary-hover;
-      }
-    }
-  }
+  @import '_twitter_typeahead.scss';
 
   .entities-list {
     max-width: 100%;

--- a/admin-dev/themes/new-theme/scss/components/_twitter_typeahead.scss
+++ b/admin-dev/themes/new-theme/scss/components/_twitter_typeahead.scss
@@ -1,0 +1,22 @@
+.twitter-typeahead {
+  .tt-menu {
+    width: 100%;
+    max-height: 19.5rem;
+    padding: 0.3125rem 0;
+    overflow: auto;
+    background: $white;
+    border: 1px solid $gray-medium;
+  }
+
+  .tt-suggestion {
+    padding: 0.3125rem 0.625rem;
+    color: $gray-medium;
+    cursor: pointer;
+
+    &:hover,
+    &.tt-cursor {
+      color: $white;
+      background-color: $primary-hover;
+    }
+  }
+}

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1751,7 +1751,7 @@ $product-page-padding-bottom: 80px !default;
 }
 
 #product_combinations_combination_manager {
-  @import '../../components/twitter_typeahead';
+  @import "../../components/twitter_typeahead";
 
   #combination-list-actions {
     display: flex;

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1751,6 +1751,8 @@ $product-page-padding-bottom: 80px !default;
 }
 
 #product_combinations_combination_manager {
+  @import '../../components/twitter_typeahead';
+
   #combination-list-actions {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | https://github.com/PrestaShop/PrestaShop/issues/32360. The dropdown background fix was easy, but there was another issue (which probably existed for a while already) - whenever you click on dropdown to select the attribute it would close whole modal. I couldn't find any better solution, but to disable the ability to close the modal when you click outside of it.
| Type?             | bug fix
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | https://github.com/PrestaShop/PrestaShop/issues/32360 (also the modal will not close when clicked outside now. Thats a side effect of main fix, but couldn't find a better solution for now :sweat: )
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/32360
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
