### PR TITLE
Update jquery.no conflict.php - prevent E_NOTICE

### DIFF
--- a/js/jquery/jquery.noConflict.php
+++ b/js/jquery/jquery.noConflict.php
@@ -1,6 +1,6 @@
 <?php
 
 header('content-type: application/x-javascript');
-if (preg_match('/^([0-9\.]+)$/Ui', $_GET['version'])) {
+if (isset($_GET['version']) && preg_match('/^([0-9\.]+)$/Ui', $_GET['version'])) {
     echo 'var $j'.str_replace('.', '', $_GET['version']).' = jQuery.noConflict(true);';
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Bots sometime access this unused file and it throws E_NOTICE into logs. 
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open file https://domain.tld/js/jquery/jquery.noConflict.php in browser, you got E_NOTICE. After this commit, E_NOTICE disappeared.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
