### PR TITLE
Improve reorder positions on grids

### DIFF
--- a/admin-dev/themes/new-theme/js/components/grid/extension/position-extension.ts
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/position-extension.ts
@@ -82,6 +82,9 @@ export default class PositionExtension {
             .removeClass('hover');
         },
       );
+
+    this.setReorderButtonLabel();
+    this.getReorderButton().on('click', (event) => this.oncClickReorderButton(event));
   }
 
   /**
@@ -254,5 +257,66 @@ export default class PositionExtension {
     }
 
     return mapping;
+  }
+
+  /**
+   * Check if position reorder is active
+   *
+   * @private
+   */
+  private isPositionsReorderActive(): boolean {
+    return this.grid.getContainer()
+      .find('.ps-sortable-column[data-sort-col-name="position"]')
+      .first()
+      .data('sort-is-current');
+  }
+
+  /**
+   * Get reorder button
+   *
+   * @private
+   */
+  private getReorderButton(): JQuery<HTMLElement> {
+    return this.grid
+      .getContainer()
+      .find('.js-btn-reorder-positions')
+      .first();
+  }
+
+  /**
+   * Set reorder button label in function of sortable column state.
+   *
+   * @private
+   */
+  private setReorderButtonLabel(): void {
+    const rearrangeButton = this.getReorderButton();
+    const label = this.isPositionsReorderActive()
+      ? rearrangeButton.data('label-save')
+      : rearrangeButton.data('label-reorder');
+    rearrangeButton.html(label);
+  }
+
+  /**
+   * Onclick reorder button
+   *
+   * @param event
+   * @private
+   */
+  private oncClickReorderButton(event: JQuery.Event): void {
+    event.preventDefault();
+    // If positions are actually being reordered...
+    if (this.isPositionsReorderActive()) {
+      // we need to reset filters and order by of the grid
+      this.grid.getContainer()
+        .find('.ps-sortable-column')
+        .first()
+        .click();
+    } else {
+      // Else, we need to set the position column as the current sort ordering
+      this.grid.getContainer()
+        .find('.ps-sortable-column[data-sort-col-name="position"]')
+        .first()
+        .click();
+    }
   }
 }

--- a/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
@@ -44,6 +44,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\PositionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use PrestaShopBundle\Form\Admin\Type\ReorderPositionsButtonType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
@@ -232,13 +233,7 @@ final class AttributeGridDefinitionFactory extends AbstractFilterableGridDefinit
             ])
             ->setAssociatedColumn('value')
             )
-            ->add((new Filter('position', TextType::class))
-            ->setTypeOptions([
-                'required' => false,
-                'attr' => [
-                    'placeholder' => $this->trans('Search position', [], 'Admin.Actions'),
-                ],
-            ])
+            ->add((new Filter('position', ReorderPositionsButtonType::class))
             ->setAssociatedColumn('position')
             )
             ->add((new Filter('actions', SearchAndResetType::class))

--- a/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
@@ -39,6 +39,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\PositionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
+use PrestaShopBundle\Form\Admin\Type\ReorderPositionsButtonType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
@@ -197,13 +198,7 @@ final class AttributeGroupGridDefinitionFactory extends AbstractFilterableGridDe
             ])
             ->setAssociatedColumn('name')
             )
