### PR TITLE
Add conditions for manufacturer fields

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5617,7 +5617,12 @@ class ProductCore extends ObjectModel
         $row['category'] = Category::getLinkRewrite((int) $row['id_category_default'], (int) $id_lang);
         $row['category_name'] = Db::getInstance()->getValue('SELECT name FROM ' . _DB_PREFIX_ . 'category_lang WHERE id_shop = ' . (int) $context->shop->id . ' AND id_lang = ' . (int) $id_lang . ' AND id_category = ' . (int) $row['id_category_default']);
         $row['link'] = $context->link->getProductLink((int) $row['id_product'], $row['link_rewrite'], $row['category'], $row['ean13']);
-        $row['manufacturer_name'] = !empty((int) $row['id_manufacturer']) ? Manufacturer::getNameById((int) $row['id_manufacturer']) : null;
+
+        if (empty($row['manufacturer_name']) && (isset($row['id_manufacturer']) && !empty((int) $row['id_manufacturer']))) {
+            $row['manufacturer_name'] = Manufacturer::getNameById((int) $row['id_manufacturer']);
+        } else {
+            $row['manufacturer_name'] = null;
+        }
 
         $row['attribute_price'] = 0;
         if ($id_product_attribute) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      |  The "id_manufacturer" property was missing in a call from the Google Analytics module, resulting in an error of type 'undefined key "id_manufacturer"' when the dev mode was enabled. <br/> It was necessary to be in multi-languages to obtain the error, as previously the content was cached since the cache key included the language ID.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see #32889
| Fixed ticket?     | Fixes #32889
| Related PRs       | -
| Sponsor company   | -
