### PR TITLE
Get employee dropdown twig component independent

### DIFF
--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -125,10 +125,6 @@
             {render_template
               smarty_template="components/layout/employee_dropdown.tpl"
               twig_template="@PrestaShop/Admin/Layout/employee_dropdown.html.twig"
-              employee=$employee
-              link=$link
-              displayBackOfficeEmployeeMenu=$displayBackOfficeEmployeeMenu
-              logout_link=$logout_link
             }
         </div>
         {if isset($displayBackOfficeTop)}{$displayBackOfficeTop}{/if}

--- a/phpstan-tmp-legacy-layout-baseline.neon
+++ b/phpstan-tmp-legacy-layout-baseline.neon
@@ -6,17 +6,12 @@ parameters:
 			path: src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
 
 		-
-			message: "#^Class Link is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
-			count: 1
+			message: "#^Namespace Context is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 2
 			path: src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
 
 		-
 			message: "#^Namespace Employee is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
-			count: 1
-			path: src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
-
-		-
-			message: "#^Namespace Link is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 1
 			path: src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/employee_dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/employee_dropdown.html.twig
@@ -31,14 +31,14 @@
       <div class="employee-wrapper-avatar">
         <div class="employee-top">
           <span class="employee-avatar">
-            <img class="avatar rounded-circle" src="{{ employee.getImage }}" alt="{{ employee.firstname }}" />
+            <img class="avatar rounded-circle" src="{{ this.employee.getImage }}" alt="{{ this.employee.firstname }}" />
           </span>
           <span class="employee_profile">
-            {{ 'Welcome back %name%'|trans({'%name%': employee.firstname}, 'Admin.Navigation.Header') }}
+            {{ 'Welcome back %name%'|trans({'%name%': this.employee.firstname}, 'Admin.Navigation.Header') }}
           </span>
         </div>
 
-        <a class="dropdown-item employee-link profile-link" href="{{ path('admin_employees_edit', {employeeId: employee.id}) }}">
+        <a class="dropdown-item employee-link profile-link" href="{{ path('admin_employees_edit', {employeeId: this.employee.id}) }}">
           <i class="material-icons">edit</i>
           <span>
             {{ 'Your profile'|trans({}, 'Admin.Navigation.Header') }}
@@ -61,7 +61,7 @@
         {% endif %}
       {% endfor %}
 
-      <a class="dropdown-item employee-link text-center" id="header_logout" href="{{ logout_link|escape('html_attr') }}">
+      <a class="dropdown-item employee-link text-center" id="header_logout" href="{{ path('AdminLogin', {'logout' : 1})|escape('html_attr') }}">
         <i class="material-icons d-lg-none">power_settings_new</i>
         <span>
           {{ 'Sign out'|trans({}, 'Admin.Navigation.Header') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Layout/employee_dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Layout/employee_dropdown.html.twig
@@ -22,9 +22,4 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-{{ component('EmployeeDropdown', {
-  employee: employee,
-  link: link,
-  displayBackOfficeEmployeeMenu: displayBackOfficeEmployeeMenu,
-  logout_link: logout_link,
-}) }}
+{{ component('EmployeeDropdown') }}

--- a/src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
+++ b/src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
@@ -28,16 +28,46 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Twig\Component;
 
+use Context;
 use Employee;
-use Link;
 use PrestaShop\PrestaShop\Core\Action\ActionsBarButtonsCollection;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
 #[AsTwigComponent(template: '@PrestaShop/Admin/Component/Layout/employee_dropdown.html.twig')]
 class EmployeeDropdown
 {
-    public Employee $employee;
-    public Link $link;
-    public ActionsBarButtonsCollection $displayBackOfficeEmployeeMenu;
-    public string $logout_link;
+    private ?Employee $employee = null;
+    public ?ActionsBarButtonsCollection $displayBackOfficeEmployeeMenu = null;
+
+    public function __construct(private HookDispatcherInterface $hookDispatcher)
+    {
+    }
+
+    public function getEmployee()
+    {
+        if ($this->employee === null) {
+            $this->employee = Context::getContext()->employee;
+        }
+
+        return $this->employee;
+    }
+
+    public function getDisplayBackOfficeEmployeeMenu()
+    {
+        if ($this->displayBackOfficeEmployeeMenu === null) {
+            $menuLinksCollections = new ActionsBarButtonsCollection();
+
+            $this->hookDispatcher->dispatchWithParameters(
+                'displayBackOfficeEmployeeMenu',
+                [
+                    'links' => $menuLinksCollections,
+                ]
+            );
+
+            $this->displayBackOfficeEmployeeMenu = $menuLinksCollections;
+        }
+
+        return $this->displayBackOfficeEmployeeMenu;
+    }
 }

--- a/src/PrestaShopBundle/Twig/Extension/PathExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/PathExtension.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\Twig\Extension;
+
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * This class adds a function to twig template which points to back url if such is found in current request.
+ */
+class PathExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly LegacyContext $context
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'path',
+                [$this, 'getPath']
+            ),
+        ];
+    }
+
+    /**
+     * Get path for legacy or symfony link.
+     *
+     * @param string $routeName
+     * @param array $parameters
+     * @param bool $relative (only for symfony links)
+     *
+     * @return string
+     */
+    public function getPath(string $routeName, array $parameters = [], bool $relative = false): string
+    {
+        try {
+            $url = $this->urlGenerator->generate(
+                $routeName,
+                $parameters,
+                $relative ? UrlGeneratorInterface::RELATIVE_PATH : UrlGeneratorInterface::ABSOLUTE_PATH
+            );
+        } catch (RouteNotFoundException $ex) {
+            $url = $this->context->getAdminLink(controller: $routeName, extraParams: $parameters);
+        }
+
+        return $url;
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Get employee dropdown twig component independent. It means that internal properties should not come from the outside of the component.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI 🟢 and auto tests 🟢 
| Fixed ticket?     | Fixes #33180
| Related PRs       | 
| Sponsor company   | 
