### PR TITLE
Fix: issue when clearing cache with opcache with enable_file_override

### DIFF
--- a/src/Core/Cache/Clearer/CacheClearerChain.php
+++ b/src/Core/Cache/Clearer/CacheClearerChain.php
@@ -52,5 +52,9 @@ final class CacheClearerChain implements CacheClearerInterface
         foreach ($this->cacheClearers as $cacheClearer) {
             $cacheClearer->clear();
         }
+
+        if (function_exists('opcache_reset')) {
+            opcache_reset();
+        }
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.1.x
| Description?      | With op cache enabled with `enable_file_override=1` and `validate_timestamps=0` when clearing the cache from the admin the `var/cache/prop/appParameters.php` file is created with permissions `000` and is then unreadable and needs to be removed manually, this is because `file_exists` will return true, but `fileperms` will return 0 because the file doesn't actually exist
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable opcache with the settings, go to clear the cache, if there is no persisting error `500` it's working correctly


In any case it's a good idea to also reset opcache when the user clears the cache manually