### PR TITLE
POC - ICU translation test

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1200,6 +1200,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         );
         $product_full['quantity_label'] = ($this->product->quantity > 1) ? $this->trans('Items', [], 'Shop.Theme.Catalog') : $this->trans('Item', [], 'Shop.Theme.Catalog');
 
+        // See Symfony\Component\Translation\Translator::trans for context
         // Option 1 - we will call it without ICU suffix and just format everything in INTL
         dump($this->product->quantity . ' ' . $this->trans(
             '{items, plural, =0 {Items} =1 {Item} other {Items}}',

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1198,15 +1198,23 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             && $this->product->available_for_order
             && !Configuration::isCatalogMode()
         );
-
         $product_full['quantity_label'] = ($this->product->quantity > 1) ? $this->trans('Items', [], 'Shop.Theme.Catalog') : $this->trans('Item', [], 'Shop.Theme.Catalog');
 
-        // It seems that the call works even without the ICU suffix and ICU logic is activated
+        // Option 1 - we will call it without ICU suffix and just format everything in INTL
         dump($this->product->quantity . ' ' . $this->trans(
             '{items, plural, =0 {Items} =1 {Item} other {Items}}',
             ['items' => $this->product->quantity],
             'Shop.Theme.Catalog'
         ));
+
+        // Option 2 - we will use the intl suffix as symfony does to detect what we want to format with INTL
+        /*
+        dump($this->product->quantity . ' ' . $this->trans(
+            '{items, plural, =0 {Items} =1 {Item} other {Items}}',
+            ['items' => $this->product->quantity],
+            'Shop.Theme.Catalog+intl-icu'
+        ));
+        */
 
         $product_full['quantity_discounts'] = $this->quantity_discounts;
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1198,7 +1198,16 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             && $this->product->available_for_order
             && !Configuration::isCatalogMode()
         );
+
         $product_full['quantity_label'] = ($this->product->quantity > 1) ? $this->trans('Items', [], 'Shop.Theme.Catalog') : $this->trans('Item', [], 'Shop.Theme.Catalog');
+
+        // It seems that the call works even without the ICU suffix and ICU logic is activated
+        dump($this->product->quantity . ' ' . $this->trans(
+            '{items, plural, =0 {Items} =1 {Item} other {Items}}',
+            ['items' => $this->product->quantity],
+            'Shop.Theme.Catalog'
+        ));
+
         $product_full['quantity_discounts'] = $this->quantity_discounts;
 
         // Adapt unit price to display settings

