### PR TITLE
Fix PDO prepare for CVE-2023-39524

### DIFF
--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -889,26 +889,27 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
             ->addGroupBy('p.id_product')
         ;
 
-        $dbSearchPhrase = sprintf('"%%%s%%"', pSQL($searchPhrase));
         $qb->where($qb->expr()->or(
-            $qb->expr()->like('pl.name', $dbSearchPhrase),
+            $qb->expr()->like('pl.name', ':dbSearchPhrase'),
 
             // Product references
-            $qb->expr()->like('p.isbn', $dbSearchPhrase),
-            $qb->expr()->like('p.upc', $dbSearchPhrase),
-            $qb->expr()->like('p.mpn', $dbSearchPhrase),
-            $qb->expr()->like('p.reference', $dbSearchPhrase),
-            $qb->expr()->like('p.ean13', $dbSearchPhrase),
-            $qb->expr()->like('p.supplier_reference', $dbSearchPhrase),
+            $qb->expr()->like('p.isbn', ':dbSearchPhrase'),
+            $qb->expr()->like('p.upc', ':dbSearchPhrase'),
+            $qb->expr()->like('p.mpn', ':dbSearchPhrase'),
+            $qb->expr()->like('p.reference', ':dbSearchPhrase'),
+            $qb->expr()->like('p.ean13', ':dbSearchPhrase'),
+            $qb->expr()->like('p.supplier_reference', ':dbSearchPhrase'),
 
             // Combination attributes
-            $qb->expr()->like('pa.isbn', $dbSearchPhrase),
-            $qb->expr()->like('pa.upc', $dbSearchPhrase),
-            $qb->expr()->like('pa.mpn', $dbSearchPhrase),
-            $qb->expr()->like('pa.reference', $dbSearchPhrase),
-            $qb->expr()->like('pa.ean13', $dbSearchPhrase),
-            $qb->expr()->like('pa.supplier_reference', $dbSearchPhrase)
+            $qb->expr()->like('pa.isbn', ':dbSearchPhrase'),
+            $qb->expr()->like('pa.upc', ':dbSearchPhrase'),
+            $qb->expr()->like('pa.mpn', ':dbSearchPhrase'),
+            $qb->expr()->like('pa.reference', ':dbSearchPhrase'),
+            $qb->expr()->like('pa.ean13', ':dbSearchPhrase'),
+            $qb->expr()->like('pa.supplier_reference', ':dbSearchPhrase')
         ));
+        $dbSearchPhrase = sprintf('%%%s%%', $searchPhrase);
+        $qb->setParameter(':dbSearchPhrase', $dbSearchPhrase);
 
         if (!empty($filters)) {
             foreach ($filters as $type => $filter) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Instead of using the legacy method pSQL() use a proper "prepare" via PDO.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | As a backoffice user, go to "edit a product" V2 page, verify the search field for "associated product" works correctly
| Fixed issue or discussion?     | Fixes #33759 
| Related PRs       | NC
| Sponsor company   | @202-ecommerce 
