### PR TITLE
Fix select for when multishop is not enabled

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/specific-price/form/combination-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/specific-price/form/combination-selector.ts
@@ -110,7 +110,13 @@ export default class CombinationSelector {
     };
 
     const shopIdSelect = <HTMLSelectElement> this.container.querySelector(SpecificPriceMap.shopIdSelect);
-    const shopId = Number(shopIdSelect.value) ?? null;
+    let shopId = null;
+
+    // This check is here for when the multishop is not enabled.
+    // The selector shopIdSelect does not exist when multishop is not enabled.
+    if (shopIdSelect !== null) {
+      shopId = Number(shopIdSelect.value);
+    }
 
     if (shopId) {
       routeParams.shopId = shopId;

--- a/admin-dev/themes/new-theme/js/pages/product/specific-price/form/customer-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/specific-price/form/customer-selector.ts
@@ -31,9 +31,13 @@ export default class CustomerSelector {
   }
 
   private init(): void {
-    const customerSearchInput = this.initCustomerSearchInput();
-    // clear selected customers whenever shop is changed, because customers may differ between shops
-    this.getShopIdSelect().addEventListener('change', () => customerSearchInput.setValues([]));
+    // This check is here for when the multishop is not enabled.
+    // The selector returned by the this.getShopIdSelect does not exist when multishop is not enabled.
+    if (this.getShopIdSelect() !== null) {
+      const customerSearchInput = this.initCustomerSearchInput();
+      // clear selected customers whenever shop is changed, because customers may differ between shops
+      this.getShopIdSelect().addEventListener('change', () => customerSearchInput.setValues([]));
+    }
   }
 
   private initCustomerSearchInput(): EntitySearchInput {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x 
| Description?      | The drop down with combinations was not populated by combinations when the multishop wasn't enabled.
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow the steps mentioned in [#33261](https://github.com/PrestaShop/PrestaShop/issues/33261)
| Fixed ticket?     | Fixes #33261
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA
