### PR TITLE
Add support for PHP 8.3

### DIFF
--- a/.github/workflows/api-module.yml
+++ b/.github/workflows/api-module.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '8.1', '8.2' ]
+        php: [ '8.1', '8.2', '8.3' ]
       fail-fast: false
     steps:
       - name: Setup PHP

--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '8.1', '8.2' ]
+        php: [ '8.1', '8.2', '8.3' ]
       fail-fast: false
     steps:
       - name: Setup PHP

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '8.1', '8.2' ]
+        php: [ '8.1', '8.2', '8.3' ]
       fail-fast: false
     steps:
       - name: Setup PHP

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '8.1', '8.2' ]
+        php: [ '8.1', '8.2', '8.3' ]
       fail-fast: false
     steps:
       - name: Setup PHP
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '8.1', '8.2' ]
+        php: [ '8.1', '8.2', '8.3' ]
       fail-fast: false
     steps:
       - name: Setup PHP

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -20,7 +20,7 @@ jobs:
     name: Sanity
     strategy:
       matrix:
-        php: [ '8.1', '8.2' ]
+        php: [ '8.1', '8.2', '8.3' ]
         browser: [ 'chromium', 'firefox', 'webkit' ]
       fail-fast: false
 

--- a/install-dev/install_version.php
+++ b/install-dev/install_version.php
@@ -28,7 +28,7 @@
 // in very basic scripts that don't use autoload and can't recognize the class
 define('_PS_INSTALL_VERSION_', '9.0.0');
 define('_PS_INSTALL_MINIMUM_PHP_VERSION_ID_', 80100);
-define('_PS_INSTALL_MAXIMUM_PHP_VERSION_ID_', 80299);
+define('_PS_INSTALL_MAXIMUM_PHP_VERSION_ID_', 80399);
 
 define('_PS_INSTALL_MINIMUM_PHP_VERSION_', '8.1');
-define('_PS_INSTALL_MAXIMUM_PHP_VERSION_', '8.2');
+define('_PS_INSTALL_MAXIMUM_PHP_VERSION_', '8.3');

--- a/tools/build/Library/InstallUnpacker/index_template.php
+++ b/tools/build/Library/InstallUnpacker/index_template.php
@@ -27,8 +27,8 @@ set_time_limit(0);
 
 define('_PS_INSTALL_MINIMUM_PHP_VERSION_ID_', 80100);
 define('_PS_INSTALL_MINIMUM_PHP_VERSION_', '8.1');
-define('_PS_INSTALL_MAXIMUM_PHP_VERSION_ID_', 80199);
-define('_PS_INSTALL_MAXIMUM_PHP_VERSION_', '8.1');
+define('_PS_INSTALL_MAXIMUM_PHP_VERSION_ID_', 80399);
+define('_PS_INSTALL_MAXIMUM_PHP_VERSION_', '8.3');
 define('_PS_VERSION_', '%ps-version-placeholder%');
 
 define('ZIP_NAME', 'prestashop.zip');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add support for PHP 8.3
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | ~
| UI Tests          | UI tests with PHP 8.3 https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/7971700654
| Fixed issue or discussion?     | ~
| Related PRs       | https://github.com/PrestaShop/docker/pull/356 First, we need the base docker in PHP 8.3 for sanity tests
| Sponsor company   | ~
