### PR TITLE
Replace employee dropdown smarty template by twig template

### DIFF
--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -107,7 +107,14 @@
         {/if}
 
         <div class="component" id="header-employee-container">
-          {include file="components/layout/employee_dropdown.tpl"}
+            {render_template
+              smarty_template="components/layout/employee_dropdown.tpl"
+              twig_template="@PrestaShop/Admin/Layout/employee_dropdown.html.twig"
+              employee=$employee
+              link=$link
+              displayBackOfficeEmployeeMenu=$displayBackOfficeEmployeeMenu
+              logout_link=$logout_link
+            }
         </div>
         {if isset($displayBackOfficeTop)}{$displayBackOfficeTop}{/if}
       </div>

--- a/phpstan-tmp-legacy-layout-baseline.neon
+++ b/phpstan-tmp-legacy-layout-baseline.neon
@@ -1,11 +1,31 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Namespace Link is forbidden, No legacy calls inside the prestashop bundle. Please create an interface and an adapter if you need to\\.$#"
+			message: "#^Class Employee is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
+
+		-
+			message: "#^Class Link is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
+
+		-
+			message: "#^Namespace Employee is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
+
+		-
+			message: "#^Namespace Link is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
+
+		-
+			message: "#^Class Link is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 1
 			path: src/PrestaShopBundle/Twig/Component/QuickAccess.php
 
 		-
-			message: "#^Class Link is forbidden, No legacy calls inside the prestashop bundle. Please create an interface and an adapter if you need to\\.$#"
+			message: "#^Namespace Link is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 1
 			path: src/PrestaShopBundle/Twig/Component/QuickAccess.php

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/employee_dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/employee_dropdown.html.twig
@@ -1,0 +1,72 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+<div class="dropdown employee-dropdown">
+    <div class="rounded-circle person" data-toggle="dropdown">
+      <i class="material-icons">account_circle</i>
+    </div>
+    <div class="dropdown-menu dropdown-menu-right">
+      <div class="employee-wrapper-avatar">
+        <div class="employee-top">
+          <span class="employee-avatar">
+            <img class="avatar rounded-circle" src="{{ employee.getImage }}" alt="{{ employee.firstname }}" />
+          </span>
+          <span class="employee_profile">
+            {{ 'Welcome back %name%'|trans({'%name%': employee.firstname}, 'Admin.Navigation.Header') }}
+          </span>
+        </div>
+
+        <a class="dropdown-item employee-link profile-link" href="{{ path('admin_employees_edit', {employeeId: employee.id}) }}">
+          <i class="material-icons">edit</i>
+          <span>
+            {{ 'Your profile'|trans({}, 'Admin.Navigation.Header') }}
+          </span>
+        </a>
+      </div>
+
+      <p class="divider"></p>
+
+      {% for menuItem in displayBackOfficeEmployeeMenu %}
+        {% set menuItemProperties = menuItem.getProperties %}
+        <a class="dropdown-item {{ menuItem.getClass }}" href="{{ menuItemProperties.link }}" target="_blank" rel="noopener noreferrer nofollow">
+          {% if menuItemProperties.icon is defined %}
+            <i class="material-icons">{{ menuItemProperties.icon }}</i>
+          {% endif %}
+          {{ menuItem.getContent }}
+        </a>
+        {% if loop.last %}
+          <p class="divider"></p>
+        {% endif %}
+      {% endfor %}
+
+      <a class="dropdown-item employee-link text-center" id="header_logout" href="{{ logout_link|escape('html_attr') }}">
+        <i class="material-icons d-lg-none">power_settings_new</i>
+        <span>
+          {{ 'Sign out'|trans({}, 'Admin.Navigation.Header') }}
+        </span>
+      </a>
+    </div>
+</div>
+

--- a/src/PrestaShopBundle/Resources/views/Admin/Layout/employee_dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Layout/employee_dropdown.html.twig
@@ -1,0 +1,30 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+{{ component('EmployeeDropdown', {
+  employee: employee,
+  link: link,
+  displayBackOfficeEmployeeMenu: displayBackOfficeEmployeeMenu,
+  logout_link: logout_link,
+}) }}

--- a/src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
+++ b/src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Twig\Component;
+
+use Employee;
+use Link;
+use PrestaShop\PrestaShop\Core\Action\ActionsBarButtonsCollection;
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent(template: '@PrestaShop/Admin/Component/Layout/employee_dropdown.html.twig')]
+class EmployeeDropdown
+{
+    public Employee $employee;
+    public Link $link;
+    public ActionsBarButtonsCollection $displayBackOfficeEmployeeMenu;
+    public string $logout_link;
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Replace employee dropdown smarty template by twig template
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI 🟢 and auto tests 🟢 
| Fixed ticket?     | Fixes #32989
| Related PRs       | 
| Sponsor company   | 


If the phpstan exceptions concern only the legacy layout, you can generate the phpstan exceptions with ./vendor/bin/phpstan analyse -c phpstan.neon.dist --generate-baseline=phpstan-tmp-legacy-layout-baseline.neon . Since the exceptions are very temporary, this way we keep tracking specific legacy layout phpstan exception and we allow us to not forget or miss anything.