### PR TITLE
Migrate more properties to lazy array

### DIFF
--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -86,6 +86,8 @@ class PackCore extends Product
         }
 
         if (!array_key_exists($id_product, self::$cacheIsPack)) {
+            // This is not very efficient, isn't an entry in pack table a proof that it's a pack?
+            // Moreover, we already have cache_is_pack column, product_type is just a duplicate.
             $result = Db::getInstance()->getValue('SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'pack` WHERE id_product_pack = ' . (int) $id_product);
             $productType = Db::getInstance()->getValue('SELECT product_type FROM `' . _DB_PREFIX_ . 'product` WHERE id_product = ' . (int) $id_product);
             self::$cacheIsPack[$id_product] = ($result > 0) || $productType === ProductType::TYPE_PACK;

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1219,9 +1219,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $extraContentFinder = new ProductExtraContentFinder();
 
         $product = $this->objectPresenter->present($this->product);
-        $product['id_product'] = (int) $this->product->id;
         $product['out_of_stock'] = (int) $this->product->out_of_stock;
-        $product['new'] = (int) $this->product->new;
         $product['id_product_attribute'] = $this->getIdProductAttributeByGroupOrRequestOrDefault();
         $product['minimal_quantity'] = $this->getProductMinimalQuantity($product);
         $product['quantity_wanted'] = $this->getRequiredQuantity($product);

--- a/src/Adapter/Presenter/Product/ProductListingLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductListingLazyArray.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Presenter\Product;
 
+use PrestaShop\PrestaShop\Core\Domain\Product\ProductCustomizabilitySettings;
 use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
 
 class ProductListingLazyArray extends ProductLazyArray
@@ -41,7 +42,7 @@ class ProductListingLazyArray extends ProductLazyArray
             return null;
         }
 
-        if ($this->product['customizable'] == 2 || !empty($this->product['customization_required'])) {
+        if ($this->product['customizable'] == ProductCustomizabilitySettings::REQUIRES_CUSTOMIZATION || !empty($this->product['customization_required'])) {
             return null;
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | refacto
| Category?         | FO
| BC breaks?        | yes - but nothing serious, if somebody is accessing these properties in a template, he won't notice a difference.
| Deprecations?     | yes
| How to test?      | Tests should be sufficient to show any error.
| UI Tests          | 🟢 https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/7046752953
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Description
- Migrates another batch of easy properties to lazy array.
- Enables passing presented Product object into getProductProperties without manually assigning id_product.
- Warms up tax rules group and pack properties so they don't have to be manually fetched.

### Performance with 24 products per category
Average load time - 470 ms ➡️ 438 ms
Query count - 636 ➡️ 538