### PR TITLE
Fix: When updating object images, old thumbnails are not deleted and updated

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1967,7 +1967,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
             /** @var PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration $imageFormatConfiguration */
             $imageFormatConfiguration = ServiceLocator::get('PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration');
-            $configuredImageFormats = $imageFormatConfiguration->getGenerationFormats();            
+            $configuredImageFormats = $imageFormatConfiguration->getGenerationFormats();
 
             $types = ImageType::getImagesTypes();
             foreach ($types as $image_type) {

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1965,11 +1965,27 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
                 return false;
             }
 
+            /** @var PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration $imageFormatConfiguration */
+            $imageFormatConfiguration = ServiceLocator::get('PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration');
+            $configuredImageFormats = $imageFormatConfiguration->getGenerationFormats();            
+
             $types = ImageType::getImagesTypes();
             foreach ($types as $image_type) {
                 if (file_exists($this->image_dir . $this->id . '-' . stripslashes($image_type['name']) . '.' . $this->image_format)
                 && !unlink($this->image_dir . $this->id . '-' . stripslashes($image_type['name']) . '.' . $this->image_format)) {
                     return false;
+                }
+
+                foreach ($configuredImageFormats as $imageFormat) {
+                    $file = $this->image_dir . $this->id . '-' . stripslashes($image_type['name']) . '.' . $imageFormat;
+                    if (file_exists($file)) {
+                        unlink($file);
+                    }
+
+                    $file = $this->image_dir . $this->id . '-' . stripslashes($image_type['name']) . '2x.' . $imageFormat;
+                    if (file_exists($file)) {
+                        unlink($file);
+                    }
                 }
             }
         }

--- a/src/Adapter/Image/Uploader/ManufacturerImageUploader.php
+++ b/src/Adapter/Image/Uploader/ManufacturerImageUploader.php
@@ -86,21 +86,35 @@ final class ManufacturerImageUploader extends AbstractImageUploader implements I
             ) {
                 $imageTypes = ImageType::getImagesTypes('manufacturers');
 
-                foreach ($imageTypes as $imageType) {
-                    $resized &= ImageManager::resize(
-                        _PS_MANU_IMG_DIR_ . $manufacturerId . '.jpg',
-                        _PS_MANU_IMG_DIR_ . $manufacturerId . '-' . stripslashes($imageType['name']) . '.jpg',
-                        (int) $imageType['width'],
-                        (int) $imageType['height']
-                    );
+                /** @var PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration $imageFormatConfiguration */
+                $imageFormatConfiguration = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get('PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration');
+                $configuredImageFormats = $imageFormatConfiguration->getGenerationFormats();
 
-                    if ($generateHighDpiImages) {
+                foreach ($imageTypes as $imageType) {
+                    foreach ($configuredImageFormats as $imageFormat) {
+                        // For JPG images, we let Imagemanager decide what to do and choose between JPG/PNG.
+                        // For webp and avif extensions, we want it to follow our command and ignore the original format.
+                        $forceFormat = ($imageFormat !== 'jpg');
+
                         $resized &= ImageManager::resize(
                             _PS_MANU_IMG_DIR_ . $manufacturerId . '.jpg',
-                            _PS_MANU_IMG_DIR_ . $manufacturerId . '-' . stripslashes($imageType['name']) . '2x.jpg',
-                            (int) $imageType['width'] * 2,
-                            (int) $imageType['height'] * 2
+                            _PS_MANU_IMG_DIR_ . $manufacturerId . '-' . stripslashes($imageType['name']) . '.' . $imageFormat,
+                            (int) $imageType['width'],
+                            (int) $imageType['height'],
+                            $imageFormat,
+                            $forceFormat
                         );
+
+                        if ($generateHighDpiImages) {
+                            $resized &= ImageManager::resize(
+                                _PS_MANU_IMG_DIR_ . $manufacturerId . '.jpg',
+                                _PS_MANU_IMG_DIR_ . $manufacturerId . '-' . stripslashes($imageType['name']) . '2x.' . $imageFormat,
+                                (int) $imageType['width'] * 2,
+                                (int) $imageType['height'] * 2,
+                                $imageFormat,
+                                $forceFormat
+                            );
+                        }
                     }
                 }
 

--- a/src/Adapter/Image/Uploader/ManufacturerImageUploader.php
+++ b/src/Adapter/Image/Uploader/ManufacturerImageUploader.php
@@ -86,7 +86,7 @@ final class ManufacturerImageUploader extends AbstractImageUploader implements I
             ) {
                 $imageTypes = ImageType::getImagesTypes('manufacturers');
 
-                /** @var PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration $imageFormatConfiguration */
+                /** @var \PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration $imageFormatConfiguration */
                 $imageFormatConfiguration = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get('PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration');
                 $configuredImageFormats = $imageFormatConfiguration->getGenerationFormats();
 

--- a/src/Adapter/Manufacturer/CommandHandler/DeleteManufacturerLogoImageHandler.php
+++ b/src/Adapter/Manufacturer/CommandHandler/DeleteManufacturerLogoImageHandler.php
@@ -63,15 +63,31 @@ class DeleteManufacturerLogoImageHandler extends AbstractManufacturerCommandHand
 
         $imageTypes = ImageType::getImagesTypes('manufacturers');
 
+        /** @var PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration $imageFormatConfiguration */
+        $imageFormatConfiguration = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get('PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration');
+        $configuredImageFormats = $imageFormatConfiguration->getGenerationFormats();
+
         foreach ($imageTypes as $imageType) {
-            $path = sprintf(
-                '%s%s-%s.jpg',
-                $this->imageDir,
-                $command->getManufacturerId()->getValue(),
-                stripslashes($imageType['name'])
-            );
-            if ($fs->exists($path)) {
-                $fs->remove($path);
+            foreach ($configuredImageFormats as $imageFormat) {
+                $path = sprintf(
+                    '%s%s-%s.' . $imageFormat,
+                    $this->imageDir,
+                    $command->getManufacturerId()->getValue(),
+                    stripslashes($imageType['name'])
+                );
+                if ($fs->exists($path)) {
+                    $fs->remove($path);
+                }
+
+                $path = sprintf(
+                    '%s%s-%s2x.' . $imageFormat,
+                    $this->imageDir,
+                    $command->getManufacturerId()->getValue(),
+                    stripslashes($imageType['name'])
+                );
+                if ($fs->exists($path)) {
+                    $fs->remove($path);
+                }
             }
         }
 

--- a/src/Adapter/Manufacturer/CommandHandler/DeleteManufacturerLogoImageHandler.php
+++ b/src/Adapter/Manufacturer/CommandHandler/DeleteManufacturerLogoImageHandler.php
@@ -63,7 +63,7 @@ class DeleteManufacturerLogoImageHandler extends AbstractManufacturerCommandHand
 
         $imageTypes = ImageType::getImagesTypes('manufacturers');
 
-        /** @var PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration $imageFormatConfiguration */
+        /** @var \PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration $imageFormatConfiguration */
         $imageFormatConfiguration = \PrestaShop\PrestaShop\Adapter\ServiceLocator::get('PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration');
         $configuredImageFormats = $imageFormatConfiguration->getGenerationFormats();
 


### PR DESCRIPTION
Delete all thumbnails of the given objects after uploading an image in backoffice.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #31809
| Sponsor company   | Codencode snc 

