### PR TITLE
Don't check all product availability in cart on add to cart action

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -540,7 +540,7 @@ class CartControllerCore extends FrontController
         CartRule::autoAddToCart();
 
         // Finally check that all other products are also available, but only if there was no previous error
-        if (empty($this->{$ErrorKey})) {
+        if ('add' !== $mode && empty($this->{$ErrorKey})) {
             $areProductsAvailable = $this->areProductsAvailable();
             if (true !== $areProductsAvailable) {
                 $this->{$ErrorKey}[] = $areProductsAvailable;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | I am targeting the 8.1.X branch because it is a fix for the regression introduced in version 8.1.2.
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow reproduction steps in the issue. There should be no issue with adding to cart products when one product quantity in cart is over max quantity in stock. 
| UI Tests          | https://github.com/Oksydan/ga.tests.ui.pr/actions/runs/6450328759
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/34206
| Related PRs       | N/A
| Sponsor company   | Waynet
