### PR TITLE
Add a check for key generation

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -82,6 +82,7 @@ class ConfigurationTestCore
             'files' => false,
             'mails_dir' => 'mails',
             'openssl' => false,
+            'openssl_key_generation' => false,
             'simplexml' => false,
             'zip' => false,
             'fileinfo' => false,
@@ -396,6 +397,20 @@ class ConfigurationTestCore
     public static function test_openssl()
     {
         return function_exists('openssl_encrypt');
+    }
+
+    public static function test_openssl_key_generation()
+    {
+        $privateKey = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+
+        if ($privateKey === false) {
+            return false;
+        }
+
+        return true;
     }
 
     public static function test_sessions()

--- a/install-dev/controllers/http/system.php
+++ b/install-dev/controllers/http/system.php
@@ -95,6 +95,7 @@ class InstallControllerHttpSystem extends InstallControllerHttp implements HttpC
                         'gd' => $this->translator->trans('GD library is not installed', [], 'Install'),
                         'json' => $this->translator->trans('JSON extension is not loaded', [], 'Install'),
                         'openssl' => $this->translator->trans('PHP OpenSSL extension is not loaded', [], 'Install'),
+                        'openssl_key_generation' => $this->translator->trans('Unable to generate private keys using openssl_pkey_new. Check your OpenSSL configuration, especially the path to openssl.cafile.', [], 'Install'),
                         'pdo_mysql' => $this->translator->trans('PDO MySQL extension is not loaded', [], 'Install'),
                         'simplexml' => $this->translator->trans('SimpleXML extension is not loaded', [], 'Install'),
                         'zip' => $this->translator->trans('ZIP extension is not enabled', [], 'Install'),

--- a/src/Adapter/Requirement/CheckRequirements.php
+++ b/src/Adapter/Requirement/CheckRequirements.php
@@ -101,6 +101,7 @@ class CheckRequirements
             'json' => $this->translator->trans('Enable the JSON extension on your server.', [], 'Admin.Advparameters.Notification'),
             'mbstring' => $this->translator->trans('Enable the Mbstring extension on your server.', [], 'Admin.Advparameters.Notification'),
             'openssl' => $this->translator->trans('Enable the OpenSSL extension on your server.', [], 'Admin.Advparameters.Notification'),
+            'openssl_key_generation' => $this->translator->trans('Unable to generate private keys using openssl_pkey_new. Check your OpenSSL configuration, especially the path to openssl.cafile.', [], 'Admin.Advparameters.Notification'),
             'pdo_mysql' => $this->translator->trans('Enable the PDO Mysql extension on your server.', [], 'Admin.Advparameters.Notification'),
             'simplexml' => $this->translator->trans('Enable the XML extension on your server.', [], 'Admin.Advparameters.Notification'),
             'zip' => $this->translator->trans('Enable the ZIP extension on your server.', [], 'Admin.Advparameters.Notification'),


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Adds warning about key generation in order not to crash the installer.
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try installing.
| Fixed ticket?     | Fixes #33286
| Related PRs       | 
| Sponsor company   | 

### Related autoupgrade PR
https://github.com/PrestaShop/autoupgrade/pull/599

### Installer (old wording - check latest code)
![Snímek obrazovky 2023-07-18 153016](https://github.com/PrestaShop/PrestaShop/assets/6097524/2c9caf0b-8555-4548-aee2-9b19b1cdb940)

### Backoffice
![Snímek obrazovky 2023-07-18 154044](https://github.com/PrestaShop/PrestaShop/assets/6097524/bd5b8856-988c-43c8-a42d-52b8d5c17b6d)