### PR TITLE
Remove module list item when force deletion

### DIFF
--- a/admin-dev/themes/new-theme/js/components/module-card.ts
+++ b/admin-dev/themes/new-theme/js/components/module-card.ts
@@ -429,12 +429,19 @@ export default class ModuleCard {
         const alteredSelector = self.getModuleItemSelector().replace('.', '');
         let mainElement = null;
 
-        if (action === 'uninstall') {
+        if (action === 'delete' && !result[moduleTechName].has_download_url) {
+          mainElement = jqElementObj.closest(`.${alteredSelector}`);
+          this.eventEmitter.emit('Module Delete', mainElement);
+        } else if (action === 'uninstall') {
           mainElement = jqElementObj.closest(`.${alteredSelector}`);
           mainElement.attr('data-installed', '0');
           mainElement.attr('data-active', '0');
 
-          this.eventEmitter.emit('Module Uninstalled', mainElement);
+          if ((forceDeletion === 'true' || forceDeletion === true) && !result[moduleTechName].has_download_url) {
+            this.eventEmitter.emit('Module Delete', mainElement);
+          } else {
+            this.eventEmitter.emit('Module Uninstalled', mainElement);
+          }
         } else if (action === 'disable') {
           mainElement = jqElementObj.closest(`.${alteredSelector}`);
           mainElement.addClass(`${alteredSelector}-isNotActive`);
@@ -458,7 +465,7 @@ export default class ModuleCard {
           mainElement = jqElementObj.closest(`.${alteredSelector}`);
 
           this.eventEmitter.emit('Module Upgraded', mainElement);
-        };
+        }
 
         // Since we replace the DOM content
         // we need to update the jquery object reference to target the new content,

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -225,6 +225,7 @@ class AdminModuleController {
     this.eventEmitter.on('Module Enabled', (context) => this.onModuleDisabled(context));
     this.eventEmitter.on('Module Disabled', (context) => this.onModuleDisabled(context));
     this.eventEmitter.on('Module Uninstalled', (context) => this.installHandler(context));
+    this.eventEmitter.on('Module Delete', (context) => this.onModuleDelete(context));
     this.eventEmitter.on('Module Installed', (context) => this.installHandler(context));
   }
 
@@ -274,6 +275,11 @@ class AdminModuleController {
     $('.modules-list').each(() => {
       self.updateModuleVisibility();
     });
+  }
+
+  onModuleDelete(event) {
+    this.modulesList = this.modulesList.filter((value) => value.techName !== $(event).data('tech-name'));
+    this.installHandler(event);
   }
 
   initPlaceholderMechanism() {

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -269,11 +269,13 @@ class AdminModuleDataProvider implements ModuleInterface
                 if (!$module->isConfigurable()) {
                     unset($urls['configure']);
                 }
-            } else {
+            } elseif ($module->isUninstalled()) {
                 $urls = [
                     'install' => $urls['install'],
                     'delete' => $urls['delete'],
                 ];
+            } else {
+                $urls = ['install' => $urls['install']];
             }
 
             // Go through the actions and remove all actions that the current environment

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -240,6 +240,11 @@ class Module implements ModuleInterface
         return (bool) $this->database->get('installed');
     }
 
+    public function isUninstalled(): bool
+    {
+        return !$this->isInstalled() && $this->disk->get('is_present');
+    }
+
     public function isConfigurable(): bool
     {
         return (bool) $this->attributes->get('is_configurable');

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -30,6 +30,7 @@ use DateTime;
 use Db;
 use Exception;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
+use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Adapter\Module\Module as ModuleAdapter;
 use PrestaShop\PrestaShop\Core\Module\ModuleCollection;
 use PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerNotFoundException;
@@ -194,33 +195,36 @@ class ModuleController extends ModuleAbstractController
             return $this->getDisabledFunctionalityResponse($request);
         }
 
-        $module = $request->get('module_name');
+        $moduleName = $request->get('module_name');
         $source = $request->query->get('source');
         $moduleManager = $this->container->get('prestashop.module.manager');
         $moduleRepository = $this->container->get('prestashop.core.admin.module.repository');
         $modulesProvider = $this->container->get('prestashop.core.admin.data_provider.module_interface');
-        $response = [$module => []];
+        $response = [$moduleName => []];
 
         if (!method_exists($moduleManager, $action)) {
-            $response[$module]['status'] = false;
-            $response[$module]['msg'] = $this->trans('Invalid action', 'Admin.Notifications.Error');
+            $response[$moduleName]['status'] = false;
+            $response[$moduleName]['msg'] = $this->trans('Invalid action', 'Admin.Notifications.Error');
 
             return new JsonResponse($response);
         }
 
         $actionTitle = AdminModuleDataProvider::ACTIONS_TRANSLATION_LABELS[$action];
-
         try {
-            $args = [$module];
+            $args = [$moduleName];
             if ($source !== null) {
                 $args[] = $source;
             }
             if ($action === ModuleAdapter::ACTION_UNINSTALL) {
                 $args[] = (bool) ($request->request->get('actionParams', [])['deletion'] ?? false);
-                $response[$module]['refresh_needed'] = $this->moduleNeedsReload($moduleRepository->getModule($module));
+                $moduleInstance = $moduleRepository->getModule($moduleName);
+                $response[$moduleName]['refresh_needed'] = $this->moduleNeedsReload($moduleInstance);
+                $response[$moduleName]['has_download_url'] = $moduleInstance->attributes->has('download_url');
             }
             if ($action === ModuleAdapter::ACTION_DELETE) {
-                $response[$module]['refresh_needed'] = false;
+                $moduleInstance = $moduleRepository->getModule($moduleName);
+                $response[$moduleName]['refresh_needed'] = false;
+                $response[$moduleName]['has_download_url'] = $moduleInstance->attributes->has('download_url');
             }
             $systemCacheClearEnabled = filter_var(
                 $request->request->get('actionParams', [])['cacheClearEnabled'] ?? true,
@@ -229,15 +233,15 @@ class ModuleController extends ModuleAbstractController
             if (!$systemCacheClearEnabled) {
                 $moduleManager->disableSystemClearCache();
             }
-            $response[$module]['status'] = call_user_func([$moduleManager, $action], ...$args);
+            $response[$moduleName]['status'] = call_user_func([$moduleManager, $action], ...$args);
         } catch (Exception $e) {
-            $response[$module]['status'] = false;
-            $response[$module]['msg'] = $this->trans(
+            $response[$moduleName]['status'] = false;
+            $response[$moduleName]['msg'] = $this->trans(
                 'Cannot %action% module %module%. %error_details%',
                 'Admin.Modules.Notification',
                 [
                     '%action%' => $actionTitle,
-                    '%module%' => $module,
+                    '%module%' => $moduleName,
                     '%error_details%' => $e->getMessage(),
                 ]
             );
@@ -245,22 +249,22 @@ class ModuleController extends ModuleAbstractController
             return new JsonResponse($response);
         }
 
-        $moduleInstance = $moduleRepository->getModule($module);
-        if ($response[$module]['status'] === true) {
-            if (!isset($response[$module]['refresh_needed'])) {
-                $response[$module]['refresh_needed'] = $this->moduleNeedsReload($moduleInstance);
+        $moduleInstance = $moduleRepository->getModule($moduleName);
+        if ($response[$moduleName]['status'] === true) {
+            if (!isset($response[$moduleName]['refresh_needed'])) {
+                $response[$moduleName]['refresh_needed'] = $this->moduleNeedsReload($moduleInstance);
             }
-            $response[$module]['msg'] = $this->trans(
+            $response[$moduleName]['msg'] = $this->trans(
                 '%action% action on module %module% succeeded.',
                 'Admin.Modules.Notification',
                 [
                     '%action%' => ucfirst($actionTitle),
-                    '%module%' => $module,
+                    '%module%' => $moduleName,
                 ]
             );
             if ($action !== 'uninstall' && $action !== 'delete') {
-                $response[$module]['module_name'] = $module;
-                $response[$module]['is_configurable'] = (bool) $moduleInstance->attributes->get('is_configurable');
+                $response[$moduleName]['module_name'] = $moduleName;
+                $response[$moduleName]['is_configurable'] = (bool) $moduleInstance->attributes->get('is_configurable');
             }
 
             $collection = ModuleCollection::createFrom([$moduleInstance]);
@@ -268,8 +272,7 @@ class ModuleController extends ModuleAbstractController
 
             $modulePresenter = $this->get('prestashop.adapter.presenter.module');
             $collectionPresented = $modulePresenter->presentCollection($collectionWithActionUrls);
-
-            $response[$module]['action_menu_html'] = $this->container->get('twig')->render(
+            $response[$moduleName]['action_menu_html'] = $this->container->get('twig')->render(
                 '@PrestaShop/Admin/Module/Includes/action_menu.html.twig',
                 [
                     'module' => $collectionPresented[0],
@@ -277,13 +280,13 @@ class ModuleController extends ModuleAbstractController
                 ]
             );
         } else {
-            $response[$module]['msg'] = $this->trans(
+            $response[$moduleName]['msg'] = $this->trans(
                 'Cannot %action% module %module%. %error_details%',
                 'Admin.Modules.Notification',
                 [
                     '%action%' => $actionTitle,
-                    '%module%' => $module,
-                    '%error_details%' => $moduleManager->getError($module),
+                    '%module%' => $moduleName,
+                    '%error_details%' => $moduleManager->getError($moduleName),
                 ]
             );
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When deleting a module, we can dynamically remove the module from the list, or force the reload of the page. I chose to do it dynamically in JS for user experience. <br/> We do not remove the module from the list if it has a download url, to be able to re-download it if necessary <br/> I also modified the behavior of the dropdowns for the buttons after uninstallation, in fact it was possible to delete a module that was already deleted
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see #30952
| Fixed ticket?     | Fixes #30952
| Related PRs       | -
| Sponsor company   | -

Attention, for the modifications to work correctly, the url of the distribution API must be modified for the purposes of the tests. Indeed the recovery of the list of modules for 8.1.x is not yet possible. See https://api.prestashop-project.org/prestashop for versions and  modify the PrestaShop/modules/ps_distributionapiclient/src/DistributionApi.php file
![image](https://github.com/PrestaShop/PrestaShop/assets/36233446/94afbc1b-0fe9-48c8-ab74-46c6dc72ce28)
