### PR TITLE
Improve error message on login page

### DIFF
--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -63,6 +63,8 @@ class AdminLoginControllerCore extends AdminController
         $this->addJS(_PS_JS_DIR_ . 'vendor/spin.js');
         $this->addJS(_PS_JS_DIR_ . 'vendor/ladda.js');
         Media::addJsDef(['img_dir' => _PS_IMG_]);
+
+        // Error wordings, one_error is not used anymore
         Media::addJsDefL('one_error', $this->trans('There is one error.', [], 'Admin.Notifications.Error'));
         Media::addJsDefL('more_errors', $this->trans('There are several errors.', [], 'Admin.Notifications.Error'));
 

--- a/js/admin/login.js
+++ b/js/admin/login.js
@@ -287,8 +287,18 @@ function doAjaxReset() {
 }
 
 function displayErrors(errors) {
-	str_errors = '<p><strong>' + (errors.length > 1 ? more_errors : one_error) + '</strong></p><ol>';
-	for (var error in errors) //IE6 bug fix
-		if (error != 'indexOf') str_errors += '<li>' + errors[error] + '</li>';
-	$('#error').html(str_errors + '</ol>').removeClass('hide').fadeIn('slow');
+	if (errors.length > 1) {
+		// If there were multiple issues, we display an error list
+		str_errors = '<p><strong>' + more_errors + '</strong></p><ol>';
+		for (var error in errors) {
+			if (error != 'indexOf') {
+				str_errors += '<li>' + errors[error] + '</li>';
+			}
+		}
+		str_errors += '</ol>';
+	} else {
+		// Otherwise, just the first error in the list
+		str_errors = '<p>' + errors[0] + '</p>';
+	}
+	$('#error').html(str_errors).removeClass('hide').fadeIn('slow');
 }

--- a/tests/UI/pages/BO/login/index.ts
+++ b/tests/UI/pages/BO/login/index.ts
@@ -47,7 +47,7 @@ class Login extends BOBasePage {
     this.passwordInput = '#passwd';
     this.submitLoginButton = '#submit_login';
     this.alertDangerDiv = '#error';
-    this.alertDangerTextBlock = `${this.alertDangerDiv} li`;
+    this.alertDangerTextBlock = `${this.alertDangerDiv} p`;
     // reset password selectors
     this.forgotPasswordLink = '#forgot-password-link';
     this.resetPasswordEmailFormField = '#email_forgot';


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | When you put a wrong email or password, it shows `There is one error: 1. Some error message` on login page. Now it will just show `Some error message` if there is just one. 
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests green.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/6785688583, 2nd attempt - https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/6791367917
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

![dasd](https://github.com/PrestaShop/PrestaShop/assets/6097524/2319e4f8-314d-40e9-90a1-527022e2aa8b)
⏬⏬⏬ 
![Snímek obrazovky 2023-11-06 233409](https://github.com/PrestaShop/PrestaShop/assets/6097524/2f9af90c-e8fa-493b-ad33-3517f561f8b0)
