### PR TITLE
Rename new-api into backoffice API

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -94,8 +94,8 @@ twig:
     disabling_switch_prefix: !php/const PrestaShopBundle\Form\Extension\DisablingSwitchExtension::FIELD_PREFIX
 
 api_platform:
-  title: PrestaShop API
-  version: 1.0.0
+  title: Backoffice API
+  version: 0.1.0
   enable_entrypoint: false
   formats:
     json:

--- a/app/config/security_dev.yml
+++ b/app/config/security_dev.yml
@@ -23,6 +23,10 @@ security:
       pattern: ^/(_(profiler|wdt)|css|images|js)/
       security: false
 
+    api_token:
+      pattern: ^/api/oauth2/token
+      security: false
+
     api:
       pattern: '^(%api_base_path%)(?!/docs)'
       stateless: true
@@ -30,6 +34,7 @@ security:
       guard:
         authenticator:
           - PrestaShop\PrestaShop\Core\Security\TokenAuthenticator
+      request_matcher: PrestaShop\PrestaShop\Core\Security\OAuth2\ApiRequestMatcher
 
     main:
       anonymous: ~

--- a/app/config/security_test.yml
+++ b/app/config/security_test.yml
@@ -24,6 +24,10 @@ security:
       pattern: ^/(_(profiler|wdt)|css|images|js)/
       security: false
 
+    api_token:
+      pattern: ^/api/oauth2/token
+      security: false
+
     api:
       pattern: '^%api_base_path%'
       stateless: true
@@ -31,6 +35,7 @@ security:
       guard:
         authenticator:
           - PrestaShop\PrestaShop\Core\Security\TokenAuthenticator
+      request_matcher: PrestaShop\PrestaShop\Core\Security\OAuth2\ApiRequestMatcher
 
     main:
       anonymous: ~

--- a/src/Core/Security/OAuth2/ApiRequestMatcher.php
+++ b/src/Core/Security/OAuth2/ApiRequestMatcher.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Security\OAuth2;
+
+use ApiPlatform\Action\PlaceholderAction;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Additional checker for api firewall, the pattern /api is too wide and matches
+ * with existing legacy APIs so we add a more detailed condition that the URI pattern
+ * matches AND it's an API handled by ApiPlatform.
+ *
+ * The legacy APIs should be moved/modified to use another prefix, then this matcher
+ * can be removed as it will be overkill.
+ */
+class ApiRequestMatcher implements RequestMatcherInterface
+{
+    public function matches(Request $request)
+    {
+        return in_array(
+            $request->attributes->get('_controller'),
+            [PlaceholderAction::class, 'api_platform.action.placeholder']
+        );
+    }
+}

