### PR TITLE
Fix WebProfiler when dev mode is active

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1411,6 +1411,11 @@ parameters:
 			path: src/PrestaShopBundle/Controller/Api/TranslationController.php
 
 		-
+			message: "#^Class PrestaShopBundle\\\\DataCollector\\\\ConfigDataCollector extends @final class Symfony\\\\Component\\\\HttpKernel\\\\DataCollector\\\\ConfigDataCollector\\.$#"
+			count: 1
+			path: src/PrestaShopBundle/DataCollector/ConfigDataCollector.php
+
+		-
 			message: "#^Namespace Tools is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 2
 			path: src/PrestaShopBundle/DependencyInjection/AddOnsConfiguration.php

--- a/src/PrestaShopBundle/DataCollector/ConfigDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/ConfigDataCollector.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\DataCollector;
+
+use PrestaShop\PrestaShop\Core\Foundation\Version;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector as SymfonyDataCollector;
+
+/**
+ * Class ConfigDataCollector.
+ * This class is used to collect some data for the WebProfiler.
+ */
+class ConfigDataCollector extends SymfonyDataCollector
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly Version $version
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function collect(Request $request, Response $response, \Throwable $exception = null)
+    {
+        parent::collect($request, $response, $exception);
+        $this->data['app_name'] = $this->name;
+        $this->data['app_version'] = $this->version->getSemVersion();
+    }
+
+    /**
+     * Get the application name.
+     */
+    public function getApplicationName(): string
+    {
+        return $this->data['app_name'];
+    }
+
+    /**
+     * Get the application version.
+     */
+    public function getApplicationVersion(): string
+    {
+        return $this->data['app_version'];
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/data_collector.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/data_collector.yml
@@ -22,8 +22,10 @@ services:
 
   # Web Profiler Bundle
   data_collector.config:
-    class: Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector
-    arguments: [ "PrestaShop", "@=service('prestashop.core.foundation.version').getSemVersion()" ]
+    class: PrestaShopBundle\DataCollector\ConfigDataCollector
+    arguments:
+      - 'PrestaShop'
+      - '@PrestaShop\PrestaShop\Core\Foundation\Version'
     public: false
     calls:
       - [ "setKernel", [ "@kernel" ] ]


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Only for `develop` branch and since upgrade to symfony 5.<br>ApplicationName and Version are deprecated in ConfigDataCollector.php since 4.2.<br/>To fix this issue, we need to extend this collector and add PrestaShop version.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go into admin and display a symfony page.<br/>2. Click on `9.0.0` at the bottom right of the debug bar.<br/>3. We have now a worked page in the profiler.
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/6249427556
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | PrestaShop SA

**Before this fix:**

https://github.com/PrestaShop/PrestaShop/assets/18699562/71b8fb0d-27e4-4acc-953f-b94665994aa3


**After this fix:**

https://github.com/PrestaShop/PrestaShop/assets/18699562/d12cc297-37db-4a2d-b79c-e00fc0a24926

