### PR TITLE
Update egulias/email-validator to 4.0.1 and bump multiple doctrine deps

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1015,35 +1015,39 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "2.13.8",
+            "version": "3.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "dc9b3c3c8592c935a6e590441f9abc0f9eba335b"
+                "reference": "96d5a70fd91efdcec81fc46316efc5bf3da17ddf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/dc9b3c3c8592c935a6e590441f9abc0f9eba335b",
-                "reference": "dc9b3c3c8592c935a6e590441f9abc0f9eba335b",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/96d5a70fd91efdcec81fc46316efc5bf3da17ddf",
+                "reference": "96d5a70fd91efdcec81fc46316efc5bf3da17ddf",
                 "shasum": ""
             },
             "require": {
-                "doctrine/cache": "^1.0|^2.0",
-                "doctrine/deprecations": "^0.5.3",
-                "doctrine/event-manager": "^1.0",
-                "ext-pdo": "*",
-                "php": "^7.1 || ^8"
+                "composer-runtime-api": "^2",
+                "doctrine/cache": "^1.11|^2.0",
+                "doctrine/deprecations": "^0.5.3|^1",
+                "doctrine/event-manager": "^1|^2",
+                "php": "^7.4 || ^8.0",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
             },
             "require-dev": {
-                "doctrine/coding-standard": "9.0.0",
-                "jetbrains/phpstorm-stubs": "2021.1",
-                "phpstan/phpstan": "1.4.6",
-                "phpunit/phpunit": "^7.5.20|^8.5|9.5.16",
-                "psalm/plugin-phpunit": "0.16.1",
-                "squizlabs/php_codesniffer": "3.6.2",
-                "symfony/cache": "^4.4",
-                "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
-                "vimeo/psalm": "4.22.0"
+                "doctrine/coding-standard": "12.0.0",
+                "fig/log-test": "^1",
+                "jetbrains/phpstorm-stubs": "2023.1",
+                "phpstan/phpstan": "1.10.21",
+                "phpstan/phpstan-strict-rules": "^1.5",
+                "phpunit/phpunit": "9.6.9",
+                "psalm/plugin-phpunit": "0.18.4",
+                "squizlabs/php_codesniffer": "3.7.2",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/console": "^4.4|^5.4|^6.0",
+                "vimeo/psalm": "4.30.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -1054,7 +1058,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\DBAL\\": "lib/Doctrine/DBAL"
+                    "Doctrine\\DBAL\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1097,14 +1101,13 @@
                 "queryobject",
                 "sasql",
                 "sql",
-                "sqlanywhere",
                 "sqlite",
                 "sqlserver",
                 "sqlsrv"
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/2.13.8"
+                "source": "https://github.com/doctrine/dbal/tree/3.6.5"
             },
             "funding": [
                 {
@@ -1120,29 +1123,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-09T15:25:46+00:00"
+            "time": "2023-07-17T09:15:50+00:00"
         },
         {
             "name": "doctrine/deprecations",
-            "version": "v0.5.3",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "9504165960a1f83cc1480e2be1dd0a0478561314"
+                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/9504165960a1f83cc1480e2be1dd0a0478561314",
-                "reference": "9504165960a1f83cc1480e2be1dd0a0478561314",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
+                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1|^8.0"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0|^7.0|^8.0",
-                "phpunit/phpunit": "^7.0|^8.0|^9.0",
-                "psr/log": "^1.0"
+                "doctrine/coding-standard": "^9",
+                "phpstan/phpstan": "1.4.10 || 1.10.15",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psalm/plugin-phpunit": "0.18.4",
+                "psr/log": "^1 || ^2 || ^3",
+                "vimeo/psalm": "4.30.0 || 5.12.0"
             },
             "suggest": {
                 "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
@@ -1161,9 +1168,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v0.5.3"
+                "source": "https://github.com/doctrine/deprecations/tree/v1.1.1"
             },
-            "time": "2021-03-21T12:59:47+00:00"
+            "time": "2023-06-03T09:27:29+00:00"
         },
         {
             "name": "doctrine/doctrine-bundle",
@@ -1534,31 +1541,33 @@
         },
         {
             "name": "doctrine/lexer",
-            "version": "1.2.3",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229"
+                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/c268e882d4dbdd85e36e4ad69e02dc284f89d229",
-                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
+                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
                 "shasum": ""
             },
             "require": {
+                "doctrine/deprecations": "^1.0",
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9.0",
+                "doctrine/coding-standard": "^9 || ^10",
                 "phpstan/phpstan": "^1.3",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.11"
+                "psalm/plugin-phpunit": "^0.18.3",
+                "vimeo/psalm": "^4.11 || ^5.0"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
+                    "Doctrine\\Common\\Lexer\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1590,7 +1599,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/1.2.3"
+                "source": "https://github.com/doctrine/lexer/tree/2.1.0"
             },
             "funding": [
                 {
@@ -1606,57 +1615,59 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-28T11:07:21+00:00"
+            "time": "2022-12-14T08:49:07+00:00"
         },
         {
             "name": "doctrine/orm",
-            "version": "2.12.1",
+            "version": "2.14.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "2e4a8722721b934149ff53b191522a6829b6d73b"
+                "reference": "a64f315dfeae5e50b17f132626fd9e9b4ec8985d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/2e4a8722721b934149ff53b191522a6829b6d73b",
-                "reference": "2e4a8722721b934149ff53b191522a6829b6d73b",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/a64f315dfeae5e50b17f132626fd9e9b4ec8985d",
+                "reference": "a64f315dfeae5e50b17f132626fd9e9b4ec8985d",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2",
                 "doctrine/cache": "^1.12.1 || ^2.1.1",
-                "doctrine/collections": "^1.5",
+                "doctrine/collections": "^1.5 || ^2.0",
                 "doctrine/common": "^3.0.3",
                 "doctrine/dbal": "^2.13.1 || ^3.2",
-                "doctrine/deprecations": "^0.5.3",
-                "doctrine/event-manager": "^1.1",
+                "doctrine/deprecations": "^0.5.3 || ^1",
+                "doctrine/event-manager": "^1.2 || ^2",
                 "doctrine/inflector": "^1.4 || ^2.0",
                 "doctrine/instantiator": "^1.3",
-                "doctrine/lexer": "^1.2.3",
+                "doctrine/lexer": "^1.2.3 || ^2",
                 "doctrine/persistence": "^2.4 || ^3",
                 "ext-ctype": "*",
                 "php": "^7.1 || ^8.0",
                 "psr/cache": "^1 || ^2 || ^3",
-                "symfony/console": "^3.0 || ^4.0 || ^5.0 || ^6.0",
+                "symfony/console": "^4.2 || ^5.0 || ^6.0",
                 "symfony/polyfill-php72": "^1.23",
                 "symfony/polyfill-php80": "^1.16"
             },
             "conflict": {
-                "doctrine/annotations": "<1.13 || >= 2.0"
+                "doctrine/annotations": "<1.13 || >= 3.0"
             },
             "require-dev": {
-                "doctrine/annotations": "^1.13",
-                "doctrine/coding-standard": "^9.0",
+                "doctrine/annotations": "^1.13 || ^2",
+                "doctrine/coding-standard": "^9.0.2 || ^11.0",
                 "phpbench/phpbench": "^0.16.10 || ^1.0",
-                "phpstan/phpstan": "~1.4.10 || 1.5.0",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
+                "phpstan/phpstan": "~1.4.10 || 1.10.6",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6",
                 "psr/log": "^1 || ^2 || ^3",
-                "squizlabs/php_codesniffer": "3.6.2",
+                "squizlabs/php_codesniffer": "3.7.2",
                 "symfony/cache": "^4.4 || ^5.4 || ^6.0",
+                "symfony/var-exporter": "^4.4 || ^5.4 || ^6.2",
                 "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-                "vimeo/psalm": "4.22.0"
+                "vimeo/psalm": "4.30.0 || 5.9.0"
             },
             "suggest": {
+                "ext-dom": "Provides support for XSD validation for XML mapping files",
                 "symfony/cache": "Provides cache support for Setup Tool with doctrine/cache 2.0",
                 "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"
             },
@@ -1703,9 +1714,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/2.12.1"
+                "source": "https://github.com/doctrine/orm/tree/2.14.3"
             },
