### PR TITLE
Introduce supplier presenter & simplify manufacturer presenter

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -2146,6 +2146,16 @@
       <title>Order Return Presenter</title>
       <description>This hook is called before an order return is presented</description>
     </hook>
+    <hook id="actionPresentSupplier">
+      <name>actionPresentSupplier</name>
+      <title>Supplier Presenter</title>
+      <description>This hook is called before a supplier is presented</description>
+    </hook>
+    <hook id="actionPresentManufacturer">
+      <name>actionPresentManufacturer</name>
+      <title>Manufacturer Presenter</title>
+      <description>This hook is called before a manufacturer is presented</description>
+    </hook>
     <hook id="actionPresentProduct">
       <name>actionPresentProduct</name>
       <title>Product Presenter</title>

--- a/src/Adapter/Presenter/Manufacturer/ManufacturerPresenter.php
+++ b/src/Adapter/Presenter/Manufacturer/ManufacturerPresenter.php
@@ -56,7 +56,7 @@ class ManufacturerPresenter
      *
      * @return ManufacturerLazyArray
      */
-    public function present($manufacturer, $language)
+    public function present(array|Manufacturer $manufacturer, Language $language)
     {
         // Convert to array if a Manufacturer object was passed
         if (is_object($manufacturer)) {

--- a/src/Adapter/Presenter/Supplier/SupplierLazyArray.php
+++ b/src/Adapter/Presenter/Supplier/SupplierLazyArray.php
@@ -24,15 +24,15 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShop\PrestaShop\Adapter\Presenter\Manufacturer;
+namespace PrestaShop\PrestaShop\Adapter\Presenter\Supplier;
 
 use Language;
 use Link;
-use Manufacturer;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
+use Supplier;
 
-class ManufacturerLazyArray extends AbstractLazyArray
+class SupplierLazyArray extends AbstractLazyArray
 {
     /**
      * @var ImageRetriever
@@ -47,7 +47,7 @@ class ManufacturerLazyArray extends AbstractLazyArray
     /**
      * @var array
      */
-    protected $manufacturer;
+    protected $supplier;
 
     /**
      * @var Language
@@ -55,28 +55,18 @@ class ManufacturerLazyArray extends AbstractLazyArray
     private $language;
 
     public function __construct(
-        array $manufacturer,
+        array $supplier,
         Language $language,
         ImageRetriever $imageRetriever,
         Link $link
     ) {
-        $this->manufacturer = $manufacturer;
+        $this->supplier = $supplier;
         $this->language = $language;
         $this->imageRetriever = $imageRetriever;
         $this->link = $link;
 
         parent::__construct();
-        $this->appendArray($this->manufacturer);
-    }
-
-    /**
-     * @arrayAccess
-     *
-     * @return string
-     */
-    public function getText()
-    {
-        return $this->manufacturer['short_description'];
+        $this->appendArray($this->supplier);
     }
 
     /**
@@ -86,7 +76,7 @@ class ManufacturerLazyArray extends AbstractLazyArray
      */
     public function getUrl()
     {
-        return $this->link->getManufacturerLink($this->manufacturer['id']);
+        return $this->link->getSupplierLink($this->supplier['id']);
     }
 
     /**
@@ -97,8 +87,8 @@ class ManufacturerLazyArray extends AbstractLazyArray
     public function getImage()
     {
         return $this->imageRetriever->getImage(
-            new Manufacturer($this->manufacturer['id'], $this->language->getId()),
-            $this->manufacturer['id']
+            new Supplier($this->supplier['id'], $this->language->getId()),
+            $this->supplier['id']
         );
     }
 
@@ -109,13 +99,13 @@ class ManufacturerLazyArray extends AbstractLazyArray
      */
     public function getNbProducts()
     {
-        if (!isset($this->manufacturer['nb_products'])) {
-            $this->manufacturer['nb_products'] = count(
-                (new Manufacturer($this->manufacturer['id'], $this->language->getId()))
+        if (!isset($this->supplier['nb_products'])) {
+            $this->supplier['nb_products'] = count(
+                (new Supplier($this->supplier['id'], $this->language->getId()))
                     ->getProductsLite($this->language->getId())
             );
         }
 
-        return $this->manufacturer['nb_products'];
+        return $this->supplier['nb_products'];
     }
 }

--- a/src/Adapter/Presenter/Supplier/SupplierPresenter.php
+++ b/src/Adapter/Presenter/Supplier/SupplierPresenter.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Presenter\Supplier;
+
+use Hook;
+use Language;
+use Link;
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+use Supplier;
+
+class SupplierPresenter
+{
+    /**
+     * @var ImageRetriever
+     */
+    protected $imageRetriever;
+
+    /**
+     * @var Link
+     */
+    protected $link;
+
+    public function __construct(Link $link)
+    {
+        $this->link = $link;
+        $this->imageRetriever = new ImageRetriever($link);
+    }
+
+    /**
+     * @param array|Supplier $supplier Supplier object or an array
+     * @param Language $language
+     *
+     * @return SupplierLazyArray
+     */
+    public function present($supplier, $language)
+    {
+        // Convert to array if a Supplier object was passed
+        if (is_object($supplier)) {
+            $supplier = (array) $supplier;
+        }
+
+        // Normalize IDs
+        if (empty($supplier['id_supplier'])) {
+            $supplier['id_supplier'] = $supplier['id'];
+        }
+        if (empty($supplier['id'])) {
+            $supplier['id'] = $supplier['id_supplier'];
+        }
+
+        $supplierLazyArray = new SupplierLazyArray(
+            $supplier,
+            $language,
+            $this->imageRetriever,
+            $this->link
+        );
+
+        Hook::exec('actionPresentSupplier',
+            ['presentedSupplier' => &$supplierLazyArray]
+        );
+
+        return $supplierLazyArray;
+    }
+}

--- a/src/Adapter/Presenter/Supplier/SupplierPresenter.php
+++ b/src/Adapter/Presenter/Supplier/SupplierPresenter.php
@@ -56,7 +56,7 @@ class SupplierPresenter
      *
      * @return SupplierLazyArray
      */
-    public function present($supplier, $language)
+    public function present(array|Supplier $supplier, Language $language)
     {
         // Convert to array if a Supplier object was passed
         if (is_object($supplier)) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Finalizes the migration to object presenters in front office, following https://github.com/PrestaShop/PrestaShop/pull/31309. It allows to lazy load data and use multiple image formats. Introduces presenter for supplier and some minor simplification on ManufacturerLazyArray introduced previously.
| Type?             | new feature
| Category?         | FO
| BC breaks?        | yes - different template structure
| Deprecations?     | no
| How to test?      | Install this, install https://github.com/PrestaShop/classic-theme/pull/117 and see that everything works the same.
| Fixed ticket?     | 
| Related PRs       | https://github.com/PrestaShop/classic-theme/pull/117, https://github.com/PrestaShop/autoupgrade/pull/614
| Sponsor company   | 

### BC breaks
- Theme change on suppliers page, some template modifications and `$suppliers` instead of `$brands` passed to the template.

### New hooks
- actionPresentSupplier
- actionPresentManufacturer