### PR TITLE
Migrate deprecated DoctrineProvider to new one

### DIFF
--- a/src/Adapter/Cache/Clearer/DoctrineCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/DoctrineCacheClearer.php
@@ -26,8 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Cache\Clearer;
 
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
-use Symfony\Component\Cache\DoctrineProvider;
 
 final class DoctrineCacheClearer implements CacheClearerInterface
 {

--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter;
 
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\ORM\Tools\Setup;
 use Exception;
 use LegacyCompilerPass;
@@ -39,7 +40,6 @@ use PrestaShopBundle\DependencyInjection\Compiler\LoadServicesFromModulesPass;
 use PrestaShopBundle\Exception\ServiceContainerException;
 use PrestaShopBundle\PrestaShopBundle;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Cache\DoctrineProvider;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileResource;
@@ -212,7 +212,7 @@ class ContainerBuilder
     private function loadDoctrineAnnotationMetadata()
     {
         //IMPORTANT: we need to provide a cache because doctrine tries to init a connection on redis, memcached, ... on its own
-        $cacheProvider = new DoctrineProvider(new ArrayAdapter());
+        $cacheProvider = DoctrineProvider::wrap(new ArrayAdapter());
         Setup::createAnnotationMetadataConfiguration([], $this->environment->isDebug(), null, $cacheProvider);
     }
 

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Addon\Module;
 
 use Context;
 use Db;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\HookManager;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
@@ -45,7 +46,6 @@ use PrestaShop\PrestaShop\Core\Util\File\YamlParser;
 use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
 use PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
-use Symfony\Component\Cache\DoctrineProvider;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Routing\Loader\YamlFileLoader;
 use Symfony\Component\Routing\Router;
@@ -170,7 +170,7 @@ class ModuleManagerBuilder
 
         $kernelDir = realpath($this->getConfigDir() . '/../../var');
         $cacheDir = $kernelDir . ($this->isDebug ? '/cache/dev' : '/cache/prod');
-        self::$cacheProvider = new DoctrineProvider(
+        self::$cacheProvider = DoctrineProvider::wrap(
             new FilesystemAdapter(
                 '',
                 0,

--- a/src/PrestaShopBundle/Resources/config/services/bundle/cache.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/cache.yml
@@ -10,7 +10,8 @@ services:
       - "%kernel.cache_dir%/doctrine"
 
   doctrine.cache.provider:
-    class: Symfony\Component\Cache\DoctrineProvider
+    class: Doctrine\Common\Cache\Psr6\DoctrineProvider
+    factory: [ Doctrine\Common\Cache\Psr6\DoctrineProvider, wrap ]
     arguments:
       - "@doctrine.cache.adapter"
 

--- a/src/PrestaShopBundle/Resources/config/services/core/circuit_breaker.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/circuit_breaker.yml
@@ -11,7 +11,8 @@ services:
       - '@=service("prestashop.adapter.environment").getCacheDir() ~ "/circuit_breaker"'
 
   prestashop.core.circuit_breaker.doctrine_cache:
-    class: Symfony\Component\Cache\DoctrineProvider
+    class: Doctrine\Common\Cache\Psr6\DoctrineProvider
+    factory: [ Doctrine\Common\Cache\Psr6\DoctrineProvider, wrap ]
     arguments:
       - '@prestashop.core.circuit_breaker.cache'
 

--- a/tests/Integration/Core/Module/ModuleRepositoryTest.php
+++ b/tests/Integration/Core/Module/ModuleRepositoryTest.php
@@ -28,13 +28,14 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Core\Module;
 
+use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\HookManager;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Cache\DoctrineProvider;
 use Symfony\Component\Translation\Translator;
 
 class ModuleRepositoryTest extends TestCase
@@ -89,10 +90,13 @@ class ModuleRepositoryTest extends TestCase
             $this->returnCallback($hookExecMethodMock)
         );
 
+        /** @var CacheProvider $cacheProvider */
+        $cacheProvider = DoctrineProvider::wrap(new ArrayAdapter());
+
         $this->moduleRepository = new ModuleRepository(
             $moduleDataProvider,
             $this->createMock(AdminModuleDataProvider::class),
-            new DoctrineProvider(new ArrayAdapter()),
+            $cacheProvider,
             $hookManager,
             dirname(__DIR__, 3) . '/Resources/modules/',
             1


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR is a preparation to migrate to Symfony 6 soon.<br> Here, we migrate `DoctrineProvider` to new one.<br>**We need to do the same with `distributionapi` too, a PR will follow asap.**
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI and Autotests need to be 🟢
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/6854573160
| Fixed issue or discussion?     | Fixes #33994
| Related PRs       | 
| Sponsor company   | PrestaShop SA
