### PR TITLE
use basename php function on some target files when reading/copying/deleting

### DIFF
--- a/classes/Attachment.php
+++ b/classes/Attachment.php
@@ -110,7 +110,7 @@ class AttachmentCore extends ObjectModel
      */
     public function delete()
     {
-        if (file_exists(_PS_DOWNLOAD_DIR_ . $this->file)) {
+        if (file_exists(_PS_DOWNLOAD_DIR_ . basename($this->file))) {
             @unlink(_PS_DOWNLOAD_DIR_ . basename($this->file));
         }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4282,7 +4282,7 @@ class CartCore extends ObjectModel
 
                 if ((int) $custom['type'] == Product::CUSTOMIZE_FILE) {
                     $customized_value = md5(uniqid((string) mt_rand(0, mt_getrandmax()), true));
-                    Tools::copy(_PS_UPLOAD_DIR_ . $custom['value'], _PS_UPLOAD_DIR_ . $customized_value);
+                    Tools::copy(_PS_UPLOAD_DIR_ . basename($custom['value']), _PS_UPLOAD_DIR_ . basename($customized_value));
                     Tools::copy(_PS_UPLOAD_DIR_ . $custom['value'] . '_small', _PS_UPLOAD_DIR_ . $customized_value . '_small');
                 }
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5142,7 +5142,7 @@ class ProductCore extends ObjectModel
         $data = [];
         foreach ($results as $row) {
             $new_filename = ProductDownload::getNewFilename();
-            copy(_PS_DOWNLOAD_DIR_ . $row['filename'], _PS_DOWNLOAD_DIR_ . $new_filename);
+            copy(_PS_DOWNLOAD_DIR_ . basename($row['filename']), _PS_DOWNLOAD_DIR_ . basename($new_filename));
 
             $data[] = [
                 'id_product' => (int) $id_product_new,

--- a/classes/ProductDownload.php
+++ b/classes/ProductDownload.php
@@ -144,7 +144,7 @@ class ProductDownloadCore extends ObjectModel
             return false;
         }
 
-        return unlink(_PS_DOWNLOAD_DIR_ . $this->filename)
+        return unlink(_PS_DOWNLOAD_DIR_ . basename($this->filename))
             && Db::getInstance()->delete('product_download', 'id_product_download = ' . (int) $idProductDownload);
     }
 

--- a/controllers/front/AttachmentController.php
+++ b/controllers/front/AttachmentController.php
@@ -43,7 +43,7 @@ class AttachmentControllerCore extends FrontController
         header('Content-Length: ' . filesize(_PS_DOWNLOAD_DIR_ . $attachment->file));
         header('Content-Disposition: attachment; filename="' . utf8_decode($attachment->file_name) . '"');
         @set_time_limit(0);
-        $this->readfileChunked(_PS_DOWNLOAD_DIR_ . $attachment->file);
+        $this->readfileChunked(_PS_DOWNLOAD_DIR_ . basename($attachment->file));
         exit;
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | add basename on target files to make sure there no additional path is added
| Type?             | improvement
| Category?         | BO
| BC breaks?        | not sure yet
| Deprecations?     | no
| How to test?      | still works as usual
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | PrestaShop SA