### PR TITLE
Add return types & fix symfony deprecations

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -38,6 +38,7 @@ framework:
   router:
     resource: "%kernel.project_dir%/app/config/routing.yml"
     strict_requirements: ~
+    utf8: true
   form: ~
   csrf_protection: ~
   validation: { enable_annotations: true }
@@ -45,6 +46,7 @@ framework:
   default_locale: "%locale%"
   trusted_hosts: ~
   session:
+    storage_factory_id: session.storage.factory.native
     handler_id: ~
   fragments: ~
   http_method_override: true
@@ -108,3 +110,7 @@ api_platform:
       - '%kernel.project_dir%/app/config/api_platform'
 
   metadata_backward_compatibility_layer: false
+
+sensio_framework_extra:
+  router:
+    annotations: false

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -14,7 +14,7 @@ imports:
 framework:
   test: ~
   session:
-    storage_id: session.storage.mock_file
+    storage_factory_id: session.storage.factory.mock_file
   profiler:
     collect: false
 

--- a/app/config/security_dev.yml
+++ b/app/config/security_dev.yml
@@ -14,7 +14,7 @@ security:
       memory:
         users: [ ]
 
-  encoders:
+  password_hashers:
     Symfony\Component\Security\Core\User\User: plaintext
 
   firewalls:

--- a/app/config/security_test.yml
+++ b/app/config/security_test.yml
@@ -15,7 +15,7 @@ security:
         users:
           my_client_id: { password: 'prestashop' }
 
-  encoders:
+  password_hashers:
     Symfony\Component\Security\Core\User\User: plaintext
 
   firewalls:

--- a/src/Core/Grid/Action/Bulk/Type/Customer/DeleteCustomersBulkAction.php
+++ b/src/Core/Grid/Action/Bulk/Type/Customer/DeleteCustomersBulkAction.php
@@ -45,7 +45,7 @@ final class DeleteCustomersBulkAction extends AbstractBulkAction
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([

--- a/src/Core/Grid/Action/Row/Type/SubmitRowAction.php
+++ b/src/Core/Grid/Action/Row/Type/SubmitRowAction.php
@@ -49,7 +49,7 @@ final class SubmitRowAction extends AbstractRowAction
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/Core/Grid/Column/Type/Common/ImageColumn.php
+++ b/src/Core/Grid/Column/Type/Common/ImageColumn.php
@@ -45,7 +45,7 @@ final class ImageColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([

--- a/src/PrestaShopBundle/Command/AppendConfigurationFileHooksListCommand.php
+++ b/src/PrestaShopBundle/Command/AppendConfigurationFileHooksListCommand.php
@@ -124,7 +124,7 @@ class AppendConfigurationFileHooksListCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->initContext();
 

--- a/src/PrestaShopBundle/Command/AppendHooksListForSqlUpgradeFileCommand.php
+++ b/src/PrestaShopBundle/Command/AppendHooksListForSqlUpgradeFileCommand.php
@@ -137,7 +137,7 @@ class AppendHooksListForSqlUpgradeFileCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->initContext();
 

--- a/src/PrestaShopBundle/Command/CheckTranslationDuplicatesCommand.php
+++ b/src/PrestaShopBundle/Command/CheckTranslationDuplicatesCommand.php
@@ -53,7 +53,7 @@ class CheckTranslationDuplicatesCommand extends Command
             ->setDescription('Find duplicates of your translations');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // Get dependancies
         $catalogue = $this->translator->getCatalogue()->all();

--- a/src/PrestaShopBundle/Command/DebugCommand.php
+++ b/src/PrestaShopBundle/Command/DebugCommand.php
@@ -82,12 +82,9 @@ class DebugCommand extends Command
     }
 
     /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     *
-     * @return int
+     * @inheritdoc
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->io = new SymfonyStyle($input, $output);
 

--- a/src/PrestaShopBundle/Command/ExportThemeCommand.php
+++ b/src/PrestaShopBundle/Command/ExportThemeCommand.php
@@ -72,7 +72,7 @@ class ExportThemeCommand extends Command
             ->addArgument('theme', InputArgument::REQUIRED, 'Theme to export directory name.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $theme = $this->themeRepository->getInstanceByName($input->getArgument('theme'));
 

--- a/src/PrestaShopBundle/Command/FeatureFlagCommand.php
+++ b/src/PrestaShopBundle/Command/FeatureFlagCommand.php
@@ -76,7 +76,7 @@ class FeatureFlagCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $action = $input->getArgument('action');
         if (!in_array($action, $this->allowedActions)) {

--- a/src/PrestaShopBundle/Command/GenerateMailTemplatesCommand.php
+++ b/src/PrestaShopBundle/Command/GenerateMailTemplatesCommand.php
@@ -74,7 +74,7 @@ class GenerateMailTemplatesCommand extends Command
      *
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $themeName = $input->getArgument('theme');
         $coreOutputFolder = $input->getArgument('coreOutputFolder');

--- a/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
+++ b/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
@@ -79,7 +79,7 @@ class LegacyLinkLinterCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $unconfiguredRoutes = $this->getUnconfiguredRoutes();
         $io = new SymfonyStyle($input, $output);

--- a/src/PrestaShopBundle/Command/ListCommandsAndQueriesCommand.php
+++ b/src/PrestaShopBundle/Command/ListCommandsAndQueriesCommand.php
@@ -68,7 +68,7 @@ class ListCommandsAndQueriesCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $outputStyle = new OutputFormatterStyle('blue', null);
         $output->getFormatter()->setStyle('blue', $outputStyle);

--- a/src/PrestaShopBundle/Command/ModuleCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleCommand.php
@@ -124,7 +124,7 @@ class ModuleCommand extends Command
         }
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->init($input, $output);
 

--- a/src/PrestaShopBundle/Command/NamingConventionLinterCommand.php
+++ b/src/PrestaShopBundle/Command/NamingConventionLinterCommand.php
@@ -73,7 +73,7 @@ final class NamingConventionLinterCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $invalidRouteNameRows = [];
         $invalidControllerRows = [];

--- a/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
+++ b/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
@@ -114,7 +114,7 @@ final class SecurityAnnotationLinterCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $actionToPerform = $input->getArgument('action');
 

--- a/src/PrestaShopBundle/Command/ThemeEnablerCommand.php
+++ b/src/PrestaShopBundle/Command/ThemeEnablerCommand.php
@@ -71,7 +71,7 @@ final class ThemeEnablerCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $theme = $input->getArgument('theme');

--- a/src/PrestaShopBundle/Command/UpdateEUTaxruleGroupsCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateEUTaxruleGroupsCommand.php
@@ -86,7 +86,7 @@ class UpdateEUTaxruleGroupsCommand extends Command
             ->setDescription('Update EU Tax rule groups');
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /* Tweak */
         $this->output = $output;

--- a/src/PrestaShopBundle/Command/UpdateLicensesCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateLicensesCommand.php
@@ -86,7 +86,7 @@ class UpdateLicensesCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->text = str_replace('{currentYear}', date('Y'), $this->text);
 

--- a/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
@@ -63,10 +63,9 @@ class UpdateSchemaCommand extends Command
     }
 
     /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
+     * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $connection = $this->em->getConnection();
         $connection->beginTransaction();

--- a/src/PrestaShopBundle/DataCollector/CommandsAndQueriesDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/CommandsAndQueriesDataCollector.php
@@ -52,7 +52,7 @@ final class CommandsAndQueriesDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, \Throwable $exception = null)
+    public function collect(Request $request, Response $response, \Throwable $exception = null): void
     {
         $this->data = [
             'executed_commands' => $this->executedCommandRegistry->getExecutedCommands(),
@@ -63,7 +63,7 @@ final class CommandsAndQueriesDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'ps.commands_and_queries_collector';
     }
@@ -71,7 +71,7 @@ final class CommandsAndQueriesDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function reset()
+    public function reset(): void
     {
         $this->data = [];
     }

--- a/src/PrestaShopBundle/DataCollector/HookDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/HookDataCollector.php
@@ -49,7 +49,7 @@ final class HookDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, \Throwable $exception = null)
+    public function collect(Request $request, Response $response, \Throwable $exception = null): void
     {
         $hooks = $this->registry->getHooks();
         $calledHooks = $this->registry->getCalledHooks();
@@ -106,7 +106,7 @@ final class HookDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function reset()
+    public function reset(): void
     {
         $this->data = [];
     }
@@ -114,7 +114,7 @@ final class HookDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'ps.hooks_collector';
     }

--- a/src/PrestaShopBundle/DependencyInjection/AddOnsConfiguration.php
+++ b/src/PrestaShopBundle/DependencyInjection/AddOnsConfiguration.php
@@ -32,7 +32,7 @@ use Tools;
 
 class AddOnsConfiguration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('prestashop');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
+++ b/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -54,7 +55,7 @@ class PrestaShopExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
     {
         return new AddOnsConfiguration();
     }
@@ -62,7 +63,7 @@ class PrestaShopExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'prestashop';
     }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
@@ -99,7 +99,7 @@ class CachingType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'performance_caching_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CombineCompressCacheType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CombineCompressCacheType.php
@@ -56,7 +56,7 @@ class CombineCompressCacheType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'performance_ccc_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
@@ -61,7 +61,7 @@ class DebugModeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'performance_debug_mode_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MediaServersType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MediaServersType.php
@@ -64,7 +64,7 @@ class MediaServersType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'performance_media_servers_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MemcacheServerType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MemcacheServerType.php
@@ -61,7 +61,7 @@ class MemcacheServerType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'performance_memcache_server_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/OptionalFeaturesType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/OptionalFeaturesType.php
@@ -81,7 +81,7 @@ class OptionalFeaturesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'performance_optional_features_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/SmartyType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/SmartyType.php
@@ -84,7 +84,7 @@ class SmartyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'performance_smarty_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
@@ -356,7 +356,7 @@ abstract class AbstractCategoryType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Catalog/Category/CategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Catalog/Category/CategoryType.php
@@ -67,7 +67,7 @@ class CategoryType extends AbstractCategoryType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
+++ b/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
@@ -103,7 +103,7 @@ class SimpleCategory extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'ajax' => false,

--- a/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
+++ b/src/PrestaShopBundle/Form/Admin/Category/SimpleCategory.php
@@ -115,7 +115,7 @@ class SimpleCategory extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'new_simple_category';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
@@ -70,7 +70,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
@@ -80,7 +80,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'administration_general_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/NotificationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/NotificationsType.php
@@ -63,7 +63,7 @@ class NotificationsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'administration_notification_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/NotificationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/NotificationsType.php
@@ -53,7 +53,7 @@ class NotificationsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
@@ -160,7 +160,7 @@ class UploadQuotaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
@@ -170,7 +170,7 @@ class UploadQuotaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'administration_upload_quota_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -259,7 +259,7 @@ final class EmployeeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagListType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagListType.php
@@ -56,7 +56,7 @@ class FeatureFlagListType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagType.php
@@ -78,7 +78,7 @@ class FeatureFlagType extends TranslatorAwareType
         ]));
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
@@ -146,7 +146,7 @@ class ImportType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
@@ -72,7 +72,7 @@ final class LogsByEmailType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
@@ -82,7 +82,7 @@ final class LogsByEmailType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'logs_by_email_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/GeneralType.php
@@ -64,7 +64,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'security_general_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/GeneralType.php
@@ -54,7 +54,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/PasswordPolicyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/PasswordPolicyType.php
@@ -98,7 +98,7 @@ class PasswordPolicyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'security_password_policy_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/PasswordPolicyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/PasswordPolicyType.php
@@ -88,7 +88,7 @@ class PasswordPolicyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceConfigurationType.php
@@ -95,7 +95,7 @@ class WebserviceConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'webservice_configuration';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceConfigurationType.php
@@ -85,7 +85,7 @@ class WebserviceConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
@@ -141,7 +141,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'customer_preferences_general_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
@@ -131,7 +131,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
@@ -148,7 +148,7 @@ class MaintenanceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'maintenance_general_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
@@ -138,7 +138,7 @@ class MaintenanceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -259,7 +259,7 @@ class PreferencesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'preferences';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -249,7 +249,7 @@ class PreferencesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -167,7 +167,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'order_preferences_general_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -157,7 +157,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
@@ -140,7 +140,7 @@ class GiftOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
@@ -150,7 +150,7 @@ class GiftOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'order_preferences_gift_options_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
@@ -69,7 +69,7 @@ class OrderReturnStateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
@@ -205,7 +205,7 @@ class OrderStateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -188,7 +188,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -198,7 +198,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_preferences_general_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -103,7 +103,7 @@ class PageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -113,7 +113,7 @@ class PageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_preferences_page_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
@@ -102,7 +102,7 @@ class PaginationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_preferences_pagination_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
@@ -92,7 +92,7 @@ class PaginationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
@@ -222,7 +222,7 @@ class StockType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_preferences_stock_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
@@ -212,7 +212,7 @@ class StockType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/ShopUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/ShopUrlType.php
@@ -98,7 +98,7 @@ class ShopUrlType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => false,

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
@@ -122,7 +122,7 @@ class UrlSchemaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => false,

