### PR TITLE
Introduce `FormHelper` and deprecate `CommonAbstractType`

### DIFF
--- a/src/Adapter/CombinationDataProvider.php
+++ b/src/Adapter/CombinationDataProvider.php
@@ -30,7 +30,7 @@ use Combination;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Product\ProductDataProvider;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
-use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use PrestaShopBundle\Form\FormHelper;
 use Product;
 use Tax;
 
@@ -145,13 +145,13 @@ class CombinationDataProvider
         $finalPrice = $productPrice
             ->plus($ecotax)
             ->plus($combinationImpactTaxExcluded)
-            ->toPrecision(CommonAbstractType::PRESTASHOP_DECIMALS);
+            ->toPrecision(FormHelper::DEFAULT_PRICE_PRECISION);
 
         $ecotaxIncluded = $combinationEcotaxIncluded->equalsZero() ? $productEcotaxIncluded : $combinationEcotaxIncluded;
         $finalPriceIncluded = $productPriceIncluded
             ->plus($ecotaxIncluded)
             ->plus($combinationImpactTaxIncluded)
-            ->toPrecision(CommonAbstractType::PRESTASHOP_DECIMALS);
+            ->toPrecision(FormHelper::DEFAULT_PRICE_PRECISION);
 
         return [
             'id_product_attribute' => $combination['id_product_attribute'],
@@ -162,13 +162,13 @@ class CombinationDataProvider
             'attribute_mpn' => $combination['mpn'],
             'attribute_wholesale_price' => $combination['wholesale_price'],
             'attribute_price_impact' => $attribute_price_impact,
-            'attribute_price' => $combinationImpactTaxExcluded->toPrecision(CommonAbstractType::PRESTASHOP_DECIMALS),
+            'attribute_price' => $combinationImpactTaxExcluded->toPrecision(FormHelper::DEFAULT_PRICE_PRECISION),
             'attribute_price_display' => $this->locale->formatPrice((string) $combinationImpactTaxExcluded, $this->context->getContext()->currency->iso_code),
             'final_price' => $finalPrice,
             'final_price_tax_included' => $finalPriceIncluded,
             'attribute_priceTI' => '',
             // The value is displayed with tax included
-            'product_ecotax' => $productEcotaxIncluded->toPrecision(CommonAbstractType::PRESTASHOP_DECIMALS),
+            'product_ecotax' => $productEcotaxIncluded->toPrecision(FormHelper::DEFAULT_PRICE_PRECISION),
             'attribute_ecotax' => $combination['ecotax_tax_included'],
             'attribute_weight_impact' => $attribute_weight_impact,
             'attribute_weight' => $combination['weight'],

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -41,7 +41,7 @@ use ObjectModel;
 use PrestaShop\PrestaShop\Adapter\Entity\Customization;
 use PrestaShop\PrestaShop\Core\Foundation\Database\EntityNotFoundException;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
-use PrestaShopBundle\Form\Extension\CustomMoneyTypeExtension;
+use PrestaShopBundle\Form\FormHelper;
 use PrestaShopBundle\Utils\FloatParser;
 use Product;
 use ProductDownload;
@@ -145,7 +145,7 @@ class AdminProductWrapper
         // This is VERY UGLY, but since ti ComputingPrecision can never return enough decimals for now we have no
         // choice but to hard code this one to make sure enough precision is saved in the DB or it results in errors
         // of 1 cent in the shop
-        $computingPrecision = CustomMoneyTypeExtension::PRESTASHOP_DECIMALS;
+        $computingPrecision = FormHelper::DEFAULT_PRICE_PRECISION;
         if (!isset($combinationValues['attribute_ecotax']) || 0.0 === (float) $combinationValues['attribute_ecotax']) {
             $combinationValues['attribute_ecotax'] = 0;
         } else {

--- a/src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php
+++ b/src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php
@@ -28,8 +28,8 @@ namespace PrestaShopBundle\Form\Admin\Feature;
 
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\TranslateType;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
-use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -60,7 +60,7 @@ class ProductFeature extends CommonAbstractType
         $this->locales = $legacyContext->getLanguages();
         $this->router = $router;
         $this->featureDataProvider = $featureDataProvider;
-        $this->features = $this->formatDataChoicesList(
+        $this->features = FormHelper::formatDataChoicesList(
             $this->featureDataProvider->getFeatures($this->locales[0]['id_lang']),
             'id_feature'
         );
@@ -108,7 +108,7 @@ class ProductFeature extends CommonAbstractType
                 return;
             }
 
-            $choices = $this->formatDataChoicesList(
+            $choices = FormHelper::formatDataChoicesList(
                 $this->featureDataProvider->getFeatureValuesWithLang($this->locales[0]['id_lang'], $data['feature']),
                 'id_feature_value',
                 'value'
@@ -125,7 +125,7 @@ class ProductFeature extends CommonAbstractType
                 return;
             }
 
-            $choices = $this->formatDataChoicesList(
+            $choices = FormHelper::formatDataChoicesList(
                 $this->featureDataProvider->getFeatureValuesWithLang($this->locales[0]['id_lang'], $data['feature']),
                 'id_feature_value',
                 'value'

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -163,7 +164,7 @@ class ProductCombination extends CommonAbstractType
             ->add('attribute_weight', NumberType::class, [
                 'prepend_unit' => true,
                 'unit' => $this->configuration->get('PS_WEIGHT_UNIT'),
-                'scale' => static::PRESTASHOP_WEIGHT_DECIMALS,
+                'scale' => FormHelper::DEFAULT_WEIGHT_PRECISION,
                 'required' => false,
                 'label' => $this->translator->trans('Impact on weight', [], 'Admin.Catalog.Feature'),
                 'attr' => ['class' => 'attribute_weight'],

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Form\Admin\Product;
 use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
@@ -69,7 +70,7 @@ class ProductCombinationBulk extends CommonAbstractType
         $builder->add('cost_price', MoneyType::class, [
             'required' => false,
             'label' => $this->translator->trans('Cost Price', [], 'Admin.Catalog.Feature'),
-            'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
+            'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
             'currency' => $isoCode,
         ])
             ->add('impact_on_weight', NumberType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -43,6 +43,7 @@ use PrestaShopBundle\Form\Admin\Type\FormattedTextareaType;
 use PrestaShopBundle\Form\Admin\Type\TranslateType;
 use PrestaShopBundle\Form\Admin\Type\TypeaheadProductCollectionType;
 use PrestaShopBundle\Form\Admin\Type\TypeaheadProductPackCollectionType;
+use PrestaShopBundle\Form\FormHelper;
 use PrestaShopBundle\Form\Validator\Constraints\TinyMceMaxLength;
 use PrestaShopBundle\Service\Routing\Router;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
@@ -145,7 +146,7 @@ class ProductInformation extends CommonAbstractType
         $this->locales = $this->context->getLanguages();
         $this->currency = $this->context->getContext()->currency;
 
-        $this->categories = $this->formatDataChoicesList(
+        $this->categories = FormHelper::formatDataChoicesList(
             $this->categoryDataProvider->getAllCategoriesName(
                 $root_category = null,
                 $id_lang = false,
@@ -160,7 +161,7 @@ class ProductInformation extends CommonAbstractType
             $active = false
         );
 
-        $this->manufacturers = $this->formatDataChoicesList(
+        $this->manufacturers = FormHelper::formatDataChoicesList(
             $this->manufacturerDataProvider->getManufacturers(
                 $get_nb_products = false,
                 $id_lang = 0,

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Form\Admin\Product;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\TranslateType;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -71,7 +72,7 @@ class ProductOptions extends CommonAbstractType
         $this->locales = $legacyContext->getLanguages();
         $this->router = $router;
 
-        $this->suppliers = $this->formatDataChoicesList(
+        $this->suppliers = FormHelper::formatDataChoicesList(
             $supplierDataProvider->getSuppliers(),
             'id_supplier'
         );
@@ -79,7 +80,7 @@ class ProductOptions extends CommonAbstractType
         $this->fullAttachmentList = $attachmentDataprovider->getAllAttachments(
             $this->context->getLanguages()[0]['id_lang']
         );
-        $this->attachmentList = $this->formatDataChoicesList(
+        $this->attachmentList = FormHelper::formatDataChoicesList(
             $this->fullAttachmentList,
             'id_attachment',
             'file'

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShop\PrestaShop\Adapter\Tax\TaxRuleDataProvider;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -129,7 +130,7 @@ class ProductPrice extends CommonAbstractType
         $this->tax_rules_rates = $taxDataProvider->getTaxRulesGroupWithRates();
         $this->eco_tax_rate = $taxDataProvider->getProductEcotaxRate();
         $this->currency = $legacyContext->getContext()->currency;
-        $this->tax_rules = $this->formatDataChoicesList(
+        $this->tax_rules = FormHelper::formatDataChoicesList(
             $taxDataProvider->getTaxRulesGroups(true),
             'id_tax_rules_group'
         );
@@ -148,7 +149,7 @@ class ProductPrice extends CommonAbstractType
             [
                 'required' => false,
                 'label' => $this->translator->trans('Retail price (tax excl.)', [], 'Admin.Catalog.Feature'),
-                'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
+                'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
                 'currency' => $this->currency->iso_code,
                 'constraints' => [
                     new Assert\NotBlank(),

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\Warehouse\WarehouseDataProvider;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\TranslateType;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -174,7 +175,7 @@ class ProductShipping extends CommonAbstractType
                 FormType\NumberType::class,
                 [
                     'unit' => $this->weightUnit,
-                    'scale' => static::PRESTASHOP_WEIGHT_DECIMALS,
+                    'scale' => FormHelper::DEFAULT_WEIGHT_PRECISION,
                     'required' => false,
                     'label' => $this->translator->trans('Weight', [], 'Admin.Catalog.Feature'),
                     'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Currency\CurrencyDataProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
 use PrestaShopBundle\Form\Admin\Type\TypeaheadCustomerCollectionType;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -119,16 +120,16 @@ class ProductSpecificPrice extends CommonAbstractType
         $this->translator = $translator;
         $this->context = $legacyContext;
         $this->locales = $legacyContext->getLanguages();
-        $this->shops = $this->formatDataChoicesList($shopContextAdapter->getShops(), 'id_shop');
-        $this->countries = $this->formatDataChoicesList(
+        $this->shops = FormHelper::formatDataChoicesList($shopContextAdapter->getShops(), 'id_shop');
+        $this->countries = FormHelper::formatDataChoicesList(
             $countryDataprovider->getCountries($this->locales[0]['id_lang']),
             'id_country'
         );
-        $this->currencies = $this->formatDataChoicesList(
+        $this->currencies = FormHelper::formatDataChoicesList(
             $currencyDataprovider->getCurrencies(),
             'id_currency'
         );
-        $this->groups = $this->formatDataChoicesList(
+        $this->groups = FormHelper::formatDataChoicesList(
             $groupDataprovider->getGroups($this->locales[0]['id_lang']),
             'id_group'
         );

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Form\Admin\Product;
 
 use PrestaShop\PrestaShop\Core\Currency\CurrencyDataProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -84,7 +85,7 @@ class ProductSupplierCombination extends CommonAbstractType
                 'product_price_currency',
                 FormType\ChoiceType::class,
                 [
-                    'choices' => $this->formatDataChoicesList($this->currencyDataProvider->getCurrencies(), 'id_currency'),
+                    'choices' => FormHelper::formatDataChoicesList($this->currencyDataProvider->getCurrencies(), 'id_currency'),
                     'required' => true,
                     'attr' => [
                         'class' => 'custom-select',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationPriceType.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -92,7 +93,7 @@ class BulkCombinationPriceType extends TranslatorAwareType
             ->add('wholesale_price', MoneyType::class, [
                 'required' => false,
                 'label' => $this->trans('Cost price (tax excl.)', 'Admin.Catalog.Feature'),
-                'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
+                'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
                 'currency' => $this->defaultCurrencyIsoCode,
                 'constraints' => [
                     new NotBlank(),
@@ -107,7 +108,7 @@ class BulkCombinationPriceType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Impact on price (tax excl.)', 'Admin.Catalog.Feature'),
                 'label_help_box' => $this->trans('If the price of this combination is different from the initial retail price, enter the value of the impact (negative or positive).', 'Admin.Catalog.Help'),
-                'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
+                'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
                 'currency' => $this->defaultCurrencyIsoCode,
                 'constraints' => [
                     new NotBlank(),
@@ -120,7 +121,7 @@ class BulkCombinationPriceType extends TranslatorAwareType
             ->add('price_tax_included', MoneyType::class, [
                 'required' => false,
                 'label' => $this->trans('Impact on price (tax incl.)', 'Admin.Catalog.Feature'),
-                'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
+                'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
                 'currency' => $this->defaultCurrencyIsoCode,
                 'constraints' => [
                     new NotBlank(),
@@ -133,7 +134,7 @@ class BulkCombinationPriceType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Impact on price per unit (tax excl.)', 'Admin.Catalog.Feature'),
                 'label_help_box' => $this->trans('If the price per unit of this combination is different from the initial price per unit, enter the value of the impact (negative or positive).', 'Admin.Catalog.Feature'),
-                'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
+                'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
                 'currency' => $this->defaultCurrencyIsoCode,
                 'constraints' => [
                     new NotBlank(),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationPriceImpactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationPriceImpactType.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\ValueObject\TaxRulesGroupId;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShopBundle\Form\Admin\Type\TextPreviewType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
@@ -122,7 +123,7 @@ class CombinationPriceImpactType extends TranslatorAwareType
                 'label' => $this->trans('Impact on price (tax excl.)', 'Admin.Catalog.Feature'),
                 'label_help_box' => $this->trans('If the price of this combination is different from the initial retail price, enter the value of the impact (negative or positive).', 'Admin.Catalog.Help'),
                 'attr' => [
-                    'data-display-price-precision' => static::PRESTASHOP_DECIMALS,
+                    'data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION,
                     'data-price-specification' => json_encode($this->contextLocale->getPriceSpecification($this->defaultCurrency->iso_code)->toArray()),
                 ],
                 'currency' => $this->defaultCurrency->iso_code,
@@ -135,7 +136,7 @@ class CombinationPriceImpactType extends TranslatorAwareType
             ->add('price_tax_included', MoneyType::class, [
                 'required' => false,
                 'label' => $this->trans('Impact on price (tax incl.)', 'Admin.Catalog.Feature'),
-                'attr' => ['data-display-price-precision' => static::PRESTASHOP_DECIMALS],
+                'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
                 'currency' => $this->defaultCurrency->iso_code,
                 'constraints' => [
                     new NotBlank(),
@@ -219,7 +220,7 @@ class CombinationPriceImpactType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Impact on price per unit (tax excl.)', 'Admin.Catalog.Feature'),
                 'label_help_box' => $this->trans('If the price per unit of this combination is different from the initial price per unit, enter the value of the impact (negative or positive).', 'Admin.Catalog.Feature'),
-                'attr' => ['data-display-price-precision' => static::PRESTASHOP_DECIMALS],
+                'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
                 'currency' => $this->defaultCurrency->iso_code,
                 'constraints' => [
                     new NotBlank(),
@@ -231,7 +232,7 @@ class CombinationPriceImpactType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Impact on price per unit (tax incl.)', 'Admin.Catalog.Feature'),
                 'label_help_box' => $this->trans('If the price per unit of this combination is different from the initial price per unit, enter the value of the impact (negative or positive).', 'Admin.Catalog.Feature'),
-                'attr' => ['data-display-price-precision' => static::PRESTASHOP_DECIMALS],
+                'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
                 'currency' => $this->defaultCurrency->iso_code,
                 'constraints' => [
                     new NotBlank(),
@@ -261,7 +262,7 @@ class CombinationPriceImpactType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Cost price (tax excl.)', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h3',
-                'attr' => ['data-display-price-precision' => static::PRESTASHOP_DECIMALS],
+                'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
                 'currency' => $this->defaultCurrency->iso_code,
                 'constraints' => [
                     new NotBlank(),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductSupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductSupplierType.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Reference;
 use PrestaShopBundle\Form\Admin\Type\CurrencyChoiceType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use PrestaShopBundle\Form\FormCloner;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -113,8 +114,8 @@ class ProductSupplierType extends TranslatorAwareType
             ->add('price_tax_excluded', MoneyType::class, [
                 'label' => $this->trans('Cost price (tax excl.)', 'Admin.Catalog.Feature'),
                 'currency' => $this->defaultCurrencyIsoCode,
-                'scale' => self::PRESTASHOP_DECIMALS,
-                'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
+                'scale' => FormHelper::DEFAULT_PRICE_PRECISION,
+                'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
                 'constraints' => [
                     new NotBlank(),
                     new Type(['type' => 'float']),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
@@ -30,6 +30,7 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product\Pricing;
 
 use PrestaShopBundle\Form\Admin\Type\IconButtonType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -78,7 +79,7 @@ class PricingType extends TranslatorAwareType
                 'label' => $this->trans('Cost price', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h3',
                 'label_subtitle' => $this->trans('Cost price (tax excl.)', 'Admin.Catalog.Feature'),
-                'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
+                'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
                 'currency' => $this->defaultCurrencyIsoCode,
                 'modify_all_shops' => true,
                 'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
@@ -38,6 +38,7 @@ use PrestaShop\PrestaShop\Core\Form\FormChoiceAttributeProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -149,7 +150,7 @@ class RetailPriceType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Retail price (tax excl.)', 'Admin.Catalog.Feature'),
                 'attr' => [
-                    'data-display-price-precision' => self::PRESTASHOP_DECIMALS,
+                    'data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION,
                     'data-price-specification' => json_encode($this->contextLocale->getPriceSpecification($this->defaultCurrency->iso_code)->toArray()),
                 ],
                 'row_attr' => [
@@ -219,7 +220,7 @@ class RetailPriceType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Retail price (tax incl.)', 'Admin.Catalog.Feature'),
                 'attr' => [
-                    'data-display-price-precision' => self::PRESTASHOP_DECIMALS,
+                    'data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION,
                 ],
                 'row_attr' => [
                     'class' => 'retail-price-tax-included',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceImpactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceImpactType.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\ValueObject\Reduction as ReductionVO;
 use PrestaShopBundle\Form\Admin\Sell\Product\DataTransformer\SpecificPriceFixedPriceTransformer;
 use PrestaShopBundle\Form\Admin\Type\PriceReductionType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -95,7 +96,7 @@ class SpecificPriceImpactType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Set specific price', 'Admin.Catalog.Feature'),
                 'label_subtitle' => $this->trans('Retail price (tax excl.)', 'Admin.Catalog.Feature'),
-                'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
+                'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
                 'row_attr' => [
                     'class' => 'js-fixed-price-row',
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/UnitPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/UnitPriceType.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Pricing;
 
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -72,7 +73,7 @@ class UnitPriceType extends TranslatorAwareType
             ->add('price_tax_excluded', MoneyType::class, [
                 'required' => false,
                 'label' => $this->trans('Retail price per unit (tax excl.)', 'Admin.Catalog.Feature'),
-                'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
+                'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
                 'currency' => $this->defaultCurrencyIsoCode,
                 'constraints' => [
                     new NotBlank(),
@@ -88,7 +89,7 @@ class UnitPriceType extends TranslatorAwareType
             ->add('price_tax_included', MoneyType::class, [
                 'required' => false,
                 'label' => $this->trans('Retail price per unit (tax incl.)', 'Admin.Catalog.Feature'),
-                'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
+                'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
                 'currency' => $this->defaultCurrencyIsoCode,
                 'constraints' => [
                     new NotBlank(),

--- a/src/PrestaShopBundle/Form/Admin/Type/CommonAbstractType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CommonAbstractType.php
@@ -83,14 +83,17 @@ abstract class CommonAbstractType extends AbstractType
     {
         @trigger_error(
             sprintf(
-                '%s is deprecated since version 9.0 and will be removed in the next major version. Use %s::%s instead.',
-                __METHOD__,
-                FormHelper::class,
-                'formatDataDuplicateChoicesList()'
+                '%s is deprecated since version 9.0 and will be removed in the next major version. There is no replacement for this method.',
+                __METHOD__
             ),
             E_USER_DEPRECATED
         );
 
-        return FormHelper::formatDataDuplicateChoicesList($list, $mapping_value, $mapping_name);
+        $new_list = [];
+        foreach ($list as $item) {
+            $new_list[$item[$mapping_value] . ' - ' . $item[$mapping_name]] = $item[$mapping_value];
+        }
+
+        return $new_list;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Type/CommonAbstractType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CommonAbstractType.php
@@ -26,15 +26,25 @@
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\AbstractType;
 
 /**
  * This subclass contains common functions for specific Form types needs.
+ *
+ * @deprecated since 9.0 use \Symfony\Component\Form\AbstractType instead
  */
 abstract class CommonAbstractType extends AbstractType
 {
-    public const PRESTASHOP_DECIMALS = 6;
-    public const PRESTASHOP_WEIGHT_DECIMALS = 6;
+    /**
+     * @deprecated since 9.0
+     */
+    public const PRESTASHOP_DECIMALS = FormHelper::DEFAULT_PRICE_PRECISION;
+
+    /**
+     * @deprecated since 9.0
+     */
+    public const PRESTASHOP_WEIGHT_DECIMALS = FormHelper::DEFAULT_WEIGHT_PRECISION;
 
     /**
      * Format legacy data list to mapping SF2 form field choice.
@@ -47,16 +57,17 @@ abstract class CommonAbstractType extends AbstractType
      */
     protected function formatDataChoicesList($list, $mapping_value = 'id', $mapping_name = 'name')
     {
-        $new_list = [];
-        foreach ($list as $item) {
-            if (array_key_exists($item[$mapping_name], $new_list)) {
-                return $this->formatDataDuplicateChoicesList($list, $mapping_value, $mapping_name);
-            } else {
-                $new_list[$item[$mapping_name]] = $item[$mapping_value];
-            }
-        }
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 9.0 and will be removed in the next major version. Use %s::%s instead.',
+                __METHOD__,
+                FormHelper::class,
+                'formatDataChoicesList()'
+            ),
+            E_USER_DEPRECATED
+        );
 
-        return $new_list;
+        return FormHelper::formatDataChoicesList($list, $mapping_value, $mapping_name);
     }
 
     /**
@@ -70,11 +81,16 @@ abstract class CommonAbstractType extends AbstractType
      */
     protected function formatDataDuplicateChoicesList($list, $mapping_value = 'id', $mapping_name = 'name')
     {
-        $new_list = [];
-        foreach ($list as $item) {
-            $new_list[$item[$mapping_value] . ' - ' . $item[$mapping_name]] = $item[$mapping_value];
-        }
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 9.0 and will be removed in the next major version. Use %s::%s instead.',
+                __METHOD__,
+                FormHelper::class,
+                'formatDataDuplicateChoicesList()'
+            ),
+            E_USER_DEPRECATED
+        );
 
-        return $new_list;
+        return FormHelper::formatDataDuplicateChoicesList($list, $mapping_value, $mapping_name);
     }
 }

--- a/src/PrestaShopBundle/Form/Extension/CustomMoneyTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/CustomMoneyTypeExtension.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Localization\Currency\PatternTransformer;
 use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Price;
+use PrestaShopBundle\Form\FormHelper;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\FormInterface;
@@ -41,8 +42,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CustomMoneyTypeExtension extends AbstractTypeExtension
 {
-    public const PRESTASHOP_DECIMALS = 6;
-
     /**
      * @var Locale
      */
@@ -85,7 +84,7 @@ class CustomMoneyTypeExtension extends AbstractTypeExtension
     {
         $resolver->setDefaults([
             'precision' => null,
-            'scale' => self::PRESTASHOP_DECIMALS,
+            'scale' => FormHelper::DEFAULT_PRICE_PRECISION,
             'grouping' => false,
             'divisor' => 1,
             'currency' => $this->currencyRepository->getIsoCode(new CurrencyId($this->defaultCurrencyId)) ?: 'EUR',

--- a/src/PrestaShopBundle/Form/FormHelper.php
+++ b/src/PrestaShopBundle/Form/FormHelper.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace PrestaShopBundle\Form;
+
+class FormHelper
+{
+    public const DEFAULT_PRICE_PRECISION = 6;
+    public const DEFAULT_WEIGHT_PRECISION = 6;
+
+    /**
+     * Format legacy data list to mapping SF2 form field choice.
+     *
+     * @param array $list
+     * @param string $mapping_value
+     * @param string $mapping_name
+     *
+     * @return array
+     */
+    public static function formatDataChoicesList($list, $mapping_value = 'id', $mapping_name = 'name')
+    {
+        $new_list = [];
+        foreach ($list as $item) {
+            if (array_key_exists($item[$mapping_name], $new_list)) {
+                return self::formatDataDuplicateChoicesList($list, $mapping_value, $mapping_name);
+            } else {
+                $new_list[$item[$mapping_name]] = $item[$mapping_value];
+            }
+        }
+
+        return $new_list;
+    }
+
+    /**
+     * Format legacy data list to mapping SF2 form field choice (possibility to have 2 name equals).
+     *
+     * @param array $list
+     * @param string $mapping_value
+     * @param string $mapping_name
+     *
+     * @return array
+     */
+    public static function formatDataDuplicateChoicesList($list, $mapping_value = 'id', $mapping_name = 'name')
+    {
+        $new_list = [];
+        foreach ($list as $item) {
+            $new_list[$item[$mapping_value] . ' - ' . $item[$mapping_name]] = $item[$mapping_value];
+        }
+
+        return $new_list;
+    }
+}

--- a/src/PrestaShopBundle/Form/FormHelper.php
+++ b/src/PrestaShopBundle/Form/FormHelper.php
@@ -39,7 +39,7 @@ class FormHelper
      *
      * @return array
      */
-    public static function formatDataDuplicateChoicesList($list, $mapping_value = 'id', $mapping_name = 'name')
+    private static function formatDataDuplicateChoicesList($list, $mapping_value = 'id', $mapping_name = 'name')
     {
         $new_list = [];
         foreach ($list as $item) {


### PR DESCRIPTION
Signed-off-by: Fabien Papet <fabien.papet@gmail.com>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When product v1 will be deleted, all functions in CommonAbsractType will no more be used. I migrated them into a `FormHelper` class that will be called statically. And deprecate CommonAbstractType usage.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | CI 🟢  and automated tests

