### PR TITLE
Fix potential TypeError in ProductLazyArray.php

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -578,7 +578,7 @@ class ProductLazyArray extends AbstractLazyArray
      */
     public function getCombinationSpecificData()
     {
-        if (!isset($this->product['attributes']) || empty($this->product['attributes'])) {
+        if (!isset($this->product['attributes']) || !is_array($this->product['attributes']) || empty($this->product['attributes'])) {
             return null;
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See bellow
| Type?             | bug fix
| Category?         | FO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | See bellow.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/34483
| Related PRs       | N/A
| Sponsor company   |Fintecture


Fix: `Fatal error: Uncaught TypeError: reset(): ProductLazyArray.php(564)`

When switch from French to English gb in the order confirmation page we have this error:
![image](https://github.com/PrestaShop/PrestaShop/assets/89129201/9af249f2-62e8-4b56-bb70-e238da60dd31)

Don't know if it's normal to receive a string however but at least it don't break the page :) 

I tried to print all values with this code in the function to find the responsible value:

```php
echo '<pre>';
var_dump($this->product['attributes']);
echo '</pre>';
```

And here's the problematic string: 

`string(9) "Taille: S"`