### PR TITLE
Improve GroupReduction

### DIFF
--- a/classes/GroupReduction.php
+++ b/classes/GroupReduction.php
@@ -63,10 +63,7 @@ class GroupReductionCore extends ObjectModel
 			WHERE cp.`id_category` = ' . (int) $this->id_category
         );
 
-        $ids = [];
-        foreach ($products as $row) {
-            $ids[] = $row['id_product'];
-        }
+        $ids = array_column($products, 'id_product');
 
         if ($ids) {
             Db::getInstance()->delete('product_group_reduction_cache', 'id_product IN (' . implode(', ', $ids) . ')');
@@ -111,14 +108,10 @@ class GroupReductionCore extends ObjectModel
             '
 			SELECT cp.`id_product`
 			FROM `' . _DB_PREFIX_ . 'category_product` cp
-			WHERE cp.`id_category` = ' . (int) $this->id_category,
-        false
+			WHERE cp.`id_category` = ' . (int) $this->id_category
         );
 
-        $ids = [];
-        foreach ($products as $product) {
-            $ids[] = $product['id_product'];
-        }
+        $ids = array_column($products, 'id_product');
 
         $result = true;
         if ($ids) {
@@ -194,15 +187,14 @@ class GroupReductionCore extends ObjectModel
 
         $categories = Product::getProductCategories((int) $id_product);
 
-        if ($categories) {
-            foreach ($categories as $category) {
-                $reductions = GroupReduction::getGroupsByCategoryId((int) $category);
-                if ($reductions) {
-                    foreach ($reductions as $reduction) {
-                        $current_group_reduction = new GroupReduction((int) $reduction['id_group_reduction']);
-                        $res &= $current_group_reduction->_setCache();
-                    }
-                }
+        foreach ($categories as $category) {
+            $reductions = GroupReduction::getGroupsByCategoryId((int) $category);
+            if (!$reductions) {
+                continue;
+            }
+            foreach ($reductions as $reduction) {
+                $current_group_reduction = new GroupReduction((int) $reduction['id_group_reduction']);
+                $res &= $current_group_reduction->_setCache();
             }
         }
 
@@ -212,11 +204,8 @@ class GroupReductionCore extends ObjectModel
     public static function deleteProductReduction($id_product)
     {
         $query = 'DELETE FROM `' . _DB_PREFIX_ . 'product_group_reduction_cache` WHERE `id_product` = ' . (int) $id_product;
-        if (Db::getInstance()->execute($query) === false) {
-            return false;
-        }
 
-        return true;
+        return Db::getInstance()->execute($query);
     }
 
     public static function duplicateReduction($id_product_old, $id_product)
@@ -245,11 +234,8 @@ class GroupReductionCore extends ObjectModel
     public static function deleteCategory($id_category)
     {
         $query = 'DELETE FROM `' . _DB_PREFIX_ . 'group_reduction` WHERE `id_category` = ' . (int) $id_category;
-        if (Db::getInstance()->execute($query) === false) {
-            return false;
-        }
 
-        return true;
+        return Db::getInstance()->execute($query);
     }
 
     /**

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -268,7 +268,7 @@ class SpecificPriceCore extends ObjectModel
         }
         $priority = 'id_customer;' . $priority;
 
-        return preg_split('/;/', $priority);
+        return explode(';', $priority);
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Use `array_column` (faster / simpler) <br> `Db::execute()` already returns bool <br> Avoid nested and deep control structures.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No need. By dev.
| Fixed ticket?     | no
| Related PRs       | no
| Sponsor company   | -
