### PR TITLE
Update retro-compat.js.php - prevent PHP Warning

### DIFF
--- a/js/retro-compat.js.php
+++ b/js/retro-compat.js.php
@@ -110,7 +110,7 @@ $plugins = array(
     array('new_file' => 'admin/tinymce.inc.js', 'name' => 'tinymce'),
 );
 
-$file = $_GET['file'];
+$file = ($_GET['file'] ?? null);
 if (!array_key_exists($file, $plugins)) {
     //check if file is a real prestashop native JS
     die('file_not_found');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Bots sometime access this file and it throws PHP Warning into server php logs: [01-Nov-2023 14:38:04 Europe/Prague] PHP Warning:  Undefined array key "file" in /XXXX/retro-compat.js.php on line 113
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Access directly via browser to this file https://domain.tld/js/retro-compat.js.php
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
