### PR TITLE
Fix smarty deprecation stripslashes and md5

### DIFF
--- a/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
+++ b/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
@@ -42,7 +42,7 @@
 						<option value="0" selected disabled>{l s='Please select a module' d='Admin.Design.Help'}</option>
 					{/if}
 					{foreach $modules as $module}
-						<option value="{$module->id|intval}"{if $id_module == $module->id || (!$id_module && $show_modules == $module->id)} selected="selected"{/if}>{$module->displayName|stripslashes}</option>
+						<option value="{$module->id|intval}"{if $id_module == $module->id || (!$id_module && $show_modules == $module->id)} selected="selected"{/if}>{stripslashes($module->displayName)}</option>
 					{/foreach}
 				</select>
 			</div>

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl
@@ -85,9 +85,9 @@
 				<table class="table">
 					{foreach $errorsArray as $key => $value}
 						<tr {if empty($value.trad)}style="background-color:#FBB"{else}{cycle values='class="alt_row",'}{/if}>
-							<td width="40%">{$key|stripslashes}</td>
+							<td width="40%">{stripslashes($key)}</td>
 							<td width="40%">
-								<input type="text" name="{$key|md5}" value="{$value.trad|regex_replace:'#"#':'&quot;'|stripslashes}"' style="width: 450px{if empty($value.trad)};background:#FBB{/if}">
+								<input type="text" name="{md5($key)}" value="{stripslashes($value.trad)|regex_replace:'#"#':'&quot;'}"' style="width: 450px{if empty($value.trad)};background:#FBB{/if}">
 							</td>
 							<td width="18%">
 								{if isset($value.use_sprintf) && $value.use_sprintf}

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl
@@ -115,17 +115,17 @@
 								{counter start=0 assign=irow}
 								{foreach $newLang as $key => $value}{counter}
 									<tr>
-										<td width="40%">{$key|stripslashes}</td>
+										<td width="40%">{stripslashes($key)}</td>
 										<td width="2%">=</td>
 										<td width="40%"> {*todo : md5 is already calculated in AdminTranslationsController*}
 											{if $key|strlen < $textarea_sized}
 												<input type="text" style="width: 450px{if empty($value.trad)};background:#FBB{/if}"
-													name="{if in_array($type, array('front', 'fields'))}{$k}_{$key|md5}{else}{$k}{$key|md5}{/if}"
-													value="{$value.trad|regex_replace:'/"/':'&quot;'|stripslashes}"' />
+													name="{if in_array($type, array('front', 'fields'))}{$k}_{md5($key)}{else}{$k}{md5($key)}{/if}"
+													value="{stripslashes($value.trad)|regex_replace:'/"/':'&quot;'}"' />
 											{else}
 												<textarea rows="{($key|strlen / $textarea_sized)|intval}" style="width: 450px{if empty($value.trad)};background:#FBB{/if}"
-												name="{if in_array($type, array('front', 'fields'))}{$k}_{$key|md5}{else}{$k}{$key|md5}{/if}"
-												>{$value.trad|regex_replace:'/"/':'&quot;'|stripslashes}</textarea>
+												name="{if in_array($type, array('front', 'fields'))}{$k}_{md5($key)}{else}{$k}{md5($key)}{/if}"
+												>{stripslashes($value.trad)|regex_replace:'/"/':'&quot;'}</textarea>
 											{/if}
 										</td>
 										<td width="18%">

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
@@ -119,7 +119,7 @@
 									<table class="table">
 										{foreach $newLang as $key => $value}
 											<tr>
-												<td width="40%">{$key|stripslashes}</td>
+												<td width="40%">{stripslashes($key)}</td>
 												<td>=</td>
 												<td>
 													{* Prepare name string for md5() *}
@@ -127,12 +127,12 @@
 													{if $key|strlen < $textarea_sized}
 														<input type="text"
 															style="width: 450px{if empty($value.trad)};background:#FBB{/if}"
-															name="{$name|md5}"
-															value="{$value.trad|regex_replace:'#"#':'&quot;'|stripslashes}" />
+															name="{md5($name)}"
+															value="{stripslashes($value.trad)|regex_replace:'#"#':'&quot;'}" />
 													{else}
 														<textarea rows="{($key|strlen / $textarea_sized)|intval}"
 															style="width: 450px{if empty($value.trad)};background:#FBB{/if}"
-															name="{$name|md5}">{$value.trad|regex_replace:'#"#':'&quot;'|stripslashes}</textarea>
+															name="{md5($name)}">{stripslashes($value.trad)|regex_replace:'#"#':'&quot;'}</textarea>
 													{/if}
 												</td>
 												<td>

--- a/themes/debug.tpl
+++ b/themes/debug.tpl
@@ -159,7 +159,7 @@
     </html>
 {/capture}
 <script type="text/javascript">
-    {$id = $template_name|default:''|md5}
+    {$id = md5($template_name|default:'')}
     _smarty_console = window.open("", "console{$id}", "width=680,height=600,resizable,scrollbars=yes");
     _smarty_console.document.write("{$debug_output|escape:'javascript' nofilter}");
     _smarty_console.document.close();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Passing `stripslashes` as a modifier in smarty is deprecated since Prestashop 8.0.4
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With PS 8.0.4 and PHP 8.1 (or 8.0) we no longer get user depreation notices in the error log.
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/32703
| Related PRs       | none
| Sponsor company   | Société Biblique de Genève
