### PR TITLE
Remove calls to get products properties

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1059,8 +1059,7 @@ class CategoryCore extends ObjectModel
             $result = array_slice($result, (int) (($pageNumber - 1) * $productPerPage), (int) $productPerPage);
         }
 
-        // Modify SQL result
-        return Product::getProductsProperties($idLang, $result);
+        return $result;
     }
 
     /**

--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -503,7 +503,7 @@ class ManufacturerCore extends ObjectModel
             $result = array_slice($result, (int) (($p - 1) * $n), (int) $n);
         }
 
-        return Product::getProductsProperties($idLang, $result);
+        return $result;
     }
 
     /**

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -405,19 +405,13 @@ class PackCore extends Product
             $line = Product::getTaxesInformations($line);
         }
 
-        if (!$full) {
-            return $result;
-        }
-
-        $array_result = [];
-        foreach ($result as $prow) {
-            if (!Pack::isPack($prow['id_product'])) {
-                $prow['id_product_attribute'] = (int) $prow['id_product_attribute_item'];
-                $array_result[] = Product::getProductProperties($id_lang, $prow);
+        foreach ($result as $k => $v) {
+            if (!Pack::isPack($v['id_product'])) {
+                $result[$k]['id_product_attribute'] = (int) $v['id_product_attribute_item'];
             }
         }
 
-        return $array_result;
+        return $result;
     }
 
     public static function getPacksTable($id_product, $id_lang, $full = false, $limit = null)
@@ -462,7 +456,7 @@ class PackCore extends Product
         $array_result = [];
         foreach ($result as $row) {
             if (!Pack::isPacked($row['id_product'])) {
-                $array_result[] = Product::getProductProperties($id_lang, $row);
+                $array_result[] = $row;
             }
         }
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3051,10 +3051,8 @@ class ProductCore extends ObjectModel
         foreach ($result as $row) {
             $products_ids[] = $row['id_product'];
         }
-        // Thus you can avoid one query per product, because there will be only one query for all the products of the cart
-        Product::cacheFrontFeatures($products_ids, $id_lang);
 
-        return Product::getProductsProperties((int) $id_lang, $result);
+        return $result;
     }
 
     /**
@@ -3175,7 +3173,7 @@ class ProductCore extends ObjectModel
 
             $row['id_product_attribute'] = (int) $result['id_product_attribute'];
 
-            return Product::getProductProperties($id_lang, $row);
+            return $row;
         } else {
             return false;
         }
@@ -3327,7 +3325,7 @@ class ProductCore extends ObjectModel
             $result = array_slice($result, (int) (($page_number - 1) * $nb_products), (int) $nb_products);
         }
 
-        return Product::getProductsProperties($id_lang, $result);
+        return $result;
     }
 
     /**
@@ -4619,7 +4617,7 @@ class ProductCore extends ObjectModel
             }
         }
 
-        return $this->getProductsProperties($id_lang, $result);
+        return $result;
     }
 
     /**
@@ -5510,8 +5508,12 @@ class ProductCore extends ObjectModel
             'context' => $context,
         ]);
 
-        if (!$row['id_product']) {
-            return false;
+        if (empty($row['id_product'])) {
+            if (!empty($row['id'])) {
+                $row['id_product'] = $row['id'];
+            } else {
+                return false;
+            }
         }
 
         if ($context == null) {

--- a/classes/ProductAssembler.php
+++ b/classes/ProductAssembler.php
@@ -26,7 +26,13 @@
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchContext;
 
 /**
- * Class ProductAssemblerCore.
+ * This class is responsible for enriching product data by all required fields
+ * in a performant way, before it goes into ProductLazyArray or ProductListingLazyArray.
+ *
+ * If you want to enrich a whole list of products, use assembleProducts method to get the data in one query.
+ *
+ * Currently, the data is passing through Product::getProductProperties also, but this step should be removed
+ * and all data from getProductProperties loaded on demand in the lazy arrays.
  */
 class ProductAssemblerCore
 {
@@ -70,7 +76,7 @@ class ProductAssemblerCore
     }
 
     /**
-     * Add missing product fields to multiple products
+     * Add missing product fields to multiple products.
      *
      * @param array $rawProducts
      *
@@ -108,7 +114,7 @@ class ProductAssemblerCore
     }
 
     /**
-     * Return the SQL query to get all product fields
+     * Return the SQL query to get all product fields.
      *
      * @param array $productIds
      *
@@ -170,6 +176,7 @@ class ProductAssemblerCore
     /**
      * Get basic product data for single product.
      * The only required property is id_product.
+     * If some data were already provided in $rawProduct, it won't be overwritten.
      *
      * @param array $rawProduct
      *
@@ -191,6 +198,7 @@ class ProductAssemblerCore
     /**
      * Get basic product data for multiple products.
      * The only required property for each product is id_product.
+     * If some data were already provided in $rawProducts, it won't be overwritten.
      *
      * @param array $rawProducts Array with multiple products
      *

--- a/classes/ProductSale.php
+++ b/classes/ProductSale.php
@@ -67,8 +67,7 @@ class ProductSaleCore
      * @param int $pageNumber Start from (optional)
      * @param int $nbProducts Number of products to return (optional)
      *
-     * @return array|bool from Product::getProductProperties
-     *                    `false` if failure
+     * @return array|bool
      */
     public static function getBestSales($idLang, $pageNumber = 0, $nbProducts = 10, $orderBy = null, $orderWay = null)
     {
@@ -158,7 +157,7 @@ class ProductSaleCore
             return false;
         }
 
