### PR TITLE
Update date_time.html.twig better check for emptiness

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/date_time.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/date_time.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% if record[column.id] == constant('PrestaShop\\PrestaShop\\Core\\Util\\DateTime\\DateTime::NULL_VALUE') %}
+{% if record[column.id] == constant('PrestaShop\\PrestaShop\\Core\\Util\\DateTime\\DateTime::NULL_VALUE') or record[column.id] is empty %}
   {{  column.options.empty_data }}
 {% else %}
   <time datetime="{{ record[column.id]|date(constant('PrestaShop\\PrestaShop\\Core\\Util\\DateTime\\DateTime::ISO_DATETIME_FORMAT')) }}">{{ record[column.id]|date(column.options.format) }}</time>


### PR DESCRIPTION
| Questions              | Answers
| -----------------      | -------------------------------------------------------
| Branch?                | develop 
| Description?           | Date_time column type allows to declare a specific data to display in case its data would be empty. However, it only checks if the date is a default value ('0000-00-00 00:00:00') and not if it is "empty" (false, null, "", ...). This PR adds a emptiness check in the template, as giving an empty data would result in the current datetime being displayed and this is not correct.
| Type?                  | bug fix 
| Category?              | BO
| BC breaks?             | no
| Deprecations?          | no
| How to test?           | In the OrderQueryBuilder class, in the getSearchQueryBuilder, replace 'o.date_add' by 'null as date_add'. Now you can check that it displays an empty string instead of current datetime.
| Fixed ticket?          | Fixes https://github.com/PrestaShop/PrestaShop/issues/33090
| Related PRs            | NA
| Sponsor company        | Evolutive Group
