### PR TITLE
Fix untranslated field names on Attribute Group error messages

### DIFF
--- a/admin-dev/init.php
+++ b/admin-dev/init.php
@@ -43,13 +43,6 @@ try {
     }
 
     $iso = $context->language->iso_code;
-    if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/fields.php')) {
-        @trigger_error(
-            'Translating ObjectModel fields using fields.php is deprecated since version 8.0.0.',
-            E_USER_DEPRECATED
-        );
-        include _PS_TRANSLATIONS_DIR_.$iso.'/fields.php';
-    }
 
     /* Server Params */
     $protocol_link = (Configuration::get('PS_SSL_ENABLED')) ? 'https://' : 'http://';

--- a/classes/AttributeGroup.php
+++ b/classes/AttributeGroup.php
@@ -49,12 +49,12 @@ class AttributeGroupCore extends ObjectModel
         'multilang' => true,
         'fields' => [
             'is_color_group' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
-            'group_type' => ['type' => self::TYPE_STRING, 'required' => true],
+            'group_type' => ['type' => self::TYPE_STRING, 'required' => true, 'trans' => ['key' => 'Attribute type', 'domain' => 'Admin.Catalog.Feature']],
             'position' => ['type' => self::TYPE_INT, 'validate' => 'isInt'],
 
             /* Lang fields */
-            'name' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => true, 'size' => 128],
-            'public_name' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => true, 'size' => 64],
+            'name' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => true, 'size' => 128, 'trans' => ['key' => 'Name', 'domain' => 'Admin.Global']],
+            'public_name' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => true, 'size' => 64, 'trans' => ['key' => 'Public name', 'domain' => 'Admin.Catalog.Feature']],
         ],
     ];
 

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -354,7 +354,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
             $mPath_to = _PS_MAIL_DIR_ . (string) $iso_to . '/';
         }
 
-        $lFiles = ['admin.php', 'errors.php', 'fields.php', 'pdf.php', 'tabs.php'];
+        $lFiles = ['admin.php', 'errors.php', 'pdf.php', 'tabs.php'];
 
         // Added natives mails files
         $mFiles = [

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1103,8 +1103,8 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     /**
      * Checks if multilingual object field values are valid before database interaction.
      *
-     * @param bool $die
-     * @param bool $errorReturn
+     * @param bool $die [default=true] If false, return a value instead of throwing an exception on error
+     * @param bool $errorReturn [default=false] If true, return error message instead of false on error
      *
      * @return bool|string true, false or error message
      *
@@ -1286,7 +1286,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     }
 
     /**
-     * Returns field name translation.
+     * Returns the human readable, translated field name.
      *
      * @param string $field Field name
      * @param string $class ObjectModel class name
@@ -1297,24 +1297,23 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
      */
     public static function displayFieldName($field, $class = __CLASS__, $htmlentities = true, Context $context = null)
     {
-        global $_FIELDS;
-
         if (!isset($context)) {
             $context = Context::getContext();
         }
 
-        if ($_FIELDS === null && file_exists(_PS_TRANSLATIONS_DIR_ . $context->language->iso_code . '/fields.php')) {
-            @trigger_error(
-                 'Translating ObjectModel fields using fields.php is deprecated since version 8.0.0.',
-                E_USER_DEPRECATED
+        if (isset(static::$definition['fields'][$field]['trans'])) {
+            $message = static::$definition['fields'][$field]['trans'];
+            $translated = $context->getTranslator()->trans(
+                $message['key'],
+                [],
+                $message['domain'],
+                $context->language->locale
             );
-
-            include_once _PS_TRANSLATIONS_DIR_ . $context->language->iso_code . '/fields.php';
+        } else {
+            $translated = $field;
         }
 
-        $key = $class . '_' . md5($field);
-
-        return (is_array($_FIELDS) && array_key_exists($key, $_FIELDS)) ? ($htmlentities ? htmlentities($_FIELDS[$key], ENT_QUOTES, 'utf-8') : $_FIELDS[$key]) : $field;
+        return $htmlentities ? htmlentities($translated, ENT_QUOTES, 'utf-8') : $translated;
     }
 
     /**

--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -954,11 +954,6 @@ class AdminCarrierWizardControllerCore extends AdminController
         return $definition;
     }
 
-    public static function displayFieldName($field)
-    {
-        return $field;
-    }
-
     public function duplicateLogo($new_id, $old_id)
     {
         $old_logo = _PS_SHIP_IMG_DIR_ . '/' . (int) $old_id . '.jpg';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Read below
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes - The fields.php files are no longer loaded if present
| Deprecations?     | no
| How to test?      | Read below
| Fixed ticket?     | N/A
| Related PRs       | N/A
| UI      | https://github.com/florine2623/testing_pr/actions/runs/8047521490
| Sponsor company   | PrestaShop SA

## About this change

This change follows the [discussion on this PR](https://github.com/PrestaShop/PrestaShop/pull/31767) and provides a different implementation.

Most error messages like "The field %s is required" from FormHelper-based forms are built by the ObjectModel itself. However, ObjectModel only knows its internal field names (eg "public_name"), not the label that was used by the form in any given language (eg. "Nom public" in French). In the past, this was resolved by "translating" field names using a global `$_FIELDS` array containing translations for ObjectModel fields. However, this array is not initialized anymore, as it belonged to [1.6 translation files](https://github.com/PrestaShop/TranslationFiles/blob/master/1.6/fr/translations/fr/fields.php) that no longer exist since 1.7.0. So this feature has been broken since then.

As a result, when the translation isn't found (= 100% of the time), the internal field name is displayed in the error message:

<img width="1015" alt="Before" src="https://github.com/PrestaShop/PrestaShop/assets/1009343/e8dbdaf0-644a-49c1-86f2-a2afb61e0e7e">

Since form labels could be anything (two forms using the same object model could use different labels for the same field), the proper fix would involve the controller telling the ObjectModel the field name to print on error messages while validating any individual form field, or even better, completely change the error system to rely on error codes or exceptions. Unfortunately, this would require substantial refactoring, and it's not worth doing it for a feature that should eventually be retired anyway.

The best solution that I found was pretty much a compromise between the proper solution and the original one. In this implementation, the ObjectModel definition now can include a `trans` part including a translation `key` and `domain` (at least for required fields). This definition is used by ObjectModel to translate field names using the translator. The syntax is specifically chosen to make it [discoverable by the translator](https://devdocs.prestashop-project.org/8/development/internationalization/translation/translation-tips/#array-literals) when extracting wordings.

After this change, we can see that error messages for `name` and `public_name` now are properly translated by the translator:

<img width="1042" alt="After" src="https://github.com/PrestaShop/PrestaShop/assets/1009343/d1ea7912-b215-4d60-a7ce-915072559738">

If this strategy is accepted, we can proceed to add labels to other ObjectModels that are still being used together with FormHelpers.

## How to test

1. Go to Catalog > Attributes
2. Click Add new
3. Submit an empty form
4. See error message