### PR TITLE
Lazyload product features

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5771,7 +5771,6 @@ class ProductCore extends ObjectModel
         }
 
         $row['id_image'] = Product::defineProductImage($row, $id_lang);
-        $row['features'] = Product::getFrontFeaturesStatic((int) $id_lang, $row['id_product']);
 
         $row['attachments'] = [];
         if (!isset($row['cache_has_attachments']) || $row['cache_has_attachments']) {

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -366,17 +366,36 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
+     * Returns all product features, not grouped yet for performance reasons.
+     *
      * @arrayAccess
      *
-     * @return array|null
+     * @return array
+     */
+    public function getFeatures()
+    {
+        /*
+         * If features were not loaded yet, we will ask for them if needed - usually on product page.
+         * However, if really hunting performance and you know you will need features in listing for bunch of products,
+         * fetch them with one query (in more performant way) and pass them here when constructing this object.
+         */
+        if (!isset($this->product['features'])) {
+            $this->product['features'] = Product::getFrontFeaturesStatic((int) $this->language->id, $this->product['id_product']);
+        }
+
+        return $this->product['features'];
+    }
+
+    /**
+     * Returns all product feature values nicely grouped by feature name.
+     *
+     * @arrayAccess
+     *
+     * @return array
      */
     public function getGroupedFeatures()
     {
-        if ($this->product['features']) {
-            return $this->buildGroupedFeatures($this->product['features']);
-        }
-
-        return null;
+        return $this->buildGroupedFeatures($this->getFeatures());
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Makes use of product lazy array and lazy loads product features only when they are needed. When product count per page is set to 24, it saves 24 database queries.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | yes - `Product::getProductsProperties` no longer contain `features`.
| Deprecations?     | no
| How to test?      | See below
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 

### How to test if nothing is broken
- Check product page and see that features display correctly. ✅ 
- Open `themes/classic/templates/catalog/_partials/miniatures/product.tpl`, put `{dump($product.features)}` somewhere and go check any product listing in FO. See that you have features available in that black box. ✅ 

### How to test performance
- Enable debug profiler in BO > Performance.
- Visit a category page, see that the query count is lower by amount products per page. If you have 12 products per page, queries will decrease from 100 to 88.