### PR TITLE
Fix minimum quantity label

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
@@ -122,7 +122,7 @@ class QuantityType extends TranslatorAwareType
                     'class' => 'small-input',
                 ],
                 'label_help_box' => $this->trans(
-                    "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity.",
+                    'The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity.',
                     'Admin.Catalog.Help'
                 ),
             ])

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
@@ -121,6 +121,10 @@ class QuantityType extends TranslatorAwareType
                 'attr' => [
                     'class' => 'small-input',
                 ],
+                'label_help_box' => $this->trans(
+                    "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity.",
+                    'Admin.Catalog.Help',
+                ),
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
@@ -123,7 +123,7 @@ class QuantityType extends TranslatorAwareType
                 ],
                 'label_help_box' => $this->trans(
                     "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity.",
-                    'Admin.Catalog.Help',
+                    'Admin.Catalog.Help'
                 ),
             ])
         ;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Adds missing minimal quantity helpbox. The wording is taken from the legacy page.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See that there is a question mark with the same text as on legacy page.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 
