### PR TITLE
Allow modules to provide language link params in correct languages

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1180,7 +1180,7 @@ class LinkCore
     }
 
     /**
-     * Create link after language change, for the change language block.
+     * Retrieves a link for the current page in different language.
      *
      * @param int $idLang Language ID
      * @param Context|null $context the context if needed
@@ -1223,6 +1223,11 @@ class LinkCore
         } elseif (isset($params['fc']) && $params['fc'] == 'module') {
             $module = Validate::isModuleName(Tools::getValue('module')) ? Tools::getValue('module') : '';
             if (!empty($module)) {
+                // Let modules provide correct $params to build the URL if they need to (rewrites in correct language).
+                Hook::exec(
+                    'actionLanguageLinkParameters',
+                    ['linkParams' => &$params, 'linkIdLang' => (int) $idLang]
+                );
                 unset($params['fc'], $params['module']);
 
                 return $this->getModuleLink($module, $controller, $params, null, (int) $idLang);

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -4504,5 +4504,10 @@
       <title>Modify back office breadcrumb</title>
       <description>This hook allows modifying back office breadcrumb</description>
     </hook>
+    <hook id="actionLanguageLinkParameters">
+      <name>actionLanguageLinkParameters</name>
+      <title>Add parameters to language link</title>
+      <description>Allows modules to provide proper parameters for links in other languages.</description>
+    </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Removes one of the limitations of the routing system - allows modules to provide correct data to the core when it gets controller links in other languages. This also fixes the built-in methods `FrontController::getAlternativeLangsUrl` (although they have some extra parameters - to be fixed).
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     |no
| How to test?      | See below
| Fixed issue or discussion?     |
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/628
| Sponsor company   | 

### How to test - without PR
0. Prepare a shop with two languages - ID 1 and 2.
1. Install [tox_langtest.zip](https://github.com/PrestaShop/PrestaShop/files/12549385/tox_langtest.zip)
2. Go to `/langtest/1-something` on your shop.
3. Check that the language switcher links all go to `/gb/langtest/1-something` and `/fr/langtest/1-something` - not good, we have no way to alter the `something`.

### How to test - with PR
4. Now try with my PR.
5. Do the same and go to `/langtest/1-something` and check that the rewrite is different for each language.

### Auto test
https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/6156343877