### PR TITLE
Fix combination modal changes detection

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/combination/combination-modal/CombinationModal.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/combination/combination-modal/CombinationModal.vue
@@ -281,6 +281,11 @@
         );
 
         iframeInputs.forEach((input: Element) => {
+          // @ts-ignore
+          if (input.type === 'hidden') {
+            return;
+          }
+
           input.addEventListener('keyup', () => {
             this.isFormUpdated = true;
           });
@@ -288,10 +293,10 @@
           input.addEventListener('change', () => {
             this.isFormUpdated = true;
           });
+        });
 
-          this.getIframeDocument().addEventListener('datepickerChange', () => {
-            this.isFormUpdated = true;
-          });
+        this.getIframeDocument().addEventListener('datepickerChange', () => {
+          this.isFormUpdated = true;
         });
       },
       applyIframeStyling(): void {

--- a/tests/UI/campaigns/productV2/functional/03_CRUDProductWithCombinations.ts
+++ b/tests/UI/campaigns/productV2/functional/03_CRUDProductWithCombinations.ts
@@ -440,7 +440,7 @@ describe('BO - Catalog - Products : CRUD product with combinations', async () =>
       expect(paginationNumber).to.contains('(page 1 / 4)');
     });
 
-    it('should change the items number to 20 per page', async function () {
+    it('should change the items number to 50 per page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'changeItemNumberTo50', baseContext);
 
       const paginationNumber = await combinationsTab.selectPaginationLimit(page, 50);

--- a/tests/UI/pages/BO/catalog/productsV2/add/combinationsTab.ts
+++ b/tests/UI/pages/BO/catalog/productsV2/add/combinationsTab.ts
@@ -143,7 +143,7 @@ class CombinationsTab extends BOBasePage {
 
   private readonly editCombinationModalSaveButton: string;
 
-  private readonly editCombinationModalCancelButton: string;
+  private readonly editCombinationModalCloseButton: string;
 
   private readonly editCombinationCloseModal: string;
 
@@ -269,7 +269,7 @@ class CombinationsTab extends BOBasePage {
     this.editCombinationModalImpactOnPriceTExcInput = '#combination_form_price_impact_price_tax_excluded';
     this.editCombinationModalReferenceInput = '#combination_form_references_reference';
     this.editCombinationModalSaveButton = `${this.editCombinationModal} footer button.btn-primary`;
-    this.editCombinationModalCancelButton = `${this.editCombinationModal} footer button.btn-close`;
+    this.editCombinationModalCloseButton = `${this.editCombinationModal} footer button.btn-close`;
     this.editCombinationCloseModal = `${this.editCombinationEditModal} div.modal-prevent-close div.modal.show`;
     this.editCombinationModalDiscardButton = `${this.editCombinationCloseModal} button.btn-primary`;
     this.combinationStockMovementsDate = (row: number) => `#combination_form_stock_quantities_stock_movements_${row - 1}_`
@@ -492,8 +492,7 @@ class CombinationsTab extends BOBasePage {
     const combinationFrame: Frame|null = await page.frame({url: /sell\/catalog\/products-v2\/combinations/gmi});
     await expect(combinationFrame).to.be.not.null;
 
-    await this.waitForSelectorAndClick(page, this.editCombinationModalCancelButton);
-    await this.waitForSelectorAndClick(page, this.editCombinationModalDiscardButton);
+    await this.waitForSelectorAndClick(page, this.editCombinationModalCloseButton);
 
     return this.elementVisible(combinationFrame!, this.editCombinationModalQuantityInput, 2000);
   }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.1.x
| Description?      | The next and previous button in the combination edition modal had a strange behaviour where even if you did not modify any field they would force you to save the current combination as if you changed something. This was due to the fact that some hidden field had eventListener on them that were triggered by an automatic calculation in the final price of the combination. By removing the listeners on the hidden field it fixes the problem.
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | See step to reproduce in #33965 
| UI Tests          | https://github.com/nesrineabdmouleh/testing_pr/actions/runs/6627419084 
| Fixed issue or discussion?     | Fixes #33965
| Sponsor company   | PrestaShop SA
