### PR TITLE
Delete data from product_carrier table after deleting product

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1346,6 +1346,7 @@ class ProductCore extends ObjectModel
             !$this->deleteProductSale() ||
             !$this->deleteSearchIndexes() ||
             !$this->deleteAccessories() ||
+            !$this->deleteCarrierRestrictions() ||
             !$this->deleteFromAccessories() ||
             !$this->deleteFromSupplier() ||
             !$this->deleteDownload() ||
@@ -4580,6 +4581,20 @@ class ProductCore extends ObjectModel
     public function deleteAccessories()
     {
         return Db::getInstance()->delete('accessory', 'id_product_1 = ' . (int) $this->id);
+    }
+
+    /**
+     * Delete product carrier restriction.
+     *
+     * @return bool Deletion result
+     */
+    public function deleteCarrierRestrictions()
+    {
+        $all_shops = Context::getContext()->shop->getContext() == Shop::CONTEXT_ALL ? true : false;
+
+        return Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'product_carrier`
+            WHERE `id_product` = ' . (int) $this->id . (!$all_shops ? ' AND `id_shop` = ' . (int) Context::getContext()->shop->id : '')
+        );
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | After deleting product, the table product_carrier was not cleaned. Now it is. Multistore logic is the same like when deleting features.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below 
| Fixed ticket?     | Fixes #29205
| Related PRs       | 
| Sponsor company   |

### How to test
- Edit any product, limit the product to some carriers.
- Open PHPMYADMIN, open ps_product_carrier, see that there are entries for this product.
- Delete this product in BO.
- Check that the entries were removed from ps_product_carrier.