### PR TITLE
Lazyload attribute_price property

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5629,11 +5629,6 @@ class ProductCore extends ObjectModel
         $row['link'] = $context->link->getProductLink((int) $row['id_product'], $row['link_rewrite'], $row['category'], $row['ean13']);
         $row['manufacturer_name'] = !empty((int) $row['id_manufacturer']) ? Manufacturer::getNameById((int) $row['id_manufacturer']) : null;
 
-        $row['attribute_price'] = 0;
-        if ($id_product_attribute) {
-            $row['attribute_price'] = (float) Combination::getPrice($id_product_attribute);
-        }
-
         if (isset($row['quantity_wanted'])) {
             // 'quantity_wanted' may very well be zero even if set
             $quantity = max((int) $row['minimal_quantity'], (int) $row['quantity_wanted']);

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Presenter\Product;
 
+use Combination;
 use Context;
 use DateTime;
 use Language;
@@ -1044,6 +1045,26 @@ class ProductLazyArray extends AbstractLazyArray
                 $this->product['availability_message'] = $config[$language->id] ?? null;
             }
         }
+    }
+
+    /**
+     * Returns extra price associated with current combination, if provided
+     *
+     * @arrayAccess
+     *
+     * @return float
+     */
+    public function getAttributePrice()
+    {
+        if (!isset($this->product['attribute_price'])) {
+            if (!empty($this->product['id_product_attribute'])) {
+                $this->product['attribute_price'] = (float) Combination::getPrice($this->product['id_product_attribute']);
+            } else {
+                $this->product['attribute_price'] = 0;
+            }
+        }
+
+        return (float) $this->product['attribute_price'];
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Lazyloads attribute_price property and since this property is unused in default themes. Saves 1 query per each product with combination - up to 24 queries per page for example.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | yes - partially, no BC break for themes, but if somebody was just using getProductProperties, the data won't be there.
| Deprecations?     | no
| How to test?      | Assign extra fee to all combinations of hummingbird t-shirt. Put `{$product.attribute_price}` somewhere to \themes\classic\templates\catalog\_partials\miniatures\product.tpl and see that it still works.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 
