### PR TITLE
Inform customer about quantity in cart

### DIFF
--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -59,6 +59,9 @@
   <configuration id="PS_DISPLAY_QTIES" name="PS_DISPLAY_QTIES">
     <value>1</value>
   </configuration>
+  <configuration id="PS_DISPLAY_AMOUNT_IN_CART" name="PS_DISPLAY_AMOUNT_IN_CART">
+    <value>1</value>
+  </configuration>
   <configuration id="PS_SHIPPING_HANDLING" name="PS_SHIPPING_HANDLING">
     <value>2</value>
   </configuration>

--- a/src/Adapter/Product/PageConfiguration.php
+++ b/src/Adapter/Product/PageConfiguration.php
@@ -55,6 +55,7 @@ class PageConfiguration implements DataConfigurationInterface
             'allow_add_variant_to_cart_from_listing' => $this->configuration->getBoolean('PS_ATTRIBUTE_CATEGORY_DISPLAY'),
             'attribute_anchor_separator' => $this->configuration->get('PS_ATTRIBUTE_ANCHOR_SEPARATOR'),
             'display_discount_price' => $this->configuration->getBoolean('PS_DISPLAY_DISCOUNT_PRICE'),
+            'display_amount_in_cart' => $this->configuration->getBoolean('PS_DISPLAY_AMOUNT_IN_CART'),
         ];
     }
 
@@ -70,6 +71,7 @@ class PageConfiguration implements DataConfigurationInterface
             $this->configuration->set('PS_ATTRIBUTE_CATEGORY_DISPLAY', (int) $config['allow_add_variant_to_cart_from_listing']);
             $this->configuration->set('PS_ATTRIBUTE_ANCHOR_SEPARATOR', $config['attribute_anchor_separator']);
             $this->configuration->set('PS_DISPLAY_DISCOUNT_PRICE', (int) $config['display_discount_price']);
+            $this->configuration->set('PS_DISPLAY_AMOUNT_IN_CART', (int) $config['display_amount_in_cart']);
         }
 
         return $errors;
@@ -86,6 +88,7 @@ class PageConfiguration implements DataConfigurationInterface
             'allow_add_variant_to_cart_from_listing',
             'attribute_anchor_separator',
             'display_discount_price',
+            'display_amount_in_cart',
         ]);
 
         $resolver->resolve($config);

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -97,6 +97,17 @@ class PageType extends TranslatorAwareType
                     'Admin.Shopparameters.Help'
                 ),
                 'required' => false,
+            ])
+            ->add('display_amount_in_cart', SwitchType::class, [
+                'label' => $this->trans(
+                    'Display notifications if the product is already in the cart',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'If your customer already has this product in their cart, a notification will be displayed on top of the product page. The customer will also be notified if the product they are browsing is part of a pack that\'s in their cart.',
+                    'Admin.Shopparameters.Help'
+                ),
+                'required' => false,
             ]);
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Displays how many pieces of product the customer has in his cart on FO product page. Both single and included in packs.
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/6797167149
| Fixed issue or discussion?     | Fix https://github.com/PrestaShop/PrestaShop/discussions/32439
| Related PRs       | 
| Sponsor company   | 

### Screenshots
![Snímek obrazovky 2023-09-13 174214](https://github.com/PrestaShop/PrestaShop/assets/6097524/9d6283c5-ee98-4b6c-a065-1a4b4b0e3823)
![Snímek obrazovky 2023-09-13 145925](https://github.com/PrestaShop/PrestaShop/assets/6097524/8351e6d5-df1c-4513-9e37-c0da03b21bae)
