### PR TITLE
Add order by for attribute by position

### DIFF
--- a/src/Adapter/Attribute/Repository/AttributeRepository.php
+++ b/src/Adapter/Attribute/Repository/AttributeRepository.php
@@ -121,6 +121,7 @@ class AttributeRepository extends AbstractObjectModelRepository
             )
             ->andWhere($qb->expr()->in('a.id_attribute_group', ':attributeGroupIds'))
             ->setParameter('attributeGroupIds', $attributeGroupIdValues, Connection::PARAM_INT_ARRAY)
+            ->addOrderBy('a.position', 'ASC')
         ;
 
         if (!empty($attributeIds)) {

--- a/tests/Integration/Behaviour/Features/Context/AttributeFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/AttributeFeatureContext.php
@@ -92,6 +92,28 @@ class AttributeFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Given /^I switch positions of attributes "(.+)" and "(.+)"$/
+     *
+     * @param string $attributeReference
+     * @param string $secondAttributeReference
+     *
+     * @return void
+     */
+    public function switchAttributePosition(string $attributeReference, string $secondAttributeReference): void
+    {
+        $attributeId = $this->getSharedStorage()->get($attributeReference);
+        $secondAttributeId = $this->getSharedStorage()->get($secondAttributeReference);
+        $attribute = new ProductAttribute($attributeId);
+        $secondAttribute = new ProductAttribute($secondAttributeId);
+
+        $position = (int) $attribute->position;
+        $attribute->position = $secondAttribute->position;
+        $secondAttribute->position = $position;
+        $attribute->save();
+        $secondAttribute->save();
+    }
+
+    /**
      * @Given attribute ":attributeReference" is not associated to shops ":shopReferences"
      *
      * @param string $attributeReference

--- a/tests/Integration/Behaviour/Features/Scenario/Attribute/list_attribute_groups.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Attribute/list_attribute_groups.feature
@@ -61,3 +61,10 @@ Feature: Attribute Group
       | Yellow      | #F1C40F | 11       | yellow    |
       | Brown       | #964B00 | 12       | brown     |
       | Pink        | #FCCACD | 13       | pink      |
+    When I switch positions of attributes "s" and "xl"
+    Then the attribute group "size" should have the following attributes:
+      | name[en-US] | color | position | reference |
+      | XL          |       | 0        | xl        |
+      | M           |       | 1        | m         |
+      | L           |       | 2        | l         |
+      | S           |       | 3        | s         |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Add missing order by so that the list of attribute values is based on positions
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | The list of attribute **values** should be based on position in the combination generation modal + https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/6108819570
| Fixed issue or discussion?     | Fixes #33605
| Related PRs       | ~
| Sponsor company   | ~
