### PR TITLE
Fix: Empty tracking URL for "in transit" email

### DIFF
--- a/classes/order/OrderCarrier.php
+++ b/classes/order/OrderCarrier.php
@@ -100,6 +100,11 @@ class OrderCarrierCore extends ObjectModel
             throw new PrestaShopException('Can\'t load Address object');
         }
 
+        if (!$carrier->url) {
+            // the url field of the carrier is empty therefore the e-mail must not be sent
+            return true;
+        }
+
         $products = $order->getCartProducts();
         $link = Context::getContext()->link;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.1.x 
| Description?      | When you enter the tracking number in an order, the "in_transit" email is sent which contains the link for tracking the shipment. Obviously, this link is valued only if the "Tracking URL" field has been valued for the courier. Perhaps it would be appropriate to send this e-mail only if the "Tracking URL" field is set, also because entering the "Sent" status another e-mail is sent.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #32508 
| Sponsor company   | Codencode snc 