### PR TITLE
Fix textarealang required field not validated

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1524,7 +1524,7 @@ class AdminControllerCore extends Controller
                 // Check if field is required
                 if ((!Shop::isFeatureActive() && !empty($values['required']))
                     || (Shop::isFeatureActive() && isset($_POST['multishopOverrideOption'][$field]) && !empty($values['required']))) {
-                    if (isset($values['type']) && $values['type'] == 'textLang') {
+                    if (isset($values['type']) && in_array($values['type'], ['textLang', 'textareaLang'])) {
                         foreach ($languages as $language) {
                             if (($value = Tools::getValue($field . '_' . $language['id_lang'])) == false && (string) $value != '0') {
                                 $this->errors[] = $this->trans('field %s is required.', [$values['title']], 'Admin.Notifications.Error');
@@ -1542,7 +1542,7 @@ class AdminControllerCore extends Controller
                 }
 
                 // Check field validator
-                if (isset($values['type']) && $values['type'] == 'textLang') {
+                if (isset($values['type']) && in_array($values['type'], ['textLang', 'textareaLang'])) {
                     foreach ($languages as $language) {
                         if (Tools::getValue($field . '_' . $language['id_lang']) && isset($values['validation'])) {
                             $values_validation = $values['validation'];

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1506,7 +1506,7 @@ class AdminControllerCore extends Controller
                 // Check if field is required
                 if ((!Shop::isFeatureActive() && !empty($values['required']))
                     || (Shop::isFeatureActive() && isset($_POST['multishopOverrideOption'][$field]) && !empty($values['required']))) {
-                    if (isset($values['type']) && $values['type'] == 'textLang') {
+                    if (isset($values['type']) && in_array($values['type'], ['textLang', 'textareaLang'])) {
                         foreach ($languages as $language) {
                             if (($value = Tools::getValue($field . '_' . $language['id_lang'])) == false && (string) $value != '0') {
                                 $this->errors[] = $this->trans('field %s is required.', [$values['title']], 'Admin.Notifications.Error');
@@ -1524,7 +1524,7 @@ class AdminControllerCore extends Controller
                 }
 
                 // Check field validator
-                if (isset($values['type']) && $values['type'] == 'textLang') {
+                if (isset($values['type']) && in_array($values['type'], ['textLang', 'textareaLang'])) {
                     foreach ($languages as $language) {
                         if (Tools::getValue($field . '_' . $language['id_lang']) && isset($values['validation'])) {
                             $values_validation = $values['validation'];


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x
| Description?      | This PR addresses a bug in cases where a class that extends AdminController has a field of type textareaLang marked as required. Due to an incorrect validation check, the textareaLang field fails to pass the required validation, resulting in unexpected behavior in extended AdminController classes. While the method can update options for textLang and textareaLang, the required check is only applied to textLang. This PR ensures that the textareaLang field correctly passes the required validation when necessary.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?    | no
| How to test?      | <ul><li>Apply this PR to your PrestaShop development environment.</li><li>In a class that extends `AdminController`, create or edit a configuration option using the `textareaLang` field type with `'required' => true`.</li><li>Save the configuration option.</li><li>Confirm that the validation correctly passes, and no error messages are displayed.</li><li>Verify that other configuration options in the same or different classes continue to function as expected.</li></ul>
| Fixed issue or discussion?     | Fixes #34323
| Related PRs       |  N/A
| Sponsor company   | N/A