### PR TITLE
Issue #22057 - Fix voucher verification on already discountedproducts

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -788,11 +788,10 @@ class CartRuleCore extends ObjectModel
 
         if ($this->reduction_exclude_special) {
             $products = $cart->getProducts();
-            $is_ok = false;
+            $is_ok = true;
             foreach ($products as $product) {
-                if (!$product['reduction_applies']) {
-                    $is_ok = true;
-
+                if ($product['reduction_applies']) {
+                    $is_ok = false;
                     break;
                 }
             }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix issue where a voucher applied to a discounted product, while it's specified in the rules that the voucher should not be applied is products are already discounted.
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     |no
| How to test?      | See #22057
| Fixed ticket?     | Fixes #22057
| Related PRs       | 
| Sponsor company   | Profileo