### PR TITLE
Improve Makefile usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,48 @@
-install: composer assets
+help: ## Display this help menu
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-composer:
+install: composer assets  ## Install PHP dependencies and build the static assets
+
+composer: ## Install PHP dependencies
 	composer install
 	./bin/console cache:clear --no-warmup
 
-assets:
+assets:  ## Rebuilds all the static assets, running npm install-clean as needed
 	./tools/assets/build.sh
 
-front-core:
+front-core: ## Building core theme assets
 	./tools/assets/build.sh front-core
 
-front-classic:
+front-classic: ## Building classic theme assets
 	./tools/assets/build.sh front-classic
 
-admin-default:
+admin-default: ## Building admin default theme assets
 	./tools/assets/build.sh admin-default
 
-admin-new-theme:
+admin-new-theme: ## Building admin new theme assets
 	./tools/assets/build.sh admin-new-theme
 
-admin: admin-default admin-new-theme
+admin: admin-default admin-new-theme ## Building admin assets
 
-front: front-core front-classic
+front: front-core front-classic ## Building front assets
 
-cs-fixer:
+cs-fixer: ## Run php-cs-fixer
 	./vendor/bin/php-cs-fixer fix
 
-phpstan:
+phpstan: ## Run phpstan analysis
 	./vendor/bin/phpstan analyse -c phpstan.neon.dist
 
-scss-fixer:
+scss-fixer: ## Run scss-fix
 	cd admin-dev/themes/new-theme && npm run scss-fix
 	cd admin-dev/themes/default && npm run scss-fix
 	cd themes/classic/_dev && npm run scss-fix
 
-es-linter:
+es-linter: ## Run lint-fix
 	cd admin-dev/themes/new-theme && npm run lint-fix
 	cd admin-dev/themes/default && npm run lint-fix
 	cd themes/classic/_dev && npm run lint-fix
 	cd themes && npm run lint-fix
+
+.PHONY: help install composer assets front-core front-classic admin-default admin-new-theme admin front cs-fixer phpstan scss-fixer es-linter
+
+.DEFAULT_GOAL := install


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Add `help` option in `Makefile` to help developers. 
| Type?             |  improvement
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run `make help` 
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | PrestaShop SA

Now, you can run `make help` to have a pretty help menu: 

![Capture d’écran 2023-08-03 à 10 43 32](https://github.com/PrestaShop/PrestaShop/assets/121870/397d875d-2618-40f2-a932-d22b1b3ede4d)

(about `.PHONY`, see https://stackoverflow.com/a/2145605)
