### PR TITLE
Fix nightly 18-05 - Add reset filter step to products table

### DIFF
--- a/tests/UI/campaigns/functional/FO/classic/08_menuAndNavigation/03_navigationAndDisplay/01_displayTags.ts
+++ b/tests/UI/campaigns/functional/FO/classic/08_menuAndNavigation/03_navigationAndDisplay/01_displayTags.ts
@@ -216,8 +216,6 @@ describe('FO - Navigation and display : Display tags', async () => {
     it('should reset all filters', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'resetFilters', baseContext);
 
-      await productsPage.resetFilter(page);
-
       const numberOfProducts = await productsPage.resetAndGetNumberOfLines(page);
       await expect(numberOfProducts).to.be.above(0);
     });
@@ -362,7 +360,7 @@ describe('FO - Navigation and display : Display tags', async () => {
 
   // Post-condition: Reset 'Number of days for which the product is considered 'new''
   describe('POST-TEST : Reset \'Number of days for which the product is considered \'new\'\'', async () => {
-    it('should go back BO', async function () {
+    it('should go back to BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goBackToBO4', baseContext);
 
       page = await homePage.closePage(browserContext, page, 0);
@@ -406,6 +404,13 @@ describe('FO - Navigation and display : Display tags', async () => {
 
       const pageTitle = await productsPage.getPageTitle(page);
       await expect(pageTitle).to.contains(productsPage.pageTitle);
+    });
+
+    it('should reset all filters', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'resetFilters2', baseContext);
+
+      const numberOfProducts = await productsPage.resetAndGetNumberOfLines(page);
+      await expect(numberOfProducts).to.be.above(0);
     });
 
     it('should filter by product name', async function () {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Add reset filter to products table
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Nightly => https://github.com/nesrineabdmouleh/testing_pr/actions/runs/5043500978
| Fixed ticket?     | no
| Related PRs       | no
| Sponsor company   |
