### PR TITLE
Fix states selector in back office stores form

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -67,7 +67,7 @@
 					<div class="form-wrapper">
 					{foreach $field as $input}
 						{block name="input_row"}
-						<div class="form-group{if isset($input.form_group_class)} {$input.form_group_class}{/if}{if $input.type == 'hidden'} hide{/if}"{if $input.name == 'id_state'} id="contains_states"{if !$contains_states} style="display:none;"{/if}{/if}{if $input.name == 'dni'} id="dni_required"{if !$dni_required} style="display:none;"{/if}{/if}{if isset($tabs) && isset($input.tab)} data-tab-id="{$input.tab}"{/if}>
+						<div class="form-group{if isset($input.form_group_class)} {$input.form_group_class}{/if}{if $input.type == 'hidden'} hide{/if}"{if $input.name == 'id_state'} id="contains_states" data-states-url={$states_url} {if !$contains_states} style="display:none;"{/if}{/if}{if $input.name == 'dni'} id="dni_required"{if !$dni_required} style="display:none;"{/if}{/if}{if isset($tabs) && isset($input.tab)} data-tab-id="{$input.tab}"{/if}>
 						{if $input.type == 'hidden'}
 							<input type="hidden" name="{$input.name}" id="{$input.name}" value="{$fields_value[$input.name]|default|escape:'html':'UTF-8'}" />
 						{else}

--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -330,6 +330,8 @@ class AdminStoresControllerCore extends AdminController
             'hours' => $hours,
         ];
 
+        $this->tpl_form_vars['states_url'] = $this->getContainer()->get('router')->generate('admin_country_states');
+
         return parent::renderForm();
     }
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -1081,20 +1081,24 @@ function getControllerActionMap(force_action) {
 function ajaxStates(id_state_selected)
 {
   $.ajax({
-    url: "index.php",
+    url: `${$('#contains_states').data('statesUrl')}&id_country=${$('#id_country').val()}`,
     cache: false,
-    data: "token="+state_token+"&ajax=1&action=states&tab=AdminStates&no_empty=0&id_country="+$('#id_country').val() + "&id_state=" + $('#id_state').val(),
-    success: function(html)
+    success: function(response)
     {
-      if (html == 'false')
-      {
-        $("#contains_states").fadeOut();
+      var $stateIdSelect = $("#id_state");
+      var $stateSelectorRow = $("#contains_states");
+
+      if (!response.states || response.states.length === 0) {
+        $stateSelectorRow.fadeOut();
+        // append initial empty value which is selected (and hidden) when there are no states
+        $stateIdSelect.append(`<option value="0">-</option>`);
         $('#id_state option[value=0]').attr("selected", "selected");
-      }
-      else
-      {
-        $("#id_state").html(html);
-        $("#contains_states").fadeIn();
+      } else {
+        $stateIdSelect.empty();
+        for (const [name, id] of Object.entries(response.states)) {
+          $stateIdSelect.append(`<option value="${id}">${name}</option>`)
+        }
+        $stateSelectorRow.fadeIn();
         $('#id_state option[value=' + id_state_selected + ']').attr("selected", "selected");
       }
     }


### PR DESCRIPTION
…point for choices

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | States controller was migrated and deleted, and apparently one ajax call in admin.js is not working anymore. You can see more in related issue (https://github.com/PrestaShop/PrestaShop/issues/32316) and initial PR (https://github.com/PrestaShop/PrestaShop/pull/32550). As stores page is being migrated and might will be finished for v9.0 (or later), this is just a quickfix for old page to still work.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | #32316
| Fixed ticket?     | #32316
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
