### PR TITLE
Fix image configuration

### DIFF
--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -484,6 +484,12 @@ class AdminImagesControllerCore extends AdminController
 
     public function beforeUpdateOptions()
     {
+        // We check this only if new image system is enabled
+        // With the old system, PS_IMAGE_FORMAT is not present in the form
+        if (!$this->isMultipleImageFormatFeatureEnabled) {
+            return;
+        }
+
         // Unset AVIF if not supported, add JPG if missing
         foreach ($_POST['PS_IMAGE_FORMAT'] as $k => $v) {
             if ($v == 'avif' && !$this->canGenerateAvif) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fixes image configuration with new image system NOT enabled. We were doing some things with a field that was not in the form.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Make sure "multiple image formats" feature flag is disabled. Go to BO > Image settings. Save the form. Will work.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #34055
| Related PRs       | 
| Sponsor company   | 