-            "time": "2022-04-22T17:46:03+00:00"
+            "time": "2023-04-20T09:46:32+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -1859,26 +1870,26 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "3.2.6",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "e5997fa97e8790cdae03a9cbd5e78e45e3c7bda7"
+                "reference": "3a85486b709bc384dae8eb78fb2eec649bdb64ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/e5997fa97e8790cdae03a9cbd5e78e45e3c7bda7",
-                "reference": "e5997fa97e8790cdae03a9cbd5e78e45e3c7bda7",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/3a85486b709bc384dae8eb78fb2eec649bdb64ff",
+                "reference": "3a85486b709bc384dae8eb78fb2eec649bdb64ff",
                 "shasum": ""
             },
             "require": {
-                "doctrine/lexer": "^1.2|^2",
-                "php": ">=7.2",
-                "symfony/polyfill-intl-idn": "^1.15"
+                "doctrine/lexer": "^2.0 || ^3.0",
+                "php": ">=8.1",
+                "symfony/polyfill-intl-idn": "^1.26"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5.8|^9.3.3",
-                "vimeo/psalm": "^4"
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^4.30"
             },
             "suggest": {
                 "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
@@ -1886,7 +1897,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -1914,7 +1925,7 @@
             ],
             "support": {
                 "issues": "https://github.com/egulias/EmailValidator/issues",
-                "source": "https://github.com/egulias/EmailValidator/tree/3.2.6"
+                "source": "https://github.com/egulias/EmailValidator/tree/4.0.1"
             },
             "funding": [
                 {
@@ -1922,7 +1933,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-06-01T07:04:22+00:00"
+            "time": "2023-01-14T14:17:03+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -23,7 +23,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception as DBALException;
 
 ob_start();
 

--- a/src/Adapter/Alias/Repository/AliasRepository.php
+++ b/src/Adapter/Alias/Repository/AliasRepository.php
@@ -123,7 +123,7 @@ class AliasRepository extends AbstractObjectModelRepository
             ->setParameter('alias', $alias)
         ;
 
-        return (bool) $qb->execute()->fetchOne();
+        return (bool) $qb->executeQuery()->fetchOne();
     }
 
     /**
@@ -140,7 +140,7 @@ class AliasRepository extends AbstractObjectModelRepository
             ->setParameter('search', $searchTerm)
         ;
 
-        return $qb->execute()->fetchFirstColumn();
+        return $qb->executeQuery()->fetchFirstColumn();
     }
 
     public function delete(AliasId $aliasId): void
@@ -175,7 +175,7 @@ class AliasRepository extends AbstractObjectModelRepository
             ->from($this->dbPrefix . 'alias', 'a')
             ->where('a.search = :searchTerm')
             ->setParameter('searchTerm', $searchTerm)
-            ->execute()
+            ->executeQuery()
             ->fetchFirstColumn()
         ;
 
@@ -216,7 +216,7 @@ class AliasRepository extends AbstractObjectModelRepository
             ->setMaxResults($limit)
             ->where('a.search LIKE :searchPhrase')
             ->setParameter('searchPhrase', '%' . $searchPhrase . '%')
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative();
     }
 }

--- a/src/Adapter/Attachment/AttachmentRepository.php
+++ b/src/Adapter/Attachment/AttachmentRepository.php
@@ -103,7 +103,7 @@ class AttachmentRepository extends AbstractObjectModelRepository
             ->setParameter('productId', $productId->getValue())
         ;
 
-        $results = $qb->execute()->fetchAll();
+        $results = $qb->executeQuery()->fetchAllAssociative();
 
         if (empty($results)) {
             return [];
@@ -151,7 +151,7 @@ class AttachmentRepository extends AbstractObjectModelRepository
             ->addGroupBy('a.id_attachment')
         ;
 
-        $results = $qb->execute()->fetchAll();
+        $results = $qb->executeQuery()->fetchAllAssociative();
 
         if (empty($results)) {
             return [];
@@ -200,7 +200,7 @@ class AttachmentRepository extends AbstractObjectModelRepository
             ->setParameter('attachmentIds', $attachmentIds, Connection::PARAM_INT_ARRAY)
         ;
 
-        $results = $qb->execute()->fetchAll();
+        $results = $qb->executeQuery()->fetchAllAssociative();
 
         $localizedAttachments = [];
         foreach ($results as $result) {

--- a/src/Adapter/Attribute/Repository/AttributeRepository.php
+++ b/src/Adapter/Attribute/Repository/AttributeRepository.php
@@ -85,7 +85,7 @@ class AttributeRepository extends AbstractObjectModelRepository
             ->setParameter('idsList', $attributeIds, Connection::PARAM_INT_ARRAY)
         ;
 
-        $result = (int) $qb->execute()->fetch()['total'];
+        $result = (int) $qb->executeQuery()->fetchAssociative()['total'];
 
         if (count($attributeIds) !== $result) {
             throw new AttributeNotFoundException('Some of provided attributes does not exist');
@@ -149,7 +149,7 @@ class AttributeRepository extends AbstractObjectModelRepository
             ;
         }
 
-        $results = $qb->execute()->fetchAllAssociative();
+        $results = $qb->executeQuery()->fetchAllAssociative();
 
         if (!$results) {
             return [];
@@ -232,7 +232,7 @@ class AttributeRepository extends AbstractObjectModelRepository
             ->where($qb->expr()->in('a.id_attribute', ':attributeIds'))
             ->setParameter('shopIds', $shopIdValues, Connection::PARAM_INT_ARRAY)
             ->setParameter('attributeIds', $attributeIdValues, Connection::PARAM_INT_ARRAY)
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative()
         ;
 
@@ -271,7 +271,7 @@ class AttributeRepository extends AbstractObjectModelRepository
             ->setParameter('combinationIds', $combinationIds, Connection::PARAM_INT_ARRAY)
         ;
 
-        return $qb->execute()->fetchAll();
+        return $qb->executeQuery()->fetchAllAssociative();
     }
 
     /**
@@ -311,7 +311,7 @@ class AttributeRepository extends AbstractObjectModelRepository
             ->setParameter('langId', $langId)
         ;
 
-        $attributesInfo = $qb->execute()->fetchAll();
+        $attributesInfo = $qb->executeQuery()->fetchAllAssociative();
 
         $attributesInfoByAttributeId = [];
         foreach ($attributesInfo as $attributeInfo) {

--- a/src/Adapter/AttributeGroup/Repository/AttributeGroupRepository.php
+++ b/src/Adapter/AttributeGroup/Repository/AttributeGroupRepository.php
@@ -163,7 +163,7 @@ class AttributeGroupRepository extends AbstractMultiShopObjectModelRepository
             ;
         }
 
-        $results = $qb->execute()->fetchAllAssociative();
+        $results = $qb->executeQuery()->fetchAllAssociative();
 
         if (!$results) {
             return [];
@@ -225,7 +225,7 @@ class AttributeGroupRepository extends AbstractMultiShopObjectModelRepository
             ->andWhere($qb->expr()->in('ag.id_attribute_group', ':attributeGroupIds'))
             ->setParameter('shopIds', $shopIdValues, Connection::PARAM_INT_ARRAY)
             ->setParameter('attributeGroupIds', $attributeGroupIdValues, Connection::PARAM_INT_ARRAY)
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative()
         ;
 

--- a/src/Adapter/Cache/MemcacheServerManager.php
+++ b/src/Adapter/Cache/MemcacheServerManager.php
@@ -60,7 +60,7 @@ class MemcacheServerManager
      */
     public function addServer($serverIp, $serverPort, $serverWeight)
     {
-        $this->connection->executeUpdate('INSERT INTO ' . $this->tableName . ' (ip, port, weight) VALUES(:serverIp, :serverPort, :serverWeight)', [
+        $this->connection->executeStatement('INSERT INTO ' . $this->tableName . ' (ip, port, weight) VALUES(:serverIp, :serverPort, :serverWeight)', [
             'serverIp' => $serverIp,
             'serverPort' => (int) $serverPort,
             'serverWeight' => (int) $serverWeight,
@@ -118,6 +118,6 @@ class MemcacheServerManager
      */
     public function getServers()
     {
-        return $this->connection->fetchAll('SELECT * FROM ' . $this->tableName, []);
+        return $this->connection->fetchAllAssociative('SELECT * FROM ' . $this->tableName);
     }
 }

--- a/src/Adapter/CartRule/Repository/CartRuleRepository.php
+++ b/src/Adapter/CartRule/Repository/CartRuleRepository.php
@@ -73,7 +73,7 @@ class CartRuleRepository extends AbstractObjectModelRepository
             ->from($this->dbPrefix . 'cart_rule')
             ->where($qb->expr()->in('id_cart_rule', ':cartRuleIds'))
             ->setParameter('cartRuleIds', $cartRuleIds, Connection::PARAM_INT_ARRAY)
-            ->execute()
+            ->executeQuery()
             ->fetchAssociative()
         ;
 
@@ -112,7 +112,7 @@ class CartRuleRepository extends AbstractObjectModelRepository
                     'id_cart_rule' => $cartRuleId->getValue(),
                     'quantity' => $restrictionRuleGroup->getRequiredQuantityInCart(),
                 ])
-                ->execute()
+                ->executeStatement()
             ;
 
             $productRuleGroupId = $this->connection->lastInsertId();
@@ -126,7 +126,7 @@ class CartRuleRepository extends AbstractObjectModelRepository
                     ])
                     ->setParameter('productRuleGroupId', $productRuleGroupId)
                     ->setParameter('type', $restrictionRule->getType())
-                    ->execute()
+                    ->executeStatement()
                 ;
 
                 $productRuleId = $this->connection->lastInsertId();
@@ -174,7 +174,7 @@ class CartRuleRepository extends AbstractObjectModelRepository
             )
             ->where('crprg.id_cart_rule = :cartRuleId')
             ->setParameter('cartRuleId', $cartRuleId->getValue())
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative()
         ;
 
@@ -190,7 +190,7 @@ class CartRuleRepository extends AbstractObjectModelRepository
             )
             ->where('crprg.id_cart_rule = :cartRuleId')
             ->setParameter('cartRuleId', $cartRuleId->getValue())
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative()
         ;
 
@@ -200,7 +200,7 @@ class CartRuleRepository extends AbstractObjectModelRepository
             ->from($this->dbPrefix . 'cart_rule_product_rule_group')
             ->where('id_cart_rule = :cartRuleId')
             ->setParameter('cartRuleId', $cartRuleId->getValue())
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative()
         ;
 
@@ -279,7 +279,7 @@ class CartRuleRepository extends AbstractObjectModelRepository
             ->from($this->dbPrefix . 'cart_rule_combination', 'crc')
             ->where('crc.id_cart_rule_1 = :cartRuleId OR crc.id_cart_rule_2 = :cartRuleId')
             ->setParameter('cartRuleId', $cartRuleIdValue)
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative()
         ;
 
@@ -377,7 +377,7 @@ class CartRuleRepository extends AbstractObjectModelRepository
             ->from($this->dbPrefix . 'cart_rule_carrier', 'crc')
             ->where('crc.id_cart_rule = :cartRuleId')
             ->setParameter('cartRuleId', $cartRuleIdValue)
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative();
 
         if (empty($results)) {
@@ -395,7 +395,7 @@ class CartRuleRepository extends AbstractObjectModelRepository
             ->from($this->dbPrefix . 'cart_rule_group', 'crc')
             ->where('crc.id_cart_rule = :cartRuleId')
             ->setParameter('cartRuleId', $cartRuleIdValue)
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative()
         ;
 
@@ -419,7 +419,7 @@ class CartRuleRepository extends AbstractObjectModelRepository
             ->from($this->dbPrefix . 'cart_rule_country', 'crc')
             ->where('crc.id_cart_rule = :cartRuleId')
             ->setParameter('cartRuleId', $cartRuleIdValue)
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative()
         ;
 
@@ -436,7 +436,7 @@ class CartRuleRepository extends AbstractObjectModelRepository
             ->delete($this->dbPrefix . 'cart_rule_combination', 'crc')
             ->where('crc.id_cart_rule_1 = :cartRuleId OR crc.id_cart_rule_2 = :cartRuleId')
             ->setParameter('cartRuleId', $cartRuleId->getValue())
-            ->execute()
+            ->executeStatement()
         ;
     }
 
@@ -468,7 +468,7 @@ class CartRuleRepository extends AbstractObjectModelRepository
             ->delete($this->dbPrefix . 'cart_rule_product_rule_group')
             ->where('id_cart_rule = :cartRuleId')
             ->setParameter('cartRuleId', $cartRuleId->getValue())
-            ->execute()
+            ->executeStatement()
         ;
     }
 
@@ -519,7 +519,7 @@ class CartRuleRepository extends AbstractObjectModelRepository
             ->delete($this->dbPrefix . 'cart_rule_' . $entityName, 'crc')
             ->where('crc.id_cart_rule = :cartRuleId')
             ->setParameter('cartRuleId', $cartRuleId->getValue())
-            ->execute()
+            ->executeStatement()
         ;
     }
 }

--- a/src/Adapter/CatalogPriceRule/Repository/CatalogPriceRuleRepository.php
+++ b/src/Adapter/CatalogPriceRule/Repository/CatalogPriceRuleRepository.php
@@ -82,11 +82,11 @@ class CatalogPriceRuleRepository
                 spr.from,
                 spr.to
             ')
-            ->setFirstResult($offset)
+            ->setFirstResult($offset ?? 0)
             ->setMaxResults($limit)
         ;
 
