### PR TITLE
Fix multistore reserved products state with shared catalog enabled

### DIFF
--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -183,7 +183,7 @@ class StockManager implements StockInterface
                 sa.id_product_attribute = od.product_attribute_id
                 GROUP BY od.product_id, od.product_attribute_id
             )
-            WHERE sa.id_shop = '. $whereShopIdCond .'
+            WHERE sa.id_shop = ' . $whereShopIdCond . '
         ';
 
         $strParams = [

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -210,7 +210,7 @@ class StockManager implements StockInterface
      *
      * @param int $shopId
      *
-     * @return ShopGroup object
+     * @return ShopGroup
      */
     private function getShopGroup($shopId)
     {

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -173,7 +173,7 @@ class StockManager implements StockInterface
                 FROM {table_prefix}orders o
                 INNER JOIN {table_prefix}order_detail od ON od.id_order = o.id_order
                 INNER JOIN {table_prefix}order_state os ON os.id_order_state = o.current_state
-                WHERE '.$whereCondition.'
+                WHERE ' . $whereCondition . '
                 os.shipped != 1 AND (
                     o.valid = 1 OR (
                         os.id_order_state != :error_state AND


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch           | develop / 8.1.x / 8.0.x / 1.7.8.x / 1.7.6.x
| Description      | This commit is to fix a bug in multistore mode with shared catalog, that decrement stock instead of place product as reserved until status set them to "Set the order as shipped". We fixed it by testing if multishop is active and shared stock is active to current shop group. In this case the sum must be made with the condition of shop_goup_id instead of shop_id for reserved product. And for physical quantity the shop_id must be 0 in this case. We tested from PS 1.7.6.4 to 8.1.x.
| Type             | bug fix 
| Category         | BO 
| BC breaks        |  no
| Deprecations     | no
| How to test      | Activate multistore, create a shop group with shared catalog, Add a shop in group. Place orders on each shop, with same and different products. Go to BO in Stocks, search for ordered products, you'll see them as reserved. Change orders status as In transit or delivred in both shops. Go to BO in Stocks search for ordered products, you'll see them without reserved and stock decremented.
| Fixed ticket     | Fixes #13210
| Related PRs       | no
| Sponsor company   | COM'ONSOFT @ComonSoft
