### PR TITLE
Do not convert 0000-00-00 to null

### DIFF
--- a/src/Adapter/Product/Update/ProductDuplicator.php
+++ b/src/Adapter/Product/Update/ProductDuplicator.php
@@ -1020,9 +1020,6 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
             $bulkInsertSql .= '(' . implode(',', array_map(static function ($columnValue): string {
                 if ($columnValue === null) {
                     return 'null';
-                } elseif (!empty($columnValue) && DateTime::isNull($columnValue)) {
-                    // We can't use 0000-00-00 as a value it's not valid in Mysql, so we use null instead
-                    return 'null';
                 }
 
                 // We stringify values to avoid SQL syntax error, the float and integers will correctly casted in the DB anyway


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Avoid converting `0000-00-00` date to null. If `0000-00-00` is inserted for new combinations, it will be valid for duplicated ones. Discussion as if `0000-00-00` or `NULL` can follow for develop branch, but it must be unified.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See steps in issue and see it's fixed.
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/33492
| Related PRs       | 
| Sponsor company   | 
