### PR TITLE
Better validate cookie length

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -357,12 +357,11 @@ class CookieCore
             $time = 1;
         }
 
-        /* 
-         * If there is some data to store, we need to check if it's compliant with RFC 2965,
-         * maximum of 4096 bytes per cookie. Major browsers follow this very closely and will
-         * refuse to save this cookie.
+        /*
+         * We need to check if the new cookie will be compliant with RFC 2965, maximum of 4096 bytes
+         * per cookie. Major browsers follow this very closely and will refuse to save this cookie.
          *
-         * If we exceed this value, some module is saving to cookie that it shouldn't,
+         * If we exceed this value, some module is saving something to cookie that it shouldn't save,
          * and overflowing the cookie. It's absolutely critical that this does not happen because
          * it breaks for example all cart functionality.
          *

--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -349,22 +349,28 @@ class CookieCore
      */
     protected function encryptAndSetCookie($cookie = null)
     {
-        // Check if the content fits in the Cookie
-        $length = null === $cookie
-            ? 0
-            : ((ini_get('mbstring.func_overload') & 2)
-                ? mb_strlen($cookie, ini_get('default_charset'))
-                : strlen($cookie));
-
-        if ($length >= 1048576) {
-            return false;
-        }
         if ($cookie) {
             $content = $this->cipherTool->encrypt($cookie);
             $time = $this->_expire;
         } else {
             $content = 0;
             $time = 1;
+        }
+
+        /* 
+         * If there is some data to store, we need to check if it's compliant with RFC 2965,
+         * maximum of 4096 bytes per cookie. Major browsers follow this very closely and will
+         * refuse to save this cookie.
+         *
+         * If we exceed this value, some module is saving to cookie that it shouldn't,
+         * and overflowing the cookie. It's absolutely critical that this does not happen because
+         * it breaks for example all cart functionality.
+         *
+         * We are using strlen because it calculates the byte count, we don't care about character
+         * count in case of multi-byte characters.
+         */
+        if (strlen($this->_name . $content) > 4096) {
+            throw new PrestaShopException('Error during setting a cookie. Combined size of name and value cannot exceed 4096 characters. Larger cookie is not compliant with RFC 2965 and will not be accepted by the browser.');
         }
 
         /*


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | See below
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/6927521249 ✅ 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Description
- This PR makes sure that the cookie is valid before sending it to the browser. Otherwise, the browser will silently refuse to save the cookie and the user will be wondering why the page won't work. If there is an overflowing cookie, the merchant will now know and it will be logged.
- There was a case like this before with ps_viewedproducts, where it saved an infinite list of products into a cookie, resulting in the cookie overflowing after some time.
- So, according to RFC 2965 I check for combined BYTE LENGTH of both the name and content.

### The original logic was broken
  - It just failed with no explanation.
  - It was using wrong count to check it.
  - It was using mb_strlen with some overloading (removed in PHP 8 btw). It must use strlen, because strlen will give you byte length.
  - It was checking the length before the encryption.
  - It was checking only the content length, you must check the combined length.

### How to test
Open `classes/controller/FrontController.php`, find `public function init()` and put this to the end of the method.

```php
$this->context->cookie->test .= 'blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabl';
```
Go to homepage and keep hitting F5. You will see that you get an exception after few hits.