### PR TITLE
Rework commands with getters

### DIFF
--- a/src/Adapter/Alias/CommandHandler/DeleteAliasHandler.php
+++ b/src/Adapter/Alias/CommandHandler/DeleteAliasHandler.php
@@ -43,6 +43,6 @@ class DeleteAliasHandler implements DeleteAliasHandlerInterface
      */
     public function handle(DeleteAliasCommand $command): void
     {
-        $this->aliasRepository->delete($command->aliasId);
+        $this->aliasRepository->delete($command->getAliasId());
     }
 }

--- a/src/Adapter/Alias/CommandHandler/UpdateAliasHandler.php
+++ b/src/Adapter/Alias/CommandHandler/UpdateAliasHandler.php
@@ -44,10 +44,10 @@ class UpdateAliasHandler implements UpdateAliasHandlerInterface
      */
     public function handle(UpdateAliasCommand $command): void
     {
-        $existingAlias = $this->aliasRepository->get($command->aliasId);
+        $existingAlias = $this->aliasRepository->get($command->getAliasId());
 
         // We need to delete existing aliases to add new alias entries
         $this->aliasRepository->deleteAliasesBySearchTerm($existingAlias->search);
-        $this->aliasRepository->create($command->searchTerm, $command->aliases);
+        $this->aliasRepository->create($command->getSearchTerm(), $command->getAliases());
     }
 }

--- a/src/Adapter/Alias/CommandHandler/UpdateAliasStatusHandler.php
+++ b/src/Adapter/Alias/CommandHandler/UpdateAliasStatusHandler.php
@@ -53,8 +53,8 @@ class UpdateAliasStatusHandler implements UpdateAliasStatusHandlerInterfaces
      */
     public function handle(UpdateAliasStatusCommand $command): void
     {
-        $alias = $this->aliasRepository->get($command->aliasId);
-        $alias->active = $command->enabled;
+        $alias = $this->aliasRepository->get($command->getAliasId());
+        $alias->active = $command->isEnabled();
         $this->aliasRepository->partialUpdate($alias, ['active'], CannotUpdateAliasException::class);
     }
 }

--- a/src/Core/Domain/Alias/Command/DeleteAliasCommand.php
+++ b/src/Core/Domain/Alias/Command/DeleteAliasCommand.php
@@ -35,7 +35,18 @@ use PrestaShop\PrestaShop\Core\Domain\Alias\ValueObject\AliasId;
  */
 class DeleteAliasCommand
 {
-    public function __construct(public readonly AliasId $aliasId)
+    private AliasId $aliasId;
+
+    public function __construct(AliasId $aliasId)
     {
+        $this->aliasId = $aliasId;
+    }
+
+    /**
+     * @return AliasId
+     */
+    public function getAliasId(): AliasId
+    {
+        return $this->aliasId;
     }
 }

--- a/src/Core/Domain/Alias/Command/DeleteAliasCommand.php
+++ b/src/Core/Domain/Alias/Command/DeleteAliasCommand.php
@@ -37,9 +37,9 @@ class DeleteAliasCommand
 {
     private AliasId $aliasId;
 
-    public function __construct(AliasId $aliasId)
+    public function __construct(int $aliasId)
     {
-        $this->aliasId = $aliasId;
+        $this->aliasId = new AliasId($aliasId);
     }
 
     /**

--- a/src/Core/Domain/Alias/Command/UpdateAliasCommand.php
+++ b/src/Core/Domain/Alias/Command/UpdateAliasCommand.php
@@ -35,7 +35,14 @@ use PrestaShop\PrestaShop\Core\Domain\Alias\ValueObject\AliasId;
  */
 class UpdateAliasCommand
 {
-    public readonly AliasId $aliasId;
+    private AliasId $aliasId;
+
+    /**
+     * @var string[]
+     */
+    private array $aliases;
+
+    private string $searchTerm;
 
     /**
      * @param int $aliasId
@@ -44,9 +51,35 @@ class UpdateAliasCommand
      */
     public function __construct(
         int $aliasId,
-        public readonly array $aliases,
-        public readonly string $searchTerm,
+        array $aliases,
+        string $searchTerm,
     ) {
         $this->aliasId = new AliasId($aliasId);
+        $this->aliases = $aliases;
+        $this->searchTerm = $searchTerm;
+    }
+
+    /**
+     * @return AliasId
+     */
+    public function getAliasId(): AliasId
+    {
+        return $this->aliasId;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAliases(): array
+    {
+        return $this->aliases;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSearchTerm(): string
+    {
+        return $this->searchTerm;
     }
 }

--- a/src/Core/Domain/Alias/Command/UpdateAliasCommand.php
+++ b/src/Core/Domain/Alias/Command/UpdateAliasCommand.php
@@ -46,7 +46,7 @@ class UpdateAliasCommand
 
     /**
      * @param int $aliasId
-     * @param string[] $aliases
+     * @param string[] $aliases this input is array of string aliases that are returned from the form input
      * @param string $searchTerm
      */
     public function __construct(
@@ -68,7 +68,9 @@ class UpdateAliasCommand
     }
 
     /**
-     * @return array
+     * Returns array of string aliases that are used in the alias form input.
+     *
+     * @return string[]
      */
     public function getAliases(): array
     {

--- a/src/Core/Domain/Alias/Command/UpdateAliasStatusCommand.php
+++ b/src/Core/Domain/Alias/Command/UpdateAliasStatusCommand.php
@@ -40,7 +40,7 @@ class UpdateAliasStatusCommand
     private bool $enabled;
 
     /**
-     * @param AliasId $aliasId
+     * @param int $aliasId
      * @param bool $enabled
      */
     public function __construct(

--- a/src/Core/Domain/Alias/Command/UpdateAliasStatusCommand.php
+++ b/src/Core/Domain/Alias/Command/UpdateAliasStatusCommand.php
@@ -44,10 +44,10 @@ class UpdateAliasStatusCommand
      * @param bool $enabled
      */
     public function __construct(
-        AliasId $aliasId,
+        int$aliasId,
         bool $enabled
     ) {
-        $this->aliasId = $aliasId;
+        $this->aliasId = new AliasId($aliasId);
         $this->enabled = $enabled;
     }
 

--- a/src/Core/Domain/Alias/Command/UpdateAliasStatusCommand.php
+++ b/src/Core/Domain/Alias/Command/UpdateAliasStatusCommand.php
@@ -44,7 +44,7 @@ class UpdateAliasStatusCommand
      * @param bool $enabled
      */
     public function __construct(
-        int$aliasId,
+        int $aliasId,
         bool $enabled
     ) {
         $this->aliasId = new AliasId($aliasId);

--- a/src/Core/Domain/Alias/Command/UpdateAliasStatusCommand.php
+++ b/src/Core/Domain/Alias/Command/UpdateAliasStatusCommand.php
@@ -35,13 +35,35 @@ use PrestaShop\PrestaShop\Core\Domain\Alias\ValueObject\AliasId;
  */
 class UpdateAliasStatusCommand
 {
+    private AliasId $aliasId;
+
+    private bool $enabled;
+
     /**
      * @param AliasId $aliasId
      * @param bool $enabled
      */
     public function __construct(
-        public readonly AliasId $aliasId,
-        public readonly bool $enabled
+        AliasId $aliasId,
+        bool $enabled
     ) {
+        $this->aliasId = $aliasId;
+        $this->enabled = $enabled;
+    }
+
+    /**
+     * @return AliasId
+     */
+    public function getAliasId(): AliasId
+    {
+        return $this->aliasId;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/AliasFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AliasFeatureContext.php
@@ -108,7 +108,7 @@ class AliasFeatureContext extends AbstractDomainFeatureContext
     public function updateAliasStatus(bool $enable, string $aliasReference): void
     {
         $this->getCommandBus()->handle(new UpdateAliasStatusCommand(
-            new AliasId((int) $this->getSharedStorage()->get($aliasReference)),
+            (int) $this->getSharedStorage()->get($aliasReference),
             $enable
         ));
     }
@@ -166,7 +166,7 @@ class AliasFeatureContext extends AbstractDomainFeatureContext
         $aliasId = $this->getSharedStorage()->get($reference);
 
         try {
-            $this->getCommandBus()->handle(new DeleteAliasCommand(new AliasId((int) $aliasId)));
+            $this->getCommandBus()->handle(new DeleteAliasCommand((int) $aliasId));
         } catch (AliasException $e) {
             $this->setLastException($e);
         }

--- a/tests/Integration/Behaviour/Features/Context/Domain/AliasFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AliasFeatureContext.php
@@ -108,7 +108,7 @@ class AliasFeatureContext extends AbstractDomainFeatureContext
     public function updateAliasStatus(bool $enable, string $aliasReference): void
     {
         $this->getCommandBus()->handle(new UpdateAliasStatusCommand(
-            (int) $this->getSharedStorage()->get($aliasReference),
+            $this->getSharedStorage()->get($aliasReference),
             $enable
         ));
     }
@@ -162,11 +162,11 @@ class AliasFeatureContext extends AbstractDomainFeatureContext
      */
     public function deleteAlias(string $reference): void
     {
-        /** @var string[] $aliasId */
+        /** @var int $aliasId */
         $aliasId = $this->getSharedStorage()->get($reference);
 
         try {
-            $this->getCommandBus()->handle(new DeleteAliasCommand((int) $aliasId));
+            $this->getCommandBus()->handle(new DeleteAliasCommand(($aliasId)));
         } catch (AliasException $e) {
             $this->setLastException($e);
         }

--- a/tests/Integration/Behaviour/Features/Context/Domain/AliasFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AliasFeatureContext.php
@@ -38,7 +38,6 @@ use PrestaShop\PrestaShop\Core\Domain\Alias\Command\UpdateAliasCommand;
 use PrestaShop\PrestaShop\Core\Domain\Alias\Command\UpdateAliasStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Alias\Exception\AliasException;
 use PrestaShop\PrestaShop\Core\Domain\Alias\Query\SearchForSearchTerm;
-use PrestaShop\PrestaShop\Core\Domain\Alias\ValueObject\AliasId;
 use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Grid\Query\AliasQueryBuilder;
 use PrestaShop\PrestaShop\Core\Search\Filters;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Alias refactoring PR. When Prestashop compatibility with PHP 8.1 was increased, we started using public readonly arguments everywhere. The decision was made to roll back to using setters/getters. This PR introduces Alias refactoring to setters/getters.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No need to test as automatic tests are implemented and Alias refactored grids are currently in development and not used in BO.
| Fixed ticket?     | Fixes #{issue number here}, Fixes #{another issue number here}
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
