### PR TITLE
Fix modules from distribution api, add badges to modules

### DIFF
--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -322,7 +322,7 @@ class ModuleRepository implements ModuleRepositoryInterface
                 }
             }
             if (!$merged) {
-                $modules[] = new Module($externalModule);
+                $modules->add(new Module($externalModule));
             }
         }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
@@ -76,6 +76,16 @@
             {% endblock %}
           </div>
           <div>
+            {% if module.database.installed != true %}
+              {% if module.attributes.download_url is defined and module.attributes.download_url is not empty %}
+                <span class="badge badge-info my-1"><i class="material-icons mr-1" style="font-size: 1rem;">cloud_download</i>{{ 'Cloud installation'|trans({}, 'Admin.Modules.Feature') }}</span>
+              {% else %}
+                <span class="badge badge-info my-1"><i class="material-icons mr-1" style="font-size: 1rem;">save</i>{{ 'On disk, not installed'|trans({}, 'Admin.Modules.Feature') }}</span>
+              {% endif %}
+            {% endif %}
+            {% if module.database.active is not null and module.database.active != true %}
+              <span class="badge badge-danger my-1">{{ 'Module disabled'|trans({}, 'Admin.Modules.Feature') }}</span>
+            {% endif %}
             {% if module.attributes.urls.upgrade is defined %}
                 <span class="badge badge-success my-1">{{ 'Upgrade available'|trans({}, 'Admin.Modules.Feature') }}</span>
             {% endif %}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Read below
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Disable a module and see that you see the badge. Does not need QA, the logic is the same as the `Upgrade available` label under it - check the code.
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/33462, (might, not blocking the PR if not https://github.com/PrestaShop/PrestaShop/issues/33295)
| Related PRs       | 
| Sponsor company   | 

### Description
- Fixes installation of modules from distribution api (possibly) 
- If a module is disabled, we show a `Module disabled` badge so the merchant knows it.
- If a module is not installed and available from API, we show cloud download badge.
- If a module is not installed and is on disk, we show a badge that it's on disk.

![available cloud](https://github.com/PrestaShop/PrestaShop/assets/6097524/4d4df431-196e-41b2-b094-13724ec8384f)
![local](https://github.com/PrestaShop/PrestaShop/assets/6097524/23ab1829-02d2-41cb-8931-eec595f3026f)
![disabled](https://github.com/PrestaShop/PrestaShop/assets/6097524/91723d9f-ecf0-46ee-97e2-7ea4b85c9d60)
