### PR TITLE
Introduce `css component` for `TypeaheadProductCollectionType`

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_typeahead_product_collection_type.scss
+++ b/admin-dev/themes/new-theme/scss/components/_typeahead_product_collection_type.scss
@@ -1,0 +1,41 @@
+.typeahead-product-collection-type {
+  .typeahead-list {
+    li {
+      @extend .p-1;
+      @extend .mt-1;
+      @extend .d-flex;
+      @extend .align-items-center;
+      border: 1px solid $gray-light;
+
+      // thumbnail
+      > .media-left {
+        img {
+          max-width: 50px;
+          max-height: 50px;
+        }
+      }
+
+      // text
+      > .media-body {
+        .label {
+          @extend .mx-1;
+        }
+
+        // delete button
+        i.delete {
+          float: right;
+          color: $medium-gray;
+          cursor: pointer;
+        }
+      }
+    }
+  }
+
+  .autocomplete-search {
+    .search-suggestion {
+      img {
+        width: 50px;
+      }
+    }
+  }
+}

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -2214,46 +2214,7 @@ $product-page-padding-bottom: 80px !default;
 #related-product,
 #id-product-redirected,
 .redirect-option-widget {
-  // list of added related products
-  .typeahead-list {
-    li {
-      @extend .p-1;
-      @extend .mt-1;
-      @extend .d-flex;
-      @extend .align-items-center;
-      border: 1px solid $gray-light;
-
-      // thumbnail
-      > .media-left {
-        img {
-          max-width: 50px;
-          max-height: 50px;
-        }
-      }
-
-      // text
-      > .media-body {
-        .label {
-          @extend .mx-1;
-        }
-
-        // delete button
-        i.delete {
-          float: right;
-          color: $medium-gray;
-          cursor: pointer;
-        }
-      }
-    }
-  }
-
-  .autocomplete-search {
-    .search-suggestion {
-      img {
-        width: 50px;
-      }
-    }
-  }
+  @import "../../components/typeahead_product_collection_type";
 }
 
 @media only screen and (min-width: 320px) and (max-width: 1450px) {

--- a/admin-dev/themes/new-theme/scss/theme.scss
+++ b/admin-dev/themes/new-theme/scss/theme.scss
@@ -70,6 +70,7 @@
 @import "components/toggable_field";
 @import "components/translatable_input";
 @import "components/unavailable-feature";
+@import "components/typeahead_product_collection_type";
 
 // Pages specifics SCSS files
 @import "pages/invoices";

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/RedirectOptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/RedirectOptionType.php
@@ -189,7 +189,7 @@ class RedirectOptionType extends TranslatorAwareType
                 'label_help_box' => $this->trans('When your product is disabled, choose to which page you’d like to redirect the customers visiting its page by typing the product or category name.', 'Admin.Catalog.Help'),
                 'columns_number' => 2,
                 'row_attr' => [
-                    'class' => 'redirect-option-widget',
+                    'class' => 'redirect-option-widget typeahead-product-collection-type',
                 ],
                 'alert_message' => $this->getRedirectionAlertMessages(),
             ])

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig
@@ -111,7 +111,7 @@
     </fieldset>
   </div>
 
-  <div class="col-md-5" id="id-product-redirected">
+  <div class="col-md-5 typeahead-product-collection-type" id="id-product-redirected">
     <fieldset class="form-group">
       <label class="form-control-label">{{ seoForm.id_type_redirected.vars.label }}</label>
       {{ form_errors(seoForm.id_type_redirected) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig
@@ -133,7 +133,7 @@
           {{ include('@Product/ProductPage/Forms/form_manufacturer.html.twig', { 'form': formManufacturer }) }}
         </div>
 
-        <div id="related-product" class="mb-3">
+        <div id="related-product" class="mb-3 typeahead-product-collection-type">
           {{ include('@Product/ProductPage/Forms/form_related_products.html.twig', { 'form': formRelatedProducts }) }}
         </div>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When you implement multiple `TypeaheadProductCollectionType`, the selected products are not displayed correctly. This because we are using an ID instead of a class.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Make sure that BO product page related products field + seo replace product work well :).
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | Evolutive
