### PR TITLE
SF6 - Remove deprecated code from TwigBundle

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -246,23 +246,3 @@ function smarty_endWithoutReference($arrayValue)
     return end($arrayValue);
 }
 
-function renderTemplate(array $params) {
-    $twigTemplate = $params['twig_template'];
-    unset($params['twig_template']);
-    $smartyTemplate = $params['smarty_template'];
-    unset($params['smarty_template']);
-
-    if (
-        SymfonyContainer::getInstance()
-            ->get(FeatureFlagStateCheckerInterface::class)
-            ->isEnabled(FeatureFlagSettings::FEATURE_FLAG_SYMFONY_LAYOUT)
-    ) {
-        /** @var Twig\Environment $twig */
-        $twig = SymfonyContainer::getInstance()->get('twig');
-        return $twig->render($twigTemplate, $params);
-    } else {
-        global $smarty;
-        $smarty->display($smartyTemplate);
-    }
-
-}

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -48,6 +48,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Validator\Constraints as Assert;
+use Twig\Environment;
 
 /**
  * Responsible of "Improve > Modules > Modules & Services > Catalog / Manage" page display.
@@ -57,6 +58,10 @@ class ModuleController extends ModuleAbstractController
     public const CONTROLLER_NAME = 'ADMINMODULESSF';
 
     public const MAX_MODULES_DISPLAYED = 6;
+
+    public function __construct(private readonly Environment $twig)
+    {
+    }
 
     /**
      * Controller responsible for displaying "Catalog Module Grid" section of Module management pages with ajax.
@@ -276,7 +281,7 @@ class ModuleController extends ModuleAbstractController
 
             $modulePresenter = $this->get('prestashop.adapter.presenter.module');
             $collectionPresented = $modulePresenter->presentCollection($collectionWithActionUrls);
-            $response[$moduleName]['action_menu_html'] = $this->get('twig')->render(
+            $response[$moduleName]['action_menu_html'] = $this->twig->render(
                 '@PrestaShop/Admin/Module/Includes/action_menu.html.twig',
                 [
                     'module' => $collectionPresented[0],

--- a/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
@@ -36,7 +36,6 @@ services:
       $environment: "%kernel.environment%"
 
   PrestaShopBundle\Twig\TranslationsExtension:
-    arguments: [ "@service_container", "@router" ]
     properties:
       logger: "@logger"
       translator: "@translator"

--- a/src/PrestaShopBundle/Twig/TranslationsExtension.php
+++ b/src/PrestaShopBundle/Twig/TranslationsExtension.php
@@ -28,9 +28,9 @@ namespace PrestaShopBundle\Twig;
 
 use PrestaShop\PrestaShop\Core\Util\Inflector;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -47,11 +47,6 @@ class TranslationsExtension extends AbstractExtension
     public $logger;
 
     /**
-     * @var ContainerInterface
-     */
-    private $container;
-
-    /**
      * @var RouterInterface
      */
     private $router;
@@ -61,10 +56,12 @@ class TranslationsExtension extends AbstractExtension
      */
     private $theme;
 
-    public function __construct(ContainerInterface $container, RouterInterface $router)
+    private Environment $twig;
+
+    public function __construct(RouterInterface $router, Environment $twig)
     {
-        $this->container = $container;
         $this->router = $router;
+        $this->twig = $twig;
     }
 
     /**
@@ -258,7 +255,7 @@ class TranslationsExtension extends AbstractExtension
 
         $breadcrumbParts = explode('_', Inflector::getInflector()->tableize($domain));
 
-        return $this->container->get('twig')->render(
+        return $this->twig->render(
             '@PrestaShop/Admin/Translations/include/form-edit-message.html.twig',
             [
                 'default_translation_value' => $defaultTranslationValue,
@@ -365,7 +362,7 @@ class TranslationsExtension extends AbstractExtension
         }
 
         if ($hasMessagesSubtree) {
-            $output .= $this->container->get('twig')->render(
+            $output .= $this->twig->render(
                 '@PrestaShop/Admin/Translations/include/button-toggle-messages-visibility.html.twig',
                 [
                     'label_show_messages' => $this->translator->trans('Show messages', [], 'Admin.International.Feature'),
@@ -377,7 +374,7 @@ class TranslationsExtension extends AbstractExtension
         }
 
         $formStart = $this->getTranslationsFormStart($subtree, $output);
-        $output = $this->container->get('twig')->render(
+        $output = $this->twig->render(
             '@PrestaShop/Admin/Translations/include/translations-form-end.html.twig',
             [
                 'form_start' => $formStart,
@@ -439,7 +436,7 @@ class TranslationsExtension extends AbstractExtension
             unset($subtree['__metadata']);
         }
 
-        return $this->container->get('twig')->render(
+        return $this->twig->render(
             '@PrestaShop/Admin/Translations/include/translations-form-start.html.twig',
             [
                 'id' => $id,
@@ -534,7 +531,7 @@ class TranslationsExtension extends AbstractExtension
      */
     protected function getNavigation($id)
     {
-        return $this->container->get('twig')->render(
+        return $this->twig->render(
             '@PrestaShop/Admin/Translations/include/pagination-bar.html.twig',
             ['page_id' => $id]
         );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Twig service is now private in sf 6
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Test UI and CI are green
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/7128788665
| Fixed issue or discussion?     | Fixes #34005 
| Related PRs       | -
| Sponsor company   | -
