### PR TITLE
Update ImageGenerator resize destination path

### DIFF
--- a/src/Adapter/Image/ImageGenerator.php
+++ b/src/Adapter/Image/ImageGenerator.php
@@ -62,13 +62,14 @@ class ImageGenerator
     /**
      * @param string $imagePath
      * @param ImageType[] $imageTypes
+     * @param int $imageId
      *
      * @return bool
      *
      * @throws ImageOptimizationException
      * @throws ImageUploadException
      */
-    public function generateImagesByTypes(string $imagePath, array $imageTypes, int $imageId): bool
+    public function generateImagesByTypes(string $imagePath, array $imageTypes, int $imageId = 0): bool
     {
         $resized = true;
 
@@ -92,10 +93,11 @@ class ImageGenerator
      *
      * @param string $filePath
      * @param ImageType $imageType
+     * @param int $imageId
      *
      * @return bool
      */
-    protected function resize(string $filePath, ImageType $imageType, int $imageId): bool
+    protected function resize(string $filePath, ImageType $imageType, int $imageId = 0): bool
     {
         if (!is_file($filePath)) {
             throw new ImageUploadException(sprintf('File "%s" does not exist', $filePath));

--- a/src/Adapter/Image/ImageGenerator.php
+++ b/src/Adapter/Image/ImageGenerator.php
@@ -68,13 +68,13 @@ class ImageGenerator
      * @throws ImageOptimizationException
      * @throws ImageUploadException
      */
-    public function generateImagesByTypes(string $imagePath, array $imageTypes): bool
+    public function generateImagesByTypes(string $imagePath, array $imageTypes, int $imageId): bool
     {
         $resized = true;
 
         try {
             foreach ($imageTypes as $imageType) {
-                $resized &= $this->resize($imagePath, $imageType);
+                $resized &= $this->resize($imagePath, $imageType, $imageId);
             }
         } catch (PrestaShopException $e) {
             throw new ImageOptimizationException('Unable to resize one or more of your pictures.');
@@ -95,7 +95,7 @@ class ImageGenerator
      *
      * @return bool
      */
-    protected function resize(string $filePath, ImageType $imageType): bool
+    protected function resize(string $filePath, ImageType $imageType, int $imageId): bool
     {
         if (!is_file($filePath)) {
             throw new ImageUploadException(sprintf('File "%s" does not exist', $filePath));
@@ -124,7 +124,7 @@ class ImageGenerator
             $forceFormat = ($imageFormat !== 'jpg');
             if (!ImageManager::resize(
                 $filePath,
-                sprintf('%s-%s.%s', rtrim($filePath, '.' . $imageFormat), stripslashes($imageType->name), $imageFormat),
+                sprintf('%s-%s.%s', dirname($filePath) . DIRECTORY_SEPARATOR . $imageId, stripslashes($imageType->name), $imageFormat),
                 $imageType->width,
                 $imageType->height,
                 $imageFormat,
@@ -132,10 +132,9 @@ class ImageGenerator
             )) {
                 $result = false;
             }
-
             if ($generate_high_dpi_images && !ImageManager::resize(
                 $filePath,
-                sprintf('%s-%s.%s', rtrim($filePath, '.' . $imageFormat), stripslashes($imageType->name) . '2x', $imageFormat),
+                sprintf('%s-%s.%s', dirname($filePath) . DIRECTORY_SEPARATOR . $imageId, stripslashes($imageType->name) . '2x', $imageFormat),
                 $imageType->width * 2,
                 $imageType->height * 2,
                 $imageFormat,

--- a/src/Adapter/Product/Image/Uploader/ProductImageUploader.php
+++ b/src/Adapter/Product/Image/Uploader/ProductImageUploader.php
@@ -119,7 +119,7 @@ class ProductImageUploader extends AbstractImageUploader
         $this->createDestinationDirectory($imageId, $productId);
         $destinationPath = $this->productImagePathFactory->getPath($imageId);
         $this->uploadFromTemp($filePath, $destinationPath);
-        $this->imageGenerator->generateImagesByTypes($destinationPath, $this->productImageRepository->getProductImageTypes());
+        $this->imageGenerator->generateImagesByTypes($destinationPath, $this->productImageRepository->getProductImageTypes(), $imageId->getValue());
 
         $this->hookDispatcher->dispatchWithParameters(
             'actionWatermark',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | The 1st part of the file name generation was not correct if we generated something other than the initial format (jpg)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see #32265
| Fixed ticket?     | #32265
| Related PRs       | -
| Sponsor company   | -

**I complete here to explain the changes.**

The BO side generation of file names for webp format had errors, here is an example :

- `24.jpg-home_default.webp` -> we want `24-home_default.webp`

here there are several solutions: 

- tweak the existing filename to remove the ".jpg" for formats !jpg -> bad idea, might as well be generic
- improve the generation of the file name by avoiding resuming the filePath. So I need to get the ID of the image:
  - I get imageId by regex on filePath params
  - I add the image ID in the method parameters because I have it above. I chose this solution