### PR TITLE
Retry downloading language packs

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1256,7 +1256,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         }
 
         // 3 attempts to download the language pack
-        for ($i = 1; $i <= 3; $i++) {
+        for ($i = 1; $i <= 3; ++$i) {
             $content = Tools::file_get_contents($url, false, null, static::PACK_DOWNLOAD_TIMEOUT);
 
             // If we managed to download the pack successfully and it's a valid zip file, we stop


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Tries to avoid temporary failures by attempting to download a language pack several times.
| Type?             |  improvement
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Check that you can update language pack correctly from back office
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/33514
| Related PRs       | 
| Sponsor company   | 
