### PR TITLE
Fix(trans): removed old htmlspecialchar parameters in smarty config

### DIFF
--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -77,10 +77,6 @@ function smartyTranslate($params, $smarty)
         $sprintf = $params['sprintf'];
     }
 
-    if (($htmlEntities || $addSlashes)) {
-        $sprintf['legacy'] = $htmlEntities ? 'htmlspecialchars': 'addslashes';
-    }
-
     if ($isInPDF) {
         return Translate::postProcessTranslation(
             Translate::getPdfTranslation(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Remove the warnings on the new carrier page. The lines I removed were used in an old translation system. In the past, in the trans() function, we had a mechanic that removed htmlspecialchars or addslashes. This system has been removed and those lines I'm removing here were a remanent of this system. They were causing problems as the current systems was detecting a parameter that shouldn't be here and was trying to replace placeholders in the translated string where there was no need of such replacement.
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | 1- Go to BO > Shipping > Carriers <br>2- Go to new carrier page<br> 3- See the errors
| Fixed ticket?     | Fixes #32355 
| Related PRs       | related to #30415 #31593
| Sponsor company   | @PrestaShopCorp