### PR TITLE
Update ProductLazyArray.php

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -511,7 +511,7 @@ class ProductLazyArray extends AbstractLazyArray
         if ($this->product['new']) {
             $flags['new'] = [
                 'type' => 'new',
-                'label' => $this->translator->trans('New', [], 'Shop.Theme.Global'),
+                'label' => $this->translator->trans('New', [], 'Shop.Theme.Catalog'),
             ];
         }
 


### PR DESCRIPTION
String for the label “new” is now sourced from `Shop.Theme.Catalog` instead from `Shop.Theme.Global` which does not have this string at all

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop but also applicable to 8.1.x
| Description?      | String for the label “new” is now sourced from `Shop.Theme.Catalog` instead from `Shop.Theme.Global` which does not have this string at all. This make the “new” label translatable with BO translation tools.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Change the translation for the string “new” in `Shop.Theme.Catalog` using BO translation utility and see the label change for new items in FO catalog and product pages.
| Fixed issue or discussion?     | Fixes #33836
| Related PRs       | None
| Sponsor company   | Your company or customer's name goes here (if applicable).
