### PR TITLE
Do not overwrite legend by empty value

### DIFF
--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -101,7 +101,7 @@ class ImageRetriever
         ) {
             // Now let's fetch extra information about thumbnail sizes etc. and add this information.
             // getImage also resolves a proper image legend, if it was missing in $image originally.
-            $image = array_merge( 
+            $image = array_merge(
                 $image,
                 $this->getImage($productInstance, $image['id_image'])
             );

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -74,18 +74,21 @@ class ImageRetriever
             $language->id
         );
 
+        // Get all product images that are related to this object
         $images = $productInstance->getImages($language->id);
-
         if (empty($images)) {
             return [];
         }
 
+        // Load all pairs of images assigned to combinations
         $combinationImages = $productInstance->getCombinationImages($language->id);
         if (!$combinationImages) {
             $combinationImages = [];
         }
-        $imageToCombinations = [];
 
+        // And resolve them by id_image
+        // We can't assign them directly because the $images array keys are not id_image
+        $imageToCombinations = [];
         foreach ($combinationImages as $imgs) {
             foreach ($imgs as $img) {
                 $imageToCombinations[$img['id_image']][] = $img['id_product_attribute'];
@@ -96,11 +99,14 @@ class ImageRetriever
             $productInstance,
             $imageToCombinations
         ) {
-            $image = array_merge($this->getImage(
-                $productInstance,
-                $image['id_image']
-            ), $image);
+            // Now let's fetch extra information about thumbnail sizes etc. and add this information.
+            // getImage also resolves a proper image legend, if it was missing in $image originally.
+            $image = array_merge( 
+                $image,
+                $this->getImage($productInstance, $image['id_image'])
+            );
 
+            // Assign a list of variants related to the given image
             if (isset($imageToCombinations[$image['id_image']])) {
                 $image['associatedVariants'] = $imageToCombinations[$image['id_image']];
             } else {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fixes empty image legends/titles. There is a fallback to object name implemented in `getImage`, but it got overwritten back to empty legend in `getAllProductImages`.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Delete image description from a product in BO. Visit that product in FO, inspect the main image and check that there is a product name in the `title` and `alt` tags. Some themes may have a fallback in them built in, test it with latest version of hummingbird.
| Fixed ticket?     | Fixes #21806
| Related PRs       | 
| Sponsor company   |
