### PR TITLE
Add of GeoCoordinates form type

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Type/GeoCoordinatesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/GeoCoordinatesType.php
@@ -85,6 +85,8 @@ class GeoCoordinatesType extends AbstractType
         $resolver->setDefaults([
             'label_latitude' => $this->translator->trans('Latitude', [], 'Admin.Global'),
             'label_longitude' => $this->translator->trans('Longitude', [], 'Admin.Global'),
+            'compound' => true,
+            'inherit_data' => true,
         ]);
         $resolver
             ->setAllowedTypes('label_latitude', 'string')

--- a/src/PrestaShopBundle/Form/Admin/Type/GeoCoordinatesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/GeoCoordinatesType.php
@@ -42,15 +42,14 @@ class GeoCoordinatesType extends AbstractType
      * @param TranslatorInterface $translator
      */
     public function __construct(
-        TranslatorInterface $translator
+        private readonly TranslatorInterface $translator
     ) {
-        $this->translator = $translator;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('latitude', NumberType::class, [
@@ -75,7 +74,7 @@ class GeoCoordinatesType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label_latitude' => $this->translator->trans('Latitude', [], 'Admin.Global'),
@@ -92,7 +91,7 @@ class GeoCoordinatesType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'geo_coordinates';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/GeoCoordinatesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/GeoCoordinatesType.php
@@ -39,11 +39,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class GeoCoordinatesType extends AbstractType
 {
     /**
-     * @var TranslatorInterface
-     */
-    protected $translator;
-
-    /**
      * @param TranslatorInterface $translator
      */
     public function __construct(

--- a/src/PrestaShopBundle/Form/Admin/Type/GeoCoordinatesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/GeoCoordinatesType.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+
+/**
+ * This form class is responsible to create a geolocation latitude/longitude coordinates field.
+ */
+class GeoCoordinatesType extends AbstractType
+{
+    /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    /**
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(
+        TranslatorInterface $translator
+    ) {
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('latitude', NumberType::class, [
+                'required' => false,
+                'label' => $options['label_latitude'],
+                'attr' => [
+                    'placeholder' => $this->translator->trans('-0.12345', [], 'Admin.Global'),
+                    'class' => 'latitude',
+                ],
+            ])
+            ->add('longitude', NumberType::class, [
+                'required' => false,
+                'label' => $options['label_longitude'],
+                'attr' => [
+                    'placeholder' => $this->translator->trans('-0.12345', [], 'Admin.Global'),
+                    'class' => 'longitude',
+                ],
+            ])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'label_latitude' => $this->translator->trans('Latitude', [], 'Admin.Global'),
+            'label_longitude' => $this->translator->trans('Longitude', [], 'Admin.Global'),
+        ]);
+        $resolver
+            ->setAllowedTypes('label_latitude', 'string')
+            ->setAllowedTypes('label_longitude', 'string')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'geo_coordinates';
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Type/GeoCoordinatesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/GeoCoordinatesType.php
@@ -28,10 +28,10 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Symfony\Component\Form\Extension\Core\Type\NumberType;
 
 /**
  * This form class is responsible to create a geolocation latitude/longitude coordinates field.

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -70,8 +70,6 @@ services:
       - '@prestashop.bundle.form.data_transformer.idn_converter'
 
   PrestaShopBundle\Form\Admin\Type\GeoCoordinatesType:
-    arguments:
-      - "@translator"
 
   PrestaShopBundle\Form\Admin\Type\LocaleChoiceType:
   PrestaShopBundle\Form\Admin\Type\DateRangeType:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -69,6 +69,10 @@ services:
     arguments:
       - '@prestashop.bundle.form.data_transformer.idn_converter'
 
+  PrestaShopBundle\Form\Admin\Type\GeoCoordinatesType:
+    arguments:
+        - "@translator"
+
   PrestaShopBundle\Form\Admin\Type\DateRangeType:
   PrestaShopBundle\Form\Admin\Category\SimpleCategory:
     deprecated: ~

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -71,7 +71,7 @@ services:
 
   PrestaShopBundle\Form\Admin\Type\GeoCoordinatesType:
     arguments:
-        - "@translator"
+      - "@translator"
 
   PrestaShopBundle\Form\Admin\Type\LocaleChoiceType:
   PrestaShopBundle\Form\Admin\Type\DateRangeType:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -73,6 +73,7 @@ services:
     arguments:
         - "@translator"
 
+  PrestaShopBundle\Form\Admin\Type\LocaleChoiceType:
   PrestaShopBundle\Form\Admin\Type\DateRangeType:
   PrestaShopBundle\Form\Admin\Category\SimpleCategory:
     deprecated: ~


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add a new Form Type to add geolocation coordinates (lat/lon).<br/>Will be used in the stores form migration to Symfony.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |  See below
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/32495
| Related PRs       | N/A
| Sponsor company   | N/A

## How to use it

Add it to a buildForm method with  `->add('latlon', GeoCoordinatesType::class, ['label' => $this->trans('Position', 'Admin.Global'), 'required' => false, 'empty_data' => '', 'label_latitude' => 'Latitude', 'label_longitude' => 'Longitude', 'attr' => ['class'=>'form-inline'],])`

## How to test

Please use example module PR https://github.com/PrestaShop/example-modules/pull/144/ :
- install the demosymfonyform module from the branch of my PR
- this module uses this form: please verify the form behaves as expected