### PR TITLE
Make search_form twig component independant

### DIFF
--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -60,10 +60,6 @@
               {render_template
                 smarty_template="components/layout/search_form.tpl"
                 twig_template="@PrestaShop/Admin/Layout/search_form.html.twig"
-                bo_query=$bo_query
-                link=$link
-                show_clear_btn= $show_clear_btn|default:null
-                search_type= $search_type|default:null
               }
             <button class="component-search-cancel d-none">{l|escape s='Cancel' d='Admin.Actions'}</button>
           </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/search_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/search_form.html.twig
@@ -25,7 +25,7 @@
 <form id="header_search"
       class="bo_search_form dropdown-form js-dropdown-form collapsed"
       method="post"
-      action="{{ link.getAdminLink('AdminSearch') }}"
+      action="{{ path('AdminSearch') }}"
       role="search">
   <input type="hidden" name="bo_search_type" id="bo_search_type" class="js-search-type" />
   {% if showClearBtn is defined and showClearBtn %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Layout/search_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Layout/search_form.html.twig
@@ -22,9 +22,4 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-{{ component('SearchForm', {
-  boQuery: bo_query,
-  link: link,
-  showClearBtn: show_clear_btn,
-  searchType: search_type
-}) }}
+{{ component('SearchForm') }}

--- a/src/PrestaShopBundle/Twig/Component/SearchForm.php
+++ b/src/PrestaShopBundle/Twig/Component/SearchForm.php
@@ -28,20 +28,24 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Twig\Component;
 
-use Link;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
 #[AsTwigComponent(template: '@PrestaShop/Admin/Component/Layout/search_form.html.twig')]
 class SearchForm
 {
     public string $boQuery;
-    public Link $link;
     public bool $showClearBtn;
-    public bool $searchType;
+    public int $searchType;
 
-    public function mount(bool $showClearBtn = null, bool $searchType = null): void
+    public function __construct(private readonly RequestStack $requestStack)
     {
-        $this->showClearBtn = $showClearBtn ?? false;
-        $this->searchType = $searchType ?? false;
+    }
+
+    public function mount(): void
+    {
+        $this->boQuery = $this->requestStack->getCurrentRequest()->query->get('bo_query') ?: "";
+        $this->searchType = (int) $this->requestStack->getCurrentRequest()->query->get('bo_search_type') ?: 0;
+        $this->showClearBtn = !empty($this->boQuery);
     }
 }

--- a/src/PrestaShopBundle/Twig/Component/SearchForm.php
+++ b/src/PrestaShopBundle/Twig/Component/SearchForm.php
@@ -48,8 +48,8 @@ class SearchForm
     public function mount(): void
     {
         $request = $this->requestStack->getCurrentRequest();
-        $this->boQuery = $request->query->get(self::BO_QUERY_PARAM) ?: '';
-        $this->searchType = (int) $request->query->get(self::BO_SEARCH_TYPE_PARAM) ?: 0;
+        $this->boQuery = $request->query->get(self::BO_QUERY_PARAM, '');
+        $this->searchType = (int) $request->query->get(self::BO_SEARCH_TYPE_PARAM, 0);
         $this->showClearBtn = !empty($this->boQuery);
     }
 }

--- a/src/PrestaShopBundle/Twig/Component/SearchForm.php
+++ b/src/PrestaShopBundle/Twig/Component/SearchForm.php
@@ -34,6 +34,9 @@ use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 #[AsTwigComponent(template: '@PrestaShop/Admin/Component/Layout/search_form.html.twig')]
 class SearchForm
 {
+    private const BO_QUERY_PARAM = 'bo_query';
+    private const BO_SEARCH_TYPE_PARAM = 'bo_search_type';
+
     public string $boQuery;
     public bool $showClearBtn;
     public int $searchType;
@@ -44,8 +47,9 @@ class SearchForm
 
     public function mount(): void
     {
-        $this->boQuery = $this->requestStack->getCurrentRequest()->query->get('bo_query') ?: "";
-        $this->searchType = (int) $this->requestStack->getCurrentRequest()->query->get('bo_search_type') ?: 0;
+        $request = $this->requestStack->getCurrentRequest();
+        $this->boQuery = $request->query->get(self::BO_QUERY_PARAM) ?: '';
+        $this->searchType = (int) $request->query->get(self::BO_SEARCH_TYPE_PARAM) ?: 0;
         $this->showClearBtn = !empty($this->boQuery);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Make search_form twig component callable independantly
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI and auto tests green
| Fixed ticket?     | Fixes #33177
| Related PRs       | 
| Sponsor company   | PrestaShop SA


https://github.com/matthieu-rolland/ga.tests.ui.pr/actions/runs/5690528844