### PR TITLE
Allow Front controller called in cli if ssl is on or maintenance mode is on

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -246,8 +246,10 @@ class FrontControllerCore extends Controller
             $useSSL = true;
         }
 
-        // Redirect to SSL variant of the page if required and visited in non-ssl mode
-        $this->sslRedirection();
+        // Redirect to SSL variant of the page if required and visited in non-ssl mode and not in cli context
+        if (!Tools::isPHPCLI()) {
+            $this->sslRedirection();
+        }
 
         if ($this->ajax) {
             $this->display_header = false;
@@ -458,7 +460,9 @@ class FrontControllerCore extends Controller
             $this->context->country = $country;
         }
 
-        $this->displayMaintenancePage();
+        if (!Tools::isPHPCLI()) {
+            $this->displayMaintenancePage();
+        }
 
         if (Country::GEOLOC_FORBIDDEN == $this->restrictedCountry) {
             $this->displayRestrictedCountryPage();

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -448,7 +448,7 @@ class FrontControllerCore extends Controller
         $this->context->smarty->assign('request_uri', Tools::safeOutput(urldecode($_SERVER['REQUEST_URI'])));
 
         // Automatically redirect to the canonical URL if needed
-        if (!empty($this->php_self) && !Tools::getValue('ajax')) {
+        if (!empty($this->php_self) && !Tools::getValue('ajax') && !Tools::isPHPCLI()) {
             $this->canonicalRedirection($this->context->link->getPageLink($this->php_self, $this->ssl, $this->context->language->id));
         }
 
@@ -464,7 +464,7 @@ class FrontControllerCore extends Controller
             $this->displayMaintenancePage();
         }
 
-        if (Country::GEOLOC_FORBIDDEN == $this->restrictedCountry) {
+        if (!Tools::isPHPCLI() && Country::GEOLOC_FORBIDDEN == $this->restrictedCountry) {
             $this->displayRestrictedCountryPage();
         }
 
@@ -856,7 +856,7 @@ class FrontControllerCore extends Controller
      */
     protected function geolocationManagement($defaultCountry)
     {
-        if (!in_array(Tools::getRemoteAddr(), ['127.0.0.1', '::1'])) {
+        if (!in_array(Tools::getRemoteAddr(), ['127.0.0.1', '::1']) && !Tools::isPHPCLI()) {
             /* Check if Maxmind Database exists */
             if (@filemtime(_PS_GEOIP_DIR_ . _PS_GEOIP_CITY_FILE_)) {
                 if (!isset($this->context->cookie->iso_code_country) || (isset($this->context->cookie->iso_code_country) && !in_array(strtoupper($this->context->cookie->iso_code_country), explode(';', Configuration::get('PS_ALLOWED_COUNTRIES'))))) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allow Front controller called in cli if ssl is on or maintenance mode is on
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See issue
| Fixed issue or discussion?     | Fixes #34670
| Sponsor company   | Creabilis
