### PR TITLE
Warning on Modules List page when Distribution API cannot be contacted

### DIFF
--- a/src/Core/Module/ModuleCollection.php
+++ b/src/Core/Module/ModuleCollection.php
@@ -43,6 +43,8 @@ class ModuleCollection implements ArrayAccess, Countable, IteratorAggregate
     /** @var ModuleInterface[] */
     private $modules = [];
 
+    private $errors = [];
+
     public function __construct(array $modules = [])
     {
         foreach ($modules as $module) {
@@ -111,5 +113,20 @@ class ModuleCollection implements ArrayAccess, Countable, IteratorAggregate
     public function filter(callable $callable): ModuleCollection
     {
         return static::createFrom(array_filter($this->modules, $callable));
+    }
+
+    public function add(ModuleInterface $module): void
+    {
+        $this->modules[] = $module;
+    }
+
+    public function addError(\Throwable $error): void
+    {
+        $this->errors[] = $error;
+    }
+
+    public function getErrors(): array
+    {
+        return $this->errors;
     }
 }

--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -90,7 +90,7 @@ class ModuleRepository implements ModuleRepositoryInterface
 
     public function getList(): ModuleCollection
     {
-        $modules = [];
+        $modules = new ModuleCollection();
         $modulesDirsList = (new Finder())->directories()
             ->in($this->modulePath)
             ->depth('== 0')
@@ -103,10 +103,10 @@ class ModuleRepository implements ModuleRepositoryInterface
                 continue;
             }
 
-            $modules[] = $this->getModule($moduleName);
+            $modules->add($this->getModule($moduleName));
         }
 
-        return ModuleCollection::createFrom($this->addModulesFromHook($modules));
+        return $this->addModulesFromHook($modules);
     }
 
     public function getInstalledModules(): ModuleCollection
@@ -292,13 +292,19 @@ class ModuleRepository implements ModuleRepositoryInterface
     }
 
     /**
-     * @param Module[] $modules
+     * @param ModuleCollection $modules
      *
-     * @return Module[]
+     * @return ModuleCollection
      */
-    protected function addModulesFromHook(array $modules): array
+    protected function addModulesFromHook(ModuleCollection $modules): ModuleCollection
     {
-        $externalModules = $this->getModulesFromHook();
+        try {
+            $externalModules = $this->getModulesFromHook();
+        } catch (\Throwable $e) {
+            $modules->addError($e);
+
+            return $modules;
+        }
 
         foreach ($externalModules as $externalModule) {
             $merged = false;
@@ -323,7 +329,12 @@ class ModuleRepository implements ModuleRepositoryInterface
      */
     protected function enrichModuleAttributesFromHook(Module $module): ModuleInterface
     {
-        $modulesFromHook = $this->getModulesFromHook();
+        try {
+            $modulesFromHook = $this->getModulesFromHook();
+        } catch (\Throwable $e) {
+            return $module;
+        }
+
         foreach ($modulesFromHook as $moduleFromHook) {
             if ($module->get('name') === $moduleFromHook['name']) {
                 $module->getAttributes()->add($moduleFromHook);

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -68,6 +68,11 @@ class ModuleController extends ModuleAbstractController
 
         $installedProducts = $moduleRepository->getList();
 
+        $moduleErrors = $installedProducts->getErrors();
+        foreach ($moduleErrors as $moduleError) {
+            $this->addFlash('warning', $moduleError->getMessage());
+        }
+
         $categories = $this->getCategories($modulesProvider, $installedProducts);
         $bulkActions = [
             'bulk-install' => $this->trans('Install', 'Admin.Actions'),


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Add a warning when Distribution API cannot be contacted to retrieve infos about modules
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go on the Modules list page when the module Distribution API Client with [this code](https://github.com/PrestaShop/ps_distributionapiclient/pull/26) is installed, on 8.1.x. You should see the message as in the screenshot below.
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/32497
| Related PRs       | https://github.com/PrestaShop/ps_distributionapiclient/pull/26
| Sponsor company   | PrestaShop

![image](https://github.com/PrestaShop/PrestaShop/assets/28731165/a0e83067-b80f-4f1a-b88f-b03e933dd0d7)

