### PR TITLE
Add message when duplicating product

### DIFF
--- a/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
@@ -372,6 +372,7 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
                 'extra_route_params' => [
                     'shopId' => $shopId,
                 ],
+                'confirm_message' => $this->trans('Remember to properly edit all information after duplicating - including SEO information and friendly URL.', [], 'Admin.Catalog.Notification'),
                 'modal_options' => new ModalOptions([
                     'title' => $this->trans('Duplicate product', [], 'Admin.Actions'),
                     'confirm_button_label' => $duplicateLabel,
@@ -475,6 +476,7 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
                 'route_param_name' => 'productId',
                 'route_param_field' => 'id_product',
                 'extra_route_params' => $extraRouteParams,
+                'confirm_message' => $this->trans('Remember to properly edit all information after duplicating - including SEO information and friendly URL.', [], 'Admin.Catalog.Notification'),
                 'modal_options' => new ModalOptions([
                     'title' => $this->trans('Duplicate product', [], 'Admin.Actions'),
                     'confirm_button_label' => $duplicateLabel,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Adds a notification to modal when duplicating a product, so the user knows he must edit the URL of the product. Change validated today on product council meet.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Click "duplicate product" and see
| Fixed ticket?     | Fixes #18529
| Related PRs       | 
| Sponsor company   | 

![Snímek obrazovky 2023-07-26 124631](https://github.com/PrestaShop/PrestaShop/assets/6097524/7ac9a296-1979-4695-8286-0a0d8f054d19)
