### PR TITLE
Remove deprecated code

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -169,7 +169,6 @@ class CombinationCore extends ObjectModel
         $this->deleteFromSupplier($this->id_product);
         $this->deleteFromPack();
         Product::updateDefaultAttribute($this->id_product);
-        Tools::clearColorListCache((int) $this->id_product);
 
         return true;
     }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2344,7 +2344,6 @@ class ProductCore extends ObjectModel
         }
 
         Hook::exec('actionProductAttributeUpdate', ['id_product_attribute' => (int) $id_product_attribute]);
-        Tools::clearColorListCache($this->id);
 
         return true;
     }
@@ -2460,8 +2459,6 @@ class ProductCore extends ObjectModel
             $combination->setImages($id_images);
         }
 
-        Tools::clearColorListCache($this->id);
-
         if (Configuration::get('PS_DEFAULT_WAREHOUSE_NEW_PRODUCT') != 0 && Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT')) {
             $warehouse_location_entity = new WarehouseProductLocation();
             $warehouse_location_entity->id_product = $this->id;
@@ -2510,7 +2507,6 @@ class ProductCore extends ObjectModel
             $result &= $combination->delete();
         }
         SpecificPriceRule::applyAllRules([(int) $this->id]);
-        Tools::clearColorListCache($this->id);
 
         return $result;
     }
@@ -8128,28 +8124,6 @@ class ProductCore extends ObjectModel
                 WHERE sa.id_product_attribute = pa.id_product_attribute AND pa.id_product=' . (int) $this->id . ' AND pac.id_attribute=' . (int) $id_attribute . '
             )'
         );
-    }
-
-    /**
-     * @deprecated since 8.1 and will be removed in next major version.
-     *
-     * @param int $id_product Product identifier
-     * @param bool $full
-     *
-     * @return string
-     */
-    public static function getColorsListCacheId($id_product, $full = true)
-    {
-        $cache_id = 'productlist_colors';
-        if ($id_product) {
-            $cache_id .= '|' . (int) $id_product;
-        }
-
-        if ($full) {
-            $cache_id .= '|' . (int) Context::getContext()->shop->id . '|' . (int) Context::getContext()->cookie->id_lang;
-        }
-
-        return $cache_id;
     }
 
     /**

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1214,11 +1214,10 @@ class ToolsCore
 
     /**
      * @param array $params
-     * @param Smarty|null $smarty unused parameter, please ignore (@todo: remove in next major)
      *
      * @return bool|string
      */
