### PR TITLE
Migrate ModuleActivated annotation to attribute

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
+use PrestaShopBundle\Security\Annotation\ModuleActivated;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector;
 use Rector\Config\RectorConfig;
@@ -93,6 +95,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
-        new AnnotationToAttribute(DemoRestricted::class), ]
-    );
+        new AnnotationToAttribute(DemoRestricted::class),
+        new AnnotationToAttribute(ModuleActivated::class),
+    ]);
 };

--- a/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
@@ -68,7 +68,6 @@ services:
       - "@router"
       - "@translator"
       - "@session"
-      - "@annotation_reader"
       - '@PrestaShop\PrestaShop\Core\Module\ModuleRepository'
     tags:
       - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }

--- a/src/PrestaShopBundle/Security/Annotation/ModuleActivated.php
+++ b/src/PrestaShopBundle/Security/Annotation/ModuleActivated.php
@@ -26,42 +26,31 @@
 
 namespace PrestaShopBundle\Security\Annotation;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationAnnotation;
-
 /**
  * Forbid access to the page if the defined module mode is inactive.
- *
- * @Annotation
  */
-class ModuleActivated extends ConfigurationAnnotation
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+class ModuleActivated
 {
-    /**
-     * The translation domain for the message.
-     *
-     * @var string
-     */
-    protected $domain = 'Admin.Notifications.Error';
-
-    /**
-     * The message of the exception.
-     *
-     * @var string
-     */
-    protected $message = 'The module %s is inactive.';
-
-    /**
-     * The route for the redirection.
-     *
-     * @var string|null
-     */
-    protected $redirectRoute;
-
-    /**
-     * The module name to check.
-     *
-     * @var string|null
-     */
-    protected $moduleName;
+    public function __construct(
+        /**
+         * The translation domain for the message.
+         */
+        private string $domain = 'Admin.Notifications.Error',
+        /**
+         * The message of the exception.
+         */
+        private string $message = 'The module %s is inactive.',
+        /**
+         * The route for the redirection.
+         */
+        private ?string $redirectRoute = 'admin_module_manage',
+        /**
+         * The module name to check.
+         */
+        private ?string $moduleName = null,
+    ) {
+    }
 
     /**
      * @return string


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Migrate `ModuleActivated` annotation to attribute.<br/>Bonus: we can add also this attribute to decorate a method in controller.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | See below.
| Fixed issue or discussion?     | Fixes #33769
| Related PRs       |
| Sponsor company   | PrestaShop SA

**How to test:**
Add attribute ModuleActivated instead of annotation.
From:  
```php
* @ModuleActivated(moduleName="ps_linklist", redirectRoute="admin_module_manage")
```

To: 
```php
#[ModuleActivated(moduleName: "ps_linklist", redirectRoute: "admin_module_manage")]
```