### PR TITLE
Change the APE field validation to match all formats

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1269,7 +1269,7 @@ class ValidateCore
      */
     public static function isApe($ape)
     {
-        return (bool) preg_match('/^[0-9]{1,2}?.[0-9]{1,2}[a-zA-Z]{1}$/s', $ape);
+        return (bool) preg_match('/^[0-9]{1,2}?\.?[0-9]{1,2}[a-zA-Z]{1}$/s', $ape);
     }
 
     public static function isControllerName($name)

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1269,7 +1269,7 @@ class ValidateCore
      */
     public static function isApe($ape)
     {
-        return (bool) preg_match('/^[0-9]{3,4}[a-zA-Z]{1}$/s', $ape);
+        return (bool) preg_match('/^[0-9]{1,2}?.[0-9]{1,2}[a-zA-Z]{1}$/s', $ape);
     }
 
     public static function isControllerName($name)

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -613,7 +613,7 @@ CREATE TABLE `PREFIX_customer` (
   `id_risk` int(10) unsigned NOT NULL DEFAULT '1',
   `company` varchar(255),
   `siret` varchar(14),
-  `ape` varchar(5),
+  `ape` varchar(6),
   `firstname` varchar(255) NOT NULL,
   `lastname` varchar(255) NOT NULL,
   `email` varchar(255) NOT NULL,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x
| Description?      | Change Validate::isApe method and PREFEX_customer table to match all APE or NAF formats.
| Type?             |  improvement 
| Category?         |  CO, IN 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Change APE code to formats XX.XXX and XXXXX
| Fixed issue or discussion?     | Fixes #34216
| Sponsor company | coquille.fr
