### PR TITLE
Add `autocomplete` option to every ChoiceType

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
+++ b/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
@@ -95,10 +95,7 @@ class SimpleCategory extends CommonAbstractType
             ->add('id_parent', ChoiceType::class, [
                 'choices' => $this->categories,
                 'required' => true,
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ],
+                'autocomplete' => true,
                 'label' => $this->translator->trans('Parent of the category', [], 'Admin.Catalog.Feature'),
             ]);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -232,10 +232,7 @@ final class EmployeeType extends AbstractType
                     [],
                     'Admin.Advparameters.Help'
                 ),
-                'attr' => [
-                    'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => 'select2',
-                ],
+                'autocomplete' => true,
                 'choices' => $this->tabChoices,
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -242,10 +242,7 @@ class PreferencesType extends TranslatorAwareType
                 ],
                 'label' => $this->trans('Main Shop Activity', 'Admin.Shopparameters.Feature'),
                 'choice_translation_domain' => 'Install',
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ],
+                'autocomplete' => true,
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -144,10 +144,7 @@ class GeneralType extends TranslatorAwareType
                 'placeholder' => $this->trans('None', 'Admin.Global'),
                 'choices' => $this->tosCmsChoices,
                 'multistore_configuration_key' => 'PS_CONDITIONS_CMS_ID',
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ],
+                'autocomplete' => true,
             ])
             ->add('enable_backorder_status', SwitchType::class, [
                 'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php
+++ b/src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php
@@ -77,10 +77,9 @@ class ProductFeature extends CommonAbstractType
             'label' => $this->translator->trans('Feature', [], 'Admin.Catalog.Feature'),
             'choices' => $this->features,
             'required' => false,
+            'autocomplete' => true,
             'attr' => [
                 'data-action' => $this->router->generate('admin_feature_get_feature_values', ['idFeature' => 1]),
-                'data-toggle' => 'select2',
-                'data-minimumResultsForSearch' => '7',
                 'class' => 'feature-selector',
             ],
             'placeholder' => $this->translator->trans('Choose a feature', [], 'Admin.Catalog.Feature'),
@@ -88,10 +87,7 @@ class ProductFeature extends CommonAbstractType
             ->add('value', FormType\ChoiceType::class, [
                 'label' => $this->translator->trans('Pre-defined value', [], 'Admin.Catalog.Feature'),
                 'required' => false,
-                'attr' => [
-                    'class' => 'feature-value-selector',
-                    'data-minimumResultsForSearch' => '7',
-                ],
+                'autocomplete' => true,
                 'placeholder' => $this->translator->trans('Choose a value', [], 'Admin.Catalog.Feature'),
                 'disabled' => true,
             ])
@@ -148,10 +144,9 @@ class ProductFeature extends CommonAbstractType
         $form->add('value', FormType\ChoiceType::class, [
             'label' => $this->translator->trans('Pre-defined value', [], 'Admin.Catalog.Feature'),
             'required' => false,
+            'autocomplete' => true,
             'attr' => [
                 'class' => 'feature-value-selector',
-                'data-minimumResultsForSearch' => '7',
-                'data-toggle' => 'select2',
             ],
             'choices' => $choices,
             'placeholder' => $this->translator->trans('Choose a value', [], 'Admin.Catalog.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
@@ -99,7 +99,7 @@ class CurrencyType extends TranslatorAwareType
                     'required' => false,
                     'placeholder' => '--',
                     'autocomplete' => true,
-                    'autocomplete_mininum_choices' => 1,
+                    'autocomplete_minimum_choices' => 1,
                 ])
                 ->add('unofficial', CheckboxType::class, [
                     'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
@@ -98,10 +98,8 @@ class CurrencyType extends TranslatorAwareType
                     'choice_translation_domain' => false,
                     'required' => false,
                     'placeholder' => '--',
-                    'attr' => [
-                        'data-toggle' => 'select2',
-                        'data-minimumResultsForSearch' => '1',
-                    ],
+                    'autocomplete' => true,
+                    'autocomplete_mininum_choices' => 1,
                 ])
                 ->add('unofficial', CheckboxType::class, [
                     'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php
@@ -72,10 +72,7 @@ class ImportLocalizationPackType extends TranslatorAwareType
                 ),
                 'choices' => $this->localizationPackChoices,
                 'choice_translation_domain' => false,
-                'attr' => [
-                    'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => 'select2',
-                ],
+                'autocomplete' => true,
             ])
             ->add('content_to_import', ChoiceType::class, [
                 'label' => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
@@ -96,10 +96,7 @@ class LocalizationConfigurationType extends TranslatorAwareType
                 ),
                 'choices' => $this->languageChoices,
                 'choice_translation_domain' => false,
-                'attr' => [
-                    'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => 'select2',
-                ],
+                'autocomplete' => true,
             ])
             ->add('detect_language_from_browser', SwitchType::class, [
                 'label' => $this->trans(
@@ -122,10 +119,7 @@ class LocalizationConfigurationType extends TranslatorAwareType
                 ),
                 'choices' => $this->countryChoices,
                 'choice_translation_domain' => false,
-                'attr' => [
-                    'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => 'select2',
-                ],
+                'autocomplete' => true,
             ])
             ->add('detect_country_from_browser', SwitchType::class, [
                 'label' => $this->trans(
@@ -149,10 +143,9 @@ class LocalizationConfigurationType extends TranslatorAwareType
                     'The default currency used in your shop.',
                     'Admin.International.Help'
                 ),
+                'autocomplete' => true,
                 'attr' => [
                     'data-warning-message' => 'Before changing the default currency, we strongly recommend that you enable maintenance mode. Indeed, any change on the default currency requires a manual adjustment of the price of each product and its combinations.',
-                    'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => 'select2',
                 ],
             ])
             ->add('timezone', ChoiceType::class, [
@@ -162,10 +155,7 @@ class LocalizationConfigurationType extends TranslatorAwareType
                 ),
                 'choices' => $this->timezoneChoices,
                 'choice_translation_domain' => false,
-                'attr' => [
-                    'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => 'select2',
-                ],
+                'autocomplete' => true,
             ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/AddUpdateLanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/AddUpdateLanguageType.php
@@ -63,10 +63,7 @@ class AddUpdateLanguageType extends TranslatorAwareType
     {
         $builder->add('iso_localization_pack', ChoiceType::class, [
             'label' => $this->trans('Please select the language you want to add or update', 'Admin.International.Feature'),
-            'attr' => [
-                'data-minimumResultsForSearch' => '7',
-                'data-toggle' => 'select2',
-            ],
+            'autocomplete' => true,
             'choices' => [
                 $this->trans('Update a language', 'Admin.International.Feature') => $this->getLocaleChoices(),
                 $this->trans('Add a language', 'Admin.International.Feature') => $this->nonInstalledLocalizationChoices,

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
@@ -137,10 +137,7 @@ class ModifyTranslationsType extends TranslatorAwareType
                     'class' => 'js-module-form-group d-none',
                 ],
                 'placeholder' => '---',
-                'attr' => [
-                    'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => 'select2',
-                ],
+                'autocomplete' => true,
                 'choices' => $this->moduleChoices,
                 'choice_translation_domain' => false,
             ])

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
@@ -91,10 +91,7 @@ class CarrierOptionsType extends TranslatorAwareType
                     'Admin.Shipping.Help'
                 ),
                 'multistore_configuration_key' => 'PS_CARRIER_DEFAULT',
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ],
+                'autocomplete' => true,
             ])
             ->add('carrier_default_order_by', ChoiceType::class, [
                 'choices' => $this->orderByChoices,

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -291,10 +291,7 @@ class ProductInformation extends CommonAbstractType
             ->add('id_manufacturer', FormType\ChoiceType::class, [
                 'choices' => $this->manufacturers,
                 'required' => false,
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ],
+                'autocomplete' => true,
                 'label' => $this->translator->trans('Brand', [], 'Admin.Catalog.Feature'),
                 'placeholder' => $this->translator->trans('Choose a brand', [], 'Admin.Catalog.Feature'),
             ])

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
@@ -192,10 +192,7 @@ class ProductPrice extends CommonAbstractType
                             'data-computation-method' => $this->tax_rules_rates[$val]['computation_method'],
                         ];
                     },
