### PR TITLE
Deprecate Configuration::hasKey / Configuration::has and remove its usage

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -353,7 +353,7 @@ class ConfigurationCore extends ObjectModel
     }
 
     // arbitrary string value nobody will use intentionally
-    private static $hasKeyDefaultDummy = "Configuration::hasKey Default Dummy Value 1802";
+    private static $hasKeyDefaultDummy = 'Configuration::hasKey Default Dummy Value 1802';
 
     /**
      * Check if key exists in configuration.
@@ -364,6 +364,7 @@ class ConfigurationCore extends ObjectModel
      * @param int|null $idShop
      *
      * @return bool
+     *
      * @deprecated use Configuration::get
      */
     public static function hasKey($key, $idLang = null, $idShopGroup = null, $idShop = null)
@@ -372,8 +373,7 @@ class ConfigurationCore extends ObjectModel
             return false;
         }
 
-        return
-            Configuration::get($key, $idLang, $idShopGroup, $idShop, self::$hasKeyDefaultDummy) != self::$hasKeyDefaultDummy;
+        return Configuration::get($key, $idLang, $idShopGroup, $idShop, self::$hasKeyDefaultDummy) != self::$hasKeyDefaultDummy;
     }
 
     /**

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -224,10 +224,6 @@ class ConfigurationCore extends ObjectModel
             return false;
         }
 
-        if (!is_int($key) && !is_string($key)) {
-            return false;
-        }
-
         // Init the cache on demand
         if (!self::$_initialized) {
             Configuration::loadConfiguration();
@@ -372,6 +368,10 @@ class ConfigurationCore extends ObjectModel
      */
     public static function hasKey($key, $idLang = null, $idShopGroup = null, $idShop = null)
     {
+        if (!is_int($key) && !is_string($key)) {
+            return false;
+        }
+
         return
             Configuration::get($key, $idLang, $idShopGroup, $idShop, self::$hasKeyDefaultDummy) != self::$hasKeyDefaultDummy;
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | see below
| Type?             | bug fix + refactoring
| Category?         | CO
| BC breaks?        | no, when finished
| Deprecations?     | yes
| How to test?      | Covered by automated tests, hopefully
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/30373
| Related PRs       | 
| Sponsor company   | headissue GmbH

Looking at the code I assume that `Configuration::hasKey` was meant to be used only internally to check the cache content. 

This PR is WIP and a starting point to explore to deprecate `Configuration::hasKey`.

I would consequently amend the PR and go on and deprecate Configuration::has in the new configuration as well, because:

- it is duplicating the code of `Configuration::get`
- there are only two usages and `Configuration::get` can be used instead easily
- it is faulty, because it is not loading the configuration as `Configuration::get` is doing

Opinions?