### PR TITLE
Remove 8.0.x branch from Update PHP Modules cron

### DIFF
--- a/.github/workflows/cron_php_update_modules.yml
+++ b/.github/workflows/cron_php_update_modules.yml
@@ -20,7 +20,6 @@ jobs:
         BRANCH:
           - develop
           - 8.1.x
-          - 8.0.x
     env:
       GH_BRANCH: ${{ matrix.BRANCH }}
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | As 8.0.x is no more maintained, we can remove 8.0.x from the cron. 
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       |  
| Sponsor company   | PrestaShop SA