### PR TITLE
Make independent Quick Access twig component

### DIFF
--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -25,10 +25,6 @@
         {render_template
           smarty_template="components/layout/quick_access.tpl"
           twig_template="@PrestaShop/Admin/Layout/quick_access.html.twig"
-          quick_access=$quick_access
-          link=$link
-          quick_access_current_link_icon=$quick_access_current_link_icon
-          quick_access_current_link_name=$quick_access_current_link_name
         }
       </div>
       <div class="component component-search" id="header-search-container">

--- a/phpstan-tmp-legacy-layout-baseline.neon
+++ b/phpstan-tmp-legacy-layout-baseline.neon
@@ -51,12 +51,7 @@ parameters:
 			path: src/PrestaShopBundle/Twig/Component/NotificationsCenter.php
 
 		-
-			message: "#^Class Link is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
-			count: 1
-			path: src/PrestaShopBundle/Twig/Component/QuickAccess.php
-
-		-
-			message: "#^Namespace Link is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			message: "#^Namespace Tools is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 1
 			path: src/PrestaShopBundle/Twig/Component/QuickAccess.php
 

--- a/src/Adapter/QuickAccess/Repository/QuickAccessRepository.php
+++ b/src/Adapter/QuickAccess/Repository/QuickAccessRepository.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\QuickAccess\Repository;
+
+use Doctrine\DBAL\Connection;
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\QuickAccess\QuickAccessRepositoryInterface;
+use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
+
+class QuickAccessRepository extends AbstractObjectModelRepository implements QuickAccessRepositoryInterface
+{
+    public function __construct(
+        private Connection $connection,
+        private string $dbPrefix
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAll(LanguageId $languageId): array
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->select('q.id_quick_access, q.new_window, q.link, ql.name')
+            ->from($this->dbPrefix . 'quick_access', 'q')
+            ->innerJoin(
+                'q',
+                $this->dbPrefix . 'quick_access_lang',
+                'ql',
+                'q.id_quick_access = ql.id_quick_access'
+            )
+            ->where('ql.id_lang = :languageId')
+            ->addOrderBy('ql.name', 'ASC')
+            ->setParameter('languageId', $languageId->getValue())
+        ;
+
+        return $qb->execute()->fetchAllAssociative();
+    }
+}

--- a/src/Core/QuickAccess/QuickAccessRepositoryInterface.php
+++ b/src/Core/QuickAccess/QuickAccessRepositoryInterface.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,5 +22,23 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
-{{ component('QuickAccess') }}
+ */
+
+namespace PrestaShop\PrestaShop\Core\QuickAccess;
+
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+
+/**
+ * Define the contract to access Quick Accesses.
+ */
+interface QuickAccessRepositoryInterface
+{
+    /**
+     * Returns the complete list of quick accesses.
+     *
+     * @param LanguageId $languageId
+     *
+     * @return array
+     */
+    public function fetchAll(LanguageId $languageId): array;
+}

--- a/src/PrestaShopBundle/Resources/config/services/adapter/quick_access.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/quick_access.yml
@@ -1,0 +1,11 @@
+services:
+  _defaults:
+    public: false
+    autowire: true
+    bind:
+      $dbPrefix: '%database_prefix%'
+
+  PrestaShop\PrestaShop\Core\QuickAccess\QuickAccessRepositoryInterface:
+    alias: PrestaShop\PrestaShop\Adapter\QuickAccess\Repository\QuickAccessRepository
+
+  PrestaShop\PrestaShop\Adapter\QuickAccess\Repository\QuickAccessRepository: ~

--- a/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
@@ -2,11 +2,15 @@ services:
   _defaults:
     public: true
 
-  prestashop.core.admin.tab.repository:
-    class: PrestaShopBundle\Entity\Repository\TabRepository
+  PrestaShopBundle\Entity\Repository\TabRepository:
     factory: [ '@doctrine.orm.default_entity_manager', getRepository ]
+    public: false
     arguments:
       - PrestaShopBundle\Entity\Tab
+
+  prestashop.core.admin.tab.repository:
+    alias: PrestaShopBundle\Entity\Repository\TabRepository
+    deprecated: ~
 
   prestashop.core.admin.shop.repository:
     class: 'PrestaShopBundle\Entity\Repository\ShopRepository'

--- a/src/PrestaShopBundle/Resources/config/services/core/security.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/security.yml
@@ -3,7 +3,7 @@ services:
     public: true
 
   prestashop.core.crypto.hashing:
-    class: 'PrestaShop\PrestaShop\Core\Crypto\Hashing'
+    class: PrestaShop\PrestaShop\Core\Crypto\Hashing
 
   prestashop.core.security.folder_guard.vendor:
     class: 'PrestaShop\PrestaShop\Core\Security\HtaccessFolderGuard'

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/quick_access.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/quick_access.html.twig
@@ -27,54 +27,47 @@
     {{ 'Quick Access'|trans({}, 'Admin.Navigation.Header') }}
   </button>
   <div class="dropdown-menu">
-    {% for quickAccess in quickAccess %}
-      <a class="
-        dropdown-item quick-row-link
+    {% for quickAccess in this.quickAccesses %}
+      <a class="dropdown-item quick-row-link
         {% if quickAccess.class is defined %}{{ quickAccess.class|escape('html_attr') }}{% endif %}
-        {% if link.matchQuickLink(quickAccess.link) %}
-          {% set matchQuickLink = quickAccess.id_quick_access %}
-          active
-        {% endif %}
-      "
+        {% if quickAccess.active %}active{% endif %}"
       href="{{ quickAccess.link|escape('html_attr') }}"
       {% if quickAccess.new_window %} target="_blank"{% endif %}
       data-item="{{ quickAccess.name }}"
       >{{ quickAccess.name|escape('html_attr') }}</a>
     {% endfor %}
     <div class="dropdown-divider"></div>
-    {% if matchQuickLink is defined %}
+    {% if this.currentQuickAccess %}
       <a id="quick-remove-link"
          class="dropdown-item js-quick-link"
          href="#"
          data-method="remove"
-         data-quicklink-id="{{ matchQuickLink }}"
+         data-quicklink-id="{{ this.currentQuickAccess.id_quick_access }}"
          data-rand="{{ random(1, 200) }}"
-         data-icon="{{ quickAccessCurrentLinkIcon }}"
-         data-url="{{ link.getQuickLink(app.request.uri) }}"
-         data-post-link="{{ link.getAdminLink('AdminQuickAccesses') }}"
+         data-url="{{ this.cleanCurrentUrl|escape('html_attr') }}"
+         data-post-link="{{ path('AdminQuickAccesses') }}"
          data-prompt-text="{{ 'Please name this shortcut:'|trans({}, 'Admin.Navigation.Header')|escape('html_attr') }}"
-         data-link="{{ quickAccessCurrentLinkName|u.truncate(32, '...') }}"
+         data-link="{{ this.currentQuickAccess.name|escape('html_attr') }}"
       >
         <i class="material-icons">remove_circle_outline</i>
         {{ 'Remove from Quick Access'|trans({}, 'Admin.Navigation.Header') }}
       </a>
     {% else %}
-    <a id="quick-add-link"
-       class="dropdown-item js-quick-link"
-       href="#"
-       data-rand="{{ random(1, 200) }}"
-       data-icon="{{ quickAccessCurrentLinkIcon }}"
-       data-method="add"
-       data-url="{{ link.getQuickLink(app.request.uri) }}"
-       data-post-link="{{ link.getAdminLink('AdminQuickAccesses') }}"
-       data-prompt-text="{{ 'Please name this shortcut:'|trans({}, 'Admin.Navigation.Header')|escape('html_attr')}}"
-       data-link="{{ quickAccessCurrentLinkName|u.truncate(32, '...') }}"
-    >
-      <i class="material-icons">add_circle</i>
-      {{ 'Add current page to Quick Access'|trans({}, 'Admin.Actions') }}
-    </a>
+      <a id="quick-add-link"
+         class="dropdown-item js-quick-link"
+         href="#"
+         data-rand="{{ random(1, 200) }}"
+         data-method="add"
+         data-url="{{ this.cleanCurrentUrl|escape('html_attr') }}"
+         data-post-link="{{ path('AdminQuickAccesses') }}"
+         data-prompt-text="{{ 'Please name this shortcut:'|trans({}, 'Admin.Navigation.Header')|escape('html_attr')}}"
+         data-link="{{ this.currentUrlTitle|escape('html_attr') }}"
+      >
+        <i class="material-icons">add_circle</i>
+        {{ 'Add current page to Quick Access'|trans({}, 'Admin.Actions') }}
+      </a>
     {% endif %}
-    <a id="quick-manage-link" class="dropdown-item" href="{{ link.getAdminLink('AdminQuickAccesses') }}">
+    <a id="quick-manage-link" class="dropdown-item" href="{{ path('AdminQuickAccesses') }}">
     <i class="material-icons">settings</i>
     {{ 'Manage your quick accesses'|trans({}, 'Admin.Navigation.Header') }}
     </a>

--- a/src/PrestaShopBundle/Twig/Component/QuickAccess.php
+++ b/src/PrestaShopBundle/Twig/Component/QuickAccess.php
@@ -28,14 +28,198 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Twig\Component;
 
-use Link;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
+use PrestaShop\PrestaShop\Core\QuickAccess\QuickAccessRepositoryInterface;
+use PrestaShop\PrestaShop\Core\Util\Url\UrlCleaner;
+use PrestaShopBundle\Entity\Repository\TabRepository;
+use PrestaShopBundle\Service\DataProvider\UserProvider;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
 #[AsTwigComponent(template: '@PrestaShop/Admin/Component/Layout/quick_access.html.twig')]
 class QuickAccess
 {
-    public array $quickAccess;
-    public Link $link;
-    public string $quickAccessCurrentLinkIcon;
-    public string $quickAccessCurrentLinkName;
+    /**
+     * link to new product creation form
+     */
+    private const NEW_PRODUCT_LINK = 'index.php/sell/catalog/products/new';
+
+    /**
+     * link to new product creation form for product v2
+     */
+    private const NEW_PRODUCT_V2_LINK = 'index.php/sell/catalog/products-v2/create';
+
+    /**
+     * List of Quick Accesses to display
+     */
+    private array|null $quickAccesses = null;
+
+    /**
+     * Current Quick access by current request uri
+     */
+    private array|false|null $currentQuickAccess = null;
+
+    /**
+     * Clean current Url
+     */
+    private ?string $currentUrl = null;
+
+    /**
+     * Current url title
+     */
+    private ?string $currentUrlTitle = null;
+
+    /**
+     * Tokenized Urls cache
+     */
+    private array $tokenizedUrls = [];
+
+    public function __construct(
+        private readonly LegacyContext $context,
+        private readonly QuickAccessRepositoryInterface $quickAccessRepository,
+        private readonly TabRepository $tabRepository,
+        private readonly CsrfTokenManagerInterface $tokenManager,
+        private readonly UserProvider $userProvider,
+        private readonly RequestStack $requestStack,
+        private readonly FeatureFlagStateCheckerInterface $featureFlagStateChecker,
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * Get quick accesses to display
+     */
+    public function getQuickAccesses(): array
+    {
+        if (null === $this->quickAccesses) {
+            // Get context
+            $context = $this->context->getContext();
+
+            // Get language and employee ids
+            $languageId = new LanguageId($context->employee->id_lang);
+
+            // Retrieve all quick accesses
+            $quickAccesses = $this->quickAccessRepository->fetchAll($languageId);
+
+            // Prepare quick accesses to render the component view properly.
+            foreach ($quickAccesses as $index => &$quick) {
+                // Initialise our Quick Access
+                $quick['class'] = '';
+                $quick['link'] = $context->link->getQuickLink($quick['link']);
+
+                // If this quick access is legacy
+                preg_match('/controller=(.+)(&.+)?$/', $quick['link'], $admin_tab);
+                if (isset($admin_tab[1])) {
+                    if (strpos($admin_tab[1], '&')) {
+                        $admin_tab[1] = substr($admin_tab[1], 0, strpos($admin_tab[1], '&'));
+                    }
+                }
+                // Let's build our url
+                if ($quick['link'] === self::NEW_PRODUCT_LINK || $quick['link'] === self::NEW_PRODUCT_V2_LINK) {
+                    if (!in_array('ROLE_MOD_TAB_ADMINPRODUCTS_CREATE', $this->userProvider->getUser()->getRoles())) {
+                        // if employee has no access, we don't show product creation link,
+                        // because it causes modal-related issues in product v2
+                        unset($quickAccesses[$index]);
+                        continue;
+                    }
+                    // if new product page feature is enabled we create new product v2 modal popup
+                    if ($this->featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_PRODUCT_PAGE_V2)) {
+                        $quick['link'] = self::NEW_PRODUCT_V2_LINK;
+                        $quick['class'] = 'new-product-button';
+                    }
+                }
+
+                // Preparation of the link to display in component view.
+                $quick['link'] = '/' . basename(_PS_ADMIN_DIR_) . '/' . $quick['link'];
+
+                // Verify if we are currently on this page.
+                $quick['active'] = $this->isCurrentPage($quick['link']);
+
+                // Add token if needed
+                $quick['link'] = $this->getTokenizedUrl($quick['link']);
+            }
+            $this->quickAccesses = $quickAccesses;
+        }
+
+        return $this->quickAccesses;
+    }
+
+    /**
+     * Retrieve and prepare quick accesses data for twig view
+     */
+    public function getCurrentQuickAccess(): array|false
+    {
+        if (null === $this->currentQuickAccess) {
+            $this->currentQuickAccess = current(array_filter($this->getQuickAccesses(), fn ($data) => $data['active']));
+        }
+
+        return $this->currentQuickAccess;
+    }
+
+    /**
+     * Get current clean url.
+     */
+    public function getCleanCurrentUrl(): string
+    {
+        if (null === $this->currentUrl) {
+            $this->currentUrl = rtrim(UrlCleaner::cleanUrl($this->requestStack->getMainRequest()->getRequestUri(), ['_token', 'token']), '/');
+        }
+
+        return $this->currentUrl;
+    }
+
+    /**
+     * Get current title
+     */
+    public function getCurrentUrlTitle(): string
+    {
+        if (null === $this->currentUrlTitle) {
+            $class_name = $this->requestStack->getMainRequest()->attributes->get('_legacy_controller');
+            $tab = $this->tabRepository->findOneByClassName($class_name);
+            $this->currentUrlTitle = $tab ? $this->translator->trans($tab->getWording(), [], $tab->getWordingDomain()) : '';
+        }
+
+        return $this->currentUrlTitle;
+    }
+
+    /**
+     * Get url tokenized
+     */
+    private function getTokenizedUrl(string $baseUrl): string
+    {
+        if (!in_array($baseUrl, $this->tokenizedUrls)) {
+            $url = $baseUrl;
+
+            // Define separator and if the url is legacy or symfony.
+            $separator = strpos($url, '?') ? '&' : '?';
+            preg_match('/controller=(\w*)/', $url, $admin_tab);
+
+            // If legacy link
+            if (isset($admin_tab[1]) && !str_contains('token', $url)) {
+                $token = $admin_tab[1] . $this->tabRepository->findOneIdByClassName($admin_tab[1]) . $this->context->getContext()->employee->id;
+                $url .= $separator . 'token=' . \Tools::getAdminToken($token);
+            }
+
+            // If symfony link
+            if (!isset($admin_tab[1]) && !str_contains('_token', $url)) {
+                $url .= $separator . '_token=' . $this->tokenManager->getToken($this->userProvider->getUsername())->getValue();
+            }
+            $this->tokenizedUrls[$baseUrl] = $url;
+        }
+
+        return $this->tokenizedUrls[$baseUrl];
+    }
+
+    /**
+     * Return true if the current page is the quick access url
+     */
+    private function isCurrentPage(string $url): bool
+    {
+        return 0 === strcasecmp($this->getCleanCurrentUrl(), rtrim($url, '/'));
+    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Make independent the Quick Access Twig component like explain in https://github.com/PrestaShop/PrestaShop/issues/33101.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Use QuickAccess on top of a Symfony page. 
| Fixed ticket?     | Fixes #33176
| Related PRs       | 
| Sponsor company   | PrestaShop SA

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PrestaShop/PrestaShop/33298)
<!-- Reviewable:end -->
