### PR TITLE
Fix image legend not used

### DIFF
--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -106,20 +106,26 @@ class ImageRetriever
             $imageToCombinations
         ) {
             // Now let's fetch extra information about thumbnail sizes etc. and add this information.
-            // getImage also resolves a proper image legend, if it was missing in $image originally.
-            $image = array_merge(
+            $finalImage = array_merge(
                 $image,
                 $this->getImage($productInstance, $image['id_image'])
             );
 
-            // Assign a list of variants related to the given image
-            if (isset($imageToCombinations[$image['id_image']])) {
-                $image['associatedVariants'] = $imageToCombinations[$image['id_image']];
-            } else {
-                $image['associatedVariants'] = [];
+            // The only special thing we can't just merge is the legend.
+            // If there is a legend on the image object, we will use it.
+            // If not, we keep the one we got from getImage method (product name).
+            if (!empty($image['legend'])) {
+                $finalImage['legend'] = $image['legend'];
             }
 
-            return $image;
+            // Assign a list of variants related to the given image
+            if (isset($imageToCombinations[$image['id_image']])) {
+                $finalImage['associatedVariants'] = $imageToCombinations[$image['id_image']];
+            } else {
+                $finalImage['associatedVariants'] = [];
+            }
+
+            return $finalImage;
         }, $images);
 
         return $images;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Product image legend was not used at all, if filled out. It was always overwritten by product name. I broke it here - https://github.com/PrestaShop/PrestaShop/pull/33387.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Prepare a product in BO with images WITH AND WITHOUT descriptions. Visit that product in FO, inspect the images and check that there is a product name OR the custom label in the `title` and `alt` tags. Test it with latest version of hummingbird.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/pull/33387#issuecomment-1826265358
| Related PRs       | 
| Sponsor company   | 
