### PR TITLE
Fix AddressController.php

### DIFF
--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -65,9 +65,6 @@ class AddressControllerCore extends FrontController
             $this->address_form->loadAddressById($id_address);
         }
 
-        // Fill the form with data
-        $this->address_form->fillWith(Tools::getAllValues());
-
         // Submit the address, don't care if it's an edit or add
         if (Tools::isSubmit('submitAddress')) {
             if (!$this->address_form->submit()) {


### PR DESCRIPTION
Duplicate call function. Address form filled second time. Fix bugs:  https://github.com/PrestaShop/PrestaShop/issues/34080 and https://github.com/PrestaShop/PrestaShop/issues/33991

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.1.x / develop
| Description?      | Duplicate function call. Address form filled two times. Fix bugs: https://github.com/PrestaShop/PrestaShop/issues/34080 and https://github.com/PrestaShop/PrestaShop/issues/33991
| Type?             | bug fix 
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | yes 
| How to test?      | Indicate how to verify that this change works as expected.
| UI Tests          | Please run UI tests and paste here the link to the run. [Read this page to know why and how to use this tool.](https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/ui-tests/).
| Fixed issue or discussion?     | Fixes #34080, Fixes #33991
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