--- a/src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php
+++ b/src/PrestaShopBundle/Form/Admin/Feature/ProductFeature.php
@@ -158,7 +158,7 @@ class ProductFeature extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_feature';
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -312,7 +312,7 @@ class CmsPageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ImportThemeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ImportThemeType.php
@@ -102,7 +102,7 @@ class ImportThemeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'post_max_size_message' => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
@@ -200,7 +200,7 @@ class LanguageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
@@ -134,7 +134,7 @@ class CarrierOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'shipping_preferences_carrier_options_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
@@ -124,7 +124,7 @@ class CarrierOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shipping.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
@@ -132,7 +132,7 @@ class HandlingType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'shipping_preferences_handling_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
@@ -122,7 +122,7 @@ class HandlingType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shipping.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductAttachement.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductAttachement.php
@@ -107,7 +107,7 @@ class ProductAttachement extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_attachment';
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCategories.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCategories.php
@@ -83,7 +83,7 @@ class ProductCategories extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_categories';
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
@@ -268,7 +268,7 @@ class ProductCombination extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_combination';
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php
@@ -120,7 +120,7 @@ class ProductCombinationBulk extends CommonAbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_combination_bulk';
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombinationBulk.php
@@ -112,7 +112,7 @@ class ProductCombinationBulk extends CommonAbstractType
             ]);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'validation_groups' => false,

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
@@ -105,7 +105,7 @@ class ProductCustomField extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_custom_field';
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -409,7 +409,7 @@ class ProductInformation extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_step1';
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductOptions.php
@@ -300,7 +300,7 @@ class ProductOptions extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_options';
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
@@ -286,7 +286,7 @@ class ProductPrice extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_price';
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
@@ -274,7 +274,7 @@ class ProductPrice extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'id_product' => self::DEFAULT_PRODUCT_ID_FOR_FORM_CREATION,

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
@@ -346,7 +346,7 @@ class ProductQuantity extends CommonAbstractType
      *
      * Configure options
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(
             [

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
@@ -360,7 +360,7 @@ class ProductQuantity extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_quantity';
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
@@ -207,7 +207,7 @@ class ProductSeo extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_seo';
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
@@ -215,7 +215,7 @@ class ProductSeo extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'mapping_type' => 'product',

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -285,7 +285,7 @@ class ProductShipping extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_shipping';
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -371,7 +371,7 @@ class ProductSpecificPrice extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_combination';
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -358,7 +358,7 @@ class ProductSpecificPrice extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'id_product' => 1, // 1 is default value for new form

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
@@ -121,7 +121,7 @@ class ProductSupplierCombination extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_supplier_combination';
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSupplierCombination.php
@@ -107,7 +107,7 @@ class ProductSupplierCombination extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'id_supplier' => null,

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php
@@ -162,7 +162,7 @@ class ProductVirtual extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_virtual';
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductWarehouseCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductWarehouseCombination.php
@@ -95,7 +95,7 @@ class ProductWarehouseCombination extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_warehouse_combination';
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductWarehouseCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductWarehouseCombination.php
@@ -83,7 +83,7 @@ class ProductWarehouseCombination extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'id_warehouse' => null,

--- a/src/PrestaShopBundle/Form/Admin/Sell/CartRule/CartRuleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CartRule/CartRuleType.php
@@ -62,7 +62,7 @@ class CartRuleType extends TranslatorAwareType
         return NavigationTabType::class;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/CartRule/DiscountType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CartRule/DiscountType.php
@@ -105,7 +105,7 @@ class DiscountType extends TranslatorAwareType
         ]);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Catalog/FeatureType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Catalog/FeatureType.php
