### PR TITLE
Override service discovery

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
@@ -109,12 +109,6 @@ services:
     tags:
       - { name: kernel.event_subscriber }
 
-  PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\FeatureFlag\EventListener\FeatureFlagTypeListener:
-    class: PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\FeatureFlag\EventListener\FeatureFlagTypeListener
-    autowire: true
-    tags:
-      - { name: core.legacy.hook.subscriber }
-
   PrestaShopBundle\EventListener\ShopConstraintListener:
     public: false
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form.yml
@@ -42,3 +42,7 @@ services:
   PrestaShopBundle\Form\Admin\Type\CustomMoneyType:
     alias: 'PrestaShopBundle\Form\Extension\CustomMoneyTypeExtension'
     deprecated: ~
+
+  PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\FeatureFlag\EventListener\FeatureFlagTypeListener:
+    tags:
+      - { name: core.legacy.hook.subscriber }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Override service discovery for service ```PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\FeatureFlag\EventListener\FeatureFlagTypeListener```
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #32881 
| Fixed ticket?     | Fixes #32881 
| Related PRs       | -
| Sponsor company   | Prestashop SA
