### PR TITLE
Allow unit price to be zero even when displayed

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/UnitPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/UnitPriceType.php
@@ -36,7 +36,6 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Positive;
 use Symfony\Component\Validator\Constraints\PositiveOrZero;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -79,9 +78,6 @@ class UnitPriceType extends TranslatorAwareType
                     new NotBlank(),
                     new Type(['type' => 'float']),
                     new PositiveOrZero(),
-                    new Positive([
-                        'groups' => [self::ENABLED_GROUP],
-                    ]),
                 ],
                 'default_empty_data' => 0.0,
                 'modify_all_shops' => true,
@@ -95,9 +91,6 @@ class UnitPriceType extends TranslatorAwareType
                     new NotBlank(),
                     new Type(['type' => 'float']),
                     new PositiveOrZero(),
-                    new Positive([
-                        'groups' => [self::ENABLED_GROUP],
-                    ]),
                 ],
                 'default_empty_data' => 0.0,
                 'modify_all_shops' => true,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Allow unit price to be set to zero even when the display option is checked : some shops have the base product unit price set to zero and use the combination's unit price impact.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to Catalog > Products > Edit a product > Price Tab, then enable unit price display and set unit price to 0. Save and publish.
| UI Tests          | https://github.com/gbelorgey/ga.tests.ui.pr/actions/runs/6691061558
| Fixed issue or discussion?     | Fixes #34418, Fixes #34260
| Related PRs       | No
| Sponsor company   | No
