### PR TITLE
 Fix for child themes/multishop themes translations

### DIFF
--- a/src/PrestaShopBundle/Translation/Loader/SqlTranslationLoader.php
+++ b/src/PrestaShopBundle/Translation/Loader/SqlTranslationLoader.php
@@ -74,11 +74,15 @@ class SqlTranslationLoader implements LoaderInterface
             throw new NotFoundResourceException(sprintf('Language not found in database: %s', $locale));
         }
 
+        // If we get translations for a theme, realistically we need to get translations
+        // for all active themes from the database, since different stores can use different themes.
+        // If we don't do that, the first store's theme you visit after the cache is cleared will
+        // be the only one that has translations.
         $selectTranslationsQuery = '
             SELECT `key`, `translation`, `domain`
             FROM `' . _DB_PREFIX_ . 'translation`
             WHERE `id_lang` = ' . $localeResults[$locale]['id_lang'] . '
-            AND theme ' . ($this->theme !== null ? '= "' . $this->theme->getName() . '"' : 'IS NULL');
+            AND theme ' . ($this->theme !== null ? ' IN (SELECT `theme` FROM `' . _DB_PREFIX_ . 'shop` WHERE `active` = 1)' : 'IS NULL');
 
         $translations = Db::getInstance()->executeS($selectTranslationsQuery) ?: [];
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.1.x
| Description?      | Description below.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow the issue.
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/30716
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).

You have a multistore.
You have two themes: classic and classic-child.
In both of them, you have custom translations.
In one store, you use classic, in the second, you use classic-child.
You clear the translations cache, now, the first store and its theme get the translation catalog properly configured. But what if you use a child-theme on the second store? Its translations won't be taken into account.

You visit the first store where you have the classic theme, and it generates a catalog of translations only for the classic theme.
We don't know that classic has any parent, so we don't know that there are more translations to get to the generated catalog files.

Possible improvements:
`setTheme` to `setForThemesContext`, `string` to `bool`, and if we want translations for themes we get them all.

I checked BO and I didn't notice change of behavior there.
