### PR TITLE
Fix: [BO] : Error notification displayed in Multistore page

### DIFF
--- a/controllers/admin/AdminShopGroupController.php
+++ b/controllers/admin/AdminShopGroupController.php
@@ -137,7 +137,7 @@ class AdminShopGroupControllerCore extends AdminController
         $this->context->smarty->assign([
             'toolbar_scroll' => 1,
             'toolbar_btn' => $this->toolbar_btn,
-            'title' => $this->toolbar_title,
+            'title' => end($this->toolbar_title),
             'shops_tree' => $shops_tree,
         ]);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | After installing the PS 810 RC version and activating the multistore option, go to the multistore page, an error notification is displayed
| Type?             | bug fix
| Category?         | BO
| Fixed ticket?     | Fixes #32680
