### PR TITLE
Fix link to blog in install

### DIFF
--- a/install-dev/theme/config.php
+++ b/install-dev/theme/config.php
@@ -25,7 +25,7 @@
  */
 
 $documentationLink = 'https://devdocs.prestashop-project.org/';
-$blogLink = 'https://build.prestashop.com/';
+$blogLink = 'https://build.prestashop-project.org/';
 
 return [
     'links' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In installer, blog link is the old link to .com . Fix it for link to .org
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On `develop` the link to "Blog" at the top right of the page is https://build.prestashop.com/ . With this PR it is fixed to https://build.prestashop-project.org/
| Fixed ticket?     | 
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
