### PR TITLE
Move getBulkActions inside a dedicated trait

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/StoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/StoreController.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\Store\Exception\CannotDeleteStoreException
 use PrestaShop\PrestaShop\Core\Domain\Store\Exception\CannotToggleStoreStatusException;
 use PrestaShop\PrestaShop\Core\Search\Filters\StoreFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Controller\BulkActionsTrait;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -43,6 +44,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class StoreController extends FrameworkBundleAdminController
 {
+    use BulkActionsTrait;
+
     /**
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -39,7 +39,6 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Extends The Symfony framework bundle controller to add common functions for PrestaShop needs.
@@ -512,26 +511,5 @@ class FrameworkBundleAdminController extends AbstractController
             $exceptionCode,
             $e->getMessage()
         );
-    }
-
-    protected function getBulkActionIds(Request $request, string $key): array
-    {
-        $ids = $request->request->get($key);
-
-        if (is_numeric($ids)) {
-            return [(int) $ids];
-        }
-
-        if (!is_array($ids)) {
-            return [];
-        }
-
-        foreach ($ids as $i => $id) {
-            $ids[$i] = (int) $id;
-        }
-
-        sort($ids);
-
-        return $ids;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CartRuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CartRuleController.php
@@ -45,6 +45,7 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\CartRuleForm
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\CartRuleFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Controller\BulkActionsTrait;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -57,6 +58,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class CartRuleController extends FrameworkBundleAdminController
 {
+    use BulkActionsTrait;
+
     /**
      * Displays cart rule listing page.
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Search\Filters\FeatureFilters;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Controller\BulkActionsTrait;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -50,6 +51,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class FeatureController extends FrameworkBundleAdminController
 {
+    use BulkActionsTrait;
+
     /**
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      */

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -65,6 +65,7 @@ use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductGridDefinitionFact
 use PrestaShop\PrestaShop\Core\Search\Filters\ProductFilters;
 use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Controller\BulkActionsTrait;
 use PrestaShopBundle\Entity\AdminFilter;
 use PrestaShopBundle\Entity\ProductDownload;
 use PrestaShopBundle\Entity\Repository\FeatureFlagRepository;
@@ -98,6 +99,8 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
  */
 class ProductController extends FrameworkBundleAdminController
 {
+    use BulkActionsTrait;
+
     /**
      * Used to validate connected user authorizations.
      */

--- a/src/PrestaShopBundle/Controller/BulkActionsTrait.php
+++ b/src/PrestaShopBundle/Controller/BulkActionsTrait.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+
+trait BulkActionsTrait
+{
+    protected function getBulkActionIds(Request $request, string $key): array
+    {
+        $ids = $request->request->get($key);
+
+        if (is_numeric($ids)) {
+            return [(int) $ids];
+        }
+
+        if (!is_array($ids)) {
+            return [];
+        }
+
+        foreach ($ids as $i => $id) {
+            $ids[$i] = (int) $id;
+        }
+
+        sort($ids);
+
+        return $ids;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Fabien Papet <fabien.papet@gmail.com>

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Discussed with @zuk3975, I refactored some code to avoid putting it inside `FrameworkBundleAdminController`, not covered by BC promise as this method has been added last month in `develop`. This is to prefer composition over in inheritance, to reduce coupling and having unused methods inside `FrameworkBundleAdminController`
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI , automated tests and nightly 🟢 
