### PR TITLE
Add WebP and Avif to mod_expires

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2548,6 +2548,8 @@ class ToolsCore
         if ($cache_control) {
             $cache_control = "<IfModule mod_expires.c>
 	ExpiresActive On
+    AddType image/webp .webp
+    ExpiresByType image/webp \"access plus 1 month\"
 	ExpiresByType image/gif \"access plus 1 month\"
 	ExpiresByType image/jpeg \"access plus 1 month\"
 	ExpiresByType image/png \"access plus 1 month\"

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2550,6 +2550,7 @@ class ToolsCore
 	ExpiresActive On
     AddType image/webp .webp
     ExpiresByType image/webp \"access plus 1 month\"
+    ExpiresByType image/avif \"access plus 1 month\"
 	ExpiresByType image/gif \"access plus 1 month\"
 	ExpiresByType image/jpeg \"access plus 1 month\"
 	ExpiresByType image/png \"access plus 1 month\"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | We forgot to add WebP and Avif to .htaccess. I had to force .webp to be recognized thus AddType.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | You can use Page Speed Insights/Lighthouse or even devtools. It should be tested by a developer.
| Fixed ticket?     | n/a
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company | impSolutions
