### PR TITLE
Cache backup fix with no products

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -308,22 +308,19 @@ class CartPresenter implements PresenterInterface
 
     /**
      * @param Cart $cart
-     * @param bool $shouldSeparateGifts
-     *
-     * @return array
      *
      * @throws \Exception
      */
-    public function present($cart, $shouldSeparateGifts = false)
+    public function present($cart, bool $shouldSeparateGifts = false): array
     {
-        $cache_id = 'presentedCart_' . (int) $shouldSeparateGifts;
+        $cache_id = 'presentedCart_' . (int) $shouldSeparateGifts . $cart->id;
         if (Cache::isStored($cache_id)) {
             return Cache::retrieve($cache_id);
         }
+
         if (!is_a($cart, 'Cart')) {
             throw new \Exception('CartPresenter can only present instance of Cart');
         }
-
         if ($shouldSeparateGifts) {
             $rawProducts = $cart->getProductsWithSeparatedGifts();
         } else {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Recently a cart caching has been implemented, but the function that takes care of doing it was called several times, and with an empty product list on the 1st calls. <br/> Also a lot of things are done in the present function, whereas we just want the products
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #32022
| Fixed ticket?     | #32022
| Related PRs       | -
| Sponsor company   | -
