### PR TITLE
Remove extra checks

### DIFF
--- a/classes/Attachment.php
+++ b/classes/Attachment.php
@@ -140,7 +140,7 @@ class AttachmentCore extends ObjectModel
      * @return bool|int Whether the selection has been successfully deleted
      * @todo: Find out if $return can be initialized with true. (breaking change)
      */
-    public function deleteSelection($attachments)
+    public function deleteSelection(array $attachments)
     {
         $return = 1;
         foreach ($attachments as $idAttachment) {

--- a/classes/AttributeGroup.php
+++ b/classes/AttributeGroup.php
@@ -261,7 +261,7 @@ class AttributeGroupCore extends ObjectModel
      *
      * @return bool Deletion result
      */
-    public function deleteSelection($selection)
+    public function deleteSelection(array $selection)
     {
         /* Also delete Attributes */
         foreach ($selection as $value) {

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -239,11 +239,8 @@ class CMSCategoryCore extends ObjectModel
      * @param array $to_delete Array reference where categories ID will be saved
      * @param array|int $id_cms_category Parent CMSCategory ID
      */
-    protected function recursiveDelete(&$to_delete, $id_cms_category)
+    protected function recursiveDelete(array &$to_delete, $id_cms_category)
     {
-        if (!is_array($to_delete)) {
-            die(Tools::displayError('Parameter "to_delete" is invalid.'));
-        }
         if (!$id_cms_category) {
             die(Tools::displayError('Parameter "id_cms_category" is invalid.'));
         }
@@ -310,7 +307,7 @@ class CMSCategoryCore extends ObjectModel
      *
      * return boolean Deletion result
      */
-    public function deleteSelection($categories)
+    public function deleteSelection(array $categories)
     {
         $return = true;
         foreach ($categories as $id_category_cms) {
@@ -341,12 +338,8 @@ class CMSCategoryCore extends ObjectModel
      *
      * @return array Categories
      */
-    public static function getCategories($id_lang, $active = true, $order = true)
+    public static function getCategories($id_lang, bool $active = true, $order = true)
     {
-        if (!Validate::isBool($active)) {
-            die(Tools::displayError('Parameter "active" is invalid.'));
-        }
-
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 		SELECT *
 		FROM `' . _DB_PREFIX_ . 'cms_category` c
@@ -385,12 +378,8 @@ class CMSCategoryCore extends ObjectModel
      *
      * @return array Categories
      */
-    public function getSubCategories($id_lang, $active = true)
+    public function getSubCategories(int $id_lang, bool $active = true)
     {
-        if (!Validate::isBool($active)) {
-            die(Tools::displayError('Parameter "active" is invalid.'));
-        }
-
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 		SELECT c.*, cl.id_lang, cl.name, cl.description, cl.link_rewrite, cl.meta_title, cl.meta_keywords, cl.meta_description
 		FROM `' . _DB_PREFIX_ . 'cms_category` c
@@ -433,12 +422,8 @@ class CMSCategoryCore extends ObjectModel
         return CMSCategory::getChildren(1, $id_lang, $active);
     }
 
-    public static function getChildren($id_parent, $id_lang, $active = true)
+    public static function getChildren($id_parent, $id_lang, bool $active = true)
     {
-        if (!Validate::isBool($active)) {
-            die(Tools::displayError('Parameter "active" is invalid.'));
-        }
-
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 		SELECT c.`id_cms_category`, cl.`name`, cl.`link_rewrite`
 		FROM `' . _DB_PREFIX_ . 'cms_category` c

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -610,15 +610,8 @@ class CarrierCore extends ObjectModel
      *
      * @return array Countries to which can be delivered
      */
-    public static function getDeliveredCountries($id_lang, $active_countries = false, $active_carriers = false, $contain_states = null)
+    public static function getDeliveredCountries(int $id_lang, bool $active_countries = false, bool $active_carriers = false, $contain_states = null)
     {
-        if (!Validate::isBool($active_countries)) {
-            die(Tools::displayError('Parameter "active_countries" is invalid.'));
-        }
-        if (!Validate::isBool($active_carriers)) {
-            die(Tools::displayError('Parameter "active_carriers" is invalid.'));
-        }
-
         $states = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
             SELECT s.*
             FROM `' . _DB_PREFIX_ . 'state` s

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -348,11 +348,8 @@ class CategoryCore extends ObjectModel
      * @param array $toDelete Array reference where categories ID will be saved
      * @param int $idCategory Parent category ID
      */
-    protected function recursiveDelete(&$toDelete, $idCategory)
+    protected function recursiveDelete(array &$toDelete, $idCategory)
     {
-        if (!is_array($toDelete)) {
-            die(Tools::displayError('Parameter "toDelete" is invalid.'));
-        }
         if (!$idCategory) {
             die(Tools::displayError('Parameter "idCategory" is invalid.'));
         }
@@ -434,7 +431,7 @@ class CategoryCore extends ObjectModel
      *
      * @return bool Deletion result
      */
-    public function deleteSelection($idCategories)
+    public function deleteSelection(array $idCategories)
     {
         $return = 1;
         foreach ($idCategories as $idCategory) {
@@ -614,11 +611,8 @@ class CategoryCore extends ObjectModel
      *
      * @return array Categories
      */
-    public static function getCategories($idLang = false, $active = true, $order = true, $sqlFilter = '', $orderBy = '', $limit = '')
+    public static function getCategories($idLang = false, bool $active = true, $order = true, $sqlFilter = '', $orderBy = '', $limit = '')
     {
-        if (!Validate::isBool($active)) {
-            die(Tools::displayError('Parameter "active" is invalid.'));
-        }
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
             '
 			SELECT *
@@ -679,7 +673,7 @@ class CategoryCore extends ObjectModel
     public static function getAllCategoriesName(
         $idRootCategory = null,
         $idLang = false,
-        $active = true,
+        bool $active = true,
         $groups = null,
         $useShopRestriction = true,
         $sqlFilter = '',
@@ -688,10 +682,6 @@ class CategoryCore extends ObjectModel
     ) {
         if (isset($idRootCategory) && !Validate::isInt($idRootCategory)) {
             die(Tools::displayError('Parameter "idRootCategory" was provided, but it\'s not a valid integer.'));
-        }
-
-        if (!Validate::isBool($active)) {
-            die(Tools::displayError('Parameter "active" is invalid.'));
         }
 
         if (isset($groups) && Group::isFeatureActive() && !is_array($groups)) {
@@ -754,7 +744,7 @@ class CategoryCore extends ObjectModel
     public static function getNestedCategories(
         $idRootCategory = null,
         $idLang = false,
-        $active = true,
+        bool $active = true,
         $groups = null,
         $useShopRestriction = true,
         $sqlFilter = '',
@@ -763,10 +753,6 @@ class CategoryCore extends ObjectModel
     ) {
         if (isset($idRootCategory) && !Validate::isInt($idRootCategory)) {
             die(Tools::displayError('Parameter "idRootCategory" was provided, but it\'s not a valid integer.'));
-        }
-
-        if (!Validate::isBool($active)) {
-            die(Tools::displayError('Parameter "active" is invalid.'));
         }
 
         if (isset($groups) && Group::isFeatureActive() && !is_array($groups)) {
@@ -1134,12 +1120,8 @@ class CategoryCore extends ObjectModel
      *
      * @return array Children of given Category
      */
-    public static function getChildren($idParent, $idLang, $active = true, $idShop = false)
+    public static function getChildren($idParent, $idLang, bool $active = true, $idShop = false)
     {
-        if (!Validate::isBool($active)) {
-            die(Tools::displayError('Parameter "active" is invalid.'));
-        }
-
         $cacheId = 'Category::getChildren_' . (int) $idParent . '-' . (int) $idLang . '-' . (bool) $active . '-' . (int) $idShop;
         if (!Cache::isStored($cacheId)) {
             $query = 'SELECT c.`id_category`, cl.`name`, cl.`link_rewrite`, category_shop.`id_shop`
@@ -1170,12 +1152,8 @@ class CategoryCore extends ObjectModel
      *
      * @return bool Indicates whether the given Category has children
      */
-    public static function hasChildren($idParent, $idLang, $active = true, $idShop = false)
+    public static function hasChildren($idParent, $idLang, bool $active = true, $idShop = false)
     {
-        if (!Validate::isBool($active)) {
-            die(Tools::displayError('Parameter "active" is invalid.'));
-        }
-
         $cacheId = 'Category::hasChildren_' . (int) $idParent . '-' . (int) $idLang . '-' . (bool) $active . '-' . (int) $idShop;
         if (!Cache::isStored($cacheId)) {
             $query = 'SELECT c.id_category, "" as name

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -441,7 +441,7 @@ class CurrencyCore extends ObjectModel
      *
      * @return bool Indicates whether the selected Currencies have been succesfully deleted
      */
-    public function deleteSelection($selection)
+    public function deleteSelection(array $selection)
     {
         if (!is_array($selection)) {
             return false;

--- a/classes/Feature.php
+++ b/classes/Feature.php
@@ -100,7 +100,7 @@ class FeatureCore extends ObjectModel
      *
      * @return bool Deletion result
      */
-    public function deleteSelection($selection)
+    public function deleteSelection(array $selection)
     {
         /* Also delete Attributes */
         foreach ($selection as $value) {

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -689,12 +689,8 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     /**
      * {@inheritdoc}
      */
-    public function deleteSelection($selection)
+    public function deleteSelection(array $selection)
     {
-        if (!is_array($selection)) {
-            die(Tools::displayError('Parameter "selection" must be an array.'));
-        }
-
         $result = true;
         foreach ($selection as $id) {
             $language = new Language($id);

--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -145,12 +145,8 @@ class ManufacturerCore extends ObjectModel
      *
      * return boolean Deletion result
      */
-    public function deleteSelection($selection)
+    public function deleteSelection(array $selection)
     {
-        if (!is_array($selection)) {
-            die(Tools::displayError('Parameter "selection" must be an array.'));
-        }
-
         $result = true;
         foreach ($selection as $id) {
             $this->id = (int) $id;

--- a/classes/Message.php
+++ b/classes/Message.php
@@ -111,12 +111,8 @@ class MessageCore extends ObjectModel
      *
      * @return array Messages
      */
-    public static function getMessagesByOrderId($idOrder, $private = false, Context $context = null)
+    public static function getMessagesByOrderId($idOrder, bool $private = false, Context $context = null)
     {
-        if (!Validate::isBool($private)) {
-            die(Tools::displayError('Parameter "private" is invalid.'));
-        }
-
         if (!$context) {
             $context = Context::getContext();
         }
@@ -146,12 +142,8 @@ class MessageCore extends ObjectModel
      *
      * @return array Messages
      */
-    public static function getMessagesByCartId($idCart, $private = false, Context $context = null)
+    public static function getMessagesByCartId($idCart, bool $private = false, Context $context = null)
     {
-        if (!Validate::isBool($private)) {
-            die(Tools::displayError('Parameter "private" is invalid.'));
-        }
-
         if (!$context) {
             $context = Context::getContext();
         }

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -252,11 +252,8 @@ class MetaCore extends ObjectModel
      *
      * @return bool
      */
-    public function deleteSelection($selection)
+    public function deleteSelection(array $selection)
     {
-        if (!is_array($selection)) {
-            die(Tools::displayError('Parameter "selection" must be an array.'));
-        }
         $result = true;
         foreach ($selection as $id) {
             $this->id = (int) $id;

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -942,7 +942,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
      *
      * @return bool
      */
-    public function deleteSelection($ids)
+    public function deleteSelection(array $ids)
     {
         $result = true;
         foreach ($ids as $id) {

--- a/classes/PrestaShopBackup.php
+++ b/classes/PrestaShopBackup.php
@@ -203,7 +203,7 @@ class PrestaShopBackupCore
      *
      * @return bool True on success
      */
-    public function deleteSelection($list)
+    public function deleteSelection(array $list)
     {
         foreach ($list as $file) {
             $backup = new PrestaShopBackup($file);

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1344,19 +1344,19 @@ class ProductCore extends ObjectModel
      *
      * @return bool|int
      */
-    public function deleteSelection($products)
+    public function deleteSelection(array $products)
     {
         $return = 1;
-        if (is_array($products) && ($count = count($products))) {
-            // Deleting products can be quite long on a cheap server. Let's say 1.5 seconds by product (I've seen it!).
-            if ((int) (ini_get('max_execution_time')) < round($count * 1.5)) {
-                ini_set('max_execution_time', (string) round($count * 1.5));
-            }
 
-            foreach ($products as $id_product) {
-                $product = new Product((int) $id_product);
-                $return &= $product->delete();
-            }
+        // Deleting products can be quite long on a cheap server. Let's say 1.5 seconds by product (I've seen it!).
+        $count = count($products);
+        if ((int) (ini_get('max_execution_time')) < round($count * 1.5)) {
+            ini_set('max_execution_time', (string) round($count * 1.5));
+        }
+
+        foreach ($products as $id_product) {
+            $product = new Product((int) $id_product);
+            $return &= $product->delete();
         }
 
         return $return;
@@ -3200,17 +3200,13 @@ class ProductCore extends ObjectModel
         $id_lang,
         $page_number = 0,
         $nb_products = 10,
-        $count = false,
+        bool $count = false,
         $order_by = null,
         $order_way = null,
         $beginning = false,
         $ending = false,
         Context $context = null
     ) {
-        if (!Validate::isBool($count)) {
-            die(Tools::displayError('Parameter "count" is invalid.'));
-        }
-
         if (!$context) {
             $context = Context::getContext();
         }
@@ -3538,7 +3534,7 @@ class ProductCore extends ObjectModel
      */
     public static function getPriceStatic(
         $id_product,
-        $usetax = true,
+        bool $usetax = true,
         $id_product_attribute = null,
         $decimals = 6,
         $divisor = null,
@@ -3566,9 +3562,6 @@ class ProductCore extends ObjectModel
             Tools::displayParameterAsDeprecated('divisor');
         }
 
-        if (!Validate::isBool($usetax)) {
-            die(Tools::displayError('Parameter "usetax" is invalid.'));
-        }
         if (!Validate::isUnsignedId($id_product)) {
             die(Tools::displayError('Product ID is invalid.'));
         }

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -931,7 +931,7 @@ class SearchCore
     public static function searchTag(
         $id_lang,
         $tag,
-        $count = false,
+        bool $count = false,
         $pageNumber = 0,
         $pageSize = 10,
         $orderBy = false,
@@ -950,7 +950,7 @@ class SearchCore
             $id_customer = 0;
         }
 
-        if (!is_numeric($pageNumber) || !is_numeric($pageSize) || !Validate::isBool($count) || !Validate::isValidSearch($tag)
+        if (!is_numeric($pageNumber) || !is_numeric($pageSize) || !Validate::isValidSearch($tag)
             || $orderBy && !$orderWay || ($orderBy && !Validate::isOrderBy($orderBy)) || ($orderWay && !Validate::isOrderBy($orderWay))
         ) {
             return false;

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -804,7 +804,7 @@ class ToolsCore
      *
      * @return string Date
      */
-    public static function displayDate($date, $full = false)
+    public static function displayDate($date, bool $full = false)
     {
         if (!$date || !($time = strtotime($date))) {
             return $date;
@@ -814,7 +814,7 @@ class ToolsCore
             return '';
         }
 
-        if (!Validate::isDate($date) || !Validate::isBool($full)) {
+        if (!Validate::isDate($date)) {
             throw new PrestaShopException('Invalid date');
         }
 

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -222,11 +222,9 @@ class WebserviceRequestCore
         return $this->_outputEnabled;
     }
 
-    public function setOutputEnabled($bool)
+    public function setOutputEnabled(bool $bool)
     {
-        if (Validate::isBool($bool)) {
-            $this->_outputEnabled = $bool;
-        }
+        $this->_outputEnabled = $bool;
 
         return $this;
     }

--- a/tests/UI/data/demo/modules.ts
+++ b/tests/UI/data/demo/modules.ts
@@ -29,7 +29,7 @@ export default {
   psFacetedSearch: new ModuleData({
     tag: 'ps_facetedsearch',
     name: 'Faceted search',
-    releaseZip: 'https://github.com/PrestaShop/ps_facetedsearch/releases/download/v3.13.1/ps_facetedsearch.zip',
+    releaseZip: 'https://github.com/PrestaShop/ps_facetedsearch/releases/download/v3.14.1/ps_facetedsearch.zip',
   }),
   contactForm: new ModuleData({
     tag: 'contactform',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removes some basic calls to validate booleans and arrays. Adds types instead.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | Yes - there is a BC break. Validate::isBool returns true even if you passed null or 0/1. This won't be allowed now.
| Deprecations?     | no
| How to test?      | Tests green should be sufficient.
| UI Tests          | 🟢  https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/7016764315
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Additional information
Some issues in tests are due to bad calls to displayDate.
- statsproducts - https://github.com/PrestaShop/statsproduct/pull/37 + https://github.com/PrestaShop/statsproduct/pull/38 ✅ 
- ps_facetedsearch - https://github.com/PrestaShop/ps_facetedsearch/pull/945 + https://github.com/PrestaShop/ps_facetedsearch/pull/946 + https://github.com/PrestaShop/ps_facetedsearch/pull/947 ✅