### PR TITLE
Add complex query with optional parameters

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -97,6 +97,11 @@ api_platform:
   title: PrestaShop API
   version: 1.0.0
   enable_entrypoint: false
+  formats:
+    json:
+      mime_types: [ 'application/json' ]
+    jsonld:
+      mime_types: [ 'application/ld+json' ]
   mapping:
     paths:
       - '%kernel.project_dir%/src/PrestaShopBundle/ApiPlatform/Resources'

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -100,5 +100,9 @@ api_platform:
   mapping:
     paths:
       - '%kernel.project_dir%/src/PrestaShopBundle/ApiPlatform/Resources'
-
+  swagger:
+    api_keys:
+      JWT:
+        name: Authorization
+        type: header
   metadata_backward_compatibility_layer: false

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -100,6 +100,7 @@ api_platform:
   formats:
     json:
       mime_types: [ 'application/json' ]
+    # Allow this format for other API endpoint than native endpoint (by default we will use json)
     jsonld:
       mime_types: [ 'application/ld+json' ]
   mapping:

--- a/src/PrestaShopBundle/ApiPlatform/Converters/ConverterInterface.php
+++ b/src/PrestaShopBundle/ApiPlatform/Converters/ConverterInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PrestaShopBundle\ApiPlatform\Converters;
+
+interface ConverterInterface
+{
+    public function convert($value);
+}

--- a/src/PrestaShopBundle/ApiPlatform/Converters/ConverterInterface.php
+++ b/src/PrestaShopBundle/ApiPlatform/Converters/ConverterInterface.php
@@ -30,7 +30,7 @@ namespace PrestaShopBundle\ApiPlatform\Converters;
 
 interface ConverterInterface
 {
-    public function convert($value);
+    public function convert(mixed $value);
 
-    public function supports($type);
+    public function supports(string $type);
 }

--- a/src/PrestaShopBundle/ApiPlatform/Converters/ConverterInterface.php
+++ b/src/PrestaShopBundle/ApiPlatform/Converters/ConverterInterface.php
@@ -1,4 +1,30 @@
 <?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
 
 namespace PrestaShopBundle\ApiPlatform\Converters;
 

--- a/src/PrestaShopBundle/ApiPlatform/Converters/ConverterInterface.php
+++ b/src/PrestaShopBundle/ApiPlatform/Converters/ConverterInterface.php
@@ -31,4 +31,6 @@ namespace PrestaShopBundle\ApiPlatform\Converters;
 interface ConverterInterface
 {
     public function convert($value);
+
+    public function supports($type);
 }

--- a/src/PrestaShopBundle/ApiPlatform/Converters/StringToIntConverter.php
+++ b/src/PrestaShopBundle/ApiPlatform/Converters/StringToIntConverter.php
@@ -34,4 +34,9 @@ class StringToIntConverter implements ConverterInterface
     {
         return (int) $value;
     }
+
+    public function supports($type): bool
+    {
+        return 'int' === $type;
+    }
 }

--- a/src/PrestaShopBundle/ApiPlatform/Converters/StringToIntConverter.php
+++ b/src/PrestaShopBundle/ApiPlatform/Converters/StringToIntConverter.php
@@ -30,12 +30,12 @@ namespace PrestaShopBundle\ApiPlatform\Converters;
 
 class StringToIntConverter implements ConverterInterface
 {
-    public function convert($value): int
+    public function convert(mixed $value): int
     {
         return (int) $value;
     }
 
-    public function supports($type): bool
+    public function supports(string $type): bool
     {
         return 'int' === $type;
     }

--- a/src/PrestaShopBundle/ApiPlatform/Converters/StringToIntConverter.php
+++ b/src/PrestaShopBundle/ApiPlatform/Converters/StringToIntConverter.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PrestaShopBundle\ApiPlatform\Converters;
+
+class StringToIntConverter implements ConverterInterface
+{
+    public function convert($value): int
+    {
+        return (int) $value;
+    }
+}

--- a/src/PrestaShopBundle/ApiPlatform/Converters/StringToIntConverter.php
+++ b/src/PrestaShopBundle/ApiPlatform/Converters/StringToIntConverter.php
@@ -1,4 +1,30 @@
 <?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
 
 namespace PrestaShopBundle\ApiPlatform\Converters;
 

--- a/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
@@ -55,17 +55,17 @@ class QueryProvider implements ProviderInterface
     {
         $queryClass = $operation->getExtraProperties()['query'] ?? null;
         $filters = $context['filters'] ?? [];
-        $uriVariables = array_merge($uriVariables, $filters);
+        $queryParameters = array_merge($uriVariables, $filters);
 
         if (null === $queryClass) {
             throw new NoExtraPropertiesFoundException();
         }
 
-        $query = $this->apiPlatformSerializer->denormalize($uriVariables, $queryClass);
+        $query = $this->apiPlatformSerializer->denormalize($queryParameters, $queryClass);
 
         //Try to call setter on additional query params
-        if (count($uriVariables)) {
-            foreach ($uriVariables as $param => $value) {
+        if (count($queryParameters)) {
+            foreach ($queryParameters as $param => $value) {
                 if ($reflectionMethod = $this->findSetterMethod($param, $queryClass)) {
                     $methodParameter = $reflectionMethod->getParameters()[0];
                     if ($methodParameter->getType() instanceof \ReflectionNamedType && $methodParameter->getType()->getName() !== gettype($value)) {

--- a/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
@@ -45,7 +45,7 @@ class QueryProvider implements ProviderInterface
     public function __construct(
         private readonly CommandBusInterface $queryBus,
         private readonly SerializerInterface $apiPlatformSerializer,
-        private readonly iterable $converters,
+        private readonly iterable $converters
     ) {
     }
 
@@ -64,7 +64,7 @@ class QueryProvider implements ProviderInterface
             throw new NoExtraPropertiesFoundException();
         }
 
-        $query = $this->apiPlatformSerializer->denormalize($uriVariables, $queryClass, null, [AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => true]);
+        $query = $this->apiPlatformSerializer->denormalize($uriVariables, $queryClass);
 
         //Try to call setter on additional query params
         if (count($uriVariables)) {

--- a/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
@@ -32,9 +32,9 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShopBundle\ApiPlatform\Converters\ConverterInterface;
+use PrestaShopBundle\ApiPlatform\Exception\NoExtraPropertiesFoundException;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Serializer;
-use PrestaShopBundle\ApiPlatform\Exception\NoExtraPropertiesFoundException;
 
 class QueryProvider implements ProviderInterface
 {

--- a/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\ApiPlatform\Provider;
 
+use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
@@ -76,10 +77,9 @@ class QueryProvider implements ProviderInterface
         }
 
         $queryResult = $this->queryBus->handle($query);
-        $isCollectionResult = is_array($queryResult);
         $normalizedQueryResult = $this->apiPlatformSerializer->normalize($queryResult);
 
-        if ($isCollectionResult) {
+        if ($operation instanceof CollectionOperationInterface) {
             foreach ($normalizedQueryResult as $key => $result) {
                 $normalizedQueryResult[$key] = $this->apiPlatformSerializer->denormalize($result, $operation->getClass());
             }

--- a/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
@@ -43,7 +43,6 @@ class QueryProvider implements ProviderInterface
         private readonly CommandBusInterface $queryBus,
         private readonly Serializer $apiPlatformSerializer,
         private readonly iterable $converters,
-        private readonly RequestStack $requestStack
     ) {
     }
 
@@ -54,8 +53,12 @@ class QueryProvider implements ProviderInterface
     public function provide(Operation $operation, array $uriVariables = [], array $context = [])
     {
         $queryClass = $operation->getExtraProperties()['query'] ?? null;
-        $queryParams = $this->requestStack->getCurrentRequest()->query->all();
-        $uriVariables = array_merge($uriVariables, $queryParams);
+        $filters = $context['filters'] ?? [];
+        $uriVariables = array_merge($uriVariables, $filters);
+
+        if (null === $queryClass) {
+            throw new NoExtraPropertiesFoundException();
+        }
 
         $reflectionMethod = new \ReflectionMethod($queryClass, '__construct');
         $constructParameters = $reflectionMethod->getParameters();

--- a/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
@@ -76,7 +76,16 @@ class QueryProvider implements ProviderInterface
         }
 
         $queryResult = $this->queryBus->handle($query);
+        $isCollectionResult = is_array($queryResult);
         $normalizedQueryResult = $this->apiPlatformSerializer->normalize($queryResult);
+
+        if ($isCollectionResult) {
+            foreach ($normalizedQueryResult as $key => $result) {
+                $normalizedQueryResult[$key] = $this->apiPlatformSerializer->denormalize($result, $operation->getClass());
+            }
+
+            return $normalizedQueryResult;
+        }
 
         return $this->apiPlatformSerializer->denormalize($normalizedQueryResult, $operation->getClass());
     }

--- a/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
@@ -47,11 +47,11 @@ class QueryProvider implements ProviderInterface
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = [])
     {
-        $query = $operation->getExtraProperties()['query'] ?? null;
+        $queryClass = $operation->getExtraProperties()['query'] ?? null;
         $converters = $operation->getExtraProperties()['paramConverters'] ?? [];
         $queryParams = $this->requestStack->getCurrentRequest()->query->all();
 
-        if (null === $query) {
+        if (null === $queryClass) {
             throw new NoExtraPropertiesFoundException();
         }
 
@@ -75,7 +75,7 @@ class QueryProvider implements ProviderInterface
         $params = array_values($uriVariables);
 
         //Add optionnal parameters in construct from query params
-        $reflectionMethod = new \ReflectionMethod($query, '__construct');
+        $reflectionMethod = new \ReflectionMethod($queryClass, '__construct');
         $constructParameters = $reflectionMethod->getParameters();
         foreach ($constructParameters as $parameter) {
             if (array_key_exists($parameter->name, $queryParams)) {
@@ -84,7 +84,7 @@ class QueryProvider implements ProviderInterface
             }
         }
 
-        $query = new $query(...$params);
+        $query = new $queryClass(...$params);
 
         //Try to call setter on additional query params
         if (count($queryParams)) {

--- a/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
@@ -57,7 +57,6 @@ class QueryProvider implements ProviderInterface
         $queryParams = $this->requestStack->getCurrentRequest()->query->all();
         $uriVariables = array_merge($uriVariables, $queryParams);
 
-        //Add optionnal parameters in construct from query params
         $reflectionMethod = new \ReflectionMethod($queryClass, '__construct');
         $constructParameters = $reflectionMethod->getParameters();
 
@@ -68,14 +67,16 @@ class QueryProvider implements ProviderInterface
                 throw new \Exception(sprintf('Required parameter %s is not present', $parameter->name));
             }
 
-            $uriValue = $uriVariables[$parameter->name];
-            //Transform parameter type if needed
-            if ($parameter->getType() instanceof \ReflectionNamedType && $parameter->getType()->getName() !== gettype($uriValue)) {
-                $uriValue = $this->findConverter($parameter->getType()->getName())->convert($uriValue);
-            }
-            $params[$parameter->getPosition()] = $uriValue;
+            if (isset($uriVariables[$parameter->name])) {
+                $uriValue = $uriVariables[$parameter->name];
+                //Transform parameter type if needed
+                if ($parameter->getType() instanceof \ReflectionNamedType && $parameter->getType()->getName() !== gettype($uriValue)) {
+                    $uriValue = $this->findConverter($parameter->getType()->getName())->convert($uriValue);
+                }
+                $params[$parameter->getPosition()] = $uriValue;
 
-            unset($uriVariables[$parameter->name]);
+                unset($uriVariables[$parameter->name]);
+            }
         }
 
         $query = new $queryClass(...$params);

--- a/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
@@ -33,19 +33,15 @@ use ApiPlatform\State\ProviderInterface;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShopBundle\ApiPlatform\Converters\ConverterInterface;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
-use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
-use Symfony\Component\Serializer\SerializerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\PropertyAccess\PropertyAccess;
-use PrestaShopBundle\ApiPlatform\Exception\NoExtraPropertiesFoundException;
 use Symfony\Component\Serializer\Serializer;
+use PrestaShopBundle\ApiPlatform\Exception\NoExtraPropertiesFoundException;
 
 class QueryProvider implements ProviderInterface
 {
     public function __construct(
         private readonly CommandBusInterface $queryBus,
-        private readonly SerializerInterface $apiPlatformSerializer,
-        private readonly iterable $converters
+        private readonly iterable $converters,
+        private readonly Serializer $apiPlatformSerializer
     ) {
     }
 

--- a/src/PrestaShopBundle/ApiPlatform/Resources/FoundProduct.php
+++ b/src/PrestaShopBundle/ApiPlatform/Resources/FoundProduct.php
@@ -28,14 +28,17 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\ApiPlatform\Resources;
 
+use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
-use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductCombination;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductCustomizationField;
 use PrestaShopBundle\ApiPlatform\Provider\QueryProvider;
 
 #[ApiResource(
     operations: [
-        new Get(
+        new GetCollection(
             uriTemplate: '/products/search/{phrase}/{resultsLimit}/{isoCode}',
             openapiContext: [
                 'parameters' => [
@@ -78,12 +81,63 @@ use PrestaShopBundle\ApiPlatform\Provider\QueryProvider;
                 'query' => SearchProducts::class,
             ]
         ),
-    ]
+    ],
 )]
-class SearchProduct
+class FoundProduct
 {
-    public string $phrase;
-    public int $resultsLimit;
-    public string $isoCode;
-    public int $orderId;
+    /**
+     * @var int
+     */
+    #[ApiProperty(identifier: true)]
+    public $productId;
+
+    /**
+     * @var bool
+     */
+    public $availableOutOfStock;
+
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var float
+     */
+    public $taxRate;
+
+    /**
+     * @var string
+     */
+    public $formattedPrice;
+
+    /**
+     * @var float
+     */
+    public $priceTaxIncl;
+
+    /**
+     * @var float
+     */
+    public $priceTaxExcl;
+
+    /**
+     * @var int
+     */
+    public $stock;
+
+    /**
+     * @var string
+     */
+    public $location;
+
+    /**
+     * @var ProductCombination[]
+     */
+    public $combinations;
+
+    /**
+     * @var ProductCustomizationField[]
+     */
+    public $customizationFields;
 }

--- a/src/PrestaShopBundle/ApiPlatform/Resources/FoundProduct.php
+++ b/src/PrestaShopBundle/ApiPlatform/Resources/FoundProduct.php
@@ -32,8 +32,6 @@ use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductCombination;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductCustomizationField;
 use PrestaShopBundle\ApiPlatform\Provider\QueryProvider;
 
 #[ApiResource(
@@ -85,59 +83,26 @@ use PrestaShopBundle\ApiPlatform\Provider\QueryProvider;
 )]
 class FoundProduct
 {
-    /**
-     * @var int
-     */
     #[ApiProperty(identifier: true)]
-    public $productId;
+    public int $productId;
 
-    /**
-     * @var bool
-     */
-    public $availableOutOfStock;
+    public bool $availableOutOfStock;
 
-    /**
-     * @var string
-     */
-    public $name;
+    public string $name;
 
-    /**
-     * @var float
-     */
-    public $taxRate;
+    public float $taxRate;
 
-    /**
-     * @var string
-     */
-    public $formattedPrice;
+    public string $formattedPrice;
 
-    /**
-     * @var float
-     */
-    public $priceTaxIncl;
+    public float $priceTaxIncl;
 
-    /**
-     * @var float
-     */
-    public $priceTaxExcl;
+    public float $priceTaxExcl;
 
-    /**
-     * @var int
-     */
-    public $stock;
+    public int $stock;
 
-    /**
-     * @var string
-     */
-    public $location;
+    public string $location;
 
-    /**
-     * @var ProductCombination[]
-     */
-    public $combinations;
+    public array $combinations;
 
-    /**
-     * @var ProductCustomizationField[]
-     */
-    public $customizationFields;
+    public array $customizationFields;
 }

--- a/src/PrestaShopBundle/ApiPlatform/Resources/SearchProduct.php
+++ b/src/PrestaShopBundle/ApiPlatform/Resources/SearchProduct.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\ApiPlatform\Resources;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
+use PrestaShopBundle\ApiPlatform\Converters\StringToIntConverter;
+use PrestaShopBundle\ApiPlatform\Provider\QueryProvider;
+
+#[ApiResource(
+    operations: [
+        new Get(
+            uriTemplate: '/products/search/{phrase}/{resultsLimit}/{isoCode}',
+            openapiContext: [
+                'parameters' => [
+                    [
+                        'name' => 'phrase',
+                        'in' => 'path',
+                        'required' => true,
+                        'schema' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                    [
+                        'name' => 'resultsLimit',
+                        'in' => 'path',
+                        'required' => true,
+                        'schema' => [
+                            'type' => 'int',
+                        ],
+                    ],
+                    [
+                        'name' => 'isoCode',
+                        'in' => 'path',
+                        'required' => true,
+                        'schema' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                    [
+                        'name' => 'orderId',
+                        'in' => 'query',
+                        'required' => false,
+                        'schema' => [
+                            'type' => 'int',
+                        ],
+                    ],
+                ],
+            ],
+            provider: QueryProvider::class,
+            extraProperties: [
+                'query' => SearchProducts::class,
+                'paramConverters' => [
+                    'resultsLimit' => StringToIntConverter::class,
+                    'orderId' => StringToIntConverter::class,
+                ],
+            ]
+        ),
+    ]
+)]
+class SearchProduct
+{
+}

--- a/src/PrestaShopBundle/ApiPlatform/Resources/SearchProduct.php
+++ b/src/PrestaShopBundle/ApiPlatform/Resources/SearchProduct.php
@@ -31,7 +31,6 @@ namespace PrestaShopBundle\ApiPlatform\Resources;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
-use PrestaShopBundle\ApiPlatform\Converters\StringToIntConverter;
 use PrestaShopBundle\ApiPlatform\Provider\QueryProvider;
 
 #[ApiResource(
@@ -77,10 +76,6 @@ use PrestaShopBundle\ApiPlatform\Provider\QueryProvider;
             provider: QueryProvider::class,
             extraProperties: [
                 'query' => SearchProducts::class,
-                'paramConverters' => [
-                    'resultsLimit' => StringToIntConverter::class,
-                    'orderId' => StringToIntConverter::class,
-                ],
             ]
         ),
     ]

--- a/src/PrestaShopBundle/ApiPlatform/Resources/SearchProduct.php
+++ b/src/PrestaShopBundle/ApiPlatform/Resources/SearchProduct.php
@@ -82,4 +82,8 @@ use PrestaShopBundle\ApiPlatform\Provider\QueryProvider;
 )]
 class SearchProduct
 {
+    public string $phrase;
+    public int $resultsLimit;
+    public string $isoCode;
+    public int $orderId;
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/new_api.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/new_api.yml
@@ -53,4 +53,4 @@ services:
 
   PrestaShopBundle\ApiPlatform\Converters\:
     resource: "../../../../ApiPlatform/Converters/*"
-    tags: ['prestashop.api.converters']
+    tags: [ 'prestashop.api.converters' ]

--- a/src/PrestaShopBundle/Resources/config/services/bundle/new_api.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/new_api.yml
@@ -50,3 +50,7 @@ services:
   PrestaShopBundle\Controller\Api\OAuth2\AccessTokenController:
     autowire: true
     autoconfigure: true
+
+  PrestaShopBundle\ApiPlatform\Converters\:
+    resource: "../../../../ApiPlatform/Converters/*"
+    tags: ['prestashop.api.converters']

--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -108,6 +108,9 @@ services:
     tags: [ 'api_platform.state_provider' ]
     public: false
     autowire: true
+    arguments:
+      - '@prestashop.core.query_bus'
+      - !tagged prestashop.api.converters
 
   PrestaShopBundle\ApiPlatform\Processor\CommandProcessor:
     tags: [ 'api_platform.state_processor' ]

--- a/tests/Integration/ApiPlatform/ApiTestCase.php
+++ b/tests/Integration/ApiPlatform/ApiTestCase.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\ApiPlatform;
+
+use ApiPlatform\Symfony\Bundle\Test\Client;
+
+abstract class ApiTestCase extends \ApiPlatform\Symfony\Bundle\Test\ApiTestCase
+{
+    protected static function createClient(array $kernelOptions = [], array $defaultOptions = []): Client
+    {
+        if (!isset($defaultOptions['headers']['accept'])) {
+            $defaultOptions['headers']['accept'] = ['application/json'];
+        }
+
+        return parent::createClient($kernelOptions, $defaultOptions);
+    }
+}

--- a/tests/Integration/ApiPlatform/GetHookStatusTest.php
+++ b/tests/Integration/ApiPlatform/GetHookStatusTest.php
@@ -52,18 +52,18 @@ class GetHookStatusTest extends ApiTestCase
         $activeHook->add();
 
         $bearerToken = $this->getBearerToken();
-        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $inactiveHook->id, ['auth_bearer' => $bearerToken]);
+        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $inactiveHook->id, ['auth_bearer' => $bearerToken, 'headers' => ['accept' => ['application/json']]]);
         self::assertEquals(json_decode($response->getContent())->active, $inactiveHook->active);
         self::assertResponseStatusCodeSame(200);
 
-        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $activeHook->id, ['auth_bearer' => $bearerToken]);
+        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $activeHook->id, ['auth_bearer' => $bearerToken, 'headers' => ['accept' => ['application/json']]]);
         self::assertEquals(json_decode($response->getContent())->active, $activeHook->active);
         self::assertResponseStatusCodeSame(200);
 
-        static::createClient()->request('GET', '/new-api/hook-status/' . 9999, ['auth_bearer' => $bearerToken]);
+        static::createClient()->request('GET', '/new-api/hook-status/' . 9999, ['auth_bearer' => $bearerToken, 'headers' => ['accept' => ['application/json']]]);
         self::assertResponseStatusCodeSame(404);
 
-        static::createClient()->request('GET', '/new-api/hook-status/' . $activeHook->id);
+        static::createClient()->request('GET', '/new-api/hook-status/' . $activeHook->id, ['headers' => ['accept' => ['application/json']]]);
         self::assertResponseStatusCodeSame(401);
 
         $inactiveHook->delete();
@@ -80,11 +80,12 @@ class GetHookStatusTest extends ApiTestCase
         $bearerToken = $this->getBearerToken();
         static::createClient()->request('PUT', '/new-api/hook-status', [
             'auth_bearer' => $bearerToken,
+            'headers' => ['accept' => ['application/json']],
             'json' => ['id' => (int) $hook->id, 'active' => false],
         ]);
         self::assertResponseStatusCodeSame(200);
 
-        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $hook->id, ['auth_bearer' => $bearerToken]);
+        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $hook->id, ['auth_bearer' => $bearerToken, 'headers' => ['accept' => ['application/json']]]);
         self::assertEquals(json_decode($response->getContent())->active, false);
         self::assertResponseStatusCodeSame(200);
     }
@@ -99,11 +100,12 @@ class GetHookStatusTest extends ApiTestCase
         $bearerToken = $this->getBearerToken();
         static::createClient()->request('PUT', '/new-api/hook-status', [
             'auth_bearer' => $bearerToken,
+            'headers' => ['accept' => ['application/json']],
             'json' => ['id' => (int) $hook->id, 'active' => true],
         ]);
         self::assertResponseStatusCodeSame(200);
 
-        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $hook->id, ['auth_bearer' => $bearerToken]);
+        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $hook->id, ['auth_bearer' => $bearerToken, 'headers' => ['accept' => ['application/json']]]);
         self::assertEquals(json_decode($response->getContent())->active, true);
         self::assertResponseStatusCodeSame(200);
     }

--- a/tests/Integration/ApiPlatform/GetHookStatusTest.php
+++ b/tests/Integration/ApiPlatform/GetHookStatusTest.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace Tests\Integration\ApiPlatform;
 
-use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use Tests\Resources\DatabaseDump;
 
 class GetHookStatusTest extends ApiTestCase
@@ -52,18 +51,18 @@ class GetHookStatusTest extends ApiTestCase
         $activeHook->add();
 
         $bearerToken = $this->getBearerToken();
-        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $inactiveHook->id, ['auth_bearer' => $bearerToken, 'headers' => ['accept' => ['application/json']]]);
+        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $inactiveHook->id, ['auth_bearer' => $bearerToken]);
         self::assertEquals(json_decode($response->getContent())->active, $inactiveHook->active);
         self::assertResponseStatusCodeSame(200);
 
