### PR TITLE
Add CTAs for edit pages

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -136,6 +136,7 @@ class CmsPageController extends FrameworkBundleAdminController
                 'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
                 'helperDocLink' => $helperBlockLinkProvider->getLink('cms_pages'),
                 'cmsPageShowcaseCardName' => ShowcaseCard::CMS_PAGES_CARD,
+                'layoutHeaderToolbarBtn' => $this->getCmsPageIndexToolbarButtons($cmsCategoryParentId),
                 'showcaseCardIsClosed' => $showcaseCardIsClosed,
             ]
         );
@@ -1233,5 +1234,37 @@ class CmsPageController extends FrameworkBundleAdminController
                 ),
             ],
         ];
+    }
+
+    /**
+     * @param int $cmsCategoryId
+     *
+     * @return array
+     */
+    private function getCmsPageIndexToolbarButtons($cmsCategoryId): array
+    {
+        $toolbarButtons = [];
+
+        if ($cmsCategoryId !== CmsPageCategoryId::ROOT_CMS_PAGE_CATEGORY_ID) {
+            $toolbarButtons['edit_cms_category'] = [
+                'href' => $this->generateUrl('admin_cms_pages_category_edit', ['cmsCategoryId' => $cmsCategoryId]),
+                'desc' => $this->trans('Edit page category', 'Admin.Design.Help'),
+                'icon' => 'mode_edit',
+            ];
+        }
+
+        $toolbarButtons['add_cms_category'] = [
+            'href' => $this->generateUrl('admin_cms_pages_category_create', ['id_cms_category' => $cmsCategoryId]),
+            'desc' => $this->trans('Add new page category', 'Admin.Design.Help'),
+            'icon' => 'add_circle_outline',
+        ];
+
+        $toolbarButtons['add_cms_page'] = [
+            'href' => $this->generateUrl('admin_cms_pages_create', ['id_cms_category' => $cmsCategoryId]),
+            'desc' => $this->trans('Add new page', 'Admin.Design.Help'),
+            'icon' => 'add_circle_outline',
+        ];
+
+        return $toolbarButtons;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -876,6 +876,12 @@ class CategoryController extends FrameworkBundleAdminController
     {
         $toolbarButtons = [];
 
+        $toolbarButtons['edit'] = [
+            'href' => $this->generateUrl('admin_categories_edit', ['categoryId' => $categoryId]),
+            'desc' => $this->trans('Edit category', 'Admin.Catalog.Feature'),
+            'icon' => 'mode_edit',
+        ];
+
         if ($this->get('prestashop.adapter.feature.multistore')->isUsed()) {
             $toolbarButtons['add_root'] = [
                 'href' => $this->generateUrl('admin_categories_create_root'),

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -121,7 +121,7 @@ class CategoryController extends FrameworkBundleAdminController
             'enableSidebar' => true,
             'categoriesGrid' => $this->presentGrid($categoryGrid),
             'categoriesKpi' => $categoriesKpiFactory->build(),
-            'layoutHeaderToolbarBtn' => $this->getCategoryToolbarButtons($request, $currentCategoryId),
+            'layoutHeaderToolbarBtn' => $this->getCategoryIndexToolbarButtons($request, $currentCategoryId),
             'currentCategoryView' => $categoryViewData,
             'deleteCategoriesForm' => $deleteCategoriesForm->createView(),
             'isSingleShopContext' => $this->get('prestashop.adapter.shop.context')->isSingleShopContext(),
@@ -872,7 +872,7 @@ class CategoryController extends FrameworkBundleAdminController
      *
      * @return array
      */
-    private function getCategoryToolbarButtons(Request $request, int $categoryId): array
+    private function getCategoryIndexToolbarButtons(Request $request, int $categoryId): array
     {
         $toolbarButtons = [];
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -868,7 +868,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     }
 
     /**
-     * @param int $customerId
+     * @param int $manufacturerId
      *
      * @return array
      */

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -100,6 +100,7 @@ class ManufacturerController extends FrameworkBundleAdminController
             'manufacturerGrid' => $this->presentGrid($manufacturerGrid),
             'manufacturerAddressGrid' => $this->presentGrid($manufacturerAddressGrid),
             'settingsTipMessage' => $this->getSettingsTipMessage(),
+            'layoutHeaderToolbarBtn' => $this->getManufacturerIndexToolbarButtons(),
         ]);
     }
 
@@ -193,6 +194,7 @@ class ManufacturerController extends FrameworkBundleAdminController
             'isAllShopContext' => $this->get('prestashop.adapter.shop.context')->isAllShopContext(),
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+            'layoutHeaderToolbarBtn' => $this->getManufacturerViewToolbarButtons($manufacturerId),
             'layoutTitle' => $this->trans(
                 'Brand %name%',
                 'Admin.Navigation.Menu',
@@ -841,5 +843,45 @@ class ManufacturerController extends FrameworkBundleAdminController
             'Admin.Catalog.Notification',
             [$urlOpening, $urlEnding]
         );
+    }
+
+    /**
+     * @return array
+     */
+    private function getManufacturerIndexToolbarButtons(): array
+    {
+        $toolbarButtons = [];
+
+        $toolbarButtons['add_manufacturer'] = [
+            'href' => $this->generateUrl('admin_manufacturers_create'),
+            'desc' => $this->trans('Add new brand', 'Admin.Catalog.Feature'),
+            'icon' => 'add_circle_outline',
+        ];
+
+        $toolbarButtons['add_manufacturer_address'] = [
+            'href' => $this->generateUrl('admin_manufacturer_addresses_create'),
+            'desc' => $this->trans('Add new brand address', 'Admin.Catalog.Feature'),
+            'icon' => 'add_circle_outline',
+        ];
+
+        return $toolbarButtons;
+    }
+
+    /**
+     * @param int $customerId
+     *
+     * @return array
+     */
+    private function getManufacturerViewToolbarButtons(int $manufacturerId): array
+    {
+        $toolbarButtons = [];
+
+        $toolbarButtons['edit'] = [
+            'href' => $this->generateUrl('admin_manufacturers_edit', ['manufacturerId' => $manufacturerId]),
+            'desc' => $this->trans('Edit brand', 'Admin.Catalog.Feature'),
+            'icon' => 'mode_edit',
+        ];
+
+        return $toolbarButtons;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -87,6 +87,7 @@ class SupplierController extends FrameworkBundleAdminController
                 'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
                 'enableSidebar' => true,
                 'settingsTipMessage' => $this->getSettingsTipMessage(),
+                'layoutHeaderToolbarBtn' => $this->getSupplierIndexToolbarButtons(),
             ]
         );
     }
@@ -406,6 +407,7 @@ class SupplierController extends FrameworkBundleAdminController
             'isAllShopContext' => $this->get('prestashop.adapter.shop.context')->isAllShopContext(),
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'enableSidebar' => true,
+            'layoutHeaderToolbarBtn' => $this->getSupplierViewToolbarButtons($supplierId),
             'layoutTitle' => $this->trans(
                 'Supplier %name%',
                 'Admin.Navigation.Menu',
@@ -604,5 +606,39 @@ class SupplierController extends FrameworkBundleAdminController
             'Admin.Catalog.Notification',
             [$urlOpening, $urlEnding]
         );
+    }
+
+    /**
+     * @return array
+     */
+    private function getSupplierIndexToolbarButtons(): array
+    {
+        $toolbarButtons = [];
+
+        $toolbarButtons['add'] = [
+            'href' => $this->generateUrl('admin_suppliers_create'),
+            'desc' => $this->trans('Add new supplier', 'Admin.Catalog.Feature'),
+            'icon' => 'add_circle_outline',
+        ];
+
+        return $toolbarButtons;
+    }
+
+    /**
+     * @param int $supplierId
+     *
+     * @return array
+     */
+    private function getSupplierViewToolbarButtons(int $supplierId): array
+    {
+        $toolbarButtons = [];
+
+        $toolbarButtons['edit'] = [
+            'href' => $this->generateUrl('admin_suppliers_edit', ['supplierId' => $supplierId]),
+            'desc' => $this->trans('Edit supplier', 'Admin.Catalog.Feature'),
+            'icon' => 'mode_edit',
+        ];
+
+        return $toolbarButtons;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -120,7 +120,7 @@ class CustomerController extends AbstractAdminController
             'deleteCustomersForm' => $deleteCustomerForm->createView(),
             'showcaseCardName' => ShowcaseCard::CUSTOMERS_CARD,
             'isShowcaseCardClosed' => $showcaseCardIsClosed,
-            'layoutHeaderToolbarBtn' => $this->getCustomerToolbarButtons(),
+            'layoutHeaderToolbarBtn' => $this->getCustomerIndexToolbarButtons(),
             'enableSidebar' => true,
         ]);
     }
