### PR TITLE
Forbidden sensitive files extensions on modules directory

### DIFF
--- a/modules/.htaccess
+++ b/modules/.htaccess
@@ -1,4 +1,4 @@
-<FilesMatch "(\.tpl|\.twig|config\.xml|config_([a-z]+)\.xml)$">
+<FilesMatch "(\.php|\.log|\.txt|\.lock|\.json|\.yml|\.yaml|\.tpl|\.twig|config\.xml|config_([a-z]+)\.xml)$">
     # Apache 2.2
     <IfModule !mod_authz_core.c>
         Order deny,allow


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Forbidden sensitive extension to prevent direct call on modules directory of<br>- *.php > see also #32566<br>- *.log: data leaks of logs files<br>- *.txt: data leaks of logs files<br>- .lock: data leaks on composer.lock or package.lock that contents dependencies libraries<br>- *.json: data leaks on composer.lock or package.lock that contents dependencies libraries<br>- *.yml or *.yaml: data leaks on config files
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | An http call /modules/mymodule/mymodule.php should return a status 403
| UI Tests          | NC.
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/32566
| Related PRs       | NC
| Sponsor company   | @202-ecommerce 
