### PR TITLE
Update czech localization pack

### DIFF
--- a/localization/cz.xml
+++ b/localization/cz.xml
@@ -2,7 +2,6 @@
 <localizationPack name="Czech republic" version="1.0">
   <currencies>
     <currency name="Česká koruna" iso_code="CZK" iso_code_num="203" sign="Kč" blank="1" format="2" decimals="1"/>
-    <currency name="Euro" iso_code="EUR" iso_code_num="978" sign="€" blank="1" format="2" decimals="1"/>
   </currencies>
   <languages>
     <language iso_code="cs"/>
@@ -10,35 +9,36 @@
   <taxes>
     <tax id="1" name="DPH CZ 21%" rate="21" eu-tax-group="virtual"/>
     <tax id="2" name="DPH CZ 15%" rate="15"/>
-    <tax id="3" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="4" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="5" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="6" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="7" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="8" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="9" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="10" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="11" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="12" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="13" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="14" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="15" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="16" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="17" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="18" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="19" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="20" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="21" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="22" name="TVA MC 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="23" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="24" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="25" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="26" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="27" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="28" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="29" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <tax id="30" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <taxRulesGroup name="CZ Standardní sazba (21%)">
+    <tax id="3" name="DPH CZ 10%" rate="10"/>
+    <tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="6" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="7" name="ΦΠΑ CY 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="8" name="MwSt. DE 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="9" name="moms DK 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="10" name="km EE 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="11" name="IVA ES 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="12" name="ALV FI 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="13" name="TVA FR 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="14" name="VAT UK 20%" rate="20.0" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="15" name="ΦΠΑ GR 24%" rate="24" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="16" name="Croatia PDV 25%" rate="25.000" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="17" name="ÁFA HU 27%" rate="27" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="18" name="VAT IE 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="19" name="IVA IT 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="20" name="PVM LT 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="21" name="TVA LU 17%" rate="17" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="22" name="PVN LV 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="23" name="TVA MC 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="24" name="VAT MT 18%" rate="18" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="25" name="BTW NL 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="26" name="PTU PL 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="27" name="IVA PT 23%" rate="23" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="28" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="29" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="30" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
+    <tax id="31" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
+    <taxRulesGroup name="CZ Základní sazba (21%)">
       <taxRule iso_code_country="be" id_tax="1"/>
       <taxRule iso_code_country="bg" id_tax="1"/>
       <taxRule iso_code_country="cz" id_tax="1"/>
@@ -100,41 +100,72 @@
       <taxRule iso_code_country="se" id_tax="2"/>
       <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
