### PR TITLE
Add a hook 'actionValidateOrderBefore' called before actionValidateOrder

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -221,6 +221,12 @@ abstract class PaymentModuleCore extends Module
             PrestaShopLogger::addLog('PaymentModule::validateOrder - Function called', 1, null, 'Cart', (int) $id_cart, true);
         }
 
+        Hook::exec('actionValidateOrderBefore', [
+            'cart' => $this->context->cart,
+            'customer' => $this->context->customer,
+            'currency' => $this->context->currency,
+        ]);
+
         $this->context->cart = new Cart((int) $id_cart);
         $this->context->customer = new Customer((int) $this->context->cart->id_customer);
         // The tax cart is loaded before the customer so re-cache the tax calculation method

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -16,6 +16,11 @@
       <title>After validating an order</title>
       <description>This hook is called after validating an order by core</description>
     </hook>
+    <hook id="actionValidateOrderBefore">
+      <name>actionValidateOrderBefore</name>
+      <title>Before validating an order</title>
+      <description>This hook is called before validating an order by core</description>
+    </hook>
     <hook id="displayMaintenance">
       <name>displayMaintenance</name>
       <title>Maintenance Page</title>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add a new hook 'actionValidateOrderBefore'. This hook is called before the creation of an order
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | From a module register the hook and create the function hookActionValidateOrderBefore
| UI Tests          | https://github.com/bibips/ga.tests.ui.pr/actions/runs/6709834106
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/34432

When the order tunnel is customized with additional steps, developers need to verify the data entered by the user within the tunnel steps.
It is of course possible to verify this data at each stage of the order tunnel, but it is also preferable to check the integrity of the data just before confirming the order.

For example, in the case of an order tunnel stage where the customer can enter a date in the future, it is necessary to check this date again when the customer confirms the order. This check avoids data inconsistencies when the customer confirms his basket several days after creating it.