### PR TITLE
Fix #34059: Reset cart_product delivery addresses for incomplete checkouts

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -243,6 +243,10 @@ class AddressCore extends ObjectModel
             Customer::resetAddressCache($this->id_customer, $this->id);
         }
 
+        // Resets the id_address_delivery field in the cart_product
+        // after deleting the current address
+        $this->resetCartProductsDeliveryAddress();
+
         // If the address is used in at least one order, we will not delete it, but only mark it and hide it from backoffice
         // However, even if this address is used, we should probably unlink it from all NON ORDERED carts
         if ($this->isUsed()) {
@@ -258,6 +262,20 @@ class AddressCore extends ObjectModel
         }
 
         return parent::delete();
+    }
+
+    /**
+     * Reset the id_address_delivery to 0 for the current address in carts 
+     * that did not complete the checkout process (no associated orders).
+     */
+    public function resetCartProductsDeliveryAddress()
+    {
+        $sql = 'UPDATE ' . _DB_PREFIX_ . 'cart_product AS cp
+                    LEFT JOIN ' . _DB_PREFIX_ . 'orders AS o ON cp.id_cart = o.id_cart
+                    SET cp.id_address_delivery = 0
+                    WHERE cp.id_address_delivery = ' . (int)$this->id . ' AND o.id_order IS NULL';
+
+        Db::getInstance()->execute($sql);
     }
 
     /**


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x
| Description?      | This pull request addresses an issue where the delivery address was not updated correctly in the `ps_cart_product` table during the checkout process. The problem scenario occurs when a user initiates the checkout process, selects a delivery address, but does not complete the payment process. If later, an administrator deletes the address that the customer previously selected from the back office, an issue arises. <br>Specifically, when the customer returns to complete their checkout and adds a new address, they encounter the error message "Unfortunately, there are no carriers available for your delivery address." This error occurs even when the new address should have carriers available.<br>With this fix, when an admin deletes a customer's address from the back office under these circumstances, the `id_delivery_address` field in the `ps_cart_product` table is automatically reset to 0 for the current deleted address. Consequently, when the customer returns to the checkout process and creates a new address, the cart's product delivery address is automatically updated with the new address's ID. This fix ensures that the cart's product delivery address is correctly synchronized with the new address, eliminating the error message and allowing carriers to be available for the new address
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |1. Add products to your cart.<br>2. Start the checkout process without completing the entire process (i.e., do not make the payment).<br>3. Delete the customer's address from the back office.<br>4. Continue with the checkout process as a cutomer, and create a new address.<br>5. Verify that the `ps_cart_product` `id_address_delivery` column for the current cart is updated with the newly created address id, resolving the "no carriers available" error.
| UI Tests          | N/A
| Fixed issue or discussion?     | Fixes #34059
| Related PRs       | N/A
| Sponsor company   | Cegedim
