### PR TITLE
Fix legacy page images

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2895,7 +2895,7 @@ class AdminProductsControllerCore extends AdminController
                     *
                     * In case of .jpg images, the actual format inside is decided by ImageManager.
                     */
-                    $configuredImageFormats = $this->get(ImageFormatConfiguration::class)->getGenerationFormats();
+                    $configuredImageFormats = SymfonyContainer::getInstance()->get(ImageFormatConfiguration::class)->getGenerationFormats();
 
                     foreach ($imagesTypes as $imageType) {
                         foreach ($configuredImageFormats as $imageFormat) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | The service could not be retrieved by `$this->get(` because the container is not initialized in `ajaxProcessaddProductImage` for some reason.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Test that the related issue is fixed.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #https://github.com/PrestaShop/PrestaShop/issues/34142
| Related PRs       | 
| Sponsor company   |