@@ -378,6 +378,7 @@ class CustomerController extends AbstractAdminController
             'isMultistoreEnabled' => $this->get('prestashop.adapter.feature.multistore')->isActive(),
             'transferGuestAccountForm' => $transferGuestAccountForm,
             'privateNoteForm' => $privateNoteForm->createView(),
+            'layoutHeaderToolbarBtn' => $this->getCustomerViewToolbarButtons($customerId),
             'layoutTitle' => $this->trans(
                 'Customer %name%',
                 'Admin.Navigation.Menu',
@@ -1089,7 +1090,7 @@ class CustomerController extends AbstractAdminController
     /**
      * @return array
      */
-    private function getCustomerToolbarButtons(): array
+    private function getCustomerIndexToolbarButtons(): array
     {
         $toolbarButtons = [];
 
@@ -1109,6 +1110,24 @@ class CustomerController extends AbstractAdminController
             );
             $toolbarButtons['add']['href'] = '#';
         }
+
+        return $toolbarButtons;
+    }
+
+    /**
+     * @param int $customerId
+     *
+     * @return array
+     */
+    private function getCustomerViewToolbarButtons(int $customerId): array
+    {
+        $toolbarButtons = [];
+
+        $toolbarButtons['edit'] = [
+            'href' => $this->generateUrl('admin_customers_edit', ['customerId' => $customerId]),
+            'desc' => $this->trans('Edit customer', 'Admin.Orderscustomers.Feature'),
+            'icon' => 'mode_edit',
+        ];
 
         return $toolbarButtons;
     }

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/index.html.twig
@@ -24,20 +24,6 @@
  *#}
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
-{% set layoutHeaderToolbarBtn = {
-  add_cms_category: {
-    href: path('admin_cms_pages_category_create', {'id_cms_category' : app.request.query.get('id_cms_category')}),
-    desc: 'Add new page category'|trans({}, 'Admin.Design.Help'),
-    icon: 'add_circle_outline',
-  },
-  add_cms_page: {
-    href: path('admin_cms_pages_create', {'id_cms_category' : app.request.query.get('id_cms_category')}),
-    desc: 'Add new page'|trans({}, 'Admin.Design.Help'),
-    icon: 'add_circle_outline',
-  }
-}
-%}
-
 {% block content %}
 
   {% include '@PrestaShop/Admin/Improve/Design/Cms/Blocks/showcase_card.html.twig' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/index.html.twig
@@ -26,20 +26,6 @@
 
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
-{% set layoutHeaderToolbarBtn = {
-  add_manufacturer: {
-    href: path('admin_manufacturers_create'),
-    desc: 'Add new brand'|trans({}, 'Admin.Catalog.Feature'),
-    icon: 'add_circle_outline',
-  },
-  add_manufacturer_address: {
-    href: path('admin_manufacturer_addresses_create'),
-    desc: 'Add new brand address'|trans({}, 'Admin.Catalog.Feature'),
-    icon: 'add_circle_outline',
-  },
-}
-%}
-
 {% block content %}
   {% block manufacturers_listing %}
     {{ ps.infotip(settingsTipMessage, true) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
@@ -26,15 +26,6 @@
 
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
-{% set layoutHeaderToolbarBtn = {
-  add: {
-    href: path('admin_suppliers_create'),
-    desc: 'Add new supplier'|trans({}, 'Admin.Catalog.Feature'),
-    icon: 'add_circle_outline',
-  }
-}
-%}
-
 {% block content %}
   {% block supplier_grid %}
     {{ ps.infotip(settingsTipMessage, true) }}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds edit buttons on several pages, so user doesn't have to click tiny buttons.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check that buttons work on these pages.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | www.danielhlavacek.cz

### Customer view (originally only a pencil in card header)
![customer](https://github.com/PrestaShop/PrestaShop/assets/6097524/7008b7a6-c42b-4e91-aec7-954a9346d302)

### Category view (you had to click the tiny "edit" in breadcrumbs)
![categories](https://github.com/PrestaShop/PrestaShop/assets/6097524/46cb7a69-6303-44f2-bcc8-57726ad8667d)

### Brand view (you had to go back to the list)
![brand](https://github.com/PrestaShop/PrestaShop/assets/6097524/d15dcd32-6940-4346-be40-5570e1bca7ff)

### Supplier view (you had to go back to the list)
![supplier](https://github.com/PrestaShop/PrestaShop/assets/6097524/158603e6-57c7-44bb-a421-97d6a164176d)

### CMS category other than root (you had to go back to the list)
![cmscategory](https://github.com/PrestaShop/PrestaShop/assets/6097524/572ffd80-ea20-461e-999f-3e767d9b4738)
