### PR TITLE
Make old style errors verbose.

### DIFF
--- a/admin-dev/filemanager/config/config.php
+++ b/admin-dev/filemanager/config/config.php
@@ -15,7 +15,7 @@ $products_accesses = Profile::getProfileAccess(Context::getContext()->employee->
 $cms_accesses = Profile::getProfileAccess(Context::getContext()->employee->id_profile, Tab::getIdFromClassName('AdminCmsContent'));
 
 if (!$products_accesses['edit'] && !$cms_accesses['edit']) {
-    die(Tools::displayError());
+    die(Tools::displayError('Access forbidden.'));
 }
 //------------------------------------------------------------------------------
 // DON'T COPY THIS VARIABLES IN FOLDERS config.php FILES

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -241,8 +241,11 @@ class CMSCategoryCore extends ObjectModel
      */
     protected function recursiveDelete(&$to_delete, $id_cms_category)
     {
-        if (!is_array($to_delete) || !$id_cms_category) {
-            die(Tools::displayError());
+        if (!is_array($to_delete)) {
+            die(Tools::displayError('Parameter "to_delete" is invalid.'));
+        }
+        if (!$id_cms_category) {
+            die(Tools::displayError('Parameter "id_cms_category" is invalid.'));
         }
 
         $result = Db::getInstance()->executeS('
@@ -341,7 +344,7 @@ class CMSCategoryCore extends ObjectModel
     public static function getCategories($id_lang, $active = true, $order = true)
     {
         if (!Validate::isBool($active)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "active" is invalid.'));
         }
 
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
@@ -385,7 +388,7 @@ class CMSCategoryCore extends ObjectModel
     public function getSubCategories($id_lang, $active = true)
     {
         if (!Validate::isBool($active)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "active" is invalid.'));
         }
 
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
@@ -433,7 +436,7 @@ class CMSCategoryCore extends ObjectModel
     public static function getChildren($id_parent, $id_lang, $active = true)
     {
         if (!Validate::isBool($active)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "active" is invalid.'));
         }
 
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -1247,7 +1247,7 @@ class CarrierCore extends ObjectModel
     public function setTaxRulesGroup($id_tax_rules_group, $all_shops = false)
     {
         if (!Validate::isUnsignedId($id_tax_rules_group)) {
-            die(Tools::displayError('Tax rule ID is invalid.'));
+            die(Tools::displayError('Parameter "id_tax_rules_group" is invalid.'));
         }
 
         if (!$all_shops) {

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -612,8 +612,11 @@ class CarrierCore extends ObjectModel
      */
     public static function getDeliveredCountries($id_lang, $active_countries = false, $active_carriers = false, $contain_states = null)
     {
-        if (!Validate::isBool($active_countries) || !Validate::isBool($active_carriers)) {
-            die(Tools::displayError());
+        if (!Validate::isBool($active_countries)) {
+            die(Tools::displayError('Parameter "active_countries" is invalid.'));
+        }
+        if (!Validate::isBool($active_carriers)) {
+            die(Tools::displayError('Parameter "active_carriers" is invalid.'));
         }
 
         $states = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
@@ -1244,7 +1247,7 @@ class CarrierCore extends ObjectModel
     public function setTaxRulesGroup($id_tax_rules_group, $all_shops = false)
     {
         if (!Validate::isUnsignedId($id_tax_rules_group)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Tax rule ID is invalid.'));
         }
 
         if (!$all_shops) {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1511,7 +1511,7 @@ class CartCore extends ObjectModel
         }
 
         if (!Validate::isLoadedObject($product)) {
-            die(Tools::displayError());
+            die(Tools::displayError(sprintf('Product with ID "%s" could not be loaded.', $id_product)));
         }
 
         if (isset(self::$_nbProducts[$this->id])) {
@@ -2029,7 +2029,7 @@ class CartCore extends ObjectModel
     {
         $cart = new Cart($id_cart);
         if (!Validate::isLoadedObject($cart)) {
-            die(Tools::displayError());
+            die(Tools::displayError(sprintf('Cart with ID "%s" could not be loaded.', $id_cart)));
         }
 
         $with_taxes = $use_tax_display ? $cart->_taxCalculationMethod != PS_TAX_EXC : true;

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -347,8 +347,11 @@ class CategoryCore extends ObjectModel
      */
     protected function recursiveDelete(&$toDelete, $idCategory)
     {
-        if (!is_array($toDelete) || !$idCategory) {
-            die(Tools::displayError());
+        if (!is_array($toDelete)) {
+            die(Tools::displayError('Parameter "toDelete" is invalid.'));
+        }
+        if (!$idCategory) {
+            die(Tools::displayError('Parameter "idCategory" is invalid.'));
         }
 
         $sql = new DbQuery();
@@ -611,7 +614,7 @@ class CategoryCore extends ObjectModel
     public static function getCategories($idLang = false, $active = true, $order = true, $sqlFilter = '', $orderBy = '', $limit = '')
     {
         if (!Validate::isBool($active)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "active" is invalid.'));
         }
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
             '
@@ -681,11 +684,11 @@ class CategoryCore extends ObjectModel
         $limit = ''
     ) {
         if (isset($idRootCategory) && !Validate::isInt($idRootCategory)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "idRootCategory" was provided, but it\'s not a valid integer.'));
         }
 
         if (!Validate::isBool($active)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "active" is invalid.'));
         }
 
         if (isset($groups) && Group::isFeatureActive() && !is_array($groups)) {
@@ -756,11 +759,11 @@ class CategoryCore extends ObjectModel
         $limit = ''
     ) {
         if (isset($idRootCategory) && !Validate::isInt($idRootCategory)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "idRootCategory" was provided, but it\'s not a valid integer.'));
         }
 
         if (!Validate::isBool($active)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "active" is invalid.'));
         }
 
         if (isset($groups) && Group::isFeatureActive() && !is_array($groups)) {
@@ -1131,7 +1134,7 @@ class CategoryCore extends ObjectModel
     public static function getChildren($idParent, $idLang, $active = true, $idShop = false)
     {
         if (!Validate::isBool($active)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "active" is invalid.'));
         }
 
         $cacheId = 'Category::getChildren_' . (int) $idParent . '-' . (int) $idLang . '-' . (bool) $active . '-' . (int) $idShop;
@@ -1167,7 +1170,7 @@ class CategoryCore extends ObjectModel
     public static function hasChildren($idParent, $idLang, $active = true, $idShop = false)
     {
         if (!Validate::isBool($active)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "active" is invalid.'));
         }
 
         $cacheId = 'Category::hasChildren_' . (int) $idParent . '-' . (int) $idLang . '-' . (bool) $active . '-' . (int) $idShop;

--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -220,7 +220,7 @@ class CookieCore
     public function __set($key, $value)
     {
         if (is_array($value)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Cookie value can\'t be an array.'));
         }
         if (preg_match('/¤|\|/', $key . $value)) {
             throw new Exception('Forbidden chars in cookie');

--- a/classes/Country.php
+++ b/classes/Country.php
@@ -211,7 +211,7 @@ class CountryCore extends ObjectModel
     public static function getIdZone($idCountry)
     {
         if (!Validate::isUnsignedId($idCountry)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Country ID is invalid.'));
         }
 
         if (isset(self::$_idZones[$idCountry])) {
@@ -362,8 +362,11 @@ class CountryCore extends ObjectModel
      */
     public static function getCountriesByZoneId($idZone, $idLang)
     {
-        if (empty($idZone) || empty($idLang)) {
-            die(Tools::displayError());
+        if (empty($idZone)) {
+            die(Tools::displayError('Zone ID is invalid.'));
+        }
+        if (empty($idLang)) {
+            die(Tools::displayError('Lang ID is invalid.'));
         }
 
         $sql = ' SELECT DISTINCT c.*, cl.*

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -829,7 +829,7 @@ class CustomerCore extends ObjectModel
     public static function checkPassword($idCustomer, $passwordHash)
     {
         if (!Validate::isUnsignedId($idCustomer)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Customer ID is invalid.'));
         }
 
         // Check that customers password hasn't changed since last login

--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -306,7 +306,7 @@ class EmployeeCore extends ObjectModel
     public function getByEmail($email, $plaintextPassword = null, $activeOnly = true)
     {
         if (!Validate::isEmail($email)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Email address is invalid.'));
         }
 
         $sql = new DbQuery();
@@ -359,7 +359,7 @@ class EmployeeCore extends ObjectModel
     public static function employeeExists($email)
     {
         if (!Validate::isEmail($email)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Email address is invalid.'));
         }
 
         return (bool) Db::getInstance()->getValue('
@@ -379,7 +379,7 @@ class EmployeeCore extends ObjectModel
     public static function checkPassword($idEmployee, $passwordHash)
     {
         if (!Validate::isUnsignedId($idEmployee)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Employee ID is invalid.'));
         }
 
         $sql = new DbQuery();

--- a/classes/Feature.php
+++ b/classes/Feature.php
@@ -155,7 +155,7 @@ class FeatureCore extends ObjectModel
         foreach ($fields as $field) {
             foreach (array_keys($field) as $key) {
                 if (!Validate::isTableOrIdentifier($key)) {
-                    die(Tools::displayError());
+                    die(Tools::displayError('Invalid column name in feature_lang table.'));
                 }
             }
 

--- a/classes/Image.php
+++ b/classes/Image.php
@@ -366,7 +366,7 @@ class ImageCore extends ObjectModel
     public static function deleteCover($idProduct)
     {
         if (!Validate::isUnsignedId($idProduct)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Product ID is invalid.'));
         }
 
         if (file_exists(_PS_TMP_IMG_DIR_ . 'product_' . $idProduct . '.jpg')) {

--- a/classes/ImageType.php
+++ b/classes/ImageType.php
@@ -136,7 +136,7 @@ class ImageTypeCore extends ObjectModel
     public static function typeAlreadyExists($typeName)
     {
         if (!Validate::isImageTypeName($typeName)) {
-            die(Tools::displayError());
+            die(Tools::displayError(sprintf('"%s" is not valid image type name.', $typeName)));
         }
 
         Db::getInstance()->executeS('

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -700,7 +700,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     public function deleteSelection($selection)
     {
         if (!is_array($selection)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "selection" must be an array.'));
         }
 
         $result = true;

--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -148,7 +148,7 @@ class ManufacturerCore extends ObjectModel
     public function deleteSelection($selection)
     {
         if (!is_array($selection)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "selection" must be an array.'));
         }
 
         $result = true;
@@ -404,7 +404,7 @@ class ManufacturerCore extends ObjectModel
         }
 
         if (!Validate::isOrderBy($orderBy) || !Validate::isOrderWay($orderWay)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Invalid sorting parameters provided.'));
         }
 
         $groups = FrontController::getCurrentCustomerGroups();

--- a/classes/Message.php
+++ b/classes/Message.php
@@ -114,7 +114,7 @@ class MessageCore extends ObjectModel
     public static function getMessagesByOrderId($idOrder, $private = false, Context $context = null)
     {
         if (!Validate::isBool($private)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "private" is invalid.'));
         }
 
         if (!$context) {
@@ -149,7 +149,7 @@ class MessageCore extends ObjectModel
     public static function getMessagesByCartId($idCart, $private = false, Context $context = null)
     {
         if (!Validate::isBool($private)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "private" is invalid.'));
         }
 
         if (!$context) {
@@ -180,8 +180,11 @@ class MessageCore extends ObjectModel
      */
     public static function markAsReaded($idMessage, $idEmployee)
     {
-        if (!Validate::isUnsignedId($idMessage) || !Validate::isUnsignedId($idEmployee)) {
-            die(Tools::displayError());
+        if (!Validate::isUnsignedId($idMessage)) {
+            die(Tools::displayError('Message ID is invalid.'));
+        }
+        if (!Validate::isUnsignedId($idEmployee)) {
+            die(Tools::displayError('Employee ID is invalid.'));
         }
 
         $result = Db::getInstance()->execute('

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -255,7 +255,7 @@ class MetaCore extends ObjectModel
     public function deleteSelection($selection)
     {
         if (!is_array($selection)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "selection" must be an array.'));
         }
         $result = true;
         foreach ($selection as $id) {

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -239,12 +239,12 @@ abstract class PaymentModuleCore extends Module
         if (!Validate::isLoadedObject($order_status)) {
             PrestaShopLogger::addLog('PaymentModule::validateOrder - Order Status cannot be loaded', 3, null, 'Cart', (int) $id_cart, true);
 
-            throw new PrestaShopException('Can\'t load Order status');
+            throw new PrestaShopException('Error processing order. Can\'t load Order status.');
         }
 
         if (!$this->active) {
             PrestaShopLogger::addLog('PaymentModule::validateOrder - Module is not active', 3, null, 'Cart', (int) $id_cart, true);
-            die(Tools::displayError());
+            die(Tools::displayError('Error processing order. Payment module is not active.'));
         }
 
         // Make sure cart is loaded and not related to an existing order
@@ -257,7 +257,7 @@ abstract class PaymentModuleCore extends Module
 
         if ($secure_key !== false && $secure_key != $this->context->cart->secure_key) {
             PrestaShopLogger::addLog('PaymentModule::validateOrder - Secure key does not match', 3, null, 'Cart', (int) $id_cart, true);
-            die(Tools::displayError());
+            die(Tools::displayError('Error processing order. Secure key does not match.'));
         }
 
         // For each package, generate an order

--- a/classes/PrestaShopBackup.php
+++ b/classes/PrestaShopBackup.php
@@ -132,7 +132,7 @@ class PrestaShopBackupCore
         }
 
         if ($backupfile === false || strncmp($backupdir, $backupfile, strlen($backupdir)) != 0) {
-            die(Tools::displayError());
+            die(Tools::displayError('Invalid backup file.'));
         }
 
         return $backupfile;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -913,7 +913,7 @@ class ProductCore extends ObjectModel
         if ((int) $id_customer > 0) {
             $customer = new Customer((int) $id_customer);
             if (!Validate::isLoadedObject($customer)) {
-                die(Tools::displayError());
+                die(Tools::displayError(sprintf('Customer with ID "%s" could not be loaded.', $id_customer)));
             }
             self::$_taxCalculationMethod = Group::getPriceDisplayMethod((int) $customer->id_default_group);
             $cur_cart = Context::getContext()->cart;
@@ -1645,7 +1645,7 @@ class ProductCore extends ObjectModel
         }
 
         if (!Validate::isOrderBy($order_by) || !Validate::isOrderWay($order_way)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Invalid sorting parameters provided.'));
         }
         if ($order_by == 'id_product' || $order_by == 'price' || $order_by == 'date_add' || $order_by == 'date_upd') {
             $order_by_prefix = 'p';
@@ -3024,7 +3024,7 @@ class ProductCore extends ObjectModel
             $order_by_prefix = 'pl';
         }
         if (!Validate::isOrderBy($order_by) || !Validate::isOrderWay($order_way)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Invalid sorting parameters provided.'));
         }
 
         $sql_groups = '';
@@ -3278,7 +3278,7 @@ class ProductCore extends ObjectModel
         Context $context = null
     ) {
         if (!Validate::isBool($count)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Parameter "count" is invalid.'));
         }
 
         if (!$context) {
@@ -3302,7 +3302,7 @@ class ProductCore extends ObjectModel
             $order_by_prefix = 'pl';
         }
         if (!Validate::isOrderBy($order_by) || !Validate::isOrderWay($order_way)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Invalid sorting parameters provided.'));
         }
         $current_date = date('Y-m-d H:i:00');
         $ids_product = Product::_getProductIdByDate((!$beginning ? $current_date : $beginning), (!$ending ? $current_date : $ending), $context);
@@ -3636,8 +3636,11 @@ class ProductCore extends ObjectModel
             Tools::displayParameterAsDeprecated('divisor');
         }
 
-        if (!Validate::isBool($usetax) || !Validate::isUnsignedId($id_product)) {
-            die(Tools::displayError());
+        if (!Validate::isBool($usetax)) {
+            die(Tools::displayError('Parameter "usetax" is invalid.'));
+        }
+        if (!Validate::isUnsignedId($id_product)) {
+            die(Tools::displayError('Product ID is invalid.'));
         }
 
         // Initializations
@@ -3657,7 +3660,7 @@ class ProductCore extends ObjectModel
             * When called from the back office, cart ID can be inexistant
             */
             if (!$id_cart && !isset($context->employee)) {
-                die(Tools::displayError());
+                die(Tools::displayError('If no employee is assigned in the context, cart ID must be provided to this method.'));
             }
             $cur_cart = new Cart($id_cart);
             // Store cart in context to avoid multiple instantiations in BO

--- a/classes/State.php
+++ b/classes/State.php
@@ -210,7 +210,7 @@ class StateCore extends ObjectModel
     public static function getStatesByIdCountry($idCountry, $active = false, $orderBy = null, $sort = 'ASC')
     {
         if (empty($idCountry)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Country ID is invalid.'));
         }
 
         $available_sort = ['DESC', 'ASC', 'asc', 'desc'];
@@ -241,7 +241,7 @@ class StateCore extends ObjectModel
     public static function getIdZone($idState)
     {
         if (!Validate::isUnsignedId($idState)) {
-            die(Tools::displayError());
+            die(Tools::displayError('State ID is invalid.'));
         }
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(

--- a/classes/Supplier.php
+++ b/classes/Supplier.php
@@ -301,7 +301,7 @@ class SupplierCore extends ObjectModel
         }
 
         if (!Validate::isOrderBy($orderBy) || !Validate::isOrderWay($orderWay)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Invalid sorting parameters provided.'));
         }
 
         $sqlGroups = '';

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1621,7 +1621,7 @@ class AdminControllerCore extends Controller
                     $back = self::$currentIndex . '&token=' . $this->token;
                 }
                 if (!Validate::isCleanHtml($back)) {
-                    die(Tools::displayError());
+                    die(Tools::displayError('Provided "back" parameter is invalid.'));
                 }
                 if (!$this->lite_display) {
                     $this->page_header_toolbar_btn['back'] = [
@@ -1694,7 +1694,7 @@ class AdminControllerCore extends Controller
                     $back = self::$currentIndex . '&token=' . $this->token;
                 }
                 if (!Validate::isCleanHtml($back)) {
-                    die(Tools::displayError());
+                    die(Tools::displayError('Provided "back" parameter is invalid.'));
                 }
                 if (!$this->lite_display) {
                     $this->toolbar_btn['cancel'] = [
@@ -1711,7 +1711,7 @@ class AdminControllerCore extends Controller
                     $back = self::$currentIndex . '&token=' . $this->token;
                 }
                 if (!Validate::isCleanHtml($back)) {
-                    die(Tools::displayError());
+                    die(Tools::displayError('Provided "back" parameter is invalid.'));
                 }
                 if (!$this->lite_display) {
                     $this->toolbar_btn['back'] = [
@@ -2497,7 +2497,7 @@ class AdminControllerCore extends Controller
                 $back = self::$currentIndex . '&token=' . $this->token;
             }
             if (!Validate::isCleanHtml($back)) {
-                die(Tools::displayError());
+                die(Tools::displayError('Provided "back" parameter is invalid.'));
             }
 
             $helper->back_url = $back;

--- a/classes/module/ModuleGraph.php
+++ b/classes/module/ModuleGraph.php
@@ -261,10 +261,10 @@ abstract class ModuleGraphCore extends Module
     public function create($render, $type, $width, $height, $layers)
     {
         if (!Validate::isModuleName($render)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Invalid graph module name.'));
         }
         if (!Tools::file_exists_cache($file = _PS_ROOT_DIR_ . '/modules/' . $render . '/' . $render . '.php')) {
-            die(Tools::displayError());
+            die(Tools::displayError('Main graph module file does not exist.'));
         }
         require_once $file;
         $this->_render = new $render($type);
@@ -295,7 +295,7 @@ abstract class ModuleGraphCore extends Module
             return Context::getContext()->getTranslator()->trans('No graph engine selected', [], 'Admin.Modules.Notification');
         }
         if (!Validate::isModuleName($render)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Invalid module name.'));
         }
         if (!file_exists(_PS_ROOT_DIR_ . '/modules/' . $render . '/' . $render . '.php')) {
             return Context::getContext()->getTranslator()->trans('Graph engine selected is unavailable.', [], 'Admin.Modules.Notification');

--- a/classes/module/ModuleGraph.php
+++ b/classes/module/ModuleGraph.php
@@ -295,7 +295,7 @@ abstract class ModuleGraphCore extends Module
             return Context::getContext()->getTranslator()->trans('No graph engine selected', [], 'Admin.Modules.Notification');
         }
         if (!Validate::isModuleName($render)) {
-            die(Tools::displayError('Invalid module name.'));
+            die(Tools::displayError('Invalid graph module name.'));
         }
         if (!file_exists(_PS_ROOT_DIR_ . '/modules/' . $render . '/' . $render . '.php')) {
             return Context::getContext()->getTranslator()->trans('Graph engine selected is unavailable.', [], 'Admin.Modules.Notification');

--- a/classes/module/ModuleGrid.php
+++ b/classes/module/ModuleGrid.php
@@ -105,7 +105,7 @@ abstract class ModuleGridCore extends Module
             return Context::getContext()->getTranslator()->trans('No grid engine selected', [], 'Admin.Modules.Notification');
         }
         if (!Validate::isModuleName($render)) {
-            die(Tools::displayError('Invalid module name.'));
+            die(Tools::displayError('Invalid grid module name.'));
         }
         if (!file_exists(_PS_ROOT_DIR_ . '/modules/' . $render . '/' . $render . '.php')) {
             return Context::getContext()->getTranslator()->trans('Grid engine selected is unavailable.', [], 'Admin.Modules.Notification');

--- a/classes/module/ModuleGrid.php
+++ b/classes/module/ModuleGrid.php
@@ -72,10 +72,10 @@ abstract class ModuleGridCore extends Module
     public function create($render, $type, $width, $height, $start, $limit, $sort, $dir)
     {
         if (!Validate::isModuleName($render)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Invalid grid module name.'));
         }
         if (!Tools::file_exists_cache($file = _PS_ROOT_DIR_ . '/modules/' . $render . '/' . $render . '.php')) {
-            die(Tools::displayError());
+            die(Tools::displayError('Main grid module file does not exist.'));
         }
         require_once $file;
         $this->_render = new $render($type);
@@ -105,7 +105,7 @@ abstract class ModuleGridCore extends Module
             return Context::getContext()->getTranslator()->trans('No grid engine selected', [], 'Admin.Modules.Notification');
         }
         if (!Validate::isModuleName($render)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Invalid module name.'));
         }
         if (!file_exists(_PS_ROOT_DIR_ . '/modules/' . $render . '/' . $render . '.php')) {
             return Context::getContext()->getTranslator()->trans('Grid engine selected is unavailable.', [], 'Admin.Modules.Notification');

--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -90,7 +90,7 @@ class OrderReturnCore extends ObjectModel
     {
         $order = new Order((int) $this->id_order);
         if (!Validate::isLoadedObject($order)) {
-            die(Tools::displayError());
+            die(Tools::displayError(sprintf('Order with ID "%s" could not be loaded.', $this->id_order)));
         }
         $products = $order->getProducts();
         /* Products already returned */
@@ -211,7 +211,7 @@ class OrderReturnCore extends ObjectModel
         $returns = Customization::getReturnedCustomizations($id_order);
         $order = new Order((int) $id_order);
         if (!Validate::isLoadedObject($order)) {
-            die(Tools::displayError());
+            die(Tools::displayError(sprintf('Order with ID "%s" could not be loaded.', $id_order)));
         }
         $products = $order->getProducts();
 

--- a/classes/tax/TaxRule.php
+++ b/classes/tax/TaxRule.php
@@ -63,7 +63,7 @@ class TaxRuleCore extends ObjectModel
     public static function deleteByGroupId($id_group)
     {
         if (empty($id_group)) {
-            die(Tools::displayError('Tax rule ID is invalid.'));
+            die(Tools::displayError('Parameter "id_group" (id_tax_rules_group you want to delete) is invalid.'));
         }
 
         return Db::getInstance()->execute(

--- a/classes/tax/TaxRule.php
+++ b/classes/tax/TaxRule.php
@@ -63,7 +63,7 @@ class TaxRuleCore extends ObjectModel
     public static function deleteByGroupId($id_group)
     {
         if (empty($id_group)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Tax rule ID is invalid.'));
         }
 
         return Db::getInstance()->execute(

--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -549,8 +549,12 @@ class AdminCustomerThreadsControllerCore extends AdminController
             }
         }
 
-        if (!$extension || !Validate::isFileName($filename)) {
-            die(Tools::displayError());
+        if (!$extension) {
+            die(Tools::displayError('Invalid file extension.'));
+        }
+
+        if (!Validate::isFileName($filename)) {
+            die(Tools::displayError('Invalid filename.'));
         }
 
         if (ob_get_level() && ob_get_length() > 0) {

--- a/controllers/admin/AdminFeaturesController.php
+++ b/controllers/admin/AdminFeaturesController.php
@@ -396,7 +396,7 @@ class AdminFeaturesControllerCore extends AdminController
             $back = self::$currentIndex . '&token=' . $this->token;
         }
         if (!Validate::isCleanHtml($back)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Provided "back" parameter is invalid.'));
         }
 
         $helper->back_url = $back;

--- a/controllers/admin/AdminRequestSqlController.php
+++ b/controllers/admin/AdminRequestSqlController.php
@@ -342,7 +342,7 @@ class AdminRequestSqlControllerCore extends AdminController
         $id = Tools::getValue($this->identifier);
         $export_dir = _PS_ADMIN_DIR_ . '/export/';
         if (!Validate::isFileName($id)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Invalid filename for export.'));
         }
         $file = 'request_sql_' . $id . '.csv';
         if ($csv = fopen($export_dir . $file, 'wb')) {

--- a/controllers/admin/AdminReturnController.php
+++ b/controllers/admin/AdminReturnController.php
@@ -232,7 +232,7 @@ class AdminReturnControllerCore extends AdminController
                     if (($id_order_return = (int) (Tools::getValue('id_order_return'))) && Validate::isUnsignedId($id_order_return)) {
                         $orderReturn = new OrderReturn($id_order_return);
                         if (!Validate::isLoadedObject($orderReturn)) {
-                            die(Tools::displayError());
+                            die(Tools::displayError(sprintf('Order return with ID "%s" could not be loaded.', $id_order_return)));
                         }
                         if ((int) ($orderReturn->countProduct()) > 1) {
                             if (OrderReturn::deleteOrderReturnDetail($id_order_return, $id_order_detail, (int) (Tools::getValue('id_customization', 0)))) {

--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -1000,7 +1000,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
         /** @var ModuleGraph|false $graph */
         $graph = Module::getInstanceByName($module);
         if (false === $graph) {
-            $this->ajaxRender(Tools::displayError());
+            $this->ajaxRender(Tools::displayError('Graph module could not be loaded.'));
 
             return;
         }
@@ -1040,7 +1040,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
         /** @var ModuleGrid|false $grid */
         $grid = Module::getInstanceByName($module);
         if (false === $grid) {
-            $this->ajaxRender(Tools::displayError());
+            $this->ajaxRender(Tools::displayError('Grid module could not be loaded.'));
 
             return;
         }

--- a/controllers/admin/AdminStatusesController.php
+++ b/controllers/admin/AdminStatusesController.php
@@ -477,7 +477,7 @@ class AdminStatusesControllerCore extends AdminController
             $back = self::$currentIndex . '&token=' . $this->token;
         }
         if (!Validate::isCleanHtml($back)) {
-            die(Tools::displayError());
+            die(Tools::displayError('Provided "back" parameter is invalid.'));
         }
 
         $helper->back_url = $back;

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -166,7 +166,7 @@ class GetFileControllerCore extends FrontController
             // Admin can directly access to file
             $filename = Tools::getValue('file');
             if (!Validate::isSha1($filename)) {
-                die(Tools::displayError());
+                die(Tools::displayError('Filename is not a valid SHA1 checksum.'));
             }
             $file = _PS_DOWNLOAD_DIR_ . (string) preg_replace('/\.{2,}/', '.', $filename);
             $filename = ProductDownload::getFilenameFromFilename(Tools::getValue('file'));

--- a/controllers/front/OrderFollowController.php
+++ b/controllers/front/OrderFollowController.php
@@ -63,7 +63,7 @@ class OrderFollowControllerCore extends FrontController
                 Tools::redirect('index.php?controller=order-detail&id_order=' . $id_order . '&errorNotReturnable');
             }
             if ($order->id_customer != $this->context->customer->id) {
-                die(Tools::displayError());
+                Tools::redirect('index.php?controller=order-detail&id_order=' . $id_order . '&errorNotReturnable');
             }
             $orderReturn = new OrderReturn();
             $orderReturn->id_customer = (int) $this->context->customer->id;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Makes all occurences of `Tools::displayError` verbose.
| Type?             | refacto
| Category?         | FO / BO / CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests green.
| UI Tests          |  https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/6731207489
| Fixed issue or discussion?     | 
| Related PRs       |
| Sponsor company   |

### Description
- Makes all occurences of Tools::displayError verbose. It will display something more meaningful in production FO instead of `Fatal error`.
- One small behavior change - if somebody tries to return an order of different customer, I redirected him to "errorNotReturnable" page, like in other cases.
- Skipped this - https://github.com/PrestaShop/PrestaShop/pull/34158
- Some of these will go away on develop, because checks like `Validate::isBool` will be superseeded by typed parameters in the methods.