### PR TITLE
Fixed $legacyKey in buildTranslationCatalogueFromLegacyFiles()

### DIFF
--- a/src/PrestaShopBundle/Translation/Provider/ExternalModuleLegacySystemProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/ExternalModuleLegacySystemProvider.php
@@ -207,7 +207,8 @@ class ExternalModuleLegacySystemProvider extends AbstractProvider implements Use
 
         foreach ($catalogueFromPhpAndSmartyFiles->all() as $currentDomain => $items) {
             foreach (array_keys($items) as $translationKey) {
-                $legacyKey = md5($translationKey);
+                // Same as in Translate::getModuleTranslation()
+                $legacyKey = md5(preg_replace("/\\\*'/", "\'", $translationKey));
 
                 if ($catalogueFromLegacyTranslationFiles->has($legacyKey, $currentDomain)) {
                     $legacyFilesCatalogue->set(


### PR DESCRIPTION
Fixed `$legacyKey` to correctly match translations for original strings containing single quotes.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Translations for strings with single quotes are not recognised in `buildTranslationCatalogueFromLegacyFiles()`. It happens because of incorrectly hashed `$legacyKey`. This fix ensures that `$legacyKey` is hashed correctly, same as in `Translate::getModuleTranslation()`
| Type?             | bug fix
| Category?         | LO
| BC breaks?        | 
| Deprecations?     | 
| How to test?      | 1. Find a module that uses legacy translation system<br>2. Find a translatable text that has a single quote in it. For example `$this->l('Don\'t forget to clear cache')`<br>3. Translate that text to **FR** or any other language, so translation is saved in `/fr.php`. It doesn't matter if translation has single quotes or not<br>4. Check output: `$container->get('prestashop.translation.external_module_provider')->setModuleName($module_name)->setLocale($locale)->getMessageCatalogue();`
| Fixed issue or discussion?     | 
| Related PRs       |  
| Sponsor company   | 
