### PR TITLE
Nightly: fix erreur on credit slip pagination test

### DIFF
--- a/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/02_sortAndPaginationCreditSlips.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/02_sortAndPaginationCreditSlips.ts
@@ -92,6 +92,18 @@ describe('BO - Orders - Credit slips : Sort (by ID, Date and OrderID) and Pagina
         await expect(pageTitle).to.contains(ordersPage.pageTitle);
       });
 
+      it(`should change the order status to '${OrderStatuses.shipped.name}' and check it`, async function () {
+        await testContext.addContextItem(
+          this,
+          'testIdentifier',
+          `updateCreatedOrderStatus${i}`,
+          `${baseContext}_preTest_${i}`,
+        );
+
+        const textResult = await ordersPage.setOrderStatus(page, 1, OrderStatuses.shipped);
+        await expect(textResult).to.equal(ordersPage.successfulUpdateMessage);
+      });
+
       it('should go to the first order page', async function () {
         await testContext.addContextItem(
           this,
@@ -104,18 +116,6 @@ describe('BO - Orders - Credit slips : Sort (by ID, Date and OrderID) and Pagina
 
         const pageTitle = await orderPageTabListBlock.getPageTitle(page);
         await expect(pageTitle).to.contains(orderPageTabListBlock.pageTitle);
-      });
-
-      it(`should change the order status to '${OrderStatuses.shipped.name}' and check it`, async function () {
-        await testContext.addContextItem(
-          this,
-          'testIdentifier',
-          `updateCreatedOrderStatus${i}`,
-          `${baseContext}_preTest_${i}`,
-        );
-
-        const result = await orderPageTabListBlock.modifyOrderStatus(page, OrderStatuses.shipped.name);
-        await expect(result).to.equal(OrderStatuses.shipped.name);
       });
 
       it('should add a partial refund', async function () {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | nightly: fix erreur on credit slip pagination test
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | no
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | PrestaShopCorp
