### PR TITLE
Fix uninstalling modules with deleted hooks.

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -648,7 +648,7 @@ class HookCore extends ObjectModel
      */
     public static function unregisterHook($module_instance, $hook_identifier, $shop_list = null)
     {
-        if (is_numeric($hook_identifier)) {
+        if (Validate::isUnsignedInt($hook_identifier)) {
             // If we received hook ID as an integer directly, we try to find it's name
             $hook_id = $hook_identifier;
 

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -655,13 +655,14 @@ class HookCore extends ObjectModel
             /*
              * Try to load hook name. The hook could be deleted, but we don't care, we can still do the job.
              * Try/catch block is here because getNameById throws an exception when the hook is not found.
-             * It would be better if this method returned false in future versions.
+             * It would be better if getNameById returned false in future versions.
              */
             try {
                 $hook_name = Hook::getNameById((int) $hook_identifier);
-            } catch (Exception $e) {
+            } catch (PrestaShopObjectNotFoundException $e) {
             }
 
+            // If getting the name failed or we got some malformed hook name
             if (empty($hook_name)) {
                 $hook_name = '';
             }
@@ -676,13 +677,15 @@ class HookCore extends ObjectModel
             return false;
         }
 
-        Hook::exec(
-            'actionModuleUnRegisterHookBefore',
-            [
-                'object' => $module_instance,
-                'hook_name' => $hook_name,
-            ]
-        );
+        if (!empty($hook_name)) {
+            Hook::exec(
+                'actionModuleUnRegisterHookBefore',
+                [
+                    'object' => $module_instance,
+                    'hook_name' => $hook_name,
+                ]
+            );
+        }
 
         // Unregister module on hook by id
         $sql = 'DELETE FROM `' . _DB_PREFIX_ . 'hook_module`
@@ -693,13 +696,15 @@ class HookCore extends ObjectModel
         // Clean modules position
         $module_instance->cleanPositions($hook_id, $shop_list);
 
-        Hook::exec(
-            'actionModuleUnRegisterHookAfter',
-            [
-                'object' => $module_instance,
-                'hook_name' => $hook_name,
-            ]
-        );
+        if (!empty($hook_name)) {
+            Hook::exec(
+                'actionModuleUnRegisterHookAfter',
+                [
+                    'object' => $module_instance,
+                    'hook_name' => $hook_name,
+                ]
+            );
+        }
 
         return $result;
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | If a hook was removed from database, you can no longer uninstall a module or unhook it from there. The only change is basically adding a try catch, renaming a variable for better clarity and some comments.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29483
| Related PRs       | 
| Sponsor company   |

### How to reproduce
1. Install [gsitemap](https://github.com/PrestaShop/gsitemap) native module. It adds a new hook `gSitemapAppendUrls`.
2. Install this [tox_hooktest.zip](https://github.com/PrestaShop/PrestaShop/files/12498038/tox_hooktest.zip), it hooks itself to `gSitemapAppendUrls`.
3. Uninstall gsitemap - it removes `gSitemapAppendUrls`.
4. Try to uninstall the test module - `Cannot Uninstall module tox_hooktest. The hook id #405 does not exist in database.`
