### PR TITLE
Fix PDF invoice generator footer which only shows a %s

### DIFF
--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -220,7 +220,7 @@ class TranslateCore
                 'Admin.International.Notification'
             );
         }
-        
+
         if (!isset($_LANGPDF) || !is_array($_LANGPDF)) {
             return str_replace('"', '&quot;', Translate::checkAndReplaceArgs($string, $sprintf));
         }

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -220,8 +220,7 @@ class TranslateCore
                 'Admin.International.Notification'
             );
         }
-
-
+        
         if (!isset($_LANGPDF) || !is_array($_LANGPDF)) {
             return str_replace('"', '&quot;', Translate::checkAndReplaceArgs($string, $sprintf));
         }

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -229,7 +229,7 @@ class TranslateCore
         $string = preg_replace("/\\\*'/", "\'", $string);
         $key = md5($string);
 
-        $str = $_LANGPDF['PDF' . $key] ?? $string;
+        $str = (array_key_exists('PDF' . $key, $_LANGPDF) ? $_LANGPDF['PDF' . $key] : $string);
 
         if (
             $sprintf !== null &&

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -221,14 +221,15 @@ class TranslateCore
             );
         }
 
+
         if (!isset($_LANGPDF) || !is_array($_LANGPDF)) {
-            return str_replace('"', '&quot;', $string);
+            return str_replace('"', '&quot;', Translate::checkAndReplaceArgs($string, $sprintf));
         }
 
         $string = preg_replace("/\\\*'/", "\'", $string);
         $key = md5($string);
 
-        $str = (array_key_exists('PDF' . $key, $_LANGPDF) ? $_LANGPDF['PDF' . $key] : $string);
+        $str = $_LANGPDF['PDF' . $key] ?? $string;
 
         if (
             $sprintf !== null &&

--- a/pdf/footer.tpl
+++ b/pdf/footer.tpl
@@ -34,11 +34,11 @@
 			{if !empty($shop_phone) OR !empty($shop_fax)}
 				{l s='For more assistance, contact Support:' d='Shop.Pdf' pdf='true'}<br />
         {if !empty($shop_phone)}
-          {l s='Tel:' d='Shop.Pdf' pdf='true'} {$shop_phone|escape:'html':'UTF-8'}
+          {l s='Tel: %s' sprintf=[$shop_phone|escape:'html':'UTF-8'] d='Shop.Pdf' pdf='true'}
         {/if}
 
         {if !empty($shop_fax)}
-          {l s='Fax:' d='Shop.Pdf' pdf='true'} {$shop_fax|escape:'html':'UTF-8'}
+          {l s='Fax: %s' sprintf=[$shop_fax|escape:'html':'UTF-8'] d='Shop.Pdf' pdf='true'}
         {/if}
 				<br />
 			{/if}

--- a/pdf/footer.tpl
+++ b/pdf/footer.tpl
@@ -32,7 +32,7 @@
       {$shop_address|escape:'html':'UTF-8'}<br />
 
       {if !empty($shop_phone) OR !empty($shop_fax)}
-        {l s='For more assistance test, contact Support:' d='Shop.Pdf' pdf='true'}<br />
+        {l s='For more assistance, contact Support:' d='Shop.Pdf' pdf='true'}<br />
         {if !empty($shop_phone)}
           {l s='Tel: %s' sprintf=[$shop_phone|escape:'html':'UTF-8'] d='Shop.Pdf' pdf='true'}
         {/if}

--- a/pdf/footer.tpl
+++ b/pdf/footer.tpl
@@ -23,34 +23,34 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *}
 <table style="width: 100%;">
-	<tr>
-		<td style="text-align: center; font-size: 6pt; color: #444;  width:100%;">
-			{if $available_in_your_account}
-				{l s='An electronic version of this invoice is available in your account. To access it, log in to our website using your e-mail address and password (which you created when placing your first order).' d='Shop.Pdf' pdf='true'}
-				<br />
-			{/if}
-			{$shop_address|escape:'html':'UTF-8'}<br />
+  <tr>
+    <td style="text-align: center; font-size: 6pt; color: #444;  width:100%;">
+      {if $available_in_your_account}
+        {l s='An electronic version of this invoice is available in your account. To access it, log in to our website using your e-mail address and password (which you created when placing your first order).' d='Shop.Pdf' pdf='true'}
+        <br />
+      {/if}
+      {$shop_address|escape:'html':'UTF-8'}<br />
 
-			{if !empty($shop_phone) OR !empty($shop_fax)}
-				{l s='For more assistance, contact Support:' d='Shop.Pdf' pdf='true'}<br />
+      {if !empty($shop_phone) OR !empty($shop_fax)}
+        {l s='For more assistance test, contact Support:' d='Shop.Pdf' pdf='true'}<br />
         {if !empty($shop_phone)}
-          {l s='Tel:' d='Shop.Pdf' pdf='true'} {$shop_phone|escape:'html':'UTF-8'}
+          {l s='Tel: %s' sprintf=[$shop_phone|escape:'html':'UTF-8'] d='Shop.Pdf' pdf='true'}
         {/if}
 
         {if !empty($shop_fax)}
