### PR TITLE
Update classname regex to allow FQDN

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -39,7 +39,7 @@ use ZxcvbnPhp\Zxcvbn;
 class ValidateCore
 {
     public const ORDER_BY_REGEXP = '/^(?:(`?)[\w!_-]+\1\.)?(?:(`?)[\w!_-]+\2)$/';
-    public const OBJECT_CLASS_NAME_REGEXP = '/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/';
+    public const OBJECT_CLASS_NAME_REGEXP = '/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*(\\\\[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)*$/';
     /**
      * Maximal 32 bits value: (2^32)-1
      *


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fix classname validation in `Validate` not allowing FQDN classnames 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install the following test module, then click on 'Configure' to trigger the test case. If no error message is displayed and a log line is properly added to the log list (Advances parameters > Logs) then the fix works. [test_33590.zip](https://github.com/PrestaShop/PrestaShop/files/12475413/test_33590.zip)
| Fixed issue or discussion?     | Fixes #33590
| Related PRs       | 
| Sponsor company   | Novius

