### PR TITLE
Fix URL sanitization and duplicate language ID

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -1023,14 +1023,22 @@ class DispatcherCore
                 }
             }
 
+            // Add controller to parameters if not present
             if (!empty($route['controller'])) {
                 $query_params['controller'] = $route['controller'];
             }
-            $query = http_build_query(array_merge($add_params, $query_params), '', '&');
+
+            // Build final parameters, add language if needed
+            $urlParams = array_merge($add_params, $query_params);
+
+            // If multilanguage is activated, we add proper language ID, overwriting
+            // the previous one if it was provided
             if ($this->multilang_activated) {
-                $query .= (!empty($query) ? '&' : '') . 'id_lang=' . (int) $id_lang;
+                $urlParams['id_lang'] = (int) $id_lang;
             }
-            $url = 'index.php?' . $query;
+
+            // Build the final URL
+            $url = 'index.php?' . http_build_query($urlParams, '', '&');
         }
 
         return $url . $anchor;

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -2151,7 +2151,7 @@ class FrontControllerCore extends Controller
             $this->redirectionExtraExcludedKeys
         );
 
-        // Go through each parameter we got from dispatcher and sanizize it
+        // Go through each parameter we got from dispatcher and sanitize it
         foreach ($params as $key => $value) {
             if (
                 in_array($key, $excludedKeys)

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -2137,18 +2137,24 @@ class FrontControllerCore extends Controller
     protected function sanitizeUrl(string $url): string
     {
         $params = [];
-        $url_details = parse_url($url);
 
+        // Extract all parts of the URL
+        $url_details = parse_url($url);
         if (!empty($url_details['query'])) {
             parse_str($url_details['query'], $query);
             $params = $this->sanitizeQueryOutput($query);
         }
 
-        $excluded_key = ['isolang', 'id_lang', 'controller', 'fc', 'id_product', 'id_category', 'id_manufacturer', 'id_supplier', 'id_cms'];
-        $excluded_key = array_merge($excluded_key, $this->redirectionExtraExcludedKeys);
-        foreach ($_GET as $key => $value) {
+        // Build a list of parameters we won't be sanitizing
+        $excludedKeys = array_merge(
+            ['isolang', 'id_lang', 'controller', 'fc', 'id_product', 'id_category', 'id_manufacturer', 'id_supplier', 'id_cms'],
+            $this->redirectionExtraExcludedKeys
+        );
+
+        // Go through each parameter we got from dispatcher and sanizize it
+        foreach ($params as $key => $value) {
             if (
-                in_array($key, $excluded_key)
+                in_array($key, $excludedKeys)
                 || !Validate::isUrl($key)
                 || !$this->validateInputAsUrl($value)
             ) {
@@ -2158,6 +2164,7 @@ class FrontControllerCore extends Controller
             $params[Tools::safeOutput($key)] = is_array($value) ? array_walk_recursive($value, 'Tools::safeOutput') : Tools::safeOutput($value);
         }
 
+        // Build back the query
         $str_params = http_build_query($params, '', '&');
         $sanitizedUrl = preg_replace('/^([^?]*)?.*$/', '$1', $url) . (!empty($str_params) ? '?' . $str_params : '');
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fixes two remaining issues in routing. See below.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/28609
| Related PRs       | 
| Sponsor company   |

### Description
- This PR fixes two issues.
- Issue 1 - With URL rewriting disabled, there was a duplicate id_lang parameter if you requested Dispatcher::createUrl with different language. Dispatcher was just appending it to the URL like `&id_lang=1` without checking if it's not already there from the request.
- Issue 2 - `FrontController::sanitizeUrl`, called from `FrontController::getAlternativeLangsUrl` was adding some extra parameters to a friendly URL so you got hreflangs with some crap. The method was using $_GET to get these parameters. We need to use the $params from the URL. :-)

### How to test
- Install [tox_langtest.zip](https://github.com/PrestaShop/PrestaShop/files/12561449/tox_langtest.zip)
- Go to `/index.php?id_lang=1&fc=module&module=tox_langtest&id_page=200&rewrite=blabla&controller=daniel&pagination=1`
- With friendly URLs enabled, see that you get a proper clean friendly URL with no extra parameters from the route. See that `pagination=1` parameter that is intentional is kept.
  - `http://localhost/81x/cs/langtest/200-blabla?pagination=1`
  - `http://localhost/81x/gb/langtest/200-blabla?pagination=1`
- With friendly URLs disabled, see that you get urls without duplicate id_lang. ✅ 
  - `http://localhost/81x/index.php?id_lang=1&pagination=1&fc=module&module=tox_langtest&id_page=200&rewrite=blabla&controller=daniel`
  - `http://localhost/81x/index.php?id_lang=2&pagination=1&fc=module&module=tox_langtest&id_page=200&rewrite=blabla&controller=daniel`

### Auto test
https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/6156334567