### PR TITLE
Allow multiple modules to use hook filterProductContent

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -427,11 +427,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 'filterProductContent',
                 ['object' => $product_for_template],
                 null,
-                false,
+                true,
                 true,
                 false,
                 null,
-                true
+                false
             );
             if (!empty($filteredProduct['object'])) {
                 $product_for_template = $filteredProduct['object'];


### PR DESCRIPTION
Bug filteredproduct hook

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | See below
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes 
| Deprecations?     | no
| How to test?      | Install several modules in hook filterProductContent.
| Fixed issue or discussion?    return string and it must return array
| Related PRs       | 
| Sponsor company   | 

## description

If the value of chain is true or array_return false when the hook:exec( method is executed, the value of $hook_args will become a string after executing the first module, because the condition if (0 !=) exists within the exec method. = $key && true === $chain) {
                    $hook_args = $output;
                } which will give $hook_args the value of $output and this will be a string.