### PR TITLE
Fix specific price datetime range

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/catalog/product/specific-price-form-handler.ts
+++ b/admin-dev/themes/new-theme/js/pages/catalog/product/specific-price-form-handler.ts
@@ -215,7 +215,10 @@ class SpecificPriceFormHandler {
    * @private
    */
   private reinitializeDatePickers() {
-    $('.datepicker input').datetimepicker({format: 'YYYY-MM-DD'});
+    $('.datepicker input').datetimepicker({
+      format: 'YYYY-MM-DD HH:mm:ss',
+      sideBySide: true,
+    });
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/catalog/product/specific-price-form-handler.ts
+++ b/admin-dev/themes/new-theme/js/pages/catalog/product/specific-price-form-handler.ts
@@ -218,6 +218,12 @@ class SpecificPriceFormHandler {
     $('.datepicker input').datetimepicker({
       format: 'YYYY-MM-DD HH:mm:ss',
       sideBySide: true,
+      icons: {
+        time: 'time',
+        date: 'date',
+        up: 'up',
+        down: 'down',
+      },
     });
   }
 

--- a/src/PrestaShopBundle/Controller/Admin/SpecificPriceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/SpecificPriceController.php
@@ -288,6 +288,6 @@ class SpecificPriceController extends FrameworkBundleAdminController
             throw new EntityDataInconsistencyException(sprintf('Found bad date for specific price: %s', $dateAsString));
         }
 
-        return $dateTime->format('Y-m-d');
+        return $dateTime->format('Y-m-d H:i:s');
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -245,7 +245,8 @@ class ProductSpecificPrice extends CommonAbstractType
                 [
                     'required' => false,
                     'label' => $this->translator->trans('Available from', [], 'Admin.Catalog.Feature'),
-                    'attr' => ['placeholder' => 'YYYY-MM-DD'],
+                    'attr' => ['placeholder' => 'YYYY-MM-DD HH:mm:ss'],
+                    'date_format' => 'YYYY-MM-DD HH:mm:ss',
                 ]
             )
             ->add(
@@ -254,7 +255,8 @@ class ProductSpecificPrice extends CommonAbstractType
                 [
                     'required' => false,
                     'label' => $this->translator->trans('to', [], 'Admin.Global'),
-                    'attr' => ['placeholder' => 'YYYY-MM-DD'],
+                    'attr' => ['placeholder' => 'YYYY-MM-DD HH:mm:ss'],
+                    'date_format' => 'YYYY-MM-DD HH:mm:ss',
                 ]
             )
             ->add(

--- a/src/PrestaShopBundle/Form/Admin/Sell/CatalogPriceRule/CatalogPriceRuleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CatalogPriceRule/CatalogPriceRuleType.php
@@ -177,6 +177,7 @@ class CatalogPriceRuleType extends AbstractType
             ])
             ->add('date_range', DateRangeType::class, [
                 'date_format' => 'YYYY-MM-DD HH:mm:ss',
+                'placeholder' => $this->translator->trans('YYYY-MM-DD HH:mm:ss', [], 'Admin.Global'),
                 'constraints' => [
                     new DateRange([
                         'message' => $this->translator->trans(

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Pricing;
 
+use DateTime;
 use PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DateRange;
@@ -182,6 +183,9 @@ class SpecificPriceType extends TranslatorAwareType
                 'label_tag_name' => 'h4',
                 'required' => false,
                 'has_unlimited_checkbox' => true,
+                'date_format' => 'YYYY-MM-DD HH:mm:ss',
+                'placeholder' => $this->trans('YYYY-MM-DD HH:mm:ss', 'Admin.Global'),
+                'default_end_value' => (new DateTime())->format('Y-m-d H:i:s'),
                 'constraints' => [
                     new DateRange([
                         'message' => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
@@ -185,7 +185,7 @@ class SpecificPriceType extends TranslatorAwareType
                 'has_unlimited_checkbox' => true,
                 'date_format' => 'YYYY-MM-DD HH:mm:ss',
                 'placeholder' => $this->trans('YYYY-MM-DD HH:mm:ss', 'Admin.Global'),
-                'default_end_value' => (new DateTime())->format('Y-m-d H:i:s'),
+                'default_end_value' => (new DateTime())->modify('+1 month')->format('Y-m-d H:i:s'),
                 'constraints' => [
                     new DateRange([
                         'message' => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Type/DateRangeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DateRangeType.php
@@ -67,13 +67,12 @@ class DateRangeType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $now = new DateTime();
         $builder
             ->add('from', DatePickerType::class, [
                 'required' => false,
                 'label' => $this->translator->trans('Start date', [], 'Admin.Global'),
                 'attr' => [
-                    'placeholder' => $this->translator->trans('YY-MM-DD', [], 'Admin.Global'),
+                    'placeholder' => $options['placeholder'],
                     'class' => 'from date-range-start-date',
                 ],
                 'date_format' => $options['date_format'],
@@ -81,9 +80,9 @@ class DateRangeType extends AbstractType
             ->add('to', DatePickerType::class, [
                 'required' => false,
                 'attr' => [
-                    'placeholder' => $this->translator->trans('YY-MM-DD', [], 'Admin.Global'),
+                    'placeholder' => $options['placeholder'],
                     'class' => 'to date-range-end-date',
-                    'data-default-value' => $now->format('Y-m-d'),
+                    'data-default-value' => $options['default_end_value'],
                 ],
                 'label' => $this->translator->trans('End date', [], 'Admin.Global'),
                 'date_format' => $options['date_format'],
@@ -130,10 +129,13 @@ class DateRangeType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
+            'placeholder' => 'YYYY-MM-DD',
             'date_format' => 'YYYY-MM-DD',
             'has_unlimited_checkbox' => false,
+            'default_end_value' => (new DateTime())->format('Y-m-d'),
         ]);
         $resolver->setAllowedTypes('date_format', 'string');
+        $resolver->setAllowedTypes('placeholder', 'string');
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Adds possibility to enter date time to specific price validity range. It works on both old and new product page, in forms and specific price listings.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See that you can enter a time to specific price, like you can on `BO > Catalog > Catalog discounts` page or previous versions of PrestaShop.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/6930352572 🟢 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/11329
| Related PRs       | 
| Sponsor company   | 

Credits also go to @PululuK who tried to fix it on V1 page here - https://github.com/PrestaShop/PrestaShop/pull/27642,
and @okom3pom here https://github.com/PrestaShop/PrestaShop/pull/8571 and here https://github.com/PrestaShop/PrestaShop/pull/28931. 🚀 

### Product page V1
`admin-dev/themes/new-theme/js/pages/catalog/product/specific-price-form-handler.ts` - init datepicker properly after opening modal
`src/PrestaShopBundle/Controller/Admin/SpecificPriceController.php` - initial value for the input
`src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php` - using proper date format and placeholder.

### Migrated catalog prices
`src/PrestaShopBundle/Form/Admin/Sell/CatalogPriceRule/CatalogPriceRuleType.php` - added missing placeholder

### Product page V2
`src/PrestaShopBundle/Form/Admin/Type/DateRangeType.php` - Allow passing custom placeholder and end value.
`src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php` - Using the new features that I put into DateRangeType.
