### PR TITLE
Check if product is active and orderable during checkout

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4991,10 +4991,10 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * Are all products of the Cart still available in the current state ? They might have been converted to another
-     * type of product since then
+     * Checks if all products of the cart are still available in the current state. They might have been converted to another
+     * type of product since then, ordering disabled or deactivated.
      *
-     * @return bool False if one of the products from the cart has been changed into a new type of product
+     * @return bool False if one of the product not publicly orderable anymore.
      */
     public function checkAllProductsAreStillAvailableInThisState()
     {
@@ -5002,7 +5002,13 @@ class CartCore extends ObjectModel
             $currentProduct = new Product();
             $currentProduct->hydrate($product);
 
+            // Check if the product combinations state is still valid
             if ($currentProduct->hasAttributes() && $product['id_product_attribute'] === '0') {
+                return false;
+            }
+
+            // Check if product is still active and possible to order
+            if (!$product['active'] || !$product['available_for_order']) {
                 return false;
             }
         }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4994,7 +4994,7 @@ class CartCore extends ObjectModel
      * Checks if all products of the cart are still available in the current state. They might have been converted to another
      * type of product since then, ordering disabled or deactivated.
      *
-     * @return bool False if one of the product not publicly orderable anymore.
+     * @return bool false if one of the product not publicly orderable anymore
      */
     public function checkAllProductsAreStillAvailableInThisState()
     {

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -733,10 +733,10 @@ class FrontControllerCore extends Controller
         }
 
         if (session_status() == PHP_SESSION_ACTIVE && isset($_SESSION['notifications'])) {
-            $notifications = array_merge($notifications, json_decode($_SESSION['notifications'], true));
+            $notifications = array_merge_recursive($notifications, json_decode($_SESSION['notifications'], true));
             unset($_SESSION['notifications']);
         } elseif (isset($_COOKIE['notifications'])) {
-            $notifications = array_merge($notifications, json_decode($_COOKIE['notifications'], true));
+            $notifications = array_merge_recursive($notifications, json_decode($_COOKIE['notifications'], true));
             unset($_COOKIE['notifications']);
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Checks if the product is active and orderable in all steps of the checkout. Should be probably unified with `Cart::checkQuantities` for v9, but this is a safe fix. This PR also backports https://github.com/PrestaShop/PrestaShop/pull/32946 by @Tofandel to make this fix work properly.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See if related issue is fixed.
| Fixed ticket?     | Fixes #33071
| Related PRs       |
| Sponsor company   | 