-                    'attr' => [
-                        'data-toggle' => 'select2',
-                        'data-minimumResultsForSearch' => '7',
-                    ],
+                    'autocomplete' => true,
                     'label' => $this->translator->trans('Tax rule', [], 'Admin.Catalog.Feature'),
                 ]
             )

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -173,10 +173,7 @@ class ProductSpecificPrice extends CommonAbstractType
                 'choices' => $this->currencies,
                 'required' => false,
                 'label' => false,
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ],
+                'autocomplete' => true,
                 'placeholder' => $this->translator->trans('All currencies', [], 'Admin.Global'),
             ]
         )
@@ -187,10 +184,7 @@ class ProductSpecificPrice extends CommonAbstractType
                     'choices' => $this->countries,
                     'required' => false,
                     'label' => false,
-                    'attr' => [
-                        'data-toggle' => 'select2',
-                        'data-minimumResultsForSearch' => '7',
-                    ],
+                    'autocomplete' => true,
                     'placeholder' => $this->translator->trans('All countries', [], 'Admin.Global'),
                 ]
             )
@@ -201,10 +195,7 @@ class ProductSpecificPrice extends CommonAbstractType
                     'choices' => $this->groups,
                     'required' => false,
                     'label' => false,
-                    'attr' => [
-                        'data-toggle' => 'select2',
-                        'data-minimumResultsForSearch' => '7',
-                    ],
+                    'autocomplete' => true,
                     'placeholder' => $this->translator->trans('All groups', [], 'Admin.Global'),
                 ]
             )

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
@@ -373,10 +373,9 @@ class CustomerAddressType extends TranslatorAwareType
                         ),
                     ]),
                 ],
