### PR TITLE
Fix ButtonCollectionType groups splitting

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -1515,7 +1515,8 @@
       <div class="{% if use_button_groups %}btn-group {% endif %}group-{{ group }}">
         {# Render inline actions #}
         {% set inlineButtonsLimit = form.vars.inline_buttons_limit %}
-        {% for action in form.children %}
+        {% for button in buttons %}
+          {% set action = attribute(form, button) %}
           {% if inlineButtonsLimit is same as(null) or loop.index <= inlineButtonsLimit %}
             {# Remove labels from inline elements if they are not forced #}
             {% if form.vars.use_inline_labels %}
@@ -1528,7 +1529,7 @@
         {% endfor %}
 
         {# Render remaining actions in dropdown #}
-        {% if inlineButtonsLimit is not same as(null) and form.children|length > inlineButtonsLimit %}
+        {% if inlineButtonsLimit is not same as(null) and buttons|length > inlineButtonsLimit %}
           <a id="{{ form.vars.id }}_dropdown" class="btn btn-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split no-rotate"
              data-toggle="dropdown"
              aria-haspopup="true"
@@ -1536,7 +1537,9 @@
           >
           </a>
           <div class="dropdown-menu">
-            {% for action in form.children|slice(inlineButtonsLimit) %}
+            {% set remainingButtons = buttons|slice(inlineButtonsLimit) %}
+            {% for button in remainingButtons %}
+              {% set action = attribute(form, button) %}
               {{ form_widget(action, {'attr': {
                 'class': 'dropdown-item ' ~ action.vars.attr.class|default('')|trim
               }}) }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix ButtonCollectionType groups splitting that was broken by inline_buttons_limit feature, the children were rendered multiple times so not displayed in the appropriate group div But more important in recent Symfony version a form cannot be rendered twice and hat used to fail silently now shouts about it (which is a good thing)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See issue #34197
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #34197
| Related PRs       | ~
| Sponsor company   | ~
