### PR TITLE
Move `FrontController::updateQueryString` to `Tools` to make reusable

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3857,7 +3857,7 @@ exit;
         return $array;
     }
 
-     /**
+    /**
      * Generate a URL corresponding to the current page but
      * with the query string altered.
      *

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3856,6 +3856,51 @@ exit;
 
         return $array;
     }
+
+     /**
+     * Generate a URL corresponding to the current page but
+     * with the query string altered.
+     *
+     * If $extraParams is set to NULL, then all query params are stripped.
+     *
+     * Otherwise, params from $extraParams that have a null value are stripped,
+     * and other params are added. Params not in $extraParams are unchanged.
+     */
+    public static function updateCurrentQueryString(array $extraParams = null): string
+    {
+        $uriWithoutParams = explode('?', $_SERVER['REQUEST_URI'])[0];
+        $url = Tools::getCurrentUrlProtocolPrefix() . $_SERVER['HTTP_HOST'] . $uriWithoutParams;
+        $params = [];
+        $paramsFromUri = '';
+        if (strpos($_SERVER['REQUEST_URI'], '?') !== false) {
+            $paramsFromUri = explode('?', $_SERVER['REQUEST_URI'])[1];
+        }
+        parse_str($paramsFromUri, $params);
+
+        if (null !== $extraParams) {
+            foreach ($extraParams as $key => $value) {
+                if (null === $value) {
+                    unset($params[$key]);
+                } else {
+                    $params[$key] = $value;
+                }
+            }
+        }
+
+        if (null !== $extraParams) {
+            foreach ($params as $key => $param) {
+                if ('' === $param) {
+                    unset($params[$key]);
+                }
+            }
+        } else {
+            $params = [];
+        }
+
+        $queryString = str_replace('%2F', '/', http_build_query($params, '', '&'));
+
+        return $url . ($queryString ? "?$queryString" : '');
+    }
 }
 
 /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1842,13 +1842,7 @@ class FrontControllerCore extends Controller
     }
 
     /**
-     * Generate a URL corresponding to the current page but
-     * with the query string altered.
-     *
-     * If $extraParams is set to NULL, then all query params are stripped.
-     *
-     * Otherwise, params from $extraParams that have a null value are stripped,
-     * and other params are added. Params not in $extraParams are unchanged.
+     * @deprecated Since 9.0 and will be removed in the next major.
      */
     protected function updateQueryString(array $extraParams = null)
     {

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1852,7 +1852,7 @@ class FrontControllerCore extends Controller
      */
     protected function updateQueryString(array $extraParams = null)
     {
-        return Tools:updateCurrentQueryString($extraParams);
+        return Tools::updateCurrentQueryString($extraParams);
     }
 
     protected function getCurrentURL()

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1852,38 +1852,7 @@ class FrontControllerCore extends Controller
      */
     protected function updateQueryString(array $extraParams = null)
     {
-        $uriWithoutParams = explode('?', $_SERVER['REQUEST_URI'])[0];
-        $url = Tools::getCurrentUrlProtocolPrefix() . $_SERVER['HTTP_HOST'] . $uriWithoutParams;
-        $params = [];
-        $paramsFromUri = '';
-        if (strpos($_SERVER['REQUEST_URI'], '?') !== false) {
-            $paramsFromUri = explode('?', $_SERVER['REQUEST_URI'])[1];
-        }
-        parse_str($paramsFromUri, $params);
-
-        if (null !== $extraParams) {
-            foreach ($extraParams as $key => $value) {
-                if (null === $value) {
-                    unset($params[$key]);
-                } else {
-                    $params[$key] = $value;
-                }
-            }
-        }
-
-        if (null !== $extraParams) {
-            foreach ($params as $key => $param) {
-                if ('' === $param) {
-                    unset($params[$key]);
-                }
-            }
-        } else {
-            $params = [];
-        }
-
-        $queryString = str_replace('%2F', '/', http_build_query($params, '', '&'));
-
-        return $url . ($queryString ? "?$queryString" : '');
+        return Tools:updateCurrentQueryString($extraParams);
     }
 
     protected function getCurrentURL()

--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -153,12 +153,12 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
         foreach ($facetsArray['filters'] as &$filter) {
             $filter['facetLabel'] = $facet->getLabel();
             if ($filter['nextEncodedFacets']) {
-                $filter['nextEncodedFacetsURL'] = $this->updateQueryString([
+                $filter['nextEncodedFacetsURL'] = Tools::updateCurrentQueryString([
                     'q' => $filter['nextEncodedFacets'],
                     'page' => null,
                 ]);
             } else {
-                $filter['nextEncodedFacetsURL'] = $this->updateQueryString([
+                $filter['nextEncodedFacetsURL'] = Tools::updateCurrentQueryString([
                     'q' => null,
                 ]);
             }
@@ -202,7 +202,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
             'js_enabled' => $this->ajax,
             'activeFilters' => $activeFilters,
             'sort_order' => $result->getCurrentSortOrder()->toString(),
-            'clear_all_link' => $this->updateQueryString(['q' => null, 'page' => null]),
+            'clear_all_link' => Tools::updateCurrentQueryString(['q' => null, 'page' => null]),
         ]);
     }
 
@@ -237,7 +237,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
 
         return $this->render('catalog/_partials/active_filters', [
             'activeFilters' => $activeFilters,
-            'clear_all_link' => $this->updateQueryString(['q' => null, 'page' => null]),
+            'clear_all_link' => Tools::updateCurrentQueryString(['q' => null, 'page' => null]),
         ]);
     }
 
@@ -435,7 +435,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
             'rendered_facets' => $rendered_facets,
             'rendered_active_filters' => $rendered_active_filters,
             'js_enabled' => $this->ajax,
-            'current_url' => $this->updateQueryString([
+            'current_url' => Tools::updateCurrentQueryString([
                 'q' => $result->getEncodedFacets(),
             ]),
         ];
@@ -508,7 +508,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
         $itemsShownTo = $query->getResultsPerPage() * $query->getPage();
 
         $pages = array_map(function ($link) {
-            $link['url'] = $this->updateQueryString([
+            $link['url'] = Tools::updateCurrentQueryString([
                 'page' => $link['page'] > 1 ? $link['page'] : null,
             ]);
 
@@ -556,7 +556,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
         return array_map(function ($sortOrder) use ($currentSortOrderURLParameter) {
             $order = $sortOrder->toArray();
             $order['current'] = $order['urlParameter'] === $currentSortOrderURLParameter;
-            $order['url'] = $this->updateQueryString([
+            $order['url'] = Tools::updateCurrentQueryString([
                 'order' => $order['urlParameter'],
                 'page' => null,
             ]);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Move `FrontController::updateQueryString` to `Tools` and make reusable.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Test green :)
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | Evolutive
