### PR TITLE
fix smarty deprecation

### DIFF
--- a/admin-dev/themes/default/template/controllers/groups/helpers/tree/tree_categories.tpl
+++ b/admin-dev/themes/default/template/controllers/groups/helpers/tree/tree_categories.tpl
@@ -82,7 +82,7 @@
 		$("#{$id|escape:'html':'UTF-8'}").tree("collapseAll");
 
 		{if isset($selected_categories)}
-			{assign var=imploded_selected_categories value='","'|implode:$selected_categories}
+			{assign var=imploded_selected_categories value=implode(',', $selected_categories)}
 			var selected_categories = new Array("{$imploded_selected_categories}");
 
 			$("#{$id|escape:'html':'UTF-8'}").find(":input").each(

--- a/admin-dev/themes/default/template/controllers/groups/helpers/tree/tree_categories.tpl
+++ b/admin-dev/themes/default/template/controllers/groups/helpers/tree/tree_categories.tpl
@@ -82,7 +82,7 @@
 		$("#{$id|escape:'html':'UTF-8'}").tree("collapseAll");
 
 		{if isset($selected_categories)}
-			{assign var=imploded_selected_categories value=implode(',', $selected_categories)}
+			{assign var=imploded_selected_categories value=implode('","', $selected_categories)}
 			var selected_categories = new Array("{$imploded_selected_categories}");
 
 			$("#{$id|escape:'html':'UTF-8'}").find(":input").each(

--- a/admin-dev/themes/default/template/helpers/tree/subtree_associated_categories.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/subtree_associated_categories.tpl
@@ -28,7 +28,7 @@
 
 <script type="text/javascript">
 {if isset($selected_categories) && !empty($selected_categories)}
-	{assign var=imploded_selected_categories value=implode(',', $selected_categories)}
+	{assign var=imploded_selected_categories value=implode('","', $selected_categories)}
 	var selected_categories = new Array("{$imploded_selected_categories}");
 
 	$('#{$id_tree}').tree('collapseAll');

--- a/admin-dev/themes/default/template/helpers/tree/subtree_associated_categories.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/subtree_associated_categories.tpl
@@ -28,7 +28,7 @@
 
 <script type="text/javascript">
 {if isset($selected_categories) && !empty($selected_categories)}
-	{assign var=imploded_selected_categories value='","'|implode:$selected_categories}
+	{assign var=imploded_selected_categories value=implode(',', $selected_categories)}
 	var selected_categories = new Array("{$imploded_selected_categories}");
 
 	$('#{$id_tree}').tree('collapseAll');

--- a/admin-dev/themes/default/template/helpers/tree/tree_associated_categories.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_associated_categories.tpl
@@ -136,7 +136,7 @@
 
 		{if isset($selected_categories)}
 			$('#no_default_category').hide();
-			{assign var=imploded_selected_categories value=implode(',', $selected_categories)}
+			{assign var=imploded_selected_categories value=implode('","', $selected_categories)}
 			var selected_categories = new Array("{$imploded_selected_categories}");
 
 			if (selected_categories.length > 1)

--- a/admin-dev/themes/default/template/helpers/tree/tree_associated_categories.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_associated_categories.tpl
@@ -136,7 +136,7 @@
 
 		{if isset($selected_categories)}
 			$('#no_default_category').hide();
-			{assign var=imploded_selected_categories value='","'|implode:$selected_categories}
+			{assign var=imploded_selected_categories value=implode(',', $selected_categories)}
 			var selected_categories = new Array("{$imploded_selected_categories}");
 
 			if (selected_categories.length > 1)

--- a/admin-dev/themes/default/template/helpers/tree/tree_categories.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_categories.tpl
@@ -80,7 +80,7 @@
 		$("#{$id|escape:'html':'UTF-8'}").tree("collapseAll");
 
 		{if isset($selected_categories)}
-			{assign var=imploded_selected_categories value=implode(',', $selected_categories)}
+			{assign var=imploded_selected_categories value=implode('","', $selected_categories)}
 			var selected_categories = new Array("{$imploded_selected_categories}");
 
 			$("#{$id|escape:'html':'UTF-8'}").find(":input").each(

--- a/admin-dev/themes/default/template/helpers/tree/tree_categories.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_categories.tpl
@@ -80,7 +80,7 @@
 		$("#{$id|escape:'html':'UTF-8'}").tree("collapseAll");
 
 		{if isset($selected_categories)}
-			{assign var=imploded_selected_categories value='","'|implode:$selected_categories}
+			{assign var=imploded_selected_categories value=implode(',', $selected_categories)}
 			var selected_categories = new Array("{$imploded_selected_categories}");
 
 			$("#{$id|escape:'html':'UTF-8'}").find(":input").each(

--- a/admin-dev/themes/default/template/helpers/tree/tree_shops.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_shops.tpl
@@ -85,7 +85,7 @@
 		);
 
 		{if isset($selected_shops)}
-			{assign var=imploded_selected_shops value=implode(',', $selected_shops)}
+			{assign var=imploded_selected_shops value=implode('","', $selected_shops)}
 			var selected_shops = new Array("{$imploded_selected_shops}");
 
 			$("#{$id|escape:'html':'UTF-8'}").find(".tree-item :input").each(

--- a/admin-dev/themes/default/template/helpers/tree/tree_shops.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_shops.tpl
@@ -85,7 +85,7 @@
 		);
 
 		{if isset($selected_shops)}
-			{assign var=imploded_selected_shops value='","'|implode:$selected_shops}
+			{assign var=imploded_selected_shops value=implode(',', $selected_shops)}
 			var selected_shops = new Array("{$imploded_selected_shops}");
 
 			$("#{$id|escape:'html':'UTF-8'}").find(".tree-item :input").each(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | fixing smarty deprecation for `\|implode` as modifier
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Before we get a smarty deprecation error. After this is fixed 
| Fixed ticket?     | Fixes #32966
| Related PRs       | none
| Sponsor company   | Société Bilique de Genève
