### PR TITLE
FrontController should not drop existing notifications

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -692,10 +692,10 @@ class FrontControllerCore extends Controller
         }
 
         if (session_status() == PHP_SESSION_ACTIVE && isset($_SESSION['notifications'])) {
-            $notifications = array_merge($notifications, json_decode($_SESSION['notifications'], true));
+            $notifications = array_merge_recursive($notifications, json_decode($_SESSION['notifications'], true));
             unset($_SESSION['notifications']);
         } elseif (isset($_COOKIE['notifications'])) {
-            $notifications = array_merge($notifications, json_decode($_COOKIE['notifications'], true));
+            $notifications = array_merge_recursive($notifications, json_decode($_COOKIE['notifications'], true));
             unset($_COOKIE['notifications']);
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When using `redirectWithNotifications` the destination page does not show `errors` that already exists on the page, it should show both the redirected page error and the error saved in `$_SESSION`, right now it only shows the one in the session because the merging is not recursive and overwrites existing errors
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Indicate how to verify that this change works as expected.
| Fixed ticket?     | Fixes #32939 
