### PR TITLE
Improve `Cart::getProducts` performances when `id_product` is given

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -645,14 +645,8 @@ class CartCore extends ObjectModel
         // Product cache must be strictly compared to NULL, or else an empty cart will add dozens of queries
         if ($this->_products !== null && !$refresh) {
             // Return product row with specified ID if it exists
-            if (is_int($id_product)) {
-                foreach ($this->_products as $product) {
-                    if ($product['id_product'] == $id_product) {
-                        return [$product];
-                    }
-                }
-
-                return [];
+            if (isset($this->_products[$id_product])) {
+                return [$this->_products[$id_product]];
             }
 
             return $this->_products;
@@ -846,7 +840,7 @@ class CartCore extends ObjectModel
                     );
                 }
 
-                $this->_products[] = $product;
+                $this->_products[$product['id_product']] = $product;
             }
         } else {
             $this->_products = $products;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Improve `Cart::getProducts` performances when `id_product` is given.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try `Cart::getProducts` and enable profiling to check the time execution
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | Evolutive