+    <taxRulesGroup name="CZ Snížená sazba (10%)">
+      <taxRule iso_code_country="be" id_tax="3"/>
+      <taxRule iso_code_country="bg" id_tax="3"/>
+      <taxRule iso_code_country="cz" id_tax="3"/>
+      <taxRule iso_code_country="dk" id_tax="3"/>
+      <taxRule iso_code_country="de" id_tax="3"/>
+      <taxRule iso_code_country="ee" id_tax="3"/>
+      <taxRule iso_code_country="gr" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
+      <taxRule iso_code_country="es" id_tax="3"/>
+      <taxRule iso_code_country="fr" id_tax="3"/>
+      <taxRule iso_code_country="mc" id_tax="3"/>
+      <taxRule iso_code_country="ie" id_tax="3"/>
+      <taxRule iso_code_country="it" id_tax="3"/>
+      <taxRule iso_code_country="cy" id_tax="3"/>
+      <taxRule iso_code_country="lv" id_tax="3"/>
+      <taxRule iso_code_country="lt" id_tax="3"/>
+      <taxRule iso_code_country="lu" id_tax="3"/>
+      <taxRule iso_code_country="hu" id_tax="3"/>
+      <taxRule iso_code_country="mt" id_tax="3"/>
+      <taxRule iso_code_country="nl" id_tax="3"/>
+      <taxRule iso_code_country="at" id_tax="3"/>
+      <taxRule iso_code_country="pl" id_tax="3"/>
+      <taxRule iso_code_country="pt" id_tax="3"/>
+      <taxRule iso_code_country="ro" id_tax="3"/>
+      <taxRule iso_code_country="si" id_tax="3"/>
+      <taxRule iso_code_country="sk" id_tax="3"/>
+      <taxRule iso_code_country="fi" id_tax="3"/>
+      <taxRule iso_code_country="se" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
+    </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="cz" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="3"/>
-      <taxRule iso_code_country="be" id_tax="4"/>
-      <taxRule iso_code_country="bg" id_tax="5"/>
-      <taxRule iso_code_country="cy" id_tax="6"/>
-      <taxRule iso_code_country="de" id_tax="7"/>
-      <taxRule iso_code_country="dk" id_tax="8"/>
-      <taxRule iso_code_country="ee" id_tax="9"/>
-      <taxRule iso_code_country="es" id_tax="10"/>
-      <taxRule iso_code_country="fi" id_tax="11"/>
-      <taxRule iso_code_country="fr" id_tax="12"/>
-      <taxRule iso_code_country="gb" id_tax="13"/>
-      <taxRule iso_code_country="gr" id_tax="14"/>
-      <taxRule iso_code_country="hr" id_tax="15"/>
-      <taxRule iso_code_country="hu" id_tax="16"/>
-      <taxRule iso_code_country="ie" id_tax="17"/>
-      <taxRule iso_code_country="it" id_tax="18"/>
-      <taxRule iso_code_country="lt" id_tax="19"/>
-      <taxRule iso_code_country="lu" id_tax="20"/>
-      <taxRule iso_code_country="lv" id_tax="21"/>
-      <taxRule iso_code_country="mc" id_tax="22"/>
-      <taxRule iso_code_country="mt" id_tax="23"/>
-      <taxRule iso_code_country="nl" id_tax="24"/>
-      <taxRule iso_code_country="pl" id_tax="25"/>
-      <taxRule iso_code_country="pt" id_tax="26"/>
-      <taxRule iso_code_country="ro" id_tax="27"/>
-      <taxRule iso_code_country="se" id_tax="28"/>
-      <taxRule iso_code_country="si" id_tax="29"/>
-      <taxRule iso_code_country="sk" id_tax="30"/>
+      <taxRule iso_code_country="at" id_tax="4"/>
+      <taxRule iso_code_country="be" id_tax="5"/>
+      <taxRule iso_code_country="bg" id_tax="6"/>
+      <taxRule iso_code_country="cy" id_tax="7"/>
+      <taxRule iso_code_country="de" id_tax="8"/>
+      <taxRule iso_code_country="dk" id_tax="9"/>
+      <taxRule iso_code_country="ee" id_tax="10"/>
+      <taxRule iso_code_country="es" id_tax="11"/>
+      <taxRule iso_code_country="fi" id_tax="12"/>
+      <taxRule iso_code_country="fr" id_tax="13"/>
+      <taxRule iso_code_country="gb" id_tax="14"/>
+      <taxRule iso_code_country="gr" id_tax="15"/>
+      <taxRule iso_code_country="hr" id_tax="16"/>
+      <taxRule iso_code_country="hu" id_tax="17"/>
+      <taxRule iso_code_country="ie" id_tax="18"/>
+      <taxRule iso_code_country="it" id_tax="19"/>
+      <taxRule iso_code_country="lt" id_tax="20"/>
+      <taxRule iso_code_country="lu" id_tax="21"/>
+      <taxRule iso_code_country="lv" id_tax="22"/>
+      <taxRule iso_code_country="mc" id_tax="23"/>
+      <taxRule iso_code_country="mt" id_tax="24"/>
+      <taxRule iso_code_country="nl" id_tax="25"/>
+      <taxRule iso_code_country="pl" id_tax="26"/>
+      <taxRule iso_code_country="pt" id_tax="27"/>
+      <taxRule iso_code_country="ro" id_tax="28"/>
+      <taxRule iso_code_country="se" id_tax="29"/>
+      <taxRule iso_code_country="si" id_tax="30"/>
+      <taxRule iso_code_country="sk" id_tax="31"/>
     </taxRulesGroup>
   </taxes>
   <units>
     <unit type="weight" value="kg"/>
-    <unit type="volume" value="L"/>
+    <unit type="volume" value="l"/>
     <unit type="short_distance" value="cm"/>
     <unit type="base_distance" value="m"/>
     <unit type="long_distance" value="km"/>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Updates czech localization pack - adds 10 % reduced VAT rate, removes EUR which we don't use _(see pl.xml, it also doesn't contain EUR)_, changes liters to lowercase.
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests green.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/25963
| Related PRs       | 
| Sponsor company   | 

### Note
A law changing reduced 10% and 15% VAT rates to one single 12% rate is currently being validated by the government. It should be effective from 01.01.2024. Validation process: https://www.psp.cz/sqw/historie.sqw?o=9&T=488

### Self QA
![1](https://github.com/PrestaShop/PrestaShop/assets/6097524/148ce27f-44b8-4470-b175-b853fb9f8f1d)
![2](https://github.com/PrestaShop/PrestaShop/assets/6097524/30145b88-7f2a-4068-af48-0a8a96f5831d)
![3](https://github.com/PrestaShop/PrestaShop/assets/6097524/b1d659c9-f807-49ed-bd6c-96816d07186d)
![4](https://github.com/PrestaShop/PrestaShop/assets/6097524/b465fc4a-73d7-4f5c-9db3-701759a28034)
