### PR TITLE
CO: improvement : Performance String Modifier

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -58,6 +58,7 @@ class ToolsCore
     protected static $file_exists_cache = [];
     protected static $_forceCompile;
     protected static $_caching;
+    protected static $_string_modifier;
     protected static $_user_plateform;
     protected static $_user_browser;
     protected static $request;
@@ -1391,7 +1392,7 @@ class ToolsCore
             $allow_accented_chars = Configuration::get('PS_ALLOW_ACCENTED_CHARS_URL');
         }
 
-        return (new StringModifier())->str2url((string) $str, $allow_accented_chars);
+        return (self::getStringModifier())->str2url((string) $str, $allow_accented_chars);
     }
 
     /**
@@ -1403,9 +1404,22 @@ class ToolsCore
      */
     public static function replaceAccentedChars($str)
     {
-        return (new StringModifier())->replaceAccentedChars($str);
+        return (self::getStringModifier())->replaceAccentedChars($str);
     }
 
+    /**
+    * Reuse the StringModifier for performance reasons.
+    *
+    * @return StringModifier
+    */
+    private static function getStringModifier()
+    {
+        if(!isset(self::$_string_modifier)) {
+            self::$_string_modifier = new StringModifier();
+        }
+        return self::$_string_modifier;
+    }
+    
     /**
      * Truncate strings.
      *

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1420,7 +1420,7 @@ class ToolsCore
 
         return self::$_string_modifier;
     }
-    
+
     /**
      * Truncate strings.
      *

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1409,9 +1409,9 @@ class ToolsCore
 
     /**
     * Reuse the StringModifier for performance reasons.
-    *
-    * @return StringModifier
-    */
+     *
+     * @return StringModifier
+     */
     private static function getStringModifier()
     {
         if (!isset(self::$_string_modifier)) {

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1417,6 +1417,7 @@ class ToolsCore
         if(!isset(self::$_string_modifier)) {
             self::$_string_modifier = new StringModifier();
         }
+
         return self::$_string_modifier;
     }
     

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1408,7 +1408,7 @@ class ToolsCore
     }
 
     /**
-    * Reuse the StringModifier for performance reasons.
+     * Reuse the StringModifier for performance reasons.
      *
      * @return StringModifier
      */

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1414,7 +1414,7 @@ class ToolsCore
     */
     private static function getStringModifier()
     {
-        if(!isset(self::$_string_modifier)) {
+        if (!isset(self::$_string_modifier)) {
             self::$_string_modifier = new StringModifier();
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This improvements makes reuse of the StringModifier. Why is this an issue? I.e. if a product has many combinations, for each combination a new StringModifier with the whole tail will be created in the initContent method of the frontend ProductController, which costs a good time. There is no need for it and we can just reuse it.
| Type?             |  improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Profile a product with 2000 combinations and look at the initContent time.
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/6747522063
| Fixed issue or discussion?     | Fixes #34453
| Sponsor company   | Shoprunners
