### PR TITLE
Fix load JqueryUI on FrontController : load only requested components

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1148,13 +1148,32 @@ class FrontControllerCore extends Controller
      */
     public function addJqueryUI($component, $theme = 'base', $check_dependencies = true)
     {
-        $css_theme_path = '/js/jquery/ui/themes/' . $theme . '/minified/jquery.ui.theme.min.css';
-        $css_path = '/js/jquery/ui/themes/' . $theme . '/minified/jquery-ui.min.css';
-        $js_path = '/js/jquery/ui/jquery-ui.min.js';
+        // If the component does not start with ui. prefix, we need to add it
+        if (substr($component, 0, 3) !== 'ui.') {
+            $component = 'ui.' . $component;
+        }
 
-        $this->registerStylesheet('jquery-ui-theme', $css_theme_path, ['media' => 'all', 'priority' => 95]);
-        $this->registerStylesheet('jquery-ui', $css_path, ['media' => 'all', 'priority' => 90]);
-        $this->registerJavascript('jquery-ui', $js_path, ['position' => 'bottom', 'priority' => 49]);
+        if (!is_array($component)) {
+            $component = [$component];
+        }
+
+        foreach ($component as $ui) {
+            $ui_path = Media::getJqueryUIPath($ui, $theme, $check_dependencies);
+            foreach ($ui_path['css'] as $uiPathCss => $uiMediaCss) {
+                $this->registerStylesheet(
+                    str_replace(_PS_JS_DIR_ . 'jquery/ui/themes/' . $theme . '/', '', $uiPathCss),
+                    str_replace(_PS_JS_DIR_, '/js/', $uiPathCss),
+                    ['media' => $uiMediaCss, 'priority' => 95]
+                );
+            }
+            foreach ($ui_path['js'] as $uiPathJs) {
+                $this->registerJavascript(
+                    str_replace(_PS_JS_DIR_ . 'jquery/ui/', '', $uiPathJs),
+                    str_replace(_PS_JS_DIR_, '/js/', $uiPathJs),
+                    ['position' => 'bottom', 'priority' => 49]
+                );
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | On the frontController, calling the addJqueryUI function automatically adds the whole jQuery UI library. <br>The function should only add the necessary components. (The jQuery library being quite heavy, it is interesting for web performance (webperf) to load only the necessary components)<br>We can also see that in the Controller classes/controller/Controller.php does it very well for the administration.<br>I adapted the function to match the loading of assets for the Front, loading only the requested components
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | <ol><li>Add search bar module (ps_searchbar). The module calls the function `$this->context->controller->addJqueryUI('ui.autocomplete');`</li><li>Check on the Front side, the list of assets loaded in the network console of the web browser</li></ol><p>If the jQuery UI library is fully loaded, we must have the following list of assets:</p><ul> <li>/js/jquery/ui/jquery-ui.min.js</li> <li>/js/jquery/ui/themes/base/minified/jquery.ui.theme.min.css</li> <li>/js/jquery/ui/themes/base/minified/jquery-ui.min.css</li></ul><p>If we only load the called jQuery components, we should have the following list:</p><ul> <li>/js/jquery/ui/jquery.ui.core.min.js</li> <li>/js/jquery/ui/jquery.ui.widget.min.js</li> <li>/js/jquery/ui/jquery.ui.position.min.js</li> <li>/js/jquery/ui/jquery.ui.menu.min.js</li> <li>/js/jquery/ui/jquery.ui.autocomplete.min.js</li> <li>/js/jquery/ui/themes/base/jquery.ui.core.css</li> <li>/js/jquery/ui/themes/base/jquery.ui.widget.css</li> <li>/js/jquery/ui/themes/base/jquery.ui.position.css</li> <li>/js/jquery/ui/themes/base/jquery.ui.menu.css</li> <li>/js/jquery/ui/themes/base/jquery.ui.autocomplete.css</li> </ul>
| Fixed ticket?     | Fixes #33558 
| Related PRs       | https://github.com/PrestaShop/ps_facetedsearch/pull/895
| Sponsor company   | Damien TUPINIER & Lord of Web