-            ->add((new Filter('position', TextType::class))
-            ->setTypeOptions([
-                'required' => false,
-                'attr' => [
-                    'placeholder' => $this->trans('Search position', [], 'Admin.Actions'),
-                ],
-            ])
+            ->add((new Filter('position', ReorderPositionsButtonType::class))
             ->setAssociatedColumn('position')
             )
             ->add((new Filter('actions', SearchAndResetType::class))

--- a/src/Core/Grid/Definition/Factory/CarrierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CarrierGridDefinitionFactory.php
@@ -44,6 +44,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\PositionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ToggleColumn;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
+use PrestaShopBundle\Form\Admin\Type\ReorderPositionsButtonType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -204,11 +205,8 @@ class CarrierGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ])
             )
             ->add(
-                (new Filter('position', TextType::class))
+                (new Filter('position', ReorderPositionsButtonType::class))
                     ->setAssociatedColumn('position')
-                    ->setTypeOptions([
-                        'required' => false,
-                    ])
             )
             ->add(
                 (new Filter('actions', SearchAndResetType::class))

--- a/src/Core/Grid/Definition/Factory/CmsPageCategoryDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageCategoryDefinitionFactory.php
@@ -43,6 +43,7 @@ use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Multistore\MultistoreContextCheckerInterface;
+use PrestaShopBundle\Form\Admin\Type\ReorderPositionsButtonType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -266,13 +267,7 @@ final class CmsPageCategoryDefinitionFactory extends AbstractFilterableGridDefin
 
         if ($this->isAllShopContextOrShopFeatureIsNotUsed()) {
             $filterCollection
-                ->add((new Filter('position', TextType::class))
-                ->setTypeOptions([
-                    'required' => false,
-                    'attr' => [
-                        'placeholder' => $this->trans('Position', [], 'Admin.Global'),
-                    ],
-                ])
+                ->add((new Filter('position', ReorderPositionsButtonType::class))
                 ->setAssociatedColumn('position')
                 )
             ;

--- a/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
@@ -44,6 +44,7 @@ use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Multistore\MultistoreContextCheckerInterface;
+use PrestaShopBundle\Form\Admin\Type\ReorderPositionsButtonType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -278,13 +279,7 @@ class CmsPageDefinitionFactory extends AbstractGridDefinitionFactory
 
         if ($this->isAllShopContextOrShopFeatureIsNotUsed()) {
             $filterCollection
-                ->add((new Filter('position', TextType::class))
-                ->setTypeOptions([
-                    'required' => false,
-                    'attr' => [
-                        'placeholder' => $this->trans('Position', [], 'Admin.Global'),
-                    ],
-                ])
+                ->add((new Filter('position', ReorderPositionsButtonType::class))
                 ->setAssociatedColumn('position')
                 )
             ;

--- a/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
@@ -57,6 +57,7 @@ use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Shop\ShopConstraintContextInterface;
 use PrestaShopBundle\Form\Admin\Type\IntegerMinMaxFilterType;
 use PrestaShopBundle\Form\Admin\Type\NumberMinMaxFilterType;
+use PrestaShopBundle\Form\Admin\Type\ReorderPositionsButtonType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\ShopSelectorType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
@@ -576,14 +577,9 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
                 (new Filter('active', YesAndNoChoiceType::class))
                     ->setAssociatedColumn('active')
             )
-            ->add((new Filter('position', TextType::class))
-            ->setAssociatedColumn('position')
-            ->setTypeOptions([
-                'required' => false,
-                'attr' => [
-                    'placeholder' => $this->trans('Search position', [], 'Admin.Actions'),
-                ],
-            ])
+            ->add(
+                (new Filter('position', ReorderPositionsButtonType::class))
+                    ->setAssociatedColumn('position')
             )
             ->add(
                 (new Filter('actions', SearchAndResetType::class))

--- a/src/PrestaShopBundle/Form/Admin/Type/ReorderPositionsButtonType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ReorderPositionsButtonType.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\Form\Admin\Type;
+
+use Symfony\Component\Form\Extension\Core\Type\ButtonType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Class ReorderPositionsButtonType.
+ */
+class ReorderPositionsButtonType extends TranslatorAwareType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('position', ButtonType::class, [
+            'label' => $this->trans('Rearrange', 'Admin.Actions'),
+            'attr' => [
+                'class' => 'btn-default js-btn-reorder-positions',
+                'data-label-reorder' => $this->trans('Rearrange', 'Admin.Actions'),
+                'data-label-save' => $this->trans('Done', 'Admin.Actions'),
+            ],
+        ]);
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Type/ReorderPositionsButtonType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ReorderPositionsButtonType.php
@@ -41,6 +41,7 @@ class ReorderPositionsButtonType extends TranslatorAwareType
     {
         $builder->add('position', ButtonType::class, [
             'label' => $this->trans('Rearrange', 'Admin.Actions'),
+            'row_attr' => ['class' => 'mb-0'],
             'attr' => [
                 'class' => 'btn-default js-btn-reorder-positions',
                 'data-label-reorder' => $this->trans('Rearrange', 'Admin.Actions'),

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -2212,3 +2212,10 @@ services:
     autowire: true
     autoconfigure: true
     public: false
+
+  PrestaShopBundle\Form\Admin\Type\ReorderPositionsButtonType:
+    autowire: true
+    autoconfigure: true
+    public: false
+    arguments:
+      $locales: "@=service('prestashop.adapter.legacy.context').getLanguages()"

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -505,7 +505,8 @@
 {%- endblock form_row %}
 
 {% block button_row -%}
-    <div class="form-group">
+  {% set rowClass = "form-group " ~ form.vars.row_attr.class|default('')|trim %}
+    <div class="{{ rowClass }}">
         {{- form_widget(form) -}}
     </div>
 {%- endblock button_row %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Add button instead of positions filter in grids. <br>On click => we display reordered drag indicator.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #32833 
| Fixed ticket?     | Fixes #32833 
| Related PRs       | 
| Sponsor company   | PrestaShop SA
