### PR TITLE
Remove default value for Customer Group form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/GroupType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/GroupType.php
@@ -53,10 +53,8 @@ class GroupType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'placeholder' => null,
             'choices' => $this->groupByIdChoiceProvider->getChoices(),
             'choice_translation_domain' => false,
-            'autocomplete' => true,
         ]);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove default value for Customer Group form.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see #32583
| Fixed ticket?     | #32583
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
