### PR TITLE
Improve front office date validation

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -696,7 +696,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 $this->combinations[$row['id_product_attribute']]['isbn'] = $row['isbn'];
                 $this->combinations[$row['id_product_attribute']]['unit_impact'] = $row['unit_price_impact'];
                 $this->combinations[$row['id_product_attribute']]['minimal_quantity'] = $row['minimal_quantity'];
-                if ($row['available_date'] != '0000-00-00' && Validate::isDate($row['available_date'])) {
+                if (!empty($row['available_date']) && $row['available_date'] != '0000-00-00' && Validate::isDate($row['available_date'])) {
                     $this->combinations[$row['id_product_attribute']]['available_date'] = $row['available_date'];
                     $this->combinations[$row['id_product_attribute']]['date_formatted'] = Tools::displayDate($row['available_date']);
                 } else {

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -43,6 +43,7 @@ use Product;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Tools;
+use Validate;
 
 /**
  * @property string $availability_message
@@ -919,7 +920,7 @@ class ProductLazyArray extends AbstractLazyArray
         }
 
         // If availability date already passed, we don't want to show it
-        if (isset($product['available_date'])) {
+        if (!empty($product['available_date']) && $product['available_date'] != '0000-00-00' && Validate::isDate($product['available_date'])) {
             $date = new DateTime($product['available_date']);
             if ($date < new DateTime()) {
                 $product['available_date'] = null;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Better validates dates in front office to account for NULL or zero dates.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests green & see below
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/6746117604
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/pull/34441#issuecomment-1790868628
| Related PRs       | 
| Sponsor company   | 

### How to test
- Duplicate a product in backoffice using new product page.
- Go to front office and there should be notices when visiting this product.

cc @florine2623 