### PR TITLE
New API Modularity - Modules can add Ressources

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -164,19 +164,6 @@ class AppKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    protected function getKernelParameters()
-    {
-        $kernelParameters = parent::getKernelParameters();
-
-        return array_merge(
-            $kernelParameters,
-            array('kernel.active_modules' => $this->getActiveModules())
-        );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getRootDir()
     {
         return __DIR__;
@@ -206,7 +193,6 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
         $installedModules = $this->getActiveModules();
-
         $loader->load($this->getRootDir() . '/config/config_' . $this->getEnvironment() . '.yml');
 
         $moduleTranslationsPaths = [];
@@ -233,9 +219,13 @@ class AppKernel extends Kernel
             }
         }
 
-        $loader->load(function (ContainerBuilder $container) use ($moduleTranslationsPaths) {
+        $loader->load(function (ContainerBuilder $container) use ($moduleTranslationsPaths, $installedModules) {
             $container->setParameter('container.autowiring.strict_mode', true);
             $container->setParameter('container.dumper.inline_class_loader', false);
+            $container->setParameter('prestashop.module_dir', _PS_MODULE_DIR_);
+            /** @deprecated kernel.active_modules is deprecated. Use prestashop.installed_modules instead. */
+            $container->setParameter('kernel.active_modules', $installedModules);
+            $container->setParameter('prestashop.installed_modules', $installedModules);
             $container->addObjectResource($this);
             $container->setParameter('modules_translation_paths', $moduleTranslationsPaths);
         });

--- a/src/Adapter/Container/ContainerParametersExtension.php
+++ b/src/Adapter/Container/ContainerParametersExtension.php
@@ -80,7 +80,11 @@ class ContainerParametersExtension implements ContainerBuilderExtensionInterface
         $container->setParameter('kernel.cache_dir', $this->environment->getCacheDir());
 
         //Init the active modules
-        $container->setParameter('kernel.active_modules', (new ModuleRepository(_PS_ROOT_DIR_, _PS_MODULE_DIR_))->getActiveModules());
+        $activeModules = (new ModuleRepository(_PS_ROOT_DIR_, _PS_MODULE_DIR_))->getActiveModules();
+        /* @deprecated kernel.active_modules is deprecated. Use prestashop.installed_modules instead. */
+        $container->setParameter('kernel.active_modules', $activeModules);
+        $container->setParameter('prestashop.installed_modules', $activeModules);
+        $container->setParameter('prestashop.module_dir', _PS_MODULE_DIR_);
 
         if (!$container->hasParameter('kernel.project_dir')) {
             $container->setParameter('kernel.project_dir', _PS_ROOT_DIR_);

--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -243,11 +243,7 @@ class ContainerBuilder
      */
     private function loadModulesAutoloader(ContainerInterface $container)
     {
-        if (!$container->hasParameter('kernel.active_modules')) {
-            return;
-        }
-
-        $activeModules = $container->getParameter('kernel.active_modules');
+        $activeModules = $container->getParameter('prestashop.installed_modules');
         /** @var array<string> $activeModules */
         foreach ($activeModules as $module) {
             $autoloader = _PS_MODULE_DIR_ . $module . '/vendor/autoload.php';

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShopBundle\DependencyInjection\Compiler;
 
-use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -46,11 +45,6 @@ class LoadServicesFromModulesPass implements CompilerPassInterface
     private $configPath;
 
     /**
-     * @var array
-     */
-    private $activeModulesPaths;
-
-    /**
      * Used to identify which scope of services need to be loaded (front services, admin
      * services or generic ones)
      *
@@ -59,7 +53,6 @@ class LoadServicesFromModulesPass implements CompilerPassInterface
     public function __construct($containerName = '')
     {
         $this->configPath = '/config/' . (empty($containerName) ? '' : trim($containerName, '/') . '/');
-        $this->activeModulesPaths = (new ModuleRepository(_PS_ROOT_DIR_, _PS_MODULE_DIR_))->getActiveModulesPaths();
     }
 
     /**
@@ -67,11 +60,11 @@ class LoadServicesFromModulesPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (empty($this->activeModulesPaths)) {
-            return;
-        }
+        $installedModules = $container->getParameter('prestashop.installed_modules');
+        $moduleDir = $container->getParameter('prestashop.module_dir');
 
-        foreach ($this->activeModulesPaths as $modulePath) {
+        foreach ($installedModules as $moduleName) {
+            $modulePath = $moduleDir . $moduleName;
             $moduleConfigPath = $modulePath . $this->configPath;
             if (file_exists($moduleConfigPath . 'services.yml')) {
                 $fileLocator = new FileLocator($moduleConfigPath);

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
@@ -47,13 +47,7 @@ class ModulesDoctrineCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        //We need the list of active modules to load their config, during install the parameter might no be available
-        //if the parameters file has not been generated yet, so we skip this part of the build
-        if (!$container->hasParameter('kernel.active_modules')) {
-            return;
-        }
-
-        $activeModules = $container->getParameter('kernel.active_modules');
+        $activeModules = $container->getParameter('prestashop.installed_modules');
         $compilerPassList = $this->getCompilerPassList($activeModules);
         /** @var CompilerPassInterface $compilerPass */
         foreach ($compilerPassList as $compilerResourcePath => $compilerPass) {

--- a/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
+++ b/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
@@ -93,12 +93,11 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
 
             /**
              * TODO: Understand why this crashes PrestaShop and redirects to Front Office - no support of entities until then
-            // Load Doctrine entities that could be used as ApiPlatform DTO resources as well in the src/Entity folder
-            $entitiesRessourcesPath = sprintf('%s/src/Entity', $modulePath);
-            if (file_exists($entitiesRessourcesPath)) {
-                $paths[] = $entitiesRessourcesPath;
-            }
-             *
+             * // Load Doctrine entities that could be used as ApiPlatform DTO resources as well in the src/Entity folder
+             * $entitiesRessourcesPath = sprintf('%s/src/Entity', $modulePath);
+             * if (file_exists($entitiesRessourcesPath)) {
+             *   $paths[] = $entitiesRessourcesPath;
+             * }
              */
 
             // Load ApiPLatform DTOs from the src/ApiPlatform/Resources folder

--- a/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
+++ b/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShopBundle\DependencyInjection;
 
-use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -38,13 +37,6 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  */
 class PrestaShopExtension extends Extension implements PrependExtensionInterface
 {
-    private $activeModulesPaths;
-
-    public function __construct()
-    {
-        $this->activeModulesPaths = (new ModuleRepository(_PS_ROOT_DIR_, _PS_MODULE_DIR_))->getActiveModulesPaths();
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -84,7 +76,11 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
     public function preprendApiConfig(ContainerBuilder $container)
     {
         $paths = [];
-        foreach ($this->activeModulesPaths as $modulePath) {
+        $installedModules = $container->getParameter('prestashop.installed_modules');
+        $moduleDir = $container->getParameter('prestashop.module_dir');
+
+        foreach ($installedModules as $moduleName) {
+            $modulePath = $moduleDir . $moduleName;
             // Load YAML definition from the config/api_platform folder in the module
             $moduleConfigPath = sprintf('%s/config/api_platform', $modulePath);
             if (file_exists($moduleConfigPath)) {

--- a/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
+++ b/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
@@ -78,9 +78,17 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
     {
         foreach ($this->activeModulesPaths as $modulePath) {
             if (str_ends_with($modulePath, 'api_module')) {
-                $moduleResourcesPath = sprintf('%s/config/api_platform', $modulePath);
-                if (file_exists($moduleResourcesPath)) {
-                    $container->prependExtensionConfig('api_platform', ['mapping' => ['paths' => [$moduleResourcesPath]]]);
+                $moduleConfigPath = sprintf('%s/config/api_platform', $modulePath);
+                if (file_exists($moduleConfigPath)) {
+                    $container->prependExtensionConfig('api_platform', ['mapping' => ['paths' => [$moduleConfigPath]]]);
+                }
+                $entitiesRessourcesPath = sprintf('%s/src/Entity', $modulePath);
+                if (file_exists($entitiesRessourcesPath)) {
+                    $container->prependExtensionConfig('api_platform', ['mapping' => ['paths' => [$entitiesRessourcesPath]]]);
+                }
+                $moduleRessourcesPath = sprintf('%s/src/ApiPlatform/Resources', $modulePath);
+                if (file_exists($moduleRessourcesPath)) {
+                    $container->prependExtensionConfig('api_platform', ['mapping' => ['paths' => [$moduleRessourcesPath]]]);
                 }
             }
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds the ability for modules to register their own API Platform Resources.
| Type?             | new feature
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | Install Example API Module and access `/admin-dev/new-api/docs`, see that there is a new `Cat` ressource coming from the module.
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/32582
| Related PRs       | https://github.com/PrestaShop/example-modules/pull/149
| Sponsor company   | PrestaShop
