### PR TITLE
Fix: Original product image converted to WebP if set Image format: Use WebP for all images #34705

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2860,7 +2860,7 @@ class AdminProductsControllerCore extends AdminController
 
                 $error = 0;
 
-                if (!ImageManager::resize($file['save_path'], $new_path . '.' . $image->image_format, null, null, 'jpg', false, $error)) {
+                if (!ImageManager::resize($file['save_path'], $new_path . '.' . $image->image_format, null, null, 'jpg', true, $error)) {
                     switch ($error) {
                         case ImageManager::ERROR_FILE_NOT_EXIST:
                             $file['error'] = $this->trans('An error occurred while copying image, the file does not exist anymore.', [], 'Admin.Catalog.Notification');

--- a/src/Adapter/Image/Uploader/AbstractImageUploader.php
+++ b/src/Adapter/Image/Uploader/AbstractImageUploader.php
@@ -107,7 +107,14 @@ abstract class AbstractImageUploader
             throw new MemoryLimitException('Cannot upload image due to memory restrictions');
         }
 
-        if (!ImageManager::resize($temporaryImageName, $destination)) {
+        if (!ImageManager::resize(
+            $temporaryImageName,
+            $destination,
+            null,
+            null,
+            'jpg',
+            true
+        )) {
             throw new ImageOptimizationException('An error occurred while uploading the image. Check your directory permissions.');
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.2.x 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed issue or discussion?     | Fixes #34705

