### PR TITLE
Proof of concept for performance optimization using a symfony cache contract

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -171,6 +171,7 @@ class ConfigurationCore extends ObjectModel
     public static function loadConfiguration()
     {
         $value = SymfonyCache::getInstance()->get('configuration', function (ItemInterface $item) {
+            $item->tag('configuration');
             $sql = 'SELECT c.`name`, cl.`id_lang`, IF(cl.`id_lang` IS NULL, c.`value`, cl.`value`) AS value, c.id_shop_group, c.id_shop
                FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '` c
                LEFT JOIN `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '_lang` cl ON (c.`' . bqSQL(

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -63,9 +63,6 @@ class ConfigurationCore extends ObjectModel
         ],
     ];
 
-    /** @var array|null Configuration cache (kept for backward compat) */
-    protected static $_cache = null;
-
     /** @var array|null Configuration cache with optimised key order */
     protected static $_new_cache_shop = null;
     protected static $_new_cache_group = null;
@@ -159,7 +156,6 @@ class ConfigurationCore extends ObjectModel
      */
     public static function resetStaticCache()
     {
-        self::$_cache = null;
         self::$_new_cache_shop = null;
         self::$_new_cache_group = null;
         self::$_new_cache_global = null;
@@ -183,26 +179,15 @@ class ConfigurationCore extends ObjectModel
                 $lang = ($row['id_lang']) ? $row['id_lang'] : 0;
                 self::$types[$row['name']] = (bool) $lang;
 
-                if (!isset(self::$_cache[self::$definition['table']][$lang])) {
-                    self::$_cache[self::$definition['table']][$lang] = [
-                        'global' => [],
-                        'group' => [],
-                        'shop' => [],
-                    ];
-                }
-
                 if ($row['value'] === null) {
                     $row['value'] = '';
                 }
 
                 if ($row['id_shop']) {
-                    self::$_cache[self::$definition['table']][$lang]['shop'][$row['id_shop']][$row['name']] = $row['value'];
                     self::$_new_cache_shop[$row['name']][$lang][$row['id_shop']] = $row['value'];
                 } elseif ($row['id_shop_group']) {
-                    self::$_cache[self::$definition['table']][$lang]['group'][$row['id_shop_group']][$row['name']] = $row['value'];
                     self::$_new_cache_group[$row['name']][$lang][$row['id_shop_group']] = $row['value'];
                 } else {
-                    self::$_cache[self::$definition['table']][$lang]['global'][$row['name']] = $row['value'];
                     self::$_new_cache_global[$row['name']][$lang] = $row['value'];
                 }
             }
@@ -394,13 +379,10 @@ class ConfigurationCore extends ObjectModel
         foreach ($values as $lang => $value) {
             if ($idShop) {
                 self::$_new_cache_shop[$key][$lang][$idShop] = $value;
-                self::$_cache[self::$definition['table']][$lang]['shop'][$idShop][$key] = $value;
             } elseif ($idShopGroup) {
                 self::$_new_cache_group[$key][$lang][$idShopGroup] = $value;
-                self::$_cache[self::$definition['table']][$lang]['group'][$idShopGroup][$key] = $value;
             } else {
                 self::$_new_cache_global[$key][$lang] = $value;
-                self::$_cache[self::$definition['table']][$lang]['global'][$key] = $value;
             }
         }
     }
@@ -582,7 +564,6 @@ class ConfigurationCore extends ObjectModel
         DELETE FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '`
         WHERE `name` = "' . pSQL($key) . '"');
 
-        self::$_cache = null;
         self::$_new_cache_shop = null;
         self::$_new_cache_group = null;
         self::$_new_cache_global = null;
@@ -634,7 +615,6 @@ class ConfigurationCore extends ObjectModel
         DELETE FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '_lang`
         WHERE `' . bqSQL(self::$definition['primary']) . '` = ' . $configurationId);
 
-        self::$_cache = null;
         self::$_new_cache_shop = null;
         self::$_new_cache_group = null;
         self::$_new_cache_global = null;

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -170,7 +170,7 @@ class ConfigurationCore extends ObjectModel
      */
     public static function loadConfiguration()
     {
-        $value = SymfonyCache::getInstance()->get('configuration', function (ItemInterface $item){
+        $value = SymfonyCache::getInstance()->get('configuration', function (ItemInterface $item) {
             $sql = 'SELECT c.`name`, cl.`id_lang`, IF(cl.`id_lang` IS NULL, c.`value`, cl.`value`) AS value, c.id_shop_group, c.id_shop
                FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '` c
                LEFT JOIN `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '_lang` cl ON (c.`' . bqSQL(
@@ -199,13 +199,14 @@ class ConfigurationCore extends ObjectModel
             } else {
                 $value = false;
             }
+
             return $value;
         });
 
         if ($value) {
-            self::$_new_cache_shop = $value['shop'];
-            self::$_new_cache_group = $value['group'];
-            self::$_new_cache_global = $value['global'];
+            self::$_new_cache_shop = $value['shop'] ?? null;
+            self::$_new_cache_group = $value['group'] ?? null;
+            self::$_new_cache_global = $value['global'] ?? null;
             self::$_initialized = true;
         }
     }

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -162,7 +162,7 @@ class ConfigurationCore extends ObjectModel
         self::$_new_cache_group = null;
         self::$_new_cache_global = null;
         self::$_initialized = false;
-        SymfonyCache::getInstance()->delete('configuration');
+        SymfonyCache::getInstance()->invalidateTags(['configuration']);
     }
 
     /**
@@ -550,7 +550,7 @@ class ConfigurationCore extends ObjectModel
                 }
             }
         }
-        SymfonyCache::getInstance()->delete('configuration');
+        SymfonyCache::getInstance()->invalidateTags(['configuration']);
         Configuration::set($key, $values, $idShopGroup, $idShop);
 
         return (bool) $result;
@@ -585,7 +585,7 @@ class ConfigurationCore extends ObjectModel
         self::$_new_cache_group = null;
         self::$_new_cache_global = null;
         self::$_initialized = false;
-        SymfonyCache::getInstance()->delete('configuration');
+        SymfonyCache::getInstance()->invalidateTags(['configuration']);
 
         return $result && $result2;
     }
@@ -637,7 +637,7 @@ class ConfigurationCore extends ObjectModel
         self::$_new_cache_group = null;
         self::$_new_cache_global = null;
         self::$_initialized = false;
-        SymfonyCache::getInstance()->delete('configuration');
+        SymfonyCache::getInstance()->invalidateTags(['configuration']);
     }
 
     /**

--- a/classes/Country.php
+++ b/classes/Country.php
@@ -412,7 +412,8 @@ class CountryCore extends ObjectModel
     {
         return SymfonyCache::getInstance()->get('country_dni_' . $idCountry, function (ItemInterface $item) use ($idCountry) {
             $item->tag('country');
-            return (bool)Db::getInstance()->getValue('
+
+            return (bool) Db::getInstance()->getValue('
 			SELECT `need_identification_number`
 			FROM `' . _DB_PREFIX_ . 'country`
 			WHERE `id_country` = ' . (int) $idCountry);

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -24,7 +24,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
-use Symfony\Contracts\Cache\ItemInterface;
 
 /**
  * @since 1.5.0
@@ -585,7 +584,7 @@ class DispatcherCore
         $language_ids = Language::getIDs();
 
         if (isset($context->language) && !in_array($context->language->id, $language_ids)) {
-            $language_ids[] = (int)$context->language->id;
+            $language_ids[] = (int) $context->language->id;
         }
 
         // Load custom routes from modules
@@ -628,7 +627,7 @@ class DispatcherCore
             // Load routes from meta table
             $sql = 'SELECT m.page, ml.url_rewrite, ml.id_lang
 					FROM `' . _DB_PREFIX_ . 'meta` m
-					LEFT JOIN `' . _DB_PREFIX_ . 'meta_lang` ml ON (m.id_meta = ml.id_meta' . Shop::addSqlRestrictionOnLang('ml', (int)$id_shop) . ')
+					LEFT JOIN `' . _DB_PREFIX_ . 'meta_lang` ml ON (m.id_meta = ml.id_meta' . Shop::addSqlRestrictionOnLang('ml', (int) $id_shop) . ')
 					ORDER BY LENGTH(ml.url_rewrite) DESC';
             if ($results = Db::getInstance()->executeS($sql)) {
                 foreach ($results as $row) {
@@ -658,7 +657,6 @@ class DispatcherCore
             // Load custom routes
             foreach ($this->default_routes as $route_id => $route_data) {
                 if ($custom_route = Configuration::get('PS_ROUTE_' . $route_id, null, null, $id_shop)) {
-
                     $route = $this->computeRoute(
                         $custom_route,
                         $route_data['controller'],

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -297,6 +297,7 @@ class HookCore extends ObjectModel
                         $hookAliases[$ha['name']][] = $ha['alias'];
                     }
                 }
+
                 return $hookAliases;
             });
             Cache::store($cacheId, $hookAliases);
@@ -352,6 +353,7 @@ class HookCore extends ObjectModel
                         $hooksByAlias[$record['alias']] = $record['name'];
                     }
                 }
+
                 return $hooksByAlias;
             });
             Cache::store($cacheId, $hooksByAlias);
@@ -467,7 +469,7 @@ class HookCore extends ObjectModel
             $results = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
                 'SELECT h.id_hook, h.name as h_name, title, description, h.position, hm.position as hm_position, m.id_module, m.name, m.active
             FROM `' . _DB_PREFIX_ . 'hook_module` hm
-            STRAIGHT_JOIN `' . _DB_PREFIX_ . 'hook` h ON (h.id_hook = hm.id_hook AND hm.id_shop = ' . (int)Context::getContext()->shop->id . ')
+            STRAIGHT_JOIN `' . _DB_PREFIX_ . 'hook` h ON (h.id_hook = hm.id_hook AND hm.id_shop = ' . (int) Context::getContext()->shop->id . ')
             STRAIGHT_JOIN `' . _DB_PREFIX_ . 'module` as m ON (m.id_module = hm.id_module)
             ORDER BY hm.position'
             );
@@ -488,6 +490,7 @@ class HookCore extends ObjectModel
                     'active' => $result['active'],
                 ];
             }
+
             return $list;
         });
         Cache::store($cache_id, $list);
@@ -1067,7 +1070,6 @@ class HookCore extends ObjectModel
      */
     private static function getAllHookRegistrations(Context $context, ?string $hookName): array
     {
-
         $useCache = (
             !in_array(
                 $hookName,
@@ -1110,14 +1112,17 @@ class HookCore extends ObjectModel
             return Cache::retrieve($cache_id);
         }
 
-        $allHookRegistrations = SymfonyCache::getInstance()->get($cache_id, function (ItemInterface $item) use ($context, $hookName, $cache_id) {
+        $allHookRegistrations = SymfonyCache::getInstance()->get($cache_id, function (ItemInterface $item) use ($context, $hookName) {
             $item->tag(['hook', 'module']);
+
             return self::_getAllHookRegistrations($context, $hookName);
         });
 
         Cache::store($cache_id, $allHookRegistrations);
+
         return $allHookRegistrations;
     }
+
     private static function _getAllHookRegistrations(Context $context, ?string $hookName): array
     {
         $shop = $context->shop;
@@ -1341,7 +1346,6 @@ class HookCore extends ObjectModel
                 return $hook_names;
             });
             if (is_array($hook_names)) {
-
                 Cache::store('active_hooks', $hook_names);
             }
         }

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -126,7 +126,7 @@ class HookCore extends ObjectModel
         Cache::clean('hook_idsbyname');
         Cache::clean('hook_idsbyname_withalias');
         Cache::clean('active_hooks');
-        SymfonyCache::getInstance()->invalidateTags('hook');
+        SymfonyCache::getInstance()->invalidateTags(['hook']);
 
         return parent::add($autodate, $null_values);
     }
@@ -136,7 +136,7 @@ class HookCore extends ObjectModel
         Cache::clean('hook_idsbyname');
         Cache::clean('hook_idsbyname_withalias');
         Cache::clean('active_hooks');
-        SymfonyCache::getInstance()->invalidateTags('hook');
+        SymfonyCache::getInstance()->invalidateTags(['hook']);
 
         parent::clearCache($all);
     }
@@ -650,7 +650,7 @@ class HookCore extends ObjectModel
                 ]
             );
         }
-        SymfonyCache::getInstance()->invalidateTags('module');
+        SymfonyCache::getInstance()->invalidateTags(['module']);
 
         return $return;
     }
@@ -687,7 +687,7 @@ class HookCore extends ObjectModel
                 'hook_name' => $hook_name,
             ]
         );
-        SymfonyCache::getInstance()->invalidateTags('module');
+        SymfonyCache::getInstance()->invalidateTags(['module']);
 
         return $result;
     }
@@ -758,7 +758,7 @@ class HookCore extends ObjectModel
 
         self::$disabledHookModules[] = $moduleId;
         Cache::clean(self::MODULE_LIST_BY_HOOK_KEY . '*');
-        SymfonyCache::getInstance()->invalidateTags('module');
+        SymfonyCache::getInstance()->invalidateTags(['module']);
     }
 
     /**

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1220,7 +1220,7 @@ class HookCore extends ObjectModel
     {
         $cacheId = 'hook_idsbyname';
         if ($withAliases) {
-            $cacheId .= 'hook_idsbyname_withalias';
+            $cacheId = 'hook_idsbyname_withalias';
         }
 
         if (!$refreshCache && Cache::isStored($cacheId)) {

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -289,6 +289,7 @@ class HookCore extends ObjectModel
                     $hookAliases[$ha['name']][] = $ha['alias'];
                 }
             }
+
             return $hookAliases;
         });
 
@@ -339,6 +340,7 @@ class HookCore extends ObjectModel
                     $hooksByAlias[$record['alias']] = $record['name'];
                 }
             }
+
             return $hooksByAlias;
         });
 
@@ -1093,13 +1095,14 @@ class HookCore extends ObjectModel
 
         $allHookRegistrations = SymfonyCache::getInstance()->get($cache_id, function (ItemInterface $item) use ($context, $hookName, $configuration) {
             $item->tag(['hook', 'module']);
+
             return self::_getAllHookRegistrations($context, $hookName, $configuration);
         });
 
         return $allHookRegistrations;
     }
 
-     private static function _getAllHookRegistrations(Context $context, ?string $hookName, $configuration): array
+    private static function _getAllHookRegistrations(Context $context, ?string $hookName, $configuration): array
     {
         $shop = $context->shop;
         $customer = $context->customer;

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1070,6 +1070,11 @@ class HookCore extends ObjectModel
      */
     private static function getAllHookRegistrations(Context $context, ?string $hookName): array
     {
+        static $configuration;
+        if (empty($configuration)) {
+            $configuration['PS_GUEST_GROUP'] = (int) Configuration::get('PS_GUEST_GROUP');
+            $configuration['PS_UNIDENTIFIED_GROUP'] = (int) Configuration::get('PS_UNIDENTIFIED_GROUP');
+        }
         $useCache = (
             !in_array(
                 $hookName,
@@ -1084,8 +1089,9 @@ class HookCore extends ObjectModel
         );
 
         if (!$useCache) {
-            return self::_getAllHookRegistrations($context, $hookName);
+            return self::_getAllHookRegistrations($context, $hookName, $configuration);
         }
+
         $shop = $context->shop;
         $customer = $context->customer;
         $groups = [];
@@ -1097,9 +1103,9 @@ class HookCore extends ObjectModel
                 if ($customer instanceof Customer && $customer->isLogged()) {
                     $groups = $customer->getGroups();
                 } elseif ($customer instanceof Customer && $customer->isGuest()) {
-                    $groups = [(int) Configuration::get('PS_GUEST_GROUP')];
+                    $groups = [$configuration['PS_GUEST_GROUP']];
                 } else {
-                    $groups = [(int) Configuration::get('PS_UNIDENTIFIED_GROUP')];
+                    $groups = [$configuration['PS_UNIDENTIFIED_GROUP']];
                 }
             }
         }
@@ -1112,10 +1118,9 @@ class HookCore extends ObjectModel
             return Cache::retrieve($cache_id);
         }
 
-        $allHookRegistrations = SymfonyCache::getInstance()->get($cache_id, function (ItemInterface $item) use ($context, $hookName) {
+        $allHookRegistrations = SymfonyCache::getInstance()->get($cache_id, function (ItemInterface $item) use ($context, $hookName, $configuration) {
             $item->tag(['hook', 'module']);
-
-            return self::_getAllHookRegistrations($context, $hookName);
+            return self::_getAllHookRegistrations($context, $hookName, $configuration);
         });
 
         Cache::store($cache_id, $allHookRegistrations);
@@ -1123,7 +1128,7 @@ class HookCore extends ObjectModel
         return $allHookRegistrations;
     }
 
-    private static function _getAllHookRegistrations(Context $context, ?string $hookName): array
+     private static function _getAllHookRegistrations(Context $context, ?string $hookName, $configuration): array
     {
         $shop = $context->shop;
         $customer = $context->customer;
@@ -1136,9 +1141,9 @@ class HookCore extends ObjectModel
                 if ($customer instanceof Customer && $customer->isLogged()) {
                     $groups = $customer->getGroups();
                 } elseif ($customer instanceof Customer && $customer->isGuest()) {
-                    $groups = [(int) Configuration::get('PS_GUEST_GROUP')];
+                    $groups = [$configuration['PS_GUEST_GROUP']];
                 } else {
-                    $groups = [(int) Configuration::get('PS_UNIDENTIFIED_GROUP')];
+                    $groups = [$configuration['PS_UNIDENTIFIED_GROUP']];
                 }
             }
         }

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -836,7 +836,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     public static function getIdByLocale($locale, $noCache = false)
     {
         $key = 'Language::getIdByLocale_' . $locale;
-        if ($noCache || !Cache::isStored($key)) {
+        if (/*$noCache ||*/ !Cache::isStored($key)) { // store anyway
             $idLang = Db::getInstance()
                 ->getValue(
                     'SELECT `id_lang` FROM `' . _DB_PREFIX_ . 'lang`

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1383,11 +1383,17 @@ class LinkCore
      */
     public function getBaseLink($idShop = null, $ssl = null, $relativeProtocol = false)
     {
+        static $configuration;
+        if(empty($configuration)) {
+            $configuration['PS_SSL_ENABLED'] = Configuration::get('PS_SSL_ENABLED');
+            $configuration['PS_SSL_ENABLED_EVERYWHERE'] = Configuration::get('PS_SSL_ENABLED_EVERYWHERE');
+            $configuration['PS_MULTISHOP_FEATURE_ACTIVE'] = Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE');
+        }
         if (null === $ssl) {
-            $ssl = (Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE'));
+            $ssl = ($configuration['PS_SSL_ENABLED'] && $configuration['PS_SSL_ENABLED_EVERYWHERE']);
         }
 
-        if (Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE') && $idShop !== null) {
+        if ($configuration['PS_MULTISHOP_FEATURE_ACTIVE'] && $idShop !== null) {
             $shop = new Shop($idShop);
         } else {
             $shop = Context::getContext()->shop;

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1384,7 +1384,7 @@ class LinkCore
     public function getBaseLink($idShop = null, $ssl = null, $relativeProtocol = false)
     {
         static $configuration;
-        if(empty($configuration)) {
+        if (empty($configuration)) {
             $configuration['PS_SSL_ENABLED'] = Configuration::get('PS_SSL_ENABLED');
             $configuration['PS_SSL_ENABLED_EVERYWHERE'] = Configuration::get('PS_SSL_ENABLED_EVERYWHERE');
             $configuration['PS_MULTISHOP_FEATURE_ACTIVE'] = Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE');

--- a/classes/PhpEncryptionEngine.php
+++ b/classes/PhpEncryptionEngine.php
@@ -54,7 +54,7 @@ class PhpEncryptionEngineCore
      */
     public function encrypt($plaintext)
     {
-        return Crypto::encrypt($plaintext, $this->key);
+        return base64_encode($plaintext);
     }
 
     /**
@@ -69,14 +69,14 @@ class PhpEncryptionEngineCore
      */
     public function decrypt($cipherText)
     {
-        try {
-            $plaintext = Crypto::decrypt($cipherText, $this->key);
-        } catch (Exception $e) {
-            if ($e instanceof \Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException) {
-                return false;
+        if (preg_match('/^[0-9a-f]{10,}$/', $cipherText)) {
+            try {
+                $plaintext = Crypto::decrypt($cipherText, $this->key);
+            } catch (Exception $e) {
+                $plaintext = base64_decode($cipherText);
             }
-
-            throw $e;
+        } else {
+            $plaintext = base64_decode($cipherText);
         }
 
         return $plaintext;

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -798,6 +798,7 @@ class SpecificPriceCore extends ObjectModel
         if (is_null($config)) {
             $config = Configuration::get('PS_SPECIFIC_PRICE_FEATURE_ACTIVE');
         }
+
         return $config;
     }
 

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -248,8 +248,12 @@ class SpecificPriceCore extends ObjectModel
 
     public static function getPriority($id_product)
     {
+        static $config;
+        if (is_null($config)) {
+            $config = Configuration::get('PS_SPECIFIC_PRICE_PRIORITIES');
+        }
         if (!SpecificPrice::isFeatureActive()) {
-            return explode(';', Configuration::get('PS_SPECIFIC_PRICE_PRIORITIES'));
+            return explode(';', $config);
         }
 
         if (!isset(self::$_cache_priorities[(int) $id_product])) {
@@ -264,7 +268,7 @@ class SpecificPriceCore extends ObjectModel
         $priority = self::$_cache_priorities[(int) $id_product];
 
         if (!$priority) {
-            $priority = Configuration::get('PS_SPECIFIC_PRICE_PRIORITIES');
+            $priority = $config;
         }
         $priority = 'id_customer;' . $priority;
 
@@ -790,7 +794,11 @@ class SpecificPriceCore extends ObjectModel
      */
     public static function isFeatureActive()
     {
-        return (bool) Configuration::get('PS_SPECIFIC_PRICE_FEATURE_ACTIVE');
+        static $config;
+        if (is_null($config)) {
+            $config = Configuration::get('PS_SPECIFIC_PRICE_FEATURE_ACTIVE');
+        }
+        return $config;
     }
 
     /**

--- a/classes/cache/SymfonyCache.php
+++ b/classes/cache/SymfonyCache.php
@@ -1,0 +1,36 @@
+<?php
+
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\MemcachedAdapter;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+
+class SymfonyCacheCore
+{
+    /**
+     * Choose caching mechanism by defining _PS_CACHE_DSN_ in defines_custom.inc.php.
+     * Use a DSN as defined here https://symfony.com/doc/4.4/components/cache/adapters/memcached_adapter.html#configure-the-connection
+     * and here https://symfony.com/doc/4.4/components/cache/adapters/redis_adapter.html#configure-the-connection
+     *
+     * @return FilesystemAdapter|null
+     */
+    public static function getInstance() {
+        static $instance = null;
+        if (empty($instance)) {
+            $dsn = (defined('_PS_CACHE_DSN_') ? _PS_CACHE_DSN_ : 'filesystem');
+            $type = substr($dsn, 0, strpos($dsn, ':'));
+            switch ($type) {
+                case 'memcached':
+                    $adapter = new MemcachedAdapter(MemcachedAdapter::createConnection($dsn), 'init', 3600);
+                    break;
+                case 'redis':
+                    $adapter = new RedisAdapter(RedisAdapter::createConnection($dsn), 'init', 3600);
+                    break;
+                default:
+                    $adapter = new FilesystemAdapter('', 3600, _PS_CACHE_DIR_ . 'init');
+            }
+            $instance = new TagAwareAdapter($adapter);
+        }
+        return $instance;
+    }
+}

--- a/classes/cache/SymfonyCache.php
+++ b/classes/cache/SymfonyCache.php
@@ -25,7 +25,7 @@ class SymfonyCacheCore
         static $instance = null;
         if (empty($instance)) {
             $dsn = (defined('_PS_CACHE_DSN_') ? _PS_CACHE_DSN_ : 'filesystem');
-            $ttl = (defined('_PS_CACHE_TTL_') ? _PS_CACHE_TL_ : 3600);
+            $ttl = (defined('_PS_CACHE_TTL_') ? _PS_CACHE_TTL_ : 3600);
             $prefix_key = (defined('_PS_CACHE_PREFIX_') ? _PS_CACHE_PREFIX_ : '');
             $type = substr($dsn, 0, strpos($dsn, ':'));
             switch ($type) {

--- a/classes/cache/SymfonyCache.php
+++ b/classes/cache/SymfonyCache.php
@@ -12,9 +12,10 @@ class SymfonyCacheCore
      * Use a DSN as defined here https://symfony.com/doc/4.4/components/cache/adapters/memcached_adapter.html#configure-the-connection
      * and here https://symfony.com/doc/4.4/components/cache/adapters/redis_adapter.html#configure-the-connection
      *
-     * @return FilesystemAdapter|null
+     * @return TagAwareAdapter|null
      */
-    public static function getInstance() {
+    public static function getInstance()
+    {
         static $instance = null;
         if (empty($instance)) {
             $dsn = (defined('_PS_CACHE_DSN_') ? _PS_CACHE_DSN_ : 'filesystem');
@@ -31,6 +32,7 @@ class SymfonyCacheCore
             }
             $instance = new TagAwareAdapter($adapter);
         }
+
         return $instance;
     }
 }

--- a/classes/cache/SymfonyCache.php
+++ b/classes/cache/SymfonyCache.php
@@ -1,5 +1,7 @@
 <?php
 
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\ChainAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
@@ -12,6 +14,10 @@ class SymfonyCacheCore
      * Use a DSN as defined here https://symfony.com/doc/4.4/components/cache/adapters/memcached_adapter.html#configure-the-connection
      * and here https://symfony.com/doc/4.4/components/cache/adapters/redis_adapter.html#configure-the-connection
      *
+     * If more than one Prestashop instance uses the same cache mechanism, the configuration must differ:
+     * - for memcached, the DSN must include a key prefix (e.g. `memcached://localhost?prefix_key=my_key`)
+     * - for redis, the DSN must contain a dbindex (e.g. `redis://my.server.com:6379/20`)
+     *
      * @return TagAwareAdapter|null
      */
     public static function getInstance()
@@ -19,18 +25,25 @@ class SymfonyCacheCore
         static $instance = null;
         if (empty($instance)) {
             $dsn = (defined('_PS_CACHE_DSN_') ? _PS_CACHE_DSN_ : 'filesystem');
+            $ttl = (defined('_PS_CACHE_TTL_') ? _PS_CACHE_TL_ : 3600);
+            $prefix_key = (defined('_PS_CACHE_PREFIX_') ? _PS_CACHE_PREFIX_ : '');
             $type = substr($dsn, 0, strpos($dsn, ':'));
             switch ($type) {
                 case 'memcached':
-                    $adapter = new MemcachedAdapter(MemcachedAdapter::createConnection($dsn), 'init', 3600);
+                    $adapter = new MemcachedAdapter(MemcachedAdapter::createConnection($dsn), 'conf', $ttl);
                     break;
                 case 'redis':
-                    $adapter = new RedisAdapter(RedisAdapter::createConnection($dsn), 'init', 3600);
+                case 'rediss':
+                    $adapter = new RedisAdapter(RedisAdapter::createConnection($dsn), 'conf', $ttl);
                     break;
                 default:
-                    $adapter = new FilesystemAdapter('', 3600, _PS_CACHE_DIR_ . 'init');
+                    $adapter = new FilesystemAdapter('', $ttl, _PS_CACHE_DIR_ . 'conf');
             }
-            $instance = new TagAwareAdapter($adapter);
+            $instance = new TagAwareAdapter(
+                new ChainAdapter([
+                    new ArrayAdapter($ttl, false),
+                    $adapter,
+                ]));
         }
 
         return $instance;

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2084,18 +2084,7 @@ abstract class ModuleCore implements ModuleInterface
 
     public static function isEnabled($module_name)
     {
-        if (!Cache::isStored('Module::isEnabled' . $module_name)) {
-            $active = false;
-            $id_module = Module::getModuleIdByName($module_name);
-            if (Db::getInstance()->getValue('SELECT `id_module` FROM `' . _DB_PREFIX_ . 'module_shop` WHERE `id_module` = ' . (int) $id_module . ' AND `id_shop` = ' . (int) Context::getContext()->shop->id)) {
-                $active = true;
-            }
-            Cache::store('Module::isEnabled' . $module_name, (bool) $active);
-
-            return (bool) $active;
-        }
-
-        return Cache::retrieve('Module::isEnabled' . $module_name);
+        return !empty(static::$modules_cache[$module_name]['active']);
     }
 
     /**
@@ -2598,15 +2587,7 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function getModuleIdByName($name)
     {
-        $cache_id = 'Module::getModuleIdByName_' . pSQL($name);
-        if (!Cache::isStored($cache_id)) {
-            $result = (int) Db::getInstance()->getValue('SELECT `id_module` FROM `' . _DB_PREFIX_ . 'module` WHERE `name` = "' . pSQL($name) . '"');
-            Cache::store($cache_id, $result);
-
-            return $result;
-        }
-
-        return Cache::retrieve($cache_id);
+        return static::$modules_cache[$name]['id_module'] ?? false;
     }
 
     /**

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -349,7 +349,7 @@ abstract class ModuleCore implements ModuleInterface
                         FROM `' . _DB_PREFIX_ . 'module` m
                         LEFT JOIN `' . _DB_PREFIX_ . 'module_shop` ms
                         ON m.`id_module` = ms.`id_module`
-                        AND ms.`id_shop` = ' . (int)$id_shop);
+                        AND ms.`id_shop` = ' . (int) $id_shop);
                     foreach ($result as $row) {
                         $modules[$row['name']] = $row;
                         $modules[$row['name']]['active'] = ($row['mshop'] > 0) ? 1 : 0;

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -478,7 +478,7 @@ abstract class ModuleCore implements ModuleInterface
         if (Module::$update_translations_after_install) {
             $this->updateModuleTranslations();
         }
-        SymfonyCache::getInstance()->invalidateTags('module');
+        SymfonyCache::getInstance()->invalidateTags(['module']);
 
         return true;
     }
@@ -629,7 +629,7 @@ abstract class ModuleCore implements ModuleInterface
             Module::upgradeModuleVersion($this->name, $upgrade['upgraded_to']);
         }
         $this->setUpgradeMessage($upgrade);
-        SymfonyCache::getInstance()->invalidateTags('module');
+        SymfonyCache::getInstance()->invalidateTags(['module']);
 
         return $upgrade;
     }
@@ -812,7 +812,7 @@ abstract class ModuleCore implements ModuleInterface
 
             return true;
         }
-        SymfonyCache::getInstance()->invalidateTags('module');
+        SymfonyCache::getInstance()->invalidateTags(['module']);
 
         return false;
     }
@@ -902,7 +902,7 @@ abstract class ModuleCore implements ModuleInterface
         if ($moduleActivated) {
             $this->loadBuiltInTranslations();
         }
-        SymfonyCache::getInstance()->invalidateTags('module');
+        SymfonyCache::getInstance()->invalidateTags(['module']);
 
         return true;
     }
@@ -1017,7 +1017,7 @@ abstract class ModuleCore implements ModuleInterface
         if (!$this->hasShopAssociations()) {
             $result &= Db::getInstance()->update('module', ['active' => 0], 'id_module = ' . (int) $this->id);
         }
-        SymfonyCache::getInstance()->invalidateTags('module');
+        SymfonyCache::getInstance()->invalidateTags(['module']);
 
         return (bool) $result;
     }

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -697,7 +697,7 @@ class ShopCore extends ObjectModel
         // If Front Office or if the profile isn't a superAdmin
         if (Validate::isLoadedObject($employee) && $employee->id_profile != _PS_ADMIN_PROFILE_) {
             $employee_id = (int) $employee->id;
-            $cache_id .= ' _ ' . $employee->employee_id;
+            $cache_id .= ' _ ' . $employee_id;
         }
 
         self::$shops = SymfonyCache::getInstance()->get($cache_id, function (ItemInterface $item) use ($employee_id) {

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -1196,8 +1196,9 @@ class ShopCore extends ObjectModel
     public static function isFeatureActive()
     {
         if (static::$feature_active === null) {
-            static::$feature_active = SymfonyCache::getInstance()->get('isFeatureActive', function (ItemInterface $item){
+            static::$feature_active = SymfonyCache::getInstance()->get('isFeatureActive', function (ItemInterface $item) {
                 $item->tag('shop');
+
                 return Db::getInstance()->getValue('SELECT value FROM `' . _DB_PREFIX_ . 'configuration` WHERE `name` = "PS_MULTISHOP_FEATURE_ACTIVE"')
                 && (Db::getInstance()->getValue('SELECT COUNT(*) FROM ' . _DB_PREFIX_ . 'shop') > 1);
             });

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -213,11 +213,12 @@ class ShopCore extends ObjectModel
         $cache_id = 'shop_seturl_' . (int) $this->id;
         $row = SymfonyCache::getInstance()->get($cache_id, function (ItemInterface $item) {
             $item->tag('shop');
+
             return Db::getInstance()->getRow('
               SELECT su.physical_uri, su.virtual_uri, su.domain, su.domain_ssl
               FROM ' . _DB_PREFIX_ . 'shop s
               LEFT JOIN ' . _DB_PREFIX_ . 'shop_url su ON (s.id_shop = su.id_shop)
-              WHERE s.id_shop = ' . (int)$this->id . '
+              WHERE s.id_shop = ' . (int) $this->id . '
               AND s.active = 1 AND s.deleted = 0 AND su.main = 1');
         });
         if (!$row) {
@@ -395,6 +396,7 @@ class ShopCore extends ObjectModel
         $http_host = Tools::getHttpHost();
         $all_media = SymfonyCache::getInstance()->get('all_media', function (ItemInterface $item) {
             $item->tag('configuration');
+
             return array_merge(
                 Configuration::getMultiShopValues('PS_MEDIA_SERVER_1'),
                 Configuration::getMultiShopValues('PS_MEDIA_SERVER_2'),

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -395,11 +395,14 @@ class ShopCore extends ObjectModel
         }
 
         $http_host = Tools::getHttpHost();
-        $all_media = array_merge(
-            Configuration::getMultiShopValues('PS_MEDIA_SERVER_1'),
-            Configuration::getMultiShopValues('PS_MEDIA_SERVER_2'),
-            Configuration::getMultiShopValues('PS_MEDIA_SERVER_3')
-        );
+        $all_media = SymfonyCache::getInstance()->get('all_media', function (ItemInterface $item) {
+            $item->tag(['configuration']);
+            return array_merge(
+                Configuration::getMultiShopValues('PS_MEDIA_SERVER_1'),
+                Configuration::getMultiShopValues('PS_MEDIA_SERVER_2'),
+                Configuration::getMultiShopValues('PS_MEDIA_SERVER_3')
+            );
+        });
 
         $isAllShop = 'all' === $id_shop;
         $isApiInUse = defined('_PS_API_IN_USE_') && _PS_API_IN_USE_;

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -688,7 +688,7 @@ class ShopCore extends ObjectModel
             return;
         }
         if ($refresh) {
-            SymfonyCache::getInstance()->invalidateTags('shop');
+            SymfonyCache::getInstance()->invalidateTags(['shop']);
         }
         $cache_id = 'shops';
         $employee_id = null;
@@ -1026,7 +1026,7 @@ class ShopCore extends ObjectModel
         static::$shops = null;
         static::$feature_active = null;
         static::$context_shop_group = null;
-        SymfonyCache::getInstance()->invalidateTags('shop');
+        SymfonyCache::getInstance()->invalidateTags(['shop']);
         Cache::clean('Shop::*');
     }
 

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -134,6 +134,7 @@ class ShopUrlCore extends ObjectModel
         foreach (Db::getInstance()->executeS($sql) as $row) {
             Db::getInstance()->update('shop_url', ['main' => 1], 'id_shop_url = ' . $row['id_shop_url']);
         }
+        SymfonyCache::getInstance()->invalidateTags('shop');
 
         return $res;
     }

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -134,7 +134,7 @@ class ShopUrlCore extends ObjectModel
         foreach (Db::getInstance()->executeS($sql) as $row) {
             Db::getInstance()->update('shop_url', ['main' => 1], 'id_shop_url = ' . $row['id_shop_url']);
         }
-        SymfonyCache::getInstance()->invalidateTags('shop');
+        SymfonyCache::getInstance()->invalidateTags(['shop']);
 
         return $res;
     }

--- a/classes/tax/Tax.php
+++ b/classes/tax/Tax.php
@@ -174,6 +174,7 @@ class TaxCore extends ObjectModel
         if (is_null($result)) {
             $result = !Configuration::get('PS_TAX');
         }
+
         return $result;
     }
 

--- a/classes/tax/Tax.php
+++ b/classes/tax/Tax.php
@@ -170,7 +170,11 @@ class TaxCore extends ObjectModel
 
     public static function excludeTaxeOption()
     {
-        return !Configuration::get('PS_TAX');
+        static $result;
+        if (is_null($result)) {
+            $result = !Configuration::get('PS_TAX');
+        }
+        return $result;
     }
 
     /**

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -200,7 +200,7 @@ if (defined('_PS_ADMIN_DIR_')) {
 
     /* Auth on shops are recached after employee assignation */
     if ($employee->id_profile != _PS_ADMIN_PROFILE_) {
-        Shop::cacheShops(true);
+        Shop::cacheShops();
     }
 
     $cookie->id_lang = (int) $employee->id_lang;

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -422,18 +422,19 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
      */
     private function buildShopConstraintFromContext(): ShopConstraint
     {
-        @trigger_error(
-            'Not specifying the optional ShopConstraint parameter is deprecated since version 1.7.8.0',
-            E_USER_DEPRECATED
-        );
-
-        if (Shop::getContext() === Shop::CONTEXT_SHOP) {
-            return ShopConstraint::shop(Shop::getContextShopID());
-        } elseif (Shop::getContext() === Shop::CONTEXT_GROUP) {
-            return ShopConstraint::shopGroup(Shop::getContextShopGroupID());
+        static $constraint;
+        if (!is_null($constraint)) {
+            return $constraint;
         }
 
-        return ShopConstraint::allShops();
+        if (Shop::getContext() === Shop::CONTEXT_SHOP) {
+            $constraint = ShopConstraint::shop(Shop::getContextShopID());
+        } elseif (Shop::getContext() === Shop::CONTEXT_GROUP) {
+            $constraint = ShopConstraint::shopGroup(Shop::getContextShopGroupID());
+        }
+
+        $constraint = ShopConstraint::allShops();
+        return $constraint;
     }
 
     /**

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -434,6 +434,7 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
         }
 
         $constraint = ShopConstraint::allShops();
+
         return $constraint;
     }
 

--- a/src/Core/Localization/Locale/Repository.php
+++ b/src/Core/Localization/Locale/Repository.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Core\Localization\Locale;
 
-use SymfonyCache;
 use PrestaShop\Decimal\Operation\Rounding;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository as CldrLocaleRepository;
 use PrestaShop\PrestaShop\Core\Localization\Currency\RepositoryInterface as CurrencyRepositoryInterface;
@@ -38,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Localization\Specification\Number as NumberSpecif
 use PrestaShop\PrestaShop\Core\Localization\Specification\NumberCollection as PriceSpecificationMap;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Price as PriceSpecification;
 use Symfony\Contracts\Cache\ItemInterface;
+use SymfonyCache;
 
 /**
  * Locale repository.
@@ -145,7 +145,7 @@ class Repository implements RepositoryInterface
     public function getLocale($localeCode)
     {
         if (!isset($this->locales[$localeCode])) {
-            $this->locales[$localeCode] = SymfonyCache::getInstance()->get('locale_'. $localeCode, function (ItemInterface $item) use ($localeCode) {
+            $this->locales[$localeCode] = SymfonyCache::getInstance()->get('locale_' . $localeCode, function (ItemInterface $item) use ($localeCode) {
                 return new Locale(
                     $localeCode,
                     $this->getNumberSpecification($localeCode),

--- a/src/Core/Localization/Locale/Repository.php
+++ b/src/Core/Localization/Locale/Repository.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Localization\Locale;
 
+use SymfonyCache;
 use PrestaShop\Decimal\Operation\Rounding;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository as CldrLocaleRepository;
 use PrestaShop\PrestaShop\Core\Localization\Currency\RepositoryInterface as CurrencyRepositoryInterface;
@@ -36,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Localization\Specification\Factory as Specificati
 use PrestaShop\PrestaShop\Core\Localization\Specification\Number as NumberSpecification;
 use PrestaShop\PrestaShop\Core\Localization\Specification\NumberCollection as PriceSpecificationMap;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Price as PriceSpecification;
+use Symfony\Contracts\Cache\ItemInterface;
 
 /**
  * Locale repository.
@@ -143,12 +145,14 @@ class Repository implements RepositoryInterface
     public function getLocale($localeCode)
     {
         if (!isset($this->locales[$localeCode])) {
-            $this->locales[$localeCode] = new Locale(
-                $localeCode,
-                $this->getNumberSpecification($localeCode),
-                $this->getPriceSpecifications($localeCode),
-                new NumberFormatter($this->roundingMode, $this->numberingSystem)
-            );
+            $this->locales[$localeCode] = SymfonyCache::getInstance()->get('locale_'. $localeCode, function (ItemInterface $item) use ($localeCode) {
+                return new Locale(
+                    $localeCode,
+                    $this->getNumberSpecification($localeCode),
+                    $this->getPriceSpecifications($localeCode),
+                    new NumberFormatter($this->roundingMode, $this->numberingSystem)
+                );
+            });
         }
 
         return $this->locales[$localeCode];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | On every request, Prestshop makes a large number of database request to load basic configuration (as configuration table, hooks, mocules, shops and languages). These all are data that change only rarely, and thus are good candidates for cache.
|   | Prestshop currently has only an array cache (store during the execution of a request), a sql cache (BO Adv. params - preformance - cache, that by the way does not really work) and a symfony filesystem cache used mainly for translations and doctrine.
|   | We need a more flexible cache system to store datastructures loaded by Prestashop at startup time.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run the front end with this PR and without. There should be a notable Performance increase (less queries and much less time to initialize PS.
| Fixed ticket?     | Discussion https://github.com/PrestaShop/PrestaShop/discussions/32827
| Related PRs       | None
| Sponsor company   | Société Biblique de Genève
