### PR TITLE
Minimal quantity should be 1 at least, not 0!

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -103,7 +103,7 @@ class CombinationCore extends ObjectModel
             'ecotax' => ['type' => self::TYPE_FLOAT, 'shop' => true, 'validate' => 'isPrice', 'size' => 20],
             'weight' => ['type' => self::TYPE_FLOAT, 'shop' => true, 'validate' => 'isFloat'],
             'unit_price_impact' => ['type' => self::TYPE_FLOAT, 'shop' => true, 'validate' => 'isNegativePrice', 'size' => 20],
-            'minimal_quantity' => ['type' => self::TYPE_INT, 'shop' => true, 'validate' => 'isUnsignedId', 'required' => true],
+            'minimal_quantity' => ['type' => self::TYPE_INT, 'shop' => true, 'validate' => 'isPositiveInt', 'required' => true],
             'low_stock_threshold' => ['type' => self::TYPE_INT, 'shop' => true, 'allow_null' => true, 'validate' => 'isInt'],
             'low_stock_alert' => ['type' => self::TYPE_BOOL, 'shop' => true, 'validate' => 'isBool'],
             'default_on' => ['type' => self::TYPE_BOOL, 'allow_null' => true, 'shop' => true, 'validate' => 'isBool'],

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -507,7 +507,7 @@ class ProductCore extends ObjectModel
             'on_sale' => ['type' => self::TYPE_BOOL, 'shop' => true, 'validate' => 'isBool'],
             'online_only' => ['type' => self::TYPE_BOOL, 'shop' => true, 'validate' => 'isBool'],
             'ecotax' => ['type' => self::TYPE_FLOAT, 'shop' => true, 'validate' => 'isPrice'],
-            'minimal_quantity' => ['type' => self::TYPE_INT, 'shop' => true, 'validate' => 'isUnsignedInt'],
+            'minimal_quantity' => ['type' => self::TYPE_INT, 'shop' => true, 'validate' => 'isPositiveInt'],
             'low_stock_threshold' => ['type' => self::TYPE_INT, 'shop' => true, 'allow_null' => true, 'validate' => 'isInt'],
             'low_stock_alert' => ['type' => self::TYPE_BOOL, 'shop' => true, 'validate' => 'isBool'],
             'price' => ['type' => self::TYPE_FLOAT, 'shop' => true, 'validate' => 'isPrice', 'required' => true],

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -911,6 +911,18 @@ class ValidateCore
     }
 
     /**
+     * Check for a number (int) bigger than 0
+     *
+     * @param mixed $value Integer with value bigger than 0 to validate
+     *
+     * @return bool Validity is ok or not
+     */
+    public static function isPositiveInt($value)
+    {
+        return self::isUnsignedInt($value) && $value > 0;
+    }
+
+    /**
      * Check for an percentage validity (between 0 and 100).
      *
      * @param float $value Float to validate

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
@@ -176,9 +176,11 @@ class ProductCombination extends CommonAbstractType
             ])
             ->add('attribute_minimal_quantity', NumberType::class, [
                 'required' => false,
+                'default_empty_data' => 1,
                 'label' => $this->translator->trans('Min. quantity for sale', [], 'Admin.Catalog.Feature'),
                 'constraints' => [
                     new Assert\NotBlank(),
+                    new Assert\Positive(),
                     new Assert\Type(['type' => 'numeric']),
                 ],
                 'attr' => [

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
@@ -179,7 +179,6 @@ class ProductCombination extends CommonAbstractType
                 'default_empty_data' => 1,
                 'label' => $this->translator->trans('Min. quantity for sale', [], 'Admin.Catalog.Feature'),
                 'constraints' => [
-                    new Assert\NotBlank(),
                     new Assert\Positive(),
                     new Assert\Type(['type' => 'numeric']),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
@@ -181,6 +181,10 @@ class ProductCombination extends CommonAbstractType
                     new Assert\NotBlank(),
                     new Assert\Type(['type' => 'numeric']),
                 ],
+                'attr' => [
+                    'min' => 1,
+                ],
+                'html5' => true,
             ])
             ->add('attribute_location', TextType::class, [
                 'label' => $this->translator->trans('Stock location', [], 'Admin.Catalog.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
@@ -181,9 +181,11 @@ class ProductQuantity extends CommonAbstractType
                 FormType\NumberType::class,
                 [
                     'required' => true,
+                    'default_empty_data' => 1,
                     'label' => $this->translator->trans('Minimum quantity for sale', [], 'Admin.Catalog.Feature'),
                     'constraints' => [
                         new Assert\NotBlank(),
+                        new Assert\Positive(),
                         new Assert\Type(['type' => 'numeric']),
                     ],
                     'attr' => [

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
@@ -184,7 +184,6 @@ class ProductQuantity extends CommonAbstractType
                     'default_empty_data' => 1,
                     'label' => $this->translator->trans('Minimum quantity for sale', [], 'Admin.Catalog.Feature'),
                     'constraints' => [
-                        new Assert\NotBlank(),
                         new Assert\Positive(),
                         new Assert\Type(['type' => 'numeric']),
                     ],

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
@@ -186,6 +186,10 @@ class ProductQuantity extends CommonAbstractType
                         new Assert\NotBlank(),
                         new Assert\Type(['type' => 'numeric']),
                     ],
+                    'attr' => [
+                        'min' => 1,
+                    ],
+                    'html5' => true,
                 ]
             )
             ->add(

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
@@ -113,10 +113,11 @@ class QuantityType extends TranslatorAwareType
                 'label' => $this->trans('Minimum quantity for sale', 'Admin.Catalog.Feature'),
                 'constraints' => [
                     new NotBlank(),
+                    new Assert\Positive(),
                     new Type(['type' => 'numeric']),
                 ],
                 'required' => false,
-                'default_empty_data' => 0,
+                'default_empty_data' => 1,
                 'modify_all_shops' => true,
                 'attr' => [
                     'class' => 'small-input',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
@@ -35,7 +35,7 @@ use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Positive;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -112,8 +112,7 @@ class QuantityType extends TranslatorAwareType
             ->add('minimal_quantity', NumberType::class, [
                 'label' => $this->trans('Minimum quantity for sale', 'Admin.Catalog.Feature'),
                 'constraints' => [
-                    new NotBlank(),
-                    new Assert\Positive(),
+                    new Positive(),
                     new Type(['type' => 'numeric']),
                 ],
                 'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
@@ -120,7 +120,9 @@ class QuantityType extends TranslatorAwareType
                 'modify_all_shops' => true,
                 'attr' => [
                     'class' => 'small-input',
+                    'min' => 1,
                 ],
+                'html5' => true,
                 'label_help_box' => $this->trans(
                     'The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity.',
                     'Admin.Catalog.Help'


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Tooltip say "The minimum quantity required to buy this product (set to 1 to disable this feature)". So minimal_quantity should be 1 at least, not 0! Related to PR: https://github.com/PrestaShop/autoupgrade/pull/646
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/6880198118
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/18850
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/646
| Sponsor company   | https://www.openservis.cz/
