### PR TITLE
Reorganize default configuration

### DIFF
--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -5,850 +5,328 @@
     <field name="value"/>
   </fields>
   <entities>
-  <configuration id="PS_CARRIER_DEFAULT" name="PS_CARRIER_DEFAULT">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_GROUP_FEATURE_ACTIVE" name="PS_GROUP_FEATURE_ACTIVE">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_CURRENCY_DEFAULT" name="PS_CURRENCY_DEFAULT">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_COUNTRY_DEFAULT" name="PS_COUNTRY_DEFAULT">
-    <value>8</value>
-  </configuration>
-  <configuration id="PS_REWRITING_SETTINGS" name="PS_REWRITING_SETTINGS">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_ORDER_OUT_OF_STOCK" name="PS_ORDER_OUT_OF_STOCK">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_LAST_QTIES" name="PS_LAST_QTIES">
-    <value>3</value>
-  </configuration>
-  <configuration id="PS_CONDITIONS" name="PS_CONDITIONS">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_RECYCLABLE_PACK" name="PS_RECYCLABLE_PACK">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_GIFT_WRAPPING" name="PS_GIFT_WRAPPING">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_GIFT_WRAPPING_PRICE" name="PS_GIFT_WRAPPING_PRICE">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_STOCK_MANAGEMENT" name="PS_STOCK_MANAGEMENT">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_NAVIGATION_PIPE" name="PS_NAVIGATION_PIPE">
-    <value>&gt;</value>
-  </configuration>
-  <configuration id="PS_PRODUCTS_PER_PAGE" name="PS_PRODUCTS_PER_PAGE">
-    <value>12</value>
-  </configuration>
-  <configuration id="PS_PURCHASE_MINIMUM" name="PS_PURCHASE_MINIMUM">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_PRODUCTS_ORDER_WAY" name="PS_PRODUCTS_ORDER_WAY">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_PRODUCTS_ORDER_BY" name="PS_PRODUCTS_ORDER_BY">
-    <value>4</value>
-  </configuration>
-  <configuration id="PS_DISPLAY_QTIES" name="PS_DISPLAY_QTIES">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_SHIPPING_HANDLING" name="PS_SHIPPING_HANDLING">
-    <value>2</value>
-  </configuration>
-  <configuration id="PS_SHIPPING_FREE_PRICE" name="PS_SHIPPING_FREE_PRICE">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_SHIPPING_FREE_WEIGHT" name="PS_SHIPPING_FREE_WEIGHT">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_SHIPPING_METHOD" name="PS_SHIPPING_METHOD">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_TAX" name="PS_TAX">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_SHOP_ENABLE" name="PS_SHOP_ENABLE">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_MAINTENANCE_ALLOW_ADMINS" name="PS_MAINTENANCE_ALLOW_ADMINS">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_NB_DAYS_NEW_PRODUCT" name="PS_NB_DAYS_NEW_PRODUCT">
-    <value>20</value>
-  </configuration>
-  <configuration id="PS_SSL_ENABLED" name="PS_SSL_ENABLED">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_WEIGHT_UNIT" name="PS_WEIGHT_UNIT">
-    <value>kg</value>
-  </configuration>
-  <configuration id="PS_BLOCK_CART_AJAX" name="PS_BLOCK_CART_AJAX">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_ORDER_RETURN" name="PS_ORDER_RETURN">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_ORDER_RETURN_NB_DAYS" name="PS_ORDER_RETURN_NB_DAYS">
-    <value>14</value>
-  </configuration>
-  <configuration id="PS_MAIL_TYPE" name="PS_MAIL_TYPE">
-    <value>3</value>
-  </configuration>
-  <configuration id="PS_PRODUCT_PICTURE_MAX_SIZE" name="PS_PRODUCT_PICTURE_MAX_SIZE">
-    <value>8388608</value>
-  </configuration>
-  <configuration id="PS_PRODUCT_PICTURE_WIDTH" name="PS_PRODUCT_PICTURE_WIDTH">
-    <value>64</value>
-  </configuration>
-  <configuration id="PS_PRODUCT_PICTURE_HEIGHT" name="PS_PRODUCT_PICTURE_HEIGHT">
-    <value>64</value>
-  </configuration>
-  <configuration id="PS_INVOICE_PREFIX" name="PS_INVOICE_PREFIX">
-    <value>#IN</value>
-  </configuration>
-  <configuration id="PS_INVCE_INVOICE_ADDR_RULES" name="PS_INVCE_INVOICE_ADDR_RULES">
-    <value>{"avoid":[]}</value>
-  </configuration>
-  <configuration id="PS_INVCE_DELIVERY_ADDR_RULES" name="PS_INVCE_DELIVERY_ADDR_RULES">
-    <value>{"avoid":[]}</value>
-  </configuration>
-  <configuration id="PS_DELIVERY_PREFIX" name="PS_DELIVERY_PREFIX">
-    <value>#DE</value>
-  </configuration>
-  <configuration id="PS_DELIVERY_NUMBER" name="PS_DELIVERY_NUMBER">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_RETURN_PREFIX" name="PS_RETURN_PREFIX">
-    <value>#RE</value>
-  </configuration>
-  <configuration id="PS_INVOICE" name="PS_INVOICE">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_PASSWD_TIME_BACK" name="PS_PASSWD_TIME_BACK">
-    <value>360</value>
-  </configuration>
-  <configuration id="PS_PASSWD_TIME_FRONT" name="PS_PASSWD_TIME_FRONT">
-    <value>360</value>
-  </configuration>
-  <configuration id="PS_PASSWD_RESET_VALIDITY" name="PS_PASSWD_RESET_VALIDITY">
-    <value>1440</value>
-  </configuration>
-  <configuration id="PS_DISP_UNAVAILABLE_ATTR" name="PS_DISP_UNAVAILABLE_ATTR">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_SEARCH_INDEXATION" name="PS_SEARCH_INDEXATION">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_SEARCH_FUZZY" name="PS_SEARCH_FUZZY">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_SEARCH_FUZZY_MAX_LOOP" name="PS_SEARCH_FUZZY_MAX_LOOP">
-    <value>4</value>
-  </configuration>
-  <configuration id="PS_SEARCH_MAX_WORD_LENGTH" name="PS_SEARCH_MAX_WORD_LENGTH">
-    <value>15</value>
-  </configuration>
-  <configuration id="PS_SEARCH_MINWORDLEN" name="PS_SEARCH_MINWORDLEN">
-    <value>3</value>
-  </configuration>
-  <configuration id="PS_SEARCH_BLACKLIST" name="PS_SEARCH_BLACKLIST">
-    <value/>
-  </configuration>
-  <configuration id="PS_SEARCH_WEIGHT_PNAME" name="PS_SEARCH_WEIGHT_PNAME">
-    <value>6</value>
-  </configuration>
-  <configuration id="PS_SEARCH_WEIGHT_REF" name="PS_SEARCH_WEIGHT_REF">
-    <value>10</value>
-  </configuration>
-  <configuration id="PS_SEARCH_WEIGHT_SHORTDESC" name="PS_SEARCH_WEIGHT_SHORTDESC">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_SEARCH_WEIGHT_DESC" name="PS_SEARCH_WEIGHT_DESC">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_SEARCH_WEIGHT_CNAME" name="PS_SEARCH_WEIGHT_CNAME">
-    <value>3</value>
-  </configuration>
-  <configuration id="PS_SEARCH_WEIGHT_MNAME" name="PS_SEARCH_WEIGHT_MNAME">
-    <value>3</value>
-  </configuration>
-  <configuration id="PS_SEARCH_WEIGHT_TAG" name="PS_SEARCH_WEIGHT_TAG">
-    <value>4</value>
-  </configuration>
-  <configuration id="PS_SEARCH_WEIGHT_ATTRIBUTE" name="PS_SEARCH_WEIGHT_ATTRIBUTE">
-    <value>2</value>
-  </configuration>
-  <configuration id="PS_SEARCH_WEIGHT_FEATURE" name="PS_SEARCH_WEIGHT_FEATURE">
-    <value>2</value>
-  </configuration>
-  <configuration id="PS_SEARCH_AJAX" name="PS_SEARCH_AJAX">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_TIMEZONE" name="PS_TIMEZONE">
-    <value>Europe/Paris</value>
-  </configuration>
-  <configuration id="PS_THEME_V11" name="PS_THEME_V11">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_TIN_ACTIVE" name="PS_TIN_ACTIVE">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_SHOW_ALL_MODULES" name="PS_SHOW_ALL_MODULES">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_BACKUP_ALL" name="PS_BACKUP_ALL">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_1_3_UPDATE_DATE" name="PS_1_3_UPDATE_DATE">
-    <value>2011-12-27 10:20:42</value>
-  </configuration>
-  <configuration id="PS_PRICE_ROUND_MODE" name="PS_PRICE_ROUND_MODE">
-    <value>2</value>
-  </configuration>
-  <configuration id="PS_1_3_2_UPDATE_DATE" name="PS_1_3_2_UPDATE_DATE">
-    <value>2011-12-27 10:20:42</value>
-  </configuration>
-  <configuration id="PS_CONDITIONS_CMS_ID" name="PS_CONDITIONS_CMS_ID">
-    <value>3</value>
-  </configuration>
-  <configuration id="PS_VOLUME_UNIT" name="PS_VOLUME_UNIT">
-    <value>cl</value>
-  </configuration>
-  <configuration id="PS_CIPHER_ALGORITHM" name="PS_CIPHER_ALGORITHM">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_ATTRIBUTE_CATEGORY_DISPLAY" name="PS_ATTRIBUTE_CATEGORY_DISPLAY">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_CUSTOMER_SERVICE_FILE_UPLOAD" name="PS_CUSTOMER_SERVICE_FILE_UPLOAD">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_CUSTOMER_SERVICE_SIGNATURE" name="PS_CUSTOMER_SERVICE_SIGNATURE">
-    <value/>
-  </configuration>
-  <configuration id="PS_BLOCK_BESTSELLERS_DISPLAY" name="PS_BLOCK_BESTSELLERS_DISPLAY">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_BLOCK_NEWPRODUCTS_DISPLAY" name="PS_BLOCK_NEWPRODUCTS_DISPLAY">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_BLOCK_SPECIALS_DISPLAY" name="PS_BLOCK_SPECIALS_DISPLAY">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_STOCK_MVT_REASON_DEFAULT" name="PS_STOCK_MVT_REASON_DEFAULT">
-    <value>3</value>
-  </configuration>
-  <configuration id="PS_SPECIFIC_PRICE_PRIORITIES" name="PS_SPECIFIC_PRICE_PRIORITIES">
-    <value>id_group;id_currency;id_country;id_shop</value>
-  </configuration>
-  <configuration id="PS_TAX_DISPLAY" name="PS_TAX_DISPLAY">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_SMARTY_FORCE_COMPILE" name="PS_SMARTY_FORCE_COMPILE">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_DISTANCE_UNIT" name="PS_DISTANCE_UNIT">
-    <value>km</value>
-  </configuration>
-  <configuration id="PS_STORES_DISPLAY_CMS" name="PS_STORES_DISPLAY_CMS">
-    <value>1</value>
-  </configuration>
-  <configuration id="SHOP_LOGO_WIDTH" name="SHOP_LOGO_WIDTH">
-    <value>209</value>
-  </configuration>
-  <configuration id="SHOP_LOGO_HEIGHT" name="SHOP_LOGO_HEIGHT">
-    <value>52</value>
-  </configuration>
-  <configuration id="EDITORIAL_IMAGE_WIDTH" name="EDITORIAL_IMAGE_WIDTH">
-    <value>530</value>
-  </configuration>
-  <configuration id="EDITORIAL_IMAGE_HEIGHT" name="EDITORIAL_IMAGE_HEIGHT">
-    <value>228</value>
-  </configuration>
-  <configuration id="PS_STATSDATA_CUSTOMER_PAGESVIEWS" name="PS_STATSDATA_CUSTOMER_PAGESVIEWS">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_STATSDATA_PAGESVIEWS" name="PS_STATSDATA_PAGESVIEWS">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_STATSDATA_PLUGINS" name="PS_STATSDATA_PLUGINS">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_GEOLOCATION_ENABLED" name="PS_GEOLOCATION_ENABLED">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_ALLOWED_COUNTRIES" name="PS_ALLOWED_COUNTRIES">
-    <value>AF;ZA;AX;AL;DZ;DE;AD;AO;AI;AQ;AG;AN;SA;AR;AM;AW;AU;AT;AZ;BS;BH;BD;BB;BY;BE;BZ;BJ;BM;BT;BO;BA;BW;BV;BR;BN;BG;BF;MM;BI;KY;KH;CM;CA;CV;CF;CL;CN;CX;CY;CC;CO;KM;CG;CD;CK;KR;KP;CR;CI;HR;CU;DK;DJ;DM;EG;IE;SV;AE;EC;ER;ES;EE;ET;FK;FO;FJ;FI;FR;GA;GM;GE;GS;GH;GI;GR;GD;GL;GP;GU;GT;GG;GN;GQ;GW;GY;GF;HT;HM;HN;HK;HU;IM;MU;VG;VI;IN;ID;IR;IQ;IS;IL;IT;JM;JP;JE;JO;KZ;KE;KG;KI;KW;LA;LS;LV;LB;LR;LY;LI;LT;LU;MO;MK;MG;MY;MW;MV;ML;MT;MP;MA;MH;MQ;MR;YT;MX;FM;MD;MC;MN;ME;MS;MZ;NA;NR;NP;NI;NE;NG;NU;NF;NO;NC;NZ;IO;OM;UG;UZ;PK;PW;PS;PA;PG;PY;NL;PE;PH;PN;PL;PF;PR;PT;QA;DO;CZ;RE;RO;GB;RU;RW;EH;BL;KN;SM;MF;PM;VA;VC;LC;SB;WS;AS;ST;SN;RS;SC;SL;SG;SK;SI;SO;SD;LK;SE;CH;SR;SJ;SZ;SY;TJ;TW;TZ;TD;TF;TH;TL;TG;TK;TO;TT;TN;TM;TC;TR;TV;UA;UY;US;VU;VE;VN;WF;YE;ZM;ZW</value>
-  </configuration>
-  <configuration id="PS_GEOLOCATION_BEHAVIOR" name="PS_GEOLOCATION_BEHAVIOR">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_LOCALE_LANGUAGE" name="PS_LOCALE_LANGUAGE">
-    <value>fr</value>
-  </configuration>
-  <configuration id="PS_LOCALE_COUNTRY" name="PS_LOCALE_COUNTRY">
-    <value>fr</value>
-  </configuration>
-  <configuration id="PS_ATTACHMENT_MAXIMUM_SIZE" name="PS_ATTACHMENT_MAXIMUM_SIZE">
-    <value>8</value>
-  </configuration>
-  <configuration id="PS_SMARTY_CACHE" name="PS_SMARTY_CACHE">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_DIMENSION_UNIT" name="PS_DIMENSION_UNIT">
-    <value>cm</value>
-  </configuration>
-  <configuration id="PS_GUEST_CHECKOUT_ENABLED" name="PS_GUEST_CHECKOUT_ENABLED">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_DISPLAY_SUPPLIERS" name="PS_DISPLAY_SUPPLIERS">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_DISPLAY_MANUFACTURERS" name="PS_DISPLAY_MANUFACTURERS">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_DISPLAY_BEST_SELLERS" name="PS_DISPLAY_BEST_SELLERS">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_CATALOG_MODE" name="PS_CATALOG_MODE">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_GEOLOCATION_WHITELIST" name="PS_GEOLOCATION_WHITELIST">
-    <value>127.0.0.1;::1</value>
-  </configuration>
-  <configuration id="PS_LOGS_BY_EMAIL" name="PS_LOGS_BY_EMAIL">
-    <value>4</value>
-  </configuration>
-  <configuration id="PS_COOKIE_CHECKIP" name="PS_COOKIE_CHECKIP">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_COOKIE_SAMESITE" name="PS_COOKIE_SAMESITE">
-    <value>Lax</value>
-  </configuration>
-  <configuration id="PS_USE_ECOTAX" name="PS_USE_ECOTAX">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_CANONICAL_REDIRECT" name="PS_CANONICAL_REDIRECT">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_IMG_UPDATE_TIME" name="PS_IMG_UPDATE_TIME">
-    <value>1324977642</value>
-  </configuration>
-  <configuration id="PS_BACKUP_DROP_TABLE" name="PS_BACKUP_DROP_TABLE">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_OS_CHEQUE" name="PS_OS_CHEQUE">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_OS_PAYMENT" name="PS_OS_PAYMENT">
-    <value>2</value>
-  </configuration>
-  <configuration id="PS_OS_PREPARATION" name="PS_OS_PREPARATION">
-    <value>3</value>
-  </configuration>
-  <configuration id="PS_OS_SHIPPING" name="PS_OS_SHIPPING">
-    <value>4</value>
-  </configuration>
-  <configuration id="PS_OS_DELIVERED" name="PS_OS_DELIVERED">
-    <value>5</value>
-  </configuration>
-  <configuration id="PS_OS_CANCELED" name="PS_OS_CANCELED">
-    <value>6</value>
-  </configuration>
-  <configuration id="PS_OS_REFUND" name="PS_OS_REFUND">
-    <value>7</value>
-  </configuration>
-  <configuration id="PS_OS_ERROR" name="PS_OS_ERROR">
-    <value>8</value>
-  </configuration>
-  <configuration id="PS_OS_OUTOFSTOCK" name="PS_OS_OUTOFSTOCK">
-    <value>9</value>
-  </configuration>
-  <configuration id="PS_OS_BANKWIRE" name="PS_OS_BANKWIRE">
-    <value>10</value>
-  </configuration>
-  <configuration id="PS_OS_WS_PAYMENT" name="PS_OS_WS_PAYMENT">
-    <value>11</value>
-  </configuration>
-  <configuration id="PS_OS_OUTOFSTOCK_PAID" name="PS_OS_OUTOFSTOCK_PAID">
-    <value>9</value>
-  </configuration>
-  <configuration id="PS_OS_OUTOFSTOCK_UNPAID" name="PS_OS_OUTOFSTOCK_UNPAID">
-    <value>12</value>
-  </configuration>
-  <configuration id="PS_OS_COD_VALIDATION" name="PS_OS_COD_VALIDATION">
-    <value>13</value>
-  </configuration>
-  <configuration id="PS_LEGACY_IMAGES" name="PS_LEGACY_IMAGES">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_IMAGE_QUALITY" name="PS_IMAGE_QUALITY">
-    <value>jpg</value>
-  </configuration>
-  <configuration id="PS_PNG_QUALITY" name="PS_PNG_QUALITY">
-    <value>7</value>
-  </configuration>
-  <configuration id="PS_JPEG_QUALITY" name="PS_JPEG_QUALITY">
-    <value>90</value>
-  </configuration>
-  <configuration id="PS_WEBP_QUALITY" name="PS_WEBP_QUALITY">
-    <value>80</value>
-  </configuration>
-  <configuration id="PS_COOKIE_LIFETIME_FO" name="PS_COOKIE_LIFETIME_FO">
-    <value>480</value>
-  </configuration>
-  <configuration id="PS_COOKIE_LIFETIME_BO" name="PS_COOKIE_LIFETIME_BO">
-    <value>480</value>
-  </configuration>
-  <configuration id="PS_RESTRICT_DELIVERED_COUNTRIES" name="PS_RESTRICT_DELIVERED_COUNTRIES">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_SHOW_NEW_ORDERS" name="PS_SHOW_NEW_ORDERS">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_SHOW_NEW_CUSTOMERS" name="PS_SHOW_NEW_CUSTOMERS">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_SHOW_NEW_MESSAGES" name="PS_SHOW_NEW_MESSAGES">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_FEATURE_FEATURE_ACTIVE" name="PS_FEATURE_FEATURE_ACTIVE">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_COMBINATION_FEATURE_ACTIVE" name="PS_COMBINATION_FEATURE_ACTIVE">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_SPECIFIC_PRICE_FEATURE_ACTIVE" name="PS_SPECIFIC_PRICE_FEATURE_ACTIVE">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_VIRTUAL_PROD_FEATURE_ACTIVE" name="PS_VIRTUAL_PROD_FEATURE_ACTIVE">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_CUSTOMIZATION_FEATURE_ACTIVE" name="PS_CUSTOMIZATION_FEATURE_ACTIVE">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_CART_RULE_FEATURE_ACTIVE" name="PS_CART_RULE_FEATURE_ACTIVE">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_PACK_FEATURE_ACTIVE" name="PS_PACK_FEATURE_ACTIVE">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_ALIAS_FEATURE_ACTIVE" name="PS_ALIAS_FEATURE_ACTIVE">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_TAX_ADDRESS_TYPE" name="PS_TAX_ADDRESS_TYPE">
-    <value>id_address_delivery</value>
-  </configuration>
-  <configuration id="PS_SHOP_DEFAULT" name="PS_SHOP_DEFAULT">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_CARRIER_DEFAULT_SORT" name="PS_CARRIER_DEFAULT_SORT">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_STOCK_MVT_INC_REASON_DEFAULT" name="PS_STOCK_MVT_INC_REASON_DEFAULT">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_STOCK_MVT_DEC_REASON_DEFAULT" name="PS_STOCK_MVT_DEC_REASON_DEFAULT">
-    <value>2</value>
-  </configuration>
-  <configuration id="PS_ADVANCED_STOCK_MANAGEMENT" name="PS_ADVANCED_STOCK_MANAGEMENT">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_STOCK_MVT_TRANSFER_TO" name="PS_STOCK_MVT_TRANSFER_TO">
-    <value>7</value>
-  </configuration>
-  <configuration id="PS_STOCK_MVT_TRANSFER_FROM" name="PS_STOCK_MVT_TRANSFER_FROM">
-    <value>6</value>
-  </configuration>
-  <configuration id="PS_CARRIER_DEFAULT_ORDER" name="PS_CARRIER_DEFAULT_ORDER">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_STOCK_MVT_SUPPLY_ORDER" name="PS_STOCK_MVT_SUPPLY_ORDER">
-    <value>8</value>
-  </configuration>
-  <configuration id="PS_STOCK_CUSTOMER_ORDER_CANCEL_REASON" name="PS_STOCK_CUSTOMER_ORDER_CANCEL_REASON">
-    <value>9</value>
-</configuration>
-  <configuration id="PS_STOCK_CUSTOMER_RETURN_REASON" name="PS_STOCK_CUSTOMER_RETURN_REASON">
-    <value>10</value>
-  </configuration>
-  <configuration id="PS_STOCK_MVT_INC_EMPLOYEE_EDITION" name="PS_STOCK_MVT_INC_EMPLOYEE_EDITION">
-    <value>11</value>
-  </configuration>
-  <configuration id="PS_STOCK_MVT_DEC_EMPLOYEE_EDITION" name="PS_STOCK_MVT_DEC_EMPLOYEE_EDITION">
-    <value>12</value>
-  </configuration>
-  <configuration id="PS_STOCK_CUSTOMER_ORDER_REASON" name="PS_STOCK_CUSTOMER_ORDER_REASON">
-    <value>3</value>
-  </configuration>
-  <configuration id="PS_UNIDENTIFIED_GROUP" name="PS_UNIDENTIFIED_GROUP">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_GUEST_GROUP" name="PS_GUEST_GROUP">
-    <value>2</value>
-  </configuration>
-  <configuration id="PS_CUSTOMER_GROUP" name="PS_CUSTOMER_GROUP">
-    <value>3</value>
-  </configuration>
-  <configuration id="PS_SMARTY_CONSOLE" name="PS_SMARTY_CONSOLE">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_INVOICE_MODEL" name="PS_INVOICE_MODEL">
-    <value>invoice</value>
-  </configuration>
-  <configuration id="PS_LIMIT_UPLOAD_IMAGE_VALUE" name="PS_LIMIT_UPLOAD_IMAGE_VALUE">
-    <value>2</value>
-  </configuration>
-  <configuration id="PS_LIMIT_UPLOAD_FILE_VALUE" name="PS_LIMIT_UPLOAD_FILE_VALUE">
-    <value>2</value>
-  </configuration>
-  <configuration id="MB_PAY_TO_EMAIL" name="MB_PAY_TO_EMAIL">
-    <value/>
-  </configuration>
-  <configuration id="MB_SECRET_WORD" name="MB_SECRET_WORD">
-    <value/>
-  </configuration>
-  <configuration id="MB_HIDE_LOGIN" name="MB_HIDE_LOGIN">
-    <value>1</value>
-  </configuration>
-  <configuration id="MB_ID_LOGO" name="MB_ID_LOGO">
-    <value>1</value>
-  </configuration>
-  <configuration id="MB_ID_LOGO_WALLET" name="MB_ID_LOGO_WALLET">
-    <value>1</value>
-  </configuration>
-  <configuration id="MB_PARAMETERS" name="MB_PARAMETERS">
-    <value>0</value>
-  </configuration>
-  <configuration id="MB_PARAMETERS_2" name="MB_PARAMETERS_2">
-    <value>0</value>
-  </configuration>
-  <configuration id="MB_DISPLAY_MODE" name="MB_DISPLAY_MODE">
-    <value>0</value>
-  </configuration>
-  <configuration id="MB_CANCEL_URL" name="MB_CANCEL_URL">
-    <value>http://www.yoursite.com</value>
-  </configuration>
-  <configuration id="MB_LOCAL_METHODS" name="MB_LOCAL_METHODS">
-    <value>2</value>
-  </configuration>
-  <configuration id="MB_INTER_METHODS" name="MB_INTER_METHODS">
-    <value>5</value>
-  </configuration>
-  <configuration id="BANK_WIRE_CURRENCIES" name="BANK_WIRE_CURRENCIES">
-    <value>2,1</value>
-  </configuration>
-  <configuration id="CHEQUE_CURRENCIES" name="CHEQUE_CURRENCIES">
-    <value>2,1</value>
-  </configuration>
-  <configuration id="PRODUCTS_VIEWED_NBR" name="PRODUCTS_VIEWED_NBR">
-    <value>2</value>
-  </configuration>
-  <configuration id="BLOCK_CATEG_DHTML" name="BLOCK_CATEG_DHTML">
-    <value>1</value>
-  </configuration>
-  <configuration id="BLOCK_CATEG_MAX_DEPTH" name="BLOCK_CATEG_MAX_DEPTH">
-    <value>4</value>
-  </configuration>
-  <configuration id="MANUFACTURER_DISPLAY_FORM" name="MANUFACTURER_DISPLAY_FORM">
-    <value>1</value>
-  </configuration>
-  <configuration id="MANUFACTURER_DISPLAY_TEXT" name="MANUFACTURER_DISPLAY_TEXT">
-    <value>1</value>
-  </configuration>
-  <configuration id="MANUFACTURER_DISPLAY_TEXT_NB" name="MANUFACTURER_DISPLAY_TEXT_NB">
-    <value>5</value>
-  </configuration>
-  <configuration id="NEW_PRODUCTS_NBR" name="NEW_PRODUCTS_NBR">
-    <value>5</value>
-  </configuration>
-  <configuration id="PS_TOKEN_ENABLE" name="PS_TOKEN_ENABLE">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_STATS_RENDER" name="PS_STATS_RENDER">
-    <value>graphnvd3</value>
-  </configuration>
-  <configuration id="PS_STATS_OLD_CONNECT_AUTO_CLEAN" name="PS_STATS_OLD_CONNECT_AUTO_CLEAN">
-    <value>never</value>
-  </configuration>
-  <configuration id="PS_STATS_GRID_RENDER" name="PS_STATS_GRID_RENDER">
-    <value>gridhtml</value>
-  </configuration>
-  <configuration id="BLOCKTAGS_NBR" name="BLOCKTAGS_NBR">
-    <value>10</value>
-  </configuration>
-  <configuration id="CHECKUP_DESCRIPTIONS_LT" name="CHECKUP_DESCRIPTIONS_LT">
-    <value>100</value>
-  </configuration>
-  <configuration id="CHECKUP_DESCRIPTIONS_GT" name="CHECKUP_DESCRIPTIONS_GT">
-    <value>400</value>
-  </configuration>
-  <configuration id="CHECKUP_IMAGES_LT" name="CHECKUP_IMAGES_LT">
-    <value>1</value>
-  </configuration>
-  <configuration id="CHECKUP_IMAGES_GT" name="CHECKUP_IMAGES_GT">
-    <value>2</value>
-  </configuration>
-  <configuration id="CHECKUP_SALES_LT" name="CHECKUP_SALES_LT">
-    <value>1</value>
-  </configuration>
-  <configuration id="CHECKUP_SALES_GT" name="CHECKUP_SALES_GT">
-    <value>2</value>
-  </configuration>
-  <configuration id="CHECKUP_STOCK_LT" name="CHECKUP_STOCK_LT">
-    <value>1</value>
-  </configuration>
-  <configuration id="CHECKUP_STOCK_GT" name="CHECKUP_STOCK_GT">
-    <value>3</value>
-  </configuration>
-  <configuration id="FOOTER_CMS" name="FOOTER_CMS">
-    <value>0_3|0_4</value>
-  </configuration>
-  <configuration id="FOOTER_BLOCK_ACTIVATION" name="FOOTER_BLOCK_ACTIVATION">
-    <value>0_3|0_4</value>
-  </configuration>
-  <configuration id="FOOTER_POWEREDBY" name="FOOTER_POWEREDBY">
-    <value>1</value>
-  </configuration>
-  <configuration id="BLOCKADVERT_LINK" name="BLOCKADVERT_LINK">
-    <value>https://www.prestashop.com</value>
-  </configuration>
-  <configuration id="BLOCKSTORE_IMG" name="BLOCKSTORE_IMG">
-    <value>store.jpg</value>
-  </configuration>
-  <configuration id="BLOCKADVERT_IMG_EXT" name="BLOCKADVERT_IMG_EXT">
-    <value>jpg</value>
-  </configuration>
-  <configuration id="MOD_BLOCKTOPMENU_ITEMS" name="MOD_BLOCKTOPMENU_ITEMS">
-    <value>CAT2,CAT3,CAT4</value>
-  </configuration>
-  <configuration id="MOD_BLOCKTOPMENU_SEARCH" name="MOD_BLOCKTOPMENU_SEARCH">
-    <value/>
-  </configuration>
-  <configuration id="blocksocial_facebook" name="BLOCKSOCIAL_FACEBOOK">
-    <value>https://www.facebook.com/prestashop</value>
-  </configuration>
-  <configuration id="blocksocial_twitter" name="BLOCKSOCIAL_TWITTER">
-    <value>https://www.twitter.com/prestashop</value>
-  </configuration>
-  <configuration id="blocksocial_rss" name="BLOCKSOCIAL_RSS">
-    <value>https://www.prestashop.com/blog/feed/</value>
-  </configuration>
-  <configuration id="blockcontactinfos_company" name="BLOCKCONTACTINFOS_COMPANY">
-    <value>Your company</value>
-  </configuration>
-  <configuration id="blockcontactinfos_address" name="BLOCKCONTACTINFOS_ADDRESS">
-    <value>Address line 1
-City
-Country</value>
-  </configuration>
-  <configuration id="blockcontactinfos_phone" name="BLOCKCONTACTINFOS_PHONE">
-    <value>0123-456-789</value>
-  </configuration>
-  <configuration id="blockcontactinfos_email" name="BLOCKCONTACTINFOS_EMAIL">
-    <value>pub@prestashop.com</value>
-  </configuration>
-  <configuration id="blockcontact_telnumber" name="BLOCKCONTACT_TELNUMBER">
-    <value>0123-456-789</value>
-  </configuration>
-  <configuration id="blockcontact_email" name="BLOCKCONTACT_EMAIL">
-    <value>pub@prestashop.com</value>
-  </configuration>
-  <configuration id="SUPPLIER_DISPLAY_TEXT" name="SUPPLIER_DISPLAY_TEXT">
-    <value>1</value>
-  </configuration>
-  <configuration id="SUPPLIER_DISPLAY_TEXT_NB" name="SUPPLIER_DISPLAY_TEXT_NB">
-    <value>5</value>
-  </configuration>
-  <configuration id="SUPPLIER_DISPLAY_FORM" name="SUPPLIER_DISPLAY_FORM">
-    <value>1</value>
-  </configuration>
-  <configuration id="BLOCK_CATEG_NBR_COLUMN_FOOTER" name="BLOCK_CATEG_NBR_COLUMN_FOOTER">
-    <value>1</value>
-  </configuration>
-  <configuration id="UPGRADER_BACKUPDB_FILENAME" name="UPGRADER_BACKUPDB_FILENAME">
-    <value/>
-  </configuration>
-  <configuration id="UPGRADER_BACKUPFILES_FILENAME" name="UPGRADER_BACKUPFILES_FILENAME">
-    <value/>
-  </configuration>
-  <configuration id="BLOCKREINSURANCE_NBBLOCKS" name="BLOCKREINSURANCE_NBBLOCKS">
-    <value>5</value>
-  </configuration>
-  <configuration id="HOMESLIDER_WIDTH" name="HOMESLIDER_WIDTH">
-    <value>535</value>
-  </configuration>
-  <configuration id="HOMESLIDER_SPEED" name="HOMESLIDER_SPEED">
-    <value>1300</value>
-  </configuration>
-  <configuration id="HOMESLIDER_PAUSE" name="HOMESLIDER_PAUSE">
-    <value>7700</value>
-  </configuration>
-  <configuration id="HOMESLIDER_LOOP" name="HOMESLIDER_LOOP">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_BASE_DISTANCE_UNIT" name="PS_BASE_DISTANCE_UNIT">
-    <value>m</value>
-  </configuration>
-  <configuration id="PS_SHOP_DOMAIN" name="PS_SHOP_DOMAIN">
-    <value>localhost</value>
-  </configuration>
-  <configuration id="PS_SHOP_DOMAIN_SSL" name="PS_SHOP_DOMAIN_SSL">
-    <value>localhost</value>
-  </configuration>
-  <configuration id="PS_SHOP_NAME" name="PS_SHOP_NAME">
-    <value>PrestaShop</value>
-  </configuration>
-  <configuration id="PS_SHOP_EMAIL" name="PS_SHOP_EMAIL">
-    <value>pub@prestashop.com</value>
-  </configuration>
-  <configuration id="PS_MAIL_METHOD" name="PS_MAIL_METHOD">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_MAIL_SUBJECT_PREFIX" name="PS_MAIL_SUBJECT_PREFIX">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_SHOP_ACTIVITY" name="PS_SHOP_ACTIVITY">
-    <value>Animaux</value>
-  </configuration>
-  <configuration id="PS_LOGO" name="PS_LOGO">
-    <value>logo.png</value>
-  </configuration>
-  <configuration id="PS_FAVICON" name="PS_FAVICON">
-    <value>favicon.ico</value>
-  </configuration>
-  <configuration id="PS_STORES_ICON" name="PS_STORES_ICON">
-    <value>logo_stores.png</value>
-  </configuration>
-  <configuration id="PS_ROOT_CATEGORY" name="PS_ROOT_CATEGORY">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_HOME_CATEGORY" name="PS_HOME_CATEGORY">
-    <value>2</value>
-  </configuration>
-  <configuration id="PS_CONFIGURATION_AGREMENT" name="PS_CONFIGURATION_AGREMENT">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_MAIL_SERVER" name="PS_MAIL_SERVER">
-    <value>smtp.</value>
-  </configuration>
-  <configuration id="PS_MAIL_USER" name="PS_MAIL_USER">
-    <value/>
-  </configuration>
-  <configuration id="PS_MAIL_PASSWD" name="PS_MAIL_PASSWD">
-    <value/>
-  </configuration>
-  <configuration id="PS_MAIL_SMTP_ENCRYPTION" name="PS_MAIL_SMTP_ENCRYPTION">
-    <value>off</value>
-  </configuration>
-  <configuration id="PS_MAIL_SMTP_PORT" name="PS_MAIL_SMTP_PORT">
-    <value>25</value>
-  </configuration>
-  <configuration id="PS_MAIL_COLOR" name="PS_MAIL_COLOR">
-    <value>#db3484</value>
-  </configuration>
-  <configuration id="PS_MAIL_DKIM_ENABLE" name="PS_MAIL_DKIM_ENABLE">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_MAIL_DKIM_DOMAIN" name="PS_MAIL_DKIM_DOMAIN">
-    <value/>
-  </configuration>
-  <configuration id="PS_MAIL_DKIM_SELECTOR" name="PS_MAIL_DKIM_SELECTOR">
-    <value/>
-  </configuration>
-  <configuration id="PS_MAIL_DKIM_KEY" name="PS_MAIL_DKIM_KEY">
-    <value/>
-  </configuration>
-  <configuration id="NW_SALT" name="NW_SALT">
-    <value>nK4KJP7jOsnzWMpo</value>
-  </configuration>
-  <configuration id="PS_PAYMENT_LOGO_CMS_ID" name="PS_PAYMENT_LOGO_CMS_ID">
-    <value>0</value>
-  </configuration>
-  <configuration id="HOME_FEATURED_NBR" name="HOME_FEATURED_NBR">
-    <value>8</value>
-  </configuration>
-  <configuration id="SEK_MIN_OCCURENCES" name="SEK_MIN_OCCURENCES">
-    <value>1</value>
-  </configuration>
-  <configuration id="SEK_FILTER_KW" name="SEK_FILTER_KW">
-    <value/>
-  </configuration>
-  <configuration id="PS_ALLOW_MOBILE_DEVICE" name="PS_ALLOW_MOBILE_DEVICE">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_CUSTOMER_CREATION_EMAIL" name="PS_CUSTOMER_CREATION_EMAIL">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_SMARTY_CONSOLE_KEY" name="PS_SMARTY_CONSOLE_KEY">
-    <value>SMARTY_DEBUG</value>
-  </configuration>
-  <configuration id="PS_ATTRIBUTE_ANCHOR_SEPARATOR" name="PS_ATTRIBUTE_ANCHOR_SEPARATOR">
-    <value>-</value>
-  </configuration>
-  <configuration id="CONF_AVERAGE_PRODUCT_MARGIN" name="CONF_AVERAGE_PRODUCT_MARGIN">
-    <value>40</value>
-  </configuration>
-  <configuration id="PS_DASHBOARD_SIMULATION" name="PS_DASHBOARD_SIMULATION">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_USE_HTMLPURIFIER" name="PS_USE_HTMLPURIFIER">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_SMARTY_LOCAL" name="PS_SMARTY_LOCAL">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_SMARTY_CLEAR_CACHE" name="PS_SMARTY_CLEAR_CACHE">
-    <value>everytime</value>
-  </configuration>
-  <configuration id="PS_DETECT_LANG" name="PS_DETECT_LANG">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_DETECT_COUNTRY" name="PS_DETECT_COUNTRY">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_ROUND_TYPE" name="PS_ROUND_TYPE">
-    <value>2</value>
-  </configuration>
-  <configuration id="PS_LOG_EMAILS" name="PS_LOG_EMAILS">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_CUSTOMER_OPTIN" name="PS_CUSTOMER_OPTIN">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_CUSTOMER_BIRTHDATE" name="PS_CUSTOMER_BIRTHDATE">
-    <value>1</value>
-  </configuration>
-  <configuration id="PS_PACK_STOCK_TYPE" name="PS_PACK_STOCK_TYPE">
-    <value>0</value>
-  </configuration>
-  <configuration id="PS_LOG_MODULE_PERFS_MODULO" name="PS_LOG_MODULE_PERFS_MODULO">
-    <value>0</value>
-  </configuration>
+
+    <!-- Dashboard -->
+    <configuration id="PS_DASHBOARD_SIMULATION" name="PS_DASHBOARD_SIMULATION">
+      <value>0</value>
+    </configuration>
+
+    <!-- Orders -->
+    <configuration id="PS_ORDER_PRODUCTS_NB_PER_PAGE" name="PS_ORDER_PRODUCTS_NB_PER_PAGE">
+      <value>8</value>
+    </configuration>
+
+    <!-- Invoices -->
+    <configuration id="PS_INVOICE" name="PS_INVOICE">
+      <value>1</value>
+    </configuration>
+    <!-- PS_INVOICE_TAXES_BREAKDOWN -->
+    <!-- PS_PDF_IMG_INVOICE -->
+    <configuration id="PS_INVOICE_PREFIX" name="PS_INVOICE_PREFIX">
+      <value>#IN</value>
+    </configuration>
+    <!-- PS_INVOICE_USE_YEAR -->
+    <!-- PS_INVOICE_RESET -->
+    <!-- PS_INVOICE_YEAR_POS -->
+    <!-- PS_INVOICE_START_NUMBER -->
+    <!-- PS_INVOICE_LEGAL_FREE_TEXT -->
+    <!-- PS_INVOICE_FREE_TEXT -->
+    <configuration id="PS_INVOICE_MODEL" name="PS_INVOICE_MODEL">
+      <value>invoice</value>
+    </configuration>
+    <!-- PS_PDF_USE_CACHE -->
+
+    <!-- Credit Notes -->
+    <!-- PS_CREDIT_SLIP_PREFIX -->
+
+    <!-- Delivery Slips -->
+    <configuration id="PS_DELIVERY_PREFIX" name="PS_DELIVERY_PREFIX">
+      <value>#DE</value>
+    </configuration>
+    <configuration id="PS_DELIVERY_NUMBER" name="PS_DELIVERY_NUMBER">
+      <value>1</value>
+    </configuration>
+    <!-- PS_PDF_IMG_DELIVERY -->
+
+    <!-- Customer Service -->
+    <configuration id="PS_CUSTOMER_SERVICE_FILE_UPLOAD" name="PS_CUSTOMER_SERVICE_FILE_UPLOAD">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_CUSTOMER_SERVICE_SIGNATURE" name="PS_CUSTOMER_SERVICE_SIGNATURE">
+      <value/>
+    </configuration>
+    <!-- PS_SAV_IMAP_URL -->
+    <!-- PS_SAV_IMAP_PORT -->
+    <!-- PS_SAV_IMAP_USER -->
+    <!-- PS_SAV_IMAP_PWD -->
+    <!-- PS_SAV_IMAP_DELETE_MSG -->
+    <!-- PS_SAV_IMAP_CREATE_THREADS -->
+    <!-- PS_SAV_IMAP_OPT_POP3 -->
+    <!-- PS_SAV_IMAP_OPT_NORSH -->
+    <!-- PS_SAV_IMAP_OPT_SSL -->
+    <!-- PS_SAV_IMAP_OPT_VALIDATE-CERT -->
+    <!-- PS_SAV_IMAP_OPT_NOVALIDATE-CERT -->
+    <!-- PS_SAV_IMAP_OPT_TLS -->
+    <!-- PS_SAV_IMAP_OPT_NOTLS -->
+
+    <!-- Merchandise Returns -->
+    <configuration id="PS_ORDER_RETURN" name="PS_ORDER_RETURN">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_ORDER_RETURN_NB_DAYS" name="PS_ORDER_RETURN_NB_DAYS">
+      <value>14</value>
+    </configuration>
+    <configuration id="PS_RETURN_PREFIX" name="PS_RETURN_PREFIX">
+      <value>#RE</value>
+    </configuration>
+
+    <!-- Image settings -->
+    <configuration id="PS_IMAGE_FORMAT" name="PS_IMAGE_FORMAT">
+      <value>jpg</value>
+    </configuration>
+    <configuration id="PS_IMAGE_QUALITY" name="PS_IMAGE_QUALITY">
+      <value>jpg</value>
+    </configuration>
+    <configuration id="PS_AVIF_QUALITY" name="PS_AVIF_QUALITY">
+      <value>90</value>
+    </configuration>
+    <configuration id="PS_JPEG_QUALITY" name="PS_JPEG_QUALITY">
+      <value>90</value>
+    </configuration>
+    <configuration id="PS_PNG_QUALITY" name="PS_PNG_QUALITY">
+      <value>7</value>
+    </configuration>
+    <configuration id="PS_WEBP_QUALITY" name="PS_WEBP_QUALITY">
+      <value>80</value>
+    </configuration>
+    <!-- PS_IMAGE_GENERATION_METHOD -->
+    <configuration id="PS_PRODUCT_PICTURE_MAX_SIZE" name="PS_PRODUCT_PICTURE_MAX_SIZE">
+      <value>8388608</value>
+    </configuration>
+    <configuration id="PS_PRODUCT_PICTURE_WIDTH" name="PS_PRODUCT_PICTURE_WIDTH">
+      <value>64</value>
+    </configuration>
+    <configuration id="PS_PRODUCT_PICTURE_HEIGHT" name="PS_PRODUCT_PICTURE_HEIGHT">
+      <value>64</value>
+    </configuration>
+    <!-- PS_HIGHT_DPI -->
+
+    <!-- Shipping > Preferences -->
+    <configuration id="PS_SHIPPING_HANDLING" name="PS_SHIPPING_HANDLING">
+      <value>2</value>
+    </configuration>
+    <configuration id="PS_SHIPPING_FREE_PRICE" name="PS_SHIPPING_FREE_PRICE">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_SHIPPING_FREE_WEIGHT" name="PS_SHIPPING_FREE_WEIGHT">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_CARRIER_DEFAULT" name="PS_CARRIER_DEFAULT">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_CARRIER_DEFAULT_SORT" name="PS_CARRIER_DEFAULT_SORT">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_CARRIER_DEFAULT_ORDER" name="PS_CARRIER_DEFAULT_ORDER">
+      <value>0</value>
+    </configuration>
+
+    <!-- Localization -->
+    <!-- PS_LANG_DEFAULT -->
+    <configuration id="PS_DETECT_LANG" name="PS_DETECT_LANG">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_COUNTRY_DEFAULT" name="PS_COUNTRY_DEFAULT">
+      <value>8</value>
+    </configuration>
+    <configuration id="PS_DETECT_COUNTRY" name="PS_DETECT_COUNTRY">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_CURRENCY_DEFAULT" name="PS_CURRENCY_DEFAULT">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_TIMEZONE" name="PS_TIMEZONE">
+      <value>Europe/Paris</value>
+    </configuration>
+    <configuration id="PS_WEIGHT_UNIT" name="PS_WEIGHT_UNIT">
+      <value>kg</value>
+    </configuration>
+    <configuration id="PS_DISTANCE_UNIT" name="PS_DISTANCE_UNIT">
+      <value>km</value>
+    </configuration>
+    <configuration id="PS_VOLUME_UNIT" name="PS_VOLUME_UNIT">
+      <value>cl</value>
+    </configuration>
+    <configuration id="PS_DIMENSION_UNIT" name="PS_DIMENSION_UNIT">
+      <value>cm</value>
+    </configuration>
+    <configuration id="PS_LOCALE_LANGUAGE" name="PS_LOCALE_LANGUAGE">
+      <value>fr</value>
+    </configuration>
+    <configuration id="PS_LOCALE_COUNTRY" name="PS_LOCALE_COUNTRY">
+      <value>fr</value>
+    </configuration>
+
+    <!-- Geolocation -->
+    <configuration id="PS_GEOLOCATION_ENABLED" name="PS_GEOLOCATION_ENABLED">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_GEOLOCATION_BEHAVIOR" name="PS_GEOLOCATION_BEHAVIOR">
+      <value>0</value>
+    </configuration>
+    <!-- PS_GEOLOCATION_NA_BEHAVIOR -->
+    <configuration id="PS_ALLOWED_COUNTRIES" name="PS_ALLOWED_COUNTRIES">
+      <value>AF;ZA;AX;AL;DZ;DE;AD;AO;AI;AQ;AG;AN;SA;AR;AM;AW;AU;AT;AZ;BS;BH;BD;BB;BY;BE;BZ;BJ;BM;BT;BO;BA;BW;BV;BR;BN;BG;BF;MM;BI;KY;KH;CM;CA;CV;CF;CL;CN;CX;CY;CC;CO;KM;CG;CD;CK;KR;KP;CR;CI;HR;CU;DK;DJ;DM;EG;IE;SV;AE;EC;ER;ES;EE;ET;FK;FO;FJ;FI;FR;GA;GM;GE;GS;GH;GI;GR;GD;GL;GP;GU;GT;GG;GN;GQ;GW;GY;GF;HT;HM;HN;HK;HU;IM;MU;VG;VI;IN;ID;IR;IQ;IS;IL;IT;JM;JP;JE;JO;KZ;KE;KG;KI;KW;LA;LS;LV;LB;LR;LY;LI;LT;LU;MO;MK;MG;MY;MW;MV;ML;MT;MP;MA;MH;MQ;MR;YT;MX;FM;MD;MC;MN;ME;MS;MZ;NA;NR;NP;NI;NE;NG;NU;NF;NO;NC;NZ;IO;OM;UG;UZ;PK;PW;PS;PA;PG;PY;NL;PE;PH;PN;PL;PF;PR;PT;QA;DO;CZ;RE;RO;GB;RU;RW;EH;BL;KN;SM;MF;PM;VA;VC;LC;SB;WS;AS;ST;SN;RS;SC;SL;SG;SK;SI;SO;SD;LK;SE;CH;SR;SJ;SZ;SY;TJ;TW;TZ;TD;TF;TH;TL;TG;TK;TO;TT;TN;TM;TC;TR;TV;UA;UY;US;VU;VE;VN;WF;YE;ZM;ZW</value>
+    </configuration>
+    <configuration id="PS_GEOLOCATION_WHITELIST" name="PS_GEOLOCATION_WHITELIST">
+      <value>127.0.0.1;::1</value>
+    </configuration>
+
+    <!-- Countries -->
+    <configuration id="PS_RESTRICT_DELIVERED_COUNTRIES" name="PS_RESTRICT_DELIVERED_COUNTRIES">
+      <value>0</value>
+    </configuration>
+
+    <!-- VAT -->
+    <configuration id="PS_TAX" name="PS_TAX">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_TAX_DISPLAY" name="PS_TAX_DISPLAY">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_TAX_ADDRESS_TYPE" name="PS_TAX_ADDRESS_TYPE">
+      <value>id_address_delivery</value>
+    </configuration>
+    <configuration id="PS_USE_ECOTAX" name="PS_USE_ECOTAX">
+      <value>0</value>
+    </configuration>
+    <!-- PS_ECOTAX_TAX_RULES_GROUP_ID -->
+
+    <!-- General -->
+    <configuration id="PS_SSL_ENABLED" name="PS_SSL_ENABLED">
+      <value>0</value>
+    </configuration>
+    <!-- PS_SSL_ENABLED_EVERYWHERE -->
+    <configuration id="PS_TOKEN_ENABLE" name="PS_TOKEN_ENABLE">
+      <value>1</value>
+    </configuration>
+    <!-- PS_ALLOW_HTML_IFRAME -->
+    <configuration id="PS_USE_HTMLPURIFIER" name="PS_USE_HTMLPURIFIER">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_PRICE_ROUND_MODE" name="PS_PRICE_ROUND_MODE">
+      <value>2</value>
+    </configuration>
+    <configuration id="PS_ROUND_TYPE" name="PS_ROUND_TYPE">
+      <value>2</value>
+    </configuration>
+    <configuration id="PS_DISPLAY_SUPPLIERS" name="PS_DISPLAY_SUPPLIERS">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_DISPLAY_MANUFACTURERS" name="PS_DISPLAY_MANUFACTURERS">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_DISPLAY_BEST_SELLERS" name="PS_DISPLAY_BEST_SELLERS">
+      <value>1</value>
+    </configuration>
+    <!-- PS_MULTISHOP_FEATURE_ACTIVE -->
+    <configuration id="PS_SHOP_ACTIVITY" name="PS_SHOP_ACTIVITY">
+      <value>Animaux</value>
+    </configuration>
+
+    <!-- Maintenance -->
+    <configuration id="PS_SHOP_ENABLE" name="PS_SHOP_ENABLE">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_MAINTENANCE_ALLOW_ADMINS" name="PS_MAINTENANCE_ALLOW_ADMINS">
+      <value>1</value>
+    </configuration>
+    <!-- PS_MAINTENANCE_IP -->
+    <configuration id="PS_MAINTENANCE_TEXT" name="PS_MAINTENANCE_TEXT">
+      <value/>
+    </configuration>
+
+    <!-- Order settings -->
+    <!-- PS_FINAL_SUMMARY_ENABLED -->
+    <configuration id="PS_GUEST_CHECKOUT_ENABLED" name="PS_GUEST_CHECKOUT_ENABLED">
+      <value>1</value>
+    </configuration>
     <configuration id="PS_DISALLOW_HISTORY_REORDERING" name="PS_DISALLOW_HISTORY_REORDERING">
       <value>0</value>
     </configuration>
-    <configuration id="PS_DISPLAY_PRODUCT_WEIGHT" name="PS_DISPLAY_PRODUCT_WEIGHT">
+    <configuration id="PS_PURCHASE_MINIMUM" name="PS_PURCHASE_MINIMUM">
       <value>0</value>
-    </configuration>
-    <configuration id="PS_PRODUCT_WEIGHT_PRECISION" name="PS_PRODUCT_WEIGHT_PRECISION">
-      <value>2</value>
     </configuration>
     <configuration id="PS_ORDER_RECALCULATE_SHIPPING" name="PS_ORDER_RECALCULATE_SHIPPING">
       <value>1</value>
     </configuration>
-    <configuration id="PS_MAINTENANCE_TEXT" name="PS_MAINTENANCE_TEXT">
-      <value/>
+    <!-- PS_SHIP_WHEN_AVAILABLE -->
+    <configuration id="PS_CONDITIONS" name="PS_CONDITIONS">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_CONDITIONS_CMS_ID" name="PS_CONDITIONS_CMS_ID">
+      <value>3</value>
+    </configuration>
+    <configuration id="PS_ENABLE_BACKORDER_STATUS" name="PS_ENABLE_BACKORDER_STATUS">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_GIFT_WRAPPING" name="PS_GIFT_WRAPPING">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_GIFT_WRAPPING_PRICE" name="PS_GIFT_WRAPPING_PRICE">
+      <value>0</value>
+    </configuration>
+    <!-- PS_GIFT_WRAPPING_TAX_RULES_GROUP -->
+    <configuration id="PS_RECYCLABLE_PACK" name="PS_RECYCLABLE_PACK">
+      <value>0</value>
+    </configuration>
+
+    <!-- Product Settings -->
+    <configuration id="PS_CATALOG_MODE" name="PS_CATALOG_MODE">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_CATALOG_MODE_WITH_PRICES" name="PS_CATALOG_MODE_WITH_PRICES">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_NB_DAYS_NEW_PRODUCT" name="PS_NB_DAYS_NEW_PRODUCT">
+      <value>20</value>
     </configuration>
     <configuration id="PS_PRODUCT_SHORT_DESC_LIMIT" name="PS_PRODUCT_SHORT_DESC_LIMIT">
       <value>800</value>
+    </configuration>
+    <!-- PS_QTY_DISCOUNT_ON_COMBINATION -->
+    <!-- PS_FORCE_FRIENDLY_PRODUCT -->
+    <!-- PS_PRODUCT_ACTIVATION_DEFAULT -->
+    <configuration id="PS_SPECIFIC_PRICE_PRIORITIES" name="PS_SPECIFIC_PRICE_PRIORITIES">
+      <value>id_group;id_currency;id_country;id_shop</value>
+    </configuration>
+    <configuration id="PS_PRODUCT_REDIRECTION_DEFAULT" name="PS_PRODUCT_REDIRECTION_DEFAULT">
+      <value>404</value>
+    </configuration>
+    <configuration id="PS_DISPLAY_QTIES" name="PS_DISPLAY_QTIES">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_ATTRIBUTE_CATEGORY_DISPLAY" name="PS_ATTRIBUTE_CATEGORY_DISPLAY">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_ATTRIBUTE_ANCHOR_SEPARATOR" name="PS_ATTRIBUTE_ANCHOR_SEPARATOR">
+      <value>-</value>
+    </configuration>
+    <!-- PS_DISPLAY_DISCOUNT_PRICE -->
+    <configuration id="PS_STOCK_MANAGEMENT" name="PS_STOCK_MANAGEMENT">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_PACK_STOCK_TYPE" name="PS_PACK_STOCK_TYPE">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_DISP_UNAVAILABLE_ATTR" name="PS_DISP_UNAVAILABLE_ATTR">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_LAST_QTIES" name="PS_LAST_QTIES">
+      <value>3</value>
+    </configuration>
+    <configuration id="PS_ORDER_OUT_OF_STOCK" name="PS_ORDER_OUT_OF_STOCK">
+      <value>0</value>
     </configuration>
     <configuration id="PS_LABEL_IN_STOCK_PRODUCTS" name="PS_LABEL_IN_STOCK_PRODUCTS">
       <value>In Stock</value>
@@ -859,47 +337,718 @@ Country</value>
     <configuration id="PS_LABEL_OOS_PRODUCTS_BOD" name="PS_LABEL_OOS_PRODUCTS_BOD">
       <value>Out-of-Stock</value>
     </configuration>
-    <configuration id="PS_CATALOG_MODE_WITH_PRICES" name="PS_CATALOG_MODE_WITH_PRICES">
+    <!-- PS_LABEL_DELIVERY_TIME_AVAILABLE -->
+    <!-- PS_LABEL_DELIVERY_TIME_OOSBOA -->
+    <configuration id="PS_SHOW_LABEL_OOS_LISTING_PAGES" name="PS_SHOW_LABEL_OOS_LISTING_PAGES">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_PRODUCTS_PER_PAGE" name="PS_PRODUCTS_PER_PAGE">
+      <value>12</value>
+    </configuration>
+    <configuration id="PS_PRODUCTS_ORDER_BY" name="PS_PRODUCTS_ORDER_BY">
+      <value>4</value>
+    </configuration>
+    <configuration id="PS_PRODUCTS_ORDER_WAY" name="PS_PRODUCTS_ORDER_WAY">
       <value>0</value>
     </configuration>
-    <configuration id="PS_MAIL_THEME" name="PS_MAIL_THEME">
-      <value>modern</value>
+
+    <!-- Customer Settings -->
+    <!-- PS_CART_FOLLOWING -->
+    <configuration id="PS_CUSTOMER_CREATION_EMAIL" name="PS_CUSTOMER_CREATION_EMAIL">
+      <value>1</value>
     </configuration>
-    <configuration id="PS_ORDER_PRODUCTS_NB_PER_PAGE" name="PS_ORDER_PRODUCTS_NB_PER_PAGE">
+    <configuration id="PS_PASSWD_TIME_FRONT" name="PS_PASSWD_TIME_FRONT">
+      <value>360</value>
+    </configuration>
+    <!-- PS_B2B_ENABLE -->
+    <configuration id="PS_CUSTOMER_BIRTHDATE" name="PS_CUSTOMER_BIRTHDATE">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_CUSTOMER_OPTIN" name="PS_CUSTOMER_OPTIN">
+      <value>1</value>
+    </configuration>
+
+    <!-- Groups -->
+    <configuration id="PS_UNIDENTIFIED_GROUP" name="PS_UNIDENTIFIED_GROUP">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_GUEST_GROUP" name="PS_GUEST_GROUP">
+      <value>2</value>
+    </configuration>
+    <configuration id="PS_CUSTOMER_GROUP" name="PS_CUSTOMER_GROUP">
+      <value>3</value>
+    </configuration>
+
+    <!-- Stores -->
+    <configuration id="PS_SHOP_NAME" name="PS_SHOP_NAME">
+      <value>PrestaShop</value>
+    </configuration>
+    <configuration id="PS_SHOP_EMAIL" name="PS_SHOP_EMAIL">
+      <value>pub@prestashop.com</value>
+    </configuration>
+    <!-- PS_SHOP_DETAILS -->
+    <!-- PS_SHOP_ADDR1 -->
+    <!-- PS_SHOP_ADDR2 -->
+    <!-- PS_SHOP_CODE -->
+    <!-- PS_SHOP_CITY -->
+    <!-- PS_SHOP_COUNTRY_ID -->
+    <!-- PS_SHOP_COUNTRY -->
+    <!-- PS_SHOP_PHONE -->
+    <!-- PS_SHOP_FAX -->
+
+    <!-- SEO & URLs -->
+    <configuration id="PS_REWRITING_SETTINGS" name="PS_REWRITING_SETTINGS">
+      <value>0</value>
+    </configuration>
+    <!-- PS_ALLOW_ACCENTED_CHARS_URL -->
+    <configuration id="PS_CANONICAL_REDIRECT" name="PS_CANONICAL_REDIRECT">
+      <value>1</value>
+    </configuration>
+    <!-- PS_HTACCESS_DISABLE_MULTIVIEWS -->
+    <!-- PS_HTACCESS_DISABLE_MODSEC -->
+    <configuration id="PS_SHOP_DOMAIN" name="PS_SHOP_DOMAIN">
+      <value>localhost</value>
+    </configuration>
+    <configuration id="PS_SHOP_DOMAIN_SSL" name="PS_SHOP_DOMAIN_SSL">
+      <value>localhost</value>
+    </configuration>
+    <!-- PS_ROUTE_product_rule -->
+    <!-- PS_ROUTE_category_rule -->
+    <!-- PS_ROUTE_supplier_rule -->
+    <!-- PS_ROUTE_manufacturer_rule -->
+    <!-- PS_ROUTE_cms_rule -->
+    <!-- PS_ROUTE_cms_category_rule -->
+    <!-- PS_ROUTE_module -->
+    <!-- PS_ROUTE_upload -->
+    <!-- PS_PRODUCT_ATTRIBUTES_IN_TITLE -->
+
+    <!-- Search -->
+    <configuration id="PS_SEARCH_INDEXATION" name="PS_SEARCH_INDEXATION">
+      <value>1</value>
+    </configuration>
+    <!-- PS_SEARCH_START -->
+    <!-- PS_SEARCH_END -->
+    <configuration id="PS_SEARCH_FUZZY" name="PS_SEARCH_FUZZY">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_SEARCH_FUZZY_MAX_LOOP" name="PS_SEARCH_FUZZY_MAX_LOOP">
+      <value>4</value>
+    </configuration>
+    <configuration id="PS_SEARCH_MINWORDLEN" name="PS_SEARCH_MINWORDLEN">
+      <value>3</value>
+    </configuration>
+    <configuration id="PS_SEARCH_MAX_WORD_LENGTH" name="PS_SEARCH_MAX_WORD_LENGTH">
+      <value>15</value>
+    </configuration>
+    <configuration id="PS_SEARCH_BLACKLIST" name="PS_SEARCH_BLACKLIST">
+      <value/>
+    </configuration>
+    <configuration id="PS_SEARCH_WEIGHT_PNAME" name="PS_SEARCH_WEIGHT_PNAME">
+      <value>6</value>
+    </configuration>
+    <configuration id="PS_SEARCH_WEIGHT_REF" name="PS_SEARCH_WEIGHT_REF">
+      <value>10</value>
+    </configuration>
+    <configuration id="PS_SEARCH_WEIGHT_SHORTDESC" name="PS_SEARCH_WEIGHT_SHORTDESC">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_SEARCH_WEIGHT_DESC" name="PS_SEARCH_WEIGHT_DESC">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_SEARCH_WEIGHT_CNAME" name="PS_SEARCH_WEIGHT_CNAME">
+      <value>3</value>
+    </configuration>
+    <configuration id="PS_SEARCH_WEIGHT_MNAME" name="PS_SEARCH_WEIGHT_MNAME">
+      <value>3</value>
+    </configuration>
+    <configuration id="PS_SEARCH_WEIGHT_TAG" name="PS_SEARCH_WEIGHT_TAG">
+      <value>4</value>
+    </configuration>
+    <configuration id="PS_SEARCH_WEIGHT_ATTRIBUTE" name="PS_SEARCH_WEIGHT_ATTRIBUTE">
+      <value>2</value>
+    </configuration>
+    <configuration id="PS_SEARCH_WEIGHT_FEATURE" name="PS_SEARCH_WEIGHT_FEATURE">
+      <value>2</value>
+    </configuration>
+
+    <!-- Performance -->
+    <configuration id="PS_SMARTY_FORCE_COMPILE" name="PS_SMARTY_FORCE_COMPILE">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_SMARTY_CACHE" name="PS_SMARTY_CACHE">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_SMARTY_LOCAL" name="PS_SMARTY_LOCAL">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_SMARTY_CLEAR_CACHE" name="PS_SMARTY_CLEAR_CACHE">
+      <value>everytime</value>
+    </configuration>
+    <!-- PS_DISABLE_OVERRIDES -->
+    <configuration id="PS_COMBINATION_FEATURE_ACTIVE" name="PS_COMBINATION_FEATURE_ACTIVE">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_FEATURE_FEATURE_ACTIVE" name="PS_FEATURE_FEATURE_ACTIVE">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_GROUP_FEATURE_ACTIVE" name="PS_GROUP_FEATURE_ACTIVE">
+      <value>0</value>
+    </configuration>
+    <!-- PS_CSS_THEME_CACHE -->
+    <!-- PS_JS_THEME_CACHE -->
+    <!-- PS_HTACCESS_CACHE_CONTROL -->
+
+    <!-- Administration -->
+    <configuration id="PS_COOKIE_CHECKIP" name="PS_COOKIE_CHECKIP">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_COOKIE_LIFETIME_FO" name="PS_COOKIE_LIFETIME_FO">
+      <value>480</value>
+    </configuration>
+    <configuration id="PS_COOKIE_LIFETIME_BO" name="PS_COOKIE_LIFETIME_BO">
+      <value>480</value>
+    </configuration>
+    <configuration id="PS_COOKIE_SAMESITE" name="PS_COOKIE_SAMESITE">
+      <value>Lax</value>
+    </configuration>
+    <configuration id="PS_ATTACHMENT_MAXIMUM_SIZE" name="PS_ATTACHMENT_MAXIMUM_SIZE">
       <value>8</value>
+    </configuration>
+    <configuration id="PS_LIMIT_UPLOAD_FILE_VALUE" name="PS_LIMIT_UPLOAD_FILE_VALUE">
+      <value>2</value>
+    </configuration>
+    <configuration id="PS_LIMIT_UPLOAD_IMAGE_VALUE" name="PS_LIMIT_UPLOAD_IMAGE_VALUE">
+      <value>2</value>
+    </configuration>
+    <configuration id="PS_SHOW_NEW_ORDERS" name="PS_SHOW_NEW_ORDERS">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_SHOW_NEW_CUSTOMERS" name="PS_SHOW_NEW_CUSTOMERS">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_SHOW_NEW_MESSAGES" name="PS_SHOW_NEW_MESSAGES">
+      <value>1</value>
+    </configuration>
+
+    <!-- Email -->
+    <!-- PS_MAIL_EMAIL_MESSAGE -->
+    <configuration id="PS_MAIL_METHOD" name="PS_MAIL_METHOD">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_MAIL_SUBJECT_PREFIX" name="PS_MAIL_SUBJECT_PREFIX">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_MAIL_TYPE" name="PS_MAIL_TYPE">
+      <value>3</value>
+    </configuration>
+    <configuration id="PS_LOG_EMAILS" name="PS_LOG_EMAILS">
+      <value>1</value>
+    </configuration>
+    <!-- PS_MAIL_DOMAIN -->
+    <configuration id="PS_MAIL_SERVER" name="PS_MAIL_SERVER">
+      <value>smtp.</value>
+    </configuration>
+    <configuration id="PS_MAIL_USER" name="PS_MAIL_USER">
+      <value/>
+    </configuration>
+    <configuration id="PS_MAIL_PASSWD" name="PS_MAIL_PASSWD">
+      <value/>
+    </configuration>
+    <configuration id="PS_MAIL_SMTP_ENCRYPTION" name="PS_MAIL_SMTP_ENCRYPTION">
+      <value>off</value>
+    </configuration>
+    <configuration id="PS_MAIL_SMTP_PORT" name="PS_MAIL_SMTP_PORT">
+      <value>25</value>
+    </configuration>
+    <configuration id="PS_MAIL_DKIM_ENABLE" name="PS_MAIL_DKIM_ENABLE">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_MAIL_DKIM_DOMAIN" name="PS_MAIL_DKIM_DOMAIN">
+      <value/>
+    </configuration>
+    <configuration id="PS_MAIL_DKIM_SELECTOR" name="PS_MAIL_DKIM_SELECTOR">
+      <value/>
+    </configuration>
+    <configuration id="PS_MAIL_DKIM_KEY" name="PS_MAIL_DKIM_KEY">
+      <value/>
+    </configuration>
+
+    <!-- Employees -->
+    <configuration id="PS_PASSWD_TIME_BACK" name="PS_PASSWD_TIME_BACK">
+      <value>360</value>
+    </configuration>
+    <!-- PS_BO_ALLOW_EMPLOYEE_FORM_LANG -->
+
+    <!-- SQL Manager -->
+    <!-- PS_ENCODING_FILE_MANAGER_SQL -->
+
+    <!-- DB Backup -->
+    <configuration id="PS_BACKUP_ALL" name="PS_BACKUP_ALL">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_BACKUP_DROP_TABLE" name="PS_BACKUP_DROP_TABLE">
+      <value>1</value>
+    </configuration>
+
+    <!-- Logs -->
+    <configuration id="PS_LOGS_BY_EMAIL" name="PS_LOGS_BY_EMAIL">
+      <value>4</value>
     </configuration>
     <configuration id="PS_LOGS_EMAIL_RECEIVERS" name="PS_LOGS_EMAIL_RECEIVERS">
       <value>pub@prestashop.com</value>
     </configuration>
-    <configuration id="PS_SHOW_LABEL_OOS_LISTING_PAGES" name="PS_SHOW_LABEL_OOS_LISTING_PAGES">
-      <value>1</value>
-    </configuration>
-    <configuration id="ADDONS_API_MODULE_CHANNEL" name="ADDONS_API_MODULE_CHANNEL">
-      <value>stable</value>
-    </configuration>
+
+    <!-- Webservice -->
+    <!-- PS_WEBSERVICE -->
+    <!-- PS_WEBSERVICE_CGI_HOST -->
+
+    <!-- Security -->
     <configuration id="PS_SECURITY_TOKEN" name="PS_SECURITY_TOKEN">
       <value>1</value>
-    </configuration>
-    <configuration id="PS_SECURITY_PASSWORD_POLICY_MAXIMUM_LENGTH" name="PS_SECURITY_PASSWORD_POLICY_MAXIMUM_LENGTH">
-      <value>72</value>
-    </configuration>
-    <configuration id="PS_SECURITY_PASSWORD_POLICY_MINIMUM_LENGTH" name="PS_SECURITY_PASSWORD_POLICY_MINIMUM_LENGTH">
-      <value>8</value>
     </configuration>
     <configuration id="PS_SECURITY_PASSWORD_POLICY_MINIMUM_SCORE" name="PS_SECURITY_PASSWORD_POLICY_MINIMUM_SCORE">
       <value>3</value>
     </configuration>
-    <configuration id="PS_ENABLE_BACKORDER_STATUS" name="PS_ENABLE_BACKORDER_STATUS">
+    <configuration id="PS_SECURITY_PASSWORD_POLICY_MINIMUM_LENGTH" name="PS_SECURITY_PASSWORD_POLICY_MINIMUM_LENGTH">
+      <value>8</value>
+    </configuration>
+    <configuration id="PS_SECURITY_PASSWORD_POLICY_MAXIMUM_LENGTH" name="PS_SECURITY_PASSWORD_POLICY_MAXIMUM_LENGTH">
+      <value>72</value>
+    </configuration>
+
+    <!-- Default order statuses -->
+    <configuration id="PS_OS_CHEQUE" name="PS_OS_CHEQUE">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_OS_PAYMENT" name="PS_OS_PAYMENT">
+      <value>2</value>
+    </configuration>
+    <configuration id="PS_OS_PREPARATION" name="PS_OS_PREPARATION">
+      <value>3</value>
+    </configuration>
+    <configuration id="PS_OS_SHIPPING" name="PS_OS_SHIPPING">
+      <value>4</value>
+    </configuration>
+    <configuration id="PS_OS_DELIVERED" name="PS_OS_DELIVERED">
+      <value>5</value>
+    </configuration>
+    <configuration id="PS_OS_CANCELED" name="PS_OS_CANCELED">
+      <value>6</value>
+    </configuration>
+    <configuration id="PS_OS_REFUND" name="PS_OS_REFUND">
+      <value>7</value>
+    </configuration>
+    <configuration id="PS_OS_ERROR" name="PS_OS_ERROR">
+      <value>8</value>
+    </configuration>
+    <configuration id="PS_OS_OUTOFSTOCK" name="PS_OS_OUTOFSTOCK">
+      <value>9</value>
+    </configuration>
+    <configuration id="PS_OS_BANKWIRE" name="PS_OS_BANKWIRE">
+      <value>10</value>
+    </configuration>
+    <configuration id="PS_OS_WS_PAYMENT" name="PS_OS_WS_PAYMENT">
+      <value>11</value>
+    </configuration>
+    <configuration id="PS_OS_OUTOFSTOCK_PAID" name="PS_OS_OUTOFSTOCK_PAID">
+      <value>9</value>
+    </configuration>
+    <configuration id="PS_OS_OUTOFSTOCK_UNPAID" name="PS_OS_OUTOFSTOCK_UNPAID">
+      <value>12</value>
+    </configuration>
+    <configuration id="PS_OS_COD_VALIDATION" name="PS_OS_COD_VALIDATION">
+      <value>13</value>
+    </configuration>
+
+    <!-- Stock movement reasons -->
+    <configuration id="PS_STOCK_MVT_REASON_DEFAULT" name="PS_STOCK_MVT_REASON_DEFAULT">
+      <value>3</value>
+    </configuration>
+    <configuration id="PS_STOCK_MVT_INC_REASON_DEFAULT" name="PS_STOCK_MVT_INC_REASON_DEFAULT">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_STOCK_MVT_DEC_REASON_DEFAULT" name="PS_STOCK_MVT_DEC_REASON_DEFAULT">
+      <value>2</value>
+    </configuration>
+    <configuration id="PS_STOCK_MVT_TRANSFER_TO" name="PS_STOCK_MVT_TRANSFER_TO">
+      <value>7</value>
+    </configuration>
+    <configuration id="PS_STOCK_MVT_TRANSFER_FROM" name="PS_STOCK_MVT_TRANSFER_FROM">
+      <value>6</value>
+    </configuration>
+    <configuration id="PS_STOCK_MVT_SUPPLY_ORDER" name="PS_STOCK_MVT_SUPPLY_ORDER">
+      <value>8</value>
+    </configuration>
+    <configuration id="PS_STOCK_CUSTOMER_ORDER_CANCEL_REASON" name="PS_STOCK_CUSTOMER_ORDER_CANCEL_REASON">
+      <value>9</value>
+    </configuration>
+    <configuration id="PS_STOCK_CUSTOMER_RETURN_REASON" name="PS_STOCK_CUSTOMER_RETURN_REASON">
+      <value>10</value>
+    </configuration>
+    <configuration id="PS_STOCK_MVT_INC_EMPLOYEE_EDITION" name="PS_STOCK_MVT_INC_EMPLOYEE_EDITION">
+      <value>11</value>
+    </configuration>
+    <configuration id="PS_STOCK_MVT_DEC_EMPLOYEE_EDITION" name="PS_STOCK_MVT_DEC_EMPLOYEE_EDITION">
+      <value>12</value>
+    </configuration>
+    <configuration id="PS_STOCK_CUSTOMER_ORDER_REASON" name="PS_STOCK_CUSTOMER_ORDER_REASON">
+      <value>3</value>
+    </configuration>
+
+    <!-- Internal use -->
+    <configuration id="PS_NAVIGATION_PIPE" name="PS_NAVIGATION_PIPE">
+      <value>&gt;</value>
+    </configuration>
+    <configuration id="PS_MAIL_COLOR" name="PS_MAIL_COLOR">
+      <value>#db3484</value>
+    </configuration>
+    <configuration id="PS_SHIPPING_METHOD" name="PS_SHIPPING_METHOD">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_INVCE_INVOICE_ADDR_RULES" name="PS_INVCE_INVOICE_ADDR_RULES">
+      <value>{"avoid":[]}</value>
+    </configuration>
+    <configuration id="PS_INVCE_DELIVERY_ADDR_RULES" name="PS_INVCE_DELIVERY_ADDR_RULES">
+      <value>{"avoid":[]}</value>
+    </configuration>
+    <configuration id="PS_PASSWD_RESET_VALIDITY" name="PS_PASSWD_RESET_VALIDITY">
+      <value>1440</value>
+    </configuration>
+    <configuration id="SHOP_LOGO_WIDTH" name="SHOP_LOGO_WIDTH">
+      <value>209</value>
+    </configuration>
+    <configuration id="SHOP_LOGO_HEIGHT" name="SHOP_LOGO_HEIGHT">
+      <value>52</value>
+    </configuration>
+    <configuration id="PS_STATSDATA_CUSTOMER_PAGESVIEWS" name="PS_STATSDATA_CUSTOMER_PAGESVIEWS">
       <value>0</value>
     </configuration>
-    <configuration id="PS_PRODUCT_REDIRECTION_DEFAULT" name="PS_PRODUCT_REDIRECTION_DEFAULT">
-      <value>404</value>
+    <configuration id="PS_STATSDATA_PAGESVIEWS" name="PS_STATSDATA_PAGESVIEWS">
+      <value>0</value>
     </configuration>
-    <configuration id="PS_AVIF_QUALITY" name="PS_AVIF_QUALITY">
-      <value>90</value>
+    <configuration id="PS_STATSDATA_PLUGINS" name="PS_STATSDATA_PLUGINS">
+      <value>0</value>
     </configuration>
-    <configuration id="PS_IMAGE_FORMAT" name="PS_IMAGE_FORMAT">
+    <configuration id="PS_IMG_UPDATE_TIME" name="PS_IMG_UPDATE_TIME">
+      <value>1324977642</value>
+    </configuration>
+    <configuration id="PS_LEGACY_IMAGES" name="PS_LEGACY_IMAGES">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_SPECIFIC_PRICE_FEATURE_ACTIVE" name="PS_SPECIFIC_PRICE_FEATURE_ACTIVE">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_VIRTUAL_PROD_FEATURE_ACTIVE" name="PS_VIRTUAL_PROD_FEATURE_ACTIVE">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_CUSTOMIZATION_FEATURE_ACTIVE" name="PS_CUSTOMIZATION_FEATURE_ACTIVE">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_CART_RULE_FEATURE_ACTIVE" name="PS_CART_RULE_FEATURE_ACTIVE">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_PACK_FEATURE_ACTIVE" name="PS_PACK_FEATURE_ACTIVE">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_ALIAS_FEATURE_ACTIVE" name="PS_ALIAS_FEATURE_ACTIVE">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_SHOP_DEFAULT" name="PS_SHOP_DEFAULT">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_SMARTY_CONSOLE" name="PS_SMARTY_CONSOLE">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_ADVANCED_STOCK_MANAGEMENT" name="PS_ADVANCED_STOCK_MANAGEMENT">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_STATS_RENDER" name="PS_STATS_RENDER">
+      <value>graphnvd3</value>
+    </configuration>
+    <configuration id="PS_STATS_OLD_CONNECT_AUTO_CLEAN" name="PS_STATS_OLD_CONNECT_AUTO_CLEAN">
+      <value>never</value>
+    </configuration>
+    <configuration id="PS_STATS_GRID_RENDER" name="PS_STATS_GRID_RENDER">
+      <value>gridhtml</value>
+    </configuration>
+    <configuration id="PS_BASE_DISTANCE_UNIT" name="PS_BASE_DISTANCE_UNIT">
+      <value>m</value>
+    </configuration>
+    <configuration id="PS_LOGO" name="PS_LOGO">
+      <value>logo.png</value>
+    </configuration>
+    <configuration id="PS_FAVICON" name="PS_FAVICON">
+      <value>favicon.ico</value>
+    </configuration>
+    <configuration id="PS_STORES_ICON" name="PS_STORES_ICON">
+      <value>logo_stores.png</value>
+    </configuration>
+    <configuration id="PS_ROOT_CATEGORY" name="PS_ROOT_CATEGORY">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_HOME_CATEGORY" name="PS_HOME_CATEGORY">
+      <value>2</value>
+    </configuration>
+    <configuration id="PS_CONFIGURATION_AGREMENT" name="PS_CONFIGURATION_AGREMENT">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_ALLOW_MOBILE_DEVICE" name="PS_ALLOW_MOBILE_DEVICE">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_SMARTY_CONSOLE_KEY" name="PS_SMARTY_CONSOLE_KEY">
+      <value>SMARTY_DEBUG</value>
+    </configuration>
+    <configuration id="CONF_AVERAGE_PRODUCT_MARGIN" name="CONF_AVERAGE_PRODUCT_MARGIN">
+      <value>40</value>
+    </configuration>
+    <configuration id="PS_MAIL_THEME" name="PS_MAIL_THEME">
+      <value>modern</value>
+    </configuration>
+
+    <!-- Module configuration in core fixtures, should be moved to modules concerned -->
+    <configuration id="PS_BLOCK_CART_AJAX" name="PS_BLOCK_CART_AJAX">
+      <value>1</value>
+    </configuration>
+    <configuration id="PRODUCTS_VIEWED_NBR" name="PRODUCTS_VIEWED_NBR">
+      <value>2</value>
+    </configuration>
+    <configuration id="BLOCK_CATEG_MAX_DEPTH" name="BLOCK_CATEG_MAX_DEPTH">
+      <value>4</value>
+    </configuration>
+    <configuration id="NEW_PRODUCTS_NBR" name="NEW_PRODUCTS_NBR">
+      <value>5</value>
+    </configuration>
+    <configuration id="CHECKUP_DESCRIPTIONS_LT" name="CHECKUP_DESCRIPTIONS_LT">
+      <value>100</value>
+    </configuration>
+    <configuration id="CHECKUP_DESCRIPTIONS_GT" name="CHECKUP_DESCRIPTIONS_GT">
+      <value>400</value>
+    </configuration>
+    <configuration id="CHECKUP_IMAGES_LT" name="CHECKUP_IMAGES_LT">
+      <value>1</value>
+    </configuration>
+    <configuration id="CHECKUP_IMAGES_GT" name="CHECKUP_IMAGES_GT">
+      <value>2</value>
+    </configuration>
+    <configuration id="CHECKUP_SALES_LT" name="CHECKUP_SALES_LT">
+      <value>1</value>
+    </configuration>
+    <configuration id="CHECKUP_SALES_GT" name="CHECKUP_SALES_GT">
+      <value>2</value>
+    </configuration>
+    <configuration id="CHECKUP_STOCK_LT" name="CHECKUP_STOCK_LT">
+      <value>1</value>
+    </configuration>
+    <configuration id="CHECKUP_STOCK_GT" name="CHECKUP_STOCK_GT">
+      <value>3</value>
+    </configuration>
+    <configuration id="MOD_BLOCKTOPMENU_ITEMS" name="MOD_BLOCKTOPMENU_ITEMS">
+      <value>CAT2,CAT3,CAT4</value>
+    </configuration>
+    <configuration id="MOD_BLOCKTOPMENU_SEARCH" name="MOD_BLOCKTOPMENU_SEARCH">
+      <value/>
+    </configuration>
+    <configuration id="blocksocial_facebook" name="BLOCKSOCIAL_FACEBOOK">
+      <value>https://www.facebook.com/prestashop</value>
+    </configuration>
+    <configuration id="blocksocial_twitter" name="BLOCKSOCIAL_TWITTER">
+      <value>https://www.twitter.com/prestashop</value>
+    </configuration>
+    <configuration id="blocksocial_rss" name="BLOCKSOCIAL_RSS">
+      <value>https://www.prestashop.com/blog/feed/</value>
+    </configuration>
+    <configuration id="blockcontactinfos_company" name="BLOCKCONTACTINFOS_COMPANY">
+      <value>Your company</value>
+    </configuration>
+    <configuration id="blockcontactinfos_address" name="BLOCKCONTACTINFOS_ADDRESS">
+      <value>Address line 1
+City
+Country</value>
+    </configuration>
+    <configuration id="blockcontactinfos_phone" name="BLOCKCONTACTINFOS_PHONE">
+      <value>0123-456-789</value>
+    </configuration>
+    <configuration id="blockcontactinfos_email" name="BLOCKCONTACTINFOS_EMAIL">
+      <value>pub@prestashop.com</value>
+    </configuration>
+    <configuration id="blockcontact_telnumber" name="BLOCKCONTACT_TELNUMBER">
+      <value>0123-456-789</value>
+    </configuration>
+    <configuration id="blockcontact_email" name="BLOCKCONTACT_EMAIL">
+      <value>pub@prestashop.com</value>
+    </configuration>
+    <configuration id="SUPPLIER_DISPLAY_TEXT" name="SUPPLIER_DISPLAY_TEXT">
+      <value>1</value>
+    </configuration>
+    <configuration id="SUPPLIER_DISPLAY_TEXT_NB" name="SUPPLIER_DISPLAY_TEXT_NB">
+      <value>5</value>
+    </configuration>
+    <configuration id="HOMESLIDER_SPEED" name="HOMESLIDER_SPEED">
+      <value>1300</value>
+    </configuration>
+    <configuration id="HOMESLIDER_PAUSE" name="HOMESLIDER_PAUSE">
+      <value>7700</value>
+    </configuration>
+    <configuration id="NW_SALT" name="NW_SALT">
+      <value>nK4KJP7jOsnzWMpo</value>
+    </configuration>
+    <configuration id="HOME_FEATURED_NBR" name="HOME_FEATURED_NBR">
+      <value>8</value>
+    </configuration>
+
+    <!-- Unused by core and native modules, to be removed in 9.0.0 -->
+    <configuration id="PS_SEARCH_AJAX" name="PS_SEARCH_AJAX">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_SHOW_ALL_MODULES" name="PS_SHOW_ALL_MODULES">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_BLOCK_BESTSELLERS_DISPLAY" name="PS_BLOCK_BESTSELLERS_DISPLAY">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_BLOCK_NEWPRODUCTS_DISPLAY" name="PS_BLOCK_NEWPRODUCTS_DISPLAY">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_BLOCK_SPECIALS_DISPLAY" name="PS_BLOCK_SPECIALS_DISPLAY">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_STORES_DISPLAY_CMS" name="PS_STORES_DISPLAY_CMS">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_THEME_V11" name="PS_THEME_V11">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_TIN_ACTIVE" name="PS_TIN_ACTIVE">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_1_3_UPDATE_DATE" name="PS_1_3_UPDATE_DATE">
+      <value>2011-12-27 10:20:42</value>
+    </configuration>
+    <configuration id="PS_1_3_2_UPDATE_DATE" name="PS_1_3_2_UPDATE_DATE">
+      <value>2011-12-27 10:20:42</value>
+    </configuration>
+    <configuration id="PS_CIPHER_ALGORITHM" name="PS_CIPHER_ALGORITHM">
+      <value>1</value>
+    </configuration>
+    <configuration id="EDITORIAL_IMAGE_WIDTH" name="EDITORIAL_IMAGE_WIDTH">
+      <value>530</value>
+    </configuration>
+    <configuration id="EDITORIAL_IMAGE_HEIGHT" name="EDITORIAL_IMAGE_HEIGHT">
+      <value>228</value>
+    </configuration>
+    <configuration id="MB_PAY_TO_EMAIL" name="MB_PAY_TO_EMAIL">
+      <value/>
+    </configuration>
+    <configuration id="MB_SECRET_WORD" name="MB_SECRET_WORD">
+      <value/>
+    </configuration>
+    <configuration id="MB_HIDE_LOGIN" name="MB_HIDE_LOGIN">
+      <value>1</value>
+    </configuration>
+    <configuration id="MB_ID_LOGO" name="MB_ID_LOGO">
+      <value>1</value>
+    </configuration>
+    <configuration id="MB_ID_LOGO_WALLET" name="MB_ID_LOGO_WALLET">
+      <value>1</value>
+    </configuration>
+    <configuration id="MB_PARAMETERS" name="MB_PARAMETERS">
+      <value>0</value>
+    </configuration>
+    <configuration id="MB_PARAMETERS_2" name="MB_PARAMETERS_2">
+      <value>0</value>
+    </configuration>
+    <configuration id="MB_DISPLAY_MODE" name="MB_DISPLAY_MODE">
+      <value>0</value>
+    </configuration>
+    <configuration id="MB_CANCEL_URL" name="MB_CANCEL_URL">
+      <value>http://www.yoursite.com</value>
+    </configuration>
+    <configuration id="MB_LOCAL_METHODS" name="MB_LOCAL_METHODS">
+      <value>2</value>
+    </configuration>
+    <configuration id="MB_INTER_METHODS" name="MB_INTER_METHODS">
+      <value>5</value>
+    </configuration>
+    <configuration id="BANK_WIRE_CURRENCIES" name="BANK_WIRE_CURRENCIES">
+      <value>2,1</value>
+    </configuration>
+    <configuration id="CHEQUE_CURRENCIES" name="CHEQUE_CURRENCIES">
+      <value>2,1</value>
+    </configuration>
+    <configuration id="BLOCK_CATEG_DHTML" name="BLOCK_CATEG_DHTML">
+      <value>1</value>
+    </configuration>
+    <configuration id="MANUFACTURER_DISPLAY_FORM" name="MANUFACTURER_DISPLAY_FORM">
+      <value>1</value>
+    </configuration>
+    <configuration id="MANUFACTURER_DISPLAY_TEXT" name="MANUFACTURER_DISPLAY_TEXT">
+      <value>1</value>
+    </configuration>
+    <configuration id="MANUFACTURER_DISPLAY_TEXT_NB" name="MANUFACTURER_DISPLAY_TEXT_NB">
+      <value>5</value>
+    </configuration>
+    <configuration id="BLOCKTAGS_NBR" name="BLOCKTAGS_NBR">
+      <value>10</value>
+    </configuration>
+    <configuration id="FOOTER_CMS" name="FOOTER_CMS">
+      <value>0_3|0_4</value>
+    </configuration>
+    <configuration id="FOOTER_BLOCK_ACTIVATION" name="FOOTER_BLOCK_ACTIVATION">
+      <value>0_3|0_4</value>
+    </configuration>
+    <configuration id="FOOTER_POWEREDBY" name="FOOTER_POWEREDBY">
+      <value>1</value>
+    </configuration>
+    <configuration id="BLOCKADVERT_LINK" name="BLOCKADVERT_LINK">
+      <value>https://www.prestashop.com</value>
+    </configuration>
+    <configuration id="BLOCKSTORE_IMG" name="BLOCKSTORE_IMG">
+      <value>store.jpg</value>
+    </configuration>
+    <configuration id="BLOCKADVERT_IMG_EXT" name="BLOCKADVERT_IMG_EXT">
       <value>jpg</value>
+    </configuration>
+    <configuration id="SUPPLIER_DISPLAY_FORM" name="SUPPLIER_DISPLAY_FORM">
+      <value>1</value>
+    </configuration>
+    <configuration id="BLOCK_CATEG_NBR_COLUMN_FOOTER" name="BLOCK_CATEG_NBR_COLUMN_FOOTER">
+      <value>1</value>
+    </configuration>
+    <configuration id="UPGRADER_BACKUPDB_FILENAME" name="UPGRADER_BACKUPDB_FILENAME">
+      <value/>
+    </configuration>
+    <configuration id="UPGRADER_BACKUPFILES_FILENAME" name="UPGRADER_BACKUPFILES_FILENAME">
+      <value/>
+    </configuration>
+    <configuration id="BLOCKREINSURANCE_NBBLOCKS" name="BLOCKREINSURANCE_NBBLOCKS">
+      <value>5</value>
+    </configuration>
+    <configuration id="HOMESLIDER_WIDTH" name="HOMESLIDER_WIDTH">
+      <value>535</value>
+    </configuration>
+    <configuration id="HOMESLIDER_LOOP" name="HOMESLIDER_LOOP">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_PAYMENT_LOGO_CMS_ID" name="PS_PAYMENT_LOGO_CMS_ID">
+      <value>0</value>
+    </configuration>
+    <configuration id="SEK_MIN_OCCURENCES" name="SEK_MIN_OCCURENCES">
+      <value>1</value>
+    </configuration>
+    <configuration id="SEK_FILTER_KW" name="SEK_FILTER_KW">
+      <value/>
+    </configuration>
+    <configuration id="PS_LOG_MODULE_PERFS_MODULO" name="PS_LOG_MODULE_PERFS_MODULO">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_DISPLAY_PRODUCT_WEIGHT" name="PS_DISPLAY_PRODUCT_WEIGHT">
+      <value>0</value>
+    </configuration>
+    <configuration id="PS_PRODUCT_WEIGHT_PRECISION" name="PS_PRODUCT_WEIGHT_PRECISION">
+      <value>2</value>
+    </configuration>
+    <configuration id="ADDONS_API_MODULE_CHANNEL" name="ADDONS_API_MODULE_CHANNEL">
+      <value>stable</value>
     </configuration>
   </entities>
 </entity_configuration>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Cleans up the default configuration file. All configuration keys are now groupped and sorted by how they are used in backoffice. Then I separated entries that mark order statuses, entries that mark movement reasons, entries that are internal only, entries that are module specific but in a core and finally entries that not used anywhere and should be removed in v9. I also added comments with missing configuration entries.
| Type?             | refacto
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### How to test
Probably to be tested by a dev.

1. Install clean 8.1.x
2. Go to phpmyadmin, open ps_configuration, show all entries, sort it by `name`, select all lines, click Export and confirm.
3. Install this PR to another folder.
4. Go to phpmyadmin and export the data again.
5. Compare the two files (https://www.diffchecker.com/) and check that only times and maybe some random strings have changed.