### PR TITLE
Remove unecessary data from legacy product queries

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1020,11 +1020,7 @@ class CategoryCore extends ObjectModel
             $nbDaysNewProduct = 20;
         }
 
-        $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) AS quantity' . (Combination::isFeatureActive() ? ', IFNULL(product_attribute_shop.id_product_attribute, 0) AS id_product_attribute,
-					product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity' : '') . ',
-					pl.`name`, m.`name` AS manufacturer_name, cl.`name` AS category_default,
-					DATEDIFF(product_shop.`date_add`, DATE_SUB("' . date('Y-m-d') . ' 00:00:00",
-					INTERVAL ' . (int) $nbDaysNewProduct . ' DAY)) > 0 AS new, product_shop.price AS orderprice
+        $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) AS quantity, pl.`name`, m.`name` AS manufacturer_name, cl.`name` AS category_default
 				FROM `' . _DB_PREFIX_ . 'category_product` cp
 				LEFT JOIN `' . _DB_PREFIX_ . 'product` p
 					ON p.`id_product` = cp.`id_product`

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1020,7 +1020,7 @@ class CategoryCore extends ObjectModel
             $nbDaysNewProduct = 20;
         }
 
-        $sql = 'SELECT p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) AS quantity' . (Combination::isFeatureActive() ? ', IFNULL(product_attribute_shop.id_product_attribute, 0) AS id_product_attribute,
+        $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) AS quantity' . (Combination::isFeatureActive() ? ', IFNULL(product_attribute_shop.id_product_attribute, 0) AS id_product_attribute,
 					product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity' : '') . ',
 					pl.`name`, m.`name` AS manufacturer_name, cl.`name` AS category_default,
 					DATEDIFF(product_shop.`date_add`, DATE_SUB("' . date('Y-m-d') . ' 00:00:00",

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1020,14 +1020,12 @@ class CategoryCore extends ObjectModel
             $nbDaysNewProduct = 20;
         }
 
-        $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) AS quantity, pl.`name`, m.`name` AS manufacturer_name, cl.`name` AS category_default
+        $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) AS quantity
 				FROM `' . _DB_PREFIX_ . 'category_product` cp
 				LEFT JOIN `' . _DB_PREFIX_ . 'product` p
 					ON p.`id_product` = cp.`id_product`
 				' . Shop::addSqlAssociation('product', 'p') .
-                (Combination::isFeatureActive() ? ' LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_shop` product_attribute_shop
-				ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id . ')' : '') . '
-				' . Product::sqlStock('p', 0) . '
+				    Product::sqlStock('p', 0) . '
 				LEFT JOIN `' . _DB_PREFIX_ . 'category_lang` cl
 					ON (product_shop.`id_category_default` = cl.`id_category`
 					AND cl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('cl') . ')

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1021,9 +1021,8 @@ class CategoryCore extends ObjectModel
         }
 
         $sql = 'SELECT p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) AS quantity' . (Combination::isFeatureActive() ? ', IFNULL(product_attribute_shop.id_product_attribute, 0) AS id_product_attribute,
-					product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity' : '') . ', pl.`description`, pl.`description_short`, pl.`available_now`,
-					pl.`available_later`, pl.`link_rewrite`, pl.`meta_description`, pl.`meta_keywords`, pl.`meta_title`, pl.`name`, image_shop.`id_image` id_image,
-					il.`legend` as legend, m.`name` AS manufacturer_name, cl.`name` AS category_default,
+					product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity' : '') . ',
+					pl.`name`, m.`name` AS manufacturer_name, cl.`name` AS category_default,
 					DATEDIFF(product_shop.`date_add`, DATE_SUB("' . date('Y-m-d') . ' 00:00:00",
 					INTERVAL ' . (int) $nbDaysNewProduct . ' DAY)) > 0 AS new, product_shop.price AS orderprice
 				FROM `' . _DB_PREFIX_ . 'category_product` cp
@@ -1039,11 +1038,6 @@ class CategoryCore extends ObjectModel
 				LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl
 					ON (p.`id_product` = pl.`id_product`
 					AND pl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('pl') . ')
-				LEFT JOIN `' . _DB_PREFIX_ . 'image_shop` image_shop
-					ON (image_shop.`id_product` = p.`id_product` AND image_shop.cover=1 AND image_shop.id_shop=' . (int) $context->shop->id . ')
-				LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il
-					ON (image_shop.`id_image` = il.`id_image`
-					AND il.`id_lang` = ' . (int) $idLang . ')
 				LEFT JOIN `' . _DB_PREFIX_ . 'manufacturer` m
 					ON m.`id_manufacturer` = p.`id_manufacturer`
 				WHERE product_shop.`id_shop` = ' . (int) $context->shop->id . '
@@ -1070,8 +1064,7 @@ class CategoryCore extends ObjectModel
             $result = array_slice($result, (int) (($pageNumber - 1) * $productPerPage), (int) $productPerPage);
         }
 
-        // Modify SQL result
-        return Product::getProductsProperties($idLang, $result);
+        return $result;
     }
 
     /**

--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -451,8 +451,7 @@ class ManufacturerCore extends ObjectModel
 
         $sql = 'SELECT p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity'
             . (Combination::isFeatureActive() ? ', product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity, IFNULL(product_attribute_shop.`id_product_attribute`,0) id_product_attribute' : '') . '
-			, pl.`description`, pl.`description_short`, pl.`link_rewrite`, pl.`meta_description`, pl.`meta_keywords`,
-			pl.`meta_title`, pl.`name`, pl.`available_now`, pl.`available_later`, image_shop.`id_image` id_image, il.`legend`, m.`name` AS manufacturer_name,
+			, pl.`name`, m.`name` AS manufacturer_name,
 				DATEDIFF(
 					product_shop.`date_add`,
 					DATE_SUB(
@@ -466,10 +465,6 @@ class ManufacturerCore extends ObjectModel
 						ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id . ')' : '') . '
 			LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl
 				ON (p.`id_product` = pl.`id_product` AND pl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('pl') . ')
-				LEFT JOIN `' . _DB_PREFIX_ . 'image_shop` image_shop
-					ON (image_shop.`id_product` = p.`id_product` AND image_shop.cover=1 AND image_shop.id_shop=' . (int) $context->shop->id . ')
-			LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il
-				ON (image_shop.`id_image` = il.`id_image` AND il.`id_lang` = ' . (int) $idLang . ')
 			LEFT JOIN `' . _DB_PREFIX_ . 'manufacturer` m
 				ON (m.`id_manufacturer` = p.`id_manufacturer`)
 			' . Product::sqlStock('p', 0);
@@ -507,7 +502,7 @@ class ManufacturerCore extends ObjectModel
             $result = array_slice($result, (int) (($p - 1) * $n), (int) $n);
         }
 
-        return Product::getProductsProperties($idLang, $result);
+        return $result;
     }
 
     /**

--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -450,12 +450,9 @@ class ManufacturerCore extends ObjectModel
         }
 
         $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity
-			, pl.`name`, m.`name` AS manufacturer_name
             FROM `' . _DB_PREFIX_ . 'product` p
 			' . Shop::addSqlAssociation('product', 'p') .
-            (Combination::isFeatureActive() ? 'LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_shop` product_attribute_shop
-						ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id . ')' : '') . '
-			LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl
+			' LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl
 				ON (p.`id_product` = pl.`id_product` AND pl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('pl') . ')
 			LEFT JOIN `' . _DB_PREFIX_ . 'manufacturer` m
 				ON (m.`id_manufacturer` = p.`id_manufacturer`)

--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -449,7 +449,7 @@ class ManufacturerCore extends ObjectModel
             $alias = 'p.';
         }
 
-        $sql = 'SELECT p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity'
+        $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity'
             . (Combination::isFeatureActive() ? ', product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity, IFNULL(product_attribute_shop.`id_product_attribute`,0) id_product_attribute' : '') . '
 			, pl.`name`, m.`name` AS manufacturer_name,
 				DATEDIFF(

--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -449,17 +449,9 @@ class ManufacturerCore extends ObjectModel
             $alias = 'p.';
         }
 
-        $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity'
-            . (Combination::isFeatureActive() ? ', product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity, IFNULL(product_attribute_shop.`id_product_attribute`,0) id_product_attribute' : '') . '
-			, pl.`name`, m.`name` AS manufacturer_name,
-				DATEDIFF(
-					product_shop.`date_add`,
-					DATE_SUB(
-						"' . date('Y-m-d') . ' 00:00:00",
-						INTERVAL ' . (Validate::isUnsignedInt(Configuration::get('PS_NB_DAYS_NEW_PRODUCT')) ? Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20) . ' DAY
-					)
-				) > 0 AS new'
-            . ' FROM `' . _DB_PREFIX_ . 'product` p
+        $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity
+			, pl.`name`, m.`name` AS manufacturer_name
+            FROM `' . _DB_PREFIX_ . 'product` p
 			' . Shop::addSqlAssociation('product', 'p') .
             (Combination::isFeatureActive() ? 'LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_shop` product_attribute_shop
 						ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id . ')' : '') . '

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -330,7 +330,7 @@ class PackCore extends Product
 
         $context = Context::getContext();
 
-        $sql = 'SELECT p.*, product_shop.*, pl.*, cl.`name` AS category_default, a.quantity AS pack_quantity, product_shop.`id_category_default`, a.id_product_pack, a.id_product_attribute_item
+        $sql = 'SELECT p.*, product_shop.*, pl.*, a.quantity AS pack_quantity, product_shop.`id_category_default`, a.id_product_pack, a.id_product_attribute_item
 				FROM `' . _DB_PREFIX_ . 'pack` a
 				LEFT JOIN `' . _DB_PREFIX_ . 'product` p ON p.id_product = a.id_product_item
 				LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl
@@ -410,15 +410,11 @@ class PackCore extends Product
             return [];
         }
 
-        $context = Context::getContext();
-
         $sql = '
 		SELECT p.*, product_shop.*, pl.*
 		FROM `' . _DB_PREFIX_ . 'product` p
 		NATURAL LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl
 		' . Shop::addSqlAssociation('product', 'p') . '
-		LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_shop` product_attribute_shop
-	   		ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id . ')
 		WHERE pl.`id_lang` = ' . (int) $id_lang . '
 			' . Shop::addSqlRestrictionOnLang('pl') . '
 			AND p.`id_product` IN (' . $packs . ')

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -413,7 +413,7 @@ class PackCore extends Product
         $context = Context::getContext();
 
         $sql = '
-		SELECT p.*, product_shop.*, pl.*, IFNULL(product_attribute_shop.id_product_attribute, 0) id_product_attribute
+		SELECT p.*, product_shop.*, pl.*
 		FROM `' . _DB_PREFIX_ . 'product` p
 		NATURAL LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl
 		' . Shop::addSqlAssociation('product', 'p') . '

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -330,15 +330,12 @@ class PackCore extends Product
 
         $context = Context::getContext();
 
-        $sql = 'SELECT p.*, product_shop.*, pl.*, image_shop.`id_image` id_image, il.`legend`, cl.`name` AS category_default, a.quantity AS pack_quantity, product_shop.`id_category_default`, a.id_product_pack, a.id_product_attribute_item
+        $sql = 'SELECT p.*, product_shop.*, pl.*, cl.`name` AS category_default, a.quantity AS pack_quantity, product_shop.`id_category_default`, a.id_product_pack, a.id_product_attribute_item
 				FROM `' . _DB_PREFIX_ . 'pack` a
 				LEFT JOIN `' . _DB_PREFIX_ . 'product` p ON p.id_product = a.id_product_item
 				LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl
 					ON p.id_product = pl.id_product
 					AND pl.`id_lang` = ' . (int) $id_lang . Shop::addSqlRestrictionOnLang('pl') . '
-				LEFT JOIN `' . _DB_PREFIX_ . 'image_shop` image_shop
-					ON (image_shop.`id_product` = p.`id_product` AND image_shop.cover=1 AND image_shop.id_shop=' . (int) $context->shop->id . ')
-				LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (image_shop.`id_image` = il.`id_image` AND il.`id_lang` = ' . (int) $id_lang . ')
 				' . Shop::addSqlAssociation('product', 'p') . '
 				LEFT JOIN `' . _DB_PREFIX_ . 'category_lang` cl
 					ON product_shop.`id_category_default` = cl.`id_category`
@@ -416,15 +413,12 @@ class PackCore extends Product
         $context = Context::getContext();
 
         $sql = '
-		SELECT p.*, product_shop.*, pl.*, image_shop.`id_image` id_image, il.`legend`, IFNULL(product_attribute_shop.id_product_attribute, 0) id_product_attribute
+		SELECT p.*, product_shop.*, pl.*, IFNULL(product_attribute_shop.id_product_attribute, 0) id_product_attribute
 		FROM `' . _DB_PREFIX_ . 'product` p
 		NATURAL LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl
 		' . Shop::addSqlAssociation('product', 'p') . '
 		LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_shop` product_attribute_shop
 	   		ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id . ')
-		LEFT JOIN `' . _DB_PREFIX_ . 'image_shop` image_shop
-			ON (image_shop.`id_product` = p.`id_product` AND image_shop.cover=1 AND image_shop.id_shop=' . (int) $context->shop->id . ')
-		LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (image_shop.`id_image` = il.`id_image` AND il.`id_lang` = ' . (int) $id_lang . ')
 		WHERE pl.`id_lang` = ' . (int) $id_lang . '
 			' . Shop::addSqlRestrictionOnLang('pl') . '
 			AND p.`id_product` IN (' . $packs . ')

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3029,10 +3029,6 @@ class ProductCore extends ObjectModel
             $sql->limit($nb_products, (int) (($page_number - 1) * $nb_products));
         }
 
-        if (Combination::isFeatureActive()) {
-            $sql->select('product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity, IFNULL(product_attribute_shop.id_product_attribute,0) id_product_attribute');
-            $sql->leftJoin('product_attribute_shop', 'product_attribute_shop', 'p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id);
-        }
         $sql->join(Product::sqlStock('p', 0));
 
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
@@ -3147,10 +3143,7 @@ class ProductCore extends ObjectModel
 
             // no group by needed : there's only one attribute with cover=1 for a given id_product + shop
             $sql = 'SELECT p.*, product_shop.*,
-                        pl.`name`,
-                        DATEDIFF(product_shop.`date_add`, DATE_SUB("' . date('Y-m-d') . ' 00:00:00",
-                        INTERVAL ' . (Validate::isUnsignedInt(Configuration::get('PS_NB_DAYS_NEW_PRODUCT')) ? Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20) . '
-                            DAY)) > 0 AS new
+                        pl.`name`
                     FROM `' . _DB_PREFIX_ . 'product` p
                     LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl ON (
                         p.`id_product` = pl.`id_product`
@@ -3277,7 +3270,6 @@ class ProductCore extends ObjectModel
         $sql = '
         SELECT
             p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity,
-            IFNULL(product_attribute_shop.id_product_attribute, 0) id_product_attribute,
             pl.`name`, m.`name` AS manufacturer_name,
             DATEDIFF(
                 p.`date_add`,
@@ -4566,14 +4558,7 @@ class ProductCore extends ObjectModel
     public function getAccessories($id_lang, $active = true)
     {
         $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity,
-                    pl.`name`, m.`name` as manufacturer_name, cl.`name` AS category_default, IFNULL(product_attribute_shop.id_product_attribute, 0) id_product_attribute,
-                    DATEDIFF(
-                        p.`date_add`,
-                        DATE_SUB(
-                            "' . date('Y-m-d') . ' 00:00:00",
-                            INTERVAL ' . (Validate::isUnsignedInt(Configuration::get('PS_NB_DAYS_NEW_PRODUCT')) ? Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20) . ' DAY
-                        )
-                    ) > 0 AS new
+                    pl.`name`, m.`name` as manufacturer_name, cl.`name` AS category_default
                 FROM `' . _DB_PREFIX_ . 'accessory`
                 LEFT JOIN `' . _DB_PREFIX_ . 'product` p ON p.`id_product` = `id_product_2`
                 ' . Shop::addSqlAssociation('product', 'p') . '

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2986,7 +2986,7 @@ class ProductCore extends ObjectModel
         }
         $sql = new DbQuery();
         $sql->select(
-            'p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity, 
+            'p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity, 
             pl.`name`, m.`name` AS manufacturer_name,
             (DATEDIFF(product_shop.`date_add`,
                 DATE_SUB(
@@ -3146,9 +3146,8 @@ class ProductCore extends ObjectModel
             }
 
             // no group by needed : there's only one attribute with cover=1 for a given id_product + shop
-            $sql = 'SELECT p.*, product_shop.*, stock.`out_of_stock` out_of_stock,
+            $sql = 'SELECT p.*, product_shop.*,
                         pl.`name`,
-                        p.`ean13`, p.`isbn`, p.`upc`, p.`mpn`,
                         DATEDIFF(product_shop.`date_add`, DATE_SUB("' . date('Y-m-d') . ' 00:00:00",
                         INTERVAL ' . (Validate::isUnsignedInt(Configuration::get('PS_NB_DAYS_NEW_PRODUCT')) ? Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20) . '
                             DAY)) > 0 AS new
@@ -3277,7 +3276,7 @@ class ProductCore extends ObjectModel
 
         $sql = '
         SELECT
-            p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity,
+            p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity,
             IFNULL(product_attribute_shop.id_product_attribute, 0) id_product_attribute,
             pl.`name`, m.`name` AS manufacturer_name,
             DATEDIFF(
@@ -4566,7 +4565,7 @@ class ProductCore extends ObjectModel
      */
     public function getAccessories($id_lang, $active = true)
     {
-        $sql = 'SELECT p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity,
+        $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity,
                     pl.`name`, m.`name` as manufacturer_name, cl.`name` AS category_default, IFNULL(product_attribute_shop.id_product_attribute, 0) id_product_attribute,
                     DATEDIFF(
                         p.`date_add`,

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2985,17 +2985,7 @@ class ProductCore extends ObjectModel
             return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
         }
         $sql = new DbQuery();
-        $sql->select(
-            'p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity, 
-            pl.`name`, m.`name` AS manufacturer_name,
-            (DATEDIFF(product_shop.`date_add`,
-                DATE_SUB(
-                    "' . $now . '",
-                    INTERVAL ' . $nb_days_new_product . ' DAY
-                )
-            ) > 0) as new'
-        );
-
+        $sql->select('p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity');
         $sql->from('product', 'p');
         $sql->join(Shop::addSqlAssociation('product', 'p'));
         $sql->leftJoin(
@@ -3269,19 +3259,9 @@ class ProductCore extends ObjectModel
 
         $sql = '
         SELECT
-            p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity,
-            pl.`name`, m.`name` AS manufacturer_name,
-            DATEDIFF(
-                p.`date_add`,
-                DATE_SUB(
-                    "' . date('Y-m-d') . ' 00:00:00",
-                    INTERVAL ' . (Validate::isUnsignedInt(Configuration::get('PS_NB_DAYS_NEW_PRODUCT')) ? Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20) . ' DAY
-                )
-            ) > 0 AS new
+            p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity
         FROM `' . _DB_PREFIX_ . 'product` p
         ' . Shop::addSqlAssociation('product', 'p') . '
-        LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_shop` product_attribute_shop
-            ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id . ')
         ' . Product::sqlStock('p', 0, false, $context->shop) . '
         LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl ON (
             p.`id_product` = pl.`id_product`
@@ -4557,13 +4537,10 @@ class ProductCore extends ObjectModel
      */
     public function getAccessories($id_lang, $active = true)
     {
-        $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity,
-                    pl.`name`, m.`name` as manufacturer_name, cl.`name` AS category_default
+        $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity
                 FROM `' . _DB_PREFIX_ . 'accessory`
                 LEFT JOIN `' . _DB_PREFIX_ . 'product` p ON p.`id_product` = `id_product_2`
                 ' . Shop::addSqlAssociation('product', 'p') . '
-                LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_shop` product_attribute_shop
-                    ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $this->id_shop . ')
                 LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl ON (
                     p.`id_product` = pl.`id_product`
                     AND pl.`id_lang` = ' . (int) $id_lang . Shop::addSqlRestrictionOnLang('pl') . '

--- a/classes/ProductSale.php
+++ b/classes/ProductSale.php
@@ -101,7 +101,7 @@ class ProductSaleCore
 
         // no group by needed : there's only one attribute with default_on=1 for a given id_product + shop
         // same for image with cover=1
-        $sql = 'SELECT p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity,
+        $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity,
 					' . (Combination::isFeatureActive() ? 'product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity,IFNULL(product_attribute_shop.id_product_attribute,0) id_product_attribute,' : '') . '
 					pl.`name`,
 					m.`name` AS manufacturer_name, p.`id_manufacturer` as id_manufacturer,
@@ -181,7 +181,7 @@ class ProductSaleCore
 		SELECT
 			p.id_product, IFNULL(product_attribute_shop.id_product_attribute,0) id_product_attribute, pl.`name`, product_shop.`id_category_default`,
 			ps.`quantity` AS sales, p.`ean13`, p.`upc`, cl.`link_rewrite` AS category, p.show_price, p.available_for_order, IFNULL(stock.quantity, 0) as quantity, p.customizable,
-			IFNULL(pa.minimal_quantity, p.minimal_quantity) as minimal_quantity, stock.out_of_stock,
+			IFNULL(pa.minimal_quantity, p.minimal_quantity) as minimal_quantity,
 			product_shop.`date_add` > "' . date('Y-m-d', strtotime('-' . (Configuration::get('PS_NB_DAYS_NEW_PRODUCT') ? (int) Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20) . ' DAY')) . '" as new,
 			product_shop.`on_sale`, product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity
 		FROM `' . _DB_PREFIX_ . 'product_sale` ps

--- a/classes/ProductSale.php
+++ b/classes/ProductSale.php
@@ -102,7 +102,6 @@ class ProductSaleCore
         // no group by needed : there's only one attribute with default_on=1 for a given id_product + shop
         // same for image with cover=1
         $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity,
-					' . (Combination::isFeatureActive() ? 'product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity,IFNULL(product_attribute_shop.id_product_attribute,0) id_product_attribute,' : '') . '
 					pl.`name`,
 					m.`name` AS manufacturer_name, p.`id_manufacturer` as id_manufacturer,
 					ps.`quantity` AS sales,
@@ -120,8 +119,6 @@ class ProductSaleCore
 					ON p.`id_product` = pl.`id_product`
 					AND pl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('pl') . '
 				LEFT JOIN `' . _DB_PREFIX_ . 'manufacturer` m ON (m.`id_manufacturer` = p.`id_manufacturer`)
-					AND tr.`id_country` = ' . (int) $context->country->id . '
-					AND tr.`id_state` = 0
 				' . Product::sqlStock('p', 0);
 
         $sql .= '

--- a/classes/ProductSale.php
+++ b/classes/ProductSale.php
@@ -103,11 +103,9 @@ class ProductSaleCore
         // same for image with cover=1
         $sql = 'SELECT p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity,
 					' . (Combination::isFeatureActive() ? 'product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity,IFNULL(product_attribute_shop.id_product_attribute,0) id_product_attribute,' : '') . '
-					pl.`description`, pl.`description_short`, pl.`link_rewrite`, pl.`meta_description`,
-					pl.`meta_keywords`, pl.`meta_title`, pl.`name`, pl.`available_now`, pl.`available_later`,
+					pl.`name`,
 					m.`name` AS manufacturer_name, p.`id_manufacturer` as id_manufacturer,
-					image_shop.`id_image` id_image, il.`legend`,
-					ps.`quantity` AS sales, t.`rate`, pl.`meta_keywords`, pl.`meta_title`, pl.`meta_description`,
+					ps.`quantity` AS sales,
 					DATEDIFF(p.`date_add`, DATE_SUB("' . date('Y-m-d') . ' 00:00:00",
 					INTERVAL ' . (int) $interval . ' DAY)) > 0 AS new'
             . ' FROM `' . _DB_PREFIX_ . 'product_sale` ps
@@ -121,14 +119,9 @@ class ProductSaleCore
         $sql .= ' LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl
 					ON p.`id_product` = pl.`id_product`
 					AND pl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('pl') . '
-				LEFT JOIN `' . _DB_PREFIX_ . 'image_shop` image_shop
-					ON (image_shop.`id_product` = p.`id_product` AND image_shop.cover=1 AND image_shop.id_shop=' . (int) $context->shop->id . ')
-				LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (image_shop.`id_image` = il.`id_image` AND il.`id_lang` = ' . (int) $idLang . ')
 				LEFT JOIN `' . _DB_PREFIX_ . 'manufacturer` m ON (m.`id_manufacturer` = p.`id_manufacturer`)
-				LEFT JOIN `' . _DB_PREFIX_ . 'tax_rule` tr ON (product_shop.`id_tax_rules_group` = tr.`id_tax_rules_group`)
 					AND tr.`id_country` = ' . (int) $context->country->id . '
 					AND tr.`id_state` = 0
-				LEFT JOIN `' . _DB_PREFIX_ . 'tax` t ON (t.`id_tax` = tr.`id_tax`)
 				' . Product::sqlStock('p', 0);
 
         $sql .= '
@@ -158,7 +151,7 @@ class ProductSaleCore
             return false;
         }
 
-        return Product::getProductsProperties($idLang, $result);
+        return $result;
     }
 
     /**
@@ -186,8 +179,7 @@ class ProductSaleCore
         // same for image with cover=1
         $sql = '
 		SELECT
-			p.id_product, IFNULL(product_attribute_shop.id_product_attribute,0) id_product_attribute, pl.`link_rewrite`, pl.`name`, pl.`description_short`, product_shop.`id_category_default`,
-			image_shop.`id_image` id_image, il.`legend`,
+			p.id_product, IFNULL(product_attribute_shop.id_product_attribute,0) id_product_attribute, pl.`name`, product_shop.`id_category_default`,
 			ps.`quantity` AS sales, p.`ean13`, p.`upc`, cl.`link_rewrite` AS category, p.show_price, p.available_for_order, IFNULL(stock.quantity, 0) as quantity, p.customizable,
 			IFNULL(pa.minimal_quantity, p.minimal_quantity) as minimal_quantity, stock.out_of_stock,
 			product_shop.`date_add` > "' . date('Y-m-d', strtotime('-' . (Configuration::get('PS_NB_DAYS_NEW_PRODUCT') ? (int) Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20) . ' DAY')) . '" as new,
@@ -201,9 +193,6 @@ class ProductSaleCore
 		LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl
 			ON p.`id_product` = pl.`id_product`
 			AND pl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('pl') . '
-		LEFT JOIN `' . _DB_PREFIX_ . 'image_shop` image_shop
-			ON (image_shop.`id_product` = p.`id_product` AND image_shop.cover=1 AND image_shop.id_shop=' . (int) $context->shop->id . ')
-		LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (image_shop.`id_image` = il.`id_image` AND il.`id_lang` = ' . (int) $idLang . ')
 		LEFT JOIN `' . _DB_PREFIX_ . 'category_lang` cl
 			ON cl.`id_category` = product_shop.`id_category_default`
 			AND cl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('cl') . Product::sqlStock('p', 0);
@@ -227,7 +216,7 @@ class ProductSaleCore
             return false;
         }
 
-        return Product::getProductsProperties($idLang, $result);
+        return $result;
     }
 
     /**

--- a/classes/ProductSale.php
+++ b/classes/ProductSale.php
@@ -97,23 +97,13 @@ class ProductSaleCore
             $orderWay = 'DESC';
         }
 
-        $interval = Validate::isUnsignedInt(Configuration::get('PS_NB_DAYS_NEW_PRODUCT')) ? Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20;
-
         // no group by needed : there's only one attribute with default_on=1 for a given id_product + shop
         // same for image with cover=1
         $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity,
-					pl.`name`,
-					m.`name` AS manufacturer_name, p.`id_manufacturer` as id_manufacturer,
-					ps.`quantity` AS sales,
-					DATEDIFF(p.`date_add`, DATE_SUB("' . date('Y-m-d') . ' 00:00:00",
-					INTERVAL ' . (int) $interval . ' DAY)) > 0 AS new'
-            . ' FROM `' . _DB_PREFIX_ . 'product_sale` ps
+					ps.`quantity` AS sales
+                FROM `' . _DB_PREFIX_ . 'product_sale` ps
 				LEFT JOIN `' . _DB_PREFIX_ . 'product` p ON ps.`id_product` = p.`id_product`
 				' . Shop::addSqlAssociation('product', 'p', false);
-        if (Combination::isFeatureActive()) {
-            $sql .= ' LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_shop` product_attribute_shop
-							ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id . ')';
-        }
 
         $sql .= ' LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl
 					ON p.`id_product` = pl.`id_product`

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -422,8 +422,7 @@ class SearchCore
             $alias = 'p.';
         }
         $sql = 'SELECT p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity,
-				pl.`description_short`, pl.`available_now`, pl.`available_later`, pl.`link_rewrite`, pl.`name`,
-			 image_shop.`id_image` id_image, il.`legend`, m.`name` manufacturer_name ' . $sqlScore . ',
+				pl.`name`, m.`name` manufacturer_name ' . $sqlScore . ',
 				DATEDIFF(
 					p.`date_add`,
 					DATE_SUB(
@@ -442,9 +441,6 @@ class SearchCore
 				' . Product::sqlStock('p', 0) . '
 				LEFT JOIN `' . _DB_PREFIX_ . 'manufacturer` m FORCE INDEX (PRIMARY)
 				    ON m.`id_manufacturer` = p.`id_manufacturer`
-				LEFT JOIN `' . _DB_PREFIX_ . 'image_shop` image_shop FORCE INDEX (id_product)
-					ON (image_shop.`id_product` = p.`id_product` AND image_shop.cover=1 AND image_shop.id_shop=' . (int) $context->shop->id . ')
-				LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (image_shop.`id_image` = il.`id_image` AND il.`id_lang` = ' . (int) $id_lang . ')
 				WHERE p.`id_product` ' . $product_pool . '
 				GROUP BY product_shop.id_product';
 
@@ -471,13 +467,7 @@ class SearchCore
 				WHERE p.`id_product` ' . $product_pool;
         $total = $db->getValue($sql, false);
 
-        if (!$result) {
-            $result_properties = false;
-        } else {
-            $result_properties = Product::getProductsProperties((int) $id_lang, $result);
-        }
-
-        return ['total' => $total, 'result' => $result_properties];
+        return ['total' => $total, 'result' => $result];
     }
 
     /**
@@ -991,8 +981,8 @@ class SearchCore
             );
         }
 
-        $sql = 'SELECT DISTINCT p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity, pl.`description_short`, pl.`link_rewrite`, pl.`name`, pl.`available_now`, pl.`available_later`,
-					MAX(image_shop.`id_image`) id_image, il.`legend`, m.`name` manufacturer_name, 1 position,
+        $sql = 'SELECT DISTINCT p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity, pl.`name`,
+					m.`name` manufacturer_name, 1 position,
 					DATEDIFF(
 						p.`date_add`,
 						DATE_SUB(
@@ -1011,9 +1001,6 @@ class SearchCore
 				' . Shop::addSqlAssociation('product', 'p', false) . '
 				LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_shop` product_attribute_shop
 				ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id . ')
-				LEFT JOIN `' . _DB_PREFIX_ . 'image_shop` image_shop
-					ON (image_shop.`id_product` = p.`id_product` AND image_shop.cover=1 AND image_shop.id_shop=' . (int) $context->shop->id . ')
-				LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (image_shop.`id_image` = il.`id_image` AND il.`id_lang` = ' . (int) $id_lang . ')
 				LEFT JOIN `' . _DB_PREFIX_ . 'manufacturer` m ON (m.`id_manufacturer` = p.`id_manufacturer`)
 				LEFT JOIN `' . _DB_PREFIX_ . 'category_product` cp ON (cp.`id_product` = p.`id_product`)
 				' . (Group::isFeatureActive() ? 'LEFT JOIN `' . _DB_PREFIX_ . 'category_group` cg ON (cg.`id_category` = cp.`id_category`)' : '') . '
@@ -1031,7 +1018,7 @@ class SearchCore
             return false;
         }
 
-        return Product::getProductsProperties((int) $id_lang, $result);
+        return $result;
     }
 
     /**

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -421,7 +421,7 @@ class SearchCore
         } elseif (in_array($order_by, ['date_upd', 'date_add'])) {
             $alias = 'p.';
         }
-        $sql = 'SELECT p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity,
+        $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity,
 				pl.`name`, m.`name` manufacturer_name ' . $sqlScore . ',
 				DATEDIFF(
 					p.`date_add`,
@@ -981,7 +981,7 @@ class SearchCore
             );
         }
 
-        $sql = 'SELECT DISTINCT p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) as quantity, pl.`name`,
+        $sql = 'SELECT DISTINCT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity, pl.`name`,
 					m.`name` manufacturer_name, 1 position,
 					DATEDIFF(
 						p.`date_add`,

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -422,14 +422,7 @@ class SearchCore
             $alias = 'p.';
         }
         $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity,
-				pl.`name`, m.`name` manufacturer_name ' . $sqlScore . ',
-				DATEDIFF(
-					p.`date_add`,
-					DATE_SUB(
-						"' . date('Y-m-d') . ' 00:00:00",
-						INTERVAL ' . (Validate::isUnsignedInt(Configuration::get('PS_NB_DAYS_NEW_PRODUCT')) ? Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20) . ' DAY
-					)
-				) > 0 new' . (Combination::isFeatureActive() ? ', product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity, IFNULL(product_attribute_shop.`id_product_attribute`,0) id_product_attribute' : '') . '
+				pl.`name`, m.`name` manufacturer_name ' . $sqlScore . '
 				FROM ' . _DB_PREFIX_ . 'product p
 				' . Shop::addSqlAssociation('product', 'p') . '
 				INNER JOIN `' . _DB_PREFIX_ . 'product_lang` pl ON (
@@ -982,14 +975,7 @@ class SearchCore
         }
 
         $sql = 'SELECT DISTINCT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity, pl.`name`,
-					m.`name` manufacturer_name, 1 position,
-					DATEDIFF(
-						p.`date_add`,
-						DATE_SUB(
-							"' . date('Y-m-d') . ' 00:00:00",
-							INTERVAL ' . (Validate::isUnsignedInt(Configuration::get('PS_NB_DAYS_NEW_PRODUCT')) ? Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20) . ' DAY
-						)
-					) > 0 new
+					m.`name` manufacturer_name, 1 position
 				FROM
 				`' . _DB_PREFIX_ . 'tag` t
 				STRAIGHT_JOIN `' . _DB_PREFIX_ . 'product_tag` pt ON (pt.`id_tag` = t.`id_tag` AND t.`id_lang` = ' . (int) $id_lang . ')

--- a/classes/Supplier.php
+++ b/classes/Supplier.php
@@ -348,15 +348,7 @@ class SupplierCore extends ObjectModel
 
         $sql = 'SELECT p.*, product_shop.*, stock.out_of_stock,
 					IFNULL(stock.quantity, 0) as quantity,
-					pl.`description`,
-					pl.`description_short`,
-					pl.`link_rewrite`,
-					pl.`meta_description`,
-					pl.`meta_keywords`,
-					pl.`meta_title`,
 					pl.`name`,
-					image_shop.`id_image` id_image,
-					il.`legend`,
 					s.`name` AS supplier_name,
 					DATEDIFF(p.`date_add`, DATE_SUB("' . date('Y-m-d') . ' 00:00:00", INTERVAL ' . ($nbDaysNewProduct) . ' DAY)) > 0 AS new,
 					m.`name` AS manufacturer_name' . (Combination::isFeatureActive() ? ', product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity, IFNULL(product_attribute_shop.id_product_attribute,0) id_product_attribute' : '') . '
@@ -367,10 +359,6 @@ class SupplierCore extends ObjectModel
 				ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id . ')' : '') . '
 				LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl ON (p.`id_product` = pl.`id_product`
 					AND pl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('pl') . ')
-				LEFT JOIN `' . _DB_PREFIX_ . 'image_shop` image_shop
-					ON (image_shop.`id_product` = p.`id_product` AND image_shop.cover=1 AND image_shop.id_shop=' . (int) $context->shop->id . ')
-				LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (image_shop.`id_image` = il.`id_image`
-					AND il.`id_lang` = ' . (int) $idLang . ')
 				LEFT JOIN `' . _DB_PREFIX_ . 'supplier` s ON s.`id_supplier` = p.`id_supplier`
 				LEFT JOIN `' . _DB_PREFIX_ . 'manufacturer` m ON m.`id_manufacturer` = p.`id_manufacturer`
 				' . Product::sqlStock('p', 0);
@@ -408,7 +396,7 @@ class SupplierCore extends ObjectModel
             $result = array_slice($result, (int) (($p - 1) * $n), (int) $n);
         }
 
-        return Product::getProductsProperties($idLang, $result);
+        return $result;
     }
 
     /**

--- a/classes/Supplier.php
+++ b/classes/Supplier.php
@@ -351,7 +351,7 @@ class SupplierCore extends ObjectModel
 					pl.`name`,
 					s.`name` AS supplier_name,
 					DATEDIFF(p.`date_add`, DATE_SUB("' . date('Y-m-d') . ' 00:00:00", INTERVAL ' . ($nbDaysNewProduct) . ' DAY)) > 0 AS new,
-					m.`name` AS manufacturer_name' . (Combination::isFeatureActive() ? ', product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity, IFNULL(product_attribute_shop.id_product_attribute,0) id_product_attribute' : '') . '
+					m.`name` AS manufacturer_name
 				 FROM `' . _DB_PREFIX_ . 'product` p
 				' . Shop::addSqlAssociation('product', 'p') . '
 				JOIN `' . _DB_PREFIX_ . 'product_supplier` ps ON (ps.id_product = p.id_product) ' .

--- a/classes/Supplier.php
+++ b/classes/Supplier.php
@@ -346,17 +346,10 @@ class SupplierCore extends ObjectModel
             $alias = 'm.';
         }
 
-        $sql = 'SELECT p.*, product_shop.*,
-					IFNULL(stock.quantity, 0) as quantity,
-					pl.`name`,
-					s.`name` AS supplier_name,
-					DATEDIFF(p.`date_add`, DATE_SUB("' . date('Y-m-d') . ' 00:00:00", INTERVAL ' . ($nbDaysNewProduct) . ' DAY)) > 0 AS new,
-					m.`name` AS manufacturer_name
-				 FROM `' . _DB_PREFIX_ . 'product` p
+        $sql = 'SELECT p.*, product_shop.*, IFNULL(stock.quantity, 0) as quantity,
+				FROM `' . _DB_PREFIX_ . 'product` p
 				' . Shop::addSqlAssociation('product', 'p') . '
-				JOIN `' . _DB_PREFIX_ . 'product_supplier` ps ON (ps.id_product = p.id_product) ' .
-                (Combination::isFeatureActive() ? 'LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_shop` product_attribute_shop
-				ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id . ')' : '') . '
+				JOIN `' . _DB_PREFIX_ . 'product_supplier` ps ON (ps.id_product = p.id_product)
 				LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl ON (p.`id_product` = pl.`id_product`
 					AND pl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('pl') . ')
 				LEFT JOIN `' . _DB_PREFIX_ . 'supplier` s ON s.`id_supplier` = p.`id_supplier`

--- a/classes/Supplier.php
+++ b/classes/Supplier.php
@@ -346,7 +346,7 @@ class SupplierCore extends ObjectModel
             $alias = 'm.';
         }
 
-        $sql = 'SELECT p.*, product_shop.*, stock.out_of_stock,
+        $sql = 'SELECT p.*, product_shop.*,
 					IFNULL(stock.quantity, 0) as quantity,
 					pl.`name`,
 					s.`name` AS supplier_name,

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -945,7 +945,7 @@ class OrderDetailCore extends ObjectModel
                     }
                 }
 
-                return Product::getProductsProperties($id_lang, $order_products);
+                return $order_products;
             }
         }
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removes extra calls to getProductsProperties, this is no longer needed for a long part of 1.7 lifetime. It's enough to provide id_product and optionally id_product_attribute. Core will fetch rest of the data anyway, with lazy loading for some things.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | Yes - but should not really affect anybody. The queries no longer return all data, but everybody should be running it through assembler and presenter. The queries are used in core to get product listings that are managed by faceted search anyway.
| Deprecations?     | no
| How to test?      | Uninstall ps_facetedsearch and check that listings on all pages work as they should, including sorting by all options available. Check that accessories on product page display correctly. Check that pack items on product page display correctly.
| Fixed ticket?     | 
| Related PRs       |
| Sponsor company   | 

TODO - check if productassembler overwrites things in original queries - if not, check if there wasnt any important data coming.