### PR TITLE
Deleting an attached file from the webservice API does not work

### DIFF
--- a/classes/webservice/WebserviceSpecificManagementAttachments.php
+++ b/classes/webservice/WebserviceSpecificManagementAttachments.php
@@ -219,7 +219,7 @@ class WebserviceSpecificManagementAttachmentsCore implements WebserviceSpecificM
                     $this->getWsObject()->executeEntityGetAndHead();
                     break;
                 case 'DELETE':
-                    $attachment = new Attachment((int) $this->getWsObject()->urlSegment[1]);
+                    $attachment = new Attachment((int) $this->getWsObject()->urlSegment[2]);
                     $attachment->delete();
                     break;
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | bug fix
| Category?         | WS
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | see the description
| Fixed ticket?     | Fixes #32700
| Related PRs       | 
| Sponsor company   | 

## Description

There is a priori a subtlety, namely that :
{url}/api/attachments/1 => work on the model in DB in the products_attachment table
{url}/api/attachments/file/1 => allows binary operations on the file itself

I delete an attachment from the API, so I send a DELETE request to https://mywebsite/api/attachments/file/1
The API answers 200, I check with Postman... And the file is still there

In the file 
/classes/webservice/WebserviceSpecificManagementAttachments.php

On line 203 there is an IF that checks that the Segment[1] = 'file'
if ($this->getWsObject()->urlSegment[1] == 'file') {

The bug is online 222
$attachment = new Attachment((int) $this->getWsObject()->urlSegment[1]);

Out urlSegment[1] = 'file'

The correction: 

$attachment = new Attachment((int) $this->getWsObject()->urlSegment[2]);

urlSegment[2] = id_attachment

with this correction, the deletion is effective