### PR TITLE
Validate smarty render calls (prevent errors from outdated themes)

### DIFF
--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -91,9 +91,26 @@ function smartyWidget($params, &$smarty)
 
 function smartyRender($params, &$smarty)
 {
+    // Check if proper object was passed
+    if (empty($params['ui']) || !method_exists($params['ui'], 'render')) {
+        if (_PS_MODE_DEV_) {
+            trigger_error(
+                sprintf(
+                    'When using {render}, you must provide proper `ui` parameter with the form. Template - %1$s',
+                    $smarty->source->filepath
+                ),
+                E_USER_NOTICE
+            );
+        }
+        return;
+    }
+
     $ui = $params['ui'];
 
-    if (array_key_exists('file', $params)) {
+    // If specific template file was provided, we pass it along
+    if (!empty($params['file'])) {
+        // Ignoring the next line because PHPStan is not aware of the object passed
+        /** @phpstan-ignore-next-line */
         $ui->setTemplate($params['file']);
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Read below
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | You should have incorrect theme or add code above to file order-confirmation.tpl. Then you will receive error 500 with guest checkout. With this PR, error 500 dissapeared and working without problems.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/6861890949
| Fixed issue or discussion?     | I found, another e-shop owners had same issues with this: https://www.prestashop.com/forums/topic/1078118-error-500-php-fatal-error-uncaught-error-call-to-a-member-function-settemplate-on-null-in-configsmartyfrontconfigincphp97/
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/

### Description
Some "up to date" templates are targeted for PS 8.1, but throwing fatal errors. For example on order confirmation page due to guest conversion box, because some templates are using obsolete code from older versions PS... :/ (check code below)

This PR improving this behaviour. Because this take 2 hours of my life to investigate, what is happening there and for other people it can be useful. It is problem with theme developers, but PrestaShop must do the best to protect customers from bad themes as well. For end customer is very complicated to find, why they are receiving Fatal error 500 with guest order only and for any developers as well........

**This PR can handle this problem and can protect eshop owners from outdated themes for example.**

This is part of incorrect usage. This is reason for Fatal error 500 (line with "{render file=XXXX}".

```
  {block name='customer_registration_form'}
    {if $customer.is_guest}
      <div id="registration-form" class="card">
        <div class="card-block">
          <h4 class="h4">{l s='Save time on your next order, sign up now' d='Shop.Theme.Checkout'}</h4>
          {render file='customer/_partials/customer-form.tpl' ui=$register_form}
        </div>
      </div>
    {/if}
  {/block}
```

Here is the part of code, what is incorrectly used and do error 500 with PS 8.1
https://github.com/PrestaShop/PrestaShop/blob/e7a1e3e7cd8be3bc7a023b3c03c3bdd51ea4f1dc/themes/classic/templates/checkout/order-confirmation.tpl#L95C10-L95C10

### The fix
This PR verifies if proper VALID parameters were submitted with the call, and point the user to faulty template. In production mode, the call will be skipped. In dev mode, it throws a notice.

Follows the same logic as in https://github.com/PrestaShop/PrestaShop/pull/31092.
![Snímek obrazovky 2023-11-02 124312](https://github.com/PrestaShop/PrestaShop/assets/6097524/1e376a65-ead5-4d23-9473-8c8e26cf94eb)
