### PR TITLE
Remove friendly url alert, put codes to columns

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1325,12 +1325,6 @@ $product-page-padding-bottom: 80px !default;
     list-style: none;
   }
 
-  #product_details_references {
-    input {
-      max-width: 415px;
-    }
-  }
-
   #product_description_related_products {
     .search-with-icon {
       max-width: 377px;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/ReferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/ReferencesType.php
@@ -110,6 +110,7 @@ class ReferencesType extends TranslatorAwareType
             'label' => $this->trans('References', 'Admin.Catalog.Feature'),
             'label_tag_name' => 'h3',
             'required' => false,
+            'columns_number' => 3,
         ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
@@ -227,16 +227,7 @@ class SEOType extends TranslatorAwareType
         $friendlyUrl = $this->router->generate('admin_metas_index') . '#meta_settings_set_up_urls_form';
         $productPreferencesUrl = $this->router->generate('admin_product_preferences') . '#configuration_fieldset_products';
 
-        if ($this->friendlyUrlEnabled) {
-            $alertMessages[] = sprintf(
-                '<strong>%s</strong> %s',
-                $this->trans('Friendly URLs are currently enabled.', 'Admin.Catalog.Notification'),
-                $this->trans('To disable it, go to [1]SEO and URLs[/1]', 'Admin.Catalog.Notification', [
-                    '[1]' => '<a target="_blank" href="' . $friendlyUrl . '">',
-                    '[/1]' => '</a>',
-                ])
-            );
-        } else {
+        if (!$this->friendlyUrlEnabled) {
             $alertMessages[] = sprintf(
                 '<strong>%s</strong> %s',
                 $this->trans('Friendly URLs are currently disabled.', 'Admin.Catalog.Notification'),


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | See below
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No need
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/7049341124
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

**Removed alert "Friendly URLs are enabled". They are enabled in 99.9% of cases, it only wastes space. Remain of the past.**

![friendlyurl](https://github.com/PrestaShop/PrestaShop/assets/6097524/8b98d2fc-3c18-419c-bb08-2899f13a102e)

**Product codes are now in columns instead of under each other. Saves 200px of vertical space.**

![codes](https://github.com/PrestaShop/PrestaShop/assets/6097524/a4866abe-5c7b-4282-89c2-8ac892956a33)

Already validated with @MatShir, putting PM ✅.