### PR TITLE
Nightly : Fixed install Node 16

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -7,6 +7,7 @@ EXPOSE 443
 
 ARG GROUP_ID
 ARG USER_ID
+ARG NODE_VERSION
 
 RUN groupmod -g $GROUP_ID www-data \
   && usermod -u $USER_ID -g $GROUP_ID www-data
@@ -19,13 +20,19 @@ RUN chown -R www-data:www-data /var/www/.npm
 RUN mkdir -p /var/www/.composer
 RUN chown -R www-data:www-data /var/www/.composer
 
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
-RUN apt install -y nodejs
+ENV NVM_DIR       /usr/local/nvm
+RUN mkdir -p $NVM_DIR \
+    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash \
+    && . $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+ENV NODE_PATH     $NVM_DIR/versions/node/v$NODE_VERSION/bin
+ENV PATH          $PATH:$NODE_PATH
 
 # Install mailutils to make sendmail work
-RUN apt install -y \
-    apt-utils \
-    mailutils
+RUN apt update && apt install -y mailutils
 
 RUN php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');" && php /tmp/composer-setup.php --no-ansi --install-dir=/usr/local/bin --filename=composer && rm -rf /tmp/composer-setup.php
 CMD ["/tmp/docker_run_git.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
         - VERSION=${VERSION:-8.1-apache}
         - USER_ID=${USER_ID:-1000}
         - GROUP_ID=${GROUP_ID:-1000}
+        - NODE_VERSION=${NODE_VERSION:-16.20.1}
     environment:
       DISABLE_MAKE: ${DISABLE_MAKE:-0}
       PS_INSTALL_AUTO: ${PS_INSTALL_AUTO:-1}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Nightly : Fixed install Node 16<br>📜 The base image php:8.1-fpm has replaced Buster by Bookworm (docker-library/php#1416), so that broke our setup of Node & use of APT
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: & Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/5401160231
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp
