### PR TITLE
Fix authorized application column length

### DIFF
--- a/src/PrestaShopBundle/Entity/AuthorizedApplication.php
+++ b/src/PrestaShopBundle/Entity/AuthorizedApplication.php
@@ -52,7 +52,7 @@ class AuthorizedApplication
     /**
      * @var string
      *
-     * @ORM\Column(name="name", type="string", length=255, unique=true)
+     * @ORM\Column(name="name", type="string", length=50, unique=true)
      */
     private $name;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fix authorized application column length to make it compatible with large versions of Mariadb. Also a length of 255 for an authorized application name is maybe overkill :D
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #33021 
| Fixed ticket?     | Fixes #33021 
| Related PRs       | -
| Sponsor company   | Prestashop SA
