### PR TITLE
Fix confirm text for bulk actions in module manager

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -172,10 +172,7 @@ class AdminModuleController {
 
       self.lastBulkAction = $(this).data('ref');
       const modulesListString = self.buildBulkActionModuleList();
-      const actionString = $(this)
-        .find(':checked')
-        .text()
-        .toLowerCase();
+      const actionString = $(this).data('display-name').toLowerCase();
       $(self.bulkConfirmModalListSelector).html(modulesListString);
       $(self.bulkConfirmModalActionNameSelector).text(actionString);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix confirmation text in modal window when we want to execute a bulk action in module manager.<br/>We must display action name.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #32670 
| Fixed ticket?     | Fixes #32670 
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/32664#issuecomment-1559192470
| Sponsor company   | 

Thanks @Hlavtox for the catch!
