### PR TITLE
Fix disabling a module for a specific shop applied to all shops

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -984,8 +984,9 @@ abstract class ModuleCore implements ModuleInterface
             $result &= $this->uninstallOverrides();
         }
 
-        // Disable module for all shops
-        $result &= Db::getInstance()->delete('module_shop', '`id_module` = ' . (int) $this->id);
+        // Disable module for all shops or contextual shops
+        $whereIdShop = $force_all ? '' : ' AND `id_shop` IN(' . implode(', ', Shop::getContextListShopID()) . ')';
+        $result &= Db::getInstance()->delete('module_shop', '`id_module` = ' . (int) $this->id . $whereIdShop);
 
         // if module has no more shop associations, set module.active = 0
         if (!$this->hasShopAssociations()) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | when disabling a module, the query must specify id shops if we don't want to disable the module for all shops
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |  See steps in issue #30262 Also make sure that the change doesn't have side effects when the shop didn't enable multishop (enable/disable module feature should still work properly)
| Fixed ticket?     | Fixes #30262 / #32211 (to be verified)
| Related PRs       | none
| Sponsor company   | PrestaShop SA