### PR TITLE
Added www-authenticate: bearer if the access token is invalid

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -101,5 +101,3 @@ api_platform:
       - '%kernel.project_dir%/src/PrestaShopBundle/ApiPlatform/Resources'
 
   metadata_backward_compatibility_layer: false
-  exception_to_status:
-    Lcobucci\JWT\Token\InvalidTokenStructure: 401

--- a/src/Core/Security/TokenAuthenticator.php
+++ b/src/Core/Security/TokenAuthenticator.php
@@ -28,6 +28,9 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Security;
 
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Token\InvalidTokenStructure;
+use Lcobucci\JWT\Token\Parser;
 use PrestaShop\PrestaShop\Core\Security\OAuth2\ResourceServerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
@@ -69,6 +72,20 @@ class TokenAuthenticator extends AbstractGuardAuthenticator
 
     public function supports(Request $request): bool
     {
+        try {
+            $authorization = $request->headers->get('Authorization') ?? null;
+            if (null === $authorization) {
+                return false;
+            }
+            $explode = explode(' ', $authorization);
+            if (count($explode) >= 2) {
+                $token = $explode[1];
+                (new Parser(new JoseEncoder()))->parse($token);
+            }
+        } catch (InvalidTokenStructure $e) {
+            return false;
+        }
+
         // Every request to the API should be handled by this Authenticator
         return true;
     }

--- a/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/02_externalAuthServer/02_resourceEndpoint.ts
+++ b/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/02_externalAuthServer/02_resourceEndpoint.ts
@@ -133,8 +133,7 @@ describe('API : External Auth Server - Resource Endpoint', async () => {
       await expect(api.getResponseHeader(apiResponse, 'WWW-Authenticate')).to.be.eq('Bearer');
     });
 
-    // @todo : https://github.com/PrestaShop/PrestaShop/issues/32768
-    it.skip('should request the endpoint /admin-dev/new-api/hook-status/1 with invalid access token', async function () {
+    it('should request the endpoint /admin-dev/new-api/hook-status/1 with invalid access token', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestEndpointWithInvalidAccessToken', baseContext);
 
       const apiResponse = await apiContext.get('new-api/hook-status/1', {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Returns a header WWW-Authenticate : Bearer if the access token is invalid
| Type?             | bug fix 
| Category?         | WS 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | https://github.com/PrestaShop/PrestaShop/issues/32882
| Fixed ticket?     | Fixes #32882
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
