### PR TITLE
Fix URL with accented chars

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1378,7 +1378,13 @@ class ToolsCore
      */
     public static function str2url($str)
     {
-        return (new StringModifier())->str2url((string) $str);
+        static $allow_accented_chars = null;
+
+        if ($allow_accented_chars === null) {
+            $allow_accented_chars = Configuration::get('PS_ALLOW_ACCENTED_CHARS_URL');
+        }
+
+        return (new StringModifier())->str2url((string) $str, $allow_accented_chars);
     }
 
     /**

--- a/src/Core/Util/String/StringModifier.php
+++ b/src/Core/Util/String/StringModifier.php
@@ -73,12 +73,14 @@ final class StringModifier implements StringModifierInterface
      *
      * @return string
      */
-    public function str2url(string $string): string
+    public function str2url(string $string, bool $allow_accented_chars): string
     {
         $return_str = trim($string);
         $return_str = mb_strtolower($return_str, 'UTF-8');
 
-        $return_str = $this->replaceAccentedChars($return_str);
+        if (!$allow_accented_chars) {
+            $return_str = $this->replaceAccentedChars($return_str);
+        }
         $return_str = preg_replace('/[^a-zA-Z0-9\s\'\:\/\[\]\-\p{L}]/u', '', $return_str);
         $return_str = preg_replace('/[\s\'\:\/\[\]\-]+/', ' ', $return_str);
 

--- a/tests/Unit/Core/Util/String/StringModifierTest.php
+++ b/tests/Unit/Core/Util/String/StringModifierTest.php
@@ -122,21 +122,22 @@ class StringModifierTest extends TestCase
     /**
      * @dataProvider str2UrlProvider
      */
-    public function testStr2url(string $input, string $expected): void
+    public function testStr2url(string $input, string $expected, bool $allow_accented_chars): void
     {
-        self::assertSame($expected, $this->stringModifier->str2url($input));
+        self::assertSame($expected, $this->stringModifier->str2url($input, $allow_accented_chars));
     }
 
     public function str2UrlProvider(): Generator
     {
-        yield ['!@#$%^&*()_+-={}[]|:;"<>,.?/', '-'];
-        yield ['Some !@#$%^&*()_+-={}[]|:;"<>,.?/ text', 'some-text'];
-        yield ['Some text 123 !@#$%^&*()_+-={}[]|:;"<>,.?/', 'some-text-123-'];
-        yield ['Some text 123 with unicode characters: áéíóú', 'some-text-123-with-unicode-characters-aeiou'];
-        yield ['!@#$%^&*()_+-={}[]|:;"<>,.?/', '-'];
-        yield ['Some !@#$%^&*()_+-={}[]|:;"<>,.?/ text', 'some-text'];
-        yield ['Some text 123 !@#$%^&*()_+-={}[]|:;"<>,.?/', 'some-text-123-'];
-        yield ['Some text 123 with unicode characters: áéíóú', 'some-text-123-with-unicode-characters-aeiou'];
+        yield ['!@#$%^&*()_+-={}[]|:;"<>,.?/', '-', false];
+        yield ['Some !@#$%^&*()_+-={}[]|:;"<>,.?/ text', 'some-text', false];
+        yield ['Some text 123 !@#$%^&*()_+-={}[]|:;"<>,.?/', 'some-text-123-', false];
+        yield ['Some text 123 with unicode characters: áéíóú', 'some-text-123-with-unicode-characters-aeiou', false];
+        yield ['!@#$%^&*()_+-={}[]|:;"<>,.?/', '-', false];
+        yield ['Some !@#$%^&*()_+-={}[]|:;"<>,.?/ text', 'some-text', false];
+        yield ['Some text 123 !@#$%^&*()_+-={}[]|:;"<>,.?/', 'some-text-123-', false];
+        yield ['Some text 123 with unicode characters: áéíóú', 'some-text-123-with-unicode-characters-aeiou', false];
+        yield ['Some text 123 with unicode characters: áéíóú', 'some-text-123-with-unicode-characters-áéíóú', true];
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | We no longer took PS_ALLOW_ACCENTED_CHARS_URL into account when switching to 8.1
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests are green, see #33642 
| UI Tests          |  https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/6328345592
| Fixed issue or discussion?     | Fixes #33642 
| Related PRs       | -
| Sponsor company   | -
