### PR TITLE
Allow html tags in BO module footer

### DIFF
--- a/admin-dev/themes/default/template/controllers/modules/configuration_bar.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/configuration_bar.tpl
@@ -29,7 +29,7 @@
   <div class="form-wrapper">
     <div class="form-group">
       <label class="control-label col-lg-4">
-        {l s='Activate module for this shop context: %s.' sprintf=[$shop_context] d='Admin.Modules.Notification'}
+        {l s='Activate module for this shop context: %s.' sprintf=[$shop_context] d='Admin.Modules.Notification' html=true}
       </label>
       <div class="col-lg-8">
         <span class="switch prestashop-switch fixed-width-lg">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes incorrecly escaped HTML in BO module footer (#34234)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Visual test, see #34234
| UI Tests          | No
| Fixed issue or discussion?     | Fixes #34234
| Related PRs       | None
| Sponsor company   | Société Biblique de Genève
