### PR TITLE
Fixing Employee Object Creation: Ensuring Correct Data Types for id and id_profile Properties

### DIFF
--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -332,8 +332,8 @@ class EmployeeCore extends ObjectModel
             return false;
         }
 
-        $this->id = $result['id_employee'];
-        $this->id_profile = $result['id_profile'];
+        $this->id = (int) $result['id_employee'];
+        $this->id_profile = (int) $result['id_profile'];
         foreach ($result as $key => $value) {
             if (property_exists($this, $key)) {
                 $this->{$key} = $value;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When the Employee object is created using getByEmail() function, it assigns string values to id and id_profile properties that are supposed to be int. The PHPDoc and validators confirm those properties are int values. Highlighting those properties in a IDE will show this will return an int value, when in fact those will be strings, making strict comparisons incorrect such as : Context::getContext()->employee->id_profile !== 1, which will always be true even if employee has the id_profile to 1.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | possible
| Deprecations?     | no
| How to test?      | You can dump or inspect with a debugger tool such as XDebug that the type of the properties is int and not string. If using xdebug, you can add a breakpoint at the end of the Employee->getByEmail() function and inspect the properties type.
| Fixed ticket?     | NA
| Related PRs       |  NA
| Sponsor company   | Evolutive Group
