### PR TITLE
Cannot set specific price with currency filter

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3884,13 +3884,13 @@ class ProductCore extends ObjectModel
         } else {
             $price = (float) $specific_price['price'];
         }
-        // convert only if the specific price is in the default currency (id_currency = 0)
+        // convert only if the specific price currency is different from the default currency
         if (
             !$specific_price ||
             !(
                 $specific_price['price'] >= 0 &&
                 $specific_price['id_currency'] &&
-                $id_currency !== $specific_price['id_currency']
+                $id_currency === $specific_price['id_currency']
             )
         ) {
             $price = Tools::convertPrice($price, $id_currency);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | one of the conditions (`$id_currency === $specific_price['id_currency']`) for the price conversion was never correct: <br/> - In 1.7.8, `$specific_price['id_currency']` is a string, and `$id_currency` int, so triple equality always returns false  <br/> - 8.1.x, both are int, but the condition in not correct, it should be `===` instant of `!==`
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #33285 / CI and tests UI are green
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/6186946394
| Fixed issue or discussion?     | Fixes #33285
| Related PRs       | -
| Sponsor company   | -
