### PR TITLE
FIX: Combinations dropdown list on Specific Prices window, not loading all combinations on new product page. Combinations dropdown list on Specific Prices window, not loading all combinations on new product page.

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
@@ -51,7 +51,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SpecificPriceType extends TranslatorAwareType
 {
-    private const COMBINATION_RESULTS_LIMIT = 20;
+    private const COMBINATION_RESULTS_LIMIT = 0;
 
     /**
      * @var ProductRepository


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Only 10 combinations are displayed in the specific price section of a combination products on PPv2 of PS 8.1.2. This straightforward fix will eliminate this limit.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | 1. Go to BO > Create a combination product<br>2. Generate more than 20 combinations <br>3.Go to Pricing > Specific price block > Add a specific price <br>4. See in "All combinations" : All combinations should be visible now.
| Fixed issue or discussion?     | Fixes #34203, Fixes #34229