+                'autocomplete' => true,
                 'attr' => [
                     'data-states-url' => $this->router->generate('admin_country_states'),
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
                 ],
             ])->add('id_state', ChoiceType::class, [
                 'label' => $this->trans('State', 'Admin.Global'),
@@ -390,10 +389,9 @@ class CustomerAddressType extends TranslatorAwareType
                 'row_attr' => [
                     'class' => 'js-address-state-select',
                 ],
+                'autocomplete' => true,
                 'attr' => [
                     'visible' => $showStates,
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
                 ],
             ])->add('phone', TextType::class, [
                 'label' => $this->trans('Phone', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
@@ -227,11 +227,10 @@ class ManufacturerAddressType extends TranslatorAwareType
             ])
             ->add('id_country', CountryChoiceType::class, [
                 'label' => $this->trans('Country', 'Admin.Global'),
+                'autocomplete' => true,
                 'attr' => [
                     'class' => 'js-manufacturer-country-select',
                     'data-states-url' => $this->router->generate('admin_country_states'),
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
                 ],
                 'required' => true,
                 'with_dni_attr' => true,
@@ -252,10 +251,7 @@ class ManufacturerAddressType extends TranslatorAwareType
                         'id_country' => $countryId,
                     ]),
                 ],
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ],
+                'autocomplete' => true,
             ])
             ->add('dni', TextType::class, [
                 'label' => $this->trans('DNI', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -322,10 +322,7 @@ class CustomerType extends TranslatorAwareType
                 'required' => false,
                 'placeholder' => null,
                 'choices' => $this->groupChoices,
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ],
+                'autocomplete' => true,
             ])
         ;
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CartSummaryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CartSummaryType.php
@@ -89,10 +89,7 @@ class CartSummaryType extends AbstractType
                     [],
                     'Admin.Actions'
                 ),
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ],
+                'autocomplete' => true,
             ])
             ->add('order_state', ChoiceType::class, [
                 'choices' => $this->orderStatesChoiceProvider->getChoices(),
@@ -102,10 +99,7 @@ class CartSummaryType extends AbstractType
                     [],
                     'Admin.Actions'
                 ),
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ],
+                'autocomplete' => true,
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderShippingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderShippingType.php
@@ -59,10 +59,7 @@ class UpdateOrderShippingType extends AbstractType
                 'choices' => $this->carrierForOrderChoiceProvider->getChoices([
                     'order_id' => $options['order_id'],
                 ]),
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ],
+                'autocomplete' => true,
             ])
             ->add('current_order_carrier_id', HiddenType::class)
             ->add('tracking_number', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderStatusType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderStatusType.php
@@ -68,10 +68,7 @@ class UpdateOrderStatusType extends AbstractType
                 'choices' => $this->statusChoiceProvider->getChoices($choiceProviderParams),
                 'choice_attr' => $this->statusChoiceAttributes,
                 'translation_domain' => false,
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ],
+                'autocomplete' => true,
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
@@ -77,10 +77,7 @@ class CategoriesType extends TranslatorAwareType
                 'constraints' => [],
                 'choices' => $this->defaultCategoryChoiceProvider->getChoices(['product_id' => $options['product_id']]),
                 'label' => $this->trans('Default category', 'Admin.Catalog.Feature'),
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ],
+                'autocomplete' => true,
             ])
             ->add('add_categories_btn', ButtonType::class, [
                 'label' => $this->trans('Add categories', 'Admin.Catalog.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/ManufacturerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/ManufacturerType.php
@@ -37,8 +37,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ManufacturerType extends AbstractType
 {
-    private const MANUFACTURER_MIN_RESULTS_FOR_SEARCH = 7;
-
     /**
      * @var TranslatorInterface
      */
@@ -83,10 +81,7 @@ class ManufacturerType extends AbstractType
             // placeholder false is important to avoid empty option in select input despite required being false
             'placeholder' => false,
             'choices' => $choices,
-            'attr' => [
-                'data-toggle' => 'select2',
-                'data-minimumResultsForSearch' => self::MANUFACTURER_MIN_RESULTS_FOR_SEARCH,
-            ],
+            'autocomplete' => true,
         ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
@@ -170,9 +170,8 @@ class RetailPriceType extends TranslatorAwareType
                 // placeholder false is important to avoid empty option in select input despite required being false
                 'placeholder' => false,
                 'choice_attr' => $this->taxRuleGroupChoicesProvider->getChoicesAttributes(),
+                'autocomplete' => true,
                 'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
                     'data-tax-enabled' => $this->isTaxEnabled,
                 ],
                 'row_attr' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -229,11 +229,10 @@ class SupplierType extends TranslatorAwareType
                         ),
                     ]),
                 ],
