### PR TITLE
Language context refacto

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -31,7 +31,7 @@ use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Context\LegacyControllerContext;
 use PrestaShop\PrestaShop\Core\Exception\ContainerNotFoundException;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
-use PrestaShop\PrestaShop\Core\Localization\Locale;
+use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
 use PrestaShopBundle\Bridge\AdminController\LegacyControllerBridgeInterface;
 use PrestaShopBundle\Install\Language as InstallLanguage;
 use PrestaShopBundle\Translation\TranslatorComponent as Translator;
@@ -92,7 +92,7 @@ class ContextCore
     /**
      * Current locale instance.
      *
-     * @var Locale|null
+     * @var LocaleInterface|null
      */
     public $currentLocale;
 
@@ -226,7 +226,7 @@ class ContextCore
     }
 
     /**
-     * @return Locale|null
+     * @return LocaleInterface|null
      */
     public function getCurrentLocale()
     {

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1717,7 +1717,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     /**
      * @return string return the language locale, or its code by default
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return !empty($this->locale) ?
             $this->locale :
@@ -1727,7 +1727,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     /**
      * {@inheritdoc}
      */
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
@@ -1735,7 +1735,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -1743,7 +1743,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     /**
      * {@inheritdoc}
      */
-    public function getIsoCode()
+    public function getIsoCode(): string
     {
         return $this->iso_code;
     }
@@ -1751,7 +1751,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     /**
      * {@inheritdoc}
      */
-    public function getLanguageCode()
+    public function getLanguageCode(): string
     {
         return $this->language_code;
     }
@@ -1759,9 +1759,25 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     /**
      * {@inheritdoc}
      */
-    public function isRTL()
+    public function isRTL(): bool
     {
         return $this->is_rtl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDateFormat(): string
+    {
+        return $this->date_format_lite;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDateTimeFormat(): string
+    {
+        return $this->date_format_full;
     }
 
     /**

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -30,8 +30,8 @@ use PrestaShop\PrestaShop\Adapter\ContainerFinder;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
 use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem as PsFileSystem;
-use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
+use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
 use PrestaShop\PrestaShop\Core\Security\Hashing;
 use PrestaShop\PrestaShop\Core\Security\OpenSsl\OpenSSL;
 use PrestaShop\PrestaShop\Core\Security\PasswordGenerator;
@@ -672,7 +672,7 @@ class ToolsCore
      *
      * @param Context $context
      *
-     * @return Locale
+     * @return LocaleInterface
      *
      * @throws Exception
      */

--- a/src/Adapter/ContextStateManager.php
+++ b/src/Adapter/ContextStateManager.php
@@ -36,6 +36,7 @@ use Currency;
 use Customer;
 use Language;
 use PrestaShop\PrestaShop\Core\Context\LegacyControllerContext;
+use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
 use Shop;
 
 /**
@@ -54,6 +55,7 @@ class ContextStateManager
         'country',
         'currency',
         'language',
+        'currentLocale',
         'customer',
         'shop',
         'shopContext',
@@ -157,6 +159,21 @@ class ContextStateManager
         if ($language) {
             $this->getContext()->getTranslator()->setLocale($language->locale);
         }
+
+        return $this;
+    }
+
+    /**
+     * Sets context localization locale and saves previous value
+     *
+     * @param LocaleInterface|null $locale
+     *
+     * @return $this
+     */
+    public function setCurrentLocale(?LocaleInterface $locale): self
+    {
+        $this->saveContextField('currentLocale');
+        $this->getContext()->currentLocale = $locale;
 
         return $this;
     }

--- a/src/Adapter/Presenter/Order/OrderDetailLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderDetailLazyArray.php
@@ -33,7 +33,7 @@ use Currency;
 use HistoryController;
 use Order;
 use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
-use PrestaShop\PrestaShop\Core\Localization\Locale;
+use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
 use PrestaShopBundle\Translation\TranslatorComponent;
 use PrestaShopException;
 use Tools;
@@ -41,7 +41,7 @@ use Tools;
 class OrderDetailLazyArray extends AbstractLazyArray
 {
     /**
-     * @var Locale
+     * @var LocaleInterface
      */
     private $locale;
 

--- a/src/Core/Context/CountryContextBuilder.php
+++ b/src/Core/Context/CountryContextBuilder.php
@@ -31,7 +31,6 @@ namespace PrestaShop\PrestaShop\Core\Context;
 use Country as LegacyCountry;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Adapter\Country\Repository\CountryRepository;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 
@@ -44,7 +43,7 @@ class CountryContextBuilder implements LegacyContextBuilderInterface
     public function __construct(
         private readonly CountryRepository $countryRepository,
         private readonly ContextStateManager $contextStateManager,
-        private readonly ConfigurationInterface $configuration,
+        private readonly LanguageContext $languageContext,
     ) {
     }
 
@@ -52,8 +51,6 @@ class CountryContextBuilder implements LegacyContextBuilderInterface
     {
         $this->assertArguments();
         $legacyCountry = $this->getLegacyCountry();
-        // Temporary solution, this should be fetched from the LanguageContext when it's available
-        $languageId = $this->configuration->get('PS_LANG_DEFAULT');
 
         return new CountryContext(
             id: $legacyCountry->id,
@@ -61,7 +58,7 @@ class CountryContextBuilder implements LegacyContextBuilderInterface
             currencyId: $legacyCountry->id_currency,
             isoCode: $legacyCountry->iso_code,
             callPrefix: $legacyCountry->call_prefix,
-            name: $legacyCountry->name[$languageId] ?? reset($legacyCountry->name),
+            name: $legacyCountry->name[$this->languageContext->getId()] ?? reset($legacyCountry->name),
             containsStates: $legacyCountry->contains_states,
             identificationNumberNeeded: $legacyCountry->need_identification_number,
             zipCodeNeeded: $legacyCountry->need_zip_code,

--- a/src/Core/Context/CurrencyContextBuilder.php
+++ b/src/Core/Context/CurrencyContextBuilder.php
@@ -31,7 +31,6 @@ namespace PrestaShop\PrestaShop\Core\Context;
 use Currency as LegacyCurrency;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
 use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 
@@ -44,7 +43,7 @@ class CurrencyContextBuilder implements LegacyContextBuilderInterface
     public function __construct(
         private readonly CurrencyRepository $currencyRepository,
         private readonly ContextStateManager $contextStateManager,
-        private readonly ConfigurationInterface $configuration
+        private readonly LanguageContext $languageContext
     ) {
     }
 
@@ -52,9 +51,8 @@ class CurrencyContextBuilder implements LegacyContextBuilderInterface
     {
         $this->assertArguments();
         $legacyCurrency = $this->getLegacyCurrency();
-        // Temporary solution, this should be fetched from the LanguageContext when it's available
-        $languageId = $this->configuration->get('PS_LANG_DEFAULT');
 
+        $languageId = $this->languageContext->getId();
         $localizedNames = $legacyCurrency->getLocalizedNames();
         $localizedPatterns = $legacyCurrency->getLocalizedPatterns();
         $localizedSymbols = $legacyCurrency->getLocalizedSymbols();

--- a/src/Core/Context/EmployeeContext.php
+++ b/src/Core/Context/EmployeeContext.php
@@ -38,7 +38,7 @@ class EmployeeContext
     public const SUPER_ADMIN_PROFILE_ID = 1;
 
     public function __construct(
-        private readonly ?Employee $employee
+        protected readonly ?Employee $employee
     ) {
     }
 

--- a/src/Core/Context/LanguageContext.php
+++ b/src/Core/Context/LanguageContext.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Context;
+
+use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
+use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
+use PrestaShop\PrestaShop\Core\Localization\Specification\NumberInterface;
+
+/**
+ * This context service gives access to all contextual data related to language.
+ *
+ * It also implements some core interfaces that are used in many places in the code so that the
+ * context can be injected and used in place of these interfaces.
+ */
+class LanguageContext implements LanguageInterface, LocaleInterface
+{
+    public function __construct(
+        private readonly int $id,
+        private readonly string $name,
+        private readonly string $isoCode,
+        private readonly string $locale,
+        private readonly string $languageCode,
+        private readonly bool $isRTL,
+        private readonly string $dateFormat,
+        private readonly string $dateTimeFormat,
+        private readonly LocaleInterface $localizationLocale
+    ) {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getIsoCode(): string
+    {
+        return $this->isoCode;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function getLanguageCode(): string
+    {
+        return $this->languageCode;
+    }
+
+    public function isRTL(): bool
+    {
+        return $this->isRTL;
+    }
+
+    public function getDateFormat(): string
+    {
+        return $this->dateFormat;
+    }
+
+    public function getDateTimeFormat(): string
+    {
+        return $this->dateTimeFormat;
+    }
+
+    public function getCode(): string
+    {
+        return $this->localizationLocale->getCode();
+    }
+
+    public function formatNumber(int|float|string $number): string
+    {
+        return $this->localizationLocale->formatNumber($number);
+    }
+
+    public function formatPrice(int|float|string $number, string $currencyCode): string
+    {
+        return $this->localizationLocale->formatPrice($number, $currencyCode);
+    }
+
+    public function getPriceSpecification(string $currencyCode): NumberInterface
+    {
+        return $this->localizationLocale->getPriceSpecification($currencyCode);
+    }
+
+    public function getNumberSpecification(): NumberInterface
+    {
+        return $this->localizationLocale->getNumberSpecification();
+    }
+}

--- a/src/Core/Context/LanguageContext.php
+++ b/src/Core/Context/LanguageContext.php
@@ -41,15 +41,15 @@ use PrestaShop\PrestaShop\Core\Localization\Specification\NumberInterface;
 class LanguageContext implements LanguageInterface, LocaleInterface
 {
     public function __construct(
-        private readonly int $id,
-        private readonly string $name,
-        private readonly string $isoCode,
-        private readonly string $locale,
-        private readonly string $languageCode,
-        private readonly bool $isRTL,
-        private readonly string $dateFormat,
-        private readonly string $dateTimeFormat,
-        private readonly LocaleInterface $localizationLocale
+        protected readonly int $id,
+        protected readonly string $name,
+        protected readonly string $isoCode,
+        protected readonly string $locale,
+        protected readonly string $languageCode,
+        protected readonly bool $isRTL,
+        protected readonly string $dateFormat,
+        protected readonly string $dateTimeFormat,
+        protected readonly LocaleInterface $localizationLocale
     ) {
     }
 

--- a/src/Core/Context/LanguageContextBuilder.php
+++ b/src/Core/Context/LanguageContextBuilder.php
@@ -31,7 +31,7 @@ namespace PrestaShop\PrestaShop\Core\Context;
 use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
 use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
-use PrestaShop\PrestaShop\Core\Localization\Locale\Repository;
+use PrestaShop\PrestaShop\Core\Localization\Locale\RepositoryInterface;
 
 class LanguageContextBuilder
 {
@@ -39,7 +39,7 @@ class LanguageContextBuilder
 
     public function __construct(
         private readonly LanguageRepositoryInterface $languageRepository,
-        private readonly Repository $localeRepository
+        private readonly RepositoryInterface $localeRepository
     ) {
     }
 

--- a/src/Core/Context/LanguageContextBuilder.php
+++ b/src/Core/Context/LanguageContextBuilder.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Context;
+
+use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
+use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
+use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
+use PrestaShop\PrestaShop\Core\Localization\Locale\Repository;
+
+class LanguageContextBuilder
+{
+    private ?int $languageId = null;
+
+    public function __construct(
+        private readonly LanguageRepositoryInterface $languageRepository,
+        private readonly Repository $localeRepository
+    ) {
+    }
+
+    public function build(): LanguageContext
+    {
+        $this->assertArguments();
+
+        /** @var LanguageInterface $language */
+        $language = $this->languageRepository->find($this->languageId);
+
+        $localizationLocale = $this->localeRepository->getLocale($language->getLocale());
+
+        return new LanguageContext(
+            id: $language->getId(),
+            name: $language->getName(),
+            isoCode: $language->getIsoCode(),
+            locale: $language->getLocale(),
+            languageCode: $language->getLanguageCode(),
+            isRTL: $language->isRTL(),
+            dateFormat: $language->getDateFormat(),
+            dateTimeFormat: $language->getDateTimeFormat(),
+            localizationLocale: $localizationLocale,
+        );
+    }
+
+    public function setLanguageId(int $languageId): void
+    {
+        $this->languageId = $languageId;
+    }
+
+    private function assertArguments(): void
+    {
+        if (null === $this->languageId) {
+            throw new InvalidArgumentException(sprintf(
+                'Cannot build Language context as no languageId has been defined you need to call %s::setLanguageId to define it before building the Language context',
+                self::class
+            ));
+        }
+    }
+}

--- a/src/Core/Context/LegacyControllerContext.php
+++ b/src/Core/Context/LegacyControllerContext.php
@@ -38,8 +38,6 @@ use Traversable;
  */
 class LegacyControllerContext
 {
-    public ?string $className;
-
     /**
      * List of CSS files.
      *
@@ -54,68 +52,78 @@ class LegacyControllerContext
      */
     public array $js_files = [];
 
-    // Controller type. Possible values: 'front', 'modulefront', 'admin', 'moduleadmin'.
-    public string $controller_type;
-
-    // Controller name.
-    public string $php_self;
+    /**
+     * Controller name alias kept for backward compatibility.
+     *
+     * @var string
+     */
+    public readonly string $php_self;
 
     /**
-     * Errors displayed after post processing
+     * Error messages displayed after refresh
      *
      * @var array<string|int, string|bool>
      */
     public array $errors = [];
 
+    /**
+     * Warning messages displayed after refresh
+     *
+     * @var array<string|int, string|bool>
+     */
     public array $warnings = [];
 
+    /**
+     * Information messages displayed after refresh
+     *
+     * @var array<string|int, string|bool>
+     */
     public array $informations = [];
 
+    /**
+     * Confirmation/success messages displayed after refresh
+     *
+     * @var array<string|int, string|bool>
+     */
     public array $confirmations = [];
 
-    public string $currentIndex;
-
-    public int $id = -1;
-
-    // Security token
-    public ?string $token;
-
-    public string $override_folder;
-
-    // Image type
+    /**
+     * Image type
+     *
+     * @var string
+     */
     public string $imageType = 'jpg';
 
-    // Current controller name without suffix
-    public string $controller_name;
-
-    public int $multishop_context = -1;
-
-    // Bootstrap variable
+    /**
+     * Array description of buttons to add in the header toolbar
+     *
+     * @var array|Traversable
+     */
     public array|Traversable $page_header_toolbar_btn = [];
 
-    // Dependency container
-    protected ContainerInterface $container;
-
+    /**
+     * @param ContainerInterface $container Dependency container
+     * @param string $controller_name Current controller name without suffix
+     * @param string $controller_type Controller type. Possible values: 'front', 'modulefront', 'admin', 'moduleadmin'.
+     * @param int $multishop_context Allowed multi shop contexts Possible values: Byte addition of ShopConstraint::ALL_SHOPS | ShopConstraint::SHOP_GROUP | ShopConstraint::SHOP
+     * @param string|null $className Legacy ObjectModel associated to the controller (if possible)
+     * @param int $id Tab ID
+     * @param string|null $token Legacy security token
+     * @param string $override_folder
+     * @param string $currentIndex Legacy current index built like a legacy URL based on controller name
+     */
     public function __construct(
-        ContainerInterface $container,
-        string $controller_name,
-        string $controller_type,
-        string $php_self,
-        int $multishop_context,
-        ?string $className,
-        int $id,
-        ?string $token,
-        string $override_folder,
+        protected readonly ContainerInterface $container,
+        public readonly string $controller_name,
+        public readonly string $controller_type,
+        public readonly int $multishop_context,
+        public readonly ?string $className,
+        public readonly int $id,
+        public readonly ?string $token,
+        public readonly string $override_folder,
+        public readonly string $currentIndex
     ) {
-        $this->container = $container;
-        $this->controller_type = $controller_type;
-        $this->php_self = $php_self;
-        $this->controller_name = $controller_name;
-        $this->multishop_context = $multishop_context;
-        $this->className = $className;
-        $this->id = $id;
-        $this->token = $token;
-        $this->override_folder = $override_folder;
+        $this->php_self = $this->controller_name;
     }
 
     public function addCSS($css_uri, $css_media_type = 'all', $offset = null, $check_path = true): void

--- a/src/Core/Context/ShopContext.php
+++ b/src/Core/Context/ShopContext.php
@@ -36,7 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 class ShopContext
 {
     public function __construct(
-        private readonly ShopConstraint $shopConstraint,
+        protected readonly ShopConstraint $shopConstraint,
         protected int $id,
         protected string $name,
         protected int $shopGroupId,

--- a/src/Core/Language/LanguageInterface.php
+++ b/src/Core/Language/LanguageInterface.php
@@ -37,40 +37,54 @@ interface LanguageInterface
      *
      * @return int
      */
-    public function getId();
+    public function getId(): int;
 
     /**
      * Explicit name of the language
      *
      * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * 2-letter iso code
      *
      * @return string
      */
-    public function getIsoCode();
+    public function getIsoCode(): string;
 
     /**
      * 5-letter iso code
      *
      * @return string
      */
-    public function getLocale();
+    public function getLocale(): string;
 
     /**
      * 5-letter iso code
      *
      * @return string
      */
-    public function getLanguageCode();
+    public function getLanguageCode(): string;
 
     /**
      * Is the language RTL (read from right to left)
      *
      * @return bool
      */
-    public function isRTL();
+    public function isRTL(): bool;
+
+    /**
+     * Returns format for a date.
+     *
+     * @return string
+     */
+    public function getDateFormat(): string;
+
+    /**
+     * Returns format for a date and time.
+     *
+     * @return string
+     */
+    public function getDateTimeFormat(): string;
 }

--- a/src/Core/Localization/Locale.php
+++ b/src/Core/Localization/Locale.php
@@ -28,9 +28,8 @@ namespace PrestaShop\PrestaShop\Core\Localization;
 
 use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
 use PrestaShop\PrestaShop\Core\Localization\Number\Formatter as NumberFormatter;
-use PrestaShop\PrestaShop\Core\Localization\Specification\Number as NumberSpecification;
-use PrestaShop\PrestaShop\Core\Localization\Specification\NumberCollection as PriceSpecificationMap;
-use PrestaShop\PrestaShop\Core\Localization\Specification\NumberInterface as NumberSpecificationInterface;
+use PrestaShop\PrestaShop\Core\Localization\Specification\NumberCollection;
+use PrestaShop\PrestaShop\Core\Localization\Specification\NumberInterface;
 
 /**
  * Locale entity.
@@ -54,7 +53,7 @@ class Locale implements LocaleInterface
      *
      * @var string
      */
-    protected $code;
+    protected string $code;
 
     /**
      * Number formatter.
@@ -62,19 +61,17 @@ class Locale implements LocaleInterface
      *
      * @var NumberFormatter
      */
-    protected $numberFormatter;
+    protected NumberFormatter $numberFormatter;
 
     /**
      * Number formatting specification.
-     *
-     * @var NumberSpecification
      */
-    protected $numberSpecification;
+    protected NumberInterface $numberSpecification;
 
     /**
      * Price formatting specifications collection (one spec per currency).
      *
-     * @var PriceSpecificationMap
+     * @var NumberCollection
      */
     protected $priceSpecifications;
 
@@ -85,20 +82,20 @@ class Locale implements LocaleInterface
      *                           The locale code (simplified IETF tag syntax)
      *                           Combination of ISO 639-1 (2-letters language code) and ISO 3166-2 (2-letters region code)
      *                           eg: fr-FR, en-US
-     * @param NumberSpecification $numberSpecification
-     *                                                 Number specification used when formatting a number
-     * @param PriceSpecificationMap $priceSpecifications
-     *                                                   Collection of Price specifications (one per installed currency)
+     * @param NumberInterface $numberSpecification
+     *                                             Number specification used when formatting a number
+     * @param NumberCollection $priceSpecifications
+     *                                              Collection of Price specifications (one per installed currency)
      * @param NumberFormatter $formatter
      *                                   This number formatter will use stored number / price specs
      */
     public function __construct(
-        $localeCode,
-        NumberSpecification $numberSpecification,
-        PriceSpecificationMap $priceSpecifications,
+        string $localeCode,
+        NumberInterface $numberSpecification,
+        NumberCollection $priceSpecifications,
         NumberFormatter $formatter
     ) {
-        $this->code = (string) $localeCode;
+        $this->code = $localeCode;
         $this->numberSpecification = $numberSpecification;
         $this->priceSpecifications = $priceSpecifications;
         $this->numberFormatter = $formatter;
@@ -111,7 +108,7 @@ class Locale implements LocaleInterface
      *
      * @return string
      */
-    public function getCode()
+    public function getCode(): string
     {
         return $this->code;
     }
@@ -127,7 +124,7 @@ class Locale implements LocaleInterface
      *
      * @throws Exception\LocalizationException
      */
-    public function formatNumber($number)
+    public function formatNumber(int|float|string $number): string
     {
         return $this->numberFormatter->format(
             $number,
@@ -147,7 +144,7 @@ class Locale implements LocaleInterface
      *
      * @throws Exception\LocalizationException
      */
-    public function formatPrice($number, $currencyCode)
+    public function formatPrice(int|float|string $number, string $currencyCode): string
     {
         return $this->numberFormatter->format(
             $number,
@@ -160,9 +157,9 @@ class Locale implements LocaleInterface
      *
      * @param string $currencyCode Currency of the price
      *
-     * @return NumberSpecificationInterface
+     * @return NumberInterface
      */
-    public function getPriceSpecification($currencyCode)
+    public function getPriceSpecification(string $currencyCode): NumberInterface
     {
         $currencyCode = (string) $currencyCode;
         $priceSpec = $this->priceSpecifications->get($currencyCode);
@@ -176,9 +173,9 @@ class Locale implements LocaleInterface
     /**
      * Get number specification
      *
-     * @return NumberSpecification
+     * @return NumberInterface
      */
-    public function getNumberSpecification()
+    public function getNumberSpecification(): NumberInterface
     {
         return $this->numberSpecification;
     }

--- a/src/Core/Localization/Locale.php
+++ b/src/Core/Localization/Locale.php
@@ -39,12 +39,7 @@ use PrestaShop\PrestaShop\Core\Localization\Specification\NumberInterface;
  */
 class Locale implements LocaleInterface
 {
-    /**
-     * Latin numbering system is the "occidental" numbering system. Number digits are 0123456789.
-     * This is the default numbering system in PrestaShop, even for arabian or asian languages, until we
-     * provide a way to configure this in admin.
-     */
-    public const NUMBERING_SYSTEM_LATIN = 'latn';
+    public const NUMBERING_SYSTEM_LATIN = LocaleInterface::NUMBERING_SYSTEM_LATIN;
 
     /**
      * The locale code (simplified IETF tag syntax)

--- a/src/Core/Localization/LocaleInterface.php
+++ b/src/Core/Localization/LocaleInterface.php
@@ -26,6 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Core\Localization;
 
+use PrestaShop\PrestaShop\Core\Localization\Specification\NumberInterface;
+
 /**
  * Locale entity interface.
  *
@@ -34,13 +36,22 @@ namespace PrestaShop\PrestaShop\Core\Localization;
 interface LocaleInterface
 {
     /**
+     * Get this locale's code (simplified IETF tag syntax)
+     * Combination of ISO 639-1 (2-letters language code) and ISO 3166-2 (2-letters region code)
+     * eg: fr-FR, en-US.
+     *
+     * @return string
+     */
+    public function getCode(): string;
+
+    /**
      * Format a number according to locale rules.
      *
      * @param int|float|string $number The number to be formatted
      *
      * @return string The formatted number
      */
-    public function formatNumber($number);
+    public function formatNumber(int|float|string $number): string;
 
     /**
      * Format a number as a price.
@@ -50,5 +61,21 @@ interface LocaleInterface
      *
      * @return string The formatted price
      */
-    public function formatPrice($number, $currencyCode);
+    public function formatPrice(int|float|string $number, string $currencyCode): string;
+
+    /**
+     * Get price specification by currency code.
+     *
+     * @param string $currencyCode Currency of the price
+     *
+     * @return NumberInterface
+     */
+    public function getPriceSpecification(string $currencyCode): NumberInterface;
+
+    /**
+     * Get number specification
+     *
+     * @return NumberInterface
+     */
+    public function getNumberSpecification(): NumberInterface;
 }

--- a/src/Core/Localization/LocaleInterface.php
+++ b/src/Core/Localization/LocaleInterface.php
@@ -36,6 +36,13 @@ use PrestaShop\PrestaShop\Core\Localization\Specification\NumberInterface;
 interface LocaleInterface
 {
     /**
+     * Latin numbering system is the "occidental" numbering system. Number digits are 0123456789.
+     * This is the default numbering system in PrestaShop, even for arabian or asian languages, until we
+     * provide a way to configure this in admin.
+     */
+    public const NUMBERING_SYSTEM_LATIN = 'latn';
+
+    /**
      * Get this locale's code (simplified IETF tag syntax)
      * Combination of ISO 639-1 (2-letters language code) and ISO 3166-2 (2-letters region code)
      * eg: fr-FR, en-US.

--- a/src/PrestaShopBundle/Bridge/Smarty/HeaderConfigurator.php
+++ b/src/PrestaShopBundle/Bridge/Smarty/HeaderConfigurator.php
@@ -39,7 +39,7 @@ use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\Action\ActionsBarButtonsCollection;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Hook\RenderedHookInterface;
-use PrestaShop\PrestaShop\Core\Localization\Locale;
+use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Number as NumberSpecification;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Price as PriceSpecification;
 use PrestaShopBundle\Bridge\AdminController\ControllerConfiguration;
@@ -71,7 +71,7 @@ class HeaderConfigurator implements ConfiguratorInterface
     private $currency;
 
     /**
-     * @var Locale
+     * @var LocaleInterface
      */
     private $currentLocale;
 
@@ -352,7 +352,7 @@ class HeaderConfigurator implements ConfiguratorInterface
         $priceSpecification = $this->currentLocale->getPriceSpecification($this->currency->iso_code);
 
         return array_merge(
-            ['symbol' => $priceSpecification->getSymbolsByNumberingSystem(Locale::NUMBERING_SYSTEM_LATIN)->toArray()],
+            ['symbol' => $priceSpecification->getSymbolsByNumberingSystem(LocaleInterface::NUMBERING_SYSTEM_LATIN)->toArray()],
             $priceSpecification->toArray()
         );
     }
@@ -368,7 +368,7 @@ class HeaderConfigurator implements ConfiguratorInterface
         $numberSpecification = $this->currentLocale->getNumberSpecification();
 
         return array_merge(
-            ['symbol' => $numberSpecification->getSymbolsByNumberingSystem(Locale::NUMBERING_SYSTEM_LATIN)->toArray()],
+            ['symbol' => $numberSpecification->getSymbolsByNumberingSystem(LocaleInterface::NUMBERING_SYSTEM_LATIN)->toArray()],
             $numberSpecification->toArray()
         );
     }

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -30,8 +30,8 @@ use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridInterface;
 use PrestaShop\PrestaShop\Core\Help\Documentation;
-use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
+use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
 use PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorInterface;
 use PrestaShop\PrestaShop\Core\Security\Permission;
 use Psr\Container\ContainerInterface;
@@ -220,9 +220,9 @@ class FrameworkBundleAdminController extends AbstractController implements Conta
     /**
      * Get the locale based on the context
      *
-     * @return Locale
+     * @return LocaleInterface
      */
-    protected function getContextLocale(): Locale
+    protected function getContextLocale(): LocaleInterface
     {
         $locale = $this->getContext()->getCurrentLocale();
         if (null !== $locale) {

--- a/src/PrestaShopBundle/Entity/Lang.php
+++ b/src/PrestaShopBundle/Entity/Lang.php
@@ -54,7 +54,7 @@ class Lang implements LanguageInterface
     private $name;
 
     /**
-     * @var int
+     * @var bool
      *
      * @ORM\Column(name="active", type="boolean")
      */
@@ -82,6 +82,8 @@ class Lang implements LanguageInterface
     private $locale;
 
     /**
+     * Badly named, it's not really light. It's just the format for a date only.
+     *
      * @var string
      *
      * @ORM\Column(name="date_format_lite", type="string", length=32)
@@ -89,6 +91,8 @@ class Lang implements LanguageInterface
     private $dateFormatLite;
 
     /**
+     * Badly named, it's not full. It's just the format for a date AND time.
+     *
      * @var string
      *
      * @ORM\Column(name="date_format_full", type="string", length=32)
@@ -129,7 +133,7 @@ class Lang implements LanguageInterface
      *
      * @return int
      */
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
@@ -141,7 +145,7 @@ class Lang implements LanguageInterface
      *
      * @return Lang
      */
-    public function setName($name)
+    public function setName(string $name)
     {
         $this->name = $name;
 
@@ -153,7 +157,7 @@ class Lang implements LanguageInterface
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -161,11 +165,11 @@ class Lang implements LanguageInterface
     /**
      * Set active.
      *
-     * @param int $active
+     * @param bool $active
      *
      * @return Lang
      */
-    public function setActive($active)
+    public function setActive(bool $active)
     {
         $this->active = $active;
 
@@ -175,9 +179,9 @@ class Lang implements LanguageInterface
     /**
      * Get active.
      *
-     * @return int
+     * @return bool
      */
-    public function getActive()
+    public function getActive(): bool
     {
         return $this->active;
     }
@@ -189,7 +193,7 @@ class Lang implements LanguageInterface
      *
      * @return Lang
      */
-    public function setIsoCode($isoCode)
+    public function setIsoCode(string $isoCode)
     {
         $this->isoCode = $isoCode;
 
@@ -201,7 +205,7 @@ class Lang implements LanguageInterface
      *
      * @return string
      */
-    public function getIsoCode()
+    public function getIsoCode(): string
     {
         return $this->isoCode;
     }
@@ -213,7 +217,7 @@ class Lang implements LanguageInterface
      *
      * @return Lang
      */
-    public function setLanguageCode($languageCode)
+    public function setLanguageCode(string $languageCode)
     {
         $this->languageCode = $languageCode;
 
@@ -225,7 +229,7 @@ class Lang implements LanguageInterface
      *
      * @return string
      */
-    public function getLanguageCode()
+    public function getLanguageCode(): string
     {
         return $this->languageCode;
     }
@@ -237,7 +241,7 @@ class Lang implements LanguageInterface
      *
      * @return Lang
      */
-    public function setDateFormatLite($dateFormatLite)
+    public function setDateFormatLite(string $dateFormatLite)
     {
         $this->dateFormatLite = $dateFormatLite;
 
@@ -249,7 +253,15 @@ class Lang implements LanguageInterface
      *
      * @return string
      */
-    public function getDateFormatLite()
+    public function getDateFormatLite(): string
+    {
+        return $this->dateFormatLite;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDateFormat(): string
     {
         return $this->dateFormatLite;
     }
@@ -261,7 +273,7 @@ class Lang implements LanguageInterface
      *
      * @return Lang
      */
-    public function setDateFormatFull($dateFormatFull)
+    public function setDateFormatFull(string $dateFormatFull)
     {
         $this->dateFormatFull = $dateFormatFull;
 
@@ -273,7 +285,15 @@ class Lang implements LanguageInterface
      *
      * @return string
      */
-    public function getDateFormatFull()
+    public function getDateFormatFull(): string
+    {
+        return $this->dateFormatFull;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDateTimeFormat(): string
     {
         return $this->dateFormatFull;
     }
@@ -297,7 +317,7 @@ class Lang implements LanguageInterface
      *
      * @return bool
      */
-    public function getIsRtl()
+    public function getIsRtl(): bool
     {
         return $this->isRtl;
     }
@@ -305,7 +325,7 @@ class Lang implements LanguageInterface
     /**
      * {@inheritdoc}
      */
-    public function isRTL()
+    public function isRTL(): bool
     {
         return $this->getIsRtl();
     }
@@ -313,7 +333,7 @@ class Lang implements LanguageInterface
     /**
      * @return string
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return !empty($this->locale) ? $this->locale : $this->getLanguageCode();
     }

--- a/src/PrestaShopBundle/EventListener/Context/Admin/LanguageContextListener.php
+++ b/src/PrestaShopBundle/EventListener/Context/Admin/LanguageContextListener.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\EventListener\Context\Admin;
+
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+class LanguageContextListener
+{
+    public function __construct(
+        private readonly LanguageContextBuilder $languageContextBuilder,
+        private readonly EmployeeContext $employeeContext,
+        private readonly ConfigurationInterface $configuration,
+    ) {
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        if ($this->employeeContext->getEmployee()) {
+            // Use the employee language if available
+            $this->languageContextBuilder->setLanguageId($this->employeeContext->getEmployee()->getLanguageId());
+        } else {
+            // If not use the default language of the shop
+            $this->languageContextBuilder->setLanguageId((int) $this->configuration->get('PS_LANG_DEFAULT'));
+        }
+    }
+}

--- a/src/PrestaShopBundle/EventListener/Context/Admin/LanguageContextListener.php
+++ b/src/PrestaShopBundle/EventListener/Context/Admin/LanguageContextListener.php
@@ -31,10 +31,13 @@ namespace PrestaShopBundle\EventListener\Context\Admin;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
 use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShopBundle\EventListener\ExternalApiTrait;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 class LanguageContextListener
 {
+    use ExternalApiTrait;
+
     public function __construct(
         private readonly LanguageContextBuilder $languageContextBuilder,
         private readonly EmployeeContext $employeeContext,
@@ -44,7 +47,7 @@ class LanguageContextListener
 
     public function onKernelRequest(RequestEvent $event): void
     {
-        if (!$event->isMainRequest()) {
+        if (!$event->isMainRequest() || $this->isExternalApiRequest($event->getRequest())) {
             return;
         }
 

--- a/src/PrestaShopBundle/EventListener/Context/Admin/LegacyControllerContextListener.php
+++ b/src/PrestaShopBundle/EventListener/Context/Admin/LegacyControllerContextListener.php
@@ -53,6 +53,11 @@ class LegacyControllerContextListener
 
         $controllerName = $this->getControllerName($event->getRequest());
         $this->legacyControllerContextBuilder->setControllerName($controllerName);
+
+        // Optional redirection url
+        if ($event->getRequest()->query->has('back')) {
+            $this->legacyControllerContextBuilder->setRedirectionUrl($event->getRequest()->query->get('back'));
+        }
     }
 
     private function getControllerName(?Request $request): string

--- a/src/PrestaShopBundle/Resources/config/services/bundle/context.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/context.yml
@@ -4,9 +4,15 @@ services:
     autowire: true
     autoconfigure: true
 
+  # Employee context must have a higher priority because Shop and Language depend on it
   PrestaShopBundle\EventListener\Context\Admin\EmployeeContextListener:
     tags:
-      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 30 }
+
+  # Language depends on Employee so its priority is lower, however it has higher priority than Currency and Country because they depend on Language
+  PrestaShopBundle\EventListener\Context\Admin\LanguageContextListener:
+    tags:
+      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 15 }
 
   PrestaShopBundle\EventListener\Context\Admin\ShopContextListener:
     tags:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
@@ -36,6 +36,8 @@ services:
     arguments:
       - PrestaShopBundle\Entity\Lang
 
+  PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface: '@prestashop.core.admin.lang.repository'
+
   prestashop.core.admin.log.repository:
     class: PrestaShopBundle\Entity\Repository\LogRepository
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/cldr.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/cldr.yml
@@ -23,6 +23,8 @@ services:
   prestashop.core.localization.locale.repository:
     alias: PrestaShop\PrestaShop\Core\Localization\Locale\Repository
 
+  PrestaShop\PrestaShop\Core\Localization\Locale\RepositoryInterface: '@PrestaShop\PrestaShop\Core\Localization\Locale\Repository'
+
   prestashop.core.localization.locale.context_locale:
     factory: [ '@prestashop.core.localization.locale.repository', 'getLocale' ]
     class: PrestaShop\PrestaShop\Core\Localization\Locale

--- a/src/PrestaShopBundle/Resources/config/services/core/context.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/context.yml
@@ -15,6 +15,11 @@ services:
     lazy: true
     factory: [ '@PrestaShop\PrestaShop\Core\Context\EmployeeContextBuilder', 'build' ]
 
+  PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder: ~
+  PrestaShop\PrestaShop\Core\Context\LanguageContext:
+    lazy: true
+    factory: [ '@PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder', 'build' ]
+
   PrestaShop\PrestaShop\Core\Context\ShopContextBuilder: ~
   PrestaShop\PrestaShop\Core\Context\ShopContext:
     lazy: true

--- a/tests/Integration/Adapter/ContextStateManagerTest.php
+++ b/tests/Integration/Adapter/ContextStateManagerTest.php
@@ -65,26 +65,26 @@ class ContextStateManagerTest extends ContextStateTestCase
 
         $this->legacyControllerContext1 = new LegacyControllerContext(
             $this->createMock(ContainerInterface::class),
-            'AdminProductsController',
+            'AdminProducts',
             'admin',
-            'AdminProductsController',
             ShopConstraint::ALL_SHOPS,
             'Product',
             20,
             'token',
-            'override_folder/'
+            'override_folder/',
+            'index.php?controller=AdminProducts'
         );
 
         $this->legacyControllerContext2 = new LegacyControllerContext(
             $this->createMock(ContainerInterface::class),
-            'AdminCartsController',
+            'AdminCarts',
             'admin',
-            'AdminCartsController',
             ShopConstraint::ALL_SHOPS,
             'Cart',
             10,
             'token',
-            'override_folder/'
+            'override_folder/',
+            'index.php?controller=AdminCarts'
         );
     }
 

--- a/tests/Integration/Core/MailTemplate/MailTemplateGeneratorTest.php
+++ b/tests/Integration/Core/MailTemplate/MailTemplateGeneratorTest.php
@@ -165,14 +165,14 @@ class MailTemplateGeneratorTest extends TestCase
         $generator = new MailTemplateGenerator($this->createRendererMock());
         $this->assertNotNull($generator);
 
-        $generator->generateTemplates($this->theme, $this->createLanguageMock(), $this->coreTempDir, $this->modulesTempDir);
+        $generator->generateTemplates($this->theme, $this->createLanguageMock('en'), $this->coreTempDir, $this->modulesTempDir);
         $expectedFiles = [
-            'core/account.html' => 'account_html__',
-            'core/account.txt' => 'account_txt__',
-            'modules/followup/mails/followup_1.html' => 'followup_1_html_followup_',
-            'modules/followup/mails/followup_1.txt' => 'followup_1_txt_followup_',
-            'modules/ps_reminder/mails/productoutofstock.html' => 'productoutofstock_html_ps_reminder_',
-            'modules/ps_reminder/mails/productoutofstock.txt' => 'productoutofstock_txt_ps_reminder_',
+            'core/en/account.html' => 'account_html__en',
+            'core/en/account.txt' => 'account_txt__en',
+            'modules/followup/mails/en/followup_1.html' => 'followup_1_html_followup_en',
+            'modules/followup/mails/en/followup_1.txt' => 'followup_1_txt_followup_en',
+            'modules/ps_reminder/mails/en/productoutofstock.html' => 'productoutofstock_html_ps_reminder_en',
+            'modules/ps_reminder/mails/en/productoutofstock.txt' => 'productoutofstock_txt_ps_reminder_en',
         ];
         $this->checkExpectedFiles($expectedFiles);
     }
@@ -288,7 +288,7 @@ class MailTemplateGeneratorTest extends TestCase
      *
      * @return MockObject|LanguageInterface
      */
-    private function createLanguageMock($isoCode = null)
+    private function createLanguageMock(?string $isoCode = null)
     {
         $languageMock = $this->getMockBuilder(LanguageInterface::class)
             ->disableOriginalConstructor()
@@ -297,7 +297,7 @@ class MailTemplateGeneratorTest extends TestCase
         $languageMock
             ->expects(null !== $isoCode ? $this->atLeastOnce() : $this->any())
             ->method('getIsoCode')
-            ->willReturn($isoCode)
+            ->willReturn($isoCode ?? 'en')
         ;
 
         return $languageMock;

--- a/tests/TestCase/ContextStateTestCase.php
+++ b/tests/TestCase/ContextStateTestCase.php
@@ -77,6 +77,14 @@ abstract class ContextStateTestCase extends TestCase
             if ($fieldName === 'language' && $contextValue instanceof Language) {
                 $contextMock->getTranslator()->setLocale('test' . $contextValue->id);
             }
+            if ($fieldName === 'currentLocale') {
+                $contextMock
+                    ->method('getCurrentLocale')
+                    ->willReturnCallback(static function () use ($contextMock) {
+                        return $contextMock->currentLocale;
+                    })
+                ;
+            }
         }
         LegacyContext::setInstanceForTesting($contextMock);
 

--- a/tests/TestCase/ContextStateTestCase.php
+++ b/tests/TestCase/ContextStateTestCase.php
@@ -38,6 +38,7 @@ use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\Context\LegacyControllerContext;
 use PrestaShopBundle\Translation\TranslatorComponent as Translator;
 use Shop;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Tests\Integration\Utility\ContextMockerTrait;
 
 abstract class ContextStateTestCase extends TestCase
@@ -113,19 +114,25 @@ abstract class ContextStateTestCase extends TestCase
         return $contextField;
     }
 
-    /**
-     * @param string $controllerName
-     *
-     * @return MockObject|LegacyControllerContext
-     */
-    protected function createLegacyControllerContextMock(string $controllerName)
+    protected function createLegacyControllerContextMock(string $controllerName): LegacyControllerContext|MockObject
     {
-        $legacyControllerContextBuilder = $this->getMockBuilder(LegacyControllerContext::class)->disableOriginalConstructor();
+        $legacyControllerContextBuilder = $this->getMockBuilder(LegacyControllerContext::class)
+            // Since most fields ar readonly and set via the constructor we must specify them this way
+            ->setConstructorArgs([
+                $this->createMock(ContainerInterface::class),
+                $controllerName,
+                'admin',
+                7,
+                null,
+                42,
+                'token',
+                '',
+                'index.php',
+            ])
+        ;
 
         /** @var LegacyControllerContext $legacyControllerContext */
         $legacyControllerContext = $legacyControllerContextBuilder->getMock();
-
-        $legacyControllerContext->controller_name = $controllerName;
 
         return $legacyControllerContext;
     }

--- a/tests/Unit/Core/Configuration/MockConfigurationTrait.php
+++ b/tests/Unit/Core/Configuration/MockConfigurationTrait.php
@@ -37,19 +37,22 @@ use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
  */
 trait MockConfigurationTrait
 {
-    protected function mockConfiguration(array $configurationValues): ShopConfigurationInterface|MockObject
+    protected function mockConfiguration(array $configurationValues = []): ShopConfigurationInterface|MockObject
     {
         $configuration = $this->createMock(ShopConfigurationInterface::class);
-        $configuration
-            ->method('get')
-            ->will($this->returnCallback(function ($configurationName) use ($configurationValues) {
-                if (isset($configurationValues[$configurationName])) {
-                    return $configurationValues[$configurationName];
-                }
 
-                throw new \InvalidArgumentException('Unhandled configuration ' . $configurationName);
-            }))
-        ;
+        if (!empty($configurationValues)) {
+            $configuration
+                ->method('get')
+                ->will($this->returnCallback(function ($configurationName) use ($configurationValues) {
+                    if (isset($configurationValues[$configurationName])) {
+                        return $configurationValues[$configurationName];
+                    }
+
+                    throw new \InvalidArgumentException('Unhandled configuration ' . $configurationName);
+                }))
+            ;
+        }
 
         return $configuration;
     }

--- a/tests/Unit/Core/Context/ContextBuilderTestCase.php
+++ b/tests/Unit/Core/Context/ContextBuilderTestCase.php
@@ -26,31 +26,22 @@
 
 declare(strict_types=1);
 
-namespace PrestaShopBundle\EventListener\Context\Admin;
+namespace Tests\Unit\Core\Context;
 
-use PrestaShop\PrestaShop\Adapter\ContextStateManager;
-use PrestaShop\PrestaShop\Adapter\Country\Repository\CountryRepository;
-use PrestaShop\PrestaShop\Core\Context\CountryContextBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
-use Symfony\Component\HttpFoundation\Request;
-use Tests\Unit\PrestaShopBundle\EventListener\Context\ContextEventListenerTestCase;
 
-class CountryContextListenerTest extends ContextEventListenerTestCase
+abstract class ContextBuilderTestCase extends TestCase
 {
-    public function testKernelRequest(): void
+    protected function mockLanguageContext(int $languageId): LanguageContext|MockObject
     {
-        $countryContextBuilder = new CountryContextBuilder(
-            $this->createMock(CountryRepository::class),
-            $this->createMock(ContextStateManager::class),
-            $this->createMock(LanguageContext::class),
-        );
-        $listener = new CountryContextListener(
-            $countryContextBuilder,
-            $this->mockConfiguration(['PS_COUNTRY_DEFAULT' => 42]),
-        );
+        $languageContext = $this->createMock(LanguageContext::class);
+        $languageContext
+            ->method('getId')
+            ->willReturn($languageId)
+        ;
 
-        $event = $this->createRequestEvent(new Request());
-        $listener->onKernelRequest($event);
-        $this->assertEquals(42, $this->getPrivateField($countryContextBuilder, 'countryId'));
+        return $languageContext;
     }
 }

--- a/tests/Unit/Core/Context/CountryContextBuilderTest.php
+++ b/tests/Unit/Core/Context/CountryContextBuilderTest.php
@@ -26,17 +26,16 @@
 
 declare(strict_types=1);
 
-namespace Core\Context;
+namespace Tests\Unit\Core\Context;
 
 use Country;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Adapter\Country\Repository\CountryRepository;
 use PrestaShop\PrestaShop\Core\Context\CountryContextBuilder;
 use Tests\Unit\Core\Configuration\MockConfigurationTrait;
 
-class CountryContextBuilderTest extends TestCase
+class CountryContextBuilderTest extends ContextBuilderTestCase
 {
     use MockConfigurationTrait;
 
@@ -56,7 +55,7 @@ class CountryContextBuilderTest extends TestCase
         $builder = new CountryContextBuilder(
             $this->mockCountryRepository($country),
             $this->createMock(ContextStateManager::class),
-            $this->mockConfiguration(['PS_LANG_DEFAULT' => $languageId])
+            $this->mockLanguageContext($languageId)
         );
         $builder->setCountryId(42);
         $countryContext = $builder->build();

--- a/tests/Unit/Core/Context/CurrencyContextBuilderTest.php
+++ b/tests/Unit/Core/Context/CurrencyContextBuilderTest.php
@@ -26,18 +26,17 @@
 
 declare(strict_types=1);
 
-namespace Core\Context;
+namespace Tests\Unit\Core\Context;
 
 use Currency;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository;
 use PrestaShop\PrestaShop\Core\Context\CurrencyContextBuilder;
 use Tests\Unit\Core\Configuration\MockConfigurationTrait;
 
-class CurrencyContextBuilderTest extends TestCase
+class CurrencyContextBuilderTest extends ContextBuilderTestCase
 {
     use MockConfigurationTrait;
 
@@ -59,7 +58,7 @@ class CurrencyContextBuilderTest extends TestCase
         $builder = new CurrencyContextBuilder(
             $this->mockCurrencyRepository($currency),
             $this->createMock(ContextStateManager::class),
-            $this->mockConfiguration(['PS_LANG_DEFAULT' => $languageId])
+            $this->mockLanguageContext($languageId)
         );
         $builder->setCurrencyId($currency->id);
 

--- a/tests/Unit/Core/Context/EmployeeContextBuilderTest.php
+++ b/tests/Unit/Core/Context/EmployeeContextBuilderTest.php
@@ -26,7 +26,7 @@
 
 declare(strict_types=1);
 
-namespace Core\Context;
+namespace Tests\Unit\Core\Context;
 
 use Employee;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Unit/Core/Context/EmployeeContextTest.php
+++ b/tests/Unit/Core/Context/EmployeeContextTest.php
@@ -26,7 +26,7 @@
 
 declare(strict_types=1);
 
-namespace Core\Context;
+namespace Tests\Unit\Core\Context;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Context\Employee;

--- a/tests/Unit/Core/Context/LanguageContextBuilderTest.php
+++ b/tests/Unit/Core/Context/LanguageContextBuilderTest.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Core\Context;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
+use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
+use PrestaShop\PrestaShop\Core\Localization\Locale\Repository;
+use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
+use PrestaShop\PrestaShop\Core\Localization\Specification\Number;
+use PrestaShop\PrestaShop\Core\Localization\Specification\NumberSymbolList;
+
+class LanguageContextBuilderTest extends TestCase
+{
+    public function testBuild(): void
+    {
+        $language = $this->mockLanguage();
+        $locale = $this->mockLocale();
+        $builder = new LanguageContextBuilder(
+            $this->mockLanguageRepository($language),
+            $this->mockLocaleRepository($locale)
+        );
+        $builder->setLanguageId($language->getId());
+
+        $languageContext = $builder->build();
+        // Check language data
+        $this->assertEquals($language->getId(), $languageContext->getId());
+        $this->assertEquals($language->getName(), $languageContext->getName());
+        $this->assertEquals($language->getIsoCode(), $languageContext->getIsoCode());
+        $this->assertEquals($language->getLocale(), $languageContext->getLocale());
+        $this->assertEquals($language->getLanguageCode(), $languageContext->getLanguageCode());
+        $this->assertEquals($language->isRTL(), $languageContext->isRTL());
+        $this->assertEquals($language->getDateFormat(), $languageContext->getDateFormat());
+        $this->assertEquals($language->getDateTimeFormat(), $languageContext->getDateTimeFormat());
+
+        // Check locale methods
+        $this->assertEquals($locale->getCode(), $languageContext->getCode());
+        $this->assertEquals($locale->formatNumber(42), $languageContext->formatNumber(42));
+        $this->assertEquals($locale->formatPrice(42, 'EUR'), $languageContext->formatPrice(42, 'EUR'));
+        $this->assertEquals($locale->getPriceSpecification('EUR'), $languageContext->getPriceSpecification('EUR'));
+        $this->assertEquals($locale->getNumberSpecification(), $languageContext->getNumberSpecification());
+    }
+
+    private function mockLanguageRepository(LanguageInterface $language): LanguageRepositoryInterface
+    {
+        $repository = $this->createMock(LanguageRepositoryInterface::class);
+        $repository
+            ->method('find')
+            ->willReturn($language)
+        ;
+
+        return $repository;
+    }
+
+    private function mockLocaleRepository(LocaleInterface $locale): Repository|MockObject
+    {
+        $repository = $this->createMock(Repository::class);
+        $repository
+            ->method('getLocale')
+            ->willReturn($locale)
+        ;
+
+        return $repository;
+    }
+
+    private function mockLocale(): LocaleInterface|MockObject
+    {
+        $locale = $this->createMock(LocaleInterface::class);
+        $locale
+            ->method('getCode')
+            ->willReturn('fr-FR')
+        ;
+        $locale
+            ->method('formatNumber')
+            ->willReturn('1.000,45')
+        ;
+        $locale
+            ->method('formatPrice')
+            ->willReturn('1.000,45 €')
+        ;
+
+        $priceSpecification = new Number(
+            '#,##0.### $',
+            '-#,##0.### $',
+            [
+                new NumberSymbolList(
+                    '.',
+                    ',',
+                    ' ',
+                    '%',
+                    '-',
+                    '+',
+                    'e',
+                    'E',
+                    '/m',
+                    'inf',
+                    'NaN'
+                ),
+            ],
+            2,
+            1,
+            false,
+            3,
+            2
+        );
+        $locale
+            ->method('getPriceSpecification')
+            ->willReturn($priceSpecification)
+        ;
+
+        $numberSpecification = new Number(
+            '#,##0.###',
+            '-#,##0.###',
+            [
+                new NumberSymbolList(
+                    '.',
+                    ',',
+                    ' ',
+                    '%',
+                    '-',
+                    '+',
+                    'e',
+                    'E',
+                    '/m',
+                    'inf',
+                    'NaN'
+                ),
+            ],
+            3,
+            2,
+            true,
+            2,
+            3
+        );
+        $locale
+            ->method('getNumberSpecification')
+            ->willReturn($numberSpecification)
+        ;
+
+        return $locale;
+    }
+
+    private function mockLanguage(): LanguageInterface|MockObject
+    {
+        $language = $this->createMock(LanguageInterface::class);
+        $language
+            ->method('getId')
+            ->willReturn(42)
+        ;
+        $language
+            ->method('getName')
+            ->willReturn('French')
+        ;
+        $language
+            ->method('getIsoCode')
+            ->willReturn('fr')
+        ;
+        $language
+            ->method('getLocale')
+            ->willReturn('fr-FR')
+        ;
+        $language
+            ->method('getLanguageCode')
+            ->willReturn('fr')
+        ;
+        $language
+            ->method('isRTL')
+            ->willReturn(false)
+        ;
+        $language
+            ->method('getDateFormat')
+            ->willReturn('d/m/Y')
+        ;
+        $language
+            ->method('getDateTimeFormat')
+            ->willReturn('d/m/Y H:i:s')
+        ;
+
+        return $language;
+    }
+}

--- a/tests/Unit/Core/Context/LanguageContextBuilderTest.php
+++ b/tests/Unit/Core/Context/LanguageContextBuilderTest.php
@@ -26,7 +26,7 @@
 
 declare(strict_types=1);
 
-namespace Core\Context;
+namespace Tests\Unit\Core\Context;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Core/Context/LegacyControllerContextBuilderTest.php
+++ b/tests/Unit/Core/Context/LegacyControllerContextBuilderTest.php
@@ -26,7 +26,7 @@
 
 declare(strict_types=1);
 
-namespace Core\Context;
+namespace Tests\Unit\Core\Context;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Core/Context/LegacyControllerContextBuilderTest.php
+++ b/tests/Unit/Core/Context/LegacyControllerContextBuilderTest.php
@@ -48,48 +48,126 @@ class LegacyControllerContextBuilderTest extends TestCase
      * @dataProvider getControllerValues
      *
      * @param string $controllerName
+     * @param string $expectedControllerName
      * @param ?string $className
      * @param int $multishopContext
+     * @param string $expectedCurrentIndex
+     * @param ?string $redirectionUrl
      */
-    public function testBuild(string $controllerName, ?string $className, int $multishopContext): void
+    public function testBuild(string $controllerName, string $expectedControllerName, ?string $className, int $multishopContext, string $expectedCurrentIndex, string $redirectionUrl = null): void
     {
         $builder = new LegacyControllerContextBuilder(
             $this->mockEmployeeContext(),
             $this->createMock(ContextStateManager::class),
-            ['AdminCartsController'],
+            ['AdminCarts'],
             $this->mockTabRepository(),
             $this->createMock(ContainerInterface::class),
         );
 
         $builder->setControllerName($controllerName);
+        if (null !== $redirectionUrl) {
+            $builder->setRedirectionUrl($redirectionUrl);
+        }
         $legacyController = $builder->build();
 
         $this->assertEquals($className, $legacyController->className);
         $this->assertEquals('admin', $legacyController->controller_type);
-        $this->assertEquals($controllerName, $legacyController->php_self);
-        $this->assertEquals($controllerName, $legacyController->controller_name);
+        $this->assertEquals($expectedControllerName, $legacyController->php_self);
+        $this->assertEquals($expectedControllerName, $legacyController->controller_name);
         $this->assertEquals(10, $legacyController->id);
         $this->assertEquals($multishopContext, $legacyController->multishop_context);
+        $this->assertEquals($expectedCurrentIndex, $legacyController->currentIndex);
     }
 
     public function getControllerValues(): iterable
     {
-        yield 'AdminCartsController' => [
-            'AdminCartsController',
+        yield 'AdminCarts default generic behaviour for all controllers' => [
+            'AdminCarts',
+            'AdminCarts',
             'Cart',
             ShopConstraint::ALL_SHOPS,
+            'index.php?controller=AdminCarts',
         ];
 
-        yield 'AdminAccessController' => [
-            'AdminAccessController',
+        yield 'AdminCarts default behaviour with redirection url' => [
+            'AdminCarts',
+            'AdminCarts',
+            'Cart',
+            ShopConstraint::ALL_SHOPS,
+            'index.php?controller=AdminCarts&back=index.php%3Fcontroller%3DAdminOrder',
+            'index.php?controller=AdminOrder',
+        ];
+
+        yield 'AdminAccess special classname' => [
+            'AdminAccess',
+            'AdminAccess',
             'Profile',
-            7,
+            ShopConstraint::ALL_SHOPS | ShopConstraint::SHOP_GROUP | ShopConstraint::SHOP,
+            'index.php?controller=AdminAccess',
         ];
 
-        yield 'AdminController' => [
+        yield 'AdminCarrierWizard special classname' => [
+            'AdminCarrierWizard',
+            'AdminCarrierWizard',
+            'Carrier',
+            ShopConstraint::ALL_SHOPS | ShopConstraint::SHOP_GROUP | ShopConstraint::SHOP,
+            'index.php?controller=AdminCarrierWizard',
+        ];
+
+        yield 'AdminImages special classname' => [
+            'AdminImages',
+            'AdminImages',
+            'ImageType',
+            ShopConstraint::ALL_SHOPS | ShopConstraint::SHOP_GROUP | ShopConstraint::SHOP,
+            'index.php?controller=AdminImages',
+        ];
+
+        yield 'AdminReturn special classname' => [
+            'AdminReturn',
+            'AdminReturn',
+            'OrderReturn',
+            ShopConstraint::ALL_SHOPS | ShopConstraint::SHOP_GROUP | ShopConstraint::SHOP,
+            'index.php?controller=AdminReturn',
+        ];
+
+        yield 'AdminSearchConf special classname' => [
+            'AdminSearchConfController',
+            'AdminSearchConf',
+            'Alias',
+            ShopConstraint::ALL_SHOPS | ShopConstraint::SHOP_GROUP | ShopConstraint::SHOP,
+            'index.php?controller=AdminSearchConf',
+        ];
+
+        yield 'AdminConfigureFaviconBo special classname' => [
+            'AdminConfigureFaviconBo',
+            'AdminConfigureFaviconBo',
+            'Configuration',
+            ShopConstraint::ALL_SHOPS | ShopConstraint::SHOP_GROUP | ShopConstraint::SHOP,
+            'index.php?controller=AdminConfigureFaviconBo',
+        ];
+
+        yield 'AdminController default fallback for symfony routes without associated legacy controller' => [
             'AdminController',
+            'Admin',
             null,
-            7,
+            ShopConstraint::ALL_SHOPS | ShopConstraint::SHOP_GROUP | ShopConstraint::SHOP,
+            'index.php?controller=Admin',
+        ];
+
+        yield 'AdminCartsController with Controller prefix' => [
+            'AdminCartsController',
+            'AdminCarts',
+            'Cart',
+            ShopConstraint::ALL_SHOPS,
+            'index.php?controller=AdminCarts',
+        ];
+
+        yield 'AdminCartsControllerOverride with ControllerOverride prefix' => [
+            'AdminCartsControllerOverride',
+            'AdminCarts',
+            'Cart',
+            ShopConstraint::ALL_SHOPS,
+            'index.php?controller=AdminCarts',
         ];
     }
 
@@ -98,7 +176,7 @@ class LegacyControllerContextBuilderTest extends TestCase
         $builder = new LegacyControllerContextBuilder(
             $this->mockEmployeeContext(),
             $this->createMock(ContextStateManager::class),
-            ['AdminCartsController'],
+            ['AdminCarts'],
             $this->mockTabRepository(),
             $this->createMock(ContainerInterface::class),
         );

--- a/tests/Unit/Core/Context/ShopContextBuilderTest.php
+++ b/tests/Unit/Core/Context/ShopContextBuilderTest.php
@@ -26,7 +26,7 @@
 
 declare(strict_types=1);
 
-namespace Core\Context;
+namespace Tests\Unit\Core\Context;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Core/Localization/Locale/LocaleTest.php
+++ b/tests/Unit/Core/Localization/Locale/LocaleTest.php
@@ -221,7 +221,6 @@ class LocaleTest extends TestCase
         return [
             'Invalid number' => ['foobar', 'EUR'],
             'Unknown currency' => [123456.789, 'USD'],
-            'Invalid currency' => [123456.789, 123],
         ];
     }
 }

--- a/tests/Unit/Core/Localization/LocaleTest.php
+++ b/tests/Unit/Core/Localization/LocaleTest.php
@@ -221,7 +221,6 @@ class LocaleTest extends TestCase
         return [
             'Invalid number' => ['foobar', 'EUR'],
             'Unknown currency' => [123456.789, 'USD'],
-            'Invalid currency' => [123456.789, 123],
         ];
     }
 }

--- a/tests/Unit/PrestaShopBundle/EventListener/Context/Admin/CurrencyContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Context/Admin/CurrencyContextListenerTest.php
@@ -30,8 +30,8 @@ namespace PrestaShopBundle\EventListener\Context\Admin;
 
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Context\CurrencyContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\Unit\PrestaShopBundle\EventListener\Context\ContextEventListenerTestCase;
 
@@ -42,7 +42,7 @@ class CurrencyContextListenerTest extends ContextEventListenerTestCase
         $currencyContextBuilder = new CurrencyContextBuilder(
             $this->createMock(CurrencyRepository::class),
             $this->createMock(ContextStateManager::class),
-            $this->createMock(ConfigurationInterface::class)
+            $this->createMock(LanguageContext::class)
         );
         $listener = new CurrencyContextListener(
             $currencyContextBuilder,

--- a/tests/Unit/PrestaShopBundle/EventListener/Context/Admin/LanguageContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Context/Admin/LanguageContextListenerTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\EventListener\Context\Admin;
+
+use Employee;
+use PHPUnit\Framework\MockObject\MockObject;
+use PrestaShop\PrestaShop\Adapter\Employee\EmployeeRepository;
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
+use PrestaShop\PrestaShop\Core\Localization\Locale\Repository;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\Unit\PrestaShopBundle\EventListener\Context\ContextEventListenerTestCase;
+
+class LanguageContextListenerTest extends ContextEventListenerTestCase
+{
+    private const CONTEXT_EMPLOYEE_LANGUAGE_ID = 42;
+    private const COOKIE_EMPLOYEE_LANGUAGE_ID = 51;
+    private const COOKIE_EMPLOYEE_ID = 69;
+    private const DEFAULT_CONFIGURATION_LANGUAGE_ID = 99;
+
+    public function testContextEmployeeLanguage(): void
+    {
+        $languageContextBuilder = new LanguageContextBuilder(
+            $this->createMock(LanguageRepositoryInterface::class),
+            $this->createMock(Repository::class),
+        );
+        $listener = new LanguageContextListener(
+            $languageContextBuilder,
+            $this->mockLegacyContext([], [
+                'employee' => $this->mockEmployee(self::CONTEXT_EMPLOYEE_LANGUAGE_ID),
+            ]),
+            $this->mockEmployeeRepository(),
+            $this->mockConfiguration(),
+        );
+
+        $event = $this->createRequestEvent(new Request());
+        $listener->onKernelRequest($event);
+        $this->assertEquals(self::CONTEXT_EMPLOYEE_LANGUAGE_ID, $this->getPrivateField($languageContextBuilder, 'languageId'));
+    }
+
+    public function testCookieEmployeeLanguage(): void
+    {
+        $languageContextBuilder = new LanguageContextBuilder(
+            $this->createMock(LanguageRepositoryInterface::class),
+            $this->createMock(Repository::class),
+        );
+        $listener = new LanguageContextListener(
+            $languageContextBuilder,
+            $this->mockLegacyContext(['id_employee' => self::COOKIE_EMPLOYEE_ID]),
+            $this->mockEmployeeRepository($this->mockEmployee(self::COOKIE_EMPLOYEE_LANGUAGE_ID), self::COOKIE_EMPLOYEE_ID),
+            $this->mockConfiguration(),
+        );
+
+        $event = $this->createRequestEvent(new Request());
+        $listener->onKernelRequest($event);
+        $this->assertEquals(self::COOKIE_EMPLOYEE_LANGUAGE_ID, $this->getPrivateField($languageContextBuilder, 'languageId'));
+    }
+
+    public function testDefaultConfigurationLanguage(): void
+    {
+        $languageContextBuilder = new LanguageContextBuilder(
+            $this->createMock(LanguageRepositoryInterface::class),
+            $this->createMock(Repository::class),
+        );
+        $listener = new LanguageContextListener(
+            $languageContextBuilder,
+            $this->mockLegacyContext(),
+            $this->mockEmployeeRepository(),
+            $this->mockConfiguration(['PS_LANG_DEFAULT' => self::DEFAULT_CONFIGURATION_LANGUAGE_ID]),
+        );
+
+        $event = $this->createRequestEvent(new Request());
+        $listener->onKernelRequest($event);
+        $this->assertEquals(self::DEFAULT_CONFIGURATION_LANGUAGE_ID, $this->getPrivateField($languageContextBuilder, 'languageId'));
+    }
+
+    private function mockEmployee(int $languageId): Employee|MockObject
+    {
+        $employee = $this->createMock(Employee::class);
+        $employee->id_lang = $languageId;
+        $employee
+            ->method('isLoggedBack')
+            ->willReturn(true)
+        ;
+
+        return $employee;
+    }
+
+    private function mockEmployeeRepository(?Employee $employee = null, ?int $expectedEmployeeId = null): EmployeeRepository|MockObject
+    {
+        $repository = $this->createMock(EmployeeRepository::class);
+        if ($employee) {
+            $repository
+                ->method('get')
+                ->with($expectedEmployeeId)
+                ->willReturn($employee)
+            ;
+        }
+
+        return $repository;
+    }
+}

--- a/tests/Unit/PrestaShopBundle/EventListener/Context/Admin/LanguageContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Context/Admin/LanguageContextListenerTest.php
@@ -33,7 +33,7 @@ use PrestaShop\PrestaShop\Core\Context\Employee;
 use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
 use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
 use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
-use PrestaShop\PrestaShop\Core\Localization\Locale\Repository;
+use PrestaShop\PrestaShop\Core\Localization\Locale\RepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\Unit\PrestaShopBundle\EventListener\Context\ContextEventListenerTestCase;
 
@@ -46,7 +46,7 @@ class LanguageContextListenerTest extends ContextEventListenerTestCase
     {
         $languageContextBuilder = new LanguageContextBuilder(
             $this->createMock(LanguageRepositoryInterface::class),
-            $this->createMock(Repository::class),
+            $this->createMock(RepositoryInterface::class),
         );
         $listener = new LanguageContextListener(
             $languageContextBuilder,
@@ -63,7 +63,7 @@ class LanguageContextListenerTest extends ContextEventListenerTestCase
     {
         $languageContextBuilder = new LanguageContextBuilder(
             $this->createMock(LanguageRepositoryInterface::class),
-            $this->createMock(Repository::class),
+            $this->createMock(RepositoryInterface::class),
         );
         $listener = new LanguageContextListener(
             $languageContextBuilder,

--- a/tests/Unit/PrestaShopBundle/EventListener/Context/Admin/LegacyControllerContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Context/Admin/LegacyControllerContextListenerTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\EventListener\Context\Admin;
+
+use PrestaShop\PrestaShop\Adapter\ContextStateManager;
+use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
+use PrestaShop\PrestaShop\Core\Context\LegacyControllerContextBuilder;
+use PrestaShopBundle\Entity\Repository\TabRepository;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\Unit\PrestaShopBundle\EventListener\Context\ContextEventListenerTestCase;
+
+class LegacyControllerContextListenerTest extends ContextEventListenerTestCase
+{
+    /**
+     * @dataProvider getControllerNameValues
+     *
+     * @param Request $request
+     * @param string $expectedControllerName
+     */
+    public function testControllerName(Request $request, string $expectedControllerName): void
+    {
+        $builder = $this->getBuilder();
+        $legacyControllerContextListener = new LegacyControllerContextListener($builder);
+        $legacyControllerContextListener->onKernelRequest($this->createRequestEvent($request));
+        $this->assertEquals($expectedControllerName, $this->getPrivateField($builder, 'controllerName'));
+        $this->assertEquals(null, $this->getPrivateField($builder, 'redirectionUrl'));
+    }
+
+    public function getControllerNameValues(): iterable
+    {
+        yield 'simple query controller' => [
+            new Request(['controller' => 'AdminProducts']),
+            'AdminProducts',
+        ];
+
+        yield 'query controller with controller suffix' => [
+            new Request(['controller' => 'AdminProductsController']),
+            'AdminProducts',
+        ];
+
+        yield 'controller from attribute' => [
+            new Request([], [], ['_legacy_controller' => 'AdminOrder']),
+            'AdminOrder',
+        ];
+
+        yield 'controller from attribute with controller suffix' => [
+            new Request([], [], ['_legacy_controller' => 'AdminOrderController']),
+            'AdminOrder',
+        ];
+    }
+
+    public function testRedirectionUrl(): void
+    {
+        $builder = $this->getBuilder();
+        $legacyControllerContextListener = new LegacyControllerContextListener($builder);
+        $legacyControllerContextListener->onKernelRequest($this->createRequestEvent(new Request(['back' => 'index.php?toto=tata'])));
+        $this->assertEquals('index.php?toto=tata', $this->getPrivateField($builder, 'redirectionUrl'));
+    }
+
+    private function getBuilder(): LegacyControllerContextBuilder
+    {
+        return new LegacyControllerContextBuilder(
+            $this->createMock(EmployeeContext::class),
+            $this->createMock(ContextStateManager::class),
+            ['AdminCarts'],
+            $this->createMock(TabRepository::class),
+            $this->createMock(ContainerInterface::class)
+        );
+    }
+}

--- a/tests/Unit/PrestaShopBundle/EventListener/Context/ContextEventListenerTestCase.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Context/ContextEventListenerTestCase.php
@@ -59,18 +59,15 @@ abstract class ContextEventListenerTestCase extends KernelTestCase
         return $reflectionProperty->getValue($object);
     }
 
-    protected function mockLegacyContext(array $cookieValues = [], array $contextFields = []): LegacyContext|MockObject
+    protected function mockLegacyContext(array $cookieValues): LegacyContext|MockObject
     {
-        $context = $this->createMock(Context::class);
         $cookie = new TestCookie();
         foreach ($cookieValues as $cookieKey => $cookieValue) {
             $cookie->{$cookieKey} = $cookieValue;
         }
-        $context->cookie = $cookie;
 
-        foreach ($contextFields as $contextField => $contextValue) {
-            $context->{$contextField} = $contextValue;
-        }
+        $context = $this->createMock(Context::class);
+        $context->cookie = $cookie;
 
         $legacyContext = $this->createMock(LegacyContext::class);
         $legacyContext

--- a/tests/Unit/PrestaShopBundle/EventListener/Context/ContextEventListenerTestCase.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Context/ContextEventListenerTestCase.php
@@ -59,15 +59,18 @@ abstract class ContextEventListenerTestCase extends KernelTestCase
         return $reflectionProperty->getValue($object);
     }
 
-    protected function mockLegacyContext(array $cookieValues): LegacyContext|MockObject
+    protected function mockLegacyContext(array $cookieValues = [], array $contextFields = []): LegacyContext|MockObject
     {
+        $context = $this->createMock(Context::class);
         $cookie = new TestCookie();
         foreach ($cookieValues as $cookieKey => $cookieValue) {
             $cookie->{$cookieKey} = $cookieValue;
         }
-
-        $context = $this->createMock(Context::class);
         $context->cookie = $cookie;
+
+        foreach ($contextFields as $contextField => $contextValue) {
+            $context->{$contextField} = $contextValue;
+        }
 
         $legacyContext = $this->createMock(LegacyContext::class);
         $legacyContext


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Language context refacto
| Type?             | refacto
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | ~
| UI Tests          | Legacy layout: https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/6861089331<br />Symfony layout: https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/6861093268
| Fixed issue or discussion?     | Fixes #33196
| Related PRs       | ~
| Sponsor company   | ~

## Breaking Changes
- Interface `PrestaShop\PrestaShop\Core\Language\LanguageInterface` was modified to use strong explicit types, and two methods `getDateFormat` and `getDateTimeFormat` were added
- All classes implementing `LanguageInterface` have been updated to match the new interface contract: legacy `Language` object model and doctrine `Lang` entity
- Interface `PrestaShop\PrestaShop\Core\Localization\LocaleInterface` was modified to use strong explicit types, and three methods were added `getCode`, `getPriceSpecification` and `getNumberSpecification`
- All classes implementing `LocaleInterface` have been updated to match the new interface contract (so only `PrestaShop\PrestaShop\Core\Localization\Locale`)
- All usages of `PrestaShop\PrestaShop\Core\Localization\Locale` were replaced with `PrestaShop\PrestaShop\Core\Localization\LocaleInterface`