-        return $qb->execute()->fetchAllAssociative();
+        return $qb->executeQuery()->fetchAllAssociative();
     }
 
     /**
@@ -100,7 +100,7 @@ class CatalogPriceRuleRepository
         $qb = $this->getCatalogPriceRulesQueryBuilder($langId, $productId)
             ->select('COUNT(spr.id_specific_price_rule) as total_catalog_price_rules');
 
-        return (int) $qb->execute()->fetch()['total_catalog_price_rules'];
+        return (int) $qb->executeQuery()->fetchAssociative()['total_catalog_price_rules'];
     }
 
     /**

--- a/src/Adapter/Category/Repository/CategoryRepository.php
+++ b/src/Adapter/Category/Repository/CategoryRepository.php
@@ -112,7 +112,7 @@ class CategoryRepository extends AbstractObjectModelRepository
             ->setParameter('categoryIds', $categoryIds, Connection::PARAM_INT_ARRAY)
         ;
 
-        $results = $qb->execute()->fetchAllAssociative();
+        $results = $qb->executeQuery()->fetchAllAssociative();
 
         if (!$results) {
             return [];
@@ -178,7 +178,7 @@ class CategoryRepository extends AbstractObjectModelRepository
             ->setParameter('duplicateNames', $duplicateNames, Connection::PARAM_STR_ARRAY)
         ;
 
-        $results = $qb->execute()->fetchAllAssociative();
+        $results = $qb->executeQuery()->fetchAllAssociative();
 
         $categoryIds = [];
         foreach ($results as $result) {
@@ -207,7 +207,7 @@ class CategoryRepository extends AbstractObjectModelRepository
             ->setParameter('languageId', $languageId->getValue())
         ;
 
-        $category = $categoryQb->execute()->fetchAssociative();
+        $category = $categoryQb->executeQuery()->fetchAssociative();
 
         if (empty($category)) {
             throw new CategoryNotFoundException($categoryId, 'Cannot find breadcrumb because category does not exist');
@@ -231,7 +231,7 @@ class CategoryRepository extends AbstractObjectModelRepository
             ->setParameter('languageId', $languageId->getValue())
         ;
 
-        $results = $qb->execute()->fetchAllAssociative();
+        $results = $qb->executeQuery()->fetchAllAssociative();
 
         if ($results) {
             $parentNames = array_column($results, 'name');
@@ -282,7 +282,7 @@ class CategoryRepository extends AbstractObjectModelRepository
             ;
         }
 
-        $results = $qb->execute()->fetchAllAssociative();
+        $results = $qb->executeQuery()->fetchAllAssociative();
 
         $categoryIds = [];
         foreach ($results as $result) {
@@ -325,7 +325,7 @@ class CategoryRepository extends AbstractObjectModelRepository
             ->andWhere('cp.id_category IN (:categories)')
             ->setParameter('categories', $categoryIds, Connection::PARAM_INT_ARRAY)
             ->groupBy('cp.id_category')
-            ->execute()->fetchAllAssociative()
+            ->executeQuery()->fetchAllAssociative()
         ;
 
         // Prepare new rows for each category if the max position was not found it's the first product associated
@@ -367,7 +367,7 @@ class CategoryRepository extends AbstractObjectModelRepository
             ->andWhere('cp.id_category IN (:categories)')
             ->setParameter('productId', $productId->getValue())
             ->setParameter('categories', $categoryIds, Connection::PARAM_INT_ARRAY)
-            ->execute()->fetchAllAssociative()
+            ->executeQuery()->fetchAllAssociative()
         ;
 
         $this->connection
@@ -377,7 +377,7 @@ class CategoryRepository extends AbstractObjectModelRepository
             ->andWhere('id_category IN (:categories)')
             ->setParameter('productId', $productId->getValue())
             ->setParameter('categories', $categoryIds, Connection::PARAM_INT_ARRAY)
-            ->execute()
+            ->executeQuery()
         ;
 
         // Decrement positions for each category impacted
@@ -403,7 +403,7 @@ class CategoryRepository extends AbstractObjectModelRepository
             ->select('s.id_category')
             ->where('s.id_shop = :shopId')
             ->setParameter('shopId', $shopId->getValue())
-            ->execute()
+            ->executeQuery()
             ->fetchAssociative()
         ;
 
@@ -446,7 +446,7 @@ class CategoryRepository extends AbstractObjectModelRepository
                 'productId' => $productId->getValue(),
                 'shopId' => $shopId->getValue(),
             ])
-            ->execute()
+            ->executeQuery()
             ->fetchAssociative()
         ;
 
@@ -484,7 +484,7 @@ class CategoryRepository extends AbstractObjectModelRepository
             ->groupBy('cl.name')
         ;
 
-        $results = $qb->execute()->fetchAllAssociative();
+        $results = $qb->executeQuery()->fetchAllAssociative();
 
         $names = [];
         foreach ($results as $result) {

--- a/src/Adapter/Feature/Repository/FeatureRepository.php
+++ b/src/Adapter/Feature/Repository/FeatureRepository.php
@@ -146,7 +146,7 @@ class FeatureRepository extends AbstractMultiShopObjectModelRepository
                 'featureId' => $featureIdValue,
                 'languageId' => $languageId->getValue(),
             ])
-            ->execute()
+            ->executeQuery()
             ->fetchAssociative()
         ;
 
@@ -168,11 +168,11 @@ class FeatureRepository extends AbstractMultiShopObjectModelRepository
     {
         $qb = $this->getFeaturesQueryBuilder($filters)
             ->select('f.*, fl.*')
-            ->setFirstResult($offset)
+            ->setFirstResult($offset ?? 0)
             ->setMaxResults($limit)
         ;
 
-        $results = $qb->execute()->fetchAll();
+        $results = $qb->executeQuery()->fetchAllAssociative();
         $localizedNames = [];
         $featuresById = [];
         foreach ($results as $result) {
@@ -213,7 +213,7 @@ class FeatureRepository extends AbstractMultiShopObjectModelRepository
             }, $this->connection->createQueryBuilder()
                 ->select('id_shop')
                 ->from($this->dbPrefix . 'feature_shop', 'fs')
-                ->execute()
+                ->executeQuery()
                 ->fetchAllAssociative()
             );
         }
@@ -245,7 +245,7 @@ class FeatureRepository extends AbstractMultiShopObjectModelRepository
 
         return array_map(static function (array $result): ShopId {
             return new ShopId((int) $result['id_shop']);
-        }, $qb->execute()->fetchAllAssociative());
+        }, $qb->executeQuery()->fetchAllAssociative());
     }
 
     /**

--- a/src/Adapter/Feature/Repository/FeatureValueRepository.php
+++ b/src/Adapter/Feature/Repository/FeatureValueRepository.php
@@ -168,11 +168,11 @@ class FeatureValueRepository extends AbstractObjectModelRepository
     {
         $qb = $this->getFeatureValuesQueryBuilder($filters)
             ->select('fv.*')
-            ->setFirstResult($offset)
+            ->setFirstResult($offset ?? 0)
             ->setMaxResults($limit)
         ;
 
-        $featureValues = $qb->execute()->fetchAll();
+        $featureValues = $qb->executeQuery()->fetchAllAssociative();
         foreach ($featureValues as $index => $featureValue) {
             $featureValues[$index]['localized_values'] = $this->getFeatureValueLocalizedValues((int) $featureValue['id_feature_value']);
         }
@@ -202,7 +202,7 @@ class FeatureValueRepository extends AbstractObjectModelRepository
             ->select('COUNT(fv.id_feature_value) AS total_feature_values')
         ;
 
-        return (int) $qb->execute()->fetch()['total_feature_values'];
+        return (int) $qb->executeQuery()->fetchAssociative()['total_feature_values'];
     }
 
     public function delete(FeatureValueId $featureValueId): void
@@ -224,7 +224,7 @@ class FeatureValueRepository extends AbstractObjectModelRepository
             ->setParameter('featureValueId', $featureValueId)
         ;
 
-        $values = $qb->execute()->fetchAll();
+        $values = $qb->executeQuery()->fetchAllAssociative();
         $localizedValues = [];
         foreach ($values as $value) {
             $localizedValues[(int) $value['id_lang']] = $value['value'];

--- a/src/Adapter/Import/ImportEntityDeleter.php
+++ b/src/Adapter/Import/ImportEntityDeleter.php
@@ -276,7 +276,7 @@ final class ImportEntityDeleter implements ImportEntityDeleterInterface
      *
      * @param array $tables
      *
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Doctrine\DBAL\Exception
      */
     private function truncateTables(array $tables)
     {
@@ -290,7 +290,7 @@ final class ImportEntityDeleter implements ImportEntityDeleterInterface
      *
      * @param array $tables
      *
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Doctrine\DBAL\Exception
      */
     private function truncateTablesIfExist(array $tables)
     {

--- a/src/Adapter/PDF/CreditSlipPdfGenerator.php
+++ b/src/Adapter/PDF/CreditSlipPdfGenerator.php
@@ -108,7 +108,7 @@ final class CreditSlipPdfGenerator implements PDFGeneratorInterface
                 ->setParameter('creditSlipIds', $creditSlipIds, Connection::PARAM_INT_ARRAY)
             ;
 
-            $slipsList = $qb->execute()->fetchAll();
+            $slipsList = $qb->executeQuery()->fetchAll();
         }
 
         if (!empty($slipsList)) {

--- a/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Combination\QueryHandler;
 
-use PDO;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
@@ -126,8 +125,8 @@ final class GetEditableCombinationsListHandler implements GetEditableCombination
             ]
         );
 
-        $combinations = $this->combinationQueryBuilder->getSearchQueryBuilder($searchCriteria)->execute()->fetchAll();
-        $total = (int) $this->combinationQueryBuilder->getCountQueryBuilder($searchCriteria)->execute()->fetch(PDO::FETCH_COLUMN);
+        $combinations = $this->combinationQueryBuilder->getSearchQueryBuilder($searchCriteria)->executeQuery()->fetchAllAssociative();
+        $total = (int) $this->combinationQueryBuilder->getCountQueryBuilder($searchCriteria)->executeQuery()->fetchOne();
 
         $combinationIds = array_map(function (array $combination): CombinationId {
             return new CombinationId((int) $combination['id_product_attribute']);

--- a/src/Adapter/Product/Combination/Repository/CombinationRepository.php
+++ b/src/Adapter/Product/Combination/Repository/CombinationRepository.php
@@ -177,7 +177,7 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('attributeIds', implode('-', $attributeIds))
             ->addGroupBy('pa.id_product_attribute')
         ;
-        $result = $qb->execute()->fetchAssociative();
+        $result = $qb->executeQuery()->fetchAssociative();
 
         if (empty($result)) {
             return null;
@@ -226,7 +226,7 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
             ->andWhere('pa.id_product_attribute = :combinationId')
             ->setParameter('combinationId', $combinationId->getValue())
         ;
-        $result = $qb->execute()->fetchAssociative();
+        $result = $qb->executeQuery()->fetchAssociative();
         if (empty($result) || empty($result['id_product'])) {
             throw new CombinationNotFoundException(sprintf('Combination #%d was not found', $combinationId->getValue()));
         }
@@ -347,7 +347,7 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('combinationId', $combinationId->getValue())
         ;
 
-        $result = $qb->execute()->fetch();
+        $result = $qb->executeQuery()->fetchAssociative();
 
         if (empty($result['id_shop_default'])) {
             throw new ProductNotFoundException(sprintf(
@@ -442,7 +442,7 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
             ->addGroupBy('pas.id_product_attribute')
         ;
 
-        $combinationIds = $qb->execute()->fetchAllAssociative();
+        $combinationIds = $qb->executeQuery()->fetchAllAssociative();
 
         return array_map(
             function (array $combination) { return new CombinationId((int) $combination['id_product_attribute']); },
@@ -478,7 +478,7 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('productId', $productId->getValue())
         ;
 
-        $result = $qb->execute()->fetchAssociative();
+        $result = $qb->executeQuery()->fetchAssociative();
 
         if (!$result) {
             return null;
@@ -506,7 +506,7 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('shopId', $shopId->getValue())
         ;
 
-        $result = $qb->execute()->fetchAssociative();
+        $result = $qb->executeQuery()->fetchAssociative();
 
         return isset($result['id_product_attribute']);
     }
@@ -533,7 +533,7 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('shopId', $shopId->getValue())
         ;
 
-        $result = $qb->execute()->fetchAssociative();
+        $result = $qb->executeQuery()->fetchAssociative();
         if (empty($result['id_product_attribute'])) {
             return null;
         }
@@ -563,7 +563,7 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
             static function (array $result): ShopId {
                 return new ShopId((int) $result['id_shop']);
             },
-            $qb->execute()->fetchAll()
+            $qb->executeQuery()->fetchAllAssociative()
         );
     }
 
@@ -593,7 +593,7 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
 
         return array_map(static function (array $shop) {
             return new ShopId((int) $shop['id_shop']);
-        }, $qb->execute()->fetchAllAssociative());
+        }, $qb->executeQuery()->fetchAllAssociative());
     }
 
     /**
@@ -650,7 +650,7 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('productId', $productId->getValue())
         ;
 
-        $this->applyShopConstraint($qb, $shopConstraint)->execute();
+        $this->applyShopConstraint($qb, $shopConstraint)->executeStatement();
     }
 
     /**
@@ -821,7 +821,7 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
             $qb->setMaxResults($limit);
         }
 
-        $results = $qb->execute()->fetchAll();
+        $results = $qb->executeQuery()->fetchAllAssociative();
         if (!$results) {
             return [];
         }
@@ -884,7 +884,7 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
             ;
         }
 
-        $results = $qb->execute()->fetchAllAssociative();
+        $results = $qb->executeQuery()->fetchAllAssociative();
 
         return array_map('intval', array_column($results, 'id_attribute'));
     }

--- a/src/Adapter/Product/Combination/Update/CombinationImagesUpdater.php
+++ b/src/Adapter/Product/Combination/Update/CombinationImagesUpdater.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\Combination\Update;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;

--- a/src/Adapter/Product/Customization/Repository/CustomizationFieldRepository.php
+++ b/src/Adapter/Product/Customization/Repository/CustomizationFieldRepository.php
@@ -188,6 +188,6 @@ class CustomizationFieldRepository extends AbstractMultiShopObjectModelRepositor
 
         return array_map(static function (array $customizationFieldId) {
             return new CustomizationFieldId((int) $customizationFieldId['id_customization_field']);
-        }, $qb->execute()->fetchAllAssociative());
+        }, $qb->executeQuery()->fetchAllAssociative());
     }
 }

--- a/src/Adapter/Product/FeatureValue/Update/ProductFeatureValueUpdater.php
+++ b/src/Adapter/Product/FeatureValue/Update/ProductFeatureValueUpdater.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\FeatureValue\Update;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use FeatureValue;
 use PrestaShop\PrestaShop\Adapter\Feature\Repository\FeatureRepository;
@@ -191,7 +191,7 @@ class ProductFeatureValueUpdater
             )
         ;
 
-        $orphanCustomFeatureValues = $qb->execute()->fetchAll();
+        $orphanCustomFeatureValues = $qb->executeQuery()->fetchAllAssociative();
         if (empty($orphanCustomFeatureValues)) {
             return;
         }
@@ -205,7 +205,7 @@ class ProductFeatureValueUpdater
         $qb->delete($this->dbPrefix . 'feature_value')
             ->where($qb->expr()->in('id_feature_value', $orphanIds))
         ;
-        $qb->execute();
+        $qb->executeStatement();
     }
 
     /**

--- a/src/Adapter/Product/Image/Repository/ProductImageRepository.php
+++ b/src/Adapter/Product/Image/Repository/ProductImageRepository.php
@@ -29,7 +29,6 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\Image\Repository;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\FetchMode;
 use Image;
 use ImageType;
 use PrestaShop\PrestaShop\Adapter\Product\Image\Validate\ProductImageValidator;
@@ -161,7 +160,7 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
 
         return array_map(static function (string $id): ImageId {
             return new ImageId((int) $id);
-        }, $qb->execute()->fetchAll(FetchMode::COLUMN));
+        }, $qb->executeQuery()->fetchFirstColumn());
     }
 
     /**
@@ -198,7 +197,7 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('productId', $productId->getValue())
             ->setParameter('shopId', $shopId->getValue())
         ;
-        $result = $qb->execute()->fetchAssociative();
+        $result = $qb->executeQuery()->fetchAssociative();
 
         if (empty($result['id_image'])) {
             return null;
@@ -238,7 +237,7 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
             ->orderBy('i.position', 'asc')
         ;
 
-        $results = $qb->execute()->fetchAll();
+        $results = $qb->executeQuery()->fetchAllAssociative();
 
         if (empty($results)) {
             return [];
@@ -311,7 +310,7 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
                 ->from($this->dbPrefix . 'image_shop')
                 ->where('id_image = :imageId')
                 ->setParameter('imageId', $imageId->getValue())
-                ->execute()
+                ->executeQuery()
                 ->fetchAllAssociative()
         );
     }
@@ -350,7 +349,7 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
 
         return array_map(static function (array $shop): ShopId {
             return new ShopId((int) $shop['id_shop']);
-        }, $qb->execute()->fetchAllAssociative());
+        }, $qb->executeQuery()->fetchAllAssociative());
     }
 
     public function create(ProductId $productId, ShopConstraint $shopConstraint): Image
@@ -453,8 +452,8 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
             ->where('id_image = :imageId')
             ->andWhere('cover = 1')
             ->setParameter('imageId', $imageId->getValue())
-            ->execute()
-            ->fetchAll()
+            ->executeQuery()
+            ->fetchAllAssociative()
         ;
 
         return array_map(
@@ -479,8 +478,8 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('productId', $productId->getValue())
             ->addOrderBy('i.id_shop', 'ASC')
             ->addOrderBy('i.id_image', 'ASC')
-            ->execute()
-            ->fetchAll()
+            ->executeQuery()
+            ->fetchAllAssociative()
         ;
 
         $productImagesByShop = [];
@@ -517,7 +516,7 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
             ->andWhere('id_shop = :shopId')
             ->setParameter('shopId', $shopId->getValue())
             ->andWhere('cover = 1')
-            ->execute()
+            ->executeQuery()
             ->fetchOne()
             ;
 
@@ -532,7 +531,7 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
             ->where('id_product = :productId')
             ->setParameter('productId', $productId->getValue())
             ->andWhere('cover = 1')
-            ->execute()
+            ->executeQuery()
             ->fetchOne()
         ;
 
@@ -555,7 +554,7 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('imageId', (int) $image->id)
             ->setParameter('shopId', $shopId->getValue())
             ->setParameter('cover', $image->cover ? 1 : null)
-            ->execute()
+            ->executeStatement()
         ;
     }
 
@@ -573,8 +572,8 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
             ->andWhere('is.id_product = :productId')
             ->setParameter('productId', $productId->getValue())
             ->addOrderBy('i.position', 'ASC')
-            ->execute()
-            ->fetchAll()
+            ->executeQuery()
+            ->fetchAllAssociative()
         ;
 
         foreach ($results as $image) {
@@ -601,7 +600,7 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
                 ->setParameter('imageId', (int) $image['id_image'])
                 ->andWhere($this->dbPrefix . 'image_shop' . '.id_shop = :shopId')
                 ->setParameter('shopId', (int) $image['id_shop'])
-                ->execute()
+                ->executeStatement()
             ;
 
             if ($coverIdGlobal === null) {
@@ -611,7 +610,7 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
                     ->setParameter('cover', $newValue)
                     ->andWhere('id_image = :imageId')
                     ->setParameter('imageId', (int) $image['id_image'])
-                    ->execute()
+                    ->executeStatement()
                 ;
             }
         }
@@ -704,7 +703,7 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
             ->orderBy('i.cover', 'DESC')
             ->setMaxResults(1)
             ->setParameter('productAttribute', $combinationId->getValue());
-        $data = $qb->execute()->fetchOne();
+        $data = $qb->executeQuery()->fetchOne();
         if ($data > 0) {
             return new ImageId((int) $data);
         }

--- a/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
+++ b/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
@@ -107,7 +107,7 @@ class ProductPackRepository extends AbstractObjectModelRepository
                 ->addGroupBy('product.id_product')
                 ->addGroupBy('attribute.id_product_attribute')
             ;
-            $packedProducts = $qb->execute()->fetchAll();
+            $packedProducts = $qb->executeQuery()->fetchAll();
         } catch (Throwable $exception) {
             throw new CoreException(
                 sprintf(
@@ -199,7 +199,7 @@ class ProductPackRepository extends AbstractObjectModelRepository
             ->setParameter('productId', $productId->getValue())
         ;
 
-        $packs = $qb->execute()->fetchAllAssociative();
+        $packs = $qb->executeQuery()->fetchAllAssociative();
 
         return array_map(function (array $packData) {
             return new PackId((int) $packData['id_product_pack']);

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -908,7 +908,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             $qb->expr()->like('pa.supplier_reference', ':dbSearchPhrase')
         ));
         $dbSearchPhrase = sprintf('%%%s%%', $searchPhrase);
-        $qb->setParameter(':dbSearchPhrase', $dbSearchPhrase);
+        $qb->setParameter('dbSearchPhrase', $dbSearchPhrase);
 
         if (!empty($filters)) {
             foreach ($filters as $type => $filter) {

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -31,7 +31,6 @@ namespace PrestaShop\PrestaShop\Adapter\Product\Repository;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Exception as ExceptionAlias;
-use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Query\QueryBuilder;
 use ObjectModel;
 use PrestaShop\PrestaShop\Adapter\Category\Repository\CategoryRepository;
@@ -156,7 +155,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('productId', $productId->getValue())
         ;
 
-        $result = $qb->execute()->fetchAssociative();
+        $result = $qb->executeQuery()->fetchAssociative();
         if (empty($result['id_shop_default'])) {
             throw new ProductNotFoundException(sprintf(
                 'Could not find Product with id %d',
@@ -201,7 +200,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('productId', $productId->getValue())
         ;
 
-        $result = $qb->execute()->fetchAllAssociative();
+        $result = $qb->executeQuery()->fetchAllAssociative();
         if (empty($result)) {
             throw new ShopGroupAssociationNotFound(sprintf(
                 'Could not find association between Product %d and Shop group %d',
@@ -321,7 +320,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->andWhere($deleteQb->expr()->in('id_shop', ':shopIds'))
             ->setParameter('productId', $productIdValue)
             ->setParameter('shopIds', $shopIds, Connection::PARAM_INT_ARRAY)
-            ->execute()
+            ->executeStatement()
         ;
 
         $insertValues = [];
@@ -385,7 +384,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
 
         return array_map(static function (array $shop) {
             return new ShopId((int) $shop['id_shop']);
-        }, $qb->execute()->fetchAllAssociative());
+        }, $qb->executeQuery()->fetchAllAssociative());
     }
 
     /**
@@ -414,7 +413,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
 
         return array_map(static function (array $shop) {
             return new ShopId((int) $shop['id_shop']);
-        }, $qb->execute()->fetchAllAssociative());
+        }, $qb->executeQuery()->fetchAllAssociative());
     }
 
     /**
@@ -464,7 +463,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->from($this->dbPrefix . 'product_attribute', 'pa')
             ->where('pa.id_product = :productId')
             ->setParameter('productId', $productId->getValue())
-            ->execute()
+            ->executeQuery()
             ->fetchOne()
         ;
 
@@ -504,7 +503,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->groupBy('a.id_attribute_group')
         ;
 
-        $results = $qb->execute()->fetchAll(FetchMode::COLUMN);
+        $results = $qb->executeQuery()->fetchFirstColumn();
 
         return array_map(static function (string $id): AttributeGroupId {
             return new AttributeGroupId((int) $id);
@@ -538,7 +537,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->groupBy('pac.id_attribute')
         ;
 
-        $results = $qb->execute()->fetchAll(FetchMode::COLUMN);
+        $results = $qb->executeQuery()->fetchFirstColumn();
 
         return array_map(static function (string $id): AttributeId {
             return new AttributeId((int) $id);
@@ -628,7 +627,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->from($this->dbPrefix . 'product', 'p')
             ->where('p.id_product = :productId')
             ->setParameter('productId', $productId->getValue())
-            ->execute()
+            ->executeQuery()
             ->fetchAssociative()
         ;
 
@@ -695,7 +694,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('categoryId', $categoryId->getValue())
         ;
 
-        $position = $qb->execute()->fetchOne();
+        $position = $qb->executeQuery()->fetchOne();
 
         if (!$position) {
             return null;
@@ -763,7 +762,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('productIds', $ids, Connection::PARAM_INT_ARRAY)
         ;
 
-        $results = $qb->execute()->fetch();
+        $results = $qb->executeQuery()->fetchAssociative();
 
         if (!$results || (int) $results['product_count'] !== count($ids)) {
             throw new ProductNotFoundException(
@@ -798,7 +797,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->addOrderBy('p.id_product', 'ASC')
         ;
 
-        return $qb->execute()->fetchAllAssociative();
+        return $qb->executeQuery()->fetchAllAssociative();
     }
 
     /**
@@ -839,7 +838,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->addOrderBy('pa.id_product_attribute', 'ASC')
         ;
 
-        return $qb->execute()->fetchAllAssociative();
+        return $qb->executeQuery()->fetchAllAssociative();
     }
 
     public function getProductTaxRulesGroupId(ProductId $productId, ShopId $shopId): TaxRulesGroupId
@@ -851,7 +850,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->andWhere('p_shop.id_shop = :shopId')
             ->setParameter('shopId', $shopId->getValue())
             ->setParameter('productId', $productId->getValue())
-            ->execute()
+            ->executeQuery()
             ->fetchOne()
         ;
 

--- a/src/Adapter/Product/Repository/ProductSupplierRepository.php
+++ b/src/Adapter/Product/Repository/ProductSupplierRepository.php
@@ -130,7 +130,7 @@ class ProductSupplierRepository extends AbstractObjectModelRepository
             ;
         }
 
-        $result = $qb->execute()->fetchAssociative();
+        $result = $qb->executeQuery()->fetchAssociative();
         if (empty($result)) {
             return null;
         }
@@ -199,7 +199,7 @@ class ProductSupplierRepository extends AbstractObjectModelRepository
             ->where('p.id_product = :productId')
         ;
 
-        $result = $qb->execute()->fetchAssociative();
+        $result = $qb->executeQuery()->fetchAssociative();
 
         if (!$result) {
             return null;
@@ -231,7 +231,7 @@ class ProductSupplierRepository extends AbstractObjectModelRepository
             ->setParameter('productId', $productId->getValue())
         ;
 
-        $result = $qb->execute()->fetch();
+        $result = $qb->executeQuery()->fetchAssociative();
 
         if (empty($result['default_supplier_id'])) {
             return null;
@@ -258,7 +258,7 @@ class ProductSupplierRepository extends AbstractObjectModelRepository
             ->addOrderBy('ps.id_product_supplier', 'ASC')
         ;
 
-        $results = $qb->execute()->fetchAllAssociative();
+        $results = $qb->executeQuery()->fetchAllAssociative();
 
         if (empty($results)) {
             return [];
@@ -289,7 +289,7 @@ class ProductSupplierRepository extends AbstractObjectModelRepository
             ->groupBy('ps.id_supplier')
         ;
 
-        $results = $qb->execute()->fetchAllAssociative();
+        $results = $qb->executeQuery()->fetchAllAssociative();
 
         if (empty($results)) {
             return [];
@@ -392,7 +392,7 @@ class ProductSupplierRepository extends AbstractObjectModelRepository
             ;
         }
 
-        return $qb->execute()->fetchAll();
+        return $qb->executeQuery()->fetchAllAssociative();
     }
 
     /**
@@ -408,7 +408,7 @@ class ProductSupplierRepository extends AbstractObjectModelRepository
             ->from($this->dbPrefix . 'supplier', 's')
         ;
 
-        $suppliers = $qb->execute()->fetchAllAssociative();
+        $suppliers = $qb->executeQuery()->fetchAllAssociative();
         $names = [];
         foreach ($suppliers as $supplier) {
             if (in_array($supplier['name'], $names)) {
@@ -445,7 +445,7 @@ class ProductSupplierRepository extends AbstractObjectModelRepository
             ))
         ;
 
-        $uselessProductSupplierIds = $qb->execute()->fetchAllAssociative();
+        $uselessProductSupplierIds = $qb->executeQuery()->fetchAllAssociative();
         if (empty($uselessProductSupplierIds)) {
             return [];
         }

--- a/src/Adapter/Product/Repository/TagRepository.php
+++ b/src/Adapter/Product/Repository/TagRepository.php
@@ -148,7 +148,7 @@ class TagRepository
             ->setParameter('productId', $productId->getValue())
         ;
 
-        $result = $qb->execute()->fetchAllAssociative();
+        $result = $qb->executeQuery()->fetchAllAssociative();
         if (empty($result)) {
             return [];
         }

--- a/src/Adapter/Product/SpecificPrice/Repository/SpecificPriceRepository.php
+++ b/src/Adapter/Product/SpecificPrice/Repository/SpecificPriceRepository.php
@@ -184,11 +184,11 @@ class SpecificPriceRepository extends AbstractObjectModelRepository
                 country_lang.name as country_name,
                 gl.name as group_name'
             )
-            ->setFirstResult($offset)
+            ->setFirstResult($offset ?? 0)
             ->setMaxResults($limit)
         ;
 
-        return $qb->execute()->fetchAllAssociative();
+        return $qb->executeQuery()->fetchAllAssociative();
     }
 
     /**
@@ -206,7 +206,7 @@ class SpecificPriceRepository extends AbstractObjectModelRepository
             ->select('sp.id_specific_price')
             ->where('sp.id_product = :productId')
             ->setParameter('productId', $productId->getValue())
-            ->execute()->fetchAllAssociative());
+            ->executeQuery()->fetchAllAssociative());
     }
 
     /**
@@ -222,7 +222,7 @@ class SpecificPriceRepository extends AbstractObjectModelRepository
             ->select('COUNT(sp.id_specific_price) AS total_specific_prices')
         ;
 
-        return (int) $qb->execute()->fetch()['total_specific_prices'];
+        return (int) $qb->executeQuery()->fetchAssociative()['total_specific_prices'];
     }
 
     /**
@@ -298,7 +298,7 @@ class SpecificPriceRepository extends AbstractObjectModelRepository
             ->setParameter('productId', $productId->getValue())
         ;
 
-        $result = $qb->execute()->fetchOne();
+        $result = $qb->executeQuery()->fetchOne();
 
         if (!$result) {
             return null;

--- a/src/Adapter/Product/Stock/Repository/StockAvailableRepository.php
+++ b/src/Adapter/Product/Stock/Repository/StockAvailableRepository.php
@@ -212,7 +212,7 @@ class StockAvailableRepository extends AbstractMultiShopObjectModelRepository
         ;
         $this->addShopCondition($qb, $shopId->getValue());
 
-        $row = $qb->execute()->fetch();
+        $row = $qb->executeQuery()->fetchAssociative();
         if (empty($row)) {
             throw new StockAvailableNotFoundException(
                 sprintf(
@@ -322,7 +322,7 @@ class StockAvailableRepository extends AbstractMultiShopObjectModelRepository
 
         return array_map(static function (array $stock) {
             return new StockId((int) $stock['id_stock_available']);
-        }, $qb->execute()->fetchAllAssociative());
+        }, $qb->executeQuery()->fetchAllAssociative());
     }
 
     /**
@@ -345,7 +345,7 @@ class StockAvailableRepository extends AbstractMultiShopObjectModelRepository
             ->where('sa.id_stock_available = :stockId')
             ->setParameter('stockId', $stockId->getValue())
         ;
-        $updateQb->execute();
+        $updateQb->executeStatement();
     }
 
     protected function updateReservedProductQuantity(StockId $stockId, OrderStateId $errorStateId, OrderStateId $canceledStateId): void
@@ -380,7 +380,7 @@ class StockAvailableRepository extends AbstractMultiShopObjectModelRepository
             ])
         ;
 
-        $result = $qb->execute()->fetchAssociative();
+        $result = $qb->executeQuery()->fetchAssociative();
         $reservedQuantity = (int) ($result['reserved_quantity'] ?? 0);
 
         if ($reservedQuantity > 0) {
@@ -391,7 +391,7 @@ class StockAvailableRepository extends AbstractMultiShopObjectModelRepository
                 ->where('sa.id_stock_available = :stockId')
                 ->setParameter('stockId', $stockId->getValue())
             ;
-            $updateQb->execute();
+            $updateQb->executeStatement();
         }
     }
 }

--- a/src/Adapter/Product/Stock/Repository/StockMovementRepository.php
+++ b/src/Adapter/Product/Stock/Repository/StockMovementRepository.php
@@ -99,7 +99,7 @@ class StockMovementRepository
 
         // It is CRITICAL to reset the counter before each request
         $this->connection->executeStatement('SET @grouping_id := null');
-        $result = $queryBuilder->execute()->fetchAllAssociative();
+        $result = $queryBuilder->executeQuery()->fetchAllAssociative();
         foreach ($result as $key => $row) {
             $totalQuantity = $row['delta_quantity_positive'] - $row['delta_quantity_negative'];
             if ($totalQuantity === 0) {

--- a/src/Adapter/Product/Update/ProductDuplicator.php
+++ b/src/Adapter/Product/Update/ProductDuplicator.php
@@ -465,7 +465,7 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
                     ->where('cp.id_category = :categoryId')
                     ->setParameter('categoryId', $categoryId)
                     ->addOrderBy('position', 'DESC')
-                    ->execute()
+                    ->executeQuery()
                     ->fetchOne()
                 ;
             }
@@ -654,7 +654,7 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
                 ->from($this->dbPrefix . 'feature_value')
                 ->select('id_feature_value')
                 ->addOrderBy('id_feature_value', 'DESC')
-                ->execute()
+                ->executeQuery()
                 ->fetchOne()
             ;
 
@@ -748,7 +748,7 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
             ->from($this->dbPrefix . 'customization_field')
             ->select('id_customization_field')
             ->addOrderBy('id_customization_field', 'DESC')
-            ->execute()
+            ->executeQuery()
             ->fetchOne()
         ;
 
@@ -1102,7 +1102,7 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
         }
 
         try {
-            $rows = $qb->execute()->fetchAllAssociative();
+            $rows = $qb->executeQuery()->fetchAllAssociative();
         } catch (Exception $e) {
             throw new CannotDuplicateProductException(
                 sprintf('Cannot select rows from table %s', $this->dbPrefix . $table),

--- a/src/Adapter/Product/Update/ProductDuplicator.php
+++ b/src/Adapter/Product/Update/ProductDuplicator.php
@@ -1087,12 +1087,12 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
                 $arrayType = is_int(reset($value)) ? Connection::PARAM_INT_ARRAY : Connection::PARAM_STR_ARRAY;
                 $qb
                     ->andWhere("$column IN (:$column)")
-                    ->setParameter(":$column", $value, $arrayType)
+                    ->setParameter($column, $value, $arrayType)
                 ;
             } else {
                 $qb
                     ->andWhere("$column = :$column")
-                    ->setParameter(":$column", $value)
+                    ->setParameter($column, $value)
                 ;
             }
         }

--- a/src/Adapter/Session/Repository/CustomerSessionRepository.php
+++ b/src/Adapter/Session/Repository/CustomerSessionRepository.php
@@ -144,7 +144,7 @@ class CustomerSessionRepository extends AbstractObjectModelRepository
                 ->where('date_upd <= :dateUpdated')
                 ->setParameter('dateUpdated', $date->format('Y-m-d H:i:s'));
 
-            $qb->execute();
+            $qb->executeStatement();
         } catch (CoreException $e) {
             throw new CannotClearCustomerSessionException();
         }

--- a/src/Adapter/Session/Repository/EmployeeSessionRepository.php
+++ b/src/Adapter/Session/Repository/EmployeeSessionRepository.php
@@ -144,7 +144,7 @@ class EmployeeSessionRepository extends AbstractObjectModelRepository
                 ->where('date_upd <= :dateUpdated')
                 ->setParameter('dateUpdated', $date->format('Y-m-d H:i:s'));
 
-            $qb->execute();
+            $qb->executeStatement();
         } catch (CoreException $e) {
             throw new CannotClearEmployeeSessionException();
         }

--- a/src/Adapter/Shop/Repository/ShopGroupRepository.php
+++ b/src/Adapter/Shop/Repository/ShopGroupRepository.php
@@ -107,7 +107,7 @@ class ShopGroupRepository extends AbstractObjectModelRepository
             ->setParameter('shopId', $shopId->getValue())
         ;
 
-        $result = $qb->execute()->fetchAssociative();
+        $result = $qb->executeQuery()->fetchAssociative();
         if (false === $result) {
             throw new ShopNotFoundException(sprintf('Could not find shop with id %d', $shopId->getValue()));
         }
@@ -144,7 +144,7 @@ class ShopGroupRepository extends AbstractObjectModelRepository
             ->from($this->dbPrefix . 'shop', 's')
             ->where('s.id_shop_group = :shopGroupId')
             ->setParameter('shopGroupId', $shopGroupId->getValue())
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative()
         );
     }

--- a/src/Adapter/Shop/Repository/ShopRepository.php
+++ b/src/Adapter/Shop/Repository/ShopRepository.php
@@ -84,7 +84,7 @@ class ShopRepository extends AbstractObjectModelRepository
             ->from($this->dbPrefix . 'shop', 's')
             ->where('s.id_shop = :shopId')
             ->setParameter('shopId', $shopId->getValue())
-            ->execute()
+            ->executeQuery()
             ->fetchAssociative()
         ;
 

--- a/src/Adapter/TaxRulesGroup/Repository/TaxRulesGroupRepository.php
+++ b/src/Adapter/TaxRulesGroup/Repository/TaxRulesGroupRepository.php
@@ -99,7 +99,7 @@ class TaxRulesGroupRepository extends AbstractMultiShopObjectModelRepository
             ])
         ;
 
-        $rawData = $qb->execute()->fetchAll();
+        $rawData = $qb->executeQuery()->fetchAllAssociative();
         if (empty($rawData)) {
             return 0;
         }

--- a/src/Core/Domain/CustomerService/CommandHandler/UpdateCustomerThreadStatusHandler.php
+++ b/src/Core/Domain/CustomerService/CommandHandler/UpdateCustomerThreadStatusHandler.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\CustomerService\CommandHandler;
 
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Connection;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\UpdateCustomerThreadStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerServiceException;
@@ -72,7 +72,7 @@ class UpdateCustomerThreadStatusHandler implements UpdateCustomerThreadStatusHan
         $statement->bindValue(':status', $command->getCustomerThreadStatus()->getValue());
         $statement->bindValue(':id_customer_thread', $command->getCustomerThreadId()->getValue());
 
-        if (false === $statement->execute()) {
+        if (0 === $statement->executeStatement()) {
             throw new CustomerServiceException('Failed to update customer thread status.', CustomerServiceException::FAILED_TO_UPDATE_STATUS);
         }
     }

--- a/src/Core/Domain/Product/Combination/QueryHandler/GetCombinationIdsHandler.php
+++ b/src/Core/Domain/Product/Combination/QueryHandler/GetCombinationIdsHandler.php
@@ -80,7 +80,7 @@ class GetCombinationIdsHandler implements GetCombinationIdsHandlerInterface
         $results = $this->productCombinationQueryBuilder
             ->getSearchQueryBuilder($searchCriteria)
             ->select('pas.id_product_attribute')
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative()
         ;
 

--- a/src/Core/Domain/Store/Repository/StoreRepository.php
+++ b/src/Core/Domain/Store/Repository/StoreRepository.php
@@ -127,7 +127,7 @@ class StoreRepository extends AbstractObjectModelRepository
             }, $this->connection->createQueryBuilder()
                 ->select('id_shop')
                 ->from($this->dbPrefix . 'store_shop', 'ss')
-                ->execute()
+                ->executeQuery()
                 ->fetchAllAssociative()
             );
         }
@@ -159,6 +159,6 @@ class StoreRepository extends AbstractObjectModelRepository
 
         return array_map(static function (array $result): ShopId {
             return new ShopId((int) $result['id_shop']);
-        }, $qb->execute()->fetchAllAssociative());
+        }, $qb->executeQuery()->fetchAllAssociative());
     }
 }

--- a/src/Core/Grid/Data/Factory/AttachmentGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/AttachmentGridDataFactoryDecorator.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
 
 use Doctrine\DBAL\Connection;
-use PDO;
 use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
@@ -155,6 +154,6 @@ final class AttachmentGridDataFactoryDecorator implements GridDataFactoryInterfa
             ->setParameter('attachmentId', $attachmentId)
             ->setParameter('langId', $this->employeeIdLang);
 
-        return $qb->execute()->fetchAll(PDO::FETCH_COLUMN);
+        return $qb->executeQuery()->fetchFirstColumn();
     }
 }

--- a/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
 
 use Doctrine\DBAL\Query\QueryBuilder;
-use PDO;
 use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Query\QueryParserInterface;
@@ -93,8 +92,8 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
             'search_criteria' => $searchCriteria,
         ]);
 
-        $records = $searchQueryBuilder->execute()->fetchAll();
-        $recordsTotal = (int) $countQueryBuilder->execute()->fetch(PDO::FETCH_COLUMN);
+        $records = $searchQueryBuilder->executeQuery()->fetchAllAssociative();
+        $recordsTotal = (int) $countQueryBuilder->executeQuery()->fetchOne();
 
         $records = new RecordCollection($records);
 

--- a/src/Core/Grid/Position/UpdateHandler/DoctrinePositionUpdateHandler.php
+++ b/src/Core/Grid/Position/UpdateHandler/DoctrinePositionUpdateHandler.php
@@ -77,7 +77,7 @@ final class DoctrinePositionUpdateHandler implements PositionUpdateHandlerInterf
                 ->setParameter('parentId', $parentId);
         }
 
-        $positions = $qb->execute()->fetchAll();
+        $positions = $qb->executeQuery()->fetchAllAssociative();
         $currentPositions = [];
         foreach ($positions as $position) {
             $positionId = $position[$positionDefinition->getIdField()];
@@ -111,7 +111,7 @@ final class DoctrinePositionUpdateHandler implements PositionUpdateHandlerInterf
                 }
 
                 try {
-                    $qb->execute();
+                    $qb->executeStatement();
                 } catch (Exception $e) {
                     throw new PositionUpdateException('Could not update #%i', 'Admin.Catalog.Notification', [$rowId]);
                 }

--- a/src/Core/Grid/Query/ProductCombinationQueryBuilder.php
+++ b/src/Core/Grid/Query/ProductCombinationQueryBuilder.php
@@ -228,7 +228,7 @@ final class ProductCombinationQueryBuilder extends AbstractDoctrineQueryBuilder
             ->setParameter('attributes', $allAttributes, Connection::PARAM_INT_ARRAY)
             ->setParameter('productId', $productId)
         ;
-        $results = $qb->execute()->fetchAll();
+        $results = $qb->executeQuery()->fetchAllAssociative();
         if (!$results) {
             return [];
         }

--- a/src/Core/Grid/Query/RequestSqlQueryBuilder.php
+++ b/src/Core/Grid/Query/RequestSqlQueryBuilder.php
@@ -65,7 +65,7 @@ final class RequestSqlQueryBuilder extends AbstractDoctrineQueryBuilder
         return $searchQueryBuilder
             ->select('rs.*')
             ->orderBy(sprintf('`%s`', $searchCriteria->getOrderBy()), $searchCriteria->getOrderWay())
-            ->setFirstResult($searchCriteria->getOffset())
+            ->setFirstResult($searchCriteria->getOffset() ?? 0)
             ->setMaxResults($searchCriteria->getLimit());
     }
 

--- a/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
@@ -102,7 +102,7 @@ class UpdateSchemaCommand extends Command
                 throw ($e);
             }
         }
-        if (!$connection->getWrappedConnection() instanceof PDO || $connection->getWrappedConnection()->inTransaction()) {
+        if (!$connection->getNativeConnection() instanceof PDO || $connection->getNativeConnection()->inTransaction()) {
             $connection->commit();
         }
 
@@ -284,8 +284,8 @@ class UpdateSchemaCommand extends Command
                 $originalFieldName = $fieldName;
                 $fieldName = str_replace('`', '', $fieldName);
                 // get old default value
-                $query = $connection->executeQuery('SHOW FULL COLUMNS FROM ' . $tableName . ' WHERE Field="' . $fieldName . '"');
-                $results = $query->fetchAllAssociative();
+                $result = $connection->executeQuery('SHOW FULL COLUMNS FROM ' . $tableName . ' WHERE Field="' . $fieldName . '"');
+                $results = $result->fetchAllAssociative();
                 if (empty($results[0])) {
                     continue;
                 }

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
@@ -110,7 +110,7 @@ class ModulesDoctrineCompilerPass implements CompilerPassInterface
             $driverDefinition->addMethodCall('addExcludePaths', [[$indexFile]]);
         }
 
-        return new DoctrineOrmMappingsPass($driverDefinition, [$moduleNamespace], [], false, [$modulePrefix => $moduleNamespace]);
+        return new DoctrineOrmMappingsPass($driverDefinition, [$moduleNamespace], [], false, []);
     }
 
     /**

--- a/src/PrestaShopBundle/Entity/Repository/CategoryRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/CategoryRepository.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Entity\Repository;
 
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Connection;
 use Employee;
 use PrestaShop\PrestaShop\Adapter\Category\CategoryDataProvider;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
@@ -125,9 +125,9 @@ class CategoryRepository
         $statement->bindValue('language_id', $this->languageId);
         $statement->bindValue('shop_id', $this->shopId);
 
-        $statement->execute();
+        $result = $statement->executeQuery();
 
-        $rows = $statement->fetchAll();
+        $rows = $result->fetchAllAssociative();
         $rows = $this->castNumericToInt($rows);
 
         if (true === $tree && !empty($rows)) {

--- a/src/PrestaShopBundle/Entity/Repository/FeatureAttributeRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/FeatureAttributeRepository.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Entity\Repository;
 
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Connection;
 use Employee;
 use PrestaShop\PrestaShop\Adapter\LegacyContext as ContextAdapter;
 use PrestaShopBundle\Exception\NotImplementedException;
@@ -141,9 +141,9 @@ class FeatureAttributeRepository
         $statement->bindValue('language_id', $this->languageId);
         $statement->bindValue('shop_id', $this->shopId);
 
-        $statement->execute();
+        $result = $statement->executeQuery();
 
-        $rows = $statement->fetchAll();
+        $rows = $result->fetchAllAssociative();
         $rows = $this->explodeCollections($rows);
 
         return $this->castNumericToInt($rows);
@@ -191,9 +191,9 @@ class FeatureAttributeRepository
         $statement->bindValue('language_id', $this->languageId);
         $statement->bindValue('shop_id', $this->shopId);
 
-        $statement->execute();
+        $result = $statement->executeQuery();
 
-        $rows = $statement->fetchAll();
+        $rows = $result->fetchAllAssociative();
         $rows = $this->explodeCollections($rows);
 
         return $this->castNumericToInt($rows);

--- a/src/PrestaShopBundle/Entity/Repository/ImportMatchRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/ImportMatchRepository.php
@@ -70,7 +70,7 @@ class ImportMatchRepository implements RepositoryInterface
             ->where('id_import_match = :id')
             ->setParameter('id', $id);
 
-        return $queryBuilder->execute()->fetch();
+        return $queryBuilder->executeQuery()->fetchAssociative();
     }
 
     /**
@@ -89,7 +89,7 @@ class ImportMatchRepository implements RepositoryInterface
             ->where('`name` = :name')
             ->setParameter('name', $name);
 
-        return $queryBuilder->execute()->fetch();
+        return $queryBuilder->executeQuery()->fetchAssociative();
     }
 
     /**
@@ -102,7 +102,7 @@ class ImportMatchRepository implements RepositoryInterface
             ->select('*')
             ->from($this->importMatchTable);
 
-        return $queryBuilder->execute()->fetchAll();
+        return $queryBuilder->executeQuery()->fetchAllAssociative();
     }
 
     /**

--- a/src/PrestaShopBundle/Entity/Repository/LogRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/LogRepository.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Entity\Repository;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception as DBALException;
 use PrestaShop\PrestaShop\Core\Repository\RepositoryInterface;
 
 /**
@@ -62,9 +63,9 @@ class LogRepository implements RepositoryInterface
      */
     public function findAll()
     {
-        $statement = $this->connection->query("SELECT l.* FROM $this->logTable l");
+        $result = $this->connection->executeQuery("SELECT l.* FROM $this->logTable l");
 
-        return $statement->fetchAll();
+        return $result->fetchAllAssociative();
     }
 
     /**
@@ -98,9 +99,9 @@ class LogRepository implements RepositoryInterface
     public function findAllWithEmployeeInformation($filters)
     {
         $queryBuilder = $this->getAllWithEmployeeInformationQuery($filters);
-        $statement = $queryBuilder->execute();
+        $statement = $queryBuilder->executeQuery();
 
-        return $statement->fetchAll(\PDO::FETCH_ASSOC);
+        return $statement->fetchAllAssociative();
     }
 
     /**
@@ -159,12 +160,12 @@ class LogRepository implements RepositoryInterface
      *
      * @return int the number of affected rows
      *
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws DBALException
      */
     public function deleteAll()
     {
         $platform = $this->connection->getDatabasePlatform();
 
-        return $this->connection->executeUpdate($platform->getTruncateTableSQL($this->logTable, true));
+        return $this->connection->executeStatement($platform->getTruncateTableSQL($this->logTable, true));
     }
 }

--- a/src/PrestaShopBundle/Entity/Repository/ManufacturerRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/ManufacturerRepository.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Entity\Repository;
 
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Connection;
 use PrestaShop\PrestaShop\Adapter\LegacyContext as ContextAdapter;
 use PrestaShopBundle\Exception\NotImplementedException;
 use RuntimeException;
@@ -102,9 +102,9 @@ class ManufacturerRepository
 
         $statement->bindValue('shop_id', $this->shopId);
 
-        $statement->execute();
+        $result = $statement->executeQuery();
 
-        $rows = $statement->fetchAll();
+        $rows = $result->fetchAllAssociative();
 
         return $this->castNumericToInt($rows);
     }

