### PR TITLE
Refacto image loading and allow cover configuration

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5549,17 +5549,6 @@ class ProductCore extends ObjectModel
             $cache_key .= '-pack' . $row['id_product_pack'];
         }
 
-        if (!isset($row['cover_image_id'])) {
-            $cover = static::getCover($row['id_product']);
-            if (isset($cover['id_image'])) {
-                $row['cover_image_id'] = $cover['id_image'];
-            }
-        }
-
-        if (isset($row['cover_image_id'])) {
-            $cache_key .= '-cover' . (int) $row['cover_image_id'];
-        }
-
         if (isset(self::$productPropertiesCache[$cache_key])) {
             return array_merge($row, self::$productPropertiesCache[$cache_key]);
         }
@@ -5716,8 +5705,6 @@ class ProductCore extends ObjectModel
                 $id_product_attribute
             );
         }
-
-        $row['id_image'] = Product::defineProductImage($row, $id_lang);
 
         /*
          * Loading of files attached to product. This is using cache_has_attachments property which needs to be managed

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -768,6 +768,9 @@ Country</value>
   <configuration id="PS_SMARTY_CONSOLE_KEY" name="PS_SMARTY_CONSOLE_KEY">
     <value>SMARTY_DEBUG</value>
   </configuration>
+  <configuration id="PS_USE_COMBINATION_IMAGE_IN_LISTING" name="PS_USE_COMBINATION_IMAGE_IN_LISTING">
+    <value>0</value>
+  </configuration>
   <configuration id="PS_ATTRIBUTE_ANCHOR_SEPARATOR" name="PS_ATTRIBUTE_ANCHOR_SEPARATOR">
     <value>-</value>
   </configuration>

--- a/src/Adapter/Product/PageConfiguration.php
+++ b/src/Adapter/Product/PageConfiguration.php
@@ -53,6 +53,7 @@ class PageConfiguration implements DataConfigurationInterface
         return [
             'display_quantities' => $this->configuration->getBoolean('PS_DISPLAY_QTIES'),
             'allow_add_variant_to_cart_from_listing' => $this->configuration->getBoolean('PS_ATTRIBUTE_CATEGORY_DISPLAY'),
+            'use_combination_image_in_listing' => $this->configuration->getBoolean('PS_USE_COMBINATION_IMAGE_IN_LISTING'),
             'attribute_anchor_separator' => $this->configuration->get('PS_ATTRIBUTE_ANCHOR_SEPARATOR'),
             'display_discount_price' => $this->configuration->getBoolean('PS_DISPLAY_DISCOUNT_PRICE'),
         ];
@@ -68,6 +69,7 @@ class PageConfiguration implements DataConfigurationInterface
         if ($this->validateConfiguration($config)) {
             $this->configuration->set('PS_DISPLAY_QTIES', (int) $config['display_quantities']);
             $this->configuration->set('PS_ATTRIBUTE_CATEGORY_DISPLAY', (int) $config['allow_add_variant_to_cart_from_listing']);
+            $this->configuration->set('PS_USE_COMBINATION_IMAGE_IN_LISTING', (int) $config['use_combination_image_in_listing']);
             $this->configuration->set('PS_ATTRIBUTE_ANCHOR_SEPARATOR', $config['attribute_anchor_separator']);
             $this->configuration->set('PS_DISPLAY_DISCOUNT_PRICE', (int) $config['display_discount_price']);
         }
@@ -84,6 +86,7 @@ class PageConfiguration implements DataConfigurationInterface
         $resolver->setRequired([
             'display_quantities',
             'allow_add_variant_to_cart_from_listing',
+            'use_combination_image_in_listing',
             'attribute_anchor_separator',
             'display_discount_price',
         ]);

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -80,7 +80,7 @@ class PageType extends TranslatorAwareType
                     'Admin.Shopparameters.Feature'
                 ),
                 'help' => $this->trans(
-                    'This option allows you to choose which image you want to use in listings for products with combinations. By default, it always uses the cover image of the product. If you enable this option and your filtering module is properly passing required information, you can show directly show the image of this combination.',
+                    'This option allows you to choose which image to display in listings for products with combinations. By default, the cover image of the product will be used. If you enable this option and your filtering module is properly passing the required information, then the default image of the combination found will be displayed.',
                     'Admin.Shopparameters.Feature'
                 ),
                 'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -74,6 +74,17 @@ class PageType extends TranslatorAwareType
                 ),
                 'required' => false,
             ])
+            ->add('use_combination_image_in_listing', SwitchType::class, [
+                'label' => $this->trans(
+                    'Use combination image in listings',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'This option allows you to choose which image you want to use in listings for products with combinations. By default, it always uses the cover image of the product. If you enable this option and your filtering module is properly passing required information, you can show directly show the image of this combination.',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'required' => false,
+            ])
             ->add('attribute_anchor_separator', ChoiceType::class, [
                 'label' => $this->trans(
                     'Separator of attribute anchor on the product links',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Read below
| Type?             | refacto
| Category?         | FO
| BC breaks?        | yes - if somebody was using cover_image_id property
| Deprecations?     | no
| How to test?      | See below
| Fixed ticket?     | 
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/659
| Sponsor company   |

### Description - performance
- This PR removes excess queries in `getProductProperties` regarding loading images. Everything is now resolved and fetched in `ProductLazyArray`.
- Query count drop on 24 products per page - 710 ➡️ 686

### Description - BC break
- Removes `cover_image_id` property that was used to override id_image. 
- You can still alter the cover by using standard presenter hook.

### Description - new behavior
- It adds a new functionality that allows to choose behavior of cover image for products with combinations.
- Right now, the cover is always forced, even if you present a product with combination specified.
- Now, it allows to specify:
  - If the cover image of products with combinations should be forced to the cover. (current behavior)
  - Or if it should select the first image associated to this combination. This could be useful if filtering module is passing some `id_product_attribute`. So you filter by "Black" attribute and you see all found products with black photos. If the merchant wants to still display the cover, he will just move it so it's the first image in the list.

### How to test
- This concerns only products with combinations.
- If you want to try it, use latest [dev branch of faceted search](https://github.com/PrestaShop/ps_facetedsearch) and enable new option in `Shop settings > Products > Use combination image in listings`.
- With the new option disabled
  - Product image in listings is the cover image all the time.
- With the new option enabled
  - On initial load or if no attribute filter is selected, you will see image of default combination.
  - Once you filter by any attribute, it passes the first `id_product_attribute` it found. You will see the image in more specific color, usually the closest combination found.

### Wording to validate
- Type: Switch
- Name: `Use combination image in listings`
- Helptext: `This option allows you to choose which image you want to display in listings for products with combinations. By default, it always uses the cover image of the product. If you enable this option and your filtering module is properly passing required information, it will display the default image of the combination found.`

### Screenshot
![Snímek obrazovky 2023-07-24 200815](https://github.com/PrestaShop/PrestaShop/assets/6097524/16e5420c-cd53-4199-b1bf-8064910138d8)