### PR TITLE
Prevent removing non restricted cart rules

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -611,6 +611,12 @@ class CartRuleCore extends ObjectModel
      */
     public static function deleteByIdCustomer($id_customer)
     {
+        // Remove cart rules only if we got some sensible ID of a customer.
+        // If we would pass zero further below, it would delete all non-customer-restricted cart rules.
+        if (empty($id_customer)) {
+            return false;
+        }
+
         $return = true;
         $cart_rules = new PrestaShopCollection('CartRule');
         $cart_rules->where('id_customer', '=', $id_customer);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Prevents removing non-restricted cart rules by passing zero as customer ID.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create some cart rules without customer restriction, call `CartRule::deleteByIdCustomer(0);`
| Fixed ticket?     | Fixes #33202
| Related PRs       | 
| Sponsor company   | 

Ping @PrestaShop/committers It should be probably never called. Is my fix correct?