+                'autocomplete' => true,
                 'attr' => [
                     'class' => 'js-supplier-country-select',
                     'data-states-url' => $this->router->generate('admin_country_states'),
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
                 ],
             ])
             ->add('id_state', ChoiceType::class, [
@@ -245,10 +244,7 @@ class SupplierType extends TranslatorAwareType
                         'id_country' => $countryId,
                     ]),
                 ],
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ],
+                'autocomplete' => true,
             ])
             ->add('dni', TextType::class, [
                 'label' => $this->trans('DNI', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Extension/AutoCompleteExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/AutoCompleteExtension.php
@@ -50,15 +50,15 @@ class AutoCompleteExtension extends AbstractTypeExtension
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefined('autocomplete');
-        $resolver->setDefined('autocomplete_mininum_choices');
+        $resolver->setDefined('autocomplete_minimum_choices');
 
         $resolver->setAllowedTypes('autocomplete', 'bool');
-        $resolver->setAllowedTypes('autocomplete_mininum_choices', 'int');
+        $resolver->setAllowedTypes('autocomplete_minimum_choices', 'int');
 
         $resolver->setNormalizer('attr', function (Options $options, ?array $attr) {
             if (isset($options['autocomplete']) && $options['autocomplete']) {
                 $attr['data-toggle'] = 'select2';
-                $attr['data-minimumResultsForSearch'] = $options['autocomplete_mininum_choices'] ?? self::DEFAULT_MINIMUM_INPUT_LENGTH;
+                $attr['data-minimumResultsForSearch'] = $options['autocomplete_minimum_choices'] ?? self::DEFAULT_MINIMUM_INPUT_LENGTH;
             }
 
             return $attr;

--- a/src/PrestaShopBundle/Form/Extension/AutoCompleteExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/AutoCompleteExtension.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Adds an option in the form builder to enable autocomplete on select inputs.
+ */
+class AutoCompleteExtension extends AbstractTypeExtension
+{
+    private const DEFAULT_MINIMUM_INPUT_LENGTH = 7;
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [
+            ChoiceType::class,
+        ];
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefined('autocomplete');
+        $resolver->setDefined('autocomplete_mininum_choices');
+
+        $resolver->setAllowedTypes('autocomplete', 'bool');
+        $resolver->setAllowedTypes('autocomplete_mininum_choices', 'int');
+
+        $resolver->setNormalizer('attr', function (Options $options, ?array $attr) {
+            if (isset($options['autocomplete']) && $options['autocomplete']) {
+                $attr['data-toggle'] = 'select2';
+                $attr['data-minimumResultsForSearch'] = $options['autocomplete_mininum_choices'] ?? self::DEFAULT_MINIMUM_INPUT_LENGTH;
+            }
+
+            return $attr;
+        });
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This add a new option to enable / disable autocomplete, I also updated all code to use this new system.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |  All choices with autocomplete should work as expected as they have been refactored only.


# Usage

```php

use PrestaShopBundle\Form\Extension\AutocompleteExtension;
use Symfony\Component\Form\AbstractType;
use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
use Symfony\Component\Form\FormBuilderInterface;

class MyFormType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder->add('my_field', ChoiceType::class, [
            'autocomplete' => true,
            'autocomplete_minimum_choices' => 1, // will enable autocomplete as there are 3 choices
            'choices' => [
                'Option 1' => 'option1',
                'Option 2' => 'option2',
                'Option 3' => 'option3',
            ],
        ]);
    }
```