-          {l s='Fax:' d='Shop.Pdf' pdf='true'} {$shop_fax|escape:'html':'UTF-8'}
+          {l s='Fax: %s' sprintf=[$shop_fax|escape:'html':'UTF-8'] d='Shop.Pdf' pdf='true'}
         {/if}
-				<br />
-			{/if}
+        <br />
+      {/if}
 
-			{if isset($shop_details)}
-				{$shop_details|escape:'html':'UTF-8'}<br />
-			{/if}
+      {if isset($shop_details)}
+        {$shop_details|escape:'html':'UTF-8'}<br />
+      {/if}
 
-			{if isset($free_text)}
-				{$free_text|escape:'html':'UTF-8'}<br />
-			{/if}
-		</td>
-	</tr>
+      {if isset($free_text)}
+        {$free_text|escape:'html':'UTF-8'}<br />
+      {/if}
+    </td>
+  </tr>
 </table>
 

--- a/pdf/footer.tpl
+++ b/pdf/footer.tpl
@@ -33,13 +33,13 @@
 
 			{if !empty($shop_phone) OR !empty($shop_fax)}
 				{l s='For more assistance, contact Support:' d='Shop.Pdf' pdf='true'}<br />
-				{if !empty($shop_phone)}
-					{l s='Tel: %s' sprintf=[$shop_phone|escape:'html':'UTF-8'] d='Shop.Pdf' pdf='true'}
-				{/if}
+        {if !empty($shop_phone)}
+          {l s='Tel:' d='Shop.Pdf' pdf='true'} {$shop_phone|escape:'html':'UTF-8'}
+        {/if}
 
-				{if !empty($shop_fax)}
-					{l s='Fax: %s' sprintf=[$shop_fax|escape:'html':'UTF-8'] d='Shop.Pdf' pdf='true'}
-				{/if}
+        {if !empty($shop_fax)}
+          {l s='Fax:' d='Shop.Pdf' pdf='true'} {$shop_fax|escape:'html':'UTF-8'}
+        {/if}
 				<br />
 			{/if}
 

--- a/pdf/footer.tpl
+++ b/pdf/footer.tpl
@@ -23,34 +23,34 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *}
 <table style="width: 100%;">
-  <tr>
-    <td style="text-align: center; font-size: 6pt; color: #444;  width:100%;">
-      {if $available_in_your_account}
-        {l s='An electronic version of this invoice is available in your account. To access it, log in to our website using your e-mail address and password (which you created when placing your first order).' d='Shop.Pdf' pdf='true'}
-        <br />
-      {/if}
-      {$shop_address|escape:'html':'UTF-8'}<br />
+	<tr>
+		<td style="text-align: center; font-size: 6pt; color: #444;  width:100%;">
+			{if $available_in_your_account}
+				{l s='An electronic version of this invoice is available in your account. To access it, log in to our website using your e-mail address and password (which you created when placing your first order).' d='Shop.Pdf' pdf='true'}
+				<br />
+			{/if}
+			{$shop_address|escape:'html':'UTF-8'}<br />
 
-      {if !empty($shop_phone) OR !empty($shop_fax)}
-        {l s='For more assistance, contact Support:' d='Shop.Pdf' pdf='true'}<br />
+			{if !empty($shop_phone) OR !empty($shop_fax)}
+				{l s='For more assistance, contact Support:' d='Shop.Pdf' pdf='true'}<br />
         {if !empty($shop_phone)}
-          {l s='Tel: %s' sprintf=[$shop_phone|escape:'html':'UTF-8'] d='Shop.Pdf' pdf='true'}
+          {l s='Tel:' d='Shop.Pdf' pdf='true'} {$shop_phone|escape:'html':'UTF-8'}
         {/if}
 
         {if !empty($shop_fax)}
-          {l s='Fax: %s' sprintf=[$shop_fax|escape:'html':'UTF-8'] d='Shop.Pdf' pdf='true'}
+          {l s='Fax:' d='Shop.Pdf' pdf='true'} {$shop_fax|escape:'html':'UTF-8'}
         {/if}
-        <br />
-      {/if}
+				<br />
+			{/if}
 
-      {if isset($shop_details)}
-        {$shop_details|escape:'html':'UTF-8'}<br />
-      {/if}
+			{if isset($shop_details)}
+				{$shop_details|escape:'html':'UTF-8'}<br />
+			{/if}
 
-      {if isset($free_text)}
-        {$free_text|escape:'html':'UTF-8'}<br />
-      {/if}
-    </td>
-  </tr>
+			{if isset($free_text)}
+				{$free_text|escape:'html':'UTF-8'}<br />
+			{/if}
+		</td>
+	</tr>
 </table>
 


### PR DESCRIPTION
…ion only show a %s

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Bug fix once generate pdf footer shop phone and shop fax information not generated by sprinf, the twig  l function may not work as expected.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Go to BO->invoice->generate pdf, then check invoice pdf footer has show correctly shop phone and fax, you have to go to BO add your shop phone and fax number to test
| Fixed ticket?     | Fixes #32485