### PR TITLE
Add .php-cs-fixer.dist.php to remove file list of the ZIP creator tool

### DIFF
--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -72,6 +72,7 @@ class ReleaseCreator
      * @var array
      */
     protected $filesRemoveList = [
+        '.php-cs-fixer.dist.php',
         '.DS_Store',
         '.gitignore',
         '.gitmodules',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | add .php-cs-fixer.dist.php to remove file list of the ZIP creator tool
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See the issue
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/31427
| Sponsor company   | Creabilis
