### PR TITLE
Rename new-api into command-api

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -100,8 +100,8 @@ swiftmailer:
   spool: { type: memory }
 
 api_platform:
-  title: PrestaShop API
-  version: 1.0.0
+  title: Backoffice API
+  version: 0.1.0
   enable_entrypoint: false
   mapping:
     paths:

--- a/src/PrestaShopBundle/Api/Api.php
+++ b/src/PrestaShopBundle/Api/Api.php
@@ -33,7 +33,7 @@ namespace PrestaShopBundle\Api;
  */
 final class Api
 {
-    public const API_BASE_PATH = '/new-api';
+    public const API_BASE_PATH = '/api';
 
     /**
      * This class is not meant to be instantiated as it is used to access encoding constants only.

--- a/tests/Integration/Api/GetHookStatusTest.php
+++ b/tests/Integration/Api/GetHookStatusTest.php
@@ -45,18 +45,18 @@ class GetHookStatusTest extends ApiTestCase
         $activeHook->add();
 
         $bearerToken = $this->getBearerToken();
-        $response = static::createClient()->request('GET', '/new-api/hook-status/' . $inactiveHook->id, ['auth_bearer' => $bearerToken]);
+        $response = static::createClient()->request('GET', '/api/hook-status/' . $inactiveHook->id, ['auth_bearer' => $bearerToken]);
         self::assertEquals(json_decode($response->getContent())->active, $inactiveHook->active);
         self::assertResponseStatusCodeSame(200);
 
-        $response = static::createClient()->request('GET', '/new-api/hook-status/' . $activeHook->id, ['auth_bearer' => $bearerToken]);
+        $response = static::createClient()->request('GET', '/api/hook-status/' . $activeHook->id, ['auth_bearer' => $bearerToken]);
         self::assertEquals(json_decode($response->getContent())->active, $activeHook->active);
         self::assertResponseStatusCodeSame(200);
 
-        static::createClient()->request('GET', '/new-api/hook-status/' . 9999, ['auth_bearer' => $bearerToken]);
+        static::createClient()->request('GET', '/api/hook-status/' . 9999, ['auth_bearer' => $bearerToken]);
         self::assertResponseStatusCodeSame(404);
 
-        static::createClient()->request('GET', '/new-api/hook-status/' . $activeHook->id);
+        static::createClient()->request('GET', '/api/hook-status/' . $activeHook->id);
         self::assertResponseStatusCodeSame(401);
 
         $inactiveHook->delete();

--- a/tests/UI/campaigns/functional/API/01_basicTest.ts
+++ b/tests/UI/campaigns/functional/API/01_basicTest.ts
@@ -18,17 +18,17 @@ describe('API : Basic Test', async () => {
   });
 
   describe('Basic Test', async () => {
-    it('should request the endpoint /admin-dev/new-api/', async function () {
+    it('should request the endpoint /admin-dev/api/', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestNewApi', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/');
+      const apiResponse = await apiContext.get('api/');
       await expect(apiResponse.status()).to.eq(404);
     });
 
-    it('should request the endpoint /admin-dev/new-api/hook-status', async function () {
+    it('should request the endpoint /admin-dev/api/hook-status', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestNewApiHookStatus', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/hook-status');
+      const apiResponse = await apiContext.get('api/hook-status');
       await expect(apiResponse.status()).to.eq(404);
     });
   });

--- a/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/01_internalAuthServer/02_resourceEndpoint.ts
+++ b/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/01_internalAuthServer/02_resourceEndpoint.ts
@@ -41,19 +41,19 @@ describe('API : Resource Endpoint', async () => {
       accessTokenExpired = api.setAccessTokenAsExpired(accessToken);
     });
 
-    it('should request the endpoint /admin-dev/new-api/hook-status/1 without access token', async function () {
+    it('should request the endpoint /admin-dev/api/hook-status/1 without access token', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestEndpointWithoutAccessToken', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/hook-status/1');
+      const apiResponse = await apiContext.get('api/hook-status/1');
       await expect(apiResponse.status()).to.eq(401);
       await expect(api.hasResponseHeader(apiResponse, 'WWW-Authenticate')).to.be.true;
       await expect(api.getResponseHeader(apiResponse, 'WWW-Authenticate')).to.be.eq('Bearer');
     });
 
-    it('should request the endpoint /admin-dev/new-api/hook-status/1 with invalid access token', async function () {
+    it('should request the endpoint /admin-dev/api/hook-status/1 with invalid access token', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestEndpointWithInvalidAccessToken', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/hook-status/1', {
+      const apiResponse = await apiContext.get('api/hook-status/1', {
         headers: {
           Authorization: 'Bearer INVALIDTOKEN',
         },
@@ -63,10 +63,10 @@ describe('API : Resource Endpoint', async () => {
       await expect(api.getResponseHeader(apiResponse, 'WWW-Authenticate')).to.be.eq('Bearer');
     });
 
-    it('should request the endpoint /admin-dev/new-api/hook-status/1 with expired access token', async function () {
+    it('should request the endpoint /admin-dev/api/hook-status/1 with expired access token', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestEndpointWithInvalidAccessToken', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/hook-status/1', {
+      const apiResponse = await apiContext.get('api/hook-status/1', {
         headers: {
           Authorization: `Bearer ${accessTokenExpired}`,
         },
@@ -76,10 +76,10 @@ describe('API : Resource Endpoint', async () => {
       await expect(api.getResponseHeader(apiResponse, 'WWW-Authenticate')).to.be.eq('Bearer');
     });
 
-    it('should request the endpoint /admin-dev/new-api/hook-status/1 with valid access token', async function () {
+    it('should request the endpoint /admin-dev/api/hook-status/1 with valid access token', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestEndpointWithValidAccessToken', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/hook-status/1', {
+      const apiResponse = await apiContext.get('api/hook-status/1', {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Read below
| Type?             | improvement
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No test needed
| Fixed ticket?     | 
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).

## Description

The new API built in 8.1.0 has still no better name than “New API” and
the endpoints are prefixed with `/new-api/`. The name “New API” is written in a few files in the software.

I think we all agree it’s not the best name ever 😆 

I suggest we rename the API as “Command API”  (as the API is supposed to plug on existing Commands from CQRS). URL prefix would become `/command-api`.

I considered the idea of using `/api/v2` for the URL prefix but PS webservices already use the `/api` prefix so it could create routing issues and confusion.

I also modify the version number from 1.0.0 to 0.1.0 to highlight the fact this is experimental and might change a lot in the next version.

Note: the new API is experimental so if the name we pick now is bad, no worries, we can change in 9.0, but at least we’ll have a proper name in 8.1.0 and not the silly "new api" name.