--- a/src/PrestaShopBundle/Api/Api.php
+++ b/src/PrestaShopBundle/Api/Api.php
@@ -33,7 +33,7 @@ namespace PrestaShopBundle\Api;
  */
 final class Api
 {
-    public const API_BASE_PATH = '/new-api';
+    public const API_BASE_PATH = '/api';
 
     /**
      * This class is not meant to be instantiated as it is used to access encoding constants only.

--- a/src/PrestaShopBundle/Resources/config/services/core/security.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/security.yml
@@ -22,3 +22,6 @@ services:
     arguments:
       - '@PrestaShop\PrestaShop\Core\OAuth2\OAuth2Interface'
       - '@Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory'
+
+  PrestaShop\PrestaShop\Core\Security\OAuth2\ApiRequestMatcher:
+    public: false

--- a/tests/Integration/ApiPlatform/GetHookStatusTest.php
+++ b/tests/Integration/ApiPlatform/GetHookStatusTest.php
@@ -51,18 +51,18 @@ class GetHookStatusTest extends ApiTestCase
         $activeHook->add();
 
         $bearerToken = $this->getBearerToken();
-        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $inactiveHook->id, ['auth_bearer' => $bearerToken]);
+        $response = static::createClient()->request('GET', '/api/hook-status/' . (int) $inactiveHook->id, ['auth_bearer' => $bearerToken]);
         self::assertEquals(json_decode($response->getContent())->active, $inactiveHook->active);
         self::assertResponseStatusCodeSame(200);
 
-        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $activeHook->id, ['auth_bearer' => $bearerToken]);
+        $response = static::createClient()->request('GET', '/api/hook-status/' . (int) $activeHook->id, ['auth_bearer' => $bearerToken]);
         self::assertEquals(json_decode($response->getContent())->active, $activeHook->active);
         self::assertResponseStatusCodeSame(200);
 
-        static::createClient()->request('GET', '/new-api/hook-status/' . 9999, ['auth_bearer' => $bearerToken]);
+        static::createClient()->request('GET', '/api/hook-status/' . 9999, ['auth_bearer' => $bearerToken]);
         self::assertResponseStatusCodeSame(404);
 
-        static::createClient()->request('GET', '/new-api/hook-status/' . $activeHook->id);
+        static::createClient()->request('GET', '/api/hook-status/' . $activeHook->id);
         self::assertResponseStatusCodeSame(401);
 
         $inactiveHook->delete();
@@ -77,13 +77,13 @@ class GetHookStatusTest extends ApiTestCase
         $hook->add();
 
         $bearerToken = $this->getBearerToken();
-        static::createClient()->request('PUT', '/new-api/hook-status', [
+        static::createClient()->request('PUT', '/api/hook-status', [
             'auth_bearer' => $bearerToken,
             'json' => ['id' => (int) $hook->id, 'active' => false],
         ]);
         self::assertResponseStatusCodeSame(200);
 
-        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $hook->id, ['auth_bearer' => $bearerToken]);
+        $response = static::createClient()->request('GET', '/api/hook-status/' . (int) $hook->id, ['auth_bearer' => $bearerToken]);
         self::assertEquals(json_decode($response->getContent())->active, false);
         self::assertResponseStatusCodeSame(200);
     }
@@ -96,13 +96,13 @@ class GetHookStatusTest extends ApiTestCase
         $hook->add();
 
         $bearerToken = $this->getBearerToken();
-        static::createClient()->request('PUT', '/new-api/hook-status', [
+        static::createClient()->request('PUT', '/api/hook-status', [
             'auth_bearer' => $bearerToken,
             'json' => ['id' => (int) $hook->id, 'active' => true],
         ]);
         self::assertResponseStatusCodeSame(200);
 
-        $response = static::createClient()->request('GET', '/new-api/hook-status/' . (int) $hook->id, ['auth_bearer' => $bearerToken]);
+        $response = static::createClient()->request('GET', '/api/hook-status/' . (int) $hook->id, ['auth_bearer' => $bearerToken]);
         self::assertEquals(json_decode($response->getContent())->active, true);
         self::assertResponseStatusCodeSame(200);
     }

--- a/tests/Integration/ApiPlatform/GetHookTest.php
+++ b/tests/Integration/ApiPlatform/GetHookTest.php
@@ -48,14 +48,14 @@ class GetHookTest extends ApiTestCase
 
         $bearerToken = $this->getBearerToken();
 
-        $response = static::createClient()->request('GET', '/new-api/hooks/' . (int) $hook->id, ['auth_bearer' => $bearerToken]);
+        $response = static::createClient()->request('GET', '/api/hooks/' . (int) $hook->id, ['auth_bearer' => $bearerToken]);
         self::assertEquals(json_decode($response->getContent())->active, $hook->active);
         self::assertResponseStatusCodeSame(200);
 
-        static::createClient()->request('GET', '/new-api/hooks/' . 9999, ['auth_bearer' => $bearerToken]);
+        static::createClient()->request('GET', '/api/hooks/' . 9999, ['auth_bearer' => $bearerToken]);
         self::assertResponseStatusCodeSame(404);
 
-        static::createClient()->request('GET', '/new-api/hooks/' . $hook->id);
+        static::createClient()->request('GET', '/api/hooks/' . $hook->id);
         self::assertResponseStatusCodeSame(401);
 
         $hook->delete();

--- a/tests/UI/campaigns/functional/API/01_basicTest.ts
+++ b/tests/UI/campaigns/functional/API/01_basicTest.ts
@@ -15,17 +15,17 @@ describe('API : Basic Test', async () => {
   });
 
   describe('Basic Test', async () => {
-    it('should request the endpoint /admin-dev/new-api/', async function () {
+    it('should request the endpoint /admin-dev/api/', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestNewApi', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/');
+      const apiResponse = await apiContext.get('api/');
       await expect(apiResponse.status()).to.eq(404);
     });
 
-    it('should request the endpoint /admin-dev/new-api/hook-status', async function () {
+    it('should request the endpoint /admin-dev/api/hook-status', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestNewApiHookStatus', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/hook-status');
+      const apiResponse = await apiContext.get('api/hook-status');
       await expect(apiResponse.status()).to.eq(405);
     });
   });

--- a/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/01_internalAuthServer/02_resourceEndpoint.ts
+++ b/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/01_internalAuthServer/02_resourceEndpoint.ts
@@ -38,19 +38,19 @@ describe('API : Internal Auth Server - Resource Endpoint', async () => {
       accessTokenExpired = api.setAccessTokenAsExpired(accessToken);
     });
 
-    it('should request the endpoint /admin-dev/new-api/hook-status/1 without access token', async function () {
+    it('should request the endpoint /admin-dev/api/hook-status/1 without access token', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestEndpointWithoutAccessToken', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/hook-status/1');
+      const apiResponse = await apiContext.get('api/hook-status/1');
       await expect(apiResponse.status()).to.eq(401);
       await expect(api.hasResponseHeader(apiResponse, 'WWW-Authenticate')).to.be.true;
       await expect(api.getResponseHeader(apiResponse, 'WWW-Authenticate')).to.be.eq('Bearer');
     });
 
-    it('should request the endpoint /admin-dev/new-api/hook-status/1 with invalid access token', async function () {
+    it('should request the endpoint /admin-dev/api/hook-status/1 with invalid access token', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestEndpointWithInvalidAccessToken', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/hook-status/1', {
+      const apiResponse = await apiContext.get('api/hook-status/1', {
         headers: {
           Authorization: 'Bearer INVALIDTOKEN',
         },
@@ -60,10 +60,10 @@ describe('API : Internal Auth Server - Resource Endpoint', async () => {
       await expect(api.getResponseHeader(apiResponse, 'WWW-Authenticate')).to.be.eq('Bearer');
     });
 
-    it('should request the endpoint /admin-dev/new-api/hook-status/1 with expired access token', async function () {
+    it('should request the endpoint /admin-dev/api/hook-status/1 with expired access token', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestEndpointWithExpiredAccessToken', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/hook-status/1', {
+      const apiResponse = await apiContext.get('api/hook-status/1', {
         headers: {
           Authorization: `Bearer ${accessTokenExpired}`,
         },
@@ -73,10 +73,10 @@ describe('API : Internal Auth Server - Resource Endpoint', async () => {
       await expect(api.getResponseHeader(apiResponse, 'WWW-Authenticate')).to.be.eq('Bearer');
     });
 
-    it('should request the endpoint /admin-dev/new-api/hook-status/1 with valid access token', async function () {
+    it('should request the endpoint /admin-dev/api/hook-status/1 with valid access token', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestEndpointWithValidAccessToken', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/hook-status/1', {
+      const apiResponse = await apiContext.get('api/hook-status/1', {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },

--- a/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/02_externalAuthServer/02_resourceEndpoint.ts
+++ b/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/02_externalAuthServer/02_resourceEndpoint.ts
@@ -124,19 +124,19 @@ describe('API : External Auth Server - Resource Endpoint', async () => {
       await expect(textResult).to.be.eq(keycloakConnectorDemo.successfulUpdateMessage);
     });
 
-    it('should request the endpoint /admin-dev/new-api/hook-status/1 without access token', async function () {
+    it('should request the endpoint /admin-dev/api/hook-status/1 without access token', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestEndpointWithoutAccessToken', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/hook-status/1');
+      const apiResponse = await apiContext.get('api/hook-status/1');
       await expect(apiResponse.status()).to.eq(401);
       await expect(api.hasResponseHeader(apiResponse, 'WWW-Authenticate')).to.be.true;
       await expect(api.getResponseHeader(apiResponse, 'WWW-Authenticate')).to.be.eq('Bearer');
     });
 
-    it('should request the endpoint /admin-dev/new-api/hook-status/1 with invalid access token', async function () {
+    it('should request the endpoint /admin-dev/api/hook-status/1 with invalid access token', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestEndpointWithInvalidAccessToken', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/hook-status/1', {
+      const apiResponse = await apiContext.get('api/hook-status/1', {
         headers: {
           Authorization: 'Bearer INVALIDTOKEN',
         },
@@ -146,10 +146,10 @@ describe('API : External Auth Server - Resource Endpoint', async () => {
       await expect(api.getResponseHeader(apiResponse, 'WWW-Authenticate')).to.be.eq('Bearer');
     });
 
-    it('should request the endpoint /admin-dev/new-api/hook-status/1 with expired access token', async function () {
+    it('should request the endpoint /admin-dev/api/hook-status/1 with expired access token', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestEndpointWithExpiredAccessToken', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/hook-status/1', {
+      const apiResponse = await apiContext.get('api/hook-status/1', {
         headers: {
           Authorization: `Bearer ${accessTokenExpiredKeycloak}`,
         },
@@ -160,10 +160,10 @@ describe('API : External Auth Server - Resource Endpoint', async () => {
       await expect(api.getResponseHeader(apiResponse, 'WWW-Authenticate')).to.be.eq('Bearer');
     });
 
-    it('should request the endpoint /admin-dev/new-api/hook-status/1 with valid access token', async function () {
+    it('should request the endpoint /admin-dev/api/hook-status/1 with valid access token', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestEndpointWithValidAccessToken', baseContext);
 
-      const apiResponse = await apiContext.get('new-api/hook-status/1', {
+      const apiResponse = await apiContext.get('api/hook-status/1', {
         headers: {
           Authorization: `Bearer ${accessTokenKeycloak}`,
         },


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | This PR renames the prefix of the new APIs handled by ApiPlatform, but this `/api` prefix was already used by "legacy APIs" So we added a checker to make sure the path matches `^/api` AND is a controller related to ApiPlatform It's a temporary solution, the legacy APIs should be modified so that they use a different prefix
| Type?             | improvement
| Category?         |  WS 
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI and tests https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/5954875944 🟢 
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | PrestaShop SA

The below description is that wrote by @matks in https://github.com/PrestaShop/PrestaShop/pull/32484

## Description

> The new API built in `develop` has still no better name than “New API” and the endpoints are prefixed with `/new-api/`. The name “New API” is written in a few files in the software.
> 
> I think we all agree it’s not the best name ever 😆 
> 
> I suggest we rename the API as “Command API”  (as the API is supposed to plug on existing Commands from CQRS). URL prefix would become `/command-api`.
> 
> I considered the idea of using `/api/v2` for the URL prefix but PS webservices already use the `/api` prefix so it could create routing issues and confusion.
> 
> I also modify the version number from 1.0.0 to 0.1.0 to highlight the fact this is experimental and might change a lot in the next version.