### PR TITLE
Add image helptext

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationImagesChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationImagesChoiceType.php
@@ -67,6 +67,7 @@ class CombinationImagesChoiceType extends TranslatorAwareType
             ->setAllowedTypes('product_id', 'int')
             ->setDefaults([
                 'label' => $this->trans('Images', 'Admin.Global'),
+                'label_subtitle' => $this->trans('You can specify which images should be displayed when customer selects this combination. If you don\'t select any image, all will be displayed. The default image of the combination will be the first one selected from the list.', 'Admin.Catalog.Feature'),
                 'choice_attr' => function (string $choice, string $key): array {
                     return ['data-image-url' => $key];
                 },


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Add info text to combination images field.
| Type?             | improvement
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check that help text is displayed in combination edit modal window.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 

![Snímek obrazovky 2023-07-28 163325](https://github.com/PrestaShop/PrestaShop/assets/6097524/b6426e92-14c1-41b0-ab05-25da4d9bfa1b)
