### PR TITLE
Fix combination unit price math

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5891,9 +5891,11 @@ class ProductCore extends ObjectModel
         // Then if combination has an impact we apply it on unit price
         if ($combinationId) {
             $combination = new Combination($combinationId);
-            if (0 != $combination->unit_price_impact && 0 != $baseUnitPrice) {
-                $baseUnitPrice = $baseUnitPrice + $combination->unit_price_impact;
-            }
+            $baseUnitPrice = $baseUnitPrice + $combination->unit_price_impact;
+        }
+
+        if ($baseUnitPrice == 0) {
+            return 0;
         }
 
         // Finally, we apply the currency rate
@@ -5901,10 +5903,6 @@ class ProductCore extends ObjectModel
         $currencyId = Validate::isLoadedObject($context->currency) ? (int) $context->currency->id : $defaultCurrencyId;
         if ($currencyId !== $defaultCurrencyId) {
             $baseUnitPrice = Tools::convertPrice($baseUnitPrice, $currencyId);
-        }
-
-        if ($baseUnitPrice == 0) {
-            return 0;
         }
 
         // Compute price ratio based on initial product price and initial unit price (without taxes, group discount, cart rules)

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -452,7 +452,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 'id_customization' => empty($customization_datas) ? null : $customization_datas[0]['id_customization'],
                 'accessories' => $accessories,
                 'product' => $product_for_template,
-                'displayUnitPrice' => !empty($this->product->unity) && $this->product->unit_price > 0.000000,
+                'displayUnitPrice' => !empty($product_for_template['unit_price_tax_excluded']),
                 'product_manufacturer' => $productManufacturer,
                 'manufacturer_image_url' => $manufacturerImageUrl,
                 'product_brand_url' => $productBrandUrl,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fix for the Product::computeUnitPriceRatio() by removing non-zero conditions for summing the product unit price and the combination unit price impact, which made final unit price zero even if one of its components (product unit price and combination unit price impact) was not zero.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | https://github.com/the-ge/ga.tests.ui.pr/actions/runs/6826988081
| Fixed issue or discussion?     | Fixes #34518
| Related PRs       | Needs #34419 to reap the full benefits
| Sponsor company   | 

How to test:
1. Go to Catalog > Products > Edit a product > Price Tab.
2. Enable unit price display.
3. Set price and unit price to 0.
4. Go to the Combinations tab and Modify a combination.
5. Set price and unit price to non-zero values.
6. Save.

Desired results:

1. The unit price display switch from step 2 should display as enabled.
2. The Front-Office product page (when the combination chosen in step 4 is selected) should display (under the full price) the unit price having the same value as the unit price impact of combination.