### PR TITLE
Profiler: measure execution time from the beginning.

### DIFF
--- a/tools/profiling/Profiler.php
+++ b/tools/profiling/Profiler.php
@@ -73,7 +73,14 @@ class Profiler
 
     private function __construct()
     {
-        $this->startTime = microtime(true);
+        global $start_time;
+        if (isset($_SERVER['REQUEST_TIME_FLOAT'])) {
+            $this->startTime = (float) $_SERVER['REQUEST_TIME_FLOAT'];
+        } elseif (!empty($start_time)) {
+            $this->startTime = $start_time;
+        } else {
+            $this->startTime = microtime(true);
+        }
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Currently the Profiler measures execution time since the call to `Profiler::__cunstruct()`. We need a beter estimate. If the server exposes the variable `$_SERVER['REQUEST_TIME_FLOAT']`, use it, else use the `$start_time` from https://github.com/PrestaShop/PrestaShop/blob/2aaa49f97f372a0efe8e91bdba045ff3617ee5c2/config/config.inc.php#L38
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Look at #32753 to see the changes
| Fixed ticket?     | Fixes #32753
| Related PRs       | none
| Sponsor company   | Société Bilique de Genève
