### PR TITLE
Fix modules page bulk action

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -155,7 +155,7 @@ class AdminModuleController {
     body.on('click', this.bulkActionCheckboxListSelector, () => {
       const selector = $(self.bulkActionDropDownSelector);
 
-      if ($(this.checkedBulkActionListSelector).length > 0) {
+      if ($(self.checkedBulkActionListSelector).length > 0) {
         selector.closest('.module-top-menu-item').removeClass('disabled');
       } else {
         selector.closest('.module-top-menu-item').addClass('disabled');
@@ -163,7 +163,7 @@ class AdminModuleController {
     });
 
     body.on('click', self.bulkItemSelector, function initializeBodyChange() {
-      if ($(this.checkedBulkActionListSelector).length === 0) {
+      if ($(self.checkedBulkActionListSelector).length === 0) {
         $.growl.warning({
           message: window.translate_javascripts['Bulk Action - One module minimum'],
         });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix bulk actions system in Module manager pages.<br/>**This PR fix also `ga.tests.ui.pr` for bulk actions ([see errors here](https://github.com/boherm/ga.tests.ui.pr/actions/runs/5000867463/jobs/8961222701))!**
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to `BO` and `Module manager`<br/>2. Select one or multiple modules with their checkboxes.<br/>3. Bulk actions dropdown must be enabled.<br/>4. Select an action in this dropdown like "Enable" for instance.<br/>5. A modal window must be showing to confirm to enable selected modules,<br/>instead of `You need to select at least one module to use the bulk action.` message.
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/32663
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/32531
| Sponsor company   | 
