### PR TITLE
Add htaccess to protect templates dir

### DIFF
--- a/templates/.htaccess
+++ b/templates/.htaccess
@@ -1,0 +1,10 @@
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fixes #33722 by adding an htaccess to protect the `templates` directory, backport of #33723. Thank you @maxime-profileo ❤️ 
| Type?             | bug fix
| Category?         | FO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | See #33722
| Fixed issue or discussion?     | Fixes #33722
| Related PRs       | 
| Sponsor company   | PrestaShop SA