--- a/translations/cs-CZ/ShopThemeCatalog.cs-CZ.xlf
+++ b/translations/cs-CZ/ShopThemeCatalog.cs-CZ.xlf
@@ -1,0 +1,700 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="classes/controller/FrontController.php" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="af342023e90ca45b0d69be497168ac56" approved="yes">
+        <source>Unit discount</source>
+        <target state="final">Jednotková sleva</target>
+        <note>Line: 1598</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/ProductController.php" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="9dea4016dbcc290b773ab2fae678aaa8" approved="yes">
+        <source>Items</source>
+        <target state="final">ks</target>
+        <note>Line: 1217</note>
+      </trans-unit>
+      <trans-unit id="7d74f3b92b19da5e606d737d339a9679" approved="yes">
+        <source>Item</source>
+        <target state="final">ks</target>
+        <note>Line: 1217</note>
+      </trans-unit>
+      <trans-unit id="7d74f3b92b19da5e606d737d339a966dsadasdasda" approved="yes">
+        <source>{items, plural, =0 {Items} =1 {Item} other {Items}}</source>
+        <target state="final">{items, plural, =0 {Položek} one {Položka} few {Položky} other {Položek}}</target>
+        <note>Line: 1217</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/SitemapController.php" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="af1b98adf7f686b84cd0b443e022b7a0" approved="yes">
+        <source>Categories</source>
+        <target state="final">Kategorie</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="453aceb005ceaf54a47da15fee8b2a26" approved="yes">
+        <source>Pages</source>
+        <target state="final">Stránky</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="c8f312df214e2295809027c6ca79d232" approved="yes">
+        <source>Price drop</source>
+        <target state="final">Slevy</target>
+        <note>Line: 206</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/BestSalesController.php" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="01f7ac959c1e6ebbb2e0ee706a7a5255" approved="yes">
+        <source>Best sellers</source>
+        <target state="final">Nejprodávanější</target>
+        <note>Line: 99</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/CategoryController.php" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="aa89fd8bf65df5c1a1c11474bf2c16b5" approved="yes">
+        <source>Category: %category_name%</source>
+        <target state="final">Kategorie: %category_name%</target>
+        <note>Line: 295</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/ManufacturerController.php" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="bd51980476ab3cd93603c9548fb78775" approved="yes">
+        <source>List of all brands</source>
+        <target state="final">Seznam všech značek</target>
+        <note>Line: 104</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/PricesDropController.php" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="6de5d0b17afc50642850ff9486934f87" approved="yes">
+        <source>Prices drop</source>
+        <target state="final">Slevy</target>
+        <note>Line: 87</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/SearchController.php" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="eb6b06cab0dd72e04c4da68d511facf2" approved="yes">
+        <source>Search results</source>
+        <target state="final">Výsledek hledání</target>
+        <note>Line: 126</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/SupplierController.php" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="108b413416adf90e7c6f21a68bb02dd2" approved="yes">
+        <source>%number% products</source>
+        <target state="final">%number% produktů</target>
+        <note>Line: 210</note>
+      </trans-unit>
+      <trans-unit id="8e7fb1213c4692b195ed6b7cf580d7f3" approved="yes">
+        <source>%number% product</source>
+        <target state="final">%number% produkt</target>
+        <note>Line: 211</note>
+      </trans-unit>
+      <trans-unit id="bcdf044a723993079e77ec66e4d6cbf2" approved="yes">
+        <source>List of products by supplier %supplier_name%</source>
+        <target state="final">Seznam produktů dodavatele %supplier_name%</target>
+        <note>Line: 93</note>
+      </trans-unit>
+      <trans-unit id="d9e0619813f9247f8a506b9b1e61599f" approved="yes">
+        <source>List of all suppliers</source>
+        <target state="final">Seznam všech dodavatelů</target>
+        <note>Line: 106</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_facetedsearch/src/Product/SearchProvider.php" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="05d61847840bcddb5d37374de3be0ccc" approved="yes">
+        <source>Name, A to Z</source>
+        <target state="final">Název, A až Z</target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="e21f2ef58ff858167655c18a874f9706" approved="yes">
+        <source>Name, Z to A</source>
+        <target state="final">Název: Z-A</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="e2174d7435696694b8f4d984d99eef03" approved="yes">
+        <source>Price, low to high</source>
+        <target state="final">Cena: vzestupně</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="0ee81913615b71aba7dc8bbf1f144672" approved="yes">
+        <source>Price, high to low</source>
+        <target state="final">Cena: sestupně</target>
+        <note>Line: 119</note>
+      </trans-unit>
+      <trans-unit id="b56ffaa1656269759857ba14573dc144" approved="yes">
+        <source>Sales, highest to lowest</source>
+        <target state="final">Prodej, od nejvyššího po nejnižší</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="900a70008b0ed52ee5f6907f7b61f0e8" approved="yes">
+        <source>Date added, newest to oldest</source>
+        <target state="final">Datum přidáno, od nejnovějšího po nejstarší</target>
+        <note>Line: 128</note>
+      </trans-unit>
+      <trans-unit id="c2718c816e7ebf8495e3c9ce20061317" approved="yes">
+        <source>Date added, oldest to newest</source>
+        <target state="final">Datum přidáno, od nejstaršího po nejnovější</target>
+        <note>Line: 125</note>
+      </trans-unit>
+      <trans-unit id="ad24ffca4f9e9c0c7e80fe1512df6db9" approved="yes">
+        <source>Relevance</source>
+        <target state="final">Důležitost</target>
+        <note>Line: 107</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_searchbar/ps_searchbar.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="5bdba1fc0fba1010d61ce253c2e57da8" approved="yes">
+        <source>Search our catalog</source>
+        <target state="final">Hledat v katalogu</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="13348442cc6a27032d2b4aa28b75a5d3" approved="yes">
+        <source>Search</source>
+        <target state="final">Vyhledávání</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Presenter/Product/ProductLazyArray.php" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="03c2e7e41ffc181a4e84080b4710e81e" approved="yes">
+        <source>New</source>
+        <target state="final">Nové</target>
+        <note>Line: 493</note>
+      </trans-unit>
+      <trans-unit id="019d1ca7d50cc54b995f60d456435e87" approved="yes">
+        <source>Used</source>
+        <target state="final">Již použité</target>
+        <note>Line: 249</note>
+      </trans-unit>
+      <trans-unit id="6da03a74721a0554b7143254225cc08a" approved="yes">
+        <source>Refurbished</source>
+        <target state="final">Repasované</target>
+        <note>Line: 255</note>
+      </trans-unit>
+      <trans-unit id="03de921a8ea82897e13d33d66c28b4db" approved="yes">
+        <source>Online only</source>
+        <target state="final">Pouze online</target>
+        <note>Line: 460</note>
+      </trans-unit>
+      <trans-unit id="800e90e940e7f1fb938b0fda5137f38c" approved="yes">
+        <source>On sale!</source>
+        <target state="final">Sleva!</target>
+        <note>Line: 467</note>
+      </trans-unit>
+      <trans-unit id="63b539babcf7978229d66ba4052ca71f" approved="yes">
+        <source>Reduced price</source>
+        <target state="final">Sleva</target>
+        <note>Line: 485</note>
+      </trans-unit>
+      <trans-unit id="4492081ca02b059f9e8af4ddaf0f7292" approved="yes">
+        <source>Pack</source>
+        <target state="final">Balení</target>
+        <note>Line: 500</note>
+      </trans-unit>
+      <trans-unit id="cb3c718c905f00adbb6735f55bfb38ef" approved="yes">
+        <source>Product available with different options</source>
+        <target state="final">Produkt je k dispozici s jinými možnostmi</target>
+        <note>Line: 1022</note>
+      </trans-unit>
+      <trans-unit id="348325afced7f3da215310efbe21f1c1" approved="yes">
+        <source>Last items in stock</source>
+        <target state="final">Poslední kus skladem</target>
+        <note>Line: 970</note>
+      </trans-unit>
+      <trans-unit id="a3b6a4d0897451813950029a3066f219" approved="yes">
+        <source>ean13</source>
+        <target state="final">ean13</target>
+        <note>Line: 1043</note>
+      </trans-unit>
+      <trans-unit id="6496117322fd76fa12ac1b87d8a4db6c" approved="yes">
+        <source>isbn</source>
+        <target state="final">isbn</target>
+        <note>Line: 1045</note>
+      </trans-unit>
+      <trans-unit id="2f9e567efb6a38663162f65eaac2d73b" approved="yes">
+        <source>upc</source>
+        <target state="final">upc</target>
+        <note>Line: 1047</note>
+      </trans-unit>
+      <trans-unit id="294598238a4d88a9920c7e6fba9bb843" approved="yes">
+        <source>MPN</source>
+        <target state="final">MPN</target>
+        <note>Line: 1049</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_bestsellers/views/templates/hook/ps_bestsellers.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="d7b2933ba512ada478c97fa43dd7ebe6" approved="yes">
+        <source>Best Sellers</source>
+        <target state="final">Nejprodávanéjší</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="eae99cd6a931f3553123420b16383812" approved="yes">
+        <source>All best sellers</source>
+        <target state="final">Všechny nejprodávanější produkty</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_brandlist/views/templates/_partials/brand_form.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="e18a22d145b38e4fff582663b5b4ec1e" approved="yes">
+        <source>All brands</source>
+        <target state="final">Všechny značky</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_brandlist/views/templates/hook/ps_brandlist.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="84be54bb4bd1b755a27d86388700d097" approved="yes">
+        <source>Brands</source>
+        <target state="final">Značky</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="633fb5d52c05cf5e69790ed8a01e0260" approved="yes">
+        <source>brands</source>
+        <target state="final">značky</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="8e41eae149ff3fa38cc9c4fde945f2c3" approved="yes">
+        <source>No brand</source>
+        <target state="final">Žádná značka</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="f55e0a28b86c2ab66ac632ab9ddf1833" approved="yes">
+        <source>%s other product in the same category:</source>
+        <target state="final">%s další produkt ve stejné kategorii:</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="bebb44f38b03407098d48198c1d0aaa5" approved="yes">
+        <source>%s other products in the same category:</source>
+        <target state="final">%s dalších produktů ve stejné kategorii:</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_crossselling/views/templates/hook/ps_crossselling.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="ef2b66b0b65479e08ff0cce29e19d006" approved="yes">
+        <source>Customers who bought this product also bought:</source>
+        <target state="final">Zákazníci, kteří si koupili tento produkt, koupili také:</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_emailalerts/views/templates/hook/my-account.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="4edfd10d0bb5f51e0fd2327df608b5a8" approved="yes">
+        <source>My alerts</source>
+        <target state="final">Moje oznámení</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="f473acb18ebcd825235ca5624203f31a" approved="yes">
+        <source>Popular Products</source>
+        <target state="final">Oblíbené produkty</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="40dec546414c1ebdfde8d9858f0938c3" approved="yes">
+        <source>All products</source>
+        <target state="final">Všechny produkty</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="9ff0635f5737513b1a6f559ac2bff745" approved="yes">
+        <source>New products</source>
+        <target state="final">Nové produkty</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="60efcc704ef1456678f77eb9ee20847b" approved="yes">
+        <source>All new products</source>
+        <target state="final">Všechny novinky</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_productinfo/views/templates/hook/ps_productinfo.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="035749e4c50392a661c0f1b220ae0516" approved="yes">
+        <source>1 person is currently watching this product.</source>
+        <target state="final">1 člověk si aktuálně prohlíží tento produkt.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="c24cf2abae9286b8f69a8ccdf7ed8d5e" approved="yes">
+        <source>%nb_people% people are currently watching this product.</source>
+        <target state="final">%nb_people% lidí si aktuálně prohlíží tento produkt.</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="247f15e3dc0e7906ab9573685423899f" approved="yes">
+        <source>Last time this product was bought: %date_last_order%</source>
+        <target state="final">Tento produkt byl naposledy zakoupen: %date_last_order%</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="160b4798999cb85c815beeb40ac268cc" approved="yes">
+        <source>Last time this product was added to a cart: %date_last_cart%</source>
+        <target state="final">Tento produkt byl naposledy přidán do košíku: %date_last_cart%</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_rssfeed/views/templates/hook/ps_rssfeed.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="10fd25dcd3353c0ba3731d4a23657f2e" approved="yes">
+        <source>No RSS feed added</source>
+        <target state="final">Nebyl přidán žádný RSS kanál</target>
+        <note>Line: 36</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_specials/views/templates/hook/ps_specials.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="588907ab2d492aca0b07b5bf9c931eea" approved="yes">
+        <source>On sale</source>
+        <target state="final">Sleva</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="f95ceb82c51c99dc9b9e5678b291c44b" approved="yes">
+        <source>All sale products</source>
+        <target state="final">Všechny produkty ve slevě</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_supplierlist/views/templates/_partials/supplier_form.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="ecf253735ac0cba84a9d2eeff1f1b87c" approved="yes">
+        <source>All suppliers</source>
+        <target state="final">Všichni dodavatelé</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_supplierlist/views/templates/hook/ps_supplierlist.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="1814d65a76028fdfbadab64a5a8076df" approved="yes">
+        <source>Suppliers</source>
+        <target state="final">Dodavatelé</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="496689fbd342f80d30f1f266d060415a" approved="yes">
+        <source>No supplier</source>
+        <target state="final">Žádný dodavatel</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_viewedproduct/views/templates/hook/ps_viewedproduct.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="43560641f91e63dc83682bc598892fa1" approved="yes">
+        <source>Viewed products</source>
+        <target state="final">Prohlédnuté produkty</target>
+        <note>Line: 26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/active_filters.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="734346d44245de59214137842ab17744" approved="yes">
+        <source>%1$s:</source>
+        <target state="final">%1$s:</target>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/miniatures/product.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="4d8adffdc001189e0202c01ac529a3a9" approved="yes">
+        <source>Regular price</source>
+        <target state="final">Běžná cena</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="3601146c4e948c32b6424d2c0a7f0118" approved="yes">
+        <source>Price</source>
+        <target state="final">Cena</target>
+        <note>Line: 102</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-add-to-cart.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="694e8d1f2ee056f98ee488bdc4982d73" approved="yes">
+        <source>Quantity</source>
+        <target state="final">Počet</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-customization.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="5d1190edfb16f1dcaaecc56570c864be" approved="yes">
+        <source>Your customization:</source>
+        <target state="final">Přizpůsobení:</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="54c02ba7929b1fda4847991a45b58a48" approved="yes">
+        <source>Product customization</source>
+        <target state="final">Přizpůsobení produktu</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-details.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="1be6f9eb563f3bf85c78b4219bf09de9" approved="yes">
+        <source>Brand</source>
+        <target state="final">Značka</target>
+        <note>Line: 14</note>
+      </trans-unit>
+      <trans-unit id="fcebe56087b9373f15514831184fa572" approved="yes">
+        <source>In stock</source>
+        <target state="final">Skladem</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="ea254ced8be4adb6c4a2750e84087da6" approved="yes">
+        <source>Availability date:</source>
+        <target state="final">Datum dostupnosti:</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="7dcd185f890fd28f69d1ed210292d77f" approved="yes">
+        <source>Data sheet</source>
+        <target state="final">Parametry</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="4594f39c6dac58760daeb19d79389576" approved="yes">
+        <source>Specific References</source>
+        <target state="final">Specifické reference</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="9e2941b3c81256fac10392aaca4ccfde" approved="yes">
+        <source>Condition</source>
+        <target state="final">Podmínka</target>
+        <note>Line: 85</note>
+      </trans-unit>
+      <trans-unit id="63d5049791d9d79d86e9a108b0a999ca" approved="yes">
+        <source>Reference</source>
+        <target state="final">Kód</target>
+        <note>Line: 23</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-discounts.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="fc21aa6a8b0bceb8570c8c81b6b38307" approved="yes">
+        <source>Volume discounts</source>
+        <target state="final">Množstevní slevy</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="861c0c6ef832cd96c5fe152f9d610973" approved="yes">
+        <source>You Save</source>
+        <target state="final">Ušetříte</target>
+        <note>Line: 34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-prices.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="d502fa4950894baeaeaf3c5195bb8206" approved="yes">
+        <source>Save %percentage%</source>
+        <target state="final">Sleva %percentage%</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="5e9ce3b8961433dfa8cd441709c78176" approved="yes">
+        <source>Save %amount%</source>
+        <target state="final">Sleva %amount%</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="e532954941a2469e3b3ae35ce44885d6" approved="yes">
+        <source>%price% tax excl.</source>
+        <target state="final">%price% bez DPH</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="a72a454b308052ed277f7b69ab307caa" approved="yes">
+        <source>Instead of %price%</source>
+        <target state="final">Namísto %price%</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="98508b5a9b590896cc627beb46d86b96" approved="yes">
+        <source>Including %amount% for ecotax</source>
+        <target state="final">vč. ekologické daně %amount%</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="a134618182b99ff9151d7e0b6b92410a" approved="yes">
+        <source>(not impacted by the discount)</source>
+        <target state="final">(Není ovlivněna slevou)</target>
+        <note>Line: 85</note>
+      </trans-unit>
+      <trans-unit id="6f3455d187a23443796efdcbe044096b" approved="yes">
+        <source>No tax</source>
+        <target state="final">Není daň</target>
+        <note>Line: 95</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-variants.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="e265492707dd0595fd1f399bb8a2690e" approved="yes">
+        <source>: </source>
+        <target state="final">: </target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/products-top.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="fb526aaa0add86e4e124263db50438c8" approved="yes">
+        <source>Showing %from%-%to% of %total% item(s)</source>
+        <target state="final">Zobrazení %from%-%to% z %total% položek</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="498007f495e00b14f415d5f6ae6a1362" approved="yes">
+        <source>There are %product_count% products.</source>
+        <target state="final">Počet produktů: %product_count%</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="79ac892bd1769d83ef1c16dae9f4eddd" approved="yes">
+        <source>There is 1 product.</source>
+        <target state="final">Je zde 1 produkt.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/listing/manufacturer.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="d0679d37c204278465192d34b1917c01" approved="yes">
+        <source>List of products by brand %brand_name%</source>
+        <target state="final">Seznam produktů značky %brand_name%</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/listing/search.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="f3b6c3bd1bbeb3a3077a5bd6c56c52aa" approved="yes">
+        <source>No matches were found for your search</source>
+        <target state="final">Pro tento výraz jsme nic nenašli</target>
+        <note>Line: 8</note>
+      </trans-unit>
+      <trans-unit id="efa34a2b5f4bc39bf375243c2a33cad0" approved="yes">
+        <source>Please try other keywords to describe what you are looking for.</source>
+        <target state="final">Zkuste použít jiná slova. Snad najdete, co hledáte.</target>
+        <note>Line: 9</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/listing/supplier.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="4c5c40c99a89125e22218cb62335c60a" approved="yes">
+        <source>List of products by supplier %s</source>
+        <target state="final">Seznam produktů dodavatele %s</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/product.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="56e11b516943cb38a57c9a53219a8370" approved="yes">
+        <source>This pack contains</source>
+        <target state="final">Tento balíček obsahuje</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="b5a7adde1af5c87d7fd797b6245c2a39" approved="yes">
+        <source>Description</source>
+        <target state="final">Popis</target>
+        <note>Line: 152</note>
+      </trans-unit>
+      <trans-unit id="b8900d8adf598b6653bb8c071bc49a1d" approved="yes">
+        <source>Product Details</source>
+        <target state="final">Detaily produktu</target>
+        <note>Line: 162</note>
+      </trans-unit>
+      <trans-unit id="7e2708aeb65763c54052f57ed1a1ec1d" approved="yes">
+        <source>Attachments</source>
+        <target state="final">Přílohy</target>
+        <note>Line: 171</note>
+      </trans-unit>
+      <trans-unit id="3767d4f3efe17bd95a1bc7cf4194bb93" approved="yes">
+        <source>You might also like</source>
+        <target state="final">Mohlo by vás také zajímat</target>
+        <note>Line: 231</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/_partials/order-detail-return.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="6c957f72dc8cdacc75762f2cbdcdfaf2" approved="yes">
+        <source>Unit price</source>
+        <target state="final">Jedn. cena</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="0eede552438475bdfe820c13f24c9399" approved="yes">
+        <source>Total price</source>
+        <target state="final">Celková cena</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/order-return.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="deb10517653c255364175796ace3553f" approved="yes">
+        <source>Product</source>
+        <target state="final">Produkt</target>
+        <note>Line: 39</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/errors/404.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="85c435036ee6b5b6ae8dc26b5c336e3a" approved="yes">
+        <source>No products available yet</source>
+        <target state="final">Zatím zde nejsou žádné produkty</target>
+        <note>Line: 34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/errors/410.tpl" source-language="en" target-language="cs" datatype="plaintext">
+    <body>
+      <trans-unit id="539fcfb998ae696968c089223fb0500d" approved="yes">
+        <source>Stay tuned! More products will be shown here as they are added.</source>
+        <target state="final">Navštivte nás za pár dní znovu. Produkty se zobrazí, hned jak je přidáme.</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="c9189b9d0be364a501aa527e5d8265d3" approved="yes">
+        <source>No products available</source>
+        <target state="final">Nejsou k dispozici žádné produkty</target>
+        <note>Line: 34</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/translations/default/ShopThemeCatalog.xlf
+++ b/translations/default/ShopThemeCatalog.xlf
@@ -21,6 +21,11 @@
         <target>Item</target>
         <note>Line: 1217</note>
       </trans-unit>
