### PR TITLE
Do not construct presenters that we already have from the parent

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -207,8 +207,10 @@ class FrontControllerCore extends Controller
             $useSSL = $this->ssl;
         }
 
+        // Prepare presenters that we will require on every page
         $this->objectPresenter = new ObjectPresenter();
         $this->cart_presenter = new CartPresenter();
+
         $this->templateFinder = new TemplateFinder($this->context->smarty->getTemplateDir(), '.tpl');
         $this->stylesheetManager = new StylesheetManager(
             [_PS_THEME_URI_, _PS_PARENT_THEME_URI_, __PS_BASE_URI__],

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -23,7 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-use PrestaShop\PrestaShop\Adapter\Presenter\Cart\CartPresenter;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 
 class CartControllerCore extends FrontController
@@ -134,8 +133,7 @@ class CartControllerCore extends FrontController
         $productQuantity = $updatedProduct['quantity'] ?? 0;
 
         if (!$this->errors) {
-            $cartPresenter = new CartPresenter();
-            $presentedCart = $cartPresenter->present($this->context->cart);
+            $presentedCart = $this->cart_presenter->present($this->context->cart);
 
             // filter product output
             $presentedCart['products'] = $this->get('prestashop.core.filter.front_end_object.product_collection')
@@ -555,8 +553,7 @@ class CartControllerCore extends FrontController
     public function getTemplateVarPage()
     {
         $page = parent::getTemplateVarPage();
-        $presenter = new CartPresenter();
-        $presented_cart = $presenter->present($this->context->cart);
+        $presented_cart = $this->cart_presenter->present($this->context->cart);
 
         if (count($presented_cart['products']) == 0) {
             $page['body_classes']['cart-empty'] = true;

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -23,7 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
 use PrestaShop\PrestaShop\Adapter\Presenter\Order\OrderPresenter;
 use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 use ZxcvbnPhp\Zxcvbn;
@@ -218,7 +217,7 @@ class OrderConfirmationControllerCore extends FrontController
             'HOOK_ORDER_CONFIRMATION' => $this->displayOrderConfirmation($this->order),
             'HOOK_PAYMENT_RETURN' => $this->displayPaymentReturn($this->order),
             'order' => (new OrderPresenter())->present($this->order),
-            'order_customer' => (new ObjectPresenter())->present($this->customer),
+            'order_customer' => $this->objectPresenter->present($this->customer),
             'registered_customer_exists' => Customer::customerExists($this->customer->email, false, true),
         ]);
         $this->setTemplate('checkout/order-confirmation');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Removes some forgotten unneeded presenter constructing. Both CartPresenter and ObjectPresenter are available from FrontControlller. It's used on other places, probably forgotten here. Saves about 0,0001 nanosecond of loading time.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No need to QA, tests green.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 
