### PR TITLE
Add debug cookie option

### DIFF
--- a/admin-dev/themes/default/js/bundle/admin_parameters/performancePageUI.js
+++ b/admin-dev/themes/default/js/bundle/admin_parameters/performancePageUI.js
@@ -26,19 +26,16 @@ const PerformancePageUI = {
   displaySmartyCache() {
     const CACHE_ENABLED = '1';
     const smartyCacheSelected = document.querySelector('input[name="smarty[cache]"]:checked');
-    const smartyCacheOptions = document.querySelectorAll('.smarty-cache-option');
-
-    if (smartyCacheSelected && smartyCacheSelected.value === CACHE_ENABLED) {
-      for (let i = 0; i < smartyCacheOptions.length; i += 1) {
-        smartyCacheOptions[i].classList.remove('d-none');
-      }
-
-      return;
-    }
-
-    for (let i = 0; i < smartyCacheOptions.length; i += 1) {
-      smartyCacheOptions[i].classList.add('d-none');
-    }
+    document.querySelectorAll('.smarty-cache-option').forEach((element) => {
+      element.classList.toggle('d-none', smartyCacheSelected.value !== CACHE_ENABLED);
+    });
+  },
+  displayDebugModeOptions() {
+    const DEBUG_MODE_ON = '1';
+    const debugModeOn = document.querySelector('input[name="debug_mode[debug_mode]"]:checked');
+    document.querySelectorAll('.debug-mode-option').forEach((element) => {
+      element.classList.toggle('d-none', debugModeOn.value !== DEBUG_MODE_ON);
+    });
   },
   displayCacheSystems() {
     const CACHE_ENABLED = '1';
@@ -83,6 +80,7 @@ const PerformancePageUI = {
  */
 window.addEventListener('load', () => {
   PerformancePageUI.displaySmartyCache();
+  PerformancePageUI.displayDebugModeOptions();
   PerformancePageUI.displayCacheSystems();
   PerformancePageUI.displayMemcacheServers();
 });
@@ -101,6 +99,9 @@ while (length--) {
     }
     if (name === 'smarty[cache]') {
       return PerformancePageUI.displaySmartyCache();
+    }
+    if (name === 'debug_mode[debug_mode]') {
+      return PerformancePageUI.displayDebugModeOptions();
     }
     if (name === 'caching[caching_system]') {
       return PerformancePageUI.displayMemcacheServers();

--- a/admin-dev/themes/new-theme/js/components/generatable-input.ts
+++ b/admin-dev/themes/new-theme/js/components/generatable-input.ts
@@ -51,15 +51,15 @@
  */
 export default class GeneratableInput {
   /**
-   * Attaches event listener on button than can generate value
+   * Attaches click event listeners on buttons than can generate random values
    *
-   * @param {String} generatorBtnSelector
+   * @param {String} generatorButtonsSelector
    */
-  public attachOn(generatorBtnSelector: string): void {
-    const generatorBtn = document.querySelector(generatorBtnSelector);
+  public attachOn(generatorButtonsSelector: string): void {
+    const generatorButtons = document.querySelectorAll(generatorButtonsSelector);
 
-    if (generatorBtn !== null) {
-      generatorBtn.addEventListener('click', (event: Event): void => {
+    generatorButtons.forEach((btn: Element): void => {
+      btn.addEventListener('click', (event: Event): void => {
         const {attributes} = <HTMLButtonElement>event.currentTarget;
 
         const targetInputId = attributes.getNamedItem('data-target-input-id')
@@ -75,7 +75,7 @@ export default class GeneratableInput {
         targetInput.value = this.generateValue(generatedValueLength);
         targetInput.dispatchEvent(new CustomEvent('change', {bubbles: true}));
       });
-    }
+    });
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/performance-preferences/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/performance-preferences/index.ts
@@ -25,6 +25,7 @@
 
 import ConfirmModal from '@components/modal/confirm-modal';
 import PerformancePreferencesPageMap from '@pages/performance-preferences/PerformancePreferencesPageMap';
+import GeneratableInput from '@components/generatable-input';
 
 const {$} = window;
 
@@ -47,4 +48,8 @@ $(() => {
 
     modal.show();
   });
+
+  // Initialize cookie name and value generatable inputs
+  const generatableInput = new GeneratableInput();
+  generatableInput.attachOn('.js-generator-btn');
 });

--- a/src/Adapter/Debug/DebugModeConfiguration.php
+++ b/src/Adapter/Debug/DebugModeConfiguration.php
@@ -91,6 +91,8 @@ class DebugModeConfiguration implements DataConfigurationInterface
         return [
             'disable_overrides' => $this->configuration->getBoolean('PS_DISABLE_OVERRIDES'),
             'debug_mode' => $this->debugMode->isDebugModeEnabled(),
+            'debug_cookie_name' => $this->configuration->get('PS_DEBUG_COOKIE_NAME'),
+            'debug_cookie_value' => $this->configuration->get('PS_DEBUG_COOKIE_VALUE'),
             'debug_profiling' => $this->debugProfiling->isProfilingEnabled(),
         ];
     }
@@ -106,10 +108,21 @@ class DebugModeConfiguration implements DataConfigurationInterface
             // Set configuration
             $this->configuration->set('PS_DISABLE_OVERRIDES', $configuration['disable_overrides']);
 
+            $this->configuration->set('PS_DEBUG_COOKIE_NAME', $configuration['debug_cookie_name']);
+            $this->configuration->set('PS_DEBUG_COOKIE_VALUE', $configuration['debug_cookie_value']);
+
+            if (empty($configuration['debug_cookie_name']) && !empty($configuration['debug_cookie_value'])) {
+                $errors[] = [
+                    'key' => 'Error: The cookie name is required when the cookie value is set.',
+                    'domain' => 'Admin.Advparameters.Notification',
+                    'parameters' => [],
+                ];
+            }
+
             $this->classIndexCacheClearer->clear();
 
             // Update Debug Mode
-            $status = $this->updateDebugMode((bool) $configuration['debug_mode']);
+            $status = $this->updateDebugMode($configuration);
             switch ($status) {
                 case DebugMode::DEBUG_MODE_ERROR_NO_WRITE_ACCESS_CUSTOM:
                 case DebugMode::DEBUG_MODE_ERROR_NO_READ_ACCESS:
@@ -169,26 +182,37 @@ class DebugModeConfiguration implements DataConfigurationInterface
      */
     public function validateConfiguration(array $configuration)
     {
-        return isset(
-            $configuration['disable_overrides'],
-            $configuration['debug_mode'],
-            $configuration['debug_profiling']
-        );
+        $keys = [
+            'disable_overrides',
+            'debug_mode',
+            'debug_cookie_name',
+            'debug_cookie_value',
+            'debug_profiling',
+        ];
+        $array_keys = array_keys($configuration);
+
+        return count(array_intersect($keys, $array_keys)) === count($keys);
     }
 
     /**
      * Change Debug mode value if needed.
      *
-     * @param bool $enableStatus
+     * @param array $configuration {
+     *                             debug_mode: bool
+     *                             debug_cookie_name: string
+     *                             debug_cookie_value: string
+     *                             }
      *
      * @return int|null Status of update
      */
-    private function updateDebugMode(bool $enableStatus): ?int
+    private function updateDebugMode(array $configuration): ?int
     {
-        $currentDebugMode = $this->debugMode->isDebugModeEnabled();
+        $currentDebugMode = $this->debugMode->getCurrentDebugMode();
 
-        if ($enableStatus !== $currentDebugMode) {
-            return (true === $enableStatus) ? $this->debugMode->enable() : $this->debugMode->disable();
+        $newDebugMode = $this->debugMode->createDebugModeFromConfiguration($configuration);
+
+        if ($newDebugMode !== $currentDebugMode) {
+            return $this->debugMode->changePsModeDevValue($newDebugMode);
         }
 
         return null;

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
@@ -26,9 +26,9 @@
 
 namespace PrestaShopBundle\Form\Admin\AdvancedParameters\Performance;
 
+use PrestaShopBundle\Form\Admin\Type\GeneratableTextType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -52,18 +52,18 @@ class DebugModeType extends TranslatorAwareType
                 'label' => $this->trans('Debug mode', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('Enable or disable debug mode. Debug mode will enable extended error reporting, display the Symfony debug bar, and other features.', 'Admin.Advparameters.Help'),
             ])
-            ->add('debug_cookie_name', TextType::class, [
+            ->add('debug_cookie_name', GeneratableTextType::class, [
                 'required' => false,
-                'attr' => ['placeholder' => 'COOKIE_NAME'],
+                'generated_value_length' => 16,
                 'label' => $this->trans('Debug cookie name', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('(Optional) Insert a cookie name to enable the debug mode only when this cookie is set.', 'Admin.Advparameters.Help'),
                 'row_attr' => [
                     'class' => 'debug-mode-option',
                 ],
             ])
-            ->add('debug_cookie_value', TextType::class, [
+            ->add('debug_cookie_value', GeneratableTextType::class, [
                 'required' => false,
-                'attr' => ['placeholder' => 'COOKIE_VALUE'],
+                'generated_value_length' => 16,
                 'label' => $this->trans('Debug cookie value', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('(Optional) Insert a value to enable the debug mode only when the cookie configured above is set to this value.', 'Admin.Advparameters.Help'),
                 'row_attr' => [

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
@@ -27,7 +27,9 @@
 namespace PrestaShopBundle\Form\Admin\AdvancedParameters\Performance;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TextPreviewType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -50,6 +52,24 @@ class DebugModeType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Debug mode', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('Enable or disable debug mode. Debug mode will enable extended error reporting, display the Symfony debug bar, and other features.', 'Admin.Advparameters.Help'),
+            ])
+            ->add('debug_cookie_name', TextType::class, [
+                'required' => false,
+                'attr' => ['placeholder' => 'COOKIE_NAME'],
+                'label' => $this->trans('Debug cookie name', 'Admin.Advparameters.Feature'),
+                'help' => $this->trans('(Optional) Insert a cookie name to enable the debug mode only when this cookie is set.', 'Admin.Advparameters.Help'),
+                'row_attr' => [
+                    'class' => 'debug-mode-option',
+                ],
+            ])
+            ->add('debug_cookie_value', TextType::class, [
+                'required' => false,
+                'attr' => ['placeholder' => 'COOKIE_VALUE'],
+                'label' => $this->trans('Debug cookie value', 'Admin.Advparameters.Feature'),
+                'help' => $this->trans('(Optional) Insert a value to enable the debug mode only when the cookie configured above is set to this value.', 'Admin.Advparameters.Help'),
+                'row_attr' => [
+                    'class' => 'debug-mode-option',
+                ],
             ])
             ->add('debug_profiling', SwitchType::class, [
                 'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Form\Admin\AdvancedParameters\Performance;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use PrestaShopBundle\Form\Admin\Type\TextPreviewType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add ability to configure a debug cookie to control the debug mode
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open the performance page and enable the debug mode, then configure a cookie and a value
| Fixed ticket?     | Discussion https://github.com/PrestaShop/PrestaShop/discussions/30840
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/660
| Sponsor company   | 

We can add other options. I only added the cookie name & value for now. It's more of a simple proof of concept. Tell me if something is too hacky or potentially unreliable.

<img width="622" alt="CleanShot 2023-06-02 at 23 04 19@2x" src="https://github.com/PrestaShop/PrestaShop/assets/793712/8cd583ad-5ff4-4bff-a2e8-5f53d92ac05b">
