### PR TITLE
Improve `Configuration` loading performance

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -171,7 +171,7 @@ class ConfigurationCore extends ObjectModel
      * @param bool $force force if configuration already loaded
      *
      */
-    public static function loadConfiguration(bool $force = false)
+    public static function loadConfiguration(bool $force = true)
     {
         if (static::configurationIsLoaded() && !$force) {
             return ;

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -168,9 +168,15 @@ class ConfigurationCore extends ObjectModel
 
     /**
      * Load all configuration data.
+     * @param bool $force force if configuration already loaded
+     *
      */
-    public static function loadConfiguration()
+    public static function loadConfiguration(bool $force = false)
     {
+        if (static::configurationIsLoaded() && !$force) {
+            return ;
+        }
+
         $sql = 'SELECT c.`name`, cl.`id_lang`, IF(cl.`id_lang` IS NULL, c.`value`, cl.`value`) AS value, c.id_shop_group, c.id_shop
                FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '` c
                LEFT JOIN `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '_lang` cl ON (c.`' . bqSQL(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Prevent to load Configuration when already loaded.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Test Ok + Enable profiling and check configuration queries
| Fixed ticket?     | N/A
| Related PRs       | N/A.
| Sponsor company   | Evolutive groupe