--- a/src/PrestaShopBundle/Entity/Repository/ModuleRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/ModuleRepository.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Entity\Repository;
 
 use Doctrine\DBAL\Connection;
-use PDO;
 
 /**
  * Class ModuleRepository is responsible for retrieving module data from database.
@@ -78,7 +77,7 @@ class ModuleRepository
             ->andWhere('mc.id_shop = :id_shop')
             ->setParameter('id_shop', $shopId);
 
-        return $qb->execute()->fetchAll(PDO::FETCH_COLUMN);
+        return $qb->executeQuery()->fetchFirstColumn();
     }
 
     /**
@@ -99,7 +98,7 @@ class ModuleRepository
             ->andWhere('mc.id_shop = :id_shop')
             ->setParameter('id_shop', $shopId);
 
-        return $qb->execute()->fetchAll(PDO::FETCH_COLUMN);
+        return $qb->executeQuery()->fetchFirstColumn();
     }
 
     /**
@@ -120,7 +119,7 @@ class ModuleRepository
             ->andWhere('mg.id_shop = :id_shop')
             ->setParameter('id_shop', $shopId);
 
-        return $qb->execute()->fetchAll(PDO::FETCH_COLUMN);
+        return $qb->executeQuery()->fetchFirstColumn();
     }
 
     /**
@@ -141,6 +140,6 @@ class ModuleRepository
             ->andWhere('mc.id_shop = :id_shop')
             ->setParameter('id_shop', $shopId);
 
-        return $qb->execute()->fetchAll(PDO::FETCH_COLUMN);
+        return $qb->executeQuery()->fetchFirstColumn();
     }
 }

--- a/src/PrestaShopBundle/Entity/Repository/OrderInvoiceRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/OrderInvoiceRepository.php
@@ -70,11 +70,11 @@ class OrderInvoiceRepository
         $sql = str_replace('{table_prefix}', $this->tablePrefix, $sql);
 
         $statement = $this->connection->prepare($sql);
-        $statement->execute();
+        $statementResult = $statement->executeQuery();
 
         $result = [];
 
-        while ($row = $statement->fetch()) {
+        while ($row = $statementResult->fetchAssociative()) {
             $result[$row['id_order_state']] = $row['nbOrders'];
         }
 

--- a/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
@@ -27,8 +27,8 @@
 namespace PrestaShopBundle\Entity\Repository;
 
 use Context;
-use Doctrine\DBAL\Driver\Connection;
-use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Statement;
 use Doctrine\ORM\EntityManager;
 use Employee;
 use PDO;
@@ -226,9 +226,9 @@ abstract class StockManagementRepository
         $statement = $this->connection->prepare($query);
         $this->bindStockManagementValues($statement, $queryParams);
 
-        $statement->execute();
-        $rows = $statement->fetchAll();
-        $statement->closeCursor();
+        $result = $statement->executeQuery();
+        $rows = $result->fetchAllAssociative();
+        $result->free();
         $this->foundRows = $this->getFoundRows();
 
         $rows = $this->addAdditionalData($rows);
@@ -267,10 +267,10 @@ abstract class StockManagementRepository
         $statement = $this->connection->prepare($query);
         $this->bindMaxResultsValue($statement, $queryParams);
 
-        $statement->execute();
+        $result = $statement->executeQuery();
 
-        $count = (int) $statement->fetchColumn();
-        $statement->closeCursor();
+        $count = (int) $result->fetchOne();
+        $result->free();
 
         return $count;
     }
@@ -438,9 +438,9 @@ abstract class StockManagementRepository
     protected function getFoundRows()
     {
         $statement = $this->connection->prepare('SELECT FOUND_ROWS()');
-        $statement->execute();
-        $rowCount = (int) $statement->fetchColumn();
-        $statement->closeCursor();
+        $result = $statement->executeQuery();
+        $rowCount = (int) $result->fetchOne();
+        $result->free();
 
         return $rowCount;
     }
@@ -535,9 +535,9 @@ abstract class StockManagementRepository
             $statement = $this->connection->prepare($query);
             $statement->bindValue('id_product', (int) $row['product_id'], \PDO::PARAM_INT);
             $statement->bindValue('shop_id', $this->getContextualShopId(), \PDO::PARAM_INT);
-            $statement->execute();
-            $this->productFeatures[$row['product_id']] = $statement->fetchColumn(0);
-            $statement->closeCursor();
+            $result = $statement->executeQuery();
+            $this->productFeatures[$row['product_id']] = $result->fetchOne();
+            $result->free();
         }
 
         return (string) $this->productFeatures[$row['product_id']];
@@ -556,9 +556,9 @@ abstract class StockManagementRepository
                   LIMIT 1';
         $statement = $this->connection->prepare($query);
         $statement->bindValue('id_product_attribute', (int) $row['combination_id'], \PDO::PARAM_INT);
-        $statement->execute();
-        $combinationCoverId = (int) $statement->fetchColumn(0);
-        $statement->closeCursor();
+        $result = $statement->executeQuery();
+        $combinationCoverId = (int) $result->fetchOne();
+        $result->free();
 
         return $combinationCoverId;
     }
@@ -584,9 +584,9 @@ abstract class StockManagementRepository
                     WHERE pac.id_product_attribute=:id_product_attribute';
         $statement = $this->connection->prepare($query);
         $statement->bindValue('id_product_attribute', (int) $row['combination_id'], \PDO::PARAM_INT);
-        $statement->execute();
-        $productAttributes = $statement->fetchColumn(0);
-        $statement->closeCursor();
+        $result = $statement->executeQuery();
+        $productAttributes = $result->fetchOne();
+        $result->free();
 
         return (string) $productAttributes;
     }

--- a/src/PrestaShopBundle/Entity/Repository/StockMovementRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockMovementRepository.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Entity\Repository;
 
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
 use PDO;
 use PrestaShop\PrestaShop\Adapter\ImageManager;
@@ -245,10 +245,10 @@ class StockMovementRepository extends StockManagementRepository
 
         $statement = $this->connection->prepare($query);
         $statement->bindValue('shop_id', $this->getContextualShopId(), PDO::PARAM_INT);
-        $statement->execute();
+        $result = $statement->executeQuery();
 
-        $rows = $statement->fetchAll();
-        $statement->closeCursor();
+        $rows = $result->fetchAllAssociative();
+        $result->free();
         $employees = $this->castNumericToInt($rows);
 
         return $employees;
@@ -289,10 +289,10 @@ class StockMovementRepository extends StockManagementRepository
         $statement = $this->connection->prepare($query);
         $statement->bindValue('language_id', $this->getCurrentLanguageId(), PDO::PARAM_INT);
         $statement->bindValue('shop_id', $this->getContextualShopId(), PDO::PARAM_INT);
-        $statement->execute();
+        $result = $statement->executeQuery();
 
-        $rows = $statement->fetchAll();
-        $statement->closeCursor();
+        $rows = $result->fetchAllAssociative();
+        $result->free();
 
         if ($grouped) {
             $types = $this->castIdsToArray($rows);

--- a/src/PrestaShopBundle/Entity/Repository/StockRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockRepository.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Entity\Repository;
 
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\ImageManager;
@@ -173,9 +173,9 @@ class StockRepository extends StockManagementRepository
         $statement = $this->connection->prepare($query);
         $this->bindStockManagementValues($statement, null, $productIdentity);
 
-        $statement->execute();
-        $rows = $statement->fetchAll();
-        $statement->closeCursor();
+        $result = $statement->executeQuery();
+        $rows = $result->fetchAllAssociative();
+        $result->free();
         $this->foundRows = $this->getFoundRows();
 
         if (count($rows) === 0) {
@@ -360,9 +360,9 @@ class StockRepository extends StockManagementRepository
                         WHERE id_product=:id_product';
             $statement = $this->connection->prepare($query);
             $statement->bindValue('id_product', (int) $row['product_id'], \PDO::PARAM_INT);
-            $statement->execute();
-            $this->totalCombinations[$row['product_id']] = $statement->fetchColumn(0);
-            $statement->closeCursor();
+            $result = $statement->executeQuery();
+            $this->totalCombinations[$row['product_id']] = $result->fetchOne();
+            $result->free();
         }
 
         return $this->totalCombinations[$row['product_id']];

--- a/src/PrestaShopBundle/Entity/Repository/SupplierRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/SupplierRepository.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Entity\Repository;
 
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Connection;
 use PrestaShop\PrestaShop\Adapter\LegacyContext as ContextAdapter;
 use PrestaShopBundle\Exception\NotImplementedException;
 use RuntimeException;
@@ -102,9 +102,9 @@ class SupplierRepository
 
         $statement->bindValue('shop_id', $this->shopId);
 
-        $statement->execute();
+        $result = $statement->executeQuery();
 
-        $rows = $statement->fetchAll();
+        $rows = $result->fetchAllAssociative();
 
         return $this->castNumericToInt($rows);
     }

--- a/tests/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
+++ b/tests/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
@@ -29,7 +29,8 @@ declare(strict_types=1);
 namespace Tests\Unit\Adapter\Module\Configuration;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\PDOMySql\Driver;
+use Doctrine\DBAL\Driver\PDO\MySQL\Driver;
+use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Statement;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\Configuration;
@@ -361,7 +362,7 @@ class ConnectionMock extends Connection
         return true;
     }
 
-    public function prepare($statement)
+    public function prepare($statement): Statement
     {
         $this->sql[] = $statement;
 
@@ -376,8 +377,15 @@ class StatementMock extends Statement
     {
     }
 
-    public function execute($params = null)
+    public function execute($params = null): Result
     {
-        return true;
+        return new ResultMock();
+    }
+}
+
+class ResultMock extends Result
+{
+    public function __construct()
+    {
     }
 }

--- a/tests/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
+++ b/tests/Unit/Core/Grid/Data/Factory/DoctrineGridDataFactoryTest.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Core\Grid\Data\Factory;
 
 use Doctrine\DBAL\Query\QueryBuilder;
-use PDOStatement;
+use Doctrine\DBAL\Result;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Grid\Data\Factory\DoctrineGridDataFactory;
 use PrestaShop\PrestaShop\Core\Grid\Data\GridDataInterface;
@@ -71,8 +71,8 @@ class DoctrineGridDataFactoryTest extends TestCase
      */
     private function createDoctrineQueryBuilderMock(): DoctrineQueryBuilderInterface
     {
-        $statement = $this->createMock(PDOStatement::class);
-        $statement->method('fetchAll')
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAllAssociative')
             ->willReturn([
                 [
                     'id' => 1,
@@ -83,12 +83,12 @@ class DoctrineGridDataFactoryTest extends TestCase
                     'name' => 'Test name 2',
                 ],
             ]);
-        $statement->method('fetch')
+        $result->method('fetchOne')
             ->willReturn(4);
 
         $qb = $this->createMock(QueryBuilder::class);
-        $qb->method('execute')
-            ->willReturn($statement);
+        $qb->method('executeQuery')
+            ->willReturn($result);
         $qb->method('getSQL')
             ->willReturn('SELECT * FROM ps_test WHERE id = :id');
         $qb->method('getParameters')

--- a/tests/Unit/PrestaShopBundle/Command/UpdateSchemaCommandTest.php
+++ b/tests/Unit/PrestaShopBundle/Command/UpdateSchemaCommandTest.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 namespace Tests\Unit\PrestaShopBundle\Command;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Result;
 use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\TestCase;
 use PrestaShopBundle\Command\UpdateSchemaCommand;
@@ -183,7 +183,7 @@ class UpdateSchemaCommandTest extends TestCase
         );
     }
 
-    public function columnsNames(string $name): Statement
+    public function columnsNames(string $name): Result
     {
         $data = [
             'SHOW FULL COLUMNS FROM ps_pa_subcontractor WHERE Field="cutting_price"' => [
@@ -263,8 +263,8 @@ class UpdateSchemaCommandTest extends TestCase
             ],
         ];
 
-        $statement = $this
-            ->getMockBuilder(Statement::class)
+        $result = $this
+            ->getMockBuilder(Result::class)
             ->disableOriginalConstructor()
             ->setMethods(
                 [
@@ -273,12 +273,12 @@ class UpdateSchemaCommandTest extends TestCase
             )
             ->getMockForAbstractClass();
 
-        $statement
+        $result
             ->expects($this->any())
             ->method('fetchAllAssociative')
             ->willReturn($data[$name]);
 
-        return $statement;
+        return $result;
     }
 
     public function getQueries(): array


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |Update egulias/email-validator to 4.0.1. This also requires updating: <br/>  doctrine/dbal from 2.13.8 to 3.6.5 <br/>  doctrine/deprecations  from 0.5.3 to 1.1.1 <br/> doctrine/lexer  from 1.2.3 to 2.1.0 <br/> doctrine/orm  from 2.12.1 to 2.14.3 
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI and tests are green
| UI tests | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/6313332809
| Fixed ticket?     | #33445
| Related PRs       | [productcomments/178](https://github.com/PrestaShop/productcomments/pull/178) https://github.com/PrestaShop/ps_linklist/pull/179
| Sponsor company   | -

###  Update details

- egulias/email-validator 4.0.1 want [doctrine/lexer](https://packagist.org/packages/doctrine/lexer): ^2.0 || ^3.0
- doctrine/lexer 2.1.0 want [doctrine/deprecations](https://packagist.org/packages/doctrine/deprecations): ^1.0
  - doctrine/dbal 2.13.8 want [doctrine/deprecations](https://packagist.org/packages/doctrine/deprecations) 0.5.3 -> should update doctrine/dbal to 2.13.9 OR 3.6.5
  - doctrine/orm 2.12.1 want  [doctrine/deprecations](https://packagist.org/packages/doctrine/deprecations) 0.5.3 -> should update to 2.14.3
  
 ### Module prefix
 
 We can no longer access module entities with a prefix like:
 
- `$entityManager->find('MyModule:Entity', $id);`
- `$entityManager->createQuery('SELECT u FROM MyModule:Entity');`

See https://github.com/doctrine/orm/issues/8818
  
###  Exhaustive list of changes made following the DBAL doctrine update

- `Statement->execute()` now return **Result** instant of **Statement**
- `Statement->closeCursor()` is now `Result->free()`
- `Doctrine\DBAL\DBALException` is now `Doctrine\DBAL\Exception`
- `QueryBuilder->setFirstResult()` no longer allow null values (adding type)
- `Connection->getWrappedConnection()->inTransaction()` move in `Connection->getNativeConnection()->inTransaction()`
- `Statement->execute()` become:
    - `Statement->executeQuery()` for 'Select'
    - `Statement->executeStatement()` for 'Delete', 'Update' or 'Insert'
- `Result->fetchAll()` is now `Result->fetchAllAssociative()`
- `Result->fetchAll(PDO::FETCH_COLUMN)` is now `Result->fetchFirstColumn()`
- `Result->fetch()` is now `Result->fetchAssociative()`
- `Result->fetch(PDO::FETCH_COLUMN)` is now `Result->fetchOne()`

