### PR TITLE
Fix sorting by Relevance in search results (develop branch version)

### DIFF
--- a/src/Adapter/Search/SearchProductSearchProvider.php
+++ b/src/Adapter/Search/SearchProductSearchProvider.php
@@ -142,7 +142,7 @@ class SearchProductSearchProvider implements ProductSearchProviderInterface
             $result->setAvailableSortOrders(
                 array_merge(
                 [
-                    (new SortOrder('product', 'position', 'asc'))->setLabel(
+                    (new SortOrder('product', 'position', 'desc'))->setLabel(
                         $this->translator->trans('Relevance', [], 'Shop.Theme.Catalog')
                     ),
                 ],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | suggested fix for issue #34174 (develop branch)
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Search option defaults to "Relevance" and selecting 'Relevance' displays in correct match order.
| UI Tests          | https://github.com/mrkalchemy/ga.tests.ui.pr/actions/runs/6905998626
| Fixed issue or discussion?     | Fixes #34174 
| Related PRs       | #34317 (8.1.x version)
| Sponsor company   | Your company or customer's name goes here (if applicable).
