### PR TITLE
Integrate external PrestaShop module for API resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,9 +122,6 @@ tests-legacy/.phpunit.result.cache
 !/admin-dev/themes/new-theme/public/theme.rtlfix
 !/admin-dev/themes/default/public/theme.rtlfix
 
-# Api platform assets
-/admin-dev/bundles
-
 themes/*/cache/*
 themes/core.js.map
 themes/core.js

--- a/admin-dev/bundles/apiplatform
+++ b/admin-dev/bundles/apiplatform
@@ -1,0 +1,1 @@
+../../vendor/api-platform/core/src/Symfony/Bundle/Resources/public/

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -96,13 +96,19 @@ twig:
 api_platform:
   title: Backoffice API
   version: 0.1.0
+  enable_docs: true
   enable_entrypoint: false
+  enable_swagger: true
+  enable_swagger_ui: true
   formats:
     json:
       mime_types: [ 'application/json' ]
     # Allow this format for other API endpoint than native endpoint (by default we will use json)
     jsonld:
       mime_types: [ 'application/ld+json' ]
+    # This is used to allow using the Swagger UI in HTML presentation
+    html:
+      mime_types: [ 'text/html' ]
   mapping:
     paths:
       - '%kernel.project_dir%/src/PrestaShopBundle/ApiPlatform/Resources'

--- a/app/config/security_test.yml
+++ b/app/config/security_test.yml
@@ -13,7 +13,7 @@ security:
     oauth2:
       memory:
         users:
-          my_client_id: { password: 'prestashop', roles: [ 'ROLE_HOOK_READ', 'ROLE_HOOK_WRITE' ] }
+          my_client_id: { password: 'prestashop', roles: [ 'ROLE_HOOK_READ', 'ROLE_HOOK_WRITE', 'ROLE_API_ACCESS_READ' ] }
 
   encoders:
     Symfony\Component\Security\Core\User\User: plaintext

--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
         "prestashop/gsitemap": "^4",
         "prestashop/pagesnotfound": "^2",
         "prestashop/productcomments": "^6.0",
+        "prestashop/ps_apiresources": "dev-dev",
         "prestashop/ps_banner": "^2",
         "prestashop/ps_bestsellers": "^1.0",
         "prestashop/ps_brandlist": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "60acf169894ee319fe6a50e661a284fa",
+    "content-hash": "4f89715abcb2550538fade0f7ff55de8",
     "packages": [
         {
             "name": "api-platform/core",
@@ -5509,6 +5509,53 @@
                 "source": "https://github.com/PrestaShop/productcomments/tree/v6.0.2"
             },
             "time": "2023-08-30T08:14:56+00:00"
+        },
+        {
+            "name": "prestashop/ps_apiresources",
+            "version": "dev-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PrestaShop/ps_apiresources.git",
+                "reference": "f55c54cef7037148bf8b8fd6d3922c44f9cf7f92"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PrestaShop/ps_apiresources/zipball/f55c54cef7037148bf8b8fd6d3922c44f9cf7f92",
+                "reference": "f55c54cef7037148bf8b8fd6d3922c44f9cf7f92",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "prestashop/php-dev-tools": "^4.2"
+            },
+            "default-branch": true,
+            "type": "prestashop-module",
+            "autoload": {
+                "psr-4": {
+                    "PrestaShop\\Module\\APIResources\\": "src/"
+                },
+                "classmap": [
+                    "ps_apiresources.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "AFL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "PrestaShop SA",
+                    "email": "contact@prestashop.com"
+                }
+            ],
+            "description": "PrestaShop - API Resources",
+            "homepage": "https://github.com/PrestaShop/ps_apiresources",
+            "support": {
+                "source": "https://github.com/PrestaShop/ps_apiresources/tree/dev"
+            },
+            "time": "2023-10-04T18:23:48+00:00"
         },
         {
             "name": "prestashop/ps_banner",
@@ -18102,7 +18149,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "prestashop/ps_apiresources": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -18123,5 +18172,5 @@
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/src/Adapter/Container/ContainerParametersExtension.php
+++ b/src/Adapter/Container/ContainerParametersExtension.php
@@ -80,10 +80,12 @@ class ContainerParametersExtension implements ContainerBuilderExtensionInterface
         $container->setParameter('kernel.cache_dir', $this->environment->getCacheDir());
 
         //Init the active modules
-        $activeModules = (new ModuleRepository(_PS_ROOT_DIR_, _PS_MODULE_DIR_))->getActiveModules();
-        /* @deprecated kernel.active_modules is deprecated. Use prestashop.installed_modules instead. */
+        $moduleRepository = new ModuleRepository(_PS_ROOT_DIR_, _PS_MODULE_DIR_);
+        $activeModules = $moduleRepository->getActiveModules();
+        /* @deprecated kernel.active_modules is deprecated. Use prestashop.active_modules instead. */
         $container->setParameter('kernel.active_modules', $activeModules);
