### PR TITLE
Migrate choice providers to autowiring 1/X

### DIFF
--- a/src/Core/Form/ChoiceProvider/DeliveryTimeNoteTypesProvider.php
+++ b/src/Core/Form/ChoiceProvider/DeliveryTimeNoteTypesProvider.php
@@ -57,24 +57,24 @@ final class DeliveryTimeNoteTypesProvider implements FormChoiceProviderInterface
     /**
      * @var int
      */
-    private $contextLanguageId;
+    private $langId;
 
     /**
      * @param TranslatorInterface $translator
      * @param RouterInterface $router
      * @param ConfigurationInterface $configuration
-     * @param int $contextLanguageId
+     * @param int $langId
      */
     public function __construct(
         TranslatorInterface $translator,
         RouterInterface $router,
         ConfigurationInterface $configuration,
-        int $contextLanguageId
+        int $langId
     ) {
         $this->translator = $translator;
         $this->router = $router;
         $this->configuration = $configuration;
-        $this->contextLanguageId = $contextLanguageId;
+        $this->langId = $langId;
     }
 
     /**
@@ -108,8 +108,8 @@ final class DeliveryTimeNoteTypesProvider implements FormChoiceProviderInterface
     private function getConfigurationLabel(string $configurationName): string
     {
         $config = $this->configuration->get($configurationName);
-        if (!empty($config[$this->contextLanguageId])) {
-            return $config[$this->contextLanguageId];
+        if (!empty($config[$this->langId])) {
+            return $config[$this->langId];
         }
 
         return $this->translator->trans('N/A', [], 'Admin.Global');

--- a/src/Core/Form/ChoiceProvider/LanguageChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/LanguageChoiceProvider.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
+use PrestaShop\PrestaShop\Adapter\Language\LanguageDataProvider;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 
 /**
@@ -38,16 +39,16 @@ use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 final class LanguageChoiceProvider implements FormChoiceProviderInterface
 {
     /**
-     * @var array
+     * @var LanguageDataProvider
      */
-    private $languages;
+    private $languageDataProvider;
 
     /**
-     * @param array $languages
+     * @param LanguageDataProvider $languageDataProvider
      */
-    public function __construct(array $languages)
+    public function __construct(LanguageDataProvider $languageDataProvider)
     {
-        $this->languages = $languages;
+        $this->languageDataProvider = $languageDataProvider;
     }
 
     /**
@@ -59,7 +60,7 @@ final class LanguageChoiceProvider implements FormChoiceProviderInterface
     {
         $choices = [];
 
-        foreach ($this->languages as $language) {
+        foreach ($this->languageDataProvider->getLanguages(false) as $language) {
             $choices[$language['name']] = $language['id_lang'];
         }
 

--- a/src/Core/Form/ChoiceProvider/LanguageChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/LanguageChoiceProvider.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
-use PrestaShop\PrestaShop\Adapter\Language\LanguageDataProvider;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 
 /**
@@ -39,16 +38,16 @@ use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 final class LanguageChoiceProvider implements FormChoiceProviderInterface
 {
     /**
-     * @var LanguageDataProvider
+     * @var array
      */
-    private $languageDataProvider;
+    private $languages;
 
     /**
-     * @param LanguageDataProvider $languageDataProvider
+     * @param array $languages
      */
-    public function __construct(LanguageDataProvider $languageDataProvider)
+    public function __construct(array $languages)
     {
-        $this->languageDataProvider = $languageDataProvider;
+        $this->languages = $languages;
     }
 
     /**
@@ -60,7 +59,7 @@ final class LanguageChoiceProvider implements FormChoiceProviderInterface
     {
         $choices = [];
 
-        foreach ($this->languageDataProvider->getLanguages(false) as $language) {
+        foreach ($this->languages as $language) {
             $choices[$language['name']] = $language['id_lang'];
         }
 

--- a/src/Core/Form/ChoiceProvider/OrderStateByIdChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/OrderStateByIdChoiceProvider.php
@@ -41,7 +41,7 @@ final class OrderStateByIdChoiceProvider implements FormChoiceProviderInterface,
     /**
      * @var int language ID
      */
-    private $languageId;
+    private $langId;
 
     /**
      * @var OrderStateDataProviderInterface
@@ -59,18 +59,18 @@ final class OrderStateByIdChoiceProvider implements FormChoiceProviderInterface,
     private $translator;
 
     /**
-     * @param int $languageId language ID
+     * @param int $langId language ID
      * @param OrderStateDataProviderInterface $orderStateDataProvider
      * @param ColorBrightnessCalculator $colorBrightnessCalculator
      * @param TranslatorInterface $translator
      */
     public function __construct(
-        $languageId,
+        $langId,
         OrderStateDataProviderInterface $orderStateDataProvider,
         ColorBrightnessCalculator $colorBrightnessCalculator,
         TranslatorInterface $translator
     ) {
-        $this->languageId = $languageId;
+        $this->langId = $langId;
         $this->orderStateDataProvider = $orderStateDataProvider;
         $this->colorBrightnessCalculator = $colorBrightnessCalculator;
         $this->translator = $translator;
@@ -85,7 +85,7 @@ final class OrderStateByIdChoiceProvider implements FormChoiceProviderInterface,
      */
     public function getChoices(array $options = [])
     {
-        $orderStates = $this->orderStateDataProvider->getOrderStates($this->languageId);
+        $orderStates = $this->orderStateDataProvider->getOrderStates($this->langId);
         $choices = [];
 
         foreach ($orderStates as $orderState) {
@@ -106,7 +106,7 @@ final class OrderStateByIdChoiceProvider implements FormChoiceProviderInterface,
      */
     public function getChoicesAttributes()
     {
-        $orderStates = $this->orderStateDataProvider->getOrderStates($this->languageId);
+        $orderStates = $this->orderStateDataProvider->getOrderStates($this->langId);
         $attrs = [];
 
         foreach ($orderStates as $orderState) {

--- a/src/Core/Form/ChoiceProvider/OutOfStockTypeChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/OutOfStockTypeChoiceProvider.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -42,20 +43,20 @@ final class OutOfStockTypeChoiceProvider implements FormChoiceProviderInterface
     private $translator;
 
     /**
-     * @var bool
+     * @var ShopConfigurationInterface
      */
-    private $outOfStockProductOrderingAvailableByDefault;
+    private $configuration;
 
     /**
      * @param TranslatorInterface $translator
-     * @param bool $outOfStockProductOrderingAvailableByDefault
+     * @param ShopConfigurationInterface $configuration
      */
     public function __construct(
         TranslatorInterface $translator,
-        bool $outOfStockProductOrderingAvailableByDefault
+        ShopConfigurationInterface $configuration
     ) {
         $this->translator = $translator;
-        $this->outOfStockProductOrderingAvailableByDefault = $outOfStockProductOrderingAvailableByDefault;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -69,7 +70,7 @@ final class OutOfStockTypeChoiceProvider implements FormChoiceProviderInterface
         $defaultLabel = sprintf(
             '%s (%s)',
             $this->translator->trans('Use default behavior', [], 'Admin.Catalog.Feature'),
-            $this->outOfStockProductOrderingAvailableByDefault ? $allowOrdersLabel : $denyOrdersLabel
+            $this->configuration->get('PS_ORDER_OUT_OF_STOCK') ? $allowOrdersLabel : $denyOrdersLabel
         );
 
         return [

--- a/src/Core/Form/ChoiceProvider/PackStockTypeChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/PackStockTypeChoiceProvider.php
@@ -50,7 +50,7 @@ final class PackStockTypeChoiceProvider implements FormChoiceProviderInterface
      */
     public function __construct(
         TranslatorInterface $translator,
-        ShopConfigurationInterface $shopConfiguration,
+        ShopConfigurationInterface $shopConfiguration
     ) {
         $this->translator = $translator;
         $this->shopConfiguration = $shopConfiguration;
@@ -66,7 +66,7 @@ final class PackStockTypeChoiceProvider implements FormChoiceProviderInterface
         $defaultLabel = sprintf(
             '%s (%s)',
             $this->translator->trans('Default', [], 'Admin.Global'),
-            array_search($this->shopConfiguration->getInt('PS_PACK_STOCK_TYPE'), $choices, true)
+            array_search((int) $this->shopConfiguration->get('PS_PACK_STOCK_TYPE'), $choices, true)
         );
 
         $choices[$defaultLabel] = PackStockType::STOCK_TYPE_DEFAULT;

--- a/src/Core/Form/ChoiceProvider/PackStockTypeChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/PackStockTypeChoiceProvider.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackStockType;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -39,33 +40,33 @@ final class PackStockTypeChoiceProvider implements FormChoiceProviderInterface
     private $translator;
 
     /**
-     * @var int
+     * @var ShopConfigurationInterface
      */
-    private $defaultPackStockType;
+    private $shopConfiguration;
 
     /**
      * @param TranslatorInterface $translator
-     * @param int $defaultPackStockType
+     * @param ShopConfigurationInterface $shopConfiguration
      */
     public function __construct(
         TranslatorInterface $translator,
-        int $defaultPackStockType
+        ShopConfigurationInterface $shopConfiguration,
     ) {
         $this->translator = $translator;
-        $this->defaultPackStockType = $defaultPackStockType;
+        $this->shopConfiguration = $shopConfiguration;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getChoices()
+    public function getChoices(): array
     {
         $choices = $this->getLabelValuePairs();
 
         $defaultLabel = sprintf(
             '%s (%s)',
             $this->translator->trans('Default', [], 'Admin.Global'),
-            array_search($this->defaultPackStockType, $choices, true)
+            array_search($this->shopConfiguration->getInt('PS_PACK_STOCK_TYPE'), $choices, true)
         );
 
         $choices[$defaultLabel] = PackStockType::STOCK_TYPE_DEFAULT;

--- a/src/Core/Form/ChoiceProvider/ProductTypeChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/ProductTypeChoiceProvider.php
@@ -28,8 +28,8 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
-use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceAttributeProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -42,20 +42,20 @@ class ProductTypeChoiceProvider implements FormChoiceProviderInterface, FormChoi
     private $translator;
 
     /**
-     * @var ShopConfigurationInterface
+     * @var FeatureInterface
      */
-    private $configuration;
+    private $combinationFeature;
 
     /**
      * @param TranslatorInterface $translator
-     * @param ShopConfigurationInterface $configuration
+     * @param FeatureInterface $combinationFeature
      */
     public function __construct(
         TranslatorInterface $translator,
-        ShopConfigurationInterface $configuration
+        FeatureInterface $combinationFeature
     ) {
         $this->translator = $translator;
-        $this->configuration = $configuration;
+        $this->combinationFeature = $combinationFeature;
     }
 
     /**
@@ -95,7 +95,7 @@ class ProductTypeChoiceProvider implements FormChoiceProviderInterface, FormChoi
             $this->trans('Virtual product', 'Admin.Catalog.Feature') => ProductType::TYPE_VIRTUAL,
         ];
 
-        if (!$this->configuration->combinationIsActive()) {
+        if (!$this->combinationFeature->isActive()) {
             unset($choices[$this->trans('Product with combinations', 'Admin.Catalog.Feature')]);
         }
 

--- a/src/Core/Form/ChoiceProvider/ProductTypeChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/ProductTypeChoiceProvider.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
-use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceAttributeProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
@@ -42,17 +42,17 @@ class ProductTypeChoiceProvider implements FormChoiceProviderInterface, FormChoi
     private $translator;
 
     /**
-     * @var Configuration
+     * @var ShopConfigurationInterface
      */
     private $configuration;
 
     /**
      * @param TranslatorInterface $translator
-     * @param Configuration $configuration
+     * @param ShopConfigurationInterface $configuration
      */
     public function __construct(
         TranslatorInterface $translator,
-        Configuration $configuration
+        ShopConfigurationInterface $configuration
     ) {
         $this->translator = $translator;
         $this->configuration = $configuration;

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -142,9 +142,7 @@ services:
 
   prestashop.adapter.language.language_pack_installer:
     class: 'PrestaShop\PrestaShop\Adapter\Language\LanguagePackInstaller'
-    arguments:
-      - '@translator'
-      - '@prestashop.core.foundation.version'
+    autowire: true
 
   prestashop.adapter.language.validator:
     class: 'PrestaShop\PrestaShop\Adapter\Language\LanguageValidator'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -134,8 +134,11 @@ services:
       - '@prestashop.adapter.multistore_feature'
       - '@prestashop.core.form.choice_provider.invoice_model_by_name'
 
+  PrestaShop\PrestaShop\Adapter\Language\LanguageDataProvider:
+    public: false
+
   prestashop.adapter.data_provider.language:
-    class: 'PrestaShop\PrestaShop\Adapter\Language\LanguageDataProvider'
+    alias: 'PrestaShop\PrestaShop\Adapter\Language\LanguageDataProvider'
 
   prestashop.adapter.language.activator:
     class: 'PrestaShop\PrestaShop\Adapter\Language\LanguageActivator'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_provider_common.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_provider_common.yml
@@ -3,7 +3,11 @@ services:
     public: true
 
   prestashop.adapter.data_provider.country:
-    class: PrestaShop\PrestaShop\Adapter\Country\CountryDataProvider
+    alias: PrestaShop\PrestaShop\Adapter\Country\CountryDataProvider
+
+  PrestaShop\PrestaShop\Adapter\Country\CountryDataProvider:
+    public: false
+    autowire: true
 
   PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider:
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/adapter/shop_feature.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/shop_feature.yml
@@ -2,9 +2,11 @@ services:
   _defaults:
     public: true
 
-  prestashop.adapter.combination_feature:
-    class: 'PrestaShop\PrestaShop\Adapter\Feature\CombinationFeature'
+  PrestaShop\PrestaShop\Adapter\Feature\CombinationFeature:
+    public: false
     arguments: [ '@prestashop.adapter.legacy.configuration' ]
+  prestashop.adapter.combination_feature:
+    alias: 'PrestaShop\PrestaShop\Adapter\Feature\CombinationFeature'
 
   prestashop.adapter.feature.feature:
     class: 'PrestaShop\PrestaShop\Adapter\Feature\FeatureFeature'

--- a/src/PrestaShopBundle/Resources/config/services/core/domain/theme.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/domain/theme.yml
@@ -32,7 +32,7 @@ services:
   prestashop.core.domain.theme.command_handler.adapt_theme_to_rtl_languages_handler:
     class: 'PrestaShop\PrestaShop\Core\Domain\Theme\CommandHandler\AdaptThemeToRTLLanguagesHandler'
     arguments:
-      - '@prestashop.core.localization.rtl.processor_factory'
+      - '@PrestaShop\PrestaShop\Core\Localization\RTL\StyleSheetProcessorFactory'
     tags:
       - name: 'tactician.handler'
         command: PrestaShop\PrestaShop\Core\Domain\Theme\Command\AdaptThemeToRTLLanguagesCommand

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -9,7 +9,15 @@ services:
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\:
     resource: '../../../Core/Form/ChoiceProvider/*'
 
+  # Todo: migrate controllers to use DI and make this private.
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider:
+    public: true
+
   PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ZoneByIdChoiceProvider:
+
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductTypeChoiceProvider:
+    arguments:
+      $combinationFeature: '@PrestaShop\PrestaShop\Adapter\Feature\CombinationFeature'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TimezoneByNameChoiceProvider:
     arguments:
@@ -116,18 +124,6 @@ services:
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerServiceOrderMessagesChoiceProvider:
     arguments:
       - '@prestashop.adapter.order_message.order_message_provider'
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DeliveryTimeNoteTypesProvider:
-    arguments:
-      - '@translator'
-      - '@router'
-      - '@prestashop.adapter.legacy.configuration'
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OutOfStockTypeChoiceProvider:
-    arguments:
-      - '@translator'
-      - '@=service("prestashop.adapter.legacy.configuration").getBoolean("PS_ORDER_OUT_OF_STOCK")'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductImagesChoiceProvider:
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -1,6 +1,7 @@
 services:
   _defaults:
-    public: true
+    public: false
+    autowire: true
 
   prestashop.core.form.choice_provider.language_by_id:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageByIdChoiceProvider'
@@ -82,13 +83,9 @@ services:
 
   prestashop.core.form.choice_provider.translation_type:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TranslationTypeChoiceProvider'
-    arguments:
-      - '@translator'
 
   prestashop.core.form.choice_provider.email_content_type:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\EmailContentTypeChoiceProvider'
-    arguments:
-      - '@translator'
 
   prestashop.core.form.choice_provider.theme_by_name:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameChoiceProvider'
@@ -107,23 +104,15 @@ services:
 
   prestashop.core.form.choice_provider.status:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\StatusChoiceProvider'
-    arguments:
-      - '@translator'
 
   prestashop.core.form.choice_provider.canonical_redirect_type:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CanonicalRedirectTypeChoiceProvider'
-    arguments:
-      - '@translator'
 
   prestashop.core.form.choice_provider.category_delete_mode:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CategoryDeleteModeChoiceProvider'
-    arguments:
-      - '@translator'
 
   prestashop.core.form.choice_provider.customer_required_fields:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerRequiredFieldsChoiceProvider'
-    arguments:
-      - '@translator'
 
   prestashop.core.form.choice_provider.import_match_configuration:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImportMatchConfigurationChoiceProvider'
@@ -138,8 +127,6 @@ services:
 
   prestashop.core.form.choice_provider.customer_delete_method:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerDeleteMethodChoiceProvider'
-    arguments:
-      - '@translator'
 
   prestashop.core.form.choice_provider.theme_page_layouts:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemePageLayoutsChoiceProvider'
@@ -163,8 +150,6 @@ services:
 
   prestashop.core.form.choice_provider.permissions_choice_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PermissionsChoiceProvider'
-    arguments:
-      - '@translator'
 
   prestashop.core.form.choice_provider.default_meta_page_name:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DefaultMetaPageNameChoiceProvider'
@@ -180,8 +165,6 @@ services:
 
   prestashop.core.form.choice_provider.tax_address_type_choice_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TaxAddressTypeChoiceProvider'
-    arguments:
-      - '@translator'
 
   prestashop.core.form.choice_provider.tax_rule_group_choice_provider:
     class: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\TaxRuleGroupChoiceProvider'
@@ -212,8 +195,6 @@ services:
 
   prestashop.core.form.choice.provider.order_discount_type:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderDiscountTypeChoiceProvider'
-    arguments:
-      - '@translator'
 
   prestashop.core.form.choice_provider.address_required_fields:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\AddressRequiredFieldsChoiceProvider'
@@ -244,13 +225,9 @@ services:
 
   prestashop.core.form.choice_provider.product_visibility_choice_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductVisibilityChoiceProvider'
-    arguments:
-      - '@translator'
 
   prestashop.core.form.choice_provider.product_condition_choice_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductConditionChoiceProvider'
-    arguments:
-      - '@translator'
 
   prestashop.core.form.choice_provider.out_of_stock_type_choice_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OutOfStockTypeChoiceProvider'
@@ -266,8 +243,6 @@ services:
 
   prestashop.core.form.choice_provider.customization_field_type_choice_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomizationFieldTypeChoiceProvider'
-    arguments:
-      - '@translator'
 
   prestashop.core.form.choice_provider.product_images_choice_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductImagesChoiceProvider'
@@ -293,13 +268,9 @@ services:
 
   prestashop.core.form.choice_provider.specific_price_priority_choice_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\SpecificPricePriorityChoiceProvider'
-    arguments:
-      - '@translator'
 
   prestashop.core.form.choice_provider.gender_choice_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GenderChoiceProvider'
-    arguments:
-      - '@translator'
 
   prestashop.core.form.choice_provider.contact_type_choice_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider'
@@ -308,29 +279,13 @@ services:
 
   prestashop.core.form.choice_provider.customer_thread_statuses_choice_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerThreadStatusesChoiceProvider'
-    arguments:
-      - '@translator'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ReductionTypeChoiceProvider:
-    autowire: true
-    public: false
-
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DiscountApplicationChoiceProvider:
-    autowire: true
-    public: false
-
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TaxInclusionChoiceProvider:
-    autowire: true
-    public: false
-
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ShippingInclusionChoiceProvider:
-    autowire: true
-    public: false
-
   # Should be public as used in some controllers
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider:
-    autowire: true
-    public: true
 
   # deprecated services
   prestashop.core.form.choice_provider.currency_by_id:

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -3,282 +3,222 @@ services:
     public: false
     autowire: true
 
-  prestashop.core.form.choice_provider.language_by_id:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageByIdChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageByIdChoiceProvider:
     arguments:
       - '@prestashop.adapter.data_provider.language'
 
-  prestashop.core.form.choice_provider.all_languages:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageChoiceProvider:
     arguments:
       - '@=service("prestashop.adapter.data_provider.language").getLanguages(false)'
 
-  prestashop.core.form.choice_provider.country_by_id:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIdChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIdChoiceProvider:
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
       - '@prestashop.adapter.data_provider.country'
 
-  prestashop.core.form.choice_provider.timezone_by_name:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TimezoneByNameChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TimezoneByNameChoiceProvider:
     arguments:
       - '@prestashop.core.admin.timezone.repository'
 
-  prestashop.core.form.choice_provider.localization_pack_by_iso_code:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LocalizationPackByIsoCodeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LocalizationPackByIsoCodeChoiceProvider:
     arguments:
       - '@prestashop.core.localization.pack.loader.remote'
       - '@prestashop.core.localization.pack.loader.local'
       - '@prestashop.adapter.legacy.configuration'
       - '@translator'
 
-  prestashop.core.form.choice_provider.non_installed_localization:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\NonInstalledLocalizationChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\NonInstalledLocalizationChoiceProvider:
     arguments:
       - '@=service("prestashop.core.language.pack.loader.remote").getLanguagePackList()'
       - '@prestashop.adapter.language.validator'
       - '@prestashop.adapter.data_provider.language'
 
-  prestashop.core.form.choice_provider.country_by_iso_code:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIsoCodeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIsoCodeChoiceProvider:
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
       - '@prestashop.adapter.data_provider.country'
 
-  prestashop.core.form.choice_provider.group_by_id:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GroupByIdChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GroupByIdChoiceProvider:
     arguments:
       - '@prestashop.adapter.data_provider.group'
       - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
 
-  prestashop.core.form.choice_provider.carrier_by_reference_id:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CarrierByReferenceChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CarrierByReferenceChoiceProvider:
     arguments:
       - '@prestashop.adapter.data_provider.carrier'
       - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
 
-  prestashop.core.form.choice_provider.order_state_by_id:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderStateByIdChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderStateByIdChoiceProvider:
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
       - '@prestashop.adapter.data_provider.order_state'
       - '@PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator'
       - '@translator'
 
-  prestashop.core.form.choice_provider.invoice_model_by_name:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\InvoiceModelByNameChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\InvoiceModelByNameChoiceProvider:
     arguments:
       - '@prestashop.core.file.cached_finder.invoice_model'
 
-  prestashop.core.form.choice_provider.mail_method:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\MailMethodChoiceProvider'
-    arguments:
-      - '@translator'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\MailMethodChoiceProvider:
 
-  prestashop.core.form.choice_provider.contact_by_id:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactByIdChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactByIdChoiceProvider:
     arguments:
       - '@prestashop.adapter.contact.repository'
       - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
 
-  prestashop.core.form.choice_provider.translation_type:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TranslationTypeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TranslationTypeChoiceProvider:
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\EmailContentTypeChoiceProvider:
 
-  prestashop.core.form.choice_provider.email_content_type:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\EmailContentTypeChoiceProvider'
-
-  prestashop.core.form.choice_provider.theme_by_name:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameChoiceProvider:
     arguments:
       - '@=service("prestashop.core.addon.theme.repository").getListAsCollection()'
 
-  prestashop.core.form.choice_provider.theme_by_name_with_emails:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameWithEmailsChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameWithEmailsChoiceProvider:
     arguments:
       - '@=service("prestashop.core.addon.theme.repository").getListAsCollection()'
 
-  prestashop.core.form.choice_provider.module_by_name:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ModuleByNameChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ModuleByNameChoiceProvider:
     arguments:
       - '@=service("prestashop.core.admin.module.repository").getInstalledModules()'
 
-  prestashop.core.form.choice_provider.status:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\StatusChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\StatusChoiceProvider:
 
-  prestashop.core.form.choice_provider.canonical_redirect_type:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CanonicalRedirectTypeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CanonicalRedirectTypeChoiceProvider:
 
-  prestashop.core.form.choice_provider.category_delete_mode:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CategoryDeleteModeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CategoryDeleteModeChoiceProvider:
 
-  prestashop.core.form.choice_provider.customer_required_fields:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerRequiredFieldsChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerRequiredFieldsChoiceProvider:
 
-  prestashop.core.form.choice_provider.import_match_configuration:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImportMatchConfigurationChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImportMatchConfigurationChoiceProvider:
     arguments:
       - '@=service("prestashop.core.admin.import_match.repository").findAll()'
 
-  prestashop.core.form.choice_provider.import_entity_field:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImportEntityFieldChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImportEntityFieldChoiceProvider:
     arguments:
       - '@=service("prestashop.core.import.fields_provider_finder")'
       - '@=service("session").get("entity")'
 
-  prestashop.core.form.choice_provider.customer_delete_method:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerDeleteMethodChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerDeleteMethodChoiceProvider:
 
-  prestashop.core.form.choice_provider.theme_page_layouts:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemePageLayoutsChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemePageLayoutsChoiceProvider:
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getContext().shop.theme'
 
-  prestashop.core.form.choice_provider.theme_zip:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeZipChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeZipChoiceProvider:
     arguments:
       - '@prestashop.adapter.legacy.configuration'
 
-  prestashop.core.form.choice_provider.theme:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeChoiceProvider:
     arguments:
       - '@prestashop.core.addon.theme.theme_provider'
 
-  prestashop.core.form.choice_provider.currency_name_by_iso_code:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyNameByIsoCodeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyNameByIsoCodeChoiceProvider:
     arguments:
       - '@=service("prestashop.core.localization.cldr.locale_repository").getLocale(service("prestashop.adapter.legacy.context").getContext().language.getLocale()).getAllCurrencies()'
 
-  prestashop.core.form.choice_provider.permissions_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PermissionsChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PermissionsChoiceProvider:
 
-  prestashop.core.form.choice_provider.default_meta_page_name:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DefaultMetaPageNameChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DefaultMetaPageNameChoiceProvider:
     arguments:
       - '@request_stack'
       - '@prestashop.adapter.meta.data_provider'
 
-  prestashop.core.form.choice_provider.module_meta_page_name:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ModuleMetaPageNameChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ModuleMetaPageNameChoiceProvider:
     arguments:
       - '@request_stack'
       - '@prestashop.adapter.meta.data_provider'
 
-  prestashop.core.form.choice_provider.tax_address_type_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TaxAddressTypeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TaxAddressTypeChoiceProvider:
 
-  prestashop.core.form.choice_provider.tax_rule_group_choice_provider:
-    class: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\TaxRuleGroupChoiceProvider'
+  PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\TaxRuleGroupChoiceProvider:
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getContext().country.id'
       - '@PrestaShop\PrestaShop\Adapter\TaxRulesGroup\Repository\TaxRulesGroupRepository'
       - '@PrestaShop\PrestaShop\Adapter\Tax\TaxComputer'
 
-  prestashop.core.form.choice_provider.cms_categories:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CmsCategoriesChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CmsCategoriesChoiceProvider:
     arguments:
       - '@=service("prestashop.adapter.cms_page.categories_provider").getAllNestedCategories()'
 
-  prestashop.core.form.choice_provider.accessible_tab:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TabChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TabChoiceProvider:
     arguments:
       - '@=service("prestashop.adapter.data_provider.tab").getViewableTabsForContextEmployee(service("prestashop.adapter.legacy.context").getLanguage().id)'
 
-  prestashop.core.form.choice_provider.profile:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProfileChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProfileChoiceProvider:
     arguments:
       - '@=service("prestashop.adapter.data_provider.profile").getProfiles(service("prestashop.adapter.legacy.context").getLanguage().id)'
 
-  prestashop.core.form.choice_provider.mail_themes:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\MailThemeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\MailThemeChoiceProvider:
     arguments:
       - '@prestashop.core.mail_template.theme_catalog'
 
-  prestashop.core.form.choice.provider.order_discount_type:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderDiscountTypeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderDiscountTypeChoiceProvider:
 
-  prestashop.core.form.choice_provider.address_required_fields:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\AddressRequiredFieldsChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\AddressRequiredFieldsChoiceProvider:
 
-  prestashop.core.form.choice_provider.customer_addresses_by_id:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerAddressesChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerAddressesChoiceProvider:
     arguments:
       - '@prestashop.adapter.data_provider.customer'
       - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
 
-  prestashop.core.form.choice_provider.customer_service_order_messages_name:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerServiceOrderMessagesNameChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerServiceOrderMessagesNameChoiceProvider:
     arguments:
       - '@=service("prestashop.adapter.order_message.order_message_provider").getMessages()'
 
-  prestashop.core.form.choice_provider.customer_service_order_messages:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerServiceOrderMessagesChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerServiceOrderMessagesChoiceProvider:
     arguments:
       - '@prestashop.adapter.order_message.order_message_provider'
 
-  prestashop.core.form.choice_provider.delivery_time_note_types_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DeliveryTimeNoteTypesProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DeliveryTimeNoteTypesProvider:
     arguments:
       - '@translator'
       - '@router'
       - '@prestashop.adapter.legacy.configuration'
       - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
 
-  prestashop.core.form.choice_provider.product_visibility_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductVisibilityChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductVisibilityChoiceProvider:
 
-  prestashop.core.form.choice_provider.product_condition_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductConditionChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductConditionChoiceProvider:
 
-  prestashop.core.form.choice_provider.out_of_stock_type_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OutOfStockTypeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OutOfStockTypeChoiceProvider:
     arguments:
       - '@translator'
       - '@=service("prestashop.adapter.legacy.configuration").getBoolean("PS_ORDER_OUT_OF_STOCK")'
 
-  prestashop.core.form.choice_provider.pack_stock_type_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PackStockTypeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PackStockTypeChoiceProvider:
     arguments:
       - '@translator'
       - '@=service("prestashop.adapter.legacy.configuration").getInt("PS_PACK_STOCK_TYPE")'
 
-  prestashop.core.form.choice_provider.customization_field_type_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomizationFieldTypeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomizationFieldTypeChoiceProvider:
 
-  prestashop.core.form.choice_provider.product_images_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductImagesChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductImagesChoiceProvider:
     arguments:
       - '@prestashop.core.command_bus'
       - '@=service("prestashop.adapter.legacy.configuration").getInt("PS_SHOP_DEFAULT")'
       - "@=service('prestashop.adapter.shop.context').getContextShopID()"
 
-  prestashop.core.form.choice_provider.product_type_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductTypeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductTypeChoiceProvider:
     arguments:
       - '@translator'
       - '@prestashop.adapter.legacy.configuration'
 
-  prestashop.core.form.choice_provider.zone_by_id:
-    class: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ZoneByIdChoiceProvider'
+  PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ZoneByIdChoiceProvider:
 
-  prestashop.core.form.choice_provider.configurable_country_by_id:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIdConfigurableChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIdConfigurableChoiceProvider:
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
       - '@prestashop.adapter.data_provider.country'
 
-  prestashop.core.form.choice_provider.specific_price_priority_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\SpecificPricePriorityChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\SpecificPricePriorityChoiceProvider:
 
-  prestashop.core.form.choice_provider.gender_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GenderChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GenderChoiceProvider:
 
-  prestashop.core.form.choice_provider.contact_type_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider:
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
 
-  prestashop.core.form.choice_provider.customer_thread_statuses_choice_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerThreadStatusesChoiceProvider'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerThreadStatusesChoiceProvider:
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ReductionTypeChoiceProvider:
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DiscountApplicationChoiceProvider:
@@ -295,5 +235,293 @@ services:
 
   prestashop.core.form.choice_provider.tax_inclusion:
     alias: PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TaxInclusionChoiceProvider
+    public: true
+    deprecated: ~
+
+
+
+# deprecated old notation since 9.0
+  prestashop.core.form.choice_provider.language_by_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageByIdChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.all_languages:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.country_by_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIdChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.timezone_by_name:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TimezoneByNameChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.localization_pack_by_iso_code:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LocalizationPackByIsoCodeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.non_installed_localization:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\NonInstalledLocalizationChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.country_by_iso_code:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIsoCodeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.group_by_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GroupByIdChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.carrier_by_reference_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CarrierByReferenceChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.order_state_by_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderStateByIdChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.invoice_model_by_name:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\InvoiceModelByNameChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.mail_method:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\MailMethodChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.contact_by_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactByIdChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.translation_type:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TranslationTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.email_content_type:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\EmailContentTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.theme_by_name:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.theme_by_name_with_emails:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameWithEmailsChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.module_by_name:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ModuleByNameChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.status:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\StatusChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.canonical_redirect_type:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CanonicalRedirectTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.category_delete_mode:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CategoryDeleteModeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.customer_required_fields:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerRequiredFieldsChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.import_match_configuration:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImportMatchConfigurationChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.import_entity_field:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImportEntityFieldChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.customer_delete_method:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerDeleteMethodChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.theme_page_layouts:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemePageLayoutsChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.theme_zip:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeZipChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.theme:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.currency_name_by_iso_code:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyNameByIsoCodeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.permissions_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PermissionsChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.default_meta_page_name:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DefaultMetaPageNameChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.module_meta_page_name:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ModuleMetaPageNameChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.tax_address_type_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TaxAddressTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.tax_rule_group_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\TaxRuleGroupChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.cms_categories:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CmsCategoriesChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.accessible_tab:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TabChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.profile:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProfileChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.mail_themes:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\MailThemeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice.provider.order_discount_type:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderDiscountTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.address_required_fields:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\AddressRequiredFieldsChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.customer_addresses_by_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerAddressesChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.customer_service_order_messages_name:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerServiceOrderMessagesNameChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.customer_service_order_messages:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerServiceOrderMessagesChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.delivery_time_note_types_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DeliveryTimeNoteTypesProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.product_visibility_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductVisibilityChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.product_condition_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductConditionChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.out_of_stock_type_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OutOfStockTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.pack_stock_type_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PackStockTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.customization_field_type_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomizationFieldTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.product_images_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductImagesChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.product_type_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.zone_by_id:
+    alias: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ZoneByIdChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.configurable_country_by_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIdConfigurableChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.specific_price_priority_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\SpecificPricePriorityChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.gender_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GenderChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.contact_type_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.customer_thread_statuses_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerThreadStatusesChoiceProvider'
     public: true
     deprecated: ~

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -9,11 +9,16 @@ services:
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\:
     resource: '../../../Core/Form/ChoiceProvider/*'
 
+  # Todo, place this service into the correct place, one day
+  PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ZoneByIdChoiceProvider: ~
+
   # Todo: migrate controllers to use DI and make this private.
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider:
     public: true
 
-  PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ZoneByIdChoiceProvider:
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageChoiceProvider:
+    arguments:
+      $languages: '@=service("prestashop.adapter.data_provider.language").getLanguages(false)'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductTypeChoiceProvider:
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -6,15 +6,10 @@ services:
       $langId: '@=service("prestashop.adapter.legacy.context").getLanguage().id'
       $themeCollection: '@=service("prestashop.core.addon.theme.repository").getListAsCollection()'
 
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageByIdChoiceProvider:
-    arguments:
-      - '@prestashop.adapter.data_provider.language'
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\:
+    resource: '../../../Core/Form/ChoiceProvider/*'
 
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageChoiceProvider:
-    arguments:
-      - '@=service("prestashop.adapter.data_provider.language").getLanguages(false)'
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIdChoiceProvider:
+  PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ZoneByIdChoiceProvider:
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TimezoneByNameChoiceProvider:
     arguments:
@@ -30,8 +25,6 @@ services:
       - '@=service("prestashop.core.language.pack.loader.remote").getLanguagePackList()'
       - '@prestashop.adapter.language.validator'
       - '@prestashop.adapter.data_provider.language'
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIsoCodeChoiceProvider:
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GroupByIdChoiceProvider:
     arguments:
@@ -55,25 +48,9 @@ services:
     arguments:
       - '@prestashop.adapter.contact.repository'
 
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TranslationTypeChoiceProvider:
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\EmailContentTypeChoiceProvider:
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameChoiceProvider:
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameWithEmailsChoiceProvider:
-
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ModuleByNameChoiceProvider:
     arguments:
       - '@=service("prestashop.core.admin.module.repository").getInstalledModules()'
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\StatusChoiceProvider:
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CanonicalRedirectTypeChoiceProvider:
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CategoryDeleteModeChoiceProvider:
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerRequiredFieldsChoiceProvider:
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImportMatchConfigurationChoiceProvider:
     arguments:
@@ -84,13 +61,9 @@ services:
       - '@=service("prestashop.core.import.fields_provider_finder")'
       - '@=service("session").get("entity")'
 
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerDeleteMethodChoiceProvider:
-
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemePageLayoutsChoiceProvider:
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getContext().shop.theme'
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeZipChoiceProvider:
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeChoiceProvider:
     arguments:
@@ -99,8 +72,6 @@ services:
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyNameByIsoCodeChoiceProvider:
     arguments:
       - '@=service("prestashop.core.localization.cldr.locale_repository").getLocale(service("prestashop.adapter.legacy.context").getContext().language.getLocale()).getAllCurrencies()'
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PermissionsChoiceProvider:
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DefaultMetaPageNameChoiceProvider:
     arguments:
@@ -111,8 +82,6 @@ services:
     arguments:
       - '@request_stack'
       - '@prestashop.adapter.meta.data_provider'
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TaxAddressTypeChoiceProvider:
 
   PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\TaxRuleGroupChoiceProvider:
     arguments:
@@ -136,10 +105,6 @@ services:
     arguments:
       - '@prestashop.core.mail_template.theme_catalog'
 
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderDiscountTypeChoiceProvider:
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\AddressRequiredFieldsChoiceProvider:
-
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerAddressesChoiceProvider:
     arguments:
       - '@prestashop.adapter.data_provider.customer'
@@ -159,332 +124,13 @@ services:
       - '@prestashop.adapter.legacy.configuration'
       - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
 
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductVisibilityChoiceProvider:
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductConditionChoiceProvider:
-
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OutOfStockTypeChoiceProvider:
     arguments:
       - '@translator'
       - '@=service("prestashop.adapter.legacy.configuration").getBoolean("PS_ORDER_OUT_OF_STOCK")'
 
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PackStockTypeChoiceProvider:
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomizationFieldTypeChoiceProvider:
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductImagesChoiceProvider:
     arguments:
       - '@prestashop.core.command_bus'
       - '@=service("prestashop.adapter.legacy.configuration").getInt("PS_SHOP_DEFAULT")'
       - "@=service('prestashop.adapter.shop.context').getContextShopID()"
-
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductTypeChoiceProvider:
-  PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ZoneByIdChoiceProvider:
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIdConfigurableChoiceProvider:
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\SpecificPricePriorityChoiceProvider:
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GenderChoiceProvider:
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider:
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerThreadStatusesChoiceProvider:
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ReductionTypeChoiceProvider:
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DiscountApplicationChoiceProvider:
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TaxInclusionChoiceProvider:
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ShippingInclusionChoiceProvider:
-  # Should be public as used in some controllers
-  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider:
-
-  # deprecated services
-  prestashop.core.form.choice_provider.currency_by_id:
-    alias: PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.tax_inclusion:
-    alias: PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TaxInclusionChoiceProvider
-    public: true
-    deprecated: ~
-
-
-
-# deprecated old notation since 9.0
-  prestashop.core.form.choice_provider.language_by_id:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageByIdChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.all_languages:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.country_by_id:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIdChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.timezone_by_name:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TimezoneByNameChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.localization_pack_by_iso_code:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LocalizationPackByIsoCodeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.non_installed_localization:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\NonInstalledLocalizationChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.country_by_iso_code:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIsoCodeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.group_by_id:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GroupByIdChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.carrier_by_reference_id:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CarrierByReferenceChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.order_state_by_id:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderStateByIdChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.invoice_model_by_name:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\InvoiceModelByNameChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.mail_method:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\MailMethodChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.contact_by_id:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactByIdChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.translation_type:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TranslationTypeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.email_content_type:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\EmailContentTypeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.theme_by_name:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.theme_by_name_with_emails:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameWithEmailsChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.module_by_name:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ModuleByNameChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.status:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\StatusChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.canonical_redirect_type:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CanonicalRedirectTypeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.category_delete_mode:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CategoryDeleteModeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.customer_required_fields:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerRequiredFieldsChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.import_match_configuration:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImportMatchConfigurationChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.import_entity_field:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImportEntityFieldChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.customer_delete_method:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerDeleteMethodChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.theme_page_layouts:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemePageLayoutsChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.theme_zip:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeZipChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.theme:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.currency_name_by_iso_code:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyNameByIsoCodeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.permissions_choice_provider:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PermissionsChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.default_meta_page_name:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DefaultMetaPageNameChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.module_meta_page_name:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ModuleMetaPageNameChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.tax_address_type_choice_provider:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TaxAddressTypeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.tax_rule_group_choice_provider:
-    alias: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\TaxRuleGroupChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.cms_categories:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CmsCategoriesChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.accessible_tab:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TabChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.profile:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProfileChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.mail_themes:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\MailThemeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice.provider.order_discount_type:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderDiscountTypeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.address_required_fields:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\AddressRequiredFieldsChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.customer_addresses_by_id:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerAddressesChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.customer_service_order_messages_name:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerServiceOrderMessagesNameChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.customer_service_order_messages:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerServiceOrderMessagesChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.delivery_time_note_types_provider:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DeliveryTimeNoteTypesProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.product_visibility_choice_provider:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductVisibilityChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.product_condition_choice_provider:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductConditionChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.out_of_stock_type_choice_provider:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OutOfStockTypeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.pack_stock_type_choice_provider:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PackStockTypeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.customization_field_type_choice_provider:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomizationFieldTypeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.product_images_choice_provider:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductImagesChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.product_type_choice_provider:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductTypeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.zone_by_id:
-    alias: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ZoneByIdChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.configurable_country_by_id:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIdConfigurableChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.specific_price_priority_choice_provider:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\SpecificPricePriorityChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.gender_choice_provider:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GenderChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.contact_type_choice_provider:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider'
-    public: true
-    deprecated: ~
-
-  prestashop.core.form.choice_provider.customer_thread_statuses_choice_provider:
-    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerThreadStatusesChoiceProvider'
-    public: true
-    deprecated: ~

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -22,10 +22,8 @@ services:
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LocalizationPackByIsoCodeChoiceProvider:
     arguments:
-      - '@prestashop.core.localization.pack.loader.remote'
-      - '@prestashop.core.localization.pack.loader.local'
-      - '@prestashop.adapter.legacy.configuration'
-      - '@translator'
+      $remoteLocalizationPackLoader: '@PrestaShop\PrestaShop\Core\Localization\Pack\Loader\RemoteLocalizationPackLoader'
+      $localLocalizationPackLoader: '@PrestaShop\PrestaShop\Core\Localization\Pack\Loader\LocalLocalizationPackLoader'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\NonInstalledLocalizationChoiceProvider:
     arguments:
@@ -93,8 +91,6 @@ services:
       - '@=service("prestashop.adapter.legacy.context").getContext().shop.theme'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeZipChoiceProvider:
-    arguments:
-      - '@prestashop.adapter.legacy.configuration'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeChoiceProvider:
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -2,6 +2,9 @@ services:
   _defaults:
     public: false
     autowire: true
+    bind:
+      $langId: '@=service("prestashop.adapter.legacy.context").getLanguage().id'
+      $themeCollection: '@=service("prestashop.core.addon.theme.repository").getListAsCollection()'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageByIdChoiceProvider:
     arguments:
@@ -12,9 +15,6 @@ services:
       - '@=service("prestashop.adapter.data_provider.language").getLanguages(false)'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIdChoiceProvider:
-    arguments:
-      - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
-      - '@prestashop.adapter.data_provider.country'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TimezoneByNameChoiceProvider:
     arguments:
@@ -34,26 +34,18 @@ services:
       - '@prestashop.adapter.data_provider.language'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIsoCodeChoiceProvider:
-    arguments:
-      - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
-      - '@prestashop.adapter.data_provider.country'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GroupByIdChoiceProvider:
     arguments:
       - '@prestashop.adapter.data_provider.group'
-      - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CarrierByReferenceChoiceProvider:
     arguments:
       - '@prestashop.adapter.data_provider.carrier'
-      - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderStateByIdChoiceProvider:
     arguments:
-      - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
-      - '@prestashop.adapter.data_provider.order_state'
-      - '@PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator'
-      - '@translator'
+      $orderStateDataProvider: '@prestashop.adapter.data_provider.order_state'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\InvoiceModelByNameChoiceProvider:
     arguments:
@@ -64,18 +56,14 @@ services:
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactByIdChoiceProvider:
     arguments:
       - '@prestashop.adapter.contact.repository'
-      - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TranslationTypeChoiceProvider:
+
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\EmailContentTypeChoiceProvider:
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameChoiceProvider:
-    arguments:
-      - '@=service("prestashop.core.addon.theme.repository").getListAsCollection()'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameWithEmailsChoiceProvider:
-    arguments:
-      - '@=service("prestashop.core.addon.theme.repository").getListAsCollection()'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ModuleByNameChoiceProvider:
     arguments:
@@ -159,7 +147,6 @@ services:
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerAddressesChoiceProvider:
     arguments:
       - '@prestashop.adapter.data_provider.customer'
-      - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerServiceOrderMessagesNameChoiceProvider:
     arguments:
@@ -186,12 +173,7 @@ services:
       - '@=service("prestashop.adapter.legacy.configuration").getBoolean("PS_ORDER_OUT_OF_STOCK")'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PackStockTypeChoiceProvider:
-    arguments:
-      - '@translator'
-      - '@=service("prestashop.adapter.legacy.configuration").getInt("PS_PACK_STOCK_TYPE")'
-
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomizationFieldTypeChoiceProvider:
-
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductImagesChoiceProvider:
     arguments:
       - '@prestashop.core.command_bus'
@@ -199,27 +181,12 @@ services:
       - "@=service('prestashop.adapter.shop.context').getContextShopID()"
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductTypeChoiceProvider:
-    arguments:
-      - '@translator'
-      - '@prestashop.adapter.legacy.configuration'
-
   PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ZoneByIdChoiceProvider:
-
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIdConfigurableChoiceProvider:
-    arguments:
-      - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
-      - '@prestashop.adapter.data_provider.country'
-
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\SpecificPricePriorityChoiceProvider:
-
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GenderChoiceProvider:
-
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider:
-    arguments:
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
-
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerThreadStatusesChoiceProvider:
-
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ReductionTypeChoiceProvider:
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DiscountApplicationChoiceProvider:
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TaxInclusionChoiceProvider:

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider_deprecated.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider_deprecated.yml
@@ -1,0 +1,296 @@
+# deprecated old notation since 9.0
+services:
+  prestashop.core.form.choice_provider.currency_by_id:
+    alias: PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.tax_inclusion:
+    alias: PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TaxInclusionChoiceProvider
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.language_by_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageByIdChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.all_languages:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.country_by_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIdChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.timezone_by_name:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TimezoneByNameChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.localization_pack_by_iso_code:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LocalizationPackByIsoCodeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.non_installed_localization:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\NonInstalledLocalizationChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.country_by_iso_code:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIsoCodeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.group_by_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GroupByIdChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.carrier_by_reference_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CarrierByReferenceChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.order_state_by_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderStateByIdChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.invoice_model_by_name:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\InvoiceModelByNameChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.mail_method:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\MailMethodChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.contact_by_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactByIdChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.translation_type:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TranslationTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.email_content_type:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\EmailContentTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.theme_by_name:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.theme_by_name_with_emails:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameWithEmailsChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.module_by_name:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ModuleByNameChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.status:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\StatusChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.canonical_redirect_type:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CanonicalRedirectTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.category_delete_mode:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CategoryDeleteModeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.customer_required_fields:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerRequiredFieldsChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.import_match_configuration:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImportMatchConfigurationChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.import_entity_field:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImportEntityFieldChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.customer_delete_method:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerDeleteMethodChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.theme_page_layouts:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemePageLayoutsChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.theme_zip:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeZipChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.theme:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.currency_name_by_iso_code:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyNameByIsoCodeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.permissions_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PermissionsChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.default_meta_page_name:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DefaultMetaPageNameChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.module_meta_page_name:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ModuleMetaPageNameChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.tax_address_type_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TaxAddressTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.tax_rule_group_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\TaxRuleGroupChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.cms_categories:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CmsCategoriesChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.accessible_tab:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TabChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.profile:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProfileChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.mail_themes:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\MailThemeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice.provider.order_discount_type:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderDiscountTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.address_required_fields:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\AddressRequiredFieldsChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.customer_addresses_by_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerAddressesChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.customer_service_order_messages_name:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerServiceOrderMessagesNameChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.customer_service_order_messages:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerServiceOrderMessagesChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.delivery_time_note_types_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DeliveryTimeNoteTypesProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.product_visibility_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductVisibilityChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.product_condition_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductConditionChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.out_of_stock_type_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OutOfStockTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.pack_stock_type_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PackStockTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.customization_field_type_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomizationFieldTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.product_images_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductImagesChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.product_type_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.zone_by_id:
+    alias: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ZoneByIdChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.configurable_country_by_id:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CountryByIdConfigurableChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.specific_price_priority_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\SpecificPricePriorityChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.gender_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\GenderChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.contact_type_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider'
+    public: true
+    deprecated: ~
+
+  prestashop.core.form.choice_provider.customer_thread_statuses_choice_provider:
+    alias: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerThreadStatusesChoiceProvider'
+    public: true
+    deprecated: ~

--- a/src/PrestaShopBundle/Resources/config/services/core/foundation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/foundation.yml
@@ -1,12 +1,17 @@
 services:
   _defaults:
-    public: true
+    public: false
 
-  prestashop.core.foundation.version:
-    class: PrestaShop\PrestaShop\Core\Foundation\Version
+  PrestaShop\PrestaShop\Core\Foundation\Version:
     arguments:
       - !php/const PrestaShop\PrestaShop\Core\Version::VERSION
       - !php/const PrestaShop\PrestaShop\Core\Version::MAJOR_VERSION_STRING
       - !php/const PrestaShop\PrestaShop\Core\Version::MAJOR_VERSION
       - !php/const PrestaShop\PrestaShop\Core\Version::MINOR_VERSION
       - !php/const PrestaShop\PrestaShop\Core\Version::RELEASE_VERSION
+
+  # Deprecated since 9.0
+  prestashop.core.foundation.version:
+    alias: PrestaShop\PrestaShop\Core\Foundation\Version
+    public: true
+    deprecated: ~

--- a/src/PrestaShopBundle/Resources/config/services/core/help.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/help.yml
@@ -6,9 +6,9 @@ services:
   PrestaShop\PrestaShop\Core\Help\Documentation:
     public: true
     class: PrestaShop\PrestaShop\Core\Help\Documentation
+    autowire: true
     arguments:
-      - "@prestashop.core.foundation.version"
-      - "https://help.prestashop-project.org/"
+      $host: "https://help.prestashop-project.org/"
 
   prestashop.core.help.documentation:
     alias: PrestaShop\PrestaShop\Core\Help\Documentation

--- a/src/PrestaShopBundle/Resources/config/services/core/language.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/language.yml
@@ -4,8 +4,7 @@ services:
 
   prestashop.core.language.pack.loader.remote:
     class: 'PrestaShop\PrestaShop\Core\Language\Pack\Loader\RemoteLanguagePackLoader'
-    arguments:
-      - '@prestashop.core.foundation.version'
+    autowire: true
 
   prestashop.core.language.language_default_fonts_catalog:
     class: 'PrestaShop\PrestaShop\Core\Language\LanguageDefaultFontsCatalog'

--- a/src/PrestaShopBundle/Resources/config/services/core/localization.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/localization.yml
@@ -1,30 +1,41 @@
 services:
   _defaults:
-    public: true
+    public: false
+    autowire: true
 
+  PrestaShop\PrestaShop\Core\Localization\Pack\Factory\LocalizationPackFactoryInterface: '@PrestaShop\PrestaShop\Core\Localization\Pack\Factory\LocalizationPackFactory'
+  PrestaShop\PrestaShop\Core\Localization\Pack\Factory\LocalizationPackFactory:
+  PrestaShop\PrestaShop\Core\Localization\Pack\Import\LocalizationPackImporter:
+    arguments:
+      $remoteLocalizationPackLoader: '@PrestaShop\PrestaShop\Core\Localization\Pack\Loader\RemoteLocalizationPackLoader'
+      $localLocalizationPackLoader: '@PrestaShop\PrestaShop\Core\Localization\Pack\Loader\LocalLocalizationPackLoader'
+
+  PrestaShop\PrestaShop\Core\Localization\Pack\Loader\LocalLocalizationPackLoader:
+  PrestaShop\PrestaShop\Core\Localization\Pack\Loader\RemoteLocalizationPackLoader:
+  PrestaShop\PrestaShop\Core\Localization\RTL\StyleSheetProcessorFactory:
+
+  # Deprecated since 9.0
   prestashop.core.localozation.pack.factory.localization_pack:
     class: 'PrestaShop\PrestaShop\Core\Localization\Pack\Factory\LocalizationPackFactory'
-
-  prestashop.core.localization.pack.import.importer:
-    class: 'PrestaShop\PrestaShop\Core\Localization\Pack\Import\LocalizationPackImporter'
-    arguments:
-      - '@prestashop.core.localization.pack.loader.remote'
-      - '@prestashop.core.localization.pack.loader.local'
-      - '@prestashop.core.localozation.pack.factory.localization_pack'
-      - '@translator'
+    deprecated: ~
+    public: true
 
   prestashop.core.localization.pack.loader.local:
-    class: 'PrestaShop\PrestaShop\Core\Localization\Pack\Loader\LocalLocalizationPackLoader'
-    arguments:
-      - '@prestashop.adapter.legacy.configuration'
+    alias: 'PrestaShop\PrestaShop\Core\Localization\Pack\Loader\LocalLocalizationPackLoader'
+    deprecated: ~
+    public: true
 
   prestashop.core.localization.pack.loader.remote:
-    class: 'PrestaShop\PrestaShop\Core\Localization\Pack\Loader\RemoteLocalizationPackLoader'
-    arguments:
-      - '@prestashop.adapter.legacy.configuration'
-      - '@prestashop.core.foundation.version'
+    alias: 'PrestaShop\PrestaShop\Core\Localization\Pack\Loader\RemoteLocalizationPackLoader'
+    deprecated: ~
+    public: true
 
   prestashop.core.localization.rtl.processor_factory:
     class: 'PrestaShop\PrestaShop\Core\Localization\RTL\StyleSheetProcessorFactory'
-    arguments:
-      - '@prestashop.adapter.legacy.configuration'
+    deprecated: ~
+    public: true
+
+  prestashop.core.localization.pack.import.importer:
+    public: true
+    alias: 'PrestaShop\PrestaShop\Core\Localization\Pack\Import\LocalizationPackImporter'
+    deprecated: ~

--- a/tests/Unit/Core/Form/ChoiceProvider/OutOfStockTypeChoiceProviderTest.php
+++ b/tests/Unit/Core/Form/ChoiceProvider/OutOfStockTypeChoiceProviderTest.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Core\Form\ChoiceProvider;
 
 use Generator;
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OutOfStockTypeChoiceProvider;
 
 class OutOfStockTypeChoiceProviderTest extends ChoiceProviderTestCase
@@ -40,9 +41,14 @@ class OutOfStockTypeChoiceProviderTest extends ChoiceProviderTestCase
      */
     public function testItProvidesChoicesAsExpected(bool $outOfStockAvailable, array $expectedChoices): void
     {
+        $mock = $this->createMock(ShopConfigurationInterface::class);
+        $mock->expects($this->once())
+            ->method('get')
+            ->willReturn($outOfStockAvailable);
+
         $choiceProvider = new OutOfStockTypeChoiceProvider(
             $this->mockTranslator(),
-            $outOfStockAvailable
+            $mock
         );
 
         $this->assertEquals($expectedChoices, $choiceProvider->getChoices());

--- a/tests/Unit/Core/Form/ChoiceProvider/PackStockTypeChoiceProviderTest.php
+++ b/tests/Unit/Core/Form/ChoiceProvider/PackStockTypeChoiceProviderTest.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Core\Form\ChoiceProvider;
 
 use Generator;
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\PackStockTypeChoiceProvider;
 
 class PackStockTypeChoiceProviderTest extends ChoiceProviderTestCase
@@ -40,9 +41,14 @@ class PackStockTypeChoiceProviderTest extends ChoiceProviderTestCase
      */
     public function testItProvidesChoicesAsExpected(int $defaultPackStockType, array $expectedChoices): void
     {
+        $mock = $this->createMock(ShopConfigurationInterface::class);
+        $mock->expects($this->once())
+            ->method('get')
+            ->willReturn($defaultPackStockType);
+
         $choiceProvider = new PackStockTypeChoiceProvider(
             $this->mockTranslator(),
-            $defaultPackStockType
+            $mock
         );
 
         $this->assertEquals($expectedChoices, $choiceProvider->getChoices());


### PR DESCRIPTION
First part, I need to update all deprecated usages to the new format. As this PR can grow really big, really fast, I'll do it in another one.

- Remove arguments with on translator and autowire everything.
- Update service names
- Update services 1/x
- Update services 2/x
- Update services 3/x
- Update services 4/x

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Switch choice providers to autowiring.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |  CI 🟢  and automated tests