### PR TITLE
Deprecate `SendCartToCustomer` in v9

### DIFF
--- a/src/Adapter/Cart/CommandHandler/SendCartToCustomerHandler.php
+++ b/src/Adapter/Cart/CommandHandler/SendCartToCustomerHandler.php
@@ -40,6 +40,7 @@ use Validate;
 
 /**
  * @internal
+ *
  * @deprecated Since 9.0 and will be removed in the next major.
  */
 #[AsCommandHandler]

--- a/src/Adapter/Cart/CommandHandler/SendCartToCustomerHandler.php
+++ b/src/Adapter/Cart/CommandHandler/SendCartToCustomerHandler.php
@@ -40,6 +40,7 @@ use Validate;
 
 /**
  * @internal
+ * @deprecated Since 9.0 and will be removed in the next major.
  */
 #[AsCommandHandler]
 final class SendCartToCustomerHandler implements SendCartToCustomerHanlderInterface

--- a/src/Core/Domain/Cart/Command/SendCartToCustomerCommand.php
+++ b/src/Core/Domain/Cart/Command/SendCartToCustomerCommand.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\ValueObject\CartId;
 
 /**
  * Sends email to the customer to process the payment for cart.
+ * @deprecated Since 9.0 and will be removed in the next major.
  */
 class SendCartToCustomerCommand
 {

--- a/src/Core/Domain/Cart/Command/SendCartToCustomerCommand.php
+++ b/src/Core/Domain/Cart/Command/SendCartToCustomerCommand.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\ValueObject\CartId;
 
 /**
  * Sends email to the customer to process the payment for cart.
+ *
  * @deprecated Since 9.0 and will be removed in the next major.
  */
 class SendCartToCustomerCommand

--- a/src/Core/Domain/Cart/CommandHandler/SendCartToCustomerHanlderInterface.php
+++ b/src/Core/Domain/Cart/CommandHandler/SendCartToCustomerHanlderInterface.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\Command\SendCartToCustomerCommand;
 
 /**
  * Interface for service that handles sending cart to customer.
+ * @deprecated Since 9.0 and will be removed in the next major.
  */
 interface SendCartToCustomerHanlderInterface
 {

--- a/src/Core/Domain/Cart/CommandHandler/SendCartToCustomerHanlderInterface.php
+++ b/src/Core/Domain/Cart/CommandHandler/SendCartToCustomerHanlderInterface.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\Command\SendCartToCustomerCommand;
 
 /**
  * Interface for service that handles sending cart to customer.
+ *
  * @deprecated Since 9.0 and will be removed in the next major.
  */
 interface SendCartToCustomerHanlderInterface

--- a/src/PrestaShopBundle/Resources/config/services/adapter/cart.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/cart.yml
@@ -61,6 +61,7 @@ services:
 
   prestashop.adapter.command_handler.send_cart_to_customer_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Cart\CommandHandler\SendCartToCustomerHandler'
+    deprecated: 'The "%service_id%" service is deprecated since 9.0 and will be removed in next major.'
     autoconfigure: true
 
   prestashop.adapter.query_handler.get_cart_for_viewing_handler:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Deprecate `SendCartToCustomer` in v9 : These command & handler are not used.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | CI is :green_circle: & Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/5598658270
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp
