### PR TITLE
Prevent Internal Server Error 500 - opcache_invalidate with restrict_api

### DIFF
--- a/src/Adapter/Configuration/PhpParameters.php
+++ b/src/Adapter/Configuration/PhpParameters.php
@@ -88,7 +88,7 @@ class PhpParameters
             $filesystem->dumpFile($this->filename, '<?php return ' . var_export($this->configuration->get(), true) . ';' . "\n");
 
             if (function_exists('opcache_invalidate')) {
-               @opcache_invalidate($this->filename);
+                @opcache_invalidate($this->filename);
             }
         } catch (IOException $e) {
             return false;

--- a/src/Adapter/Configuration/PhpParameters.php
+++ b/src/Adapter/Configuration/PhpParameters.php
@@ -88,7 +88,7 @@ class PhpParameters
             $filesystem->dumpFile($this->filename, '<?php return ' . var_export($this->configuration->get(), true) . ';' . "\n");
 
             if (function_exists('opcache_invalidate')) {
-                opcache_invalidate($this->filename);
+               @opcache_invalidate($this->filename);
             }
         } catch (IOException $e) {
             return false;

--- a/src/Adapter/Debug/DebugMode.php
+++ b/src/Adapter/Debug/DebugMode.php
@@ -128,7 +128,7 @@ class DebugMode
         }
 
         if (function_exists('opcache_invalidate')) {
-            opcache_invalidate($filename);
+            @opcache_invalidate($filename);
         }
 
         return self::DEBUG_MODE_SUCCEEDED;
@@ -157,7 +157,7 @@ class DebugMode
         }
 
         if (function_exists('opcache_invalidate')) {
-            opcache_invalidate($customFileName);
+            @opcache_invalidate($customFileName);
         }
 
         return self::DEBUG_MODE_SUCCEEDED;

--- a/src/Adapter/Debug/DebugProfiling.php
+++ b/src/Adapter/Debug/DebugProfiling.php
@@ -129,7 +129,7 @@ class DebugProfiling
         }
 
         if (function_exists('opcache_invalidate')) {
-            opcache_invalidate($filename);
+            @opcache_invalidate($filename);
         }
 
         return self::DEBUG_PROFILING_SUCCEEDED;
@@ -158,7 +158,7 @@ class DebugProfiling
         }
 
         if (function_exists('opcache_invalidate')) {
-            opcache_invalidate($customFileName);
+            @opcache_invalidate($customFileName);
         }
 
         return self::DEBUG_PROFILING_SUCCEEDED;

--- a/src/Adapter/Smarty/SmartyCacheConfiguration.php
+++ b/src/Adapter/Smarty/SmartyCacheConfiguration.php
@@ -137,7 +137,7 @@ class SmartyCacheConfiguration implements DataConfigurationInterface
         $status = file_put_contents($file, preg_replace(self::PATTERN, $replacement, $content));
 
         if (function_exists('opcache_invalidate')) {
-           @opcache_invalidate($file);
+            @opcache_invalidate($file);
         }
 
         return $status !== false;

--- a/src/Adapter/Smarty/SmartyCacheConfiguration.php
+++ b/src/Adapter/Smarty/SmartyCacheConfiguration.php
@@ -137,7 +137,7 @@ class SmartyCacheConfiguration implements DataConfigurationInterface
         $status = file_put_contents($file, preg_replace(self::PATTERN, $replacement, $content));
 
         if (function_exists('opcache_invalidate')) {
-            opcache_invalidate($file);
+           @opcache_invalidate($file);
         }
 
         return $status !== false;

--- a/src/Core/SqlManager/Configuration/SqlRequestConfiguration.php
+++ b/src/Core/SqlManager/Configuration/SqlRequestConfiguration.php
@@ -147,7 +147,7 @@ final class SqlRequestConfiguration implements DataConfigurationInterface
         $status = file_put_contents($file, preg_replace(self::PATTERN, $replacement, $content));
 
         if (function_exists('opcache_invalidate')) {
-            opcache_invalidate($file);
+            @opcache_invalidate($file);
         }
 
         return $status !== false;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Check below
| Type?             | improvement
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Check below
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/

**Description:**
 - If opcache is enabled and webhosting have restrict_api enabled (for security reasons to other folder), you will got Internal Server Error 500 when you enable Debug mode via BO everytime. (check screenshot below)
 -  this is very specific setting for shared webhostings, because restrict_api prevent leak informations from other virtual hosts of other customers at webhosting environment.
  - btw - For profiling it's same, so I updated all files with "opcache_invalidate" - it should be same on every place...

**How to test?:**

- enable opcache and set "restrict_api" to other folder outside of your website
- enable debug mode (PrestaShop BO) and you will get error 500.


This PR fixing this problem with supress of warning from function opcache_invalidate.
_Supress isn't ideal way, but there isn't any other way._

(This PR is already tested over years on more than 100 PrestaShop e-shops without any negative impact)

![Untitled](https://github.com/PrestaShop/PrestaShop/assets/8518736/6b3a1a1e-c990-4f80-bffb-ee8879b6e9e0)
