### PR TITLE
Remove redundant constraints

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -44,7 +44,6 @@ use PrestaShopBundle\Form\Admin\Type\TranslateType;
 use PrestaShopBundle\Form\Admin\Type\TypeaheadProductCollectionType;
 use PrestaShopBundle\Form\Admin\Type\TypeaheadProductPackCollectionType;
 use PrestaShopBundle\Form\FormHelper;
-use PrestaShopBundle\Form\Validator\Constraints\TinyMceMaxLength;
 use PrestaShopBundle\Service\Routing\Router;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
 use Symfony\Component\Form\FormBuilderInterface;

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -251,11 +251,6 @@ class ProductInformation extends CommonAbstractType
                     'attr' => [
                         'class' => 'serp-default-description',
                     ],
-                    'constraints' => [
-                        new TinyMceMaxLength([
-                            'max' => FormattedTextareaType::LIMIT_TEXT_UTF8,
-                        ]),
-                    ],
                 ],
                 'locales' => $this->locales,
                 'hideTabs' => true,
@@ -269,11 +264,6 @@ class ProductInformation extends CommonAbstractType
                         'class' => 'autoload_rte',
                         'placeholder' => $this->translator->trans('The summary is a short sentence describing your product.<br />It will appears at the top of your shop\'s product page, in product lists, and in search engines\' results page (so it\'s important for SEO). To give more details about your product, use the "Description" tab.', [], 'Admin.Catalog.Help'),
                         'counter' => $shortDescriptionLimit,
-                    ],
-                    'constraints' => [
-                        new TinyMceMaxLength([
-                            'max' => $shortDescriptionLimit,
-                        ]),
                     ],
                     'required' => false,
                 ],


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | If not passed, TinyMceMaxLength constraints are automatically initialized to a proper limit in FormattedTextareaType.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check that BO > Product > New/edit description fields still have counters to proper length 
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 
