### PR TITLE
Fix broken trans call

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -752,7 +752,7 @@
           data-trigger="hover"
           data-container=".{{ popoverContainer }}"
         >
-          <i class="material-icons form-error-icon">error_outline</i> <u> {{ '%count% errors'|trans(errors|length, {}, 'Admin.Global') }}</u>
+          <i class="material-icons form-error-icon">error_outline</i> <u> {{ '%count% errors'|trans({'%count%': errors|length}, 'Admin.Global') }}</u>
         </span>
       {% endset %}
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | transchoice was badly migrated to trans in https://github.com/PrestaShop/PrestaShop/commit/9ae8a531d37db51a810dc49c0ec5b34288fab819, which results in a an error when this code is used.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/pull/27590#pullrequestreview-1566715158
| Related PRs       | 
| Sponsor company   |

### How to test
1. Get develop
2. Setup 2 languages.
3. Go edit a CMS page, put `<>={}` as a name to both languages.
4. Before - fatal error 🔴 
5. After - "2 errors" next to the field. 🟢