### PR TITLE
Refacto getShopLogo remove hasKey usage

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1633,10 +1633,10 @@ class FrontControllerCore extends Controller
             'long' => Configuration::get('PS_STORES_CENTER_LONG'),
             'lat' => Configuration::get('PS_STORES_CENTER_LAT'),
 
-            'logo' => Configuration::hasKey('PS_LOGO') ? $psImageUrl . Configuration::get('PS_LOGO') : '',
+            'logo' => self::configuredImageUrl('PS_LOGO', $psImageUrl),
             'logo_details' => $this->getShopLogo(),
-            'stores_icon' => Configuration::hasKey('PS_STORES_ICON') ? $psImageUrl . Configuration::get('PS_STORES_ICON') : '',
-            'favicon' => Configuration::hasKey('PS_FAVICON') ? $psImageUrl . Configuration::get('PS_FAVICON') : '',
+            'stores_icon' => self::configuredImageUrl('PS_STORES_ICON', $psImageUrl),
+            'favicon' => self::configuredImageUrl('PS_STORES_ICON', $psImageUrl),
             'favicon_update_time' => Configuration::get('PS_IMG_UPDATE_TIME'),
 
             'address' => [
@@ -1653,6 +1653,11 @@ class FrontControllerCore extends Controller
         ];
 
         return $shop;
+    }
+
+    private static function configuredImageUrl(string $configKey, $psImageUrl) {
+        $image = Configuration::get($configKey);
+        return $image ? $psImageUrl . $image : '';
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1586,11 +1586,11 @@ class FrontControllerCore extends Controller
      */
     public function getShopLogo(): array
     {
-        if (!Configuration::hasKey('PS_LOGO')) {
+        $logoFileName = Configuration::get('PS_LOGO');
+        if ($logoFileName == null) {
             return [];
         }
 
-        $logoFileName = Configuration::get('PS_LOGO');
         $logoFileDir = _PS_IMG_DIR_ . $logoFileName;
 
         if (!file_exists($logoFileDir)) {

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1655,8 +1655,10 @@ class FrontControllerCore extends Controller
         return $shop;
     }
 
-    private static function configuredImageUrl(string $configKey, $psImageUrl) {
+    private static function configuredImageUrl(string $configKey, $psImageUrl)
+    {
         $image = Configuration::get($configKey);
+
         return $image ? $psImageUrl . $image : '';
     }
 

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1587,7 +1587,7 @@ class FrontControllerCore extends Controller
     public function getShopLogo(): array
     {
         $logoFileName = Configuration::get('PS_LOGO');
-        if ($logoFileName == null) {
+        if (!$logoFileName) {
             return [];
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Remove usage of `Configuraton::hasKey` in FrontController. This serves as a starting point for potentially remove this at other places as well
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | I hope that this is covered by automated tests
| Fixed ticket?     | partial, https://github.com/PrestaShop/PrestaShop/issues/30373
| Related PRs       | 
| Sponsor company   | headissue GmbH