### PR TITLE
Fix modules from distribution api

### DIFF
--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -322,7 +322,7 @@ class ModuleRepository implements ModuleRepositoryInterface
                 }
             }
             if (!$merged) {
-                $modules[] = new Module($externalModule);
+                $modules->add(new Module($externalModule));
             }
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | (Extracted from https://github.com/PrestaShop/PrestaShop/pull/33452.) This PR -  https://github.com/PrestaShop/PrestaShop/pull/32789 changed the `$module` from `array` to `ModuleCollection`, but did not change `$modules[]` to `$modules->add`, which doesn't work, at least on PHP 8.1 and Windows. Check this line in the same file, where it is done correctly. https://github.com/PrestaShop/PrestaShop/blob/99284a79260886016ce7430b21fe29fde41d571f/src/Core/Module/ModuleRepository.php#L113
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install 8.1.x branch on PHP 8.1, make sure distribution api works, see that you can see the full list of about 70 modules in the list.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 

## Information
### There are 67 modules available from distribution api
![external](https://github.com/PrestaShop/PrestaShop/assets/6097524/09b5aab6-a837-456d-8881-a5320d6daadd)

### There are 49 modules on the disk
![Snímek obrazovky 2023-08-10 160547](https://github.com/PrestaShop/PrestaShop/assets/6097524/d2b0c283-ae6e-49b2-8ee0-1bbc5c7f02e6)

### Now, it should add the modules from api to the list

### But for some reason it adds only one with an empty key
![Snímek obrazovky 2023-08-10 160600](https://github.com/PrestaShop/PrestaShop/assets/6097524/bf31048b-b4ff-4e8c-a521-3bc42acfe380)
