### PR TITLE
Update EmailConfigurationTester.php

### DIFF
--- a/src/Adapter/Email/EmailConfigurationTester.php
+++ b/src/Adapter/Email/EmailConfigurationTester.php
@@ -90,8 +90,8 @@ final class EmailConfigurationTester implements EmailConfigurationTesterInterfac
         $result = Mail::sendMailTest(
             Tools::htmlentitiesUTF8($smtpChecked),
             Tools::htmlentitiesUTF8($config['smtp_server']),
-            Tools::htmlentitiesUTF8($content),
-            Tools::htmlentitiesUTF8($subject),
+            Tools::htmlentitiesDecodeUTF8($content),
+            Tools::htmlentitiesDecodeUTF8($subject),
             Tools::htmlentitiesUTF8('text/html'),
             Tools::htmlentitiesUTF8($config['send_email_to']),
             Tools::htmlentitiesUTF8($this->configuration->get('PS_SHOP_EMAIL')),


### PR DESCRIPTION
Fix UTF-8 decoding for characters such as áéíóúßü, etc

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This will fix the encoding issues present on utf-8 languages when sending test emails from the back office. Example at the end of this table.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Use the Español (es/mx) language and send a test email from the email settings.
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/32564 Fixes https://github.com/PrestaShop/PrestaShop/issues/15469
| Related PRs       | No
| Sponsor company   | Cubix Tech

The email reads:
`Este es un mensaje de prueba. Tu servidor est&aacute; ahora configurado para enviar correo electr&oacute;nico.`

With this PR, it will have the correct characters:
`Este es un mensaje de prueba. Tu servidor está ahora configurado para enviar correo electrónico. `