### PR TITLE
Error in cache id naming

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1197,7 +1197,7 @@ class HookCore extends ObjectModel
     {
         $cacheId = 'hook_idsbyname';
         if ($withAliases) {
-            $cacheId .= 'hook_idsbyname_withalias';
+            $cacheId = 'hook_idsbyname_withalias';
         }
 
         if (!$refreshCache && Cache::isStored($cacheId)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix incorrect cache id
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `echo $cacheId;` @ https://github.com/PrestaShop/PrestaShop/blob/32b958d86912b5ece2087e307dfc6aca9c7ba385/classes/Hook.php#L1225
| Fixed ticket?     | Fixes #32837
| Related PRs       | None
| Sponsor company   | Société Biblique de Genève
