### PR TITLE
Fix invalid token in redirection after editing himself

### DIFF
--- a/src/PrestaShopBundle/Service/Routing/Router.php
+++ b/src/PrestaShopBundle/Service/Routing/Router.php
@@ -60,7 +60,10 @@ class Router extends BaseRouter
     {
         $url = parent::generate($name, $parameters, $referenceType);
 
-        if (TokenInUrls::isDisabled()) {
+        // For now, if we generate a _token and pass it in parameters, we must use it instead of use TokenManager.
+        // todo: to be improved when UserProvider is also improved.
+        // @see https://github.com/PrestaShop/PrestaShop/pull/32861
+        if (TokenInUrls::isDisabled() || isset($parameters['_token'])) {
             return $url;
         }
 

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/OrderControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/OrderControllerTest.php
@@ -79,7 +79,6 @@ class OrderControllerTest extends WebTestCase
 
     public function testSearchProductsWithContent(): void
     {
-        $token = $this->tokenManager->getToken('form');
         $this->client->request(
             'GET',
             $this->router->generate(
@@ -88,7 +87,6 @@ class OrderControllerTest extends WebTestCase
                     'search_phrase' => 'Brown bear',
                     'currency_id' => 1,
                     'order_id' => 1,
-                    '_token' => $token->getValue(),
                 ]
             )
         );
@@ -106,7 +104,6 @@ class OrderControllerTest extends WebTestCase
 
     public function testSearchProductsEmptyPhrase(): void
     {
-        $token = $this->tokenManager->getToken('form');
         $this->client->request(
             'GET',
             $this->router->generate(
@@ -115,7 +112,6 @@ class OrderControllerTest extends WebTestCase
                     'search_phrase' => '',
                     'currency_id' => 1,
                     'order_id' => 1,
-                    '_token' => $token->getValue(),
                 ]
             )
         );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix invalid token on redirection when we self editing in BO team page.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #32734 
| Fixed ticket?     | Fixes #32734 
| Related PRs       | 
| Sponsor company   | 

## Problem
To fix this properly, we need to understand how token is generated on the cyclelife of requests.
In fact, when we generate a route (or redirect to a route) from an admin controller, our Router get token from username (also know as employee's email address) of current logged employee. Our Router retreive username from UserProvider that is unmuttable, but in this usecase the current employee has changed! (We change his email address and and therefore also his username!) Our Router generate therefore an invalid token for current logged employee. And this token is store in memory to avoid the need to regenerate a token when we need to generate an admin route.

## Solution (for now)
For now, I force this behaviour: 
- We generate a new `_token` in `EmployeeController::editAction` with new username.
- When we pass a `_token` in parameters of route, we used it and not regenerated this token in Router.

## But we need to do in a cleaner (and clever) way!
Admin controllers must not control the way of generate tokens, but why not reset already generated tokens.
We need also to improve UserProvider / TokenStorage / TokenManager stuff, to have only one clever way to deal with tokens. (generate / verify / display compromised page / ...)