### PR TITLE
Changed error code when access token is invalid

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -108,3 +108,5 @@ api_platform:
       - '%kernel.project_dir%/app/config/api_platform'
 
   metadata_backward_compatibility_layer: false
+  exception_to_status:
+    Lcobucci\JWT\Token\InvalidTokenStructure: 401


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x 
| Description?      | Replaced error code (`500` to `401`) when access token is invalid
| Type?             | bug fix 
| Category?         | WS 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #32768
| Fixed ticket?     | Fixes #32768
| Related PRs       | ~
| Sponsor company   | PrestaShop SA 