-        $container->setParameter('prestashop.installed_modules', $activeModules);
+        $container->setParameter('prestashop.active_modules', $activeModules);
+        $container->setParameter('prestashop.installed_modules', $moduleRepository->getInstalledModules());
         $container->setParameter('prestashop.module_dir', _PS_MODULE_DIR_);
 
         if (!$container->hasParameter('kernel.project_dir')) {

--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -245,9 +245,9 @@ class ContainerBuilder
      */
     private function loadModulesAutoloader(ContainerInterface $container)
     {
-        $activeModules = $container->getParameter('prestashop.installed_modules');
-        /** @var array<string> $activeModules */
-        foreach ($activeModules as $module) {
+        $installedModules = $container->getParameter('prestashop.installed_modules');
+        /** @var array<string> $installedModules */
+        foreach ($installedModules as $module) {
             $autoloader = _PS_MODULE_DIR_ . $module . '/vendor/autoload.php';
 
             if (file_exists($autoloader)) {

--- a/src/Adapter/Module/Repository/ModuleRepository.php
+++ b/src/Adapter/Module/Repository/ModuleRepository.php
@@ -84,7 +84,10 @@ class ModuleRepository extends AbstractObjectModelRepository
     }
 
     /**
-     * Return active modules.
+     * Return active modules (active in DB and present on the disk).
+     *
+     * This method must not trigger any exception because it is called during install and/or on kernel initialisation,
+     * it must not block those steps in any occasion.
      *
      * @return array
      */
@@ -101,15 +104,60 @@ class ModuleRepository extends AbstractObjectModelRepository
             );
 
             if (is_array($modulesData)) {
-                $activeModules = array_map(function (array $module): string {
+                $activeModulesInDb = array_map(function (array $module): string {
                     return $module['name'];
                 }, $modulesData);
+
+                foreach ($this->getModulesFromFolder() as $moduleName => $modulePath) {
+                    if (in_array($moduleName, $activeModulesInDb)) {
+                        $activeModules[] = $moduleName;
+                    }
+                }
             }
-        } catch (Exception $exception) {
+        } catch (Exception) {
             // DO nothing. getActiveModules() can be called during install BEFORE the database configuration has been defined
+            return [];
         }
 
         return $activeModules;
+    }
+
+    /**
+     * Return installed modules (present in DB regardless of its state AND in the modules folder).
+     *
+     * This method must not trigger any exception because it is called during install and/or on kernel initialisation,
+     * it must not block those steps in any occasion.
+     *
+     * @return array
+     */
+    public function getInstalledModules(): array
+    {
+        if (!defined('_DB_PREFIX_')) {
+            return [];
+        }
+
+        $installedModules = [];
+        try {
+            $modulesData = \Db::getInstance()->executeS(
+                'SELECT m.* FROM `' . _DB_PREFIX_ . 'module` m'
+            );
+
+            if (is_array($modulesData)) {
+                $installedModulesInDb = array_map(function (array $module): string {
+                    return $module['name'];
+                }, $modulesData);
+
+                foreach ($this->getModulesFromFolder() as $moduleName => $modulePath) {
+                    if (in_array($moduleName, $installedModulesInDb)) {
+                        $installedModules[] = $moduleName;
+                    }
+                }
+            }
+        } catch (Exception) {
+            return [];
+        }
+
+        return $installedModules;
     }
 
     /**
@@ -123,7 +171,7 @@ class ModuleRepository extends AbstractObjectModelRepository
             $this->activeModulesPaths = [];
             $activeModules = $this->getActiveModules();
 
-            foreach ($this->getModules() as $moduleName => $modulePath) {
+            foreach ($this->getModulesFromFolder() as $moduleName => $modulePath) {
                 if (in_array($moduleName, $activeModules)) {
                     $this->activeModulesPaths[$moduleName] = $modulePath;
                 }
@@ -174,7 +222,7 @@ class ModuleRepository extends AbstractObjectModelRepository
 
         $modules = [];
 
-        foreach ($this->getModules() as $moduleName => $modulePath) {
+        foreach ($this->getModulesFromFolder() as $moduleName => $modulePath) {
             if (!in_array($moduleName, $nativeModules)) {
                 $modules[] = $moduleName;
             }
@@ -188,7 +236,7 @@ class ModuleRepository extends AbstractObjectModelRepository
      *
      * @return iterable
      */
-    private function getModules(): iterable
+    private function getModulesFromFolder(): iterable
     {
         $modulesFiles = Finder::create()->directories()->in($this->moduleDir)->depth(0);
         foreach ($modulesFiles as $moduleFile) {

--- a/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
+++ b/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryHandler\SearchProductsHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\FoundProduct;
@@ -109,6 +110,10 @@ final class SearchProductsHandler extends AbstractOrderHandler implements Search
     public function handle(SearchProducts $query): array
     {
         $currency = $this->currencyDataProvider->getCurrencyByIsoCode($query->getAlphaIsoCode()->getValue());
+        if (null === $currency) {
+            throw new CurrencyNotFoundException(sprintf('Could not find currency matching ISO code %s', $query->getAlphaIsoCode()->getValue()));
+        }
+
         $this->contextStateManager
             ->setCurrency($currency)
         ;

--- a/src/Core/Module/EventSubscriber.php
+++ b/src/Core/Module/EventSubscriber.php
@@ -53,11 +53,13 @@ class EventSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            ModuleManagementEvent::INSTALL => 'onModuleInstalledOrUninstalled',
-            ModuleManagementEvent::UNINSTALL => 'onModuleInstalledOrUninstalled',
-            ModuleManagementEvent::UPGRADE => 'onModuleInstalledOrUninstalled',
+            ModuleManagementEvent::INSTALL => 'onModuleStateChanged',
+            ModuleManagementEvent::POST_INSTALL => 'onModuleStateChanged',
+            ModuleManagementEvent::UNINSTALL => 'onModuleStateChanged',
+            ModuleManagementEvent::UPGRADE => 'onModuleStateChanged',
             ModuleManagementEvent::ENABLE => 'onModuleStateChanged',
             ModuleManagementEvent::DISABLE => 'onModuleStateChanged',
+            ModuleManagementEvent::DELETE => 'onModuleStateChanged',
         ];
     }
 
@@ -65,11 +67,6 @@ class EventSubscriber implements EventSubscriberInterface
     {
         $moduleName = $event->getModule()->get('name');
         $this->moduleRepository->clearCache($moduleName, true);
-    }
-
-    public function onModuleInstalledOrUninstalled(ModuleManagementEvent $event): void
-    {
-        $this->onModuleStateChanged($event);
         $this->cacheClearer->clear();
     }
 }

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
@@ -60,7 +60,7 @@ class LoadServicesFromModulesPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $installedModules = $container->getParameter('prestashop.installed_modules');
+        $installedModules = $container->getParameter('prestashop.active_modules');
         $moduleDir = $container->getParameter('prestashop.module_dir');
 
         foreach ($installedModules as $moduleName) {

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
@@ -47,7 +47,7 @@ class ModulesDoctrineCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $activeModules = $container->getParameter('prestashop.installed_modules');
+        $activeModules = $container->getParameter('prestashop.active_modules');
         $compilerPassList = $this->getCompilerPassList($activeModules);
         /** @var CompilerPassInterface $compilerPass */
         foreach ($compilerPassList as $compilerResourcePath => $compilerPass) {

--- a/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
+++ b/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
@@ -92,7 +92,7 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
              */
 
             // Load ApiPLatform DTOs from the src/ApiPlatform/Resources folder
-            $moduleRessourcesPath = sprintf('%s/src/ApiPlatform/Resource', $modulePath);
+            $moduleRessourcesPath = sprintf('%s/src/ApiPlatform/Resources', $modulePath);
             if (file_exists($moduleRessourcesPath)) {
                 $paths[] = $moduleRessourcesPath;
             }

--- a/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
+++ b/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
@@ -71,10 +71,11 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
     public function preprendApiConfig(ContainerBuilder $container)
     {
         $paths = [];
-        $installedModules = $container->getParameter('prestashop.installed_modules');
+        $activeModules = $container->getParameter('prestashop.active_modules');
         $moduleDir = $container->getParameter('prestashop.module_dir');
 
-        foreach ($installedModules as $moduleName) {
+        // We only load endpoints from active modules
+        foreach ($activeModules as $moduleName) {
             $modulePath = $moduleDir . $moduleName;
             // Load YAML definition from the config/api_platform folder in the module
             $moduleConfigPath = sprintf('%s/config/api_platform', $modulePath);
@@ -83,7 +84,7 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
             }
 
             /**
-             * TODO: Understand why this crashes PrestaShop and redirects to Front Office - no support of entities until then
+             * TODO: Understand why this crashes PrestaShop and redirects to Front Office - maybe duplicated/conflicts with ModulesDoctrineCompilerPass that could be removed in favor of this method
              * // Load Doctrine entities that could be used as ApiPlatform DTO resources as well in the src/Entity folder
              * $entitiesRessourcesPath = sprintf('%s/src/Entity', $modulePath);
              * if (file_exists($entitiesRessourcesPath)) {
@@ -91,7 +92,7 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
              * }
              */
 
-            // Load ApiPLatform DTOs from the src/ApiPlatform/Resources folder
+            // Load ApiPlatform DTOs from the src/ApiPlatform/Resources folder
             $moduleRessourcesPath = sprintf('%s/src/ApiPlatform/Resources', $modulePath);
             if (file_exists($moduleRessourcesPath)) {
                 $paths[] = $moduleRessourcesPath;

--- a/src/PrestaShopBundle/Entity/FeatureFlag.php
+++ b/src/PrestaShopBundle/Entity/FeatureFlag.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
@@ -38,7 +37,6 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
  * @ORM\Entity(repositoryClass="PrestaShopBundle\Entity\Repository\FeatureFlagRepository")
  * @ORM\Table()
  * @UniqueEntity("name")
- * @ApiResource()
  */
 class FeatureFlag
 {

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/AuthorizationServer/ApiAccess/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/AuthorizationServer/ApiAccess/index.html.twig
@@ -26,6 +26,24 @@
 {% trans_default_domain "Admin.Advparameters.Feature" %}
 
 {% block content %}
+  <div class="alert alert-info" role="alert">
+    <p class="alert-text">
+      {{ 'PrestaShop provides numerous APIs if you need you can see their details in the dedicated automated documentation:'|trans({}, 'Admin.Advparameters.Feature') }}
+      <ul>
+        <li>
+          <a target="_blank" href="{{ path('api_doc') }}">
+            {{ 'API Documentation (HTML format)'|trans({}, 'Admin.Advparameters.Feature') }}
+          </a>
+        </li>
+        <li>
+          <a target="_blank" href="{{ path('api_doc', {_format: 'json'}) }}">
+            {{ 'API Documentation (JSON format)'|trans({}, 'Admin.Advparameters.Feature') }}
+          </a>
+        </li>
+      </ul>
+    </p>
+  </div>
+
   {% block api_access_listing %}
     {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': apiAccessGrid} %}
   {% endblock %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Integrate external PrestaShop module for API resources To make the dynamisation of endpoint integration work as expected some other things were modified in this PR:<ul><li>Fix of module events, the cache was not cleared in most of them which is a mistake, any change on the module state should force clearing the cache</li><li>The container parameter `prestashop.installed_modules` was not correctly filled, or at its name was not correct, it now contains the real list of installed modules and a new `prestashop.active_modules` contains the list of active modules (introduced on v9 so no BC break)</li><li>The `SymfonyCacheClearer` service now clears cache for both prod and dev environments</li></ul>
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Activate Authorization server in feature flags<br/>2. Go to Advanced Parameters > Authorization server<br/>3. You can use the link to open the Swagger docs<br/>4. The API resources module is installed by default so you should see the `/api/api-access/{apiAccessId}` API available<br/>5. Go to module manager and disable the API resource module<br/>6. Refresh the sagger doc, the API access endpoint should have disappeared<br/>7. Repeat the action by enabling, disabling, installing, uninstalling the module Check the API Docs after each operation the endpoint should only be visible when the module is installed and enabled
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/6418903645
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~

## Screenshots

### Link available to access API docs easily

![Capture d’écran 2023-10-05 à 14 44 39](https://github.com/PrestaShop/PrestaShop/assets/13801017/cea118cf-04be-4adf-9491-2709cd49313a)

### API Endpoint integrated thanks to the PrestaShop API Resources module

![Capture d’écran 2023-10-05 à 14 44 47](https://github.com/PrestaShop/PrestaShop/assets/13801017/7cc591aa-032f-46a4-801d-0bb009a699c2)

