### PR TITLE
Improve installation language fallback system

### DIFF
--- a/install-dev/classes/controllerHttp.php
+++ b/install-dev/classes/controllerHttp.php
@@ -147,25 +147,17 @@ class InstallControllerHttp
         $detect_language = $this->language->detectLanguage();
 
         if (empty($this->session->lang)) {
-            $this->session->lang = $detect_language['primarytag'];
+            // Set the en as default fallback in case we can't detect a better one
+            $this->session->lang = 'en';
+            if (isset($detect_language['primarytag'])
+                && in_array($detect_language['primarytag'], $this->language->getIsoList())) {
+                $this->session->lang = $detect_language['primarytag'];
+            }
         }
 
-        Context::getContext()->language = $this->language->getLanguage(
-            $this->session->lang ?: false
-        );
-
+        Context::getContext()->language = $this->language->getLanguage($this->session->lang);
         $this->translator = Context::getContext()->getTranslator(true);
-
-        if (isset($this->session->lang)) {
-            $lang = $this->session->lang;
-        } else {
-            $lang = (isset($detect_language['primarytag'])) ? $detect_language['primarytag'] : false;
-        }
-
-        if (!in_array($lang, $this->language->getIsoList())) {
-            $lang = 'en';
-        }
-        $this->language->setLanguage($lang);
+        $this->language->setLanguage($this->session->lang);
 
         if (empty(self::getSteps())) {
             $this->initSteps();

--- a/src/PrestaShopBundle/Install/LanguageList.php
+++ b/src/PrestaShopBundle/Install/LanguageList.php
@@ -187,7 +187,7 @@ class LanguageList
     public function detectLanguage()
     {
         // This code is from a php.net comment : http://www.php.net/manual/fr/reserved.variables.server.php#94237
-        $split_languages = explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE']);
+        $split_languages = isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE']) : [];
         if (!is_array($split_languages)) {
             return false;
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In installation from browser the fallback when HTTP_ACCEPT_LANGUAGE was not set did not work properly, this is fixed so that we can curl the page correctly in CI workflows
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/6480520412
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | @PrestaShopCorp
