### PR TITLE
Change the APE field validation to match all formats

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -29,6 +29,7 @@ use Egulias\EmailValidator\Validation\RFCValidation;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CustomerName;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Factory\CustomerNameValidatorFactory;
 use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\NumericIsoCode;
+use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\ApeCode;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
 use PrestaShop\PrestaShop\Core\Email\SwiftMailerValidation;
 use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
@@ -1322,7 +1323,7 @@ class ValidateCore
      */
     public static function isApe($ape)
     {
-        return (bool) preg_match('/^[0-9]{1,2}?\.?[0-9]{1,2}[a-zA-Z]{1}$/s', $ape);
+        return (bool) preg_match(ApeCode::PATTERN, $ape);
     }
 
     public static function isControllerName($name)

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1322,7 +1322,7 @@ class ValidateCore
      */
     public static function isApe($ape)
     {
-        return (bool) preg_match('/^[0-9]{3,4}[a-zA-Z]{1}$/s', $ape);
+        return (bool) preg_match('/^[0-9]{1,2}?\.?[0-9]{1,2}[a-zA-Z]{1}$/s', $ape);
     }
 
     public static function isControllerName($name)

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -613,7 +613,7 @@ CREATE TABLE `PREFIX_customer` (
   `id_risk` int(10) unsigned NOT NULL DEFAULT '1',
   `company` varchar(255),
   `siret` varchar(14),
-  `ape` varchar(5),
+  `ape` varchar(6),
   `firstname` varchar(255) NOT NULL,
   `lastname` varchar(255) NOT NULL,
   `email` varchar(255) NOT NULL,

--- a/src/Core/Domain/Customer/ValueObject/ApeCode.php
+++ b/src/Core/Domain/Customer/ValueObject/ApeCode.php
@@ -40,6 +40,11 @@ class ApeCode
     private $code;
 
     /**
+     * @var string
+     */
+    public const PATTERN = '/^[0-9]{1,2}?\.?[0-9]{1,2}[a-zA-Z]{1}$/s';
+    
+    /**
      * @param mixed $code
      */
     public function __construct($code)
@@ -60,7 +65,7 @@ class ApeCode
     private function assertIsApeCode($code)
     {
         if (!is_string($code)
-            || (!empty($code) && !((bool) preg_match('/^[0-9]{1,2}?\.?[0-9]{1,2}[a-zA-Z]{1}$/s', $code)))
+            || (!empty($code) && !((bool) preg_match($this::PATTERN, $code)))
             ) {
             throw new CustomerConstraintException(sprintf('Invalid ape code %s provided', var_export($code, true)), CustomerConstraintException::INVALID_APE_CODE);
         }

--- a/src/Core/Domain/Customer/ValueObject/ApeCode.php
+++ b/src/Core/Domain/Customer/ValueObject/ApeCode.php
@@ -43,7 +43,7 @@ class ApeCode
      * @var string
      */
     public const PATTERN = '/^[0-9]{1,2}?\.?[0-9]{1,2}[a-zA-Z]{1}$/s';
-    
+
     /**
      * @param mixed $code
      */

--- a/src/Core/Domain/Customer/ValueObject/ApeCode.php
+++ b/src/Core/Domain/Customer/ValueObject/ApeCode.php
@@ -60,7 +60,7 @@ class ApeCode
     private function assertIsApeCode($code)
     {
         if (!is_string($code)
-            || (!empty($code) && !((bool) preg_match('/^\d{3,4}[a-zA-Z]{1}$/', $code)))
+            || (!empty($code) && !((bool) preg_match('/^[0-9]{1,2}?\.?[0-9]{1,2}[a-zA-Z]{1}$/s', $code)))
             ) {
             throw new CustomerConstraintException(sprintf('Invalid ape code %s provided', var_export($code, true)), CustomerConstraintException::INVALID_APE_CODE);
         }

--- a/src/Core/Domain/Customer/ValueObject/ApeCode.php
+++ b/src/Core/Domain/Customer/ValueObject/ApeCode.php
@@ -65,7 +65,7 @@ class ApeCode
     private function assertIsApeCode($code)
     {
         if (!is_string($code)
-            || (!empty($code) && !((bool) preg_match($this::PATTERN, $code)))
+            || (!empty($code) && !((bool) preg_match(self::PATTERN, $code)))
             ) {
             throw new CustomerConstraintException(sprintf('Invalid ape code %s provided', var_export($code, true)), CustomerConstraintException::INVALID_APE_CODE);
         }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\LastName;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email as DomainEmail;
 use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
+use PrestaShopBundle\Form\Admin\Type\ApeType;
 use PrestaShopBundle\Form\Admin\Type\EmailType;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTableType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
@@ -50,7 +51,6 @@ use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Regex;
-use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Validate;
 
@@ -303,15 +303,9 @@ class CustomerType extends TranslatorAwareType
                     'label' => $this->trans('SIRET', 'Admin.Orderscustomers.Feature'),
                     'required' => false,
                 ])
-                ->add('ape_code', TextType::class, [
+                ->add('ape_code', ApeType::class, [
                     'label' => $this->trans('APE', 'Admin.Orderscustomers.Feature'),
                     'required' => false,
-                    'constraints' => [
-                        new Regex([
-                            'pattern' => '/^[0-9]{1,2}?\.?[0-9]{1,2}[a-zA-Z]{1}$/s',
-                            'message' => $this->trans('This field is invalid.', 'Admin.Notifications.Error'),
-                        ]),
-                    ],
                 ])
                 ->add('website', TextType::class, [
                     'label' => $this->trans('Website', 'Admin.Orderscustomers.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -49,6 +49,7 @@ use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Range;
+use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Validate;
@@ -306,8 +307,8 @@ class CustomerType extends TranslatorAwareType
                     'label' => $this->trans('APE', 'Admin.Orderscustomers.Feature'),
                     'required' => false,
                     'constraints' => [
-                        new Type([
-                            'type' => 'alnum',
+                       new Regex([
+                            'pattern' => '/^[0-9]{1,2}?\.?[0-9]{1,2}[a-zA-Z]{1}$/s',
                             'message' => $this->trans('This field is invalid.', 'Admin.Notifications.Error'),
                         ]),
                     ],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -50,7 +50,6 @@ use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Range;
-use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Validate;
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -307,7 +307,7 @@ class CustomerType extends TranslatorAwareType
                     'label' => $this->trans('APE', 'Admin.Orderscustomers.Feature'),
                     'required' => false,
                     'constraints' => [
-                       new Regex([
+                        new Regex([
                             'pattern' => '/^[0-9]{1,2}?\.?[0-9]{1,2}[a-zA-Z]{1}$/s',
                             'message' => $this->trans('This field is invalid.', 'Admin.Notifications.Error'),
                         ]),

--- a/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
+use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\ApeCode;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataTransformerInterface;
@@ -50,7 +51,7 @@ class ApeType extends AbstractType implements DataTransformerInterface
         $resolver->setDefaults([
             'constraints' => [
                 new Regex([
-                    'pattern' => '/^[0-9]{1,2}?\.?[0-9]{1,2}[a-zA-Z]{1}$/s',
+                    'pattern' => ApeCode::PATTERN,
                     'message' => $this->trans('This field is invalid.', [], 'Admin.Notifications.Error'),
                 ]),
             ],

--- a/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
@@ -1,5 +1,29 @@
 <?php
-
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+ 
 declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Type;

--- a/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use PrestaShopBundle\Translation\TranslatorAwareTrait;

--- a/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
@@ -23,7 +23,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
- 
+
 declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Type;

--- a/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
@@ -73,3 +73,4 @@ class ApeType extends AbstractType implements DataTransformerInterface
         return $value;
     }
 }
+

--- a/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace PrestaShopBundle\Form\Admin\Type;
+
+use PrestaShopBundle\Translation\TranslatorAwareTrait;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Regex;
+
+class ApeType extends AbstractType implements DataTransformerInterface
+{
+    use TranslatorAwareTrait;
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addModelTransformer($this);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'constraints' => [
+                new Regex([
+                    'pattern' => '/^[0-9]{1,2}?\.?[0-9]{1,2}[a-zA-Z]{1}$/s',
+                    'message' => $this->trans('This field is invalid.', [], 'Admin.Notifications.Error'),
+                ]),
+            ],
+        ]);
+    }
+
+    public function getParent()
+    {
+        return TextType::class;
+    }
+
+    public function transform($value)
+    {
+        return $value;
+    }
+
+    public function reverseTransform($value)
+    {
+        return $value;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
@@ -73,4 +73,3 @@ class ApeType extends AbstractType implements DataTransformerInterface
         return $value;
     }
 }
-

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -2220,3 +2220,11 @@ services:
     public: false
     arguments:
       $locales: "@=service('prestashop.adapter.legacy.context').getLanguages()"
+
+  PrestaShopBundle\Form\Admin\Type\ApeType:
+    class: 'PrestaShopBundle\Form\Admin\Type\ApeType'
+    public: true
+    calls:
+      - { method: setTranslator, arguments: [ '@translator' ] }
+    tags:
+      - { name: form.type }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -2222,8 +2222,6 @@ services:
       $locales: "@=service('prestashop.adapter.legacy.context').getLanguages()"
 
   PrestaShopBundle\Form\Admin\Type\ApeType:
-    class: 'PrestaShopBundle\Form\Admin\Type\ApeType'
-    public: true
     calls:
       - { method: setTranslator, arguments: [ '@translator' ] }
     tags:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -2222,6 +2222,8 @@ services:
       $locales: "@=service('prestashop.adapter.legacy.context').getLanguages()"
 
   PrestaShopBundle\Form\Admin\Type\ApeType:
+    public: false
+    autowire: true
     calls:
       - { method: setTranslator, arguments: [ '@translator' ] }
     tags:


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Change Validate::isApe method and PREFEX_customer table to match all APE or NAF formats.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Change APE code to formats XX.XXX and XXXXX
| Fixed issue or discussion?     | Fixes #34216
| Related PRs       | [autoupgrade](https://github.com/PrestaShop/autoupgrade/pull/639)
| Sponsor company   | coquille.fr
