### PR TITLE
Add string casting for boolean fields

### DIFF
--- a/src/Adapter/EntityMapper.php
+++ b/src/Adapter/EntityMapper.php
@@ -95,7 +95,13 @@ class EntityMapper
                 foreach ($object_datas as $key => $value) {
                     if (array_key_exists($key, $entity_defs['fields'])
                         || array_key_exists($key, $objectVars)) {
-                        $entity->{$key} = $value;
+                        if (isset($entity_defs['fields'][$key]['type']) && in_array($entity_defs['fields'][$key]['type'], [
+                            \ObjectModel::TYPE_BOOL,
+                        ])) {
+                            $entity->{$key} = (string) $value;
+                        } else {
+                            $entity->{$key} = $value;
+                        }
                     } else {
                         unset($object_datas[$key]);
                     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x 
| Description?      | PHP 8.x is more strict than before to we have to change `tinyInt` to get `strings`.
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #31958
| Fixed ticket?     | Fixes #31958 
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
