### PR TITLE
Fix(ci) backport fixes to github action template from develop

### DIFF
--- a/.github/workflows/cron_update_modules/script.php
+++ b/.github/workflows/cron_update_modules/script.php
@@ -28,8 +28,7 @@ declare(strict_types=1);
 
 const VENDOR_NAME = 'prestashop/';
 
-function fetchVersionComposerLock(): array
-{
+function fetchVersionComposerLock(): array {
     $composerLock = file_get_contents('composer.lock');
     $composerLock = json_decode($composerLock, true);
 
@@ -46,7 +45,7 @@ function fetchVersionComposerLock(): array
 
 // Fetch modules from the repository PrestaShop/prestashop-modules
 $hCurl = curl_init();
-curl_setopt($hCurl, CURLOPT_USERAGENT, 'PrestaShop/CronUpdateModules');
+curl_setopt($hCurl, CURLOPT_USERAGENT,'PrestaShop/CronUpdateModules');
 curl_setopt($hCurl, CURLOPT_URL, 'https://api.github.com/repos/PrestaShop/prestashop-modules/git/trees/master');
 curl_setopt($hCurl, CURLOPT_RETURNTRANSFER, 1);
 $gitJSON = curl_exec($hCurl);
@@ -61,7 +60,7 @@ if (empty($gitJSON['tree'])) {
     echo 'Empty return from the API';
     die();
 }
-$modulesGit = array_filter($gitJSON['tree'], function (array $val) {
+$modulesGit = array_filter($gitJSON['tree'], function(array $val) {
     return $val['type'] === 'commit';
 });
 
@@ -104,7 +103,7 @@ foreach ($moduleComposerLockOriginal as $moduleName => $moduleVersion) {
     if ($moduleVersion === $moduleComposerLockAfterUpdate[$moduleName]) {
         continue;
     }
-    $pullRequestBodyBumpModules .= 'Module `' . $moduleName . '`: Bump version from `' . $moduleVersion
+    $pullRequestBodyBumpModules .= 'Module `' . $moduleName. '`: Bump version from `' . $moduleVersion
         . '` to `' . $moduleComposerLockAfterUpdate[$moduleName] . '`<br />';
 }
 
@@ -113,17 +112,22 @@ if (empty($pullRequestBodyBumpModules)) {
     exit();
 }
 
+$branch = $argv[1] ?? 'develop';
+
+$prTable = '| Questions         | Answers' . "|\r\n";
+$prTable .= '| ----------------- | -------------------------------------------------------' . "|\r\n";
+$prTable .= '| Branch?           | ' . $branch . "|\r\n";
+$prTable .= '| Description?      | Updated PrestaShop composer packages, details below.' . "|\r\n";
+$prTable .= '| Type?             | improvement' . "|\r\n";
+$prTable .= '| Category?         | CO' . "|\r\n";
+$prTable .= '| BC breaks?        | no' . "|\r\n";
+$prTable .= '| Deprecations?     | no' . "|\r\n";
+$prTable .= '| Fixed ticket?     | N/A' . "|\r\n";
+$prTable .= '| How to test?      | N/A' . "|\r\n";
+$prTable .= "\r\n\r\n";
+$prTable .= $pullRequestBodyBumpModules;
+
 file_put_contents(
     'cron_php_update_modules.txt',
-    '| Questions         | Answers |' . PHP_EOL
-        . '| ----------------- | ----------------- |' . PHP_EOL
-        . '| Branch?           | develop |' . PHP_EOL
-        . '| Description?      | ' . $pullRequestBodyBumpModules . ' |' . PHP_EOL
-        . '| Type?             | improvement' . PHP_EOL
-        . '| Category?         | CO |' . PHP_EOL
-        . '| BC breaks?        | no |' . PHP_EOL
-        . '| Deprecations?     | no |' . PHP_EOL
-        . '| Fixed ticket?     | N/A |' . PHP_EOL
-        . '| How to test?      | N/A |' . PHP_EOL
-        . '| Possible impacts? | N/A |' . PHP_EOL
+    $prTable
 );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x 
| Description?      | This PR is fixing the table generated by the github action Cron Update PHP Modules.
| Type?             |  improvement 
| Category?         |  PM
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | Restart the github action Cron Update PHP Modules and check the PR opened by the bot
| Fixed ticket?     | Fixes #32585
| Related PRs       | N/A
| Sponsor company   | Prestashop