@@ -67,7 +67,7 @@ class FeatureType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -411,7 +411,7 @@ class CustomerType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
@@ -87,7 +87,7 @@ final class GeneratePdfByDateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
@@ -80,7 +80,7 @@ class SlipOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'order_delivery_slip_options';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipPdfType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipPdfType.php
@@ -80,7 +80,7 @@ class SlipPdfType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'order_delivery_slip_options';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByDateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByDateType.php
@@ -60,7 +60,7 @@ class GenerateByDateType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'orders_invoices_by_date_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByDateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByDateType.php
@@ -50,7 +50,7 @@ class GenerateByDateType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Orderscustomers.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByStatusType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByStatusType.php
@@ -90,7 +90,7 @@ class GenerateByStatusType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Orderscustomers.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByStatusType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByStatusType.php
@@ -100,7 +100,7 @@ class GenerateByStatusType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'orders_invoices_by_status_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsType.php
@@ -249,7 +249,7 @@ class InvoiceOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Orderscustomers.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
@@ -93,7 +93,7 @@ class CategoriesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryFilterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryFilterType.php
@@ -83,7 +83,7 @@ class CategoryFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $nestedTree = $this->categoryProvider->getNestedCategories(null, $this->contextLangId, false);

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryFilterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryFilterType.php
@@ -113,7 +113,7 @@ class CategoryFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'category_filter';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryTagsCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryTagsCollectionType.php
@@ -50,7 +50,7 @@ class CategoryTagsCollectionType extends CollectionType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryTreeSelectorType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryTreeSelectorType.php
@@ -94,7 +94,7 @@ class CategoryTreeSelectorType extends CollectionType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationImagesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationImagesType.php
@@ -47,7 +47,7 @@ class BulkCombinationImagesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationReferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationReferencesType.php
@@ -102,7 +102,7 @@ class BulkCombinationReferencesType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
@@ -169,7 +169,7 @@ class BulkCombinationStockType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationType.php
@@ -57,7 +57,7 @@ class BulkCombinationType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
@@ -99,7 +99,7 @@ class CombinationAvailabilityType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationFormType.php
@@ -103,7 +103,7 @@ class CombinationFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationHeaderType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationHeaderType.php
@@ -63,7 +63,7 @@ class CombinationHeaderType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationImagesChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationImagesChoiceType.php
@@ -57,7 +57,7 @@ class CombinationImagesChoiceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationListType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationListType.php
@@ -38,7 +38,7 @@ class CombinationListType extends CollectionType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationListType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationListType.php
@@ -55,7 +55,7 @@ class CombinationListType extends CollectionType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'combination_list';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationManagerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationManagerType.php
@@ -67,7 +67,7 @@ class CombinationManagerType extends TranslatorAwareType
         $view->vars['isMultiStoreActive'] = $this->multiStoreFeature->isActive();
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationPriceImpactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationPriceImpactType.php
@@ -287,7 +287,7 @@ class CombinationPriceImpactType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
@@ -109,7 +109,7 @@ class CombinationStockType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationsType.php
@@ -44,7 +44,7 @@ class CombinationsType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/CreateProductFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/CreateProductFormType.php
@@ -86,7 +86,7 @@ class CreateProductFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'create_product';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/CreateProductFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/CreateProductFormType.php
@@ -70,7 +70,7 @@ class CreateProductFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/DescriptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/DescriptionType.php
@@ -161,7 +161,7 @@ class DescriptionType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/CustomizationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/CustomizationsType.php
@@ -58,7 +58,7 @@ class CustomizationsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/DetailsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/DetailsType.php
@@ -105,7 +105,7 @@ class DetailsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeaturesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeaturesType.php
@@ -62,7 +62,7 @@ class FeaturesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/ReferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/ReferencesType.php
@@ -103,7 +103,7 @@ class ReferencesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EditProductFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EditProductFormType.php
@@ -194,7 +194,7 @@ class EditProductFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EditProductFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EditProductFormType.php
@@ -146,7 +146,7 @@ class EditProductFormType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ExtraModulesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ExtraModulesType.php
@@ -87,7 +87,7 @@ class ExtraModulesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
@@ -220,7 +220,7 @@ class FooterType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
@@ -156,7 +156,7 @@ class HeaderType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Image/ImageDropzoneType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Image/ImageDropzoneType.php
@@ -95,7 +95,7 @@ class ImageDropzoneType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/OptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/OptionsType.php
@@ -51,7 +51,7 @@ class OptionsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductAttachmentsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductAttachmentsType.php
@@ -96,7 +96,7 @@ class ProductAttachmentsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductSupplierCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductSupplierCollectionType.php
@@ -44,7 +44,7 @@ class ProductSupplierCollectionType extends CollectionType
         $this->translator = $translator;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/SuppliersType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/SuppliersType.php
@@ -92,7 +92,7 @@ class SuppliersType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/VisibilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/VisibilityType.php
@@ -101,7 +101,7 @@ class VisibilityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/ApplicableGroupsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/ApplicableGroupsType.php
@@ -137,7 +137,7 @@ class ApplicableGroupsType extends TranslatorAwareType
         return $choices;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/CatalogPriceRulesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/CatalogPriceRulesType.php
@@ -64,7 +64,7 @@ class CatalogPriceRulesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PriceSummaryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PriceSummaryType.php
@@ -33,7 +33,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PriceSummaryType extends TranslatorAwareType
 {
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => $this->trans('Summary', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
@@ -122,7 +122,7 @@ class PricingType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
@@ -263,7 +263,7 @@ class RetailPriceType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceImpactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceImpactType.php
@@ -116,7 +116,7 @@ class SpecificPriceImpactType extends TranslatorAwareType
         $builder->get('fixed_price_tax_excluded')->addViewTransformer(new SpecificPriceFixedPriceTransformer());
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPricePriorityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPricePriorityType.php
@@ -48,7 +48,7 @@ class SpecificPricePriorityType extends CollectionType
         $this->priorityChoiceProvider = $priorityChoiceProvider;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
@@ -166,7 +166,7 @@ class SpecificPriceType extends TranslatorAwareType
         $builder->addEventSubscriber($this->specificPriceCombinationListener);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPricesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPricesType.php
@@ -56,7 +56,7 @@ class SpecificPricesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/UnitPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/UnitPriceType.php
@@ -120,7 +120,7 @@ class UnitPriceType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductShopsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductShopsType.php
@@ -81,7 +81,7 @@ class ProductShopsType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/RedirectOptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/RedirectOptionType.php
@@ -178,7 +178,7 @@ class RedirectOptionType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
@@ -248,7 +248,7 @@ class SEOType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SerpType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SerpType.php
@@ -36,7 +36,7 @@ class SerpType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DeliveryTimeNotesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DeliveryTimeNotesType.php
@@ -73,7 +73,7 @@ class DeliveryTimeNotesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DimensionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DimensionsType.php
@@ -146,7 +146,7 @@ class DimensionsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/ShippingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/ShippingType.php
@@ -135,7 +135,7 @@ class ShippingType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
@@ -143,7 +143,7 @@ class AvailabilityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
@@ -132,7 +132,7 @@ class QuantityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockOptionsType.php
@@ -106,7 +106,7 @@ class StockOptionsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
@@ -120,7 +120,7 @@ class StockType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/VirtualProductFileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/VirtualProductFileType.php
@@ -181,7 +181,7 @@ class VirtualProductFileType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'virtual_product_file_id' => null,

--- a/src/PrestaShopBundle/Form/Admin/Type/AccordionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/AccordionType.php
@@ -45,7 +45,7 @@ class AccordionType extends AbstractType
         $view->vars['display_one'] = $options['display_one'];
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'expand_first' => true,

--- a/src/PrestaShopBundle/Form/Admin/Type/ButtonCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ButtonCollectionType.php
@@ -80,7 +80,7 @@ class ButtonCollectionType extends AbstractType
         $view->vars['use_button_groups'] = $options['use_button_groups'];
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/CategoryChoiceTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CategoryChoiceTreeType.php
@@ -51,7 +51,7 @@ class CategoryChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices_tree' => $this->categoryTreeChoices,

--- a/src/PrestaShopBundle/Form/Admin/Type/CategorySeoPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CategorySeoPreviewType.php
@@ -39,7 +39,7 @@ class CategorySeoPreviewType extends AbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'category_seo_preview';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
@@ -74,7 +74,7 @@ class ChoiceCategoriesTreeType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => '',

--- a/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
@@ -90,7 +90,7 @@ class ChoiceCategoriesTreeType extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'choice_tree';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/ColorPickerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ColorPickerType.php
@@ -48,7 +48,7 @@ class ColorPickerType extends AbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'color_picker';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/Common/Team/ProfileChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Common/Team/ProfileChoiceType.php
@@ -51,7 +51,7 @@ class ProfileChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/ConfigurableCountryChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ConfigurableCountryChoiceType.php
@@ -55,7 +55,7 @@ class ConfigurableCountryChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         // Set normalizer enables to use closure for choice generation with options
         $resolver->setNormalizer(

--- a/src/PrestaShopBundle/Form/Admin/Type/CountryChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CountryChoiceType.php
@@ -85,7 +85,7 @@ class CountryChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices' => $this->countriesChoiceProvider->getChoices(),

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomContentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomContentType.php
@@ -48,7 +48,7 @@ final class CustomContentType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomerSearchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomerSearchType.php
@@ -47,7 +47,7 @@ class CustomerSearchType extends EntitySearchInputType
         $this->router = $router;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
@@ -73,7 +73,7 @@ class DatePickerType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'widget' => 'single_text',

--- a/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
@@ -88,7 +88,7 @@ class DatePickerType extends AbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'date_picker';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/DateRangeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DateRangeType.php
@@ -133,7 +133,7 @@ class DateRangeType extends AbstractType
         }
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'date_format' => self::DEFAULT_DATE_FORMAT,

--- a/src/PrestaShopBundle/Form/Admin/Type/DateRangeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DateRangeType.php
@@ -151,7 +151,7 @@ class DateRangeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'date_range';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/DeltaQuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DeltaQuantityType.php
@@ -130,7 +130,7 @@ class DeltaQuantityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'delta_quantity';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/DeltaQuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DeltaQuantityType.php
@@ -114,7 +114,7 @@ class DeltaQuantityType extends TranslatorAwareType
         $view->vars['initialQuantity'] = $initialQuantity;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Type/DisablingSwitchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DisablingSwitchType.php
@@ -42,7 +42,7 @@ class DisablingSwitchType extends SwitchType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/EntitySearchInputType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/EntitySearchInputType.php
@@ -70,7 +70,7 @@ class EntitySearchInputType extends CollectionType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/EntitySearchInputType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/EntitySearchInputType.php
@@ -193,7 +193,7 @@ class EntitySearchInputType extends CollectionType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'entity_search_input';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/FormattedTextareaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/FormattedTextareaType.php
@@ -46,7 +46,7 @@ class FormattedTextareaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefined(['message'])

--- a/src/PrestaShopBundle/Form/Admin/Type/GeneratableTextType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/GeneratableTextType.php
@@ -42,7 +42,7 @@ class GeneratableTextType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/IconButtonType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/IconButtonType.php
@@ -76,7 +76,7 @@ class IconButtonType extends ButtonType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'icon_button';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/IconButtonType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/IconButtonType.php
@@ -41,7 +41,7 @@ class IconButtonType extends ButtonType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Type/ImagePreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ImagePreviewType.php
@@ -65,7 +65,7 @@ class ImagePreviewType extends HiddenType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'image_preview';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/ImagePreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ImagePreviewType.php
@@ -53,7 +53,7 @@ class ImagePreviewType extends HiddenType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/ImageWithPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ImageWithPreviewType.php
@@ -77,7 +77,7 @@ class ImageWithPreviewType extends FileType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'image_with_preview';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/ImageWithPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ImageWithPreviewType.php
@@ -55,7 +55,7 @@ class ImageWithPreviewType extends FileType
         $view->vars['warning_message'] = $options['warning_message'];
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/IntegerMinMaxFilterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/IntegerMinMaxFilterType.php
@@ -50,7 +50,7 @@ final class IntegerMinMaxFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'min_field_options' => [],

--- a/src/PrestaShopBundle/Form/Admin/Type/IpAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/IpAddressType.php
@@ -48,7 +48,7 @@ class IpAddressType extends TextType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'ip_address_text';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/IpAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/IpAddressType.php
@@ -56,7 +56,7 @@ class IpAddressType extends TextType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/LinkPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/LinkPreviewType.php
@@ -53,7 +53,7 @@ class LinkPreviewType extends HiddenType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'link_preview';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/LinkPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/LinkPreviewType.php
@@ -61,7 +61,7 @@ class LinkPreviewType extends HiddenType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/LogSeverityChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/LogSeverityChoiceType.php
@@ -40,7 +40,7 @@ class LogSeverityChoiceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices' => $this->getSeveritysChoices(),

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableType.php
@@ -40,7 +40,7 @@ class MaterialChoiceTableType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'expanded' => true,

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableType.php
@@ -67,7 +67,7 @@ class MaterialChoiceTableType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'material_choice_table';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTreeType.php
@@ -55,7 +55,7 @@ class MaterialChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTreeType.php
@@ -81,7 +81,7 @@ class MaterialChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'material_choice_tree';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialMultipleChoiceTableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialMultipleChoiceTableType.php
@@ -126,7 +126,7 @@ class MaterialMultipleChoiceTableType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'material_multiple_choice_table';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialMultipleChoiceTableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialMultipleChoiceTableType.php
@@ -97,7 +97,7 @@ class MaterialMultipleChoiceTableType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([

--- a/src/PrestaShopBundle/Form/Admin/Type/MoneyWithSuffixType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/MoneyWithSuffixType.php
@@ -59,7 +59,7 @@ class MoneyWithSuffixType extends MoneyType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/NavigationTabType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/NavigationTabType.php
@@ -87,7 +87,7 @@ class NavigationTabType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Type/NumberMinMaxFilterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/NumberMinMaxFilterType.php
@@ -50,7 +50,7 @@ final class NumberMinMaxFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'min_field_options' => [],

--- a/src/PrestaShopBundle/Form/Admin/Type/PriceReductionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/PriceReductionType.php
@@ -103,7 +103,7 @@ class PriceReductionType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/SearchAndResetType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SearchAndResetType.php
@@ -116,7 +116,7 @@ class SearchAndResetType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'search_and_reset';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/SearchAndResetType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SearchAndResetType.php
@@ -97,7 +97,7 @@ class SearchAndResetType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/ShopChoiceTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ShopChoiceTreeType.php
@@ -91,7 +91,7 @@ class ShopChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/ShopRestrictionCheckboxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ShopRestrictionCheckboxType.php
@@ -54,7 +54,7 @@ class ShopRestrictionCheckboxType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Type/SubmittableInputType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SubmittableInputType.php
@@ -60,7 +60,7 @@ class SubmittableInputType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefault('type', NumberType::class)

--- a/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
@@ -42,7 +42,7 @@ class SwitchType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices' => [

--- a/src/PrestaShopBundle/Form/Admin/Type/TextPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextPreviewType.php
@@ -68,7 +68,7 @@ class TextPreviewType extends TextType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/TextPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextPreviewType.php
@@ -60,7 +60,7 @@ class TextPreviewType extends TextType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'text_preview';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TextWithLengthCounterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextWithLengthCounterType.php
@@ -50,7 +50,7 @@ class TextWithLengthCounterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([

--- a/src/PrestaShopBundle/Form/Admin/Type/TextWithLengthCounterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextWithLengthCounterType.php
@@ -72,7 +72,7 @@ class TextWithLengthCounterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'text_with_length_counter';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TextWithRecommendedLengthType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextWithRecommendedLengthType.php
@@ -50,7 +50,7 @@ class TextWithRecommendedLengthType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableChoiceType.php
@@ -63,7 +63,7 @@ class TranslatableChoiceType extends TranslatableType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'translatable_choice';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableChoiceType.php
@@ -47,7 +47,7 @@ class TranslatableChoiceType extends TranslatableType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices' => [],

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -166,7 +166,7 @@ class TranslatableType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'type' => TextType::class,

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -196,7 +196,7 @@ class TranslatableType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'translatable';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslateType.php
@@ -134,7 +134,7 @@ class TranslateType extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'translatefields';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslateType.php
@@ -119,7 +119,7 @@ class TranslateType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'type' => null,

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadCustomerCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadCustomerCollectionType.php
@@ -108,7 +108,7 @@ class TypeaheadCustomerCollectionType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'remote_url' => '',

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadCustomerCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadCustomerCollectionType.php
@@ -125,7 +125,7 @@ class TypeaheadCustomerCollectionType extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'typeahead_customer_collection';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
@@ -148,7 +148,7 @@ class TypeaheadProductCollectionType extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'typeahead_product_collection';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
@@ -130,7 +130,7 @@ class TypeaheadProductCollectionType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'remote_url' => '',

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductPackCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductPackCollectionType.php
@@ -78,7 +78,7 @@ class TypeaheadProductPackCollectionType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'remote_url' => '',

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductPackCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductPackCollectionType.php
@@ -94,7 +94,7 @@ class TypeaheadProductPackCollectionType extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'typeahead_product_pack_collection';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/UnavailableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/UnavailableType.php
@@ -38,7 +38,7 @@ class UnavailableType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/YesAndNoChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/YesAndNoChoiceType.php
@@ -37,7 +37,7 @@ class YesAndNoChoiceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices' => [

--- a/src/PrestaShopBundle/Form/Admin/Type/ZoneChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ZoneChoiceType.php
@@ -55,7 +55,7 @@ class ZoneChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         // Set normalizer enables to use closure for choice generation with options
         $resolver->setNormalizer(

--- a/src/PrestaShopBundle/Form/DataTransformer/ArabicToLatinDigitDataTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/ArabicToLatinDigitDataTransformer.php
@@ -52,7 +52,7 @@ final class ArabicToLatinDigitDataTransformer implements DataTransformerInterfac
      *
      * {@inheritdoc}
      */
-    public function transform($value)
+    public function transform($value): mixed
     {
         return $value;
     }
@@ -60,7 +60,7 @@ final class ArabicToLatinDigitDataTransformer implements DataTransformerInterfac
     /**
      * {@inheritdoc}
      */
-    public function reverseTransform($value)
+    public function reverseTransform($value): mixed
     {
         if (null === $value || '' === $value) {
             return null;

--- a/src/PrestaShopBundle/Form/DataTransformer/DefaultEmptyDataTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/DefaultEmptyDataTransformer.php
@@ -94,7 +94,7 @@ class DefaultEmptyDataTransformer implements DataTransformerInterface
     /**
      * {@inheritDoc}
      */
-    public function transform($value)
+    public function transform($value): mixed
     {
         return empty($value) ? $this->viewEmptyData : $value;
     }
@@ -102,7 +102,7 @@ class DefaultEmptyDataTransformer implements DataTransformerInterface
     /**
      * {@inheritDoc}
      */
-    public function reverseTransform($value)
+    public function reverseTransform($value): mixed
     {
         return empty($value) ? $this->emptyData : $value;
     }

--- a/src/PrestaShopBundle/Form/DataTransformer/DefaultLanguageToFilledArrayDataTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/DefaultLanguageToFilledArrayDataTransformer.php
@@ -50,7 +50,7 @@ final class DefaultLanguageToFilledArrayDataTransformer implements DataTransform
     /**
      * {@inheritdoc}
      */
-    public function transform($value)
+    public function transform($value): mixed
     {
         // No transformation is required here due to this data is being sent to template
         return $value;
@@ -61,7 +61,7 @@ final class DefaultLanguageToFilledArrayDataTransformer implements DataTransform
      *
      * @param array $values
      */
-    public function reverseTransform($values)
+    public function reverseTransform($values): mixed
     {
         if (!$this->assertIsValidForDataTransforming($values)) {
             return $values;

--- a/src/PrestaShopBundle/Form/DataTransformer/IDNConverterDataTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/IDNConverterDataTransformer.php
@@ -51,7 +51,7 @@ final class IDNConverterDataTransformer implements DataTransformerInterface
      *
      * Do not convert utf8 to punycode, should be done on the client side
      */
-    public function transform($value)
+    public function transform($value): mixed
     {
         return $value;
     }
@@ -61,7 +61,7 @@ final class IDNConverterDataTransformer implements DataTransformerInterface
      *
      * Convert punycode to utf8 (prestashop@xn--80aswg.xn--p1ai -> prestashop@сайт.рф)
      */
-    public function reverseTransform($value)
+    public function reverseTransform($value): mixed
     {
         return is_string($value) ? $this->converter->emailToUtf8($value) : $value;
     }

--- a/src/PrestaShopBundle/Form/DataTransformer/StringArrayToIntegerArrayDataTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/StringArrayToIntegerArrayDataTransformer.php
@@ -37,7 +37,7 @@ final class StringArrayToIntegerArrayDataTransformer implements DataTransformerI
     /**
      * {@inheritdoc}
      */
-    public function transform($value)
+    public function transform($value): mixed
     {
         // No transformation is required here due to this data is being sent to template
         return $value;
@@ -46,7 +46,7 @@ final class StringArrayToIntegerArrayDataTransformer implements DataTransformerI
     /**
      * {@inheritdoc}
      */
-    public function reverseTransform($value)
+    public function reverseTransform($value): mixed
     {
         if (!is_array($value)) {
             return $value;

--- a/src/PrestaShopBundle/Form/Extension/AlertExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/AlertExtension.php
@@ -44,7 +44,7 @@ class AlertExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/ColumnsNumberExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/ColumnsNumberExtension.php
@@ -49,7 +49,7 @@ class ColumnsNumberExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/CustomMoneyTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/CustomMoneyTypeExtension.php
@@ -80,7 +80,7 @@ class CustomMoneyTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'precision' => null,

--- a/src/PrestaShopBundle/Form/Extension/ExternalLinkExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/ExternalLinkExtension.php
@@ -52,7 +52,7 @@ class ExternalLinkExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/FormThemeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/FormThemeExtension.php
@@ -101,7 +101,7 @@ class FormThemeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/HelpTextExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/HelpTextExtension.php
@@ -40,7 +40,7 @@ class HelpTextExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/HintTextExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/HintTextExtension.php
@@ -41,7 +41,7 @@ class HintTextExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/LabelOptionsExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/LabelOptionsExtension.php
@@ -46,7 +46,7 @@ class LabelOptionsExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/ResizableTextTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/ResizableTextTypeExtension.php
@@ -48,7 +48,7 @@ class ResizableTextTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefined('size')

--- a/src/PrestaShopBundle/Form/Extension/RowAttributesExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/RowAttributesExtension.php
@@ -48,7 +48,7 @@ class RowAttributesExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/UnitTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/UnitTypeExtension.php
@@ -43,7 +43,7 @@ class UnitTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefined('unit')

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -345,7 +345,6 @@ services:
       $riskChoices: '@=service("prestashop.adapter.form.choice_provider.risk_by_id_choice_provider").getChoices()'
       $isB2bFeatureEnabled: '@=service("prestashop.core.b2b.b2b_feature").isActive()'
       $isPartnerOffersEnabled: '@=service("prestashop.adapter.legacy.configuration").get("PS_CUSTOMER_OPTIN")'
-      $formCloner: '@form.form_cloner'
 
   PrestaShopBundle\Form\Admin\Improve\International\Currencies\CurrencyType:
     arguments:

--- a/src/PrestaShopBundle/Security/Admin/SessionRenewer.php
+++ b/src/PrestaShopBundle/Security/Admin/SessionRenewer.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Security\Admin;
 
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Csrf\TokenStorage\ClearableTokenStorageInterface;
 
 /**
@@ -39,24 +39,10 @@ use Symfony\Component\Security\Csrf\TokenStorage\ClearableTokenStorageInterface;
  */
 final class SessionRenewer
 {
-    /**
-     * @var ClearableTokenStorageInterface
-     */
-    private $storage;
-
-    /**
-     * @var SessionInterface
-     */
-    private $session;
-
-    /**
-     * @param ClearableTokenStorageInterface $storage
-     * @param SessionInterface $session
-     */
-    public function __construct(ClearableTokenStorageInterface $storage, SessionInterface $session)
-    {
-        $this->storage = $storage;
-        $this->session = $session;
+    public function __construct(
+        private readonly ClearableTokenStorageInterface $storage,
+        private readonly RequestStack $requeststack
+    ) {
     }
 
     /**
@@ -66,11 +52,13 @@ final class SessionRenewer
      */
     public function renew(): void
     {
-        if (!$this->session->isStarted()) {
-            $this->session->start();
+        $session = $this->requeststack->getSession();
+
+        if (!$session->isStarted()) {
+            $session->start();
         }
 
-        $this->session->migrate(true);
+        $session->migrate(true);
         $this->storage->clear();
     }
 }

--- a/src/PrestaShopBundle/Twig/Extension/ColorBrightnessCalculatorExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/ColorBrightnessCalculatorExtension.php
@@ -51,7 +51,7 @@ class ColorBrightnessCalculatorExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction(

--- a/src/PrestaShopBundle/Twig/Extension/DocumentationLinkExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/DocumentationLinkExtension.php
@@ -51,7 +51,7 @@ class DocumentationLinkExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction(

--- a/src/PrestaShopBundle/Twig/Extension/EntitySearchExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/EntitySearchExtension.php
@@ -39,7 +39,7 @@ use Twig\TwigFilter;
  */
 class EntitySearchExtension extends AbstractExtension
 {
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('entity_field', [$this, 'getEntityField']),

--- a/src/PrestaShopBundle/Twig/Extension/GridExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/GridExtension.php
@@ -69,7 +69,7 @@ class GridExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('column_content', [$this, 'renderColumnContent'], [

--- a/src/PrestaShopBundle/Twig/Extension/NumberExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/NumberExtension.php
@@ -40,7 +40,7 @@ class NumberExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [new TwigFunction('number', [$this, 'createNumber'])];
     }

--- a/tests/Integration/PrestaShopBundle/Form/AdvancedFormType.php
+++ b/tests/Integration/PrestaShopBundle/Form/AdvancedFormType.php
@@ -99,7 +99,7 @@ class AdvancedFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/tests/Integration/PrestaShopBundle/Form/TestDataTransformer.php
+++ b/tests/Integration/PrestaShopBundle/Form/TestDataTransformer.php
@@ -38,7 +38,7 @@ class TestDataTransformer implements DataTransformerInterface
     /**
      * {@inheritDoc}
      */
-    public function transform($value)
+    public function transform($value): mixed
     {
         return $value;
     }
@@ -46,7 +46,7 @@ class TestDataTransformer implements DataTransformerInterface
     /**
      * {@inheritDoc}
      */
-    public function reverseTransform($value)
+    public function reverseTransform($value): mixed
     {
         return $value;
     }

--- a/tests/Integration/PrestaShopBundle/Form/TestProductFormType.php
+++ b/tests/Integration/PrestaShopBundle/Form/TestProductFormType.php
@@ -84,7 +84,7 @@ class TestProductFormType extends CommonAbstractType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | improvement
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | CI + Auto tests

- Fix symfony configuration
- Stop using session as service
- Add return types for forms `getBlockPrefix`
- Add return types for forms `configureOptions`
- Add return types for data collectors
- Add return types for data transformers
- Add return types for twig extensions
- Add return types for commands
