### PR TITLE
Fix rounding of no pack price

### DIFF
--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -156,7 +156,7 @@ class PackCore extends Product
                         $pricePerItem,
                         Context::getContext()->getComputingPrecision()
                     ) * $item->pack_quantity;
-    
+
                     break;
             }
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fixes (missing) rounding of no pack price. The PR does not affect any product, cart rule, discount or cart calculations. `noPackPrice` is only fetched and displayed on product page.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Simulate the related issue and check attached excel here.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/6223614267
| Fixed issue or discussion?     | Fixes #33962
| Related PRs       | 
| Sponsor company   | 

### Expected results
[Calculations.xlsx](https://github.com/PrestaShop/PrestaShop/files/12648585/Calculations.xlsx)

### Calculations - see that the "no pack price" matches the cart calculation if you add the items
Round each line ➡️ 
![ROUND LINE](https://github.com/PrestaShop/PrestaShop/assets/6097524/d84b5560-7de6-4ea6-a638-1ce84c98e0b4)
Round total ➡️ 
![ROUND TOTAL](https://github.com/PrestaShop/PrestaShop/assets/6097524/54be0cab-7683-4b6e-b30f-26e05918440f)
Round each item ➡️ 
![ROUND ITEM](https://github.com/PrestaShop/PrestaShop/assets/6097524/d1fa4ef7-4f81-4f7d-a653-0b55f4f3648e)
