### PR TITLE
Fix(authServ): repair auth server page in BO

### DIFF
--- a/src/Core/Grid/Definition/Factory/ApiAccessGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ApiAccessGridDefinitionFactory.php
@@ -76,10 +76,10 @@ final class ApiAccessGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ])
             )
             ->add(
-                (new ToggleColumn('active'))
+                (new ToggleColumn('enabled'))
                     ->setName($this->trans('Api access state', [], 'Admin.Global'))
                     ->setOptions([
-                        'field' => 'active',
+                        'field' => 'enabled',
                         'primary_field' => 'id_api_access',
                         'route' => 'admin_api_accesses_toggle_active',
                         'route_param_name' => 'apiAccessId',

--- a/src/Core/Grid/Query/AuthorizedApplicationQueryBuilder.php
+++ b/src/Core/Grid/Query/AuthorizedApplicationQueryBuilder.php
@@ -108,10 +108,9 @@ final class AuthorizedApplicationQueryBuilder extends AbstractDoctrineQueryBuild
     private function appendActiveApiAccessQuery(QueryBuilder $queryBuilder): void
     {
         $shopQueryBuilder = $this->getQueryBuilder()
-            ->select('count(api.active)')
+            ->select('count(api.enabled)')
             ->from($this->dbPrefix . 'api_access', 'api')
-            ->where('api.id_authorized_application = aa.id_authorized_application')
-            ->andWhere('api.active = 1');
+            ->Where('api.enabled = 1');
 
         $queryBuilder->addSelect('(' . $shopQueryBuilder->getSQL() . ') as active_api_access');
     }
@@ -121,8 +120,7 @@ final class AuthorizedApplicationQueryBuilder extends AbstractDoctrineQueryBuild
         $shopQueryBuilder = $this->getQueryBuilder()
             ->select('count(api.id_api_access)')
             ->from($this->dbPrefix . 'api_access', 'api')
-            ->where('api.id_authorized_application = aa.id_authorized_application')
-            ->andWhere('api.active = 0');
+            ->Where('api.enabled = 0');
 
         $queryBuilder->addSelect('(' . $shopQueryBuilder->getSQL() . ') as inactive_api_access');
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | A field in the ApiAccess entity has been renamed in another PR. The experimental BO page was broken because of this change. This PR fixes this.
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Activate the experimental Auth Server page. Then access it.
| UI Tests          |  https://github.com/tleon/ga.tests.ui.pr/actions/runs/6353483501
| Related PRs       | #33833 
| Sponsor company   | PrestaShop SA