### PR TITLE
Register commonly used deprecated modifiers to Smarty config

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -119,6 +119,18 @@ smartyRegisterFunction($smarty, 'modifier', 'print_r', 'print_r');
 smartyRegisterFunction($smarty, 'modifier', 'var_dump', 'var_dump');
 smartyRegisterFunction($smarty, 'modifier', 'lcfirst', 'lcfirst');
 smartyRegisterFunction($smarty, 'modifier', 'nl2br', 'nl2br');
+smartyRegisterFunction($smarty, 'modifier', 'sizeof', 'sizeof');
+smartyRegisterFunction($smarty, 'modifier', 'in_array', 'in_array');
+smartyRegisterFunction($smarty, 'modifier', 'substr', 'substr');
+smartyRegisterFunction($smarty, 'modifier', 'intval', 'intval');
+smartyRegisterFunction($smarty, 'modifier', 'date', 'date');
+smartyRegisterFunction($smarty, 'modifier', 'trim', 'trim');
+smartyRegisterFunction($smarty, 'modifier', 'json_encode', 'json_encode');
+smartyRegisterFunction($smarty, 'modifier', 'in_array', 'in_array');
+smartyRegisterFunction($smarty, 'modifier', 'stripslashes', 'stripslashes');
+smartyRegisterFunction($smarty, 'modifier', 'mt_rand', 'mt_rand');
+smartyRegisterFunction($smarty, 'modifier', 'md5', 'md5');
+smartyRegisterFunction($smarty, 'modifier', 'floatval', 'floatval');
 
 function smarty_modifier_htmlentitiesUTF8($string)
 {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | I discovered that many Smarty modifiers were not available and threw deprecate warnings after the recent Smarty upgrade.
| Type?             | bug fix 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Autotests and CI should be enough, to me, the best way to see before and after, was to see the modules translations page and theme translations page with debug mode enabled
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/32703
| Related PRs       | n/a
| Sponsor company | impSolutions