-        return Product::getProductsProperties($idLang, $result);
+        return $result;
     }
 
     /**
@@ -227,7 +226,7 @@ class ProductSaleCore
             return false;
         }
 
-        return Product::getProductsProperties($idLang, $result);
+        return $result;
     }
 
     /**

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -471,13 +471,7 @@ class SearchCore
 				WHERE p.`id_product` ' . $product_pool;
         $total = $db->getValue($sql, false);
 
-        if (!$result) {
-            $result_properties = false;
-        } else {
-            $result_properties = Product::getProductsProperties((int) $id_lang, $result);
-        }
-
-        return ['total' => $total, 'result' => $result_properties];
+        return ['total' => $total, 'result' => $result];
     }
 
     /**
@@ -1031,7 +1025,7 @@ class SearchCore
             return false;
         }
 
-        return Product::getProductsProperties((int) $id_lang, $result);
+        return $result;
     }
 
     /**

--- a/classes/Supplier.php
+++ b/classes/Supplier.php
@@ -408,7 +408,7 @@ class SupplierCore extends ObjectModel
             $result = array_slice($result, (int) (($p - 1) * $n), (int) $n);
         }
 
-        return Product::getProductsProperties($idLang, $result);
+        return $result;
     }
 
     /**

--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -78,8 +78,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
     private function prepareProductForTemplate(array $rawProduct)
     {
         // Enrich data of product
-        $product = (new ProductAssembler($this->context))
-            ->assembleProduct($rawProduct);
+        $product = (new ProductAssembler($this->context))->assembleProduct($rawProduct);
 
         // Prepare configuration
         $presenter = $this->getProductPresenter();
@@ -104,8 +103,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
     protected function prepareMultipleProductsForTemplate(array $products)
     {
         // Enrich data set of products
-        $products = (new ProductAssembler($this->context))
-            ->assembleProducts($products);
+        $products = (new ProductAssembler($this->context))->assembleProducts($products);
 
         // Prepare configuration
         $presenter = $this->getProductPresenter();

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -945,7 +945,7 @@ class OrderDetailCore extends ObjectModel
                     }
                 }
 
-                return Product::getProductsProperties($id_lang, $order_products);
+                return $order_products;
             }
         }
     }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -414,7 +414,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 foreach ($accessories as &$accessory) {
                     $accessory = $presenter->present(
                         $presentationSettings,
-                        Product::getProductProperties($this->context->language->id, $accessory, $this->context),
+                        $assembler->assembleProduct($accessory),
                         $this->context->language
                     );
                 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removes all calls to `Product::getProductsProperties` as everything should be handled by the assembler. One step closer to removing `Product::getProductProperties` and moving everything towards ProductLazyArray.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | yes
| How to test?      | Tests should catch all issues. It affects only listings without faceted search, and there is only ID product needed. Accessories have been checked manually and they work properly.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/7030974202
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 
