### PR TITLE
Add time selector to date_format

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -341,7 +341,7 @@ class SpecificPriceCore extends ObjectModel
     {
         $first_date = date('Y-m-d 00:00:00');
         $last_date = date('Y-m-d 23:59:59');
-        $now = date('Y-m-d H:i:00');
+        $now = date('Y-m-d H:i:s');
         if ($beginning === null) {
             $beginning = $now;
         }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
@@ -159,6 +159,7 @@ class SpecificPriceType extends TranslatorAwareType
                     ]),
                 ],
                 'columns_number' => 2,
+                'date_format' => 'YYYY-MM-DD HH:mm:ss',
             ])
             ->add('impact', SpecificPriceImpactType::class)
         ;


### PR DESCRIPTION
Questions | Answers
-- | --
Branch? | develop
Description? | When adding or editing a specific price from the edit product page date picker is not showing hour, minutes and seconds options. If cart rule date picker allows to set hour, minute and second we should allow it in product specific price too. Original:![specific_price_time_v1](https://github.com/PrestaShop/PrestaShop/assets/5434642/e0035972-03ca-4e8d-9ebb-aa669b2c1f68)After changes:![specific_price_time_v2](https://github.com/PrestaShop/PrestaShop/assets/5434642/059b0ae3-644a-4449-8c94-570f6e4e1406)If cart rule date picker allows to set hour, minute and second we should allow it in product specific price too.
Type? | improvement
Category? | BO 
BC breaks? | no
Deprecations? | no
How to test? | Try to edit or add a product specific price from the backoffice
UI Tests | NA
Fixed issue or discussion? | NA
Related PRs | NA
Sponsor company | Ecomm360