### PR TITLE
New employees need atleast default bo theme

### DIFF
--- a/src/Adapter/Profile/Employee/CommandHandler/AddEmployeeHandler.php
+++ b/src/Adapter/Profile/Employee/CommandHandler/AddEmployeeHandler.php
@@ -121,6 +121,7 @@ final class AddEmployeeHandler extends AbstractEmployeeHandler implements AddEmp
         $employee->id_last_customer_message = $employee->getLastElementsForNotify('customer_message');
         $employee->id_last_customer = $employee->getLastElementsForNotify('customer');
         $employee->has_enabled_gravatar = $command->hasEnabledGravatar();
+        $employee->bo_theme = 'default';
 
         if (false === $employee->add()) {
             throw new EmployeeException(sprintf('Failed to add new employee with email "%s"', $command->getEmail()->getValue()));


### PR DESCRIPTION
When creating a new employee it currently does not set a default bo theme.   Since PS 8 for example filemanager needs a default bo theme to function.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | New employees need a default BO theme.
| Type?             | bug fix 
| Category?         | BO 
| How to test?      | Create new user, check db for default bo theme and now filemanager still works.
