### PR TITLE
add _PS_ROOT_DIR_ from const CACHE for stop file_exists() open_basedi…

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -209,19 +209,19 @@ abstract class ModuleCore implements ModuleInterface
     /** @var int Defines the multistore compatibility level of the module */
     public $multistoreCompatibility = self::MULTISTORE_COMPATIBILITY_UNKNOWN;
 
-    const CACHE_FILE_MODULES_LIST = '/config/xml/modules_list.xml';
+    const CACHE_FILE_MODULES_LIST = _PS_ROOT_DIR_ .  '/config/xml/modules_list.xml';
 
-    const CACHE_FILE_TAB_MODULES_LIST = '/config/xml/tab_modules_list.xml';
+    const CACHE_FILE_TAB_MODULES_LIST = _PS_ROOT_DIR_ .  '/config/xml/tab_modules_list.xml';
 
-    const CACHE_FILE_ALL_COUNTRY_MODULES_LIST = '/config/xml/modules_native_addons.xml';
-    const CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST = '/config/xml/default_country_modules_list.xml';
+    const CACHE_FILE_ALL_COUNTRY_MODULES_LIST = _PS_ROOT_DIR_ .  '/config/xml/modules_native_addons.xml';
+    const CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST = _PS_ROOT_DIR_ .  '/config/xml/default_country_modules_list.xml';
 
-    const CACHE_FILE_CUSTOMER_MODULES_LIST = '/config/xml/customer_modules_list.xml';
+    const CACHE_FILE_CUSTOMER_MODULES_LIST = _PS_ROOT_DIR_ .  '/config/xml/customer_modules_list.xml';
 
-    const CACHE_FILE_MUST_HAVE_MODULES_LIST = '/config/xml/must_have_modules_list.xml';
+    const CACHE_FILE_MUST_HAVE_MODULES_LIST = _PS_ROOT_DIR_ .  '/config/xml/must_have_modules_list.xml';
 
-    const CACHE_FILE_TRUSTED_MODULES_LIST = '/config/xml/trusted_modules_list.xml';
-    const CACHE_FILE_UNTRUSTED_MODULES_LIST = '/config/xml/untrusted_modules_list.xml';
+    const CACHE_FILE_TRUSTED_MODULES_LIST = _PS_ROOT_DIR_ .  '/config/xml/trusted_modules_list.xml';
+    const CACHE_FILE_UNTRUSTED_MODULES_LIST = _PS_ROOT_DIR_ .  '/config/xml/untrusted_modules_list.xml';
 
     public const MULTISTORE_COMPATIBILITY_NO = -20;
     public const MULTISTORE_COMPATIBILITY_NOT_CONCERNED = -10;


### PR DESCRIPTION
When you try to update default contry, prestashop call methode clearModuleListCache() from  /src/Adapter/Module/AdminModuleDataProvider.php

This methode call file_exists(LegacyModule::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST)) LegacyModule::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST == '/config/xml/default_country_modules_list.xml'

the folder /config is in root of systeme

i add the  _PS_ROOT_DIR_ before for working in the prestashop root folder

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      |  plesk - ubuntu - php 7.4.33
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| How to test?      | enable debug mode and try to update default contry in internationnal -> Localisation -> settings
| Sponsor company   | https://www.lyondev.fr - Julien DOMBRET
