### PR TITLE
Order: add "invoice" bool for orders with no invoice requested

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -34,6 +34,9 @@ class OrderCore extends ObjectModel
     /** @var int Delivery address id */
     public $id_address_delivery;
 
+    /** @var bool True if customer wants an invoice */
+    public $invoice = true;
+
     /** @var int Invoice address id */
     public $id_address_invoice;
 
@@ -192,6 +195,7 @@ class OrderCore extends ObjectModel
         'primary' => 'id_order',
         'fields' => [
             'id_address_delivery' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true],
+            'invoice' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'id_address_invoice' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true],
             'id_cart' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true],
             'id_currency' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true],

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1220,6 +1220,7 @@ CREATE TABLE `PREFIX_orders` (
   `id_cart` int(10) unsigned NOT NULL,
   `id_currency` int(10) unsigned NOT NULL,
   `id_address_delivery` int(10) unsigned NOT NULL,
+  `invoice` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `id_address_invoice` int(10) unsigned NOT NULL,
   `current_state` int(10) unsigned NOT NULL,
   `secure_key` varchar(32) NOT NULL DEFAULT '-1',

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -224,7 +224,8 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $this->getLinkedOrders($order),
             $this->addressFormatter->format(new AddressId((int) $order->id_address_delivery)),
             $this->addressFormatter->format(new AddressId((int) $order->id_address_invoice)),
-            (string) $order->note
+            (string) $order->note,
+            (bool) $order->invoice
         );
     }
 

--- a/src/Core/Domain/Order/QueryResult/OrderForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderForViewing.php
@@ -198,6 +198,11 @@ class OrderForViewing
     private $note;
 
     /**
+     * @var bool
+     */
+    private $invoice;
+
+    /**
      * @param int $orderId
      * @param int $currencyId
      * @param int $carrierId
@@ -231,6 +236,7 @@ class OrderForViewing
      * @param string $shippingAddressFormatted
      * @param string $invoiceAddressFormatted
      * @param string $note
+     * @param bool $invoice
      */
     public function __construct(
         int $orderId,
@@ -265,7 +271,8 @@ class OrderForViewing
         LinkedOrdersForViewing $linkedOrders,
         string $shippingAddressFormatted = '',
         string $invoiceAddressFormatted = '',
-        string $note = ''
+        string $note = '',
+        bool $invoice = true
     ) {
         $this->reference = $reference;
         $this->customer = $customer;
@@ -300,6 +307,7 @@ class OrderForViewing
         $this->shippingAddressFormatted = $shippingAddressFormatted;
         $this->invoiceAddressFormatted = $invoiceAddressFormatted;
         $this->note = $note;
+        $this->invoice = $invoice;
     }
 
     /**
@@ -584,5 +592,13 @@ class OrderForViewing
     public function getNote(): string
     {
         return $this->note;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getInvoice(): bool
+    {
+        return $this->invoice;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -171,11 +171,13 @@
               </a>
 
               <div class="dropdown-menu dropdown-menu-right">
-                <a class="dropdown-item" id="js-invoice-address-edit-btn"
-                   href="{{ path('admin_order_addresses_edit', {'orderId': orderForViewing.id, 'addressType': 'invoice', 'liteDisplaying': 1, 'submitFormAjax': 1}) }}"
-                >
-                  {{ 'Edit existing address'|trans({}, 'Admin.Actions') }}
-                </a>
+	        {% if orderForViewing.invoice %}
+                  <a class="dropdown-item" id="js-invoice-address-edit-btn"
+                     href="{{ path('admin_order_addresses_edit', {'orderId': orderForViewing.id, 'addressType': 'invoice', 'liteDisplaying': 1, 'submitFormAjax': 1}) }}"
+                  >
+                    {{ 'Edit existing address'|trans({}, 'Admin.Actions') }}
+                  </a>
+                {% endif %}
 
                 <a href="#"
                    class="dropdown-item js-update-customer-address-modal-btn"
@@ -189,9 +191,11 @@
             {% endif %}
           </div>
 
-          {% for line in orderForViewing.invoiceAddressFormatted|split("\n") %}
-            <p class="mb-0">{{ line }}</p>
-          {% endfor %}
+	  {% if orderForViewing.invoice %}
+            {% for line in orderForViewing.invoiceAddressFormatted|split("\n") %}
+              <p class="mb-0">{{ line }}</p>
+            {% endfor %}
+	  {% endif %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `In some countries / shops / cases the main purchase document is a`<br>`receipt. The main difference (comparing to invoice) is a lack of buyer`<br>`name and address.`<br>`Issuing invoice for every order may be unneeded or highly inconvenient`<br>`(invoices usually require some extra tax-related processing).`<br><br>`This change is required to let customers not request an invoice (resign`<br>`from it). On top of this BO change it'll be possible to adjust checkout`<br>`code / modules to let customers skip providing invoice address.`<br><br>`Having "invoice" kind of invalidates "id_address_invoice". We can't make`<br>`"id_address_invoice" NULL-able however as that would break too many`<br>`modules.`
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set `invoice` to 0 for any order. Verify invoice address doesn't get displayed in BO.
| Fixed ticket?     | Fixes #31068
| Related PRs       | Alternative solution to the #31079
| Sponsor company   |