### PR TITLE
Prevent deleting main URL of a store

### DIFF
--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -106,7 +106,8 @@ class AdminShopUrlControllerCore extends AdminController
 
     public function renderList()
     {
-        $this->addRowActionSkipList('delete', [1]);
+        // We will hide "delete" action for all URLs that are set as main ones for the store
+        $this->addRowActionSkipList('delete', $this->getUnremovableUrls());
 
         $this->addRowAction('edit');
         $this->addRowAction('delete');
@@ -120,6 +121,19 @@ class AdminShopUrlControllerCore extends AdminController
         $this->_use_found_rows = false;
 
         return parent::renderList();
+    }
+
+    /**
+     * Returns a list of URLs that are selected as main ones for some store.
+     *
+     * @return array of URLs that are selected as main
+     */
+    protected function getUnremovableUrls()
+    {
+        return array_column(
+            Db::getInstance()->executeS('SELECT id_shop_url FROM ' . _DB_PREFIX_ . 'shop_url WHERE main = 1'),
+            'id_shop_url'
+        );
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | In shop URL controller, there was a first row hardcoded, that should not be deleted. This is not correct, we must prevent deleting the real main URLs of stores. Got inspired in group and statuses controller and got the IDs with a query.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Main URL of a store is not deletable anymore.
| Fixed ticket?     | Fixes #32864
| Related PRs       | 
| Sponsor company   | 
