### PR TITLE
Introduce category presenter

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -2166,6 +2166,11 @@
       <title>Store Presenter</title>
       <description>This hook is called before a store is presented</description>
     </hook>
+    <hook id="actionPresentCategory">
+      <name>actionPresentCategory</name>
+      <title>Category Presenter</title>
+      <description>This hook is called before a category is presented</description>
+    </hook>
     <hook id="actionAdminAdminPreferencesControllerPostProcessBefore">
       <name>actionAdminAdminPreferencesControllerPostProcessBefore</name>
       <title>On post-process in Admin Preferences</title>

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -137,7 +137,7 @@ class ImageRetriever
 
     /**
      * @param Product|Store|Category|Manufacturer|Supplier $object
-     * @param int $id_image
+     * @param int|string $id_image Identifier of the image
      *
      * @return array|null
      *
@@ -267,13 +267,13 @@ class ImageRetriever
     /**
      * @param string $originalImagePath
      * @param string $imageFolderPath
-     * @param int $idImage
+     * @param int|string $idImage
      * @param array $imageTypeData
      * @param string $imageFormat
      *
      * @return void
      */
-    private function checkOrGenerateImageType(string $originalImagePath, string $imageFolderPath, int $idImage, array $imageTypeData, string $imageFormat)
+    private function checkOrGenerateImageType(string $originalImagePath, string $imageFolderPath, int|string $idImage, array $imageTypeData, string $imageFormat)
     {
         $fileName = sprintf('%s-%s.%s', $idImage, $imageTypeData['name'], $imageFormat);
         $resizedImagePath = implode(DIRECTORY_SEPARATOR, [

--- a/src/Adapter/Presenter/Category/CategoryLazyArray.php
+++ b/src/Adapter/Presenter/Category/CategoryLazyArray.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Presenter\Category;
+
+use Category;
+use Language;
+use Link;
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
+
+class CategoryLazyArray extends AbstractLazyArray
+{
+    /**
+     * @var ImageRetriever
+     */
+    private $imageRetriever;
+
+    /**
+     * @var Link
+     */
+    private $link;
+
+    /**
+     * @var array
+     */
+    protected $category;
+
+    /**
+     * @var Language
+     */
+    private $language;
+
+    public function __construct(
+        array $category,
+        Language $language,
+        ImageRetriever $imageRetriever,
+        Link $link
+    ) {
+        $this->category = $category;
+        $this->language = $language;
+        $this->imageRetriever = $imageRetriever;
+        $this->link = $link;
+
+        parent::__construct();
+        $this->appendArray($this->category);
+    }
+
+    /**
+     * @arrayAccess
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->link->getCategoryLink(
+            $this->category['id'],
+            $this->category['link_rewrite']
+        );
+    }
+
+    /**
+     * @arrayAccess
+     *
+     * This method returns standardized category image array created from CATEGORYID.jpg, with one exception.
+     * One thumbnail size - CATEGORYID-small_default.jpg is generated from CATEGORYID_thumb.jpg instead.
+     * This must be resolved in the future.
+     *
+     * @return array|null
+     */
+    public function getImage()
+    {
+        /*
+         * Category is a bit different that other objects. It's image ID is defined by a special id_image property.
+         * When constructing Category object model, this value is a numeric ID if image exists or false if it doesn't.
+         * In case of getSubCategories method, this value is a numeric ID if image exists OR a default "not found" image if it doesn't.
+         */
+        if (empty($this->category['id_image'])) {
+            return null;
+        }
+
+        return $this->imageRetriever->getImage(
+            new Category($this->category['id'], $this->language->getId()),
+            $this->category['id_image']
+        );
+    }
+
+    /**
+     * @arrayAccess
+     *
+     * @return array|null
+     */
+    public function getCover()
+    {
+        return $this->getImage();
+    }
+
+    /**
+     * @todo This should return category thumbnail image (miniatures of CATEGORYID_thumb.jpg) instead,
+     * after support in ImageRetriever is implemented.
+     *
+     * @arrayAccess
+     *
+     * @return array|null
+     */
+    public function getThumbnail()
+    {
+        return $this->getImage();
+    }
+}

--- a/src/Adapter/Presenter/Category/CategoryPresenter.php
+++ b/src/Adapter/Presenter/Category/CategoryPresenter.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Presenter\Category;
+
+use Category;
+use Hook;
+use Language;
+use Link;
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+
+class CategoryPresenter
+{
+    /**
+     * @var ImageRetriever
+     */
+    protected $imageRetriever;
+
+    /**
+     * @var Link
+     */
+    protected $link;
+
+    public function __construct(Link $link)
+    {
+        $this->link = $link;
+        $this->imageRetriever = new ImageRetriever($link);
+    }
+
+    /**
+     * @param array|Category $category Category object or an array
+     * @param Language $language
+     *
+     * @return CategoryLazyArray
+     */
+    public function present(array|Category $category, Language $language)
+    {
+        // Convert to array if a Category object was passed
+        if (is_object($category)) {
+            $category = (array) $category;
+        }
+
+        // Normalize IDs
+        if (empty($category['id_category'])) {
+            $category['id_category'] = $category['id'];
+        }
+        if (empty($category['id'])) {
+            $category['id'] = $category['id_category'];
+        }
+
+        $categoryLazyArray = new CategoryLazyArray(
+            $category,
+            $language,
+            $this->imageRetriever,
+            $this->link
+        );
+
+        Hook::exec('actionPresentCategory',
+            ['presentedCategory' => &$categoryLazyArray]
+        );
+
+        return $categoryLazyArray;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Introduces presenter and lazy array for categories in front office, following https://github.com/PrestaShop/PrestaShop/pull/31309. It allows to lazy load data and use multiple image formats.
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | yes - `CategoryController::getImage`
| How to test?      | Install this PR, see that categories in FO work the same.
| Fixed ticket?     | 
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/614
| Sponsor company   | 

### New hooks
- actionPresentCategory

### Note
- An improvement will probably follow after this PR is merged to properly support category thumbnails.