### PR TITLE
fix: fix php warning

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2666,7 +2666,7 @@ class ProductCore extends ObjectModel
                 ORDER BY pa.`id_product_attribute`');
 
         if (!$combinations) {
-            return false;
+            return [];
         }
 
         $combinations = array_column($combinations, null, 'id_product_attribute');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Small fix for a PHP warning in foreach. check this issue #33678 
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | You need error_log enabled in your server to test. more details in issue #33678 
| Fixed issue or discussion?     | Fixes #33678 
| Related PRs       | Not found
| Sponsor company   | They don't want to be known anymore :)
