### PR TITLE
Fix sorting by "time" in profiler's stopwatch SQL

### DIFF
--- a/tools/profiling/templates/stopwatch.tpl
+++ b/tools/profiling/templates/stopwatch.tpl
@@ -48,7 +48,7 @@
         <tr>
           <td>{$data['id']}</td>
           <td class="pre" style="max-width: 60vw"><pre>{preg_replace("/(^[\s]*)/m", "", htmlspecialchars($data['query'], ENT_NOQUOTES, 'utf-8', false))}</pre></td>
-          <td data-value="{$data['time']}">
+          <td data-value="{sprintf('%01.6f', $data['time'])}">
             {load_time data=($data['time'])}
           </td>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | With profiler enabled, when sorting in stopwatch SQL by the "time" column, if the values are really low, they will get a bit wonky (see image below), which prevents queries from being sorted correctly.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable profiling and sort queries in stopwatch SQL by the "time" column.
| Fixed issue or discussion?     | -

Example value on the "time" column:
![image](https://github.com/PrestaShop/PrestaShop/assets/10223434/3999531b-4b97-4de7-92b3-24989276229c)
