### PR TITLE
Replace help text by tooltip in delivery slips page

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
@@ -50,7 +50,7 @@ class SlipOptionsType extends TranslatorAwareType
                 [
                     'type' => TextType::class,
                     'label' => $this->trans('Delivery prefix', 'Admin.Orderscustomers.Feature'),
-                    'help' => $this->trans('Prefix used for delivery slips.', 'Admin.Orderscustomers.Help'),
+                    'label_help_box' => $this->trans('Prefix used for delivery slips.', 'Admin.Orderscustomers.Help'),
                 ]
             )
             ->add(
@@ -58,7 +58,7 @@ class SlipOptionsType extends TranslatorAwareType
                 NumberType::class,
                 [
                     'label' => $this->trans('Delivery number', 'Admin.Orderscustomers.Feature'),
-                    'help' => $this->trans(
+                    'label_help_box' => $this->trans(
                         'The next delivery slip will begin with this number and then increase with each additional slip.',
                         'Admin.Orderscustomers.Help'
                     ),
@@ -69,7 +69,7 @@ class SlipOptionsType extends TranslatorAwareType
                 SwitchType::class,
                 [
                     'label' => $this->trans('Enable product image', 'Admin.Orderscustomers.Feature'),
-                    'help' => $this->trans(
+                    'label_help_box' => $this->trans(
                         'Add an image before the product name on delivery slips.',
                         'Admin.Orderscustomers.Help'
                     ),


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Replace help text by tooltip in delivery slips page
| Type?             | improvement 
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/32422 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/32422 
| Related PRs       | 
| Sponsor company   | PrestaShop SA 

Now, the delivery slips page looks like : 

![Capture d’écran 2023-09-08 à 11 04 11](https://github.com/PrestaShop/PrestaShop/assets/121870/8eb7028e-1b2b-489b-b7d5-5ecbe1ab90cf)
![Capture d’écran 2023-09-08 à 11 04 16](https://github.com/PrestaShop/PrestaShop/assets/121870/4ad7ef50-f45b-46d1-a3a5-67f2c683b08f)
![Capture d’écran 2023-09-08 à 11 04 20](https://github.com/PrestaShop/PrestaShop/assets/121870/006f201c-5dda-4e10-b6fb-3e630aec6231)
