### PR TITLE
Fix: PPV2 - Specific prices can't be created for a particular combination

### DIFF
--- a/src/Adapter/Product/Combination/Repository/CombinationRepository.php
+++ b/src/Adapter/Product/Combination/Repository/CombinationRepository.php
@@ -790,7 +790,7 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
         }
 
         $qb = $this->connection->createQueryBuilder()
-            ->select('pac.id_product_attribute, pac.id_attribute')
+            ->select('DISTINCT pac.id_product_attribute')
             ->from($this->dbPrefix . 'product_attribute_combination', 'pac')
         ;
 
@@ -817,18 +817,20 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
             ->setParameter('productId', $productId->getValue())
         ;
 
-        if ($limit) {
-            $qb->setMaxResults($limit);
-        }
-
         $results = $qb->execute()->fetchAll();
         if (!$results) {
             return [];
         }
 
-        return array_map(static function (array $result): CombinationId {
+        $combinationsIds = array_map(static function (array $result): CombinationId {
             return new CombinationId((int) $result['id_product_attribute']);
         }, $results);
+
+        if ($limit) {
+            $combinationsIds = array_slice($combinationsIds, 0, $limit);
+        }
+
+        return $combinationsIds;
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.1.x
| Description?      | In PS 8.1.2, I want to create a specific price for a combination in particular. But all the combinations are not displayed; also I can't search for the said combination, there's no search field.
| Type?             | bug fix
| Category?         | BO
| Fixed issue or discussion?     | Fixes #34229 
