### PR TITLE
fix fatal error when translation key is numeric

### DIFF
--- a/src/Core/Translation/Storage/Provider/ModuleCatalogueLayersProvider.php
+++ b/src/Core/Translation/Storage/Provider/ModuleCatalogueLayersProvider.php
@@ -303,7 +303,7 @@ class ModuleCatalogueLayersProvider implements CatalogueLayersProviderInterface
 
         foreach ($catalogueFromPhpAndSmartyFiles->all() as $currentDomain => $items) {
             foreach (array_keys($items) as $translationKey) {
-                $legacyKey = md5($translationKey);
+                $legacyKey = md5((string)$translationKey);
 
                 if ($catalogueFromLegacyTranslationFiles->has($legacyKey, $currentDomain)) {
                     $legacyFilesCatalogue->set(

--- a/src/Core/Translation/Storage/Provider/ModuleCatalogueLayersProvider.php
+++ b/src/Core/Translation/Storage/Provider/ModuleCatalogueLayersProvider.php
@@ -303,7 +303,7 @@ class ModuleCatalogueLayersProvider implements CatalogueLayersProviderInterface
 
         foreach ($catalogueFromPhpAndSmartyFiles->all() as $currentDomain => $items) {
             foreach (array_keys($items) as $translationKey) {
-                $legacyKey = md5((string)$translationKey);
+                $legacyKey = md5((string) $translationKey);
 
                 if ($catalogueFromLegacyTranslationFiles->has($legacyKey, $currentDomain)) {
                     $legacyFilesCatalogue->set(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This is affecting every prestashop version after 1.7.8.9 (tested after this version). The md5 function will throw an error if you feed it with a numeric value. This will cause the system to be unable to load the backoffice translations page. e.g. the url admin/index.php/api/translations/tree/el/themes/.....  will throw exception
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | Add a translation file with the legacy system using a numeric key. 
| UI Tests          | https://github.com/nicosomb/ga.tests.ui.pr/actions/runs/6901292359
| Fixed issue or discussion?     | #34603 
| Related PRs       | None
| Sponsor company   | IOWEB TECHNOLOGIES


Exception thrown


```
Type error: md5() expects parameter 1 to be string, int given

[Symfony\Component\Debug\Exception\FatalThrowableError 0]

```

![image](https://github.com/PrestaShop/PrestaShop/assets/20220341/728baad8-a23b-4a6d-a834-8387a91bf652)
