### PR TITLE
FIX: PPV2 - multistore - Exception is displayed when I change my context shop while editing a product

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductShopsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductShopsType.php
@@ -70,7 +70,7 @@ class ProductShopsType extends TranslatorAwareType
                     ],
                     'submit' => [
                         'type' => SubmitType::class,
-                        'group' => 'right',
+                        'group' => 'left',
                         'options' => [
                             'label' => $this->trans('Save', 'Admin.Global'),
                         ],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Exception is displayed when I change my context shop while editing a product
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow same steps described in #34197
| UI Tests          | Please run UI tests and paste here the link to the run. [Read this page to know why and how to use this tool.](https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/ui-tests/).
| Fixed issue or discussion?     | Fixes #34197 
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).


The same group name prevent from duplicating a "submit" - "cancel" button and prevent the exception triggered by form_widget twig function.