### PR TITLE
Do not allow products with required customization to be used as a gift

### DIFF
--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -239,6 +239,11 @@ class AdminCartRulesControllerCore extends AdminController
                 $_POST['gift_product_attribute'] = (int) Tools::getValue('ipa_' . $id_product);
             }
 
+            // Do not allow products with required customization
+            if (!empty($_POST['gift_product']) && count(Product::getRequiredCustomizableFieldsStatic((int) $_POST['gift_product']))) {
+                $this->errors[] = $this->trans('Product with required customization fields cannot be used as a gift.', [], 'Admin.Catalog.Notification');
+            }
+
             // Idiot-proof control
             if (strtotime(Tools::getValue('date_from')) > strtotime(Tools::getValue('date_to'))) {
                 $this->errors[] = $this->trans('The voucher cannot end before it begins.', [], 'Admin.Catalog.Notification');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fixes an issue discovered by @florine2623 when testing https://github.com/PrestaShop/PrestaShop/pull/34464#pullrequestreview-1729739843. Found out that you can add a gift product that has a required customization, which should NOT be possible.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to create a cart rule and try to use a product with REQUIRED customization as a gift - like `Customizable mug` from default data.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/pull/34464#pullrequestreview-1729739843
| Related PRs       | 
| Sponsor company   | 

![Snímek obrazovky 2023-11-14 160331](https://github.com/PrestaShop/PrestaShop/assets/6097524/f326d867-014c-425e-8679-6d1a8ec3b5d7)