### PR TITLE
Update module versions in composer.lock (develop)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4791,23 +4791,23 @@
         },
         {
             "name": "prestashop/blockreassurance",
-            "version": "v5.1.2",
+            "version": "v5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/blockreassurance.git",
-                "reference": "fce56506ba8a29409faf6fd4763ba7c8bc149d78"
+                "reference": "e2d375e11b2e7d8a925754b3b75ee3cd2a27820d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/blockreassurance/zipball/fce56506ba8a29409faf6fd4763ba7c8bc149d78",
-                "reference": "fce56506ba8a29409faf6fd4763ba7c8bc149d78",
+                "url": "https://api.github.com/repos/PrestaShop/blockreassurance/zipball/e2d375e11b2e7d8a925754b3b75ee3cd2a27820d",
+                "reference": "e2d375e11b2e7d8a925754b3b75ee3cd2a27820d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.6.0"
             },
             "require-dev": {
-                "prestashop/php-dev-tools": "^3.4"
+                "prestashop/php-dev-tools": "^4.3"
             },
             "type": "prestashop-module",
             "autoload": {
@@ -4833,9 +4833,9 @@
             "description": "PrestaShop module blockreassurance",
             "homepage": "https://github.com/PrestaShop/blockreassurance",
             "support": {
-                "source": "https://github.com/PrestaShop/blockreassurance/tree/v5.1.2"
+                "source": "https://github.com/PrestaShop/blockreassurance/tree/v5.1.3"
             },
-            "time": "2023-03-02T09:50:00+00:00"
+            "time": "2023-10-02T05:44:46+00:00"
         },
         {
             "name": "prestashop/blockwishlist",
@@ -5430,20 +5430,23 @@
         },
         {
             "name": "prestashop/pagesnotfound",
-            "version": "v2.0.2",
+            "version": "v2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/pagesnotfound.git",
-                "reference": "ac5b640daa39356c8ca96679cbe58e83964b41d2"
+                "reference": "cf05fc7770f9beff2a5c2f17bdfe2da7652744db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/pagesnotfound/zipball/ac5b640daa39356c8ca96679cbe58e83964b41d2",
-                "reference": "ac5b640daa39356c8ca96679cbe58e83964b41d2",
+                "url": "https://api.github.com/repos/PrestaShop/pagesnotfound/zipball/cf05fc7770f9beff2a5c2f17bdfe2da7652744db",
+                "reference": "cf05fc7770f9beff2a5c2f17bdfe2da7652744db",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "prestashop/php-dev-tools": "^4.3"
             },
             "type": "prestashop-module",
             "notification-url": "https://packagist.org/downloads/",
@@ -5459,9 +5462,9 @@
             "description": "PrestaShop module pagesnotfound",
             "homepage": "https://github.com/PrestaShop/pagesnotfound",
             "support": {
-                "source": "https://github.com/PrestaShop/pagesnotfound/tree/v2.0.2"
+                "source": "https://github.com/PrestaShop/pagesnotfound/tree/v2.0.3"
             },
-            "time": "2022-01-11T07:53:21+00:00"
+            "time": "2023-06-16T10:59:52+00:00"
         },
         {
             "name": "prestashop/productcomments",
@@ -6365,16 +6368,16 @@
         },
         {
             "name": "prestashop/ps_featuredproducts",
-            "version": "v2.1.4",
+            "version": "v2.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_featuredproducts.git",
-                "reference": "4f546c142af54779a341c05e021577060d156c4b"
+                "reference": "7a2af5e20c987821c926ef8a8fdb502dfe07b533"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_featuredproducts/zipball/4f546c142af54779a341c05e021577060d156c4b",
-                "reference": "4f546c142af54779a341c05e021577060d156c4b",
+                "url": "https://api.github.com/repos/PrestaShop/ps_featuredproducts/zipball/7a2af5e20c987821c926ef8a8fdb502dfe07b533",
+                "reference": "7a2af5e20c987821c926ef8a8fdb502dfe07b533",
                 "shasum": ""
             },
             "require": {
@@ -6403,9 +6406,9 @@
             "description": "PrestaShop - Featured products",
             "homepage": "https://github.com/PrestaShop/ps_featuredproducts",
             "support": {
-                "source": "https://github.com/PrestaShop/ps_featuredproducts/tree/v2.1.4"
+                "source": "https://github.com/PrestaShop/ps_featuredproducts/tree/v2.1.5"
             },
-            "time": "2023-02-07T12:59:26+00:00"
+            "time": "2023-10-02T09:29:44+00:00"
         },
         {
             "name": "prestashop/ps_googleanalytics",
@@ -18174,5 +18177,5 @@
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | those are all patch module upgrades
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI and UI tests green
| UI Tests          | https://github.com/matthieu-rolland/ga.tests.ui.pr/actions/runs/6638523169
| Fixed issue or discussion?     | https://github.com/orgs/PrestaShop/projects/7/views/79?pane=issue&itemId=35204277
| Related PRs       | none
| Sponsor company   | Your company or customer's name goes here (if applicable).

## Updated modules:


- prestashop/blockreassurance :        v5.1.2 => v5.1.3
- prestashop/pagesnotfound :            v2.0.2 => v2.0.3            
- prestashop/ps_featuredproducts :   v2.1.4 => v2.1.5            
