### PR TITLE
Twig mail templates: Do not convert from HTML to text if it is already a text template

### DIFF
--- a/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
+++ b/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
@@ -37,7 +37,6 @@ use PrestaShop\PrestaShop\Core\MailTemplate\MailTemplateRendererInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationCollection;
 use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationInterface;
 use Twig\Environment;
-use Twig\Error\LoaderError;
 
 /**
  * MailTemplateTwigRenderer is a basic implementation of MailTemplateRendererInterface
@@ -145,6 +144,7 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
                 ->apply($renderedTemplate, $layoutVariables)
             ;
         }
+
         return $renderedTemplate;
     }
 

--- a/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
+++ b/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
@@ -135,11 +135,7 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
             $layoutPath = !empty($layout->getTxtPath()) ? $layout->getTxtPath() : $layout->getHtmlPath();
         }
 
-        try {
-            $renderedTemplate = $this->twig->render($layoutPath, $layoutVariables);
-        } catch (LoaderError $e) {
-            throw new FileNotFoundException(sprintf('Could not find layout file: %s', $layoutPath));
-        }
+        $renderedTemplate = $this->twig->render($layoutPath, $layoutVariables);
 
         $templateTransformations = $this->getMailLayoutTransformations($layout, $templateType);
         /** @var TransformationInterface $transformation */
@@ -149,7 +145,6 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
                 ->apply($renderedTemplate, $layoutVariables)
             ;
         }
-
         return $renderedTemplate;
     }
 

--- a/src/Core/MailTemplate/Transformation/HTMLToTextTransformation.php
+++ b/src/Core/MailTemplate/Transformation/HTMLToTextTransformation.php
@@ -47,6 +47,12 @@ class HTMLToTextTransformation extends AbstractTransformation
      */
     public function apply($templateContent, array $templateVariables)
     {
+        // The input could be in HTML or raw text. If it is HTML it starts with <!DOCTYPE
+        // As heuristic we interpret the first character and skip transformation if this looks
+        // like text already.
+        if (strlen($templateContent) > 0 && substr($templateContent, 0, 1) != '<') {
+            return $templateContent;
+        }
         $templateContent = Html2Text::convert($templateContent, ['ignore_errors' => true]);
         if (PHP_EOL != $templateContent[strlen($templateContent) - 1]) {
             $templateContent .= PHP_EOL;

--- a/tests/Unit/Adapter/MailTemplate/MailTemplateTwigRendererTest.php
+++ b/tests/Unit/Adapter/MailTemplate/MailTemplateTwigRendererTest.php
@@ -29,7 +29,6 @@ namespace Tests\Unit\Adapter\MailTemplate;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\MailTemplate\MailTemplateTwigRenderer;
-use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\Layout\LayoutInterface;
@@ -39,7 +38,6 @@ use PrestaShop\PrestaShop\Core\MailTemplate\MailTemplateRendererInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationCollectionInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationInterface;
 use Twig\Environment;
-use Twig\Error\LoaderError;
 
 class MailTemplateTwigRendererTest extends TestCase
 {

--- a/tests/Unit/Adapter/MailTemplate/MailTemplateTwigRendererTest.php
+++ b/tests/Unit/Adapter/MailTemplate/MailTemplateTwigRendererTest.php
@@ -64,43 +64,6 @@ class MailTemplateTwigRendererTest extends TestCase
         $this->assertNotNull($generator);
     }
 
-    public function testFileNotFound()
-    {
-        $this->expectException(FileNotFoundException::class);
-
-        $templatePaths = [
-            MailTemplateInterface::HTML_TYPE => '@Resources/path/to/non_existent_template.html.twig',
-        ];
-        $expectedVariables = ['locale' => null, 'url' => 'http://test.com'];
-        $expectedLanguage = $this->createLanguageMock();
-        $mailLayout = $this->createMailLayoutMock($templatePaths);
-        $engineMock = $this->getMockBuilder(Environment::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-        $engineMock
-            ->expects($this->once())
-            ->method('render')
-            ->willThrowException(new LoaderError(''))
-        ;
-        /** @var HookDispatcherInterface $dispatcherMock */
-        $dispatcherMock = $this->getMockBuilder(HookDispatcherInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-
-        /** @var Environment $engineMock */
-        $generator = new MailTemplateTwigRenderer(
-            $engineMock,
-            $this->createVariablesBuilderMock($expectedVariables, $expectedLanguage),
-            $dispatcherMock,
-            false
-        );
-        $this->assertNotNull($generator);
-
-        $generator->renderHtml($mailLayout, $expectedLanguage);
-    }
-
     public function testRenderHtml(): void
     {
         $templatePaths = [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Do not convert the mail template from HTML to text if it is already text. Also remove try catch from MailTemplateTwigRenderer since it is masking the original error and giving wrong information
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See linked issue
| Fixed ticket?     | #32971
| Related PRs       |
| Sponsor company   | headissue GmbH

### Compatibility Discussion

The patch detects HTML by inspecting the first character. If it is '<' it is HTML and conversion needs to happen.
This works 100% correctly for the build-in themes.

### Alternatives

Add the layout file to the template variables and only convert if it is originating from a `html.twig`

