### PR TITLE
Check if external carrier module exists

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -533,7 +533,8 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
 
         if ($carrier->is_module) {
             $module = Module::getInstanceByName($carrier->external_module_name);
-            if (method_exists($module, 'displayInfoByCart')) {
+            // We need to check if this module is still installed and if it implements the method
+            if (Validate::isLoadedObject($module) && method_exists($module, 'displayInfoByCart')) {
                 $carrierModuleInfo = $module->displayInfoByCart($order->id_cart);
             }
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Check if external carrier module exists to prevent a crash in order view. Simmilar check like here: https://github.com/PrestaShop/PrestaShop/blob/6f5126c44472edaad5c29831b9a49cbbb07ed5e1/classes/Cart.php#L3751
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | You can try to simulate the issue (steps in the issue), or just look at the code and trust me. :-)
| Fixed ticket?     | Fixes #33494
| Related PRs       |
| Sponsor company   | 
