### PR TITLE
Update Address.php - small phpdoc edit (@return value)

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -429,7 +429,7 @@ class AddressCore extends ObjectModel
      *
      * @param int $id_address Address ID
      *
-     * @return array
+     * @return array|bool
      */
     public static function getCountryAndState($id_address)
     {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | phpdoc is refering to @return array, but there can be returned **bool** as well (if $id_address is 0). So, fixing phpdoc @return value. Only small phpdoc change. Nothing else.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | 
| UI Tests          |
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
