### PR TITLE
Remove useless htaccess rule for not existing file retro-compat.css.php

### DIFF
--- a/js/.htaccess
+++ b/js/.htaccess
@@ -2,8 +2,6 @@
     RewriteEngine on
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule "([^/]*)\.js$" retro-compat.js.php?file=$1.js [QSA,L]
-    RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule "([^/]*)\.css$" ../css/retro-compat.css.php?file=$1.css [QSA,L]
 </IfModule>
 
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | The purpose of this rule was to redirect all legacy calls to CSS files to this PHP file. But, file retro-compat.css.php doesn't exist anymore, so this .htaccess rule is totally useless.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Look for existence of file retro-compat.css.php (not exists)
| UI Tests          | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
