### PR TITLE
Load theme css on maintenance page

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -761,6 +761,7 @@ class FrontControllerCore extends Controller
                 header('HTTP/1.1 503 Service Unavailable');
                 header('Retry-After: 3600');
 
+                $this->setMedia();
                 $this->registerStylesheet('theme-error', '/assets/css/error.css', ['media' => 'all', 'priority' => 50]);
                 $this->context->smarty->assign([
                     'urls' => $this->getTemplateVarUrls(),


### PR DESCRIPTION
loads the theme css including custom.css on maintenance page.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix for issue 13505
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow instructions in issue report.
| UI Tests | https://github.com/florine2623/testing_pr/actions/runs/7102350393
| Fixed issue or discussion?     | Fixes #13505 
| Sponsor company   | Prestaworks AB