### PR TITLE
Hide stores from web if no stores are configured

### DIFF
--- a/classes/Store.php
+++ b/classes/Store.php
@@ -202,4 +202,14 @@ class StoreCore extends ObjectModel
 
         return isset($row['id_store']);
     }
+
+    /**
+     * This method checks if at least one store is configured
+     *
+     * @return bool
+     */
+    public static function atLeastOneStoreExists()
+    {
+        return (bool) Db::getInstance()->getValue('SELECT `id_store` FROM ' . _DB_PREFIX_ . 'store', false);
+    }
 }

--- a/controllers/front/SitemapController.php
+++ b/controllers/front/SitemapController.php
@@ -107,11 +107,14 @@ class SitemapControllerCore extends FrontController
         $cms = CMSCategory::getRecurseCategory($this->context->language->id, 1, 1, 1);
         $links = $this->getCmsTree($cms);
 
-        $links[] = [
-            'id' => 'stores-page',
-            'label' => $this->trans('Our stores', [], 'Shop.Theme.Global'),
-            'url' => $this->context->link->getPageLink('stores'),
-        ];
+        // We hide stores page, if there is no page configured
+        if (Store::atLeastOneStoreExists()) {
+            $links[] = [
+                'id' => 'stores-page',
+                'label' => $this->trans('Our stores', [], 'Shop.Theme.Global'),
+                'url' => $this->context->link->getPageLink('stores'),
+            ];
+        }
 
         $links[] = [
             'id' => 'contact-page',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | If no stores are configured, we hide stores page from public sitemap and we refuse access to it. Also, removed some old methods related to store locator, which was deleted long time ago.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | yes - some old methods removed
| Deprecations?     | no
| How to test?      | Delete all stores, try to access stores page in FO. Check frontend sitemap page and see that it disappeared.
| Fixed ticket?     | Fixes #16133
| Related PRs       | 
| Sponsor company   | 

### Removed methods
- StoreController::processStoreAddress
- StoreController::getStoresForXml
- StoreController::displayAjax