### PR TITLE
Fix field new not displayed on GET from API

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1717,12 +1717,7 @@ class ProductCore extends ObjectModel
      */
     public function getWsIsNew()
     {
-        $isNew = $this->isNew();
-        if (true === $isNew) {
-            return 1;
-        }
-
-        return 0;
+        return $this->isNew() === true ? 1 : 0;
     }
 
     /**

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -601,7 +601,10 @@ class ProductCore extends ObjectModel
             'id_category_default' => [
                 'xlink_resource' => 'categories',
             ],
-            'new' => [],
+            'new' => [
+                'getter' => 'getWsIsNew',
+                'setter' => false,
+            ],
             'cache_default_attribute' => [],
             'id_default_image' => [
                 'getter' => 'getCoverWs',
@@ -1705,6 +1708,21 @@ class ProductCore extends ObjectModel
             AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . $nbDaysNewProduct;
 
         return (bool) Db::getInstance()->getValue($query, false);
+    }
+
+    /**
+     * Webservice getter : get if product is new.
+     *
+     * @return int
+     */
+    public function getWsIsNew()
+    {
+        $isNew = $this->isNew();
+        if (true === $isNew) {
+            return 1;
+        }
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix display of new value on get of product from webservice API.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow instructions in reported issue.
| Fixed issue or discussion?     | Fixes #33429
| Sponsor company   | Prestaworks AB
