### PR TITLE
Removes the placeholder for the import form on advanced parameters

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
@@ -75,6 +75,7 @@ class ImportType extends TranslatorAwareType
             ])
             ->add('iso_lang', LocaleChoiceType::class, [
                 'required' => true,
+                'placeholder' => null,
                 'label' => $this->trans('Language of the file', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('The locale must be installed', 'Admin.Advparameters.Notification'),
             ])


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removes the placeholder for the import form on advanced parameters to bring back the language being selected by default
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See ticket
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/32443
| Related PRs       | N/A
| Sponsor company   | PrestaShop
