### PR TITLE
Protect js folder from dangerous files

### DIFF
--- a/js/.htaccess
+++ b/js/.htaccess
@@ -11,7 +11,7 @@
 <IfModule !mod_authz_core.c>
     Order deny,allow
     Deny from all
-    <Files ~ "(?i)^.*\.(css|js|gif|png)$">
+    <Files ~ "(?i)^.*\.(css|js|gif|png|jpg|svg|html|map|eot|ttf|woff)$">
         Allow from all
     </Files>
     <Files ~ "(?i)^.*(jquery\.noConflict\.php|retro-compat\.js\.php)$">
@@ -22,7 +22,7 @@
 # Apache 2.4
 <IfModule mod_authz_core.c>
     Require all denied
-    <Files ~ "(?i)^.*\.(css|js|gif|png)$">
+    <Files ~ "(?i)^.*\.(css|js|gif|png|jpg|svg|html|map|eot|ttf|woff)$">
         Require all granted
     </Files>
     <Files ~ "(?i)^.*(jquery\.noConflict\.php|retro-compat\.js\.php)$">

--- a/js/.htaccess
+++ b/js/.htaccess
@@ -7,3 +7,25 @@
 </IfModule>
 
 
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+    <Files ~ "(?i)^.*\.(css|js|gif|png)$">
+        Allow from all
+    </Files>
+    <Files ~ "(?i)^.*(jquery\.noConflict\.php|retro-compat\.js\.php)$">
+        Allow from all
+    </Files>
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+    <Files ~ "(?i)^.*\.(css|js|gif|png)$">
+        Require all granted
+    </Files>
+    <Files ~ "(?i)^.*(jquery\.noConflict\.php|retro-compat\.js\.php)$">
+        Require all granted
+    </Files>
+</IfModule>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | There were several attacks where the attacker stored some PHP files into js folder. This PR prevents this and allows only selected files. Exceptions are two native files there. (jquery.noConflict, retro-compat)
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests green, try to put some PHP file in /js directory and try to access it from your browser.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
