### PR TITLE
Add primary key to DB table accessory

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -6,7 +6,7 @@ SET
 CREATE TABLE `PREFIX_accessory` (
   `id_product_1` int(10) unsigned NOT NULL,
   `id_product_2` int(10) unsigned NOT NULL,
-  KEY `accessory_product` (`id_product_1`, `id_product_2`)
+  PRIMARY KEY `accessory_product` (`id_product_1`, `id_product_2`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 
 /* Address info associated with a user */


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Every DB table should have PRIMARY index. But DB table accessorry doesn't have. There is problem with Percona as well "_Percona-XtraDB-Cluster prohibits use of DML command on a table (prestashop_41c9cd86_mysql.ps_accessory) without an explicit primary key with pxc_strict_mode = ENFORCING or MASTER_" (check related issue below) - after/if this PR will be merged to 8.1.3, PR for module "autoupgrade" already done (https://github.com/PrestaShop/autoupgrade/pull/645)
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/7487740011
| Fixed issue or discussion?     | Fixes #30022
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/645
| Sponsor company   | https://www.openservis.cz/