+      <trans-unit id="7d74f3b92b19da5e606d737d339a966dsadasdasda">
+        <source>{items, plural, =0 {Items} =1 {Item} other {Items}}</source>
+        <target>{items, plural, =0 {Items} =1 {Item} other {Items}}</target>
+        <note>Line: 1217</note>
+      </trans-unit>
     </body>
   </file>
   <file original="controllers/front/SitemapController.php" source-language="en-US" target-language="en" datatype="plaintext">

--- a/vendor/symfony/translation/Translator.php
+++ b/vendor/symfony/translation/Translator.php
@@ -1,0 +1,494 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation;
+
+use Symfony\Component\Config\ConfigCacheFactory;
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
+use Symfony\Component\Config\ConfigCacheInterface;
+use Symfony\Component\Translation\Exception\InvalidArgumentException;
+use Symfony\Component\Translation\Exception\NotFoundResourceException;
+use Symfony\Component\Translation\Exception\RuntimeException;
+use Symfony\Component\Translation\Formatter\IntlFormatterInterface;
+use Symfony\Component\Translation\Formatter\MessageFormatter;
+use Symfony\Component\Translation\Formatter\MessageFormatterInterface;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Contracts\Translation\LocaleAwareInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+// Help opcache.preload discover always-needed symbols
+class_exists(MessageCatalogue::class);
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleAwareInterface
+{
+    /**
+     * @var MessageCatalogueInterface[]
+     */
+    protected $catalogues = [];
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var string[]
+     */
+    private $fallbackLocales = [];
+
+    /**
+     * @var LoaderInterface[]
+     */
+    private $loaders = [];
+
+    /**
+     * @var array
+     */
+    private $resources = [];
+
+    /**
+     * @var MessageFormatterInterface
+     */
+    private $formatter;
+
+    /**
+     * @var string
+     */
+    private $cacheDir;
+
+    /**
+     * @var bool
+     */
+    private $debug;
+
+    private $cacheVary;
+
+    /**
+     * @var ConfigCacheFactoryInterface|null
+     */
+    private $configCacheFactory;
+
+    /**
+     * @var array|null
+     */
+    private $parentLocales;
+
+    private $hasIntlFormatter;
+
+    /**
+     * @throws InvalidArgumentException If a locale contains invalid characters
+     */
+    public function __construct(string $locale, MessageFormatterInterface $formatter = null, string $cacheDir = null, bool $debug = false, array $cacheVary = [])
+    {
+        $this->setLocale($locale);
+
+        if (null === $formatter) {
+            $formatter = new MessageFormatter();
+        }
+
+        $this->formatter = $formatter;
+        $this->cacheDir = $cacheDir;
+        $this->debug = $debug;
+        $this->cacheVary = $cacheVary;
+        $this->hasIntlFormatter = $formatter instanceof IntlFormatterInterface;
+    }
+
+    public function setConfigCacheFactory(ConfigCacheFactoryInterface $configCacheFactory)
+    {
+        $this->configCacheFactory = $configCacheFactory;
+    }
+
+    /**
+     * Adds a Loader.
+     *
+     * @param string $format The name of the loader (@see addResource())
+     */
+    public function addLoader(string $format, LoaderInterface $loader)
+    {
+        $this->loaders[$format] = $loader;
+    }
+
+    /**
+     * Adds a Resource.
+     *
+     * @param string $format   The name of the loader (@see addLoader())
+     * @param mixed  $resource The resource name
+     *
+     * @throws InvalidArgumentException If the locale contains invalid characters
+     */
+    public function addResource(string $format, $resource, string $locale, string $domain = null)
+    {
+        if (null === $domain) {
+            $domain = 'messages';
+        }
+
+        $this->assertValidLocale($locale);
+        $locale ?: $locale = class_exists(\Locale::class) ? \Locale::getDefault() : 'en';
+
+        $this->resources[$locale][] = [$format, $resource, $domain];
+
+        if (\in_array($locale, $this->fallbackLocales)) {
+            $this->catalogues = [];
+        } else {
+            unset($this->catalogues[$locale]);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLocale(string $locale)
+    {
+        $this->assertValidLocale($locale);
+        $this->locale = $locale;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLocale()
+    {
+        return $this->locale ?: (class_exists(\Locale::class) ? \Locale::getDefault() : 'en');
+    }
+
+    /**
+     * Sets the fallback locales.
+     *
+     * @param string[] $locales
+     *
+     * @throws InvalidArgumentException If a locale contains invalid characters
+     */
+    public function setFallbackLocales(array $locales)
+    {
+        // needed as the fallback locales are linked to the already loaded catalogues
+        $this->catalogues = [];
+
+        foreach ($locales as $locale) {
+            $this->assertValidLocale($locale);
+        }
+
+        $this->fallbackLocales = $this->cacheVary['fallback_locales'] = $locales;
+    }
+
+    /**
+     * Gets the fallback locales.
+     *
+     * @internal
+     */
+    public function getFallbackLocales(): array
+    {
+        return $this->fallbackLocales;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function trans(?string $id, array $parameters = [], string $domain = null, string $locale = null)
+    {
+        if (null === $id || '' === $id) {
+            return '';
+        }
+
+        if (null === $domain) {
+            $domain = 'messages';
+        }
+
+        $catalogue = $this->getCatalogue($locale);
+        $locale = $catalogue->getLocale();
+        while (!$catalogue->defines($id, $domain)) {
+            if ($cat = $catalogue->getFallbackCatalogue()) {
+                $catalogue = $cat;
+                $locale = $catalogue->getLocale();
+            } else {
+                break;
+            }
+        }
+
+        $len = \strlen(MessageCatalogue::INTL_DOMAIN_SUFFIX);
+        if ($this->hasIntlFormatter
+            && ($catalogue->defines($id, $domain.MessageCatalogue::INTL_DOMAIN_SUFFIX)
+            || (\strlen($domain) > $len && 0 === substr_compare($domain, MessageCatalogue::INTL_DOMAIN_SUFFIX, -$len, $len)))
+        ) {
+            return $this->formatter->formatIntl($catalogue->get($id, $domain), $locale, $parameters);
+        }
+
+        return $this->formatter->format($catalogue->get($id, $domain), $locale, $parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCatalogue(string $locale = null)
+    {
+        if (!$locale) {
+            $locale = $this->getLocale();
+        } else {
+            $this->assertValidLocale($locale);
+        }
+
+        if (!isset($this->catalogues[$locale])) {
+            $this->loadCatalogue($locale);
+        }
+
+        return $this->catalogues[$locale];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCatalogues(): array
+    {
+        return array_values($this->catalogues);
+    }
+
+    /**
+     * Gets the loaders.
+     *
+     * @return LoaderInterface[]
+     */
+    protected function getLoaders()
+    {
+        return $this->loaders;
+    }
+
+    protected function loadCatalogue(string $locale)
+    {
+        if (null === $this->cacheDir) {
+            $this->initializeCatalogue($locale);
+        } else {
+            $this->initializeCacheCatalogue($locale);
+        }
+    }
+
+    protected function initializeCatalogue(string $locale)
+    {
+        $this->assertValidLocale($locale);
+
+        try {
+            $this->doLoadCatalogue($locale);
+        } catch (NotFoundResourceException $e) {
+            if (!$this->computeFallbackLocales($locale)) {
+                throw $e;
+            }
+        }
+        $this->loadFallbackCatalogues($locale);
+    }
+
+    private function initializeCacheCatalogue(string $locale): void
+    {
+        if (isset($this->catalogues[$locale])) {
+            /* Catalogue already initialized. */
+            return;
+        }
+
+        $this->assertValidLocale($locale);
+        $cache = $this->getConfigCacheFactory()->cache($this->getCatalogueCachePath($locale),
+            function (ConfigCacheInterface $cache) use ($locale) {
+                $this->dumpCatalogue($locale, $cache);
+            }
+        );
+
+        if (isset($this->catalogues[$locale])) {
+            /* Catalogue has been initialized as it was written out to cache. */
+            return;
+        }
+
+        /* Read catalogue from cache. */
+        $this->catalogues[$locale] = include $cache->getPath();
+    }
+
+    private function dumpCatalogue(string $locale, ConfigCacheInterface $cache): void
+    {
+        $this->initializeCatalogue($locale);
+        $fallbackContent = $this->getFallbackContent($this->catalogues[$locale]);
+
+        $content = sprintf(<<<EOF
+<?php
+
+use Symfony\Component\Translation\MessageCatalogue;
+
+\$catalogue = new MessageCatalogue('%s', %s);
+
+%s
+return \$catalogue;
+
+EOF
+            ,
+            $locale,
+            var_export($this->getAllMessages($this->catalogues[$locale]), true),
+            $fallbackContent
+        );
+
+        $cache->write($content, $this->catalogues[$locale]->getResources());
+    }
+
+    private function getFallbackContent(MessageCatalogue $catalogue): string
+    {
+        $fallbackContent = '';
+        $current = '';
+        $replacementPattern = '/[^a-z0-9_]/i';
+        $fallbackCatalogue = $catalogue->getFallbackCatalogue();
+        while ($fallbackCatalogue) {
+            $fallback = $fallbackCatalogue->getLocale();
+            $fallbackSuffix = ucfirst(preg_replace($replacementPattern, '_', $fallback));
+            $currentSuffix = ucfirst(preg_replace($replacementPattern, '_', $current));
+
+            $fallbackContent .= sprintf(<<<'EOF'
+$catalogue%s = new MessageCatalogue('%s', %s);
+$catalogue%s->addFallbackCatalogue($catalogue%s);
+
+EOF
+                ,
+                $fallbackSuffix,
+                $fallback,
+                var_export($this->getAllMessages($fallbackCatalogue), true),
+                $currentSuffix,
+                $fallbackSuffix
+            );
+            $current = $fallbackCatalogue->getLocale();
+            $fallbackCatalogue = $fallbackCatalogue->getFallbackCatalogue();
+        }
+
+        return $fallbackContent;
+    }
+
+    private function getCatalogueCachePath(string $locale): string
+    {
+        return $this->cacheDir.'/catalogue.'.$locale.'.'.strtr(substr(base64_encode(hash('sha256', serialize($this->cacheVary), true)), 0, 7), '/', '_').'.php';
+    }
+
+    /**
+     * @internal
+     */
+    protected function doLoadCatalogue(string $locale): void
+    {
+        $this->catalogues[$locale] = new MessageCatalogue($locale);
+
+        if (isset($this->resources[$locale])) {
+            foreach ($this->resources[$locale] as $resource) {
+                if (!isset($this->loaders[$resource[0]])) {
+                    if (\is_string($resource[1])) {
+                        throw new RuntimeException(sprintf('No loader is registered for the "%s" format when loading the "%s" resource.', $resource[0], $resource[1]));
+                    }
+
+                    throw new RuntimeException(sprintf('No loader is registered for the "%s" format.', $resource[0]));
+                }
+                $this->catalogues[$locale]->addCatalogue($this->loaders[$resource[0]]->load($resource[1], $locale, $resource[2]));
+            }
+        }
+    }
+
+    private function loadFallbackCatalogues(string $locale): void
+    {
+        $current = $this->catalogues[$locale];
+
+        foreach ($this->computeFallbackLocales($locale) as $fallback) {
+            if (!isset($this->catalogues[$fallback])) {
+                $this->initializeCatalogue($fallback);
+            }
+
+            $fallbackCatalogue = new MessageCatalogue($fallback, $this->getAllMessages($this->catalogues[$fallback]));
+            foreach ($this->catalogues[$fallback]->getResources() as $resource) {
+                $fallbackCatalogue->addResource($resource);
+            }
+            $current->addFallbackCatalogue($fallbackCatalogue);
+            $current = $fallbackCatalogue;
+        }
+    }
+
+    protected function computeFallbackLocales(string $locale)
+    {
+        if (null === $this->parentLocales) {
+            $this->parentLocales = json_decode(file_get_contents(__DIR__.'/Resources/data/parents.json'), true);
+        }
+
+        $originLocale = $locale;
+        $locales = [];
+
+        while ($locale) {
+            $parent = $this->parentLocales[$locale] ?? null;
+
+            if ($parent) {
+                $locale = 'root' !== $parent ? $parent : null;
+            } elseif (\function_exists('locale_parse')) {
+                $localeSubTags = locale_parse($locale);
+                $locale = null;
+                if (1 < \count($localeSubTags)) {
+                    array_pop($localeSubTags);
+                    $locale = locale_compose($localeSubTags) ?: null;
+                }
+            } elseif ($i = strrpos($locale, '_') ?: strrpos($locale, '-')) {
+                $locale = substr($locale, 0, $i);
+            } else {
+                $locale = null;
+            }
+
+            if (null !== $locale) {
+                $locales[] = $locale;
+            }
+        }
+
+        foreach ($this->fallbackLocales as $fallback) {
+            if ($fallback === $originLocale) {
+                continue;
+            }
+
+            $locales[] = $fallback;
+        }
+
+        return array_unique($locales);
+    }
+
+    /**
+     * Asserts that the locale is valid, throws an Exception if not.
+     *
+     * @throws InvalidArgumentException If the locale contains invalid characters
+     */
+    protected function assertValidLocale(string $locale)
+    {
+        if (!preg_match('/^[a-z0-9@_\\.\\-]*$/i', $locale)) {
+            throw new InvalidArgumentException(sprintf('Invalid "%s" locale.', $locale));
+        }
+    }
+
+    /**
+     * Provides the ConfigCache factory implementation, falling back to a
+     * default implementation if necessary.
+     */
+    private function getConfigCacheFactory(): ConfigCacheFactoryInterface
+    {
+        if (!$this->configCacheFactory) {
+            $this->configCacheFactory = new ConfigCacheFactory($this->debug);
+        }
+
+        return $this->configCacheFactory;
+    }
+
+    private function getAllMessages(MessageCatalogueInterface $catalogue): array
+    {
+        $allMessages = [];
+
+        foreach ($catalogue->all() as $domain => $messages) {
+            if ($intlMessages = $catalogue->all($domain.MessageCatalogue::INTL_DOMAIN_SUFFIX)) {
+                $allMessages[$domain.MessageCatalogue::INTL_DOMAIN_SUFFIX] = $intlMessages;
+                $messages = array_diff_key($messages, $intlMessages);
+            }
+            if ($messages) {
+                $allMessages[$domain] = $messages;
+            }
+        }
+
+        return $allMessages;
+    }
+}

--- a/vendor/symfony/translation/Translator.php
+++ b/vendor/symfony/translation/Translator.php
@@ -206,11 +206,11 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
 
         // Option 2 - Check if ICU is in the domain, write down this info.
         // Replace ICU part in the domain to keep using our old catalogs without the suffix.
-        $useIntl = false;
+        /*$useIntl = false;
         if (strpos($domain, MessageCatalogue::INTL_DOMAIN_SUFFIX)) {
             $useIntl = true;
             $domain = str_replace(MessageCatalogue::INTL_DOMAIN_SUFFIX, '', $domain);
-        }
+        }*/
 
         $catalogue = $this->getCatalogue($locale);
         $locale = $catalogue->getLocale();

--- a/vendor/symfony/translation/Translator.php
+++ b/vendor/symfony/translation/Translator.php
@@ -216,10 +216,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
         }
 
         $len = \strlen(MessageCatalogue::INTL_DOMAIN_SUFFIX);
-        if ($this->hasIntlFormatter
-            && ($catalogue->defines($id, $domain.MessageCatalogue::INTL_DOMAIN_SUFFIX)
-            || (\strlen($domain) > $len && 0 === substr_compare($domain, MessageCatalogue::INTL_DOMAIN_SUFFIX, -$len, $len)))
-        ) {
+        if ($this->hasIntlFormatter) {
             return $this->formatter->formatIntl($catalogue->get($id, $domain), $locale, $parameters);
         }
 

--- a/vendor/symfony/translation/Translator.php
+++ b/vendor/symfony/translation/Translator.php
@@ -204,6 +204,14 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
             $domain = 'messages';
         }
 
+        // Option 2 - Check if ICU is in the domain, write down this info.
+        // Replace ICU part in the domain to keep using our old catalogs without the suffix.
+        $useIntl = false;
+        if (strpos($domain, MessageCatalogue::INTL_DOMAIN_SUFFIX)) {
+            $useIntl = true;
+            $domain = str_replace(MessageCatalogue::INTL_DOMAIN_SUFFIX, '', $domain);
+        }
+
         $catalogue = $this->getCatalogue($locale);
         $locale = $catalogue->getLocale();
         while (!$catalogue->defines($id, $domain)) {
@@ -215,8 +223,21 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
             }
         }
 
-        $len = \strlen(MessageCatalogue::INTL_DOMAIN_SUFFIX);
+        // Option 1 - just format everything in ICU
         if ($this->hasIntlFormatter) {
+            return $this->formatter->formatIntl($catalogue->get($id, $domain), $locale, $parameters);
+        }
+
+        // Option 2 - just format everything in ICU
+        /* if ($this->hasIntlFormatter && $useIntl) {
+            return $this->formatter->formatIntl($catalogue->get($id, $domain), $locale, $parameters);
+        }*/
+
+        $len = \strlen(MessageCatalogue::INTL_DOMAIN_SUFFIX);
+        if ($this->hasIntlFormatter
+            && ($catalogue->defines($id, $domain.MessageCatalogue::INTL_DOMAIN_SUFFIX)
+            || (\strlen($domain) > $len && 0 === substr_compare($domain, MessageCatalogue::INTL_DOMAIN_SUFFIX, -$len, $len)))
+        ) {
             return $this->formatter->formatIntl($catalogue->get($id, $domain), $locale, $parameters);
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | A test of translations using the ICU syntax (https://unicode-org.github.io/icu/userguide/format_parse/messages/). This will finally allow us to properly translate plural forms in all languages.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| Fixed ticket?     | Fixes #15870
| Related PRs       | 
| Sponsor company   | 

### How to test
- Install prestashop in czech, checkout to this PR so you have translations there.
- Delete `var/cache/prod|dev/translations`.
- See any product in FO.

### Findings
- Symfony uses the domain ending suffix to detect if it should use IntlFormatter or MessageFormatter. If we manage to change this, it's all we must do. By temporarily removing this condition, everything works:
  - We can use the normal catalog.
  - Translation shows up in the interface.
  - We can modify the translation and use SQL version of it.

### What now
- Do we just translate everything like it is ICU format?
- Do we keep adding ICU to domain like it should be done, but load our messages from normal domains? It would make it safer.