### PR TITLE
Provide rendered category footer

### DIFF
--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -157,9 +157,14 @@ class CategoryControllerCore extends ProductListingFrontController
 
     protected function getAjaxProductSearchVariables()
     {
+        // Basic data with rendered products, facets, active filters etc.
         $data = parent::getAjaxProductSearchVariables();
-        $rendered_products_header = $this->render('catalog/_partials/category-header', ['listing' => $data]);
-        $data['rendered_products_header'] = $rendered_products_header;
+
+        // Extra data for category pages, so we can dynamically update also these parts
+        $rendered_category_header = $this->render('catalog/_partials/category-header', ['listing' => $data]);
+        $data['rendered_products_header'] = $rendered_category_header;
+        $rendered_category_footer = $this->render('catalog/_partials/category-footer', ['listing' => $data]);
+        $data['rendered_products_footer'] = $rendered_category_footer;
 
         return $data;
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | We added bottom description to categories. It's cool, but some shops and themes including the default ones don't want to display it on other pages than categories. This updates are handled by theme scripts. If we want to enable themes updating it, the first step is to provide this data as we do for the header. Other PRs can follow.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests green.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/6170190200
| Fixed issue or discussion?     | Fixes #33903
| Related PRs       | 
| Sponsor company   |
