### PR TITLE
Fix: [BO] : Error notification displayed in Multistore page

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -98,7 +98,7 @@ smartyRegisterFunction($smarty, 'function', 'url', array('Link', 'getUrlSmarty')
 smartyRegisterFunction($smarty, 'modifier', 'addcslashes', 'addcslashes');
 smartyRegisterFunction($smarty, 'modifier', 'addslashes', 'addslashes');
 smartyRegisterFunction($smarty, 'modifier', 'date','date');
-smartyRegisterFunction($smarty, 'modifier', 'end','end');
+smartyRegisterFunction($smarty, 'modifier', 'end', 'smarty_endWithoutReference');
 smartyRegisterFunction($smarty, 'modifier', 'floatval', 'floatval');
 smartyRegisterFunction($smarty, 'modifier', 'htmlentities', 'htmlentities');
 smartyRegisterFunction($smarty, 'modifier', 'intval', 'intval');
@@ -113,6 +113,12 @@ smartyRegisterFunction($smarty, 'modifier', 'trim', 'trim');
 smartyRegisterFunction($smarty, 'modifier', 'ucfirst', 'ucfirst');
 smartyRegisterFunction($smarty, 'modifier', 'urlencode','urlencode');
 smartyRegisterFunction($smarty, 'modifier', 'htmlspecialchars','htmlspecialchars');
+smartyRegisterFunction($smarty, 'modifier', 'implode', 'implode');
+smartyRegisterFunction($smarty, 'modifier', 'explode', 'explode');
+smartyRegisterFunction($smarty, 'modifier', 'print_r', 'print_r');
+smartyRegisterFunction($smarty, 'modifier', 'var_dump', 'var_dump');
+smartyRegisterFunction($smarty, 'modifier', 'lcfirst', 'lcfirst');
+smartyRegisterFunction($smarty, 'modifier', 'nl2br', 'nl2br');
 
 function smarty_modifier_htmlentitiesUTF8($string)
 {
@@ -212,4 +218,16 @@ function smartyClassnames(array $classnames)
     }
 
     return implode(' ', $enabled_classes);
+}
+
+/**
+ * We add this intermediate method to prevent a warning because end expects its input to be a reference
+ *
+ * @param $arrayValue
+ *
+ * @return false|mixed
+ */
+function smarty_endWithoutReference($arrayValue)
+{
+    return end($arrayValue);
 }

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -223,7 +223,7 @@ function smartyClassnames(array $classnames)
 /**
  * We add this intermediate method to prevent a warning because end expects its input to be a reference
  *
- * @param $arrayValue
+ * @param array<mixed> $arrayValue
  *
  * @return false|mixed
  */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      |After installing the PS 810 RC version and activating the multistore option, go to the multistore page, an error notification is displayed
| Type?             | bug fix
| Category?         | BO
| Fixed ticket?     | Fixes #32680 and #32654
| Sponsor company   | Codencode snc 