### PR TITLE
Fixed: use return consistently in the getAttributesResume method

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2709,7 +2709,7 @@ class ProductCore extends ObjectModel
      * @param string $attribute_value_separator
      * @param string $attribute_separator
      *
-     * @return bool|array Product attributes combinations
+     * @return array Product attributes combinations
      */
     public function getAttributesResume($id_lang, $attribute_value_separator = ' - ', $attribute_separator = ', ')
     {
@@ -2725,7 +2725,7 @@ class ProductCore extends ObjectModel
                 ORDER BY pa.`id_product_attribute`');
 
         if (!$combinations) {
-            return false;
+            return [];
         }
 
         $combinations = array_column($combinations, null, 'id_product_attribute');


### PR DESCRIPTION
Use return consistently in the Product getAttributesResume method.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Use return consistently in the getAttributesResume method to prevent "invalid argument supplied for foreach" PHP warning.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     no
| How to test?      | Navigate to category page with debug mode activated. Before this change, a PHP warning appears. After this change, this warning dissapears.
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/33678
| Related PRs       | 
| Sponsor company   | 
