### PR TITLE
Use proper limit for CMS page content

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -268,6 +268,7 @@ class CmsPageType extends TranslatorAwareType
                 'type' => FormattedTextareaType::class,
                 'required' => false,
                 'options' => [
+                    'limit' => FormattedTextareaType::LIMIT_LONGTEXT_UTF8,
                     'constraints' => [
                         new CleanHtml([
                             'message' => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Type/FormattedTextareaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/FormattedTextareaType.php
@@ -39,9 +39,12 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class FormattedTextareaType extends TranslatorAwareType
 {
     /**
-     * Max size of UTF-8 content in MySQL text column
+     * Max size of UTF-8 content in MySQL text columns
      */
+    public const LIMIT_TINYTEXT_UTF8 = 84;
     public const LIMIT_TEXT_UTF8 = 21844;
+    public const LIMIT_MEDIUMTEXT_UTF8 = 5592414;
+    public const LIMIT_LONGTEXT_UTF8 = 1431655764;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | CMS page content is a LONGTEXT in database, which has a safe limit for multibyte characters much higher than 21844. Now a proper limit is used. (Note - there are no other columns in the database like this, this is the only usage.)
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See that you can successfully save CMS pages longer than 21844 characters.
| Fixed ticket?     | Slack discussion
| Related PRs       | 
| Sponsor company   |
