### PR TITLE
Fix php warning webservice

### DIFF
--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -91,7 +91,7 @@ if (!class_exists($class_name)) {
 WebserviceRequest::$ws_current_classname = $class_name;
 $request = call_user_func([$class_name, 'getInstance']);
 
-$result = $request->fetch($key, $method, $_GET['url'], $params, $bad_class_name, $input_xml);
+$result = $request->fetch($key, $method, (isset($_GET['url']) ?? null), $params, $bad_class_name, $input_xml);
 // display result
 if (ob_get_length() != 0) {
     header('Content-Type: application/javascript');

--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -91,7 +91,7 @@ if (!class_exists($class_name)) {
 WebserviceRequest::$ws_current_classname = $class_name;
 $request = call_user_func([$class_name, 'getInstance']);
 
-$result = $request->fetch($key, $method, (isset($_GET['url']) ?? null), $params, $bad_class_name, $input_xml);
+$result = $request->fetch($key, $method, ($_GET['url'] ?? ''), $params, $bad_class_name, $input_xml);
 // display result
 if (ob_get_length() != 0) {
     header('Content-Type: application/javascript');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | If you access via browser to URL https://YOUR_KEY@domain.tld/webservice/dispatcher.php, php error log will be filled with PHP warning, like this: <br/>`PHP Warning:  Undefined array key "url" in /XXX/webservice/dispatcher.php on line 94`
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create webservice key, enable webservice and then open URL https://YOUR_KEY@domain.tld/webservice/dispatcher.php. php warning will not be logged again after fix
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/6730164748
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
