### PR TITLE
Fix new file button target in product attachment form;

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/manager/attachments-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/manager/attachments-manager.ts
@@ -68,7 +68,7 @@ export default class AttachmentsManager {
         id: 'modal-create-product-attachment',
         modalTitle: this.$addAttachmentBtn.data('modalTitle'),
         formSelector: 'form[name="attachment"]',
-        formUrl: $(event.target).prop('href'),
+        formUrl: $(event.currentTarget).prop('href'),
         closable: true,
         onFormLoaded: (form: HTMLElement, formData: FormData, dataAttributes: DOMStringMap | null): void => {
           if (dataAttributes && dataAttributes.attachmentId) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Event.target element that triggred the event. So when you click on the text which element is span there will be href undefined. So changed it to currentTarget which targets event listener hence tag a.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #33036
| Fixed ticket?     | Closes #33036
