### PR TITLE
Fix combination search in PPV2 specific price

### DIFF
--- a/src/Adapter/Product/Combination/Repository/CombinationRepository.php
+++ b/src/Adapter/Product/Combination/Repository/CombinationRepository.php
@@ -815,6 +815,7 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
             ->andWhere($qb->expr()->in('pac.id_attribute', ':attributes'))
             ->setParameter('attributes', $attributeIds, Connection::PARAM_INT_ARRAY)
             ->setParameter('productId', $productId->getValue())
+            ->groupBy('pac.id_product_attribute')
         ;
 
         if ($limit) {

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/SearchProductCombinationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/SearchProductCombinationFeatureContext.php
@@ -120,6 +120,36 @@ class SearchProductCombinationFeatureContext extends AbstractCombinationFeatureC
     }
 
     /**
+     * @When I list product ":productReference" combinations in language ":langIso" for shop ":shopReference" limited to ":limit" results I should see following results:
+     *
+     * @param string $productReference
+     * @param string $langIso
+     * @param string $shopReference
+     * @param int $limit
+     * @param ProductCombinationsCollection $expectedResults
+     *
+     * @return void
+     *
+     * @see transformProductCombinationsResult for $expectedResults type transformation
+     */
+    public function listProductCombinationsForShop(
+        string $productReference,
+        string $langIso,
+        string $shopReference,
+        int $limit,
+        ProductCombinationsCollection $expectedResults
+    ): void {
+        $this->searchProductCombinations(
+            $productReference,
+            '',
+            $langIso,
+            ShopConstraint::shop($this->getSharedStorage()->get($shopReference)),
+            $limit,
+            $expectedResults
+        );
+    }
+
+    /**
      * @param string $productReference
      * @param string $searchPhrase
      * @param string $langIso

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_product_combinations.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_product_combinations.feature
@@ -62,6 +62,14 @@ Feature: Search attribute combinations for product in Back Office (BO) of multip
       | product1Blue  | Color - Blue     |           | [Color:Blue]  | 0               | 0        | false      |
 
   Scenario: Search combinations by attributes
+    When I list product "product1" combinations in language "en" for shop "shop1" limited to "10" results I should see following results:
+      | id reference   | combination name        |
+      | product1SWhite | Size - S, Color - White |
+      | product1SBlack | Size - S, Color - Black |
+      | product1SBlue  | Size - S, Color - Blue  |
+      | product1MWhite | Size - M, Color - White |
+      | product1MBlack | Size - M, Color - Black |
+      | product1MBlue  | Size - M, Color - Blue  |
     When I search product "product1" combinations by phrase "b" in language "en" for shop "shop2" limited to "20" results I should see following results:
       | id reference  | combination name |
       | product1Black | Color - Black    |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | A groupBy was missing on the sql query. The results being distorted and the display condition of the search field not filled
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #34229
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/7020936190
| Fixed issue or discussion?     | Fixes #34229
| Related PRs       | -
| Sponsor company   | -
