### PR TITLE
Generate image for store after uploading it

### DIFF
--- a/tests/UI/campaigns/functional/BO/08_design/06_imageSettings/15_checkStoreImageFormat.ts
+++ b/tests/UI/campaigns/functional/BO/08_design/06_imageSettings/15_checkStoreImageFormat.ts
@@ -218,8 +218,6 @@ describe('BO - Design - Image Settings - Check product image format', async () =
         await expect(imageTypeJPG).to.be.eq(arg.extOriginal);
 
         // Check the WebP file
-        /*
-         * @todo : https://github.com/PrestaShop/PrestaShop/issues/32528
         const pathImageWEBP: string = `${files.getRootPath()}/img/st/${idStore}-stores_default.webp`;
 
         const fileExistsWEBP = await files.doesFileExist(pathImageWEBP);
@@ -227,7 +225,6 @@ describe('BO - Design - Image Settings - Check product image format', async () =
 
         const imageTypeWEBP = await files.getImageType(pathImageWEBP);
         await expect(imageTypeWEBP).to.be.eq('webp');
-         */
       });
 
       it('should go to FO page', async function () {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Generates all image formats for given store on the fly.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow steps in https://github.com/PrestaShop/PrestaShop/issues/32528.
| Fixed ticket?     | Fixes #32528
| Related PRs       | 
| Sponsor company   | 

Ping @Progi1984 - can you test please? :-)
