### PR TITLE
Cart rule shop association handling in new page (a.k.a shop_restrictions)

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
@@ -141,6 +141,34 @@
 		{l s='Restrictions' d='Admin.Catalog.Feature'}
 	</label>
 	<div class="col-lg-9">
+    {if ($all_shops|@count) > 1}
+      <div id="shop_restriction_div">
+        <br/>
+        <table class="table">
+          <tr>
+            <td>
+              <p>{l s='Unselected shops' d='Admin.Catalog.Feature'}</p>
+              <select id="shop_select_1" multiple>
+                  {foreach from=$shops.unselected item='shop'}
+                    <option value="{$shop.id_shop|intval}">&nbsp;{$shop.name|escape}</option>
+                  {/foreach}
+              </select>
+              <a id="shop_select_add" class="btn btn-default btn-block clearfix" >{l s='Add' d='Admin.Actions'} <i class="icon-arrow-right"></i></a>
+            </td>
+            <td>
+              <p>{l s='Selected shops' d='Admin.Catalog.Feature'}</p>
+              <select name="shop_select[]" id="shop_select_2" multiple>
+                  {foreach from=$shops.selected item='shop'}
+                    <option value="{$shop.id_shop|intval}">&nbsp;{$shop.name|escape}</option>
+                  {/foreach}
+              </select>
+              <a id="shop_select_remove" class="btn btn-default btn-block clearfix" ><i class="icon-arrow-left"></i> {l s='Remove' d='Admin.Actions'}</a>
+            </td>
+          </tr>
+        </table>
+      </div>
+    {/if}
+
 		{if ($countries.unselected|@count) + ($countries.selected|@count) > 1}
 			<p class="checkbox">
 				<label>
@@ -293,39 +321,5 @@
 					<i class="icon-plus-sign"></i> {l s='Product selection' d='Admin.Catalog.Feature'}
 				</a>
 			</div>
-
-		{if ($all_shops|@count) > 1}
-			<p class="checkbox">
-				<label>
-					<input type="checkbox" id="shop_restriction" name="shop_restriction" value="1" {if $shops.selected|@count || ($shops.selected|@count + $shops.unselected|@count < $all_shops|@count)}checked="checked"{/if} />
-					{l s='Store selection' d='Admin.Catalog.Feature'}
-				</label>
-			</p>
-			<div id="shop_restriction_div">
-				<br/>
-				<table class="table">
-					<tr>
-						<td>
-							<p>{l s='Unselected shops' d='Admin.Catalog.Feature'}</p>
-							<select id="shop_select_1" multiple>
-								{foreach from=$shops.unselected item='shop'}
-									<option value="{$shop.id_shop|intval}">&nbsp;{$shop.name|escape}</option>
-								{/foreach}
-							</select>
-							<a id="shop_select_add" class="btn btn-default btn-block clearfix" >{l s='Add' d='Admin.Actions'} <i class="icon-arrow-right"></i></a>
-						</td>
-						<td>
-							<p>{l s='Selected shops' d='Admin.Catalog.Feature'}</p>
-							<select name="shop_select[]" id="shop_select_2" multiple>
-								{foreach from=$shops.selected item='shop'}
-									<option value="{$shop.id_shop|intval}">&nbsp;{$shop.name|escape}</option>
-								{/foreach}
-							</select>
-							<a id="shop_select_remove" class="btn btn-default btn-block clearfix" ><i class="icon-arrow-left"></i> {l s='Remove' d='Admin.Actions'}</a>
-						</td>
-					</tr>
-				</table>
-			</div>
-		{/if}
 	</div>
 </div>

--- a/admin-dev/themes/new-theme/js/pages/cart-rule/cart-rule-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/cart-rule/cart-rule-map.ts
@@ -41,4 +41,5 @@ export default {
   reductionValueSymbol: `${discountContainer} .price-reduction-value .input-group .input-group-append .input-group-text, .price-reduction-value .input-group .input-group-prepend .input-group-text`,
   specificProductSearchComponent: '#cart_rule_actions_discount_specific_product',
   specificProductSearchContainer: '.specific-product-search-container',
+  shopAssociationTree: '#cart_rule_conditions_shop_association',
 };

--- a/admin-dev/themes/new-theme/js/pages/cart-rule/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/cart-rule/form/index.ts
@@ -30,6 +30,7 @@ import CartRuleEventMap from '@pages/cart-rule/cart-rule-event-map';
 import CustomerSearchInput from '@components/form/customer-search-input';
 import DiscountManager from '@pages/cart-rule/form/discount-manager';
 import ProductSearchInput from '@components/form/product-search-input';
+import ChoiceTree from '@components/form/choice-tree';
 
 $(() => {
   window.prestashop.component.initComponents([
@@ -46,6 +47,7 @@ $(() => {
     'DisablingSwitch',
   ]);
 
+  new ChoiceTree(CartRuleMap.shopAssociationTree).enableAutoCheckChildren();
   new GeneratableInput().attachOn(CartRuleMap.codeGeneratorBtn);
   new FormFieldToggler({
     disablingInputSelector: CartRuleMap.codeInput,

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -82,7 +82,12 @@ class CartRuleCore extends ObjectModel
     public $cart_rule_restriction;
     /** @var bool */
     public $product_restriction;
-    /** @var bool */
+
+    /**
+     * @deprecated this property is always forced to true, so and cart_rule_shop table must always be filled with shop association
+     *
+     * @var bool
+     */
     public $shop_restriction = true;
     /** @var bool */
     public $free_shipping;
@@ -180,6 +185,9 @@ class CartRuleCore extends ObjectModel
             $this->reduction_currency = Currency::getDefaultCurrencyId();
         }
 
+        // force shop_restriction to always be truthy, so that cart_rule_shop table is always considered
+        // and can work as simple shop association as in any other entity
+        $this->shop_restriction = true;
         if (!parent::add($autodate, $null_values)) {
             return false;
         }
@@ -207,6 +215,9 @@ class CartRuleCore extends ObjectModel
             $this->reduction_currency = Currency::getDefaultCurrencyId();
         }
 
+        // force shop_restriction to always be truthy, so that cart_rule_shop table is always considered
+        // and can work as simple shop association as in any other entity
+        $this->shop_restriction = true;
         if (!parent::update($null_values)) {
             return false;
         }

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -83,7 +83,7 @@ class CartRuleCore extends ObjectModel
     /** @var bool */
     public $product_restriction;
     /** @var bool */
-    public $shop_restriction;
+    public $shop_restriction = true;
     /** @var bool */
     public $free_shipping;
     public $reduction_percent;
@@ -260,9 +260,6 @@ class CartRuleCore extends ObjectModel
      */
     public static function copyConditions($id_cart_rule_source, $id_cart_rule_destination)
     {
-        Db::getInstance()->execute('
-		INSERT INTO `' . _DB_PREFIX_ . 'cart_rule_shop` (`id_cart_rule`, `id_shop`)
-		(SELECT ' . (int) $id_cart_rule_destination . ', id_shop FROM `' . _DB_PREFIX_ . 'cart_rule_shop` WHERE `id_cart_rule` = ' . (int) $id_cart_rule_source . ')');
         Db::getInstance()->execute('
 		INSERT INTO `' . _DB_PREFIX_ . 'cart_rule_carrier` (`id_cart_rule`, `id_carrier`)
 		(SELECT ' . (int) $id_cart_rule_destination . ', id_carrier FROM `' . _DB_PREFIX_ . 'cart_rule_carrier` WHERE `id_cart_rule` = ' . (int) $id_cart_rule_source . ')');
@@ -802,7 +799,7 @@ class CartRuleCore extends ObjectModel
         }
 
         // Check if the cart rules appliy to the shop browsed by the customer
-        if ($this->shop_restriction && $context->shop->id && Shop::isFeatureActive()) {
+        if ($this->shop_restriction && $context->shop->id) {
             $id_cart_rule = (int) Db::getInstance()->getValue('
 			SELECT crs.id_cart_rule
 			FROM ' . _DB_PREFIX_ . 'cart_rule_shop crs

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -455,7 +455,7 @@ class CartRuleCore extends ObjectModel
             if ($cart_rule['shop_restriction']) {
                 $cartRuleShops = Db::getInstance()->executeS('SELECT id_shop FROM ' . _DB_PREFIX_ . 'cart_rule_shop WHERE id_cart_rule = ' . (int) $cart_rule['id_cart_rule']);
                 foreach ($cartRuleShops as $cartRuleShop) {
-                    if (Shop::isFeatureActive() && ($cartRuleShop['id_shop'] == Context::getContext()->shop->id)) {
+                    if ($cartRuleShop['id_shop'] == Context::getContext()->shop->id) {
                         continue 2;
                     }
                 }
@@ -1679,7 +1679,7 @@ class CartRuleCore extends ObjectModel
 		)
 		AND (
 			cr.`shop_restriction` = 0
-			' . ((Shop::isFeatureActive() && $context->shop->id) ? 'OR crs.id_shop = ' . (int) $context->shop->id : '') . '
+			' . ($context->shop->id ? 'OR crs.id_shop = ' . (int) $context->shop->id : '') . '
 		)
 		AND (
 			cr.`group_restriction` = 0

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -661,11 +661,6 @@ class ShopCore extends ObjectModel
         return true;
     }
 
-    public static function removeTableAssociation(string $tableName): void
-    {
-        unset(Shop::$asso_tables[$tableName]);
-    }
-
     /**
      * Check if given table is associated to shop.
      *

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -162,6 +162,7 @@ class ShopCore extends ObjectModel
         $asso_tables = [
             'carrier' => ['type' => 'shop'],
             'carrier_lang' => ['type' => 'fk_shop'],
+            'cart_rule' => ['type' => 'shop'],
             'category' => ['type' => 'shop'],
             'category_lang' => ['type' => 'fk_shop'],
             'cms' => ['type' => 'shop'],

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -660,6 +660,11 @@ class ShopCore extends ObjectModel
         return true;
     }
 
+    public static function removeTableAssociation(string $tableName): void
+    {
+        unset(Shop::$asso_tables[$tableName]);
+    }
+
     /**
      * Check if given table is associated to shop.
      *

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -225,6 +225,10 @@ class AdminCartRulesControllerCore extends AdminController
                 }
             }
 
+            if (empty(Tools::getValue('shop_select'))) {
+                $this->errors[] = $this->trans('The associated stores must be selected.', [], 'Admin.Catalog.Notification');
+            }
+
             // Remove the gift if the radio button is set to "no"
             if (!(int) Tools::getValue('free_gift')) {
                 $_POST['gift_product'] = 0;
@@ -273,9 +277,21 @@ class AdminCartRulesControllerCore extends AdminController
         return $res;
     }
 
-    protected function updateAssoShop($id_object)
+    /**
+     * {@inheritDoc}
+     */
+    protected function getSelectedAssoShop($table): array
     {
-        //@todo:Now we override so the cart_rule_shop table is not cleaned up every time. But need to back to this to check employee access to shops
+        $selectedShopIds = Tools::getValue('shop_select');
+
+        // fallback to context shop id, in case its empty (e.g. when multishop feature is off we still want to insert cart_rule_shop row)
+        if (!is_array($selectedShopIds)) {
+            return [(int) $this->context->shop->id];
+        }
+
+        return array_map(static function ($shopId): int {
+            return (int) $shopId;
+        }, $selectedShopIds);
     }
 
     /**
@@ -316,23 +332,6 @@ class AdminCartRulesControllerCore extends AdminController
         }
 
         return $cart_rule;
-    }
-
-    /**
-     * @param CartRule $cartRule
-     *
-     * @return bool
-     */
-    protected function beforeAdd($cartRule)
-    {
-        $selectedShopIds = Tools::getValue('shop_select');
-        if (Tools::getValue('shop_restriction') && is_array($selectedShopIds)) {
-            $cartRule->id_shop_list = array_map(static function ($shopId): int {
-                return (int) $shopId;
-            }, $selectedShopIds);
-        }
-
-        return true;
     }
 
     /**

--- a/src/Adapter/CartRule/CommandHandler/AddCartRuleHandler.php
+++ b/src/Adapter/CartRule/CommandHandler/AddCartRuleHandler.php
@@ -68,7 +68,10 @@ class AddCartRuleHandler implements AddCartRuleHandlerInterface
      */
     public function handle(AddCartRuleCommand $command): CartRuleId
     {
-        $cartRule = $this->cartRuleRepository->add($this->buildCartRuleFromCommandData($command));
+        $cartRule = $this->cartRuleRepository->add(
+            $this->buildCartRuleFromCommandData($command),
+            $command->getAssociatedShopIds()
+        );
 
         return new CartRuleId((int) $cartRule->id);
     }

--- a/src/Adapter/CartRule/CommandHandler/EditCartRuleHandler.php
+++ b/src/Adapter/CartRule/CommandHandler/EditCartRuleHandler.php
@@ -35,7 +35,6 @@ use PrestaShop\PrestaShop\Core\Domain\CartRule\Command\EditCartRuleCommand;
 use PrestaShop\PrestaShop\Core\Domain\CartRule\CommandHandler\EditCartRuleHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
-use Shop;
 
 class EditCartRuleHandler extends AbstractObjectModelHandler implements EditCartRuleHandlerInterface
 {
@@ -69,16 +68,9 @@ class EditCartRuleHandler extends AbstractObjectModelHandler implements EditCart
         $this->cartRuleRepository->partialUpdate($cartRule, $updatableProperties);
 
         if (null !== $command->getAssociatedShopIds()) {
-            // by default table shop association doesn't exist because legacy used to handle it differently,
-            // but it seems to work just fine handling it as all other entities shop associations
-//            Shop::addTableAssociation('cart_rule', ['type' => 'shop']);
-
             $this->associateWithShops($cartRule, array_map(static function (ShopId $shopId) {
                 return $shopId->getValue();
             }, $command->getAssociatedShopIds()));
-
-            // revert back the default shop table associations in case cartRule is created using legacy method
-//            Shop::removeTableAssociation('cart_rule');
         }
     }
 

--- a/src/Adapter/CartRule/CommandHandler/EditCartRuleHandler.php
+++ b/src/Adapter/CartRule/CommandHandler/EditCartRuleHandler.php
@@ -76,6 +76,9 @@ class EditCartRuleHandler extends AbstractObjectModelHandler implements EditCart
             $this->associateWithShops($cartRule, array_map(static function (ShopId $shopId) {
                 return $shopId->getValue();
             }, $command->getAssociatedShopIds()));
+
+            // revert back the default shop table associations in case cartRule is created using legacy method
+            Shop::removeTableAssociation('cart_rule');
         }
     }
 

--- a/src/Adapter/CartRule/CommandHandler/EditCartRuleHandler.php
+++ b/src/Adapter/CartRule/CommandHandler/EditCartRuleHandler.php
@@ -71,14 +71,14 @@ class EditCartRuleHandler extends AbstractObjectModelHandler implements EditCart
         if (null !== $command->getAssociatedShopIds()) {
             // by default table shop association doesn't exist because legacy used to handle it differently,
             // but it seems to work just fine handling it as all other entities shop associations
-            Shop::addTableAssociation('cart_rule', ['type' => 'shop']);
+//            Shop::addTableAssociation('cart_rule', ['type' => 'shop']);
 
             $this->associateWithShops($cartRule, array_map(static function (ShopId $shopId) {
                 return $shopId->getValue();
             }, $command->getAssociatedShopIds()));
 
             // revert back the default shop table associations in case cartRule is created using legacy method
-            Shop::removeTableAssociation('cart_rule');
+//            Shop::removeTableAssociation('cart_rule');
         }
     }
 

--- a/src/Adapter/CartRule/CommandHandler/EditCartRuleHandler.php
+++ b/src/Adapter/CartRule/CommandHandler/EditCartRuleHandler.php
@@ -30,11 +30,13 @@ namespace PrestaShop\PrestaShop\Adapter\CartRule\CommandHandler;
 use CartRule;
 use PrestaShop\PrestaShop\Adapter\CartRule\CartRuleActionFiller;
 use PrestaShop\PrestaShop\Adapter\CartRule\Repository\CartRuleRepository;
+use PrestaShop\PrestaShop\Adapter\Domain\AbstractObjectModelHandler;
 use PrestaShop\PrestaShop\Core\Domain\CartRule\Command\EditCartRuleCommand;
 use PrestaShop\PrestaShop\Core\Domain\CartRule\CommandHandler\EditCartRuleHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 
-class EditCartRuleHandler implements EditCartRuleHandlerInterface
+class EditCartRuleHandler extends AbstractObjectModelHandler implements EditCartRuleHandlerInterface
 {
     /**
      * @var CartRuleRepository
@@ -64,6 +66,12 @@ class EditCartRuleHandler implements EditCartRuleHandlerInterface
         }
 
         $this->cartRuleRepository->partialUpdate($cartRule, $updatableProperties);
+
+        if (null !== $command->getAssociatedShopIds()) {
+            $this->associateWithShops($cartRule, array_map(static function (ShopId $shopId) {
+                return $shopId->getValue();
+            }, $command->getAssociatedShopIds()));
+        }
     }
 
     /**

--- a/src/Adapter/CartRule/QueryHandler/GetCartRuleForEditingHandler.php
+++ b/src/Adapter/CartRule/QueryHandler/GetCartRuleForEditingHandler.php
@@ -134,7 +134,8 @@ class GetCartRuleForEditingHandler implements GetCartRuleForEditingHandlerInterf
             (int) $cartRule->quantity,
             (int) $cartRule->quantity_per_user,
             $cartRuleMinimum,
-            $cartRuleRestrictions
+            $cartRuleRestrictions,
+            $cartRule->getAssociatedShops()
         );
     }
 

--- a/src/Adapter/CartRule/QueryHandler/GetCartRuleForEditingHandler.php
+++ b/src/Adapter/CartRule/QueryHandler/GetCartRuleForEditingHandler.php
@@ -117,9 +117,10 @@ class GetCartRuleForEditingHandler implements GetCartRuleForEditingHandlerInterf
             }
         }
 
+        $cartRuleId = new CartRuleId((int) $cartRule->id);
         $restrictedCartRules = [];
         if ($cartRule->cart_rule_restriction) {
-            $restrictedCartRules = $this->cartRuleRepository->getRestrictedCartRuleIds(new CartRuleId((int) $cartRule->id));
+            $restrictedCartRules = $this->cartRuleRepository->getRestrictedCartRuleIds($cartRuleId);
         }
 
         $cartRuleRestrictions = new CartRuleRestrictionsForEditing(
@@ -135,7 +136,7 @@ class GetCartRuleForEditingHandler implements GetCartRuleForEditingHandlerInterf
             (int) $cartRule->quantity_per_user,
             $cartRuleMinimum,
             $cartRuleRestrictions,
-            $cartRule->getAssociatedShops()
+            $this->cartRuleRepository->getAssociatedShopIds($cartRuleId)
         );
     }
 

--- a/src/Adapter/CartRule/Repository/CartRuleRepository.php
+++ b/src/Adapter/CartRule/Repository/CartRuleRepository.php
@@ -350,6 +350,27 @@ class CartRuleRepository extends AbstractMultiShopObjectModelRepository
         );
     }
 
+    /**
+     * @param CartRuleId $cartRuleId
+     *
+     * @return int[]
+     */
+    public function getAssociatedShopIds(CartRuleId $cartRuleId): array
+    {
+        $results = $this->connection->createQueryBuilder()
+            ->select('id_shop')
+            ->from($this->dbPrefix . 'cart_rule_shop')
+            ->where('id_cart_rule = :cartRuleId')
+            ->setParameter('cartRuleId', $cartRuleId->getValue())
+            ->execute()
+            ->fetchAllAssociative()
+        ;
+
+        return array_map(static function (array $result): int {
+            return (int) $result['id_shop'];
+        }, $results);
+    }
+
     private function removeRestrictedCartRules(CartRuleId $cartRuleId): void
     {
         $this->connection->createQueryBuilder()

--- a/src/Adapter/CartRule/Repository/CartRuleRepository.php
+++ b/src/Adapter/CartRule/Repository/CartRuleRepository.php
@@ -39,7 +39,6 @@ use PrestaShop\PrestaShop\Core\Domain\CartRule\ValueObject\Restriction\Restricti
 use PrestaShop\PrestaShop\Core\Domain\CartRule\ValueObject\Restriction\RestrictionRuleGroup;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Repository\AbstractMultiShopObjectModelRepository;
-use Shop;
 
 class CartRuleRepository extends AbstractMultiShopObjectModelRepository
 {
@@ -58,22 +57,8 @@ class CartRuleRepository extends AbstractMultiShopObjectModelRepository
      */
     public function add(CartRule $cartRule, array $associatedShopIds): CartRule
     {
-        // cart rule works well with cart_rule_shop table as all the other entities when we add the table association
-        // except it uses "shop_restrictions" property for some reason, so we force it to true to avoid breaking legacy code
-        //@todo: need to confirm. Is it ok that we always force the shop_restriction = true?
-        //       in legacy code shop_restriction = false means rule can be used in all shops
-        //       (and it is same if we add all the shops into cart_rule_shop table)
-        //       so can we just make sure new code always puts related shops into cart_rule_shop table (even if its single shop context)
-        //       and eventually we can get rid of shop_restriction prop?
-        //       also the shopTableAssociaton could be moved to Shop:init(), so we don't need to do it in handlers anymore (not sure how would it affect legacy code)
-//        Shop::addTableAssociation('cart_rule', ['type' => 'shop']);
-        $cartRule->shop_restriction = true;
-
         $this->cartRuleValidator->validate($cartRule);
         $this->addObjectModelToShops($cartRule, $associatedShopIds, CannotAddCartRuleException::class);
-
-        // revert back the default shop table associations in case cartRule is created using legacy method
-//        Shop::removeTableAssociation('cart_rule');
 
         return $cartRule;
     }

--- a/src/Adapter/CartRule/Repository/CartRuleRepository.php
+++ b/src/Adapter/CartRule/Repository/CartRuleRepository.php
@@ -72,6 +72,9 @@ class CartRuleRepository extends AbstractMultiShopObjectModelRepository
         $this->cartRuleValidator->validate($cartRule);
         $this->addObjectModelToShops($cartRule, $associatedShopIds, CannotAddCartRuleException::class);
 
+        // revert back the default shop table associations in case cartRule is created using legacy method
+        Shop::removeTableAssociation('cart_rule');
+
         return $cartRule;
     }
 

--- a/src/Adapter/CartRule/Repository/CartRuleRepository.php
+++ b/src/Adapter/CartRule/Repository/CartRuleRepository.php
@@ -60,6 +60,12 @@ class CartRuleRepository extends AbstractMultiShopObjectModelRepository
     {
         // cart rule works well with cart_rule_shop table as all the other entities when we add the table association
         // except it uses "shop_restrictions" property for some reason, so we force it to true to avoid breaking legacy code
+        //@todo: need to confirm. Is it ok that we always force the shop_restriction = true?
+        //       in legacy code shop_restriction = false means rule can be used in all shops
+        //       (and it is same if we add all the shops into cart_rule_shop table)
+        //       so can we just make sure new code always puts related shops into cart_rule_shop table (even if its single shop context)
+        //       and eventually we can get rid of shop_restriction prop?
+        //       also the shopTableAssociaton could be moved to Shop:init(), so we don't need to do it in handlers anymore (not sure how would it affect legacy code)
         Shop::addTableAssociation('cart_rule', ['type' => 'shop']);
         $cartRule->shop_restriction = true;
 

--- a/src/Adapter/CartRule/Repository/CartRuleRepository.php
+++ b/src/Adapter/CartRule/Repository/CartRuleRepository.php
@@ -66,14 +66,14 @@ class CartRuleRepository extends AbstractMultiShopObjectModelRepository
         //       so can we just make sure new code always puts related shops into cart_rule_shop table (even if its single shop context)
         //       and eventually we can get rid of shop_restriction prop?
         //       also the shopTableAssociaton could be moved to Shop:init(), so we don't need to do it in handlers anymore (not sure how would it affect legacy code)
-        Shop::addTableAssociation('cart_rule', ['type' => 'shop']);
+//        Shop::addTableAssociation('cart_rule', ['type' => 'shop']);
         $cartRule->shop_restriction = true;
 
         $this->cartRuleValidator->validate($cartRule);
         $this->addObjectModelToShops($cartRule, $associatedShopIds, CannotAddCartRuleException::class);
 
         // revert back the default shop table associations in case cartRule is created using legacy method
-        Shop::removeTableAssociation('cart_rule');
+//        Shop::removeTableAssociation('cart_rule');
 
         return $cartRule;
     }

--- a/src/Core/Domain/CartRule/Command/AddCartRuleCommand.php
+++ b/src/Core/Domain/CartRule/Command/AddCartRuleCommand.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Domain\CartRule\ValueObject\CartRuleAction;
 use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Money;
 
 /**
@@ -117,12 +118,24 @@ class AddCartRuleCommand
      */
     private $quantityPerUser = 1;
 
+    /**
+     * @var ShopId[]
+     */
+    private array $associatedShopIds;
+
+    /**
+     * @param array<int, string> $localizedNames
+     * @param CartRuleAction $cartRuleAction
+     * @param int[] $associatedShopIds
+     */
     public function __construct(
         array $localizedNames,
-        CartRuleAction $cartRuleAction
+        CartRuleAction $cartRuleAction,
+        array $associatedShopIds
     ) {
         $this->setLocalizedNames($localizedNames);
         $this->cartRuleAction = $cartRuleAction;
+        $this->setAssociatedShopIds($associatedShopIds);
     }
 
     public function getDescription(): string
@@ -317,6 +330,14 @@ class AddCartRuleCommand
     }
 
     /**
+     * @return ShopId[]
+     */
+    public function getAssociatedShopIds(): array
+    {
+        return $this->associatedShopIds;
+    }
+
+    /**
      * @param array<int, string> $localizedNames
      *
      * @return AddCartRuleCommand
@@ -335,5 +356,19 @@ class AddCartRuleCommand
         if ($dateFrom > $dateTo) {
             throw new CartRuleConstraintException('Date from cannot be greater than date to.', CartRuleConstraintException::DATE_FROM_GREATER_THAN_DATE_TO);
         }
+    }
+
+    /**
+     * @param int[] $associatedShopIds
+     */
+    private function setAssociatedShopIds(array $associatedShopIds): void
+    {
+        if (empty($associatedShopIds)) {
+            throw new CartRuleConstraintException('Shop association cannot be empty', CartRuleConstraintException::INVALID_SHOP_ASSOCIATION);
+        }
+
+        $this->associatedShopIds = array_map(static function (int $shopId): ShopId {
+            return new ShopId($shopId);
+        }, $associatedShopIds);
     }
 }

--- a/src/Core/Domain/CartRule/Command/AddCartRuleCommand.php
+++ b/src/Core/Domain/CartRule/Command/AddCartRuleCommand.php
@@ -134,8 +134,8 @@ class AddCartRuleCommand
         array $associatedShopIds
     ) {
         $this->setLocalizedNames($localizedNames);
-        $this->cartRuleAction = $cartRuleAction;
         $this->setAssociatedShopIds($associatedShopIds);
+        $this->cartRuleAction = $cartRuleAction;
     }
 
     public function getDescription(): string

--- a/src/Core/Domain/CartRule/Command/EditCartRuleCommand.php
+++ b/src/Core/Domain/CartRule/Command/EditCartRuleCommand.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerIdInterface;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\NoCustomerId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Money;
 
 class EditCartRuleCommand
@@ -120,6 +121,11 @@ class EditCartRuleCommand
      * @var CartRuleAction|null
      */
     private $cartRuleAction;
+
+    /**
+     * @var ShopId[]|null
+     */
+    private $associatedShopIds;
 
     public function __construct(
         int $cartRuleId
@@ -334,6 +340,32 @@ class EditCartRuleCommand
         $this->cartRuleAction = $cartRuleAction;
 
         return $this;
+    }
+
+    /**
+     * @param int[] $associatedShopIds
+     *
+     * @return EditCartRuleCommand
+     */
+    public function setAssociatedShopIds(array $associatedShopIds): EditCartRuleCommand
+    {
+        if (empty($associatedShopIds)) {
+            throw new CartRuleConstraintException('Shop association cannot be empty', CartRuleConstraintException::INVALID_SHOP_ASSOCIATION);
+        }
+
+        $this->associatedShopIds = array_map(static function (int $shopId): ShopId {
+            return new ShopId($shopId);
+        }, $associatedShopIds);
+
+        return $this;
+    }
+
+    /**
+     * @return ShopId[]|null
+     */
+    public function getAssociatedShopIds(): ?array
+    {
+        return $this->associatedShopIds;
     }
 
     private function assertDateRangeIsValid(DateTimeImmutable $dateFrom, DateTimeImmutable $dateTo): void

--- a/src/Core/Domain/CartRule/Exception/CartRuleConstraintException.php
+++ b/src/Core/Domain/CartRule/Exception/CartRuleConstraintException.php
@@ -77,4 +77,5 @@ class CartRuleConstraintException extends CartRuleException
     public const INVALID_RESTRICTION_RULE_ID = 41;
     public const EMPTY_RESTRICTION_RULE_IDS = 42;
     public const EMPTY_RESTRICTION_RULES = 43;
+    public const INVALID_SHOP_ASSOCIATION = 44;
 }

--- a/src/Core/Domain/CartRule/QueryResult/CartRuleConditionsForEditing.php
+++ b/src/Core/Domain/CartRule/QueryResult/CartRuleConditionsForEditing.php
@@ -68,6 +68,11 @@ class CartRuleConditionsForEditing
      */
     private $restrictions;
 
+    /**
+     * @var int[]
+     */
+    private array $associatedShopIds;
+
     public function __construct(
         CustomerIdInterface $customerId,
         ?DateTime $dateFrom,
@@ -75,7 +80,8 @@ class CartRuleConditionsForEditing
         int $quantity,
         int $quantityPerUser,
         ?CartRuleMinimumForEditing $minimum,
-        CartRuleRestrictionsForEditing $restrictions
+        CartRuleRestrictionsForEditing $restrictions,
+        array $associatedShopIds
     ) {
         $this->customerId = $customerId;
         $this->dateFrom = $dateFrom;
@@ -84,6 +90,7 @@ class CartRuleConditionsForEditing
         $this->quantityPerUser = $quantityPerUser;
         $this->minimum = $minimum;
         $this->restrictions = $restrictions;
+        $this->associatedShopIds = $associatedShopIds;
     }
 
     /**
@@ -140,5 +147,13 @@ class CartRuleConditionsForEditing
     public function getRestrictions(): CartRuleRestrictionsForEditing
     {
         return $this->restrictions;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getAssociatedShopIds(): array
+    {
+        return $this->associatedShopIds;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataHandler/CartRuleFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CartRuleFormDataHandler.php
@@ -64,7 +64,8 @@ class CartRuleFormDataHandler implements FormDataHandlerInterface
 
         $command = new AddCartRuleCommand(
             $informationData['name'],
-            $this->cartRuleActionBuilder->build($data['actions'])
+            $this->cartRuleActionBuilder->build($data['actions']),
+            $data['conditions']['shop_association']
         );
 
         $command

--- a/src/Core/Form/IdentifiableObject/DataProvider/CartRuleFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CartRuleFormDataProvider.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\CartRule\Query\GetCartRuleForEditing;
 use PrestaShop\PrestaShop\Core\Domain\CartRule\QueryResult\CartRuleForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Reduction;
+use PrestaShop\PrestaShop\Core\Shop\ShopContextInterface;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 
 class CartRuleFormDataProvider implements FormDataProviderInterface
@@ -47,12 +48,16 @@ class CartRuleFormDataProvider implements FormDataProviderInterface
      */
     private $configuration;
 
+    private ShopContextInterface $shopContext;
+
     public function __construct(
         CommandBusInterface $queryBus,
-        ShopConfigurationInterface $configuration
+        ShopConfigurationInterface $configuration,
+        ShopContextInterface $shopContext
     ) {
         $this->queryBus = $queryBus;
         $this->configuration = $configuration;
+        $this->shopContext = $shopContext;
     }
 
     /**
@@ -100,6 +105,7 @@ class CartRuleFormDataProvider implements FormDataProviderInterface
                 'available_per_user' => 1,
                 'restrictions' => [],
                 'customer' => [],
+                'shop_association' => $this->shopContext->getContextShopIds(),
             ],
             'actions' => [
                 'free_shipping' => false,

--- a/src/PrestaShopBundle/Form/Admin/Sell/CartRule/ConditionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CartRule/ConditionsType.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Form\Admin\Sell\CartRule;
 
 use PrestaShopBundle\Form\Admin\Type\CustomerSearchType;
 use PrestaShopBundle\Form\Admin\Type\DateRangeType;
+use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -62,6 +63,9 @@ class ConditionsType extends TranslatorAwareType
                     'A customer will only be able to use the cart rule "X" time(s).',
                     'Admin.Catalog.Help'
                 ),
+            ])
+            ->add('shop_association', ShopChoiceTreeType::class, [
+                'label' => $this->trans('Store association', 'Admin.Global'),
             ])
             //@todo: Restrictions not handled. Will be in separate PR.
         ;

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CartRule/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CartRule/Blocks/form.html.twig
@@ -32,7 +32,7 @@
     <div class="form-wrapper">
       {{ form_widget(cartRuleForm) }}
       {% block cart_rule_form_rest %}
-        {{ form_row(cartRuleForm) }}
+        {{ form_rest(cartRuleForm) }}
       {% endblock %}
     </div>
   </div>

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartRule/AbstractCartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartRule/AbstractCartRuleFeatureContext.php
@@ -48,7 +48,10 @@ abstract class AbstractCartRuleFeatureContext extends AbstractDomainFeatureConte
     {
         $command = new AddCartRuleCommand(
             $data['name'],
-            $this->getCartRuleActionBuilder()->build($this->formatDataForActionBuilder($data))
+            $this->getCartRuleActionBuilder()->build($this->formatDataForActionBuilder($data)),
+            isset($localizedData['associated shops']) ?
+                $this->referencesToIds($localizedData['associated shops']) :
+                $this->getDefaultShopId()
         );
 
         if (isset($data['highlight'])) {

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartRule/AbstractCartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartRule/AbstractCartRuleFeatureContext.php
@@ -49,9 +49,9 @@ abstract class AbstractCartRuleFeatureContext extends AbstractDomainFeatureConte
         $command = new AddCartRuleCommand(
             $data['name'],
             $this->getCartRuleActionBuilder()->build($this->formatDataForActionBuilder($data)),
-            isset($localizedData['associated shops']) ?
-                $this->referencesToIds($localizedData['associated shops']) :
-                $this->getDefaultShopId()
+            isset($data['associated shops']) ?
+                $this->referencesToIds($data['associated shops']) :
+                [$this->getDefaultShopId()]
         );
 
         if (isset($data['highlight'])) {
@@ -294,6 +294,14 @@ abstract class AbstractCartRuleFeatureContext extends AbstractDomainFeatureConte
                 $expectedRestrictedCartRuleIds,
                 $conditions->getRestrictions()->getRestrictedCartRuleIds(),
                 'Unexpected cart rule restrictions'
+            );
+        }
+
+        if (isset($expectedData['associated shops'])) {
+            Assert::assertSame(
+                $this->referencesToIds($expectedData['associated shops']),
+                $conditions->getAssociatedShopIds(),
+                'Unexpected cart rule associated shop ids'
             );
         }
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartRule/CartRuleAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartRule/CartRuleAssertionFeatureContext.php
@@ -132,6 +132,10 @@ class CartRuleAssertionFeatureContext extends AbstractCartRuleFeatureContext
                 'class' => CartRuleNotFoundException::class,
                 'code' => 0,
             ],
+            'invalid shop association' => [
+                'class' => CartRuleConstraintException::class,
+                'code' => CartRuleConstraintException::INVALID_SHOP_ASSOCIATION,
+            ],
         ];
 
         if (!isset($errorMap[$error])) {

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartRule/EditCartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartRule/EditCartRuleFeatureContext.php
@@ -138,6 +138,10 @@ class EditCartRuleFeatureContext extends AbstractCartRuleFeatureContext
             );
         }
 
+        if (isset($data['associated shops'])) {
+            $command->setAssociatedShopIds($this->referencesToIds($data['associated shops']));
+        }
+
         $cartRuleActionBuilder = $this->getCartRuleActionBuilder();
         $formattedActionData = $this->formatDataForActionBuilder($data);
 

--- a/tests/Integration/Behaviour/Features/Scenario/CartRule/add_cart_rule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CartRule/add_cart_rule.feature
@@ -56,6 +56,7 @@ Feature: Add cart rule
       | discount_currency                | usd                    |
       | discount_includes_tax            | true                   |
       | discount_application_type        | order_without_shipping |
+      | associated shops                 | shop1                  |
 
   Scenario: Create a cart rule with percentage discount
     When I create cart rule "cart_rule_2" with following properties:
@@ -149,3 +150,43 @@ Feature: Add cart rule
       | free_shipping     | true                |
       | code              | testcode1           |
     Then I should get cart rule error about "non unique cart rule code"
+
+  Scenario: Add cart rule and associate it to different shops when multishop is enabled
+    Given I enable multishop feature
+    And shop group "default_shop_group" with name "Default" exists
+    And I add a shop "shop2" with name "default_shop_group" and color "red" for the group "default_shop_group"
+    And single shop context is loaded
+    When I create cart rule "cart_rule_5" with following properties:
+      | name[en-US]   | Promotion   |
+      | free_shipping | true        |
+      | code          | cart_rule_5 |
+    And cart rule "cart_rule_5" should have the following properties:
+      | name[en-US]      | Promotion   |
+      | free_shipping    | true        |
+      | code             | cart_rule_5 |
+      | associated shops | shop1       |
+    When I create cart rule "cart_rule_6" with following properties:
+      | name[en-US]      | Promotion 6 |
+      | free_shipping    | true        |
+      | code             | cart_rule_6 |
+      | associated shops | shop1,shop2 |
+    And cart rule "cart_rule_6" should have the following properties:
+      | name[en-US]      | Promotion 6 |
+      | free_shipping    | true        |
+      | code             | cart_rule_6 |
+      | associated shops | shop1,shop2 |
+    When I create cart rule "cart_rule_7" with following properties:
+      | name[en-US]      | Promotion 7 |
+      | free_shipping    | true        |
+      | code             | cart_rule_7 |
+      | associated shops | shop2       |
+    And cart rule "cart_rule_7" should have the following properties:
+      | name[en-US]      | Promotion 7 |
+      | free_shipping    | true        |
+      | code             | cart_rule_7 |
+      | associated shops | shop2       |
+    When I create cart rule "cart_rule_8" with following properties:
+      | name[en-US]      | Promotion 8 |
+      | free_shipping    | true        |
+      | associated shops |             |
+    Then I should get cart rule error about "invalid shop association"

--- a/tests/Integration/Behaviour/Features/Scenario/CartRule/edit_cart_rule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CartRule/edit_cart_rule.feature
@@ -361,3 +361,33 @@ Feature: Add cart rule
     When I bulk disable cart rules "cart_rule_4,cart_rule_5"
     Then cart rule with reference "cart_rule_4" is disabled
     And cart rule with reference "cart_rule_5" is disabled
+
+  Scenario: Update cart rule shop association when multishop feature is on
+    Given I enable multishop feature
+    And shop group "default_shop_group" with name "Default" exists
+    And I add a shop "shop2" with name "default_shop_group" and color "red" for the group "default_shop_group"
+    And single shop context is loaded
+    When I create cart rule "cart_rule_6" with following properties:
+      | name[en-US]   | Cart Rule 6 |
+      | free_shipping | true        |
+    Then cart rule cart_rule_6 should have the following properties:
+      | active           | true  |
+      | associated shops | shop1 |
+    When I edit cart rule cart_rule_6 with following properties:
+      | active | false |
+    Then cart rule cart_rule_6 should have the following properties:
+      | active           | false |
+      | associated shops | shop1 |
+    When I edit cart rule cart_rule_6 with following properties:
+      | associated shops | shop1,shop2 |
+    Then cart rule cart_rule_6 should have the following properties:
+      | associated shops | shop1,shop2 |
+    When I edit cart rule cart_rule_6 with following properties:
+      | associated shops | shop2 |
+    Then cart rule cart_rule_6 should have the following properties:
+      | associated shops | shop2 |
+    When I edit cart rule cart_rule_6 with following properties:
+      | associated shops |  |
+    Then I should get cart rule error about "invalid shop association"
+    And cart rule cart_rule_6 should have the following properties:
+      | associated shops | shop2 |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Handle shop association in CQRS commands and creation form (edit form is not done yet).
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Page is not finished yet so no need for manual QA yet. Behat tests should be enough
| Fixed ticket?     | part of https://github.com/PrestaShop/PrestaShop/issues/10547
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).

This PR changes the handling of cart_rule_shop table and cartRule->shop_restriction. CartRule->shop_restriction is now always forced to true, and we always expect to fill the cart_rule_shop table with associated shops (so it technically is the same shop association as in any other entity). for this reason :warning:  **the Autoupgrade module must add a relation to all existing shops if the cart_rule_shop was empty AND force the cart_rule.shop_restriction to true for every existing cart rule.** :warning: 
