### PR TITLE
Update Link.php to fix an issue with invalid URLs

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1208,17 +1208,17 @@ class LinkCore
             $controller = $context->controller->php_self;
         }
 
-        if ($controller == 'product' && isset($params['id_product']) && $params['id_product'] !== false) {
+        if ($controller == 'product' && isset($params['id_product'])) {
             return $this->getProductLink((int) $params['id_product'], null, null, null, (int) $idLang);
-        } elseif ($controller == 'category' && isset($params['id_category']) && $params['id_category'] !== false) {
+        } elseif ($controller == 'category' && isset($params['id_category'])) {
             return $this->getCategoryLink((int) $params['id_category'], null, (int) $idLang);
-        } elseif ($controller == 'supplier' && isset($params['id_supplier']) && $params['id_supplier'] !== false) {
+        } elseif ($controller == 'supplier' && isset($params['id_supplier'])) {
             return $this->getSupplierLink((int) $params['id_supplier'], null, (int) $idLang);
-        } elseif ($controller == 'manufacturer' && isset($params['id_manufacturer']) && $params['id_manufacturer'] !== false) {
+        } elseif ($controller == 'manufacturer' && isset($params['id_manufacturer'])) {
             return $this->getManufacturerLink((int) $params['id_manufacturer'], null, (int) $idLang);
-        } elseif ($controller == 'cms' && isset($params['id_cms']) && $params['id_cms'] !== false) {
+        } elseif ($controller == 'cms' && isset($params['id_cms'])) {
             return $this->getCMSLink(new CMS((int) $params['id_cms']), null, null, (int) $idLang);
-        } elseif ($controller == 'cms' && isset($params['id_cms_category']) && $params['id_cms_category'] !== false) {
+        } elseif ($controller == 'cms' && isset($params['id_cms_category'])) {
             return $this->getCMSCategoryLink(new CMSCategory((int) $params['id_cms_category']), null, (int) $idLang);
         } elseif (isset($params['fc']) && $params['fc'] == 'module') {
             $module = Validate::isModuleName(Tools::getValue('module')) ? Tools::getValue('module') : '';

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1208,17 +1208,17 @@ class LinkCore
             $controller = $context->controller->php_self;
         }
 
-        if ($controller == 'product' && isset($params['id_product'])) {
+        if ($controller == 'product' && isset($params['id_product']) && $params['id_product'] !== false) {
             return $this->getProductLink((int) $params['id_product'], null, null, null, (int) $idLang);
-        } elseif ($controller == 'category' && isset($params['id_category'])) {
+        } elseif ($controller == 'category' && isset($params['id_category']) && $params['id_category'] !== false) {
             return $this->getCategoryLink((int) $params['id_category'], null, (int) $idLang);
-        } elseif ($controller == 'supplier' && isset($params['id_supplier'])) {
+        } elseif ($controller == 'supplier' && isset($params['id_supplier']) && $params['id_supplier'] !== false) {
             return $this->getSupplierLink((int) $params['id_supplier'], null, (int) $idLang);
-        } elseif ($controller == 'manufacturer' && isset($params['id_manufacturer'])) {
+        } elseif ($controller == 'manufacturer' && isset($params['id_manufacturer']) && $params['id_manufacturer'] !== false) {
             return $this->getManufacturerLink((int) $params['id_manufacturer'], null, (int) $idLang);
-        } elseif ($controller == 'cms' && isset($params['id_cms'])) {
+        } elseif ($controller == 'cms' && isset($params['id_cms']) && $params['id_cms'] !== false) {
             return $this->getCMSLink(new CMS((int) $params['id_cms']), null, null, (int) $idLang);
-        } elseif ($controller == 'cms' && isset($params['id_cms_category'])) {
+        } elseif ($controller == 'cms' && isset($params['id_cms_category']) && $params['id_cms_category'] !== false) {
             return $this->getCMSCategoryLink(new CMSCategory((int) $params['id_cms_category']), null, (int) $idLang);
         } elseif (isset($params['fc']) && $params['fc'] == 'module') {
             $module = Validate::isModuleName(Tools::getValue('module')) ? Tools::getValue('module') : '';

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1329,7 +1329,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
-        if(! $this->product) {
+        if (!$this->product) {
             return $breadcrumb;
         }
 
@@ -1352,7 +1352,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             ];
         }
 
-        if( ! $this->product ) {
+        if (!$this->product) {
             return $breadcrumb;
         }
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1348,6 +1348,10 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             ];
         }
 
+        if( ! $this->product ) {
+            return $breadcrumb;
+        }
+
         $breadcrumb['links'][] = [
             'title' => $this->product->name,
             'url' => $this->context->link->getProductLink($this->product, null, null, null, null, null, (int) $this->getIdProductAttributeByRequest()),

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1329,6 +1329,10 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
+        if(! $this->product) {
+            return $breadcrumb;
+        }
+
         $categoryDefault = new Category($this->product->id_category_default, $this->context->language->id);
 
         foreach ($categoryDefault->getAllParents() as $category) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers|
| ----------------- | -------------------------------------------------------|
| Branch?           | 8.1.x
| Description?      | Inside the method `getLanguageLink` the check for the `$params` is always done wrong as the key is present when a page is not found but the actual value is `false` on the key corresponding to the ID.<br>That makes the application raise a fatal later on when it search for the link:<br> `Invalid product vars at line 174 in file classes/Link.php`<br> `category vars at line 405 in file classes/Link.php`|
| Type?             | bug fix|
| Category?         | FO|
| BC breaks?        | no|
| Deprecations?     | no|
| How to test?      | The easiest way I found to test this is to install [`SEO Friendly URL Module](https://github.com/softwaremistri/smseourl)` which gonna remove the behavior on top of that method to redirect the user and makes it complex to reproduce the issue.<br>Then you can enter any wrong URL in category or product and problem gonna show up.|
| Fixed ticket?     | Fixes #33258, #33306|
| Sponsor company   | MBS Design|
