### PR TITLE
Add webservice order returns - issue #17753

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -312,6 +312,7 @@ class WebserviceRequestCore
             'order_invoices' => ['description' => 'The Order invoices', 'class' => 'OrderInvoice'],
             'orders' => ['description' => 'The Customers orders', 'class' => 'Order'],
             'order_payments' => ['description' => 'The Order payments', 'class' => 'OrderPayment'],
+			'order_returns' => ['description' => 'The Customers orders returns', 'class' => 'OrderReturn'],
             'order_states' => ['description' => 'The Order statuses', 'class' => 'OrderState'],
             'order_slip' => ['description' => 'The Order slips', 'class' => 'OrderSlip'],
             'price_ranges' => ['description' => 'Price ranges', 'class' => 'RangePrice'],

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -312,7 +312,7 @@ class WebserviceRequestCore
             'order_invoices' => ['description' => 'The Order invoices', 'class' => 'OrderInvoice'],
             'orders' => ['description' => 'The Customers orders', 'class' => 'Order'],
             'order_payments' => ['description' => 'The Order payments', 'class' => 'OrderPayment'],
-			'order_returns' => ['description' => 'The Customers orders returns', 'class' => 'OrderReturn'],
+            'order_returns' => ['description' => 'The Customers orders returns', 'class' => 'OrderReturn'],
             'order_states' => ['description' => 'The Order statuses', 'class' => 'OrderState'],
             'order_slip' => ['description' => 'The Order slips', 'class' => 'OrderSlip'],
             'price_ranges' => ['description' => 'Price ranges', 'class' => 'RangePrice'],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | add orders returns support to webservice
| Type?             | new feature
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable the webservice, you'll see a new method, called order_returns. You can use this method to see and update all returns.
| Fixed ticket?     | #17753
| Related PRs       | N/A
| Sponsor company   | Vaisonet
