### PR TITLE
Make MobileQuickAccess twig component independent

### DIFF
--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -66,10 +66,6 @@
             {render_template
               smarty_template="components/layout/mobile_quickaccess.tpl"
               twig_template="@PrestaShop/Admin/Layout/mobile_quick_access.html.twig"
-              quick_access=$quick_access
-              link=$link
-              quick_access_current_link_icon=$quick_access_current_link_icon
-              quick_access_current_link_name=$quick_access_current_link_name
             }
         </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/mobile_quick_access.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/mobile_quick_access.html.twig
@@ -24,49 +24,47 @@
  *#}
 <div class="component-search-quickaccess d-none">
   <p class="component-search-title">{{ 'Quick Access'|trans({}, 'Admin.Navigation.Header') }}</p>
-  {% for quick in quickAccess %}
-    <a class="dropdown-item quick-row-link{% if link.matchQuickLink(quick.link) %}{% set matchQuickLink = quick.id_quick_access %} active{% endif %}"
-      href="{{ quick.link|escape('html_attr') }}"
-      {% if quick.new_window %} target="_blank"{% endif %}
-      data-item="{{ quick.name }}"
+  {% for quickAccess in this.quickAccesses %}
+    <a class="dropdown-item quick-row-link{% if quickAccess.active %} active{% endif %}"
+      href="{{ quickAccess.link|escape('html_attr') }}"
+      {% if quickAccess.new_window %} target="_blank"{% endif %}
+      data-item="{{ quickAccess.name }}"
       >
-      {{ quick.name }}
+      {{ quickAccess.name|escape('html_attr') }}
   </a>
   {% endfor %}
   <div class="dropdown-divider"></div>
-  {% if matchQuickLink is defined %}
-  <a id="quick-remove-link"
-     class="dropdown-item js-quick-link"
-     href="#"
-     data-method="remove"
-     data-quicklink-id="{{ matchQuickLink }}"
-     data-rand="{{ random(1, 200) }}"
-     data-icon="{{ quickAccessCurrentLinkIcon }}"
-     data-url="{{ link.getQuickLink(app.request.uri) }}"
-     data-post-link="{{ link.getAdminLink('AdminQuickAccesses') }}"
-     data-prompt-text="{{ 'Please name this shortcut:'|trans({}, 'Admin.Navigation.Header')|escape('html_attr')}}"
-     data-link="{{ quickAccessCurrentLinkName|u.truncate(32, '...') }}"
-  >
-    <i class="material-icons">remove_circle_outline</i>
-    {{ 'Remove from Quick Access'|trans({}, 'Admin.Navigation.Header') }}
-  </a>
+  {% if this.currentQuickAccess %}
+    <a id="quick-remove-link"
+       class="dropdown-item js-quick-link"
+       href="#"
+       data-method="remove"
+       data-quicklink-id="{{ this.currentQuickAccess.id_quick_access }}"
+       data-rand="{{ random(1, 200) }}"
+       data-url="{{ this.cleanCurrentUrl|escape('html_attr') }}"
+       data-post-link="{{ path('AdminQuickAccesses') }}"
+       data-prompt-text="{{ 'Please name this shortcut:'|trans({}, 'Admin.Navigation.Header')|escape('html_attr') }}"
+       data-link="{{ this.currentQuickAccess.name|escape('html_attr') }}"
+    >
+      <i class="material-icons">remove_circle_outline</i>
+      {{ 'Remove from Quick Access'|trans({}, 'Admin.Navigation.Header') }}
+    </a>
   {% else %}
-  <a id="quick-add-link"
-     class="dropdown-item js-quick-link"
-     href="#"
-     data-rand="{{ random(1, 200) }}"
-     data-icon="{{ quickAccessCurrentLinkIcon }}"
-     data-method="add"
-     data-url="{{ link.getQuickLink(app.request.uri) }}"
-     data-post-link="{{ link.getAdminLink('AdminQuickAccesses') }}"
-     data-prompt-text="{{ 'Please name this shortcut:'|trans({}, 'Admin.Navigation.Header')|escape('html_attr')}}"
-     data-link="{{ quickAccessCurrentLinkName|u.truncate(32, '...') }}"
-  >
-    <i class="material-icons">add_circle</i>
-    {{ 'Add current page to Quick Access'|trans({}, 'Admin.Actions') }}
-  </a>
+    <a id="quick-add-link"
+       class="dropdown-item js-quick-link"
+       href="#"
+       data-rand="{{ random(1, 200) }}"
+       data-method="add"
+       data-url="{{ this.cleanCurrentUrl|escape('html_attr') }}"
+       data-post-link="{{ path('AdminQuickAccesses') }}"
+       data-prompt-text="{{ 'Please name this shortcut:'|trans({}, 'Admin.Navigation.Header')|escape('html_attr')}}"
+       data-link="{{ this.currentUrlTitle|escape('html_attr') }}"
+    >
+      <i class="material-icons">add_circle</i>
+      {{ 'Add current page to Quick Access'|trans({}, 'Admin.Actions') }}
+    </a>
   {% endif %}
-  <a id="quick-manage-link" class="dropdown-item" href="{{ link.getAdminLink('AdminQuickAccesses') }}">
+  <a id="quick-manage-link" class="dropdown-item" href="{{ path('AdminQuickAccesses') }}">
   <i class="material-icons">settings</i>
     {{ 'Manage your quick accesses'|trans({}, 'Admin.Navigation.Header') }}
   </a>

--- a/src/PrestaShopBundle/Resources/views/Admin/Layout/mobile_quick_access.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Layout/mobile_quick_access.html.twig
@@ -22,9 +22,4 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-{{ component('MobileQuickAccess', {
-  quickAccess: quick_access,
-  link: link,
-  quickAccessCurrentLinkIcon: quick_access_current_link_icon,
-  quickAccessCurrentLinkName: quick_access_current_link_name
-}) }}
+{{ component('MobileQuickAccess') }}

--- a/src/PrestaShopBundle/Twig/Component/MobileQuickAccess.php
+++ b/src/PrestaShopBundle/Twig/Component/MobileQuickAccess.php
@@ -28,14 +28,9 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Twig\Component;
 
-use Link;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
 #[AsTwigComponent(template: '@PrestaShop/Admin/Component/Layout/mobile_quick_access.html.twig')]
-class MobileQuickAccess
+class MobileQuickAccess extends QuickAccess
 {
-    public array $quickAccess;
-    public Link $link;
-    public string $quickAccessCurrentLinkIcon;
-    public string $quickAccessCurrentLinkName;
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Make MobileQuickAccess twig component independent.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI 🟢 & UI tests 🟢
| UI Tests | - Legacy: https://github.com/boherm/ga.tests.ui.pr/actions/runs/6082756791<br/>- Symfony: https://github.com/boherm/ga.tests.ui.pr/actions/runs/6082757825
| Fixed issue or discussion?     | Fixes #33803
| Related PRs       | 
| Sponsor company   | PrestaShop SA
