### PR TITLE
 Fix for product editor is not storing some fields in multi shop context conservative fix for 8.1.x

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1899,6 +1899,16 @@ class AdminProductsControllerCore extends AdminController
                 if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
                     $values = (array) Tools::getValue('multishop_check', []);
                     $values['state'] = Product::STATE_SAVED;
+                    $values['id_manufacturer'] = true;
+                    $values['ean13'] = true;
+                    $values['mpn'] = true;
+                    $values['isbn'] = true;
+                    $values['upc'] = true;
+                    $values['reference'] = true;
+                    $values['weight'] = true;
+                    $values['depth'] = true;
+                    $values['width'] = true;
+                    $values['height'] = true;
 
                     $object->setFieldsToUpdate($values);
                 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fix for: Product editor is not storing fields like reference or EAN in multi shop context
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable multishop and two shops, edit product reference
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/31287
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/33116
| Sponsor company   | headissue GmbH

This is the conservative fix for 8.1.x. For develop I suggest to remove all the `multishop_check`  related code and stay with: https://github.com/PrestaShop/PrestaShop/pull/33116