### PR TITLE
Fixed SQL apostrophe (') incompatibility

### DIFF
--- a/src/Adapter/Product/Update/ProductDuplicator.php
+++ b/src/Adapter/Product/Update/ProductDuplicator.php
@@ -1025,7 +1025,7 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
                     return 'null';
                 }
 
-                if(gettype($columnValue) == "string") {
+                if (gettype($columnValue) == 'string') {
                     $columnValue = str_replace("'", "''", $columnValue);
                 }
 

--- a/src/Adapter/Product/Update/ProductDuplicator.php
+++ b/src/Adapter/Product/Update/ProductDuplicator.php
@@ -1025,7 +1025,7 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
                     return 'null';
                 }
 
-                if (gettype($columnValue) == 'string') {
+                if (is_string($columnValue)) {
                     $columnValue = str_replace("'", "''", $columnValue);
                 }
 

--- a/src/Adapter/Product/Update/ProductDuplicator.php
+++ b/src/Adapter/Product/Update/ProductDuplicator.php
@@ -1025,6 +1025,10 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
                     return 'null';
                 }
 
+                if(gettype($columnValue) == "string") {
+                    $columnValue = str_replace("'", "''", $columnValue);
+                }
+
                 // We stringify values to avoid SQL syntax error, the float and integers will correctly casted in the DB anyway
                 // however string values and date time need to be quoted
                 return "'$columnValue'";


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fixed the problem that was caused by apostrophes in SQL queries, this problem happened when the user write something like "Merci d'insérer votre personnalisation" as the apostrophe (') was considered as the end of the string.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to duplicate an item with a apostrophe (') in the customization field
| Fixed issue or discussion?     | Fixes #34442
