### PR TITLE
Bump to mysql 8 in CI

### DIFF
--- a/.github/workflows/cron_js_routing.yml
+++ b/.github/workflows/cron_js_routing.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup MySQL
         uses: mirromutth/mysql-action@v1.1
         with:
-          mysql version: '5.7'
+          mysql version: '8.0'
           mysql database: 'prestashop'
           mysql root password: 'password'
 
@@ -55,9 +55,11 @@ jobs:
 
       - name: Install Composer dependencies
         run: composer install --prefer-dist
-
       - name: Build assets
         run: make assets
+
+      - name: Change MySQL authentication method
+        run: mysql -h127.0.0.1 -uroot -ppassword -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'password'; FLUSH PRIVILEGES;"
 
       - name: Install PrestaShop
         run: php install-dev/index_cli.php --language=en --country=fr --domain=localhost --db_server=127.0.0.1 --db_password=password --db_name=prestashop --db_create=1 --name=prestashop.unit.test --email=demo@prestashop.com --password=prestashop_demo

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
             -   name: Setup MySQL
                 uses: mirromutth/mysql-action@v1.1
                 with:
-                    mysql version: '5.7'
+                    mysql version: '8.0'
                     mysql database: 'prestashop'
                     mysql root password: 'password'
 
@@ -55,12 +55,14 @@ jobs:
 
             -   name: Composer Install
                 run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
-
             -   name: Build assets
                 run: make assets
 
             -   name: Prepare PrestaShop parameters
                 run: cp .github/workflows/phpunit/parameters.php app/config/parameters.php
+
+            -   name: Change MySQL authentication method
+                run: mysql -h127.0.0.1 -uroot -ppassword -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'password'; FLUSH PRIVILEGES;"
 
             -   name: Run integration-tests
                 run: composer run-script integration-tests --timeout=0

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -119,7 +119,7 @@ jobs:
         -   name: Setup MySQL
             uses: mirromutth/mysql-action@v1.1
             with:
-                mysql version: '5.7'
+                mysql version: '8.0'
                 mysql database: 'prestashop'
                 mysql root password: 'password'
 
@@ -143,6 +143,9 @@ jobs:
 
         -   name: Composer Install
             run: composer install --ansi --prefer-dist --no-interaction --no-progress
+
+        -   name: Change MySQL authentication method
+            run: mysql -h127.0.0.1 -uroot -ppassword -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'password'; FLUSH PRIVILEGES;"
 
         -   name: Install PrestaShop
             run: php install-dev/index_cli.php --language=en --country=fr --domain=localhost --db_server=127.0.0.1 --db_password=password --db_name=prestashop --db_create=1 --name=prestashop.unit.test --email=demo@prestashop.com --password=prestashop_demo

--- a/.github/workflows/sanity-72.yml
+++ b/.github/workflows/sanity-72.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup MySQL
         uses: mirromutth/mysql-action@v1.1
         with:
-          mysql version: '5.7'
+          mysql version: '8.0'
           mysql database: 'prestashop'
           mysql root password: 'password'
 
@@ -76,6 +76,9 @@ jobs:
         with:
           path: ~/.cache/ms-playwright/
           key: ${{ runner.os }}-browsers
+
+      - name: Change MySQL authentication method
+        run: mysql -h127.0.0.1 -uroot -ppassword -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'password'; FLUSH PRIVILEGES;"
 
       - name: Run tests
         run: |

--- a/.github/workflows/sanity-73.yml
+++ b/.github/workflows/sanity-73.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup MySQL
         uses: mirromutth/mysql-action@v1.1
         with:
-          mysql version: '5.7'
+          mysql version: '8.0'
           mysql database: 'prestashop'
           mysql root password: 'password'
 
@@ -76,6 +76,9 @@ jobs:
         with:
           path: ~/.cache/ms-playwright/
           key: ${{ runner.os }}-browsers
+
+      - name: Change MySQL authentication method
+        run: mysql -h127.0.0.1 -uroot -ppassword -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'password'; FLUSH PRIVILEGES;"
 
       - name: Run tests
         run: |

--- a/.github/workflows/sanity-74.yml
+++ b/.github/workflows/sanity-74.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup MySQL
         uses: mirromutth/mysql-action@v1.1
         with:
-          mysql version: '5.7'
+          mysql version: '8.0'
           mysql database: 'prestashop'
           mysql root password: 'password'
 
@@ -76,6 +76,9 @@ jobs:
         with:
           path: ~/.cache/ms-playwright/
           key: ${{ runner.os }}-browsers
+
+      - name: Change MySQL authentication method
+        run: mysql -h127.0.0.1 -uroot -ppassword -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'password'; FLUSH PRIVILEGES;"
 
       - name: Run tests
         run: |

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup MySQL
         uses: mirromutth/mysql-action@v1.1
         with:
-          mysql version: '5.7'
+          mysql version: '8.0'
           mysql database: 'prestashop'
           mysql root password: 'password'
 
@@ -77,6 +77,9 @@ jobs:
         with:
           path: ~/.cache/ms-playwright/
           key: ${{ runner.os }}-browsers
+
+      - name: Change MySQL authentication method
+        run: mysql -h127.0.0.1 -uroot -ppassword -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'password'; FLUSH PRIVILEGES;"
 
       - name: Run tests
         run: |

--- a/src/Adapter/Order/Delivery/SlipPdfConfiguration.php
+++ b/src/Adapter/Order/Delivery/SlipPdfConfiguration.php
@@ -78,6 +78,10 @@ final class SlipPdfConfiguration implements DataConfigurationInterface
                 ];
             }
 
+            if (!empty($errors)) {
+                return $errors;
+            }
+
             if (empty(Invoice::getByDeliveryDateInterval($configuration['date_from'], $configuration['date_to']))) {
                 $errors[] = [
                     'key' => 'No delivery slip was found for this period.',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  1.7.8.x
| Description?      | As we use ubuntu latest in the ci instead of ubuntu 18.04, we have to bump mysql version. Indeed, currently ubuntu latest = 22.04 and it ships mysql 8 by default. It's seems like we can use mysql 5.7 on ubuntu latest but it's not native and it demands some efforts to set it up.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | The CI should be 🟢
| Fixed ticket?     | Fixes #32915
| Related PRs       | 
| Sponsor company   |
