### PR TITLE
Fix dropExistingForeignKeys method when updating doctrine schema

### DIFF
--- a/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
@@ -122,7 +122,7 @@ class UpdateSchemaCommand extends Command
      */
     public function dropExistingForeignKeys(Connection $connection, OutputInterface $output): int
     {
-        // First drop any existing FK
+        // Get foreign key list in all tables with our prefix
         $query = $connection->executeQuery(
             'SELECT CONSTRAINT_NAME, TABLE_NAME ' .
             'FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS ' .
@@ -132,16 +132,16 @@ class UpdateSchemaCommand extends Command
         );
 
         $results = $query->fetchAllAssociative();
-        $nbQueries = 0;
+        $affectedRows = 0;
 
         foreach ($results as $result) {
             $drop = 'ALTER TABLE ' . $result['TABLE_NAME'] . ' DROP FOREIGN KEY ' . $result['CONSTRAINT_NAME'];
             $output->writeln('Executing: ' . $drop);
 
-            $nbQueries += $connection->executeQuery($drop);
+            $affectedRows += $connection->executeQuery($drop)->rowCount();
         }
 
-        return $nbQueries;
+        return $affectedRows;
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fixes doctrine schema update process for some installations. We must add the number of affected rows, not an object. Fix suggested by @ChillCode. 👍
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Test if upgrade from 8.1.0 to 8.1.1 goes without errors. If automatic tests DO test upgrade process to 8.1.x branch, they are enough.
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/33564, Fixes https://github.com/PrestaShop/PrestaShop/issues/32099, Fixes https://www.prestashop.com/forums/topic/1079161-prestashop-804-to-811-error/
| Related PRs       | 
| Sponsor company   | 
