### PR TITLE
Module manager - Empty category - Add raw filter to display html content

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_manage_empty.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_manage_empty.html.twig
@@ -29,7 +29,7 @@
     <div class="module-short-list">
       <span id="{{ category.refMenu }}_modules" class="module-search-result-title">{{ category.name | trans({}, 'Admin.Modules.Feature') }}</span>
       <div class="modules-list module-list-empty" data-name="{{ category.refMenu }}">
-        {{ hookData }}
+        {{ hookData|raw }}
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | .Module manager - Empty category - Add raw filter to allow html content
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow issue description and see that links are correct now
| Fixed ticket?     | Fixes #33235 