### PR TITLE
Fix use of front_legacy_context constant in FrontController

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -2081,8 +2081,7 @@ class FrontControllerCore extends Controller
      */
     protected function buildContainer(): ContainerInterface
     {
-        /* @phpstan-ignore-next-line */
-        if (FRONT_LEGACY_CONTEXT) {
+        if (!defined('FRONT_LEGACY_CONTEXT') || FRONT_LEGACY_CONTEXT) {
             return ContainerBuilder::getContainer('front', _PS_MODE_DEV_);
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix the use of the `FRONT_LEGACY_CONTEXT` constant in `FrontController.php` file. Oopsy!
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/7024058666
| Fixed issue or discussion?     | Fixes #34717
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/32719
| Sponsor company   | PrestaShop SA

## How to test?

Please read the bug description #34717 . This bug cannot be reproduced right now because of PR https://github.com/PrestaShop/PrestaShop/pull/34184 . So what you need to do is
1. Undo (locally) the changes of PR https://github.com/PrestaShop/PrestaShop/pull/34184
2. Follow the bug #34717 steps, see the error
3. Verify the PR fixes the bug