### PR TITLE
Extract FeatureChoiceType

### DIFF
--- a/src/Adapter/Form/ChoiceProvider/FeaturesChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/FeaturesChoiceProvider.php
@@ -30,33 +30,16 @@ namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
 
 use PrestaShop\PrestaShop\Adapter\Feature\Repository\FeatureRepository;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 
 class FeaturesChoiceProvider implements FormChoiceProviderInterface
 {
-    /**
-     * @var FeatureRepository
-     */
-    private $featureRepository;
-
-    /**
-     * @var int
-     */
-    private $contextLanguageId;
-
-    /**
-     * @var int
-     */
-    private $defaultLanguageId;
-
     public function __construct(
-        FeatureRepository $featureRepository,
-        LegacyContext $legacyContext,
-        int $defaultLanguageId
+        protected readonly FeatureRepository $featureRepository,
+        protected readonly LegacyContext $legacyContext,
+        protected readonly ConfigurationInterface $configuration
     ) {
-        $this->featureRepository = $featureRepository;
-        $this->contextLanguageId = (int) $legacyContext->getLanguage()->getId();
-        $this->defaultLanguageId = $defaultLanguageId;
     }
 
     /**
@@ -64,13 +47,15 @@ class FeaturesChoiceProvider implements FormChoiceProviderInterface
      */
     public function getChoices()
     {
-        $features = $this->featureRepository->getFeatures();
+        $defaultLangId = (int) $this->configuration->get('PS_LANG_DEFAULT');
+        $contextLangId = (int) $this->legacyContext->getLanguage()->getId();
+
         $choices = [];
-        foreach ($features as $feature) {
-            if (!empty($feature['localized_names'][$this->contextLanguageId])) {
-                $featureName = $feature['localized_names'][$this->contextLanguageId];
+        foreach ($this->featureRepository->getFeatures() as $feature) {
+            if (!empty($feature['localized_names'][$contextLangId])) {
+                $featureName = $feature['localized_names'][$contextLangId];
             } else {
-                $featureName = $feature['localized_names'][$this->defaultLanguageId];
+                $featureName = $feature['localized_names'][$defaultLangId];
             }
             $choices[$featureName] = $feature['id_feature'];
         }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeatureValueType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeatureValueType.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Details;
 
-use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShopBundle\Form\Admin\Type\FeatureChoiceType;
 use PrestaShopBundle\Form\Admin\Type\IconButtonType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
@@ -42,25 +42,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FeatureValueType extends TranslatorAwareType
 {
-    /**
-     * @var FormChoiceProviderInterface
-     */
-    private $featuresChoiceProvider;
-
-    /**
-     * @var EventSubscriberInterface
-     */
-    private $featureValueListener;
-
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        FormChoiceProviderInterface $featuresChoiceProvider,
-        EventSubscriberInterface $featureValueListener
+        protected readonly EventSubscriberInterface $featureValueListener
     ) {
         parent::__construct($translator, $locales);
-        $this->featuresChoiceProvider = $featuresChoiceProvider;
-        $this->featureValueListener = $featureValueListener;
     }
 
     /**
@@ -68,19 +55,11 @@ class FeatureValueType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $features = $this->featuresChoiceProvider->getChoices();
-
         $builder
-            ->add('feature_id', ChoiceType::class, [
+            ->add('feature_id', FeatureChoiceType::class, [
                 'empty_data' => null,
-                'choices' => $features,
                 'required' => false,
                 'placeholder' => $this->trans('Choose a feature', 'Admin.Catalog.Feature'),
-                'label' => $this->trans('Feature', 'Admin.Catalog.Feature'),
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'class' => 'feature-selector',
-                ],
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->trans('Choose a feature', 'Admin.Catalog.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Type/FeatureChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/FeatureChoiceType.php
@@ -48,8 +48,8 @@ class FeatureChoiceType extends TranslatorAwareType
         $resolver->setDefaults([
             'choices' => $this->featureChoiceProvider->getChoices(),
             'label' => $this->trans('Feature', 'Admin.Catalog.Feature'),
+            'autocomplete' => true,
             'attr' => [
-                'data-toggle' => 'select2',
                 'class' => 'feature-selector',
             ],
         ]);

--- a/src/PrestaShopBundle/Form/Admin/Type/FeatureChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/FeatureChoiceType.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Type;
+
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class FeatureChoiceType extends TranslatorAwareType
+{
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        protected readonly FormChoiceProviderInterface $featureChoiceProvider
+    ) {
+        parent::__construct($translator, $locales);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'choices' => $this->featureChoiceProvider->getChoices(),
+            'label' => $this->trans('Feature', 'Admin.Catalog.Feature'),
+            'attr' => [
+                'data-toggle' => 'select2',
+                'class' => 'feature-selector',
+            ],
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return ChoiceType::class;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/adapter/form.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/form.yml
@@ -98,7 +98,6 @@ services:
       - '@PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilderInterface'
       - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
 
-
   PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ShopTreeChoiceProvider:
     autowire: true
     public: false
@@ -106,8 +105,6 @@ services:
   PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\FeaturesChoiceProvider:
     public: false
     autowire: true
-    arguments:
-      $defaultLanguageId: "@=service('prestashop.adapter.legacy.configuration').getInt('PS_LANG_DEFAULT')"
 
   # deprecated
   prestashop.adapter.form.choice_provider.shop_tree_choice_provider:

--- a/src/PrestaShopBundle/Resources/config/services/adapter/form.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/form.yml
@@ -71,13 +71,6 @@ services:
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getLanguage().id'
 
-  prestashop.adapter.form.choice_provider.features_choice_provider:
-    class: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\FeaturesChoiceProvider'
-    arguments:
-      - '@PrestaShop\PrestaShop\Adapter\Feature\Repository\FeatureRepository'
-      - '@prestashop.adapter.legacy.context'
-      - "@=service('prestashop.adapter.legacy.configuration').getInt('PS_LANG_DEFAULT')"
-
   prestashop.adapter.form.choice_provider.feature_values_choice_provider:
     class: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\FeatureValuesChoiceProvider'
     arguments:
@@ -110,7 +103,17 @@ services:
     autowire: true
     public: false
 
+  PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\FeaturesChoiceProvider:
+    public: false
+    autowire: true
+    arguments:
+      $defaultLanguageId: "@=service('prestashop.adapter.legacy.configuration').getInt('PS_LANG_DEFAULT')"
+
   # deprecated
   prestashop.adapter.form.choice_provider.shop_tree_choice_provider:
     alias: PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ShopTreeChoiceProvider
+    deprecated: ~
+
+  prestashop.adapter.form.choice_provider.features_choice_provider:
+    alias: PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\FeaturesChoiceProvider
     deprecated: ~

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -504,7 +504,6 @@ services:
 
   PrestaShopBundle\Form\Admin\Sell\Product\Details\FeatureValueType:
     arguments:
-      $featuresChoiceProvider: '@prestashop.adapter.form.choice_provider.features_choice_provider'
       $featureValueListener: '@PrestaShopBundle\Form\Admin\Sell\Product\EventListener\FeatureValueListener'
 
   PrestaShopBundle\Form\Admin\Sell\Product\Stock\StockType:
@@ -657,7 +656,9 @@ services:
       $permissionChoices: '@=service("prestashop.core.form.choice_provider.permissions_choice_provider").getChoices()'
 
   PrestaShopBundle\Form\Admin\Improve\International\Tax\TaxRulesGroupType:
-
+  PrestaShopBundle\Form\Admin\Type\FeatureChoiceType:
+    arguments:
+      $featureChoiceProvider: '@PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\FeaturesChoiceProvider'
 
   # Deprecated
   form.type.sell.product.event_listener.categories_listener:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Derrived from review comment - https://github.com/PrestaShop/PrestaShop/pull/32994#discussion_r1242048353. Extracted FeatureChoiceType which is now only used in Product page, but will as well be used in FeatureValue form (and can later be reused elsewhere if needed). This reduces the need to duplicate usage of FeaturesChoiceProviders and some recurring options everytime its used.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to product page -> Details and see that feature choice input works as before.
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/pull/32994#discussion_r1242048353
| Related PRs       | 
| Sponsor company   | 
