### PR TITLE
Fix wrong discount amount displayed

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -151,13 +151,14 @@ class CartPresenter implements PresenterInterface
             }
         }
 
+        $rawProduct['price'] = Tools::ps_round($rawProduct['price'], Context::getContext()->getComputingPrecision());
+        $rawProduct['price_wt'] = Tools::ps_round($rawProduct['price_wt'], Context::getContext()->getComputingPrecision());
+
         if ($this->includeTaxes()) {
-            $rawProduct['price_amount'] = $rawProduct['price_wt'];
-            $rawProduct['price'] = $this->priceFormatter->format($rawProduct['price_wt']);
+            $rawProduct['price_amount'] = $rawProduct['price'] = $rawProduct['price_wt'];
             $rawProduct['unit_price'] = $rawProduct['unit_price_tax_included'];
         } else {
-            $rawProduct['price_amount'] = $rawProduct['price'];
-            $rawProduct['price'] = $rawProduct['price_tax_exc'] = $this->priceFormatter->format($rawProduct['price']);
+            $rawProduct['price_amount'] = $rawProduct['price_tax_exc'] = $rawProduct['price'];
             $rawProduct['unit_price'] = $rawProduct['unit_price_tax_excluded'];
         }
 

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -780,16 +780,14 @@ class ProductLazyArray extends AbstractLazyArray
             $this->product['discount_percentage_absolute'] = Tools::displayNumber($presAbsoluteReduction) . '%';
             if ($settings->include_taxes) {
                 $regular_price = $product['price_without_reduction'];
-                $this->product['discount_amount'] = $this->priceFormatter->format(
-                    $product['reduction']
-                );
             } else {
                 $regular_price = $product['price_without_reduction_without_tax'];
-                $this->product['discount_amount'] = $this->priceFormatter->format(
-                    $product['reduction_without_tax']
-                );
             }
-            $this->product['discount_amount_to_display'] = '-' . $this->product['discount_amount'];
+            // We must calculate the real amount of discount.
+            // see @https://github.com/PrestaShop/PrestaShop/issues/32924
+            $product['reduction'] = $regular_price - $price;
+            $this->product['discount_amount'] = $this->priceFormatter->format($product['reduction']);
+            $this->product['discount_amount_to_display'] = '-' . $this->priceFormatter->format($product['reduction']);
         }
 
         $this->product['price_amount'] = $price;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fix wrong discount amount displayed on cart & product pages.<br/>As we improve pricing system in the futur, it's preferable to don't change anythings in price calculation.<br/>This PR aim to fix only display.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | ⚠️ **Group reduction aren't considered as a discount by PrestaShop**<br/>See #32924
| Fixed ticket?     | Fixes #32924
| Related PRs       | 
| Sponsor company   | 