-        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $activeHook->id, ['auth_bearer' => $bearerToken, 'headers' => ['accept' => ['application/json']]]);
+        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $activeHook->id, ['auth_bearer' => $bearerToken]);
         self::assertEquals(json_decode($response->getContent())->active, $activeHook->active);
         self::assertResponseStatusCodeSame(200);
 
-        static::createClient()->request('GET', '/new-api/hook-status/' . 9999, ['auth_bearer' => $bearerToken, 'headers' => ['accept' => ['application/json']]]);
+        static::createClient()->request('GET', '/new-api/hook-status/' . 9999, ['auth_bearer' => $bearerToken]);
         self::assertResponseStatusCodeSame(404);
 
-        static::createClient()->request('GET', '/new-api/hook-status/' . $activeHook->id, ['headers' => ['accept' => ['application/json']]]);
+        static::createClient()->request('GET', '/new-api/hook-status/' . $activeHook->id);
         self::assertResponseStatusCodeSame(401);
 
         $inactiveHook->delete();
@@ -80,12 +79,11 @@ class GetHookStatusTest extends ApiTestCase
         $bearerToken = $this->getBearerToken();
         static::createClient()->request('PUT', '/new-api/hook-status', [
             'auth_bearer' => $bearerToken,
-            'headers' => ['accept' => ['application/json']],
             'json' => ['id' => (int) $hook->id, 'active' => false],
         ]);
         self::assertResponseStatusCodeSame(200);
 
-        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $hook->id, ['auth_bearer' => $bearerToken, 'headers' => ['accept' => ['application/json']]]);
+        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $hook->id, ['auth_bearer' => $bearerToken]);
         self::assertEquals(json_decode($response->getContent())->active, false);
         self::assertResponseStatusCodeSame(200);
     }
@@ -100,12 +98,11 @@ class GetHookStatusTest extends ApiTestCase
         $bearerToken = $this->getBearerToken();
         static::createClient()->request('PUT', '/new-api/hook-status', [
             'auth_bearer' => $bearerToken,
-            'headers' => ['accept' => ['application/json']],
             'json' => ['id' => (int) $hook->id, 'active' => true],
         ]);
         self::assertResponseStatusCodeSame(200);
 
-        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $hook->id, ['auth_bearer' => $bearerToken, 'headers' => ['accept' => ['application/json']]]);
+        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $hook->id, ['auth_bearer' => $bearerToken]);
         self::assertEquals(json_decode($response->getContent())->active, true);
         self::assertResponseStatusCodeSame(200);
     }

--- a/tests/Integration/ApiPlatform/GetHookTest.php
+++ b/tests/Integration/ApiPlatform/GetHookTest.php
@@ -29,7 +29,6 @@ declare(strict_types=1);
 
 namespace Tests\Integration\ApiPlatform;
 
-use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use Tests\Resources\DatabaseDump;
 
 class GetHookTest extends ApiTestCase
@@ -49,11 +48,11 @@ class GetHookTest extends ApiTestCase
 
         $bearerToken = $this->getBearerToken();
 
-        $response = static::createClient()->request('GET', '/new-api/hooks/' . (int) $hook->id, ['auth_bearer' => $bearerToken, 'headers' => ['accept' => ['application/json']]]);
+        $response = static::createClient()->request('GET', '/new-api/hooks/' . (int) $hook->id, ['auth_bearer' => $bearerToken]);
         self::assertEquals(json_decode($response->getContent())->active, $hook->active);
         self::assertResponseStatusCodeSame(200);
 
-        static::createClient()->request('GET', '/new-api/hooks/' . 9999, ['auth_bearer' => $bearerToken, 'headers' => ['accept' => ['application/json']]]);
+        static::createClient()->request('GET', '/new-api/hooks/' . 9999, ['auth_bearer' => $bearerToken]);
         self::assertResponseStatusCodeSame(404);
 
         static::createClient()->request('GET', '/new-api/hooks/' . $hook->id);

--- a/tests/Integration/ApiPlatform/GetHookTest.php
+++ b/tests/Integration/ApiPlatform/GetHookTest.php
@@ -49,11 +49,11 @@ class GetHookTest extends ApiTestCase
 
         $bearerToken = $this->getBearerToken();
 
-        $response = static::createClient()->request('GET', '/new-api/hooks/' . (int) $hook->id, ['auth_bearer' => $bearerToken]);
+        $response = static::createClient()->request('GET', '/new-api/hooks/' . (int) $hook->id, ['auth_bearer' => $bearerToken, 'headers' => ['accept' => ['application/json']]]);
         self::assertEquals(json_decode($response->getContent())->active, $hook->active);
         self::assertResponseStatusCodeSame(200);
 
-        static::createClient()->request('GET', '/new-api/hooks/' . 9999, ['auth_bearer' => $bearerToken]);
+        static::createClient()->request('GET', '/new-api/hooks/' . 9999, ['auth_bearer' => $bearerToken, 'headers' => ['accept' => ['application/json']]]);
         self::assertResponseStatusCodeSame(404);
 
         static::createClient()->request('GET', '/new-api/hooks/' . $hook->id);

--- a/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/01_internalAuthServer/02_resourceEndpoint.ts
+++ b/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/01_internalAuthServer/02_resourceEndpoint.ts
@@ -83,7 +83,7 @@ describe('API : Internal Auth Server - Resource Endpoint', async () => {
       });
       await expect(apiResponse.status()).to.eq(200);
       await expect(api.hasResponseHeader(apiResponse, 'Content-Type')).to.be.true;
-      await expect(api.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/ld+json');
+      await expect(api.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
 
       const jsonResponse = await apiResponse.json();
       await expect(jsonResponse).to.have.property('id');

--- a/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/02_externalAuthServer/02_resourceEndpoint.ts
+++ b/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/02_externalAuthServer/02_resourceEndpoint.ts
@@ -171,7 +171,7 @@ describe('API : External Auth Server - Resource Endpoint', async () => {
 
       await expect(apiResponse.status()).to.eq(200);
       await expect(api.hasResponseHeader(apiResponse, 'Content-Type')).to.be.true;
-      await expect(api.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/ld+json');
+      await expect(api.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
 
       const jsonResponse = await apiResponse.json();
       await expect(jsonResponse).to.have.property('id');

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
@@ -101,7 +101,7 @@ class QueryProviderTest extends TestCase
     /**
      * @return FoundProduct[]
      */
-    public function createsSearchProductResultBasedOnQuery(SearchProducts $query): array
+    private function createsSearchProductResultBasedOnQuery(SearchProducts $query): array
     {
         if ($query->getPhrase() === 'mug') {
             return [
@@ -132,10 +132,6 @@ class QueryProviderTest extends TestCase
         $get = new Get();
         $get = $get->withExtraProperties([
             'query' => SearchProducts::class,
-            'paramConverters' => [
-                'resultsLimit' => StringToIntConverter::class,
-                'orderId' => StringToIntConverter::class,
-            ],
         ]);
         $searchProducts = $searchProductProvider->provide($get, ['phrase' => 'mug', 'resultsLimit' => 10, 'isoCode' => 'EUR']);
         self::assertCount(1, $searchProducts);

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
@@ -68,9 +68,6 @@ class QueryProviderTest extends TestCase
         $this->queryBus
             ->method('handle')
             ->willReturnCallback(function ($query) {
-                return $this->createHookStatusResultBasedOnQuery($query);
-            })
-            ->willReturnCallback(function ($query) {
                 switch (get_class($query)) {
                     case GetHookStatus::class:
                         return $this->createHookStatusResultBasedOnQuery($query);

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
@@ -136,7 +136,7 @@ class QueryProviderTest extends TestCase
                     10,
                     '',
                     true
-                )
+                ),
             ];
         }
 

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
@@ -108,7 +108,7 @@ class QueryProviderTest extends TestCase
 
     public function testProvideHookStatus(): void
     {
-        $hookStatusProvider = new QueryProvider($this->queryBus, $this->requestStack);
+        $hookStatusProvider = new QueryProvider($this->queryBus, [new StringToIntConverter()], $this->requestStack);
         $get = new Get();
         $get = $get->withExtraProperties(['query' => GetHookStatus::class]);
         /** @var HookStatus $hookStatus */
@@ -149,7 +149,7 @@ class QueryProviderTest extends TestCase
 
     public function testSearchProduct(): void
     {
-        $searchProductProvider = new QueryProvider($this->queryBus, $this->requestStack);
+        $searchProductProvider = new QueryProvider($this->queryBus, [new StringToIntConverter()], $this->requestStack);
         $get = new Get();
         $get = $get->withExtraProperties([
             'query' => SearchProducts::class,
@@ -162,7 +162,7 @@ class QueryProviderTest extends TestCase
         self::assertCount(1, $searchProducts);
 
         $this->requestStack->getCurrentRequest()->query = new InputBag(['orderId' => 1]);
-        $searchProductProvider = new QueryProvider($this->queryBus, $this->requestStack);
+        $searchProductProvider = new QueryProvider($this->queryBus, [new StringToIntConverter()], $this->requestStack);
         $searchProducts = $searchProductProvider->provide($get, ['phrase' => 'search with order id', 'resultsLimit' => 10, 'isoCode' => 'EUR']);
         self::assertCount(0, $searchProducts);
     }

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
@@ -36,10 +36,16 @@ use PrestaShop\PrestaShop\Core\Domain\Hook\Query\GetHook;
 use PrestaShop\PrestaShop\Core\Domain\Hook\Query\GetHookStatus;
 use PrestaShop\PrestaShop\Core\Domain\Hook\QueryResult\Hook as HookQuery;
 use PrestaShop\PrestaShop\Core\Domain\Hook\QueryResult\HookStatus;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\FoundProduct;
+use PrestaShopBundle\ApiPlatform\Converters\StringToIntConverter;
 use PrestaShopBundle\ApiPlatform\Exception\NoExtraPropertiesFoundException;
 use PrestaShopBundle\ApiPlatform\Provider\QueryProvider;
 use PrestaShopBundle\ApiPlatform\Resources\Hook;
 use RuntimeException;
+use Symfony\Component\HttpFoundation\InputBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 
@@ -50,110 +56,114 @@ class QueryProviderTest extends TestCase
      */
     private $queryBus;
 
-    private Serializer|MockObject $serializer;
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
 
-    protected function setUp(): void
+    /**
+     * Set up dependencies for HookStatusProvider
+     */
+    public function setUp(): void
     {
         $this->serializer = new Serializer([new ObjectNormalizer()]);
         $this->queryBus = $this->createMock(CommandBusInterface::class);
-
+        $this->requestStack = $this->createMock(RequestStack::class);
+        $requestMock = $this
+            ->getMockBuilder(Request::class)
+            ->getMock();
+        $requestMock->query = new InputBag();
+        $this->requestStack
+            ->method('getCurrentRequest')
+            ->willReturn($requestMock);
         $this->queryBus
             ->method('handle')
             ->willReturnCallback(function ($query) {
+                return $this->createHookStatusResultBasedOnQuery($query);
+            })
+            ->willReturnCallback(function ($query) {
                 switch (get_class($query)) {
                     case GetHookStatus::class:
-                        return $this->createResultBasedOnHookStatusQuery($query);
-                    case GetHook::class:
-                        return $this->createResultBasedOnHookQuery($query);
+                        return $this->createHookStatusResultBasedOnQuery($query);
+                    case SearchProducts::class:
+                        return $this->createsSearchProductResultBasedOnQuery($query);
                 }
 
                 throw new RuntimeException(sprintf('Query type %s was not expected in query bus mock', get_class($query)));
             });
     }
 
-    private function createResultBasedOnHookStatusQuery(GetHookStatus $query): HookStatus
+    private function createHookStatusResultBasedOnQuery(GetHookStatus $query): HookStatus
     {
-        if ($query->getId()->getValue() === 1) {
-            return new HookStatus($query->getId()->getValue(), false);
+        if ($query->getHookId()->getValue() === 1) {
+            return new HookStatus($query->getHookId()->getValue(), false);
         }
 
-        if ($query->getId()->getValue() === 2) {
-            return new HookStatus($query->getId()->getValue(), true);
+        if ($query->getHookId()->getValue() === 2) {
+            return new HookStatus($query->getHookId()->getValue(), true);
         }
 
-        throw new RuntimeException(sprintf('Hook "%s" was not expected in query bus mock', $query->getId()->getValue()));
-    }
-
-    private function createResultBasedOnHookQuery(GetHook $query): HookQuery
-    {
-        if ($query->getId()->getValue() === 1) {
-            return new HookQuery(
-                $query->getId()->getValue(),
-                false,
-                'testName1',
-                'testTitle1',
-                'testDescription1'
-            );
-        }
-
-        if ($query->getId()->getValue() === 2) {
-            return new HookQuery(
-                $query->getId()->getValue(),
-                true,
-                'testName1',
-                'testTitle1',
-                'testDescription1'
-            );
-        }
-
-        throw new RuntimeException(sprintf('Hook "%s" was not expected in query bus mock', $query->getId()->getValue()));
+        throw new RuntimeException(sprintf('Hook "%s" was not expected in query bus mock', $query->getHookId()->getValue()));
     }
 
     public function testProvideHookStatus(): void
     {
-        $hookStatusProvider = new QueryProvider(
-            $this->queryBus,
-            $this->serializer,
-        );
+        $hookStatusProvider = new QueryProvider($this->queryBus, $this->requestStack);
         $get = new Get();
-        $get = $get
-            ->withExtraProperties(['query' => "PrestaShop\PrestaShop\Core\Domain\Hook\Query\GetHookStatus"])
-            ->withClass(Hook::class);
-        /** @var Hook $hookStatus */
-        $hookStatus = $hookStatusProvider->provide($get, ['id' => 1]);
-        self::assertEquals(false, $hookStatus->active);
-        /** @var Hook $hookStatus */
-        $hookStatus = $hookStatusProvider->provide($get, ['id' => 2]);
-        self::assertTrue($hookStatus->active);
+        $get = $get->withExtraProperties(['query' => GetHookStatus::class]);
+        /** @var HookStatus $hookStatus */
+        $hookStatus = $hookStatusProvider->provide($get, ['hookId' => 1]);
+        self::assertEquals(false, $hookStatus->isActive());
+        /** @var HookStatus $hookStatus */
+        $hookStatus = $hookStatusProvider->provide($get, ['hookId' => 2]);
+        self::assertTrue($hookStatus->isActive());
     }
 
-    public function testProvideHook(): void
+    /**
+     * @return FoundProduct[]
+     */
+    public function createsSearchProductResultBasedOnQuery(SearchProducts $query): array
     {
-        $hookStatusProvider = new QueryProvider(
-            $this->queryBus,
-            $this->serializer,
-        );
-        $get = new Get();
-        $get = $get
-            ->withExtraProperties(['query' => 'PrestaShop\PrestaShop\Core\Domain\Hook\Query\GetHook'])
-            ->withClass(Hook::class);
-        /** @var Hook $hookDto */
-        $hookDto = $hookStatusProvider->provide($get, ['id' => 1]);
-        self::assertEquals(false, $hookDto->active);
-        /** @var Hook $hookDto */
-        $hookDto = $hookStatusProvider->provide($get, ['id' => 2]);
-        self::assertTrue($hookDto->active);
+        if ($query->getPhrase() === 'mug') {
+            return [
+                new FoundProduct(
+                    1,
+                    'mug',
+                    '10 €',
+                    10,
+                    10,
+                    0,
+                    10,
+                    '',
+                    true
+                )
+            ];
+        }
+
+        if ($query->getOrderId() && ($query->getOrderId()->getValue() === 1)) {
+            return [];
+        }
+
+        throw new RuntimeException(sprintf('SearchProduct "%s" was not expected in query bus mock', $query->getPhrase()));
     }
 
-    public function testProvideNoQueryThrowsException(): void
+    public function testSearchProduct(): void
     {
-        $hookStatusProvider = new QueryProvider(
-            $this->queryBus,
-            $this->serializer,
-        );
+        $searchProductProvider = new QueryProvider($this->queryBus, $this->requestStack);
         $get = new Get();
+        $get = $get->withExtraProperties([
+            'query' => SearchProducts::class,
+            'paramConverters' => [
+                'resultsLimit' => StringToIntConverter::class,
+                'orderId' => StringToIntConverter::class,
+            ],
+        ]);
+        $searchProducts = $searchProductProvider->provide($get, ['phrase' => 'mug', 'resultsLimit' => 10, 'isoCode' => 'EUR']);
+        self::assertCount(1, $searchProducts);
 
-        $this->expectException(NoExtraPropertiesFoundException::class);
-        $hookStatusProvider->provide($get, ['id' => 1]);
+        $this->requestStack->getCurrentRequest()->query = new InputBag(['orderId' => 1]);
+        $searchProductProvider = new QueryProvider($this->queryBus, $this->requestStack);
+        $searchProducts = $searchProductProvider->provide($get, ['phrase' => 'search with order id', 'resultsLimit' => 10, 'isoCode' => 'EUR']);
+        self::assertCount(0, $searchProducts);
     }
 }

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace Tests\Unit\PrestaShopBundle\ApiPlatform\StateProvider;
 
 use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
@@ -39,8 +40,8 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\FoundProduct;
 use PrestaShopBundle\ApiPlatform\Converters\StringToIntConverter;
 use PrestaShopBundle\ApiPlatform\Exception\NoExtraPropertiesFoundException;
 use PrestaShopBundle\ApiPlatform\Provider\QueryProvider;
+use PrestaShopBundle\ApiPlatform\Resources\FoundProduct as FoundProductDto;
 use PrestaShopBundle\ApiPlatform\Resources\Hook;
-use PrestaShopBundle\ApiPlatform\Resources\SearchProduct;
 use RuntimeException;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -99,10 +100,10 @@ class QueryProviderTest extends TestCase
     public function testSearchProduct(): void
     {
         $searchProductProvider = new QueryProvider($this->queryBus, [new StringToIntConverter()], $this->serializer);
-        $get = new Get();
+        $get = new GetCollection();
         $get = $get
             ->withExtraProperties(['query' => SearchProducts::class])
-            ->withClass(SearchProduct::class);
+            ->withClass(FoundProductDto::class);
         $searchProducts = $searchProductProvider->provide($get, ['phrase' => 'mug', 'resultsLimit' => 10, 'isoCode' => 'EUR']);
         self::assertCount(1, $searchProducts);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add complexe query with optionnal parameters callable from new-api
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | <ul><li>Get an bearer token by requesting the /api/oauth2/token endpoint</li><li>Call https://prestashop.local/admin-dev/new-api/products/search/mug/10/EUR?orderId=1</li> <li> [Auto Tests](https://github.com/mflasquin/ga.tests.ui.pr/actions/runs/5723785551) :green_circle: </ul>
| Fixed ticket?     | Fixes #32803 
| Related PRs       | -
| Sponsor company   | Prestashop SA 


More informations on how to get your bearer token :

You need to add a return statement at the start of the onKernelRequest method of the SslMiddleware.php file. If you don't do this postman won't be able to handle the current ssl protocol.
You need to modify the security_dev.yml and copy the user key of the oauth2 node from the security_test.yml
