### PR TITLE
Bump classic theme to 2.1.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5346,16 +5346,16 @@
         },
         {
             "name": "prestashop/classic",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/classic-theme.git",
-                "reference": "9cf6e28af5549ebc0f8d700c77bbfdf646f6b43f"
+                "reference": "481b7af6c5d5f82b4db05ec4fd747a9cc5ff87e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/classic-theme/zipball/9cf6e28af5549ebc0f8d700c77bbfdf646f6b43f",
-                "reference": "9cf6e28af5549ebc0f8d700c77bbfdf646f6b43f",
+                "url": "https://api.github.com/repos/PrestaShop/classic-theme/zipball/481b7af6c5d5f82b4db05ec4fd747a9cc5ff87e3",
+                "reference": "481b7af6c5d5f82b4db05ec4fd747a9cc5ff87e3",
                 "shasum": ""
             },
             "require-dev": {
@@ -5379,9 +5379,9 @@
             ],
             "description": "Classic theme for PrestaShop 1.7",
             "support": {
-                "source": "https://github.com/PrestaShop/classic-theme/tree/2.1.0"
+                "source": "https://github.com/PrestaShop/classic-theme/tree/2.1.1"
             },
-            "time": "2023-02-24T16:27:02+00:00"
+            "time": "2023-03-13T21:18:14+00:00"
         },
         {
             "name": "prestashop/contactform",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Update Composer dependency prestashop/classic for 8.1.0 Release Candidate 1. Bumps version of Classic theme from 2.1.0 to 2.1.1 . See below for details
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI should be green. Auto tests: https://github.com/lartist/ga.tests.ui.pr/actions/runs/4978433670
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 

## Details about 2.1.1 version

Difference between 2.1.0 and 2.1.1 https://github.com/PrestaShop/classic-theme/compare/2.1.0...2.1.1

Two PRs in this new version
- Update the version number https://github.com/PrestaShop/classic-theme/pull/108
- Adapt theme to dynamic sitemap URLs https://github.com/PrestaShop/classic-theme/pull/110