### PR TITLE
do not discount cheapest product with price 0

### DIFF
--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -158,6 +158,8 @@ class CartRuleCalculator
                             ($cartRule->reduction_exclude_special && !$product['reduction_applies'])
                             || !$cartRule->reduction_exclude_special
                         ) && (
+                            $cartRow->getInitialUnitPrice()->getTaxIncluded() > 0
+                        ) && (
                             $cartRowCheapest === null
                             || $cartRowCheapest->getInitialUnitPrice()->getTaxIncluded() > $cartRow->getInitialUnitPrice()->getTaxIncluded()
                         )


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Do not discount cheapest product with price 0. Find the cheapest product where the price is also greater than 0.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket     | Fixes #33059 
| How to test?      | Create a product with price 0, and another product with a price greater than 0. Create a discount code that discounts 100% on the cheapest product. On the checkout, after applying the discount code, the cheapest product detected will be the one with the price 0. That means the discount code is useless.