-    public static function getAdminTokenLiteSmarty($params, &$smarty = null)
+    public static function getAdminTokenLiteSmarty($params)
     {
         $context = Context::getContext();
 
@@ -3145,20 +3144,6 @@ exit;
     {
         Tools::clearSmartyCache();
         Tools::clearSf2Cache();
-    }
-
-    /**
-     * @deprecated since 8.1 and will be removed in next major version.
-     *
-     * @param int|bool $id_product
-     */
-    public static function clearColorListCache($id_product = false)
-    {
-        // Change template dir if called from the BackOffice
-        $current_template_dir = Context::getContext()->smarty->getTemplateDir();
-        Context::getContext()->smarty->setTemplateDir(_PS_THEME_DIR_);
-        Tools::clearCache(null, _PS_THEME_DIR_ . 'product-list-colors.tpl', Product::getColorsListCacheId((int) $id_product, false));
-        Context::getContext()->smarty->setTemplateDir($current_template_dir);
     }
 
     /**

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -47,16 +47,6 @@ class ValidateCore
      */
     public const MYSQL_UNSIGNED_INT_MAX = 4294967295;
 
-    /**
-     * @deprecated since 8.0.0 use PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH
-     */
-    public const ADMIN_PASSWORD_LENGTH = 8;
-
-    /**
-     * @deprecated since 8.0.0 use PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH
-     */
-    public const PASSWORD_LENGTH = 5;
-
     public static function isIp2Long($ip)
     {
         return preg_match('#^-?[0-9]+$#', (string) $ip);
@@ -538,8 +528,6 @@ class ValidateCore
      * @param string $password Password to validate
      *
      * @return bool Indicates whether the given string is a valid password
-     *
-     * @since 8.0.0
      */
     public static function isAcceptablePasswordScore(string $password): bool
     {
@@ -558,8 +546,6 @@ class ValidateCore
      * @param string $password Password to validate
      *
      * @return bool Indicates whether the given string is a valid password length
-     *
-     * @since 8.0.0
      */
     public static function isAcceptablePasswordLength(string $password): bool
     {
@@ -573,24 +559,6 @@ class ValidateCore
 
         // If value doesn't exist in database, use default behavior check
         return $passwordLength >= PasswordPolicyConfiguration::DEFAULT_MINIMUM_LENGTH && $passwordLength <= PasswordPolicyConfiguration::DEFAULT_MAXIMUM_LENGTH;
-    }
-
-    /**
-     * Check if plaintext password is valid
-     * Size is limited by `password_hash()` (72 chars).
-     *
-     * @param string $plaintextPasswd Password to validate
-     * @param int $size
-     *
-     * @return bool Indicates whether the given string is a valid plaintext password
-     *
-     * @since 1.7.0
-     * @deprecated since 8.0, use Validate::isAcceptablePasswordLength instead
-     */
-    public static function isPlaintextPassword($plaintextPasswd, $size = Validate::PASSWORD_LENGTH)
-    {
-        // The password length is limited by `password_hash()`
-        return Tools::strlen($plaintextPasswd) >= $size && Tools::strlen($plaintextPasswd) <= 72;
     }
 
     /**
@@ -608,14 +576,6 @@ class ValidateCore
     public static function isHashedPassword($hashedPasswd)
     {
         return Tools::strlen($hashedPasswd) == 32 || Tools::strlen($hashedPasswd) == 60;
-    }
-
-    /**
-     * @deprecated since 8.0
-     */
-    public static function isPasswdAdmin($passwd)
-    {
-        return Validate::isPlaintextPassword($passwd, Validate::ADMIN_PASSWORD_LENGTH);
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -48,46 +48,8 @@ class FrontControllerCore extends Controller
     /** @var string Language ISO code */
     public $iso;
 
-    /**
-     * @deprecated Since 8.0 and will be removed in the next major.
-     *
-     * @var string ORDER BY field
-     */
-    public $orderBy;
-
-    /**
-     * @deprecated Since 8.0 and will be removed in the next major.
-     *
-     * @var string Order way string ('ASC', 'DESC')
-     */
-    public $orderWay;
-
-    /**
-     * @deprecated Since 8.0 and will be removed in the next major.
-     *
-     * @var int Current page number
-     */
-    public $p;
-
-    /**
-     * @deprecated Since 8.0 and will be removed in the next major.
-     *
-     * @var int Items (products) per page
-     */
-    public $n;
-
     /** @var bool If set to true, will redirected user to login page during init function. */
     public $auth = false;
-
-    /**
-     * If set to true, user can be logged in as guest when checking if logged in.
-     *
-     * @deprecated Since 8.0 and will be removed in the next major.
-     * @see $auth
-     *
-     * @var bool
-     */
-    public $guestAllowed = false;
 
     /**
      * Route of PrestaShop page to redirect to after forced login.
@@ -122,13 +84,6 @@ class FrontControllerCore extends Controller
      * @var array Holds current customer's groups
      */
     protected static $currentCustomerGroups;
-
-    /**
-     * @deprecated Since 8.0 and will be removed in the next major.
-     *
-     * @var int
-     */
-    public $nb_items_per_page;
 
     /**
      * @var ObjectPresenter
@@ -1445,60 +1400,6 @@ class FrontControllerCore extends Controller
             $params['id'],
             $locale
         );
-    }
-
-    /**
-     * Renders and adds color list HTML for each product in a list.
-     *
-     * @deprecated since 8.1 and will be removed in next major version.
-     *
-     * @param array $products
-     */
-    public function addColorsToProductList(&$products)
-    {
-        if (!is_array($products) || !count($products) || !file_exists(_PS_THEME_DIR_ . 'product-list-colors.tpl')) {
-            return;
-        }
-
-        $products_need_cache = [];
-        foreach ($products as $product) {
-            if (!$this->isCached(_PS_THEME_DIR_ . 'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']))) {
-                $products_need_cache[] = (int) $product['id_product'];
-            }
-        }
-
-        $colors = false;
-        if (count($products_need_cache)) {
-            $colors = Product::getAttributesColorList($products_need_cache);
-        }
-
-        Tools::enableCache();
-        foreach ($products as &$product) {
-            $tpl = $this->context->smarty->createTemplate(_PS_THEME_DIR_ . 'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
-            $tpl->assign([
-                'id_product' => $product['id_product'],
-                'colors_list' => isset($colors[$product['id_product']]) ? $colors[$product['id_product']] : null,
-                'link' => Context::getContext()->link,
-                'img_col_dir' => _THEME_COL_DIR_,
-                'col_img_dir' => _PS_COL_IMG_DIR_,
-            ]);
-            $product['color_list'] = $tpl->fetch(_PS_THEME_DIR_ . 'product-list-colors.tpl', $this->getColorsListCacheId($product['id_product']));
-        }
-        Tools::restoreCacheSettings();
-    }
-
-    /**
-     * Returns cache ID for product color list.
-     *
-     * @deprecated since 8.1 and will be removed in next major version.
-     *
-     * @param int $id_product
-     *
-     * @return string
-     */
-    protected function getColorsListCacheId($id_product)
-    {
-        return Product::getColorsListCacheId($id_product);
     }
 
     /**

--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -512,8 +512,6 @@ class StockAvailableCore extends ObjectModel
                 $product = new Product((int) $this->id_product);
                 foreach ($colors as $color) {
                     if ($product->isColorUnavailable((int) $color['id_attribute'], (int) $this->id_shop)) {
-                        Tools::clearColorListCache($product->id);
-
                         break;
                     }
                 }

--- a/controllers/admin/AdminAttributesGroupsController.php
+++ b/controllers/admin/AdminAttributesGroupsController.php
@@ -478,10 +478,6 @@ class AdminAttributesGroupsControllerCore extends AdminController
             $this->setTypeAttribute();
         }
 
-        if (Tools::isSubmit('updateattribute') || Tools::isSubmit('deleteattribute') || Tools::isSubmit('submitAddattribute') || Tools::isSubmit('submitBulkdeleteattribute')) {
-            Tools::clearColorListCache();
-        }
-
         return $object;
     }
 

--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -238,7 +238,7 @@ class AdminLoginControllerCore extends AdminController
 
         if (empty($passwd)) {
             $this->errors[] = $this->trans('The password field is blank.', [], 'Admin.Notifications.Error');
-        } elseif (!Validate::isPlaintextPassword($passwd)) {
+        } elseif (!Validate::isAcceptablePasswordLength($passwd)) {
             $this->errors[] = $this->trans('Invalid password.', [], 'Admin.Notifications.Error');
         }
 
@@ -426,7 +426,7 @@ class AdminLoginControllerCore extends AdminController
         } elseif (!$reset_password) {
             // password (twice)
             $this->errors[] = $this->trans('The password is missing: please enter your new password.', [], 'Admin.Login.Notification');
-        } elseif (!Validate::isPlaintextPassword($reset_password)) {
+        } elseif (!Validate::isAcceptablePasswordLength($reset_password)) {
             $this->errors[] = $this->trans('The password is not in a valid format.', [], 'Admin.Login.Notification');
         } elseif (!$reset_confirm) {
             $this->errors[] = $this->trans('The confirmation is empty: please fill in the password confirmation as well.', [], 'Admin.Login.Notification');

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1369,7 +1369,6 @@ class AdminProductsControllerCore extends AdminController
                 } else {
                     $product->deleteAttributeCombination((int) $id_product_attribute);
                     $product->checkDefaultAttributes();
-                    Tools::clearColorListCache((int) $product->id);
                     if (!$product->hasAttributes()) {
                         $product->cache_default_attribute = 0;
                         $product->update();

--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -33,18 +33,14 @@ class CmsControllerCore extends FrontController
     public $assignCase;
 
     /**
-     * @deprecated Since 8.1, it will become protected in next major version. Use getCms() method instead.
-     *
      * @var CMS|null
      */
-    public $cms;
+    protected $cms;
 
     /**
-     * @deprecated Since 8.1, it will become protected in next major version. Use getCmsCategory() method instead.
-     *
      * @var CMSCategory|null
      */
-    public $cms_category;
+    protected $cms_category;
 
     /** @var bool */
     public $ssl = false;

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -160,7 +160,7 @@ class PasswordControllerCore extends FrontController
                         $this->errors[] = $this->trans('The confirmation password doesn\'t match.', [], 'Shop.Notifications.Error');
                     }
 
-                    if (!Validate::isPlaintextPassword($passwd)) {
+                    if (!Validate::isAcceptablePasswordLength($passwd)) {
                         $this->errors[] = $this->trans('The password is not in a valid format.', [], 'Shop.Notifications.Error');
                     }
                 }

--- a/src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php
+++ b/src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php
@@ -33,7 +33,6 @@ use Product;
 use SpecificPriceRule;
 use Stock;
 use StockAvailable;
-use Tools;
 use Validate;
 
 /**
@@ -121,7 +120,6 @@ class AdminAttributeGeneratorControllerWrapper
             } else {
                 $product->deleteAttributeCombination((int) $idAttribute);
                 $product->checkDefaultAttributes();
-                Tools::clearColorListCache((int) $product->id);
                 if (!$product->hasAttributes()) {
                     $product->cache_default_attribute = 0;
                     $product->update();

--- a/tests/Resources/modules_tests/override/AdminProductsController.php
+++ b/tests/Resources/modules_tests/override/AdminProductsController.php
@@ -1169,7 +1169,6 @@ class AdminProductsController extends AdminProductsControllerCore
                 } else {
                     $product->deleteAttributeCombination((int) $id_product_attribute);
                     $product->checkDefaultAttributes();
-                    Tools::clearColorListCache((int) $product->id);
                     if (!$product->hasAttributes()) {
                         $product->cache_default_attribute = 0;
                         $product->update();

--- a/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
+++ b/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
@@ -1177,7 +1177,6 @@ class AdminProductsController extends AdminProductsControllerCore
                 } else {
                     $product->deleteAttributeCombination((int) $id_product_attribute);
                     $product->checkDefaultAttributes();
-                    Tools::clearColorListCache((int) $product->id);
                     if (!$product->hasAttributes()) {
                         $product->cache_default_attribute = 0;
                         $product->update();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removes part of deprecated code scheduled for deletion in v9.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | See below
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 

### What to test
- Try registering, login and password reset in both BO and FO.
- Try to edit some product combinations and see if colors in FO product list still work.
![Bez názvu](https://github.com/PrestaShop/PrestaShop/assets/6097524/6daa51d0-d561-4062-90a1-92104620026c)

### Removed methods
- Product::getColorsListCacheId
- Tools::clearColorListCache
- Validate::isPlaintextPassword
- Validate::isPasswdAdmin
- FrontController::addColorsToProductList
- FrontController::getColorsListCacheId
