### PR TITLE
Improve Product::getAnchor()

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7599,11 +7599,10 @@ class ProductCore extends ObjectModel
         $attributes = Product::getAttributesParams($this->id, $id_product_attribute);
         $anchor = '#';
         $sep = Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR');
-        foreach ($attributes as &$a) {
-            foreach ($a as &$b) {
-                $b = str_replace($sep, '_', Tools::str2url((string) $b));
-            }
-            $anchor .= '/' . ($with_id && isset($a['id_attribute']) && $a['id_attribute'] ? (int) $a['id_attribute'] . $sep : '') . $a['group'] . $sep . $a['name'];
+        foreach ($attributes as &$attr) {
+            $group = str_replace($sep, '_', Tools::str2url((string) $attr['group']));
+            $name = str_replace($sep, '_', Tools::str2url((string) $attr['name']));
+            $anchor .= '/' . ($with_id ? (int) $attr['id_attribute'] . $sep : '') . $group . $sep . $name;
         }
 
         return $anchor;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7599,9 +7599,10 @@ class ProductCore extends ObjectModel
         $attributes = Product::getAttributesParams($this->id, $id_product_attribute);
         $anchor = '#';
         $sep = Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR');
+        $replace = $sep === '_' ? '-' : '_';
         foreach ($attributes as &$attr) {
-            $group = str_replace($sep, '_', Tools::str2url((string) $attr['group']));
-            $name = str_replace($sep, '_', Tools::str2url((string) $attr['name']));
+            $group = str_replace($sep, $replace, Tools::str2url((string) $attr['group']));
+            $name = str_replace($sep, $replace, Tools::str2url((string) $attr['name']));
             $anchor .= '/' . ($with_id ? (int) $attr['id_attribute'] . $sep : '') . $group . $sep . $name;
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Improvements: <br> 1. Loop to replace `$sep` is done on all columns (unused and also on ids).<br> 2. isset is always true. <br> 3. Handle separator edge case.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green, Product combination urls are generated as before.
| Fixed ticket?     | no
| Related PRs       | no
| Sponsor company   | -


## 1
```php
foreach ($a as &$b) {
    $b = str_replace($sep, '_', Tools::str2url((string) $b));
}
```
is the same as
```php
$a['id_attribute'] = str_replace($sep, '_', Tools::str2url((string) a['id_attribute']));
$a['id_attribute_group'] = str_replace($sep, '_', Tools::str2url((string) a['id_attribute_group']));
$a['name'] = str_replace($sep, '_', Tools::str2url((string) $a['name']));
$a['group'] = str_replace($sep, '_', Tools::str2url((string) $a['group']));
$a['reference'] = str_replace($sep, '_', Tools::str2url((string) $a['reference']));
$a['ean13'] = str_replace($sep, '_', Tools::str2url((string) $a['ean13']));
$a['isbn'] = str_replace($sep, '_', Tools::str2url((string) $a['isbn']));
$a['upc'] = str_replace($sep, '_', Tools::str2url((string) $a['upc']));
$a['mpn'] = str_replace($sep, '_', Tools::str2url((string) $a['mpn']));
$a['available_now'] = str_replace($sep, '_', Tools::str2url((string) $a['available_now']));
$a['available_later'] = str_replace($sep, '_', Tools::str2url((string) $a['available_later']));
```
But only `name` and `group` are used.

## 2
`isset($a['id_attribute']) && $a['id_attribute']` is always true because is the primary key of the table and there are no `RIGHT OUTER JOIN` in the query performed in `Product::getAttributesParams()`. Also, `0` value has no sense.

## 3
Since the separator is not a constant, it could be `_`, so this edge case is handled replacing  all separator char in the name/group by `-` instead of `_`.