### PR TITLE
Upgrade cssjanus to 2.1.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -510,25 +510,25 @@
         },
         {
             "name": "cssjanus/cssjanus",
-            "version": "v2.1.0",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/cssjanus/php-cssjanus.git",
-                "reference": "de7483c0805750a6462b372eab55d022d555df02"
+                "url": "https://github.com/wikimedia/php-cssjanus.git",
+                "reference": "befd1eb7b1e70ee2cd71cd5b9a86ff250d2e8423"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cssjanus/php-cssjanus/zipball/de7483c0805750a6462b372eab55d022d555df02",
-                "reference": "de7483c0805750a6462b372eab55d022d555df02",
+                "url": "https://api.github.com/repos/wikimedia/php-cssjanus/zipball/befd1eb7b1e70ee2cd71cd5b9a86ff250d2e8423",
+                "reference": "befd1eb7b1e70ee2cd71cd5b9a86ff250d2e8423",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "require-dev": {
-                "mediawiki/mediawiki-phan-config": "0.10.6",
+                "mediawiki/mediawiki-phan-config": "0.12.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.0",
-                "phpunit/phpunit": "^8.5.15",
+                "phpunit/phpunit": "^9.5",
                 "squizlabs/php_codesniffer": "^3.6.0"
             },
             "type": "library",
@@ -553,11 +553,11 @@
                 }
             ],
             "description": "Convert CSS stylesheets between left-to-right and right-to-left.",
+            "homepage": "https://www.mediawiki.org/wiki/CSSJanus",
             "support": {
-                "issues": "https://github.com/cssjanus/php-cssjanus/issues",
-                "source": "https://github.com/cssjanus/php-cssjanus/tree/v2.1.0"
+                "source": "https://github.com/wikimedia/php-cssjanus/tree/v2.1.1"
             },
-            "time": "2021-09-09T17:58:26+00:00"
+            "time": "2023-01-08T17:45:35+00:00"
         },
         {
             "name": "curl/curl",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Upgrade cssjanus to 2.1.1 . Diff between 2.1.1 and 2.1.0 is only internal https://github.com/wikimedia/php-cssjanus/compare/v2.1.0...v2.1.1
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Automated tests should be enough
| Fixed ticket?     | 
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
