### PR TITLE
Make getProductPageTitle() public to allow override

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1475,7 +1475,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      *
      * @return string
      */
-    private function getProductPageTitle(array $meta = null)
+    public function getProductPageTitle(array $meta = null)
     {
         $title = $this->product->name;
         if (isset($meta['title'])) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x
| Description?      | Be able to customise the page title with override in the module.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a `ProductController` subclass that overrides `getProductPageTitle`
| Fixed issue or discussion?     | 
| Related PRs       |
| Sponsor company   | Packing Panic

For the [Packing Panic](https://www.packingpanic.com) webshop we like to customise the page title and add text coming from the variation names.

The PR just makes the method `getProductPageTitle` public, so it is possible to add a custom override.


