### PR TITLE
Change hook status command logic

### DIFF
--- a/src/Adapter/Hook/CommandHandler/UpdateHookStatusCommandHandler.php
+++ b/src/Adapter/Hook/CommandHandler/UpdateHookStatusCommandHandler.php
@@ -51,7 +51,7 @@ class UpdateHookStatusCommandHandler implements UpdateHookStatusCommandHandlerIn
             throw new HookNotFoundException(sprintf('Hook with id "%d" was not found', $hookId));
         }
 
-        $hook->active = !$command->getStatus();
+        $hook->active = $command->getStatus();
         if (!$hook->save()) {
             throw new CannotUpdateHookException(sprintf('Cannot update status for hook with id "%d"', $hookId));
         }

--- a/src/Core/Domain/Hook/Command/UpdateHookStatusCommand.php
+++ b/src/Core/Domain/Hook/Command/UpdateHookStatusCommand.php
@@ -41,6 +41,8 @@ class UpdateHookStatusCommand
     private $hookId;
 
     /**
+     * New hook status
+     *
      * @var bool
      */
     private $status;

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
@@ -259,7 +259,7 @@ class PositionsController extends FrameworkBundleAdminController
         $hookStatus = false;
 
         try {
-            $hookStatus = $this->getQueryBus()->handle(new GetHookStatus($hookId));
+            $hookStatus = !$this->getQueryBus()->handle(new GetHookStatus($hookId));
             $this->getCommandBus()->handle(new UpdateHookStatusCommand($hookId, (bool) $hookStatus));
             $response = [
                 'status' => true,
@@ -272,7 +272,7 @@ class PositionsController extends FrameworkBundleAdminController
             ];
         }
 
-        $response['hook_status'] = !$hookStatus;
+        $response['hook_status'] = $hookStatus;
 
         return $this->json($response);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Change hook status command logic. The command UpdateHookStatusCommand assumes that it is given the status of the current hook and that this status is reversed.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Apparence > Positions : Check hook status change works as expected
| Fixed ticket?     | -
| Related PRs       | -
| Sponsor company   | Prestashop SA


Breaking change : Change the behaviour of the command, before change the given status was reversed, now the status passed to the command will be the new status of the hook.