### PR TITLE
Fix arabic numbers displayed

### DIFF
--- a/src/Core/Localization/Number/LocaleNumberTransformer.php
+++ b/src/Core/Localization/Number/LocaleNumberTransformer.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Localization\Number;
+
+use PrestaShop\PrestaShop\Core\Localization\Locale;
+
+class LocaleNumberTransformer
+{
+    /** @var Locale */
+    private $locale;
+
+    /** @var string[] */
+    private const FORCED_LOCALES_TO_EN_NUMBERS = ['ar', 'bn', 'fa'];
+
+    public function __construct(Locale $locale)
+    {
+        $this->locale = $locale;
+    }
+
+    /**
+     * Retrieve locale for numbers.
+     * (to avoid use of persian/arabic numbers)
+     *
+     * @return string
+     */
+    public function getLocaleForNumberInputs()
+    {
+        $locale = substr($this->locale->getCode(), 0, 2);
+
+        return in_array($locale, self::FORCED_LOCALES_TO_EN_NUMBERS) ? 'en' : $locale;
+    }
+}

--- a/src/PrestaShopBundle/Form/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\DataTransformer;
+
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\Form\Extension\Core\DataTransformer\NumberToLocalizedStringTransformer;
+
+/**
+ * Transforms between a normalized format and a localized money string.
+ * (Copy from Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php to add $locale in it!)
+ */
+class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransformer
+{
+    private $divisor;
+
+    public function __construct(?int $scale = 2, ?bool $grouping = true, ?int $roundingMode = self::ROUND_HALF_UP, ?int $divisor = 1, string $locale = null)
+    {
+        parent::__construct($scale ?? 2, $grouping ?? true, $roundingMode, $locale);
+
+        $this->divisor = $divisor ?? 1;
+    }
+
+    /**
+     * Transforms a normalized format into a localized money string.
+     *
+     * @param int|float|null $value Normalized number
+     *
+     * @return string Localized money string
+     *
+     * @throws TransformationFailedException if the given value is not numeric or
+     *                                       if the value can not be transformed
+     */
+    public function transform($value)
+    {
+        if (null !== $value && 1 !== $this->divisor) {
+            if (!is_numeric($value)) {
+                throw new TransformationFailedException('Expected a numeric.');
+            }
+            $value /= $this->divisor;
+        }
+
+        return parent::transform($value);
+    }
+
+    /**
+     * Transforms a localized money string into a normalized format.
+     *
+     * @param string $value Localized money string
+     *
+     * @return int|float|null Normalized number
+     *
+     * @throws TransformationFailedException if the given value is not a string
+     *                                       or if the value can not be transformed
+     */
+    public function reverseTransform($value)
+    {
+        $value = parent::reverseTransform($value);
+        if (null !== $value && 1 !== $this->divisor) {
+            $value = (float) (string) ($value * $this->divisor);
+        }
+
+        return $value;
+    }
+}

--- a/src/PrestaShopBundle/Form/Extension/IntegerTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/IntegerTypeExtension.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Extension;
+
+use PrestaShop\PrestaShop\Core\Localization\Number\LocaleNumberTransformer;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\DataTransformer\IntegerToLocalizedStringTransformer;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class IntegerTypeExtension extends AbstractTypeExtension
+{
+    /**
+     * @var LocaleNumberTransformer
+     */
+    private $localeNumberTransformer;
+
+    public function __construct(
+        LocaleNumberTransformer $localeNumberTransformer
+    ) {
+        $this->localeNumberTransformer = $localeNumberTransformer;
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [IntegerType::class];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        // We only want to replace/adapt the IntegerToLocalizedStringTransformer, so we save the current transformers
+        // to restore them after replacing the new IntegerToLocalizedStringTransformer.
+        $viewTransformers = $builder->getViewTransformers();
+        $builder->resetViewTransformers();
+
+        foreach ($viewTransformers as $viewTransformer) {
+            if ($viewTransformer instanceof IntegerToLocalizedStringTransformer) {
+                $builder
+                    ->addViewTransformer(new IntegerToLocalizedStringTransformer(
+                        $options['grouping'],
+                        $options['rounding_mode'],
+                        !$options['grouping'] ? 'en' : $this->localeNumberTransformer->getLocaleForNumberInputs()
+                    ))
+                ;
+            } else {
+                $builder->addViewTransformer($viewTransformer);
+            }
+        }
+    }
+}

--- a/src/PrestaShopBundle/Form/Extension/NumberTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/NumberTypeExtension.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Extension;
+
+use PrestaShop\PrestaShop\Core\Localization\Number\LocaleNumberTransformer;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\DataTransformer\NumberToLocalizedStringTransformer;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class NumberTypeExtension extends AbstractTypeExtension
+{
+    /**
+     * @var LocaleNumberTransformer
+     */
+    private $localeNumberTransformer;
+
+    public function __construct(
+        LocaleNumberTransformer $localeNumberTransformer
+    ) {
+        $this->localeNumberTransformer = $localeNumberTransformer;
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [NumberType::class];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        // We only want to replace/adapt the NumberToLocalizedStringTransformer, so we save the current transformers
+        // to restore them after replacing the new NumberToLocalizedStringTransformer.
+        $viewTransformers = $builder->getViewTransformers();
+        $builder->resetViewTransformers();
+
+        foreach ($viewTransformers as $viewTransformer) {
+            if ($viewTransformer instanceof NumberToLocalizedStringTransformer) {
+                $builder
+                    ->addViewTransformer(new NumberToLocalizedStringTransformer(
+                        $options['scale'],
+                        $options['grouping'],
+                        $options['rounding_mode'],
+                        $options['html5'] ? 'en' : $this->localeNumberTransformer->getLocaleForNumberInputs()
+                    ))
+                ;
+            } else {
+                $builder->addViewTransformer($viewTransformer);
+            }
+        }
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
@@ -17,6 +17,12 @@ services:
     tags:
       - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\MoneyType }
 
+  PrestaShopBundle\Form\Extension\NumberTypeExtension:
+    public: false
+    autowire: true
+    tags:
+      - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\NumberType }
+
   form.type.extension.resizable_text:
     class: 'PrestaShopBundle\Form\Admin\Type\ResizableTextType'
     tags:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
@@ -23,6 +23,12 @@ services:
     tags:
       - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\NumberType }
 
+  PrestaShopBundle\Form\Extension\IntegerTypeExtension:
+    public: false
+    autowire: true
+    tags:
+      - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\IntegerType }
+
   form.type.extension.resizable_text:
     class: 'PrestaShopBundle\Form\Admin\Type\ResizableTextType'
     tags:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
@@ -13,6 +13,7 @@ services:
       - '@prestashop.core.localization.locale.context_locale'
       - '@=service("prestashop.adapter.legacy.configuration").get("PS_CURRENCY_DEFAULT")'
       - '@PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository'
+      - '@PrestaShop\PrestaShop\Core\Localization\Number\LocaleNumberTransformer'
     tags:
       - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\MoneyType }
 

--- a/src/PrestaShopBundle/Resources/config/services/core/localization.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/localization.yml
@@ -28,3 +28,8 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Localization\RTL\StyleSheetProcessorFactory'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+
+  PrestaShop\PrestaShop\Core\Localization\Number\LocaleNumberTransformer:
+    public: false
+    arguments:
+      - '@prestashop.core.localization.locale.context_locale'

--- a/tests/Unit/Core/Localization/Number/LocaleNumberTransformerTest.php
+++ b/tests/Unit/Core/Localization/Number/LocaleNumberTransformerTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Localization\Number;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Localization\Locale;
+use PrestaShop\PrestaShop\Core\Localization\Number\LocaleNumberTransformer;
+
+class LocaleNumberTransformerTest extends TestCase
+{
+    /**
+     * Instantiate a LocaleNumberTransformer with custom locale.
+     *
+     * @param string $localeCode
+     *
+     * @return LocaleNumberTransformer
+     */
+    protected function createTransformer(string $localeCode): LocaleNumberTransformer
+    {
+        $locale = $this->createMock(Locale::class);
+        $locale->method('getCode')->willReturn($localeCode);
+
+        return new LocaleNumberTransformer($locale);
+    }
+
+    /**
+     * Test transformer
+     *
+     * @param string $localeCode
+     * @param string $expectedLocale
+     *
+     * @return void
+     *
+     * @dataProvider provideTransformerTest
+     */
+    public function testTransformer(string $localeCode, string $expectedLocale): void
+    {
+        $transformer = $this->createTransformer($localeCode);
+        $this->assertEquals($expectedLocale, $transformer->getLocaleForNumberInputs());
+    }
+
+    /**
+     * Provide data for transformer test.
+     *
+     * @return array[]
+     */
+    public function provideTransformerTest(): array
+    {
+        return [
+            ['ar_SA', 'en'],
+            ['fr_FR', 'fr'],
+            ['en_US', 'en'],
+            ['bn_BN', 'en'],
+            ['es_ES', 'es'],
+            ['fa_FA', 'en'],
+            ['it_IT', 'it'],
+        ];
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Extension/CustomMoneyTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Extension/CustomMoneyTypeTest.php
@@ -30,6 +30,7 @@ namespace Tests\Unit\PrestaShopBundle\Form\Admin\Extension;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
+use PrestaShop\PrestaShop\Core\Localization\Number\LocaleNumberTransformer;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Price;
 use PrestaShopBundle\Form\Admin\Type\CustomMoneyType;
 use Symfony\Component\Form\FormInterface;
@@ -53,12 +54,15 @@ class CustomMoneyTypeTest extends TestCase
         string $cldrPattern,
         string $expectedPattern
     ): void {
+        $localeNumberTransformer = $this->createMock(LocaleNumberTransformer::class);
+        $localeNumberTransformer->method('getLocaleForNumberInputs')->willReturn('en');
         $currencyRepository = $this->createMock(CurrencyRepository::class);
         $currencyRepository->method('getIsoCode')->willReturn($currencyIso);
         $customMoneyType = new CustomMoneyType(
             $this->mockLocale($cldrPattern, $symbol),
             self::DEFAULT_CURRENCY_ID,
-            $currencyRepository
+            $currencyRepository,
+            $localeNumberTransformer
         );
         $formView = $this->mockFormView();
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fix numbers format on some locales: `ar-SA` `bn-BD` and `fa-IR`.<br>In theses locales, we need to fallback to `en`, because admin front not worked at all with persian numbers.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #33871 
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/7084643335
| Fixed issue or discussion?     | Fixes #33871
| Related PRs       | 
| Sponsor company   | PrestaShop SA
