### PR TITLE
Replace php error smarty template by twig component

### DIFF
--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -157,7 +157,11 @@
 {/if}
 
 {if isset($php_errors)}
-  {include file="error.tpl"}
+    {render_template
+      smarty_template="error.tpl"
+      twig_template="@PrestaShop/Admin/Layout/php_errors.html.twig"
+      php_errors=$php_errors
+    }
 {/if}
 
 {if (!isset($lite_display) || (isset($lite_display) && !$lite_display))}

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/php_errors.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/php_errors.html.twig
@@ -1,0 +1,44 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+{% if phpErrors|length > 0 %}
+<div class="bootstrap">
+  <div id="error-modal" class="modal fade">
+    <div class="modal-dialog">
+      <div class="alert alert-danger clearfix">
+        {% for phpError in phpErrors %}
+          {{ '%1$s on line %2$s in file %3$s'|trans({
+            '%1$s': phpError.type,
+            '%2$s': phpError.errline,
+            '%3$s': phpError.errfile,
+            }, 'Admin.Notifications.Error')
+          }}<br />
+          [{{ phpError.errno }}] {{ phpError.errstr }}<br /><br />
+        {% endfor %}
+        <button type="button" class="btn btn-default float-right" data-dismiss="modal"><i class="icon-remove"></i> {{ 'Close'|trans({}, 'Admin.Actions') }}</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Layout/php_errors.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Layout/php_errors.html.twig
@@ -1,0 +1,27 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+{{ component('PHPErrors', {
+  phpErrors: php_errors,
+}) }}

--- a/src/PrestaShopBundle/Twig/Component/PHPErrors.php
+++ b/src/PrestaShopBundle/Twig/Component/PHPErrors.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Twig\Component;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+
+#[AsTwigComponent(template: '@PrestaShop/Admin/Component/Layout/php_errors.html.twig')]
+class PHPErrors
+{
+    public array $phpErrors;
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Replace php error smarty template by twig component
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI 🟢 and auto tests 🟢 
| Fixed ticket?     | Fixes #33088
| Related PRs       |
| Sponsor company   |
