### PR TITLE
SF6 - Remove deprecated code from HttpKernel

### DIFF
--- a/index.php
+++ b/index.php
@@ -55,7 +55,7 @@ if (isset($_ENV['PS_FF_FRONT_CONTAINER_V2']) && filter_var($_ENV['PS_FF_FRONT_CO
 
     // Try to handle request
     try {
-        $response = $kernel->handle($request, HttpKernelInterface::MASTER_REQUEST, false);
+        $response = $kernel->handle($request, HttpKernelInterface::MAIN_REQUEST, false);
         $response->send();
         define('FRONT_LEGACY_CONTEXT', false);
         $kernel->terminate($request, $response);

--- a/src/PrestaShopBundle/Controller/Api/Readme.md
+++ b/src/PrestaShopBundle/Controller/Api/Readme.md
@@ -22,7 +22,7 @@ api_warehouse_list_warehouses:
     path: /warehouses
     methods: [GET]
     defaults:
-        _controller: prestashop.core.api.warehouse.controller:listWarehousesAction
+        _controller: PrestaShopBundle\Controller\Api\WarehouseController::listWarehousesAction
 
 ```
 

--- a/src/PrestaShopBundle/Resources/config/routing/api/attributes.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/api/attributes.yml
@@ -2,4 +2,4 @@ api_stock_list_attributes:
   path: /
   methods: [ GET ]
   defaults:
-    _controller: prestashop.core.api.attribute.controller:listAttributesAction
+    _controller: PrestaShopBundle\Controller\Api\AttributeController::listAttributesAction

--- a/src/PrestaShopBundle/Resources/config/routing/api/categories.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/api/categories.yml
@@ -2,4 +2,4 @@ api_stock_list_categories:
   path: /
   methods: [ GET ]
   defaults:
-    _controller: prestashop.core.api.category.controller:listCategoriesAction
+    _controller: PrestaShopBundle\Controller\Api\CategoryController::listCategoriesAction

--- a/src/PrestaShopBundle/Resources/config/routing/api/features.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/api/features.yml
@@ -2,4 +2,4 @@ api_stock_list_features:
   path: /
   methods: [ GET ]
   defaults:
-    _controller: prestashop.core.api.feature.controller:listFeaturesAction
+    _controller: PrestaShopBundle\Controller\Api\FeatureController::listFeaturesAction

--- a/src/PrestaShopBundle/Resources/config/routing/api/i18n.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/api/i18n.yml
@@ -2,6 +2,6 @@ api_i18n_translations_list:
   path: /{page}
   methods: [ GET ]
   defaults:
-    _controller: prestashop.core.api.i18n.controller:listTranslationAction
+    _controller: PrestaShopBundle\Controller\Api\I18nController::listTranslationAction
   requirements:
     page: \w+

--- a/src/PrestaShopBundle/Resources/config/routing/api/improve/design/positions.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/api/improve/design/positions.yml
@@ -2,5 +2,5 @@ api_improve_design_positions_update:
   path: /update
   methods: [ POST ]
   defaults:
-    _controller: prestashop.core.api.improve.design.postions.controller:updateAction
+    _controller: PrestaShopBundle\Controller\Api\Improve\Design\PositionsController::updateAction
     _legacy_controller: AdminModulesPositions

--- a/src/PrestaShopBundle/Resources/config/routing/api/manufacturers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/api/manufacturers.yml
@@ -2,4 +2,4 @@ api_stock_list_manufacturers:
   path: /
   methods: [ GET ]
   defaults:
-    _controller: prestashop.core.api.manufacturer.controller:listManufacturersAction
+    _controller: PrestaShopBundle\Controller\Api\ManufacturerController::listManufacturersAction

--- a/src/PrestaShopBundle/Resources/config/routing/api/stock_movements.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/api/stock_movements.yml
@@ -2,14 +2,14 @@ api_stock_list_movements:
   path: /
   methods: [ GET ]
   defaults:
-    _controller: prestashop.core.api.stock_movement.controller:listMovementsAction
+    _controller: PrestaShopBundle\Controller\Api\StockMovementController::listMovementsAction
     _legacy_controller: AdminStockManagement
 
 api_stock_product_list_movements:
   path: /product/{productId}
   methods: [ GET ]
   defaults:
-    _controller: prestashop.core.api.stock_movement.controller:listMovementsAction
+    _controller: PrestaShopBundle\Controller\Api\StockMovementController::listMovementsAction
     _legacy_controller: AdminStockManagement
   requirements:
     productId: \d+
@@ -18,13 +18,12 @@ api_stock_list_movements_employees:
   path: /employees
   methods: [ GET ]
   defaults:
-    _controller: prestashop.core.api.stock_movement.controller:listMovementsEmployeesAction
+    _controller: PrestaShopBundle\Controller\Api\StockMovementController::listMovementsEmployeesAction
     _legacy_controller: AdminStockManagement
-
 
 api_stock_list_movements_types:
   path: /types
   methods: [ GET ]
   defaults:
-    _controller: prestashop.core.api.stock_movement.controller:listMovementsTypesAction
+    _controller: PrestaShopBundle\Controller\Api\StockMovementController::listMovementsTypesAction
     _legacy_controller: AdminStockManagement

--- a/src/PrestaShopBundle/Resources/config/routing/api/stocks.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/api/stocks.yml
@@ -2,21 +2,21 @@ api_stock_list_products:
   path: /
   methods: [ GET ]
   defaults:
-    _controller: prestashop.core.api.stock.controller:listProductsAction
+    _controller: PrestaShopBundle\Controller\Api\StockController::listProductsAction
     _legacy_controller: AdminStockManagement
 
 api_stock_list_products_export:
   path: /export
   methods: [ GET ]
   defaults:
-    _controller: prestashop.core.api.stock.controller:listProductsExportAction
+    _controller: PrestaShopBundle\Controller\Api\StockController::listProductsExportAction
     _legacy_controller: AdminStockManagement
 
 api_stock_list_product_combinations:
   path: /{productId}
   methods: [ GET ]
   defaults:
-    _controller: prestashop.core.api.stock.controller:listProductsAction
+    _controller: PrestaShopBundle\Controller\Api\StockController::listProductsAction
     _legacy_controller: AdminStockManagement
   requirements:
     productId: \d+
@@ -25,7 +25,7 @@ api_stock_edit_product:
   path: /product/{productId}
   methods: [ POST ]
   defaults:
-    _controller: prestashop.core.api.stock.controller:editProductAction
+    _controller: PrestaShopBundle\Controller\Api\StockController::editProductAction
     _legacy_controller: AdminStockManagement
   requirements:
     productId: \d+
@@ -34,7 +34,7 @@ api_stock_edit_product_combination:
   path: /product/{productId}/combination/{combinationId}
   methods: [ POST ]
   defaults:
-    _controller: prestashop.core.api.stock.controller:editProductAction
+    _controller: PrestaShopBundle\Controller\Api\StockController::editProductAction
     _legacy_controller: AdminStockManagement
   requirements:
     productId: \d+
@@ -44,5 +44,5 @@ api_stock_bulk_edit_products:
   path: /products
   methods: [ POST ]
   defaults:
-    _controller: prestashop.core.api.stock.controller:bulkEditProductsAction
+    _controller: PrestaShopBundle\Controller\Api\StockController::bulkEditProductsAction
     _legacy_controller: AdminStockManagement

--- a/src/PrestaShopBundle/Resources/config/routing/api/suppliers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/api/suppliers.yml
@@ -2,4 +2,4 @@ api_stock_list_suppliers:
   path: /
   methods: [ GET ]
   defaults:
-    _controller: prestashop.core.api.supplier.controller:listSuppliersAction
+    _controller: PrestaShopBundle\Controller\Api\SupplierController::listSuppliersAction

--- a/src/PrestaShopBundle/Resources/config/routing/api/translations.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/api/translations.yml
@@ -2,7 +2,7 @@ api_translation_domains_tree:
   path: /tree/{lang}/{type}/{selected}
   methods: [ GET ]
   defaults:
-    _controller: prestashop.core.api.translation.controller:listTreeAction
+    _controller: PrestaShopBundle\Controller\Api\TranslationController::listTreeAction
     _legacy_controller: AdminTranslations
     selected: null
 
@@ -10,7 +10,7 @@ api_translation_domain_catalog:
   path: /{locale}/{domain}/{theme}
   methods: [ GET ]
   defaults:
-    _controller: prestashop.core.api.translation.controller:listDomainTranslationAction
+    _controller: PrestaShopBundle\Controller\Api\TranslationController::listDomainTranslationAction
     _legacy_controller: AdminTranslations
     theme: null
     module: null
@@ -19,12 +19,12 @@ api_translation_value_edit:
   path: /edit
   methods: [ POST ]
   defaults:
-    _controller: prestashop.core.api.translation.controller:translationEditAction
+    _controller: PrestaShopBundle\Controller\Api\TranslationController::translationEditAction
     _legacy_controller: AdminTranslations
 
 api_translation_value_reset:
   path: /reset
   methods: [ POST ]
   defaults:
-    _controller: prestashop.core.api.translation.controller:translationResetAction
+    _controller: PrestaShopBundle\Controller\Api\TranslationController::translationResetAction
     _legacy_controller: AdminTranslations

--- a/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
@@ -31,9 +31,6 @@ services:
       stockRepository: "@prestashop.core.api.stock.repository"
       queryParams: "@prestashop.core.api.query_stock_params_collection"
 
-  prestashop.core.api.stock.controller:
-    alias: PrestaShopBundle\Controller\Api\StockController
-
   PrestaShopBundle\Controller\Api\StockMovementController:
     class: PrestaShopBundle\Controller\Api\StockMovementController
     parent: PrestaShopBundle\Controller\Api\ApiController
@@ -52,18 +49,12 @@ services:
     properties:
       supplierRepository: "@prestashop.core.api.supplier.repository"
 
-  prestashop.core.api.supplier.controller:
-    alias: PrestaShopBundle\Controller\Api\SupplierController
-
   PrestaShopBundle\Controller\Api\ManufacturerController:
     class: PrestaShopBundle\Controller\Api\ManufacturerController
     parent: PrestaShopBundle\Controller\Api\ApiController
     public: true
     properties:
       manufacturerRepository: "@prestashop.core.api.manufacturer.repository"
-
-  prestashop.core.api.manufacturer.controller:
-    alias: PrestaShopBundle\Controller\Api\ManufacturerController
 
   PrestaShopBundle\Controller\Api\CategoryController:
     class: PrestaShopBundle\Controller\Api\CategoryController
@@ -72,18 +63,12 @@ services:
     properties:
       categoryRepository: "@prestashop.core.api.category.repository"
 
-  prestashop.core.api.category.controller:
-    alias: PrestaShopBundle\Controller\Api\CategoryController
-
   PrestaShopBundle\Controller\Api\AttributeController:
     class: PrestaShopBundle\Controller\Api\AttributeController
     parent: PrestaShopBundle\Controller\Api\ApiController
     public: true
     properties:
       featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
-
-  prestashop.core.api.attribute.controller:
-    alias: PrestaShopBundle\Controller\Api\AttributeController
 
   PrestaShopBundle\Controller\Api\FeatureController:
     class: PrestaShopBundle\Controller\Api\FeatureController
@@ -92,16 +77,10 @@ services:
     properties:
       featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
 
-  prestashop.core.api.feature.controller:
-    alias: PrestaShopBundle\Controller\Api\FeatureController
-
   PrestaShopBundle\Controller\Api\I18nController:
     class: PrestaShopBundle\Controller\Api\I18nController
     parent: PrestaShopBundle\Controller\Api\ApiController
     public: true
-
-  prestashop.core.api.i18n.controller:
-    alias: PrestaShopBundle\Controller\Api\I18nController
 
   PrestaShopBundle\Controller\Api\TranslationController:
     class: PrestaShopBundle\Controller\Api\TranslationController
@@ -111,16 +90,10 @@ services:
       translationService: "@prestashop.service.translation"
       queryParams: "@prestashop.core.api.query_translation_params_collection"
 
-  prestashop.core.api.translation.controller:
-    alias: PrestaShopBundle\Controller\Api\TranslationController
-
   PrestaShopBundle\Controller\Api\Improve\Design\PositionsController:
     class: PrestaShopBundle\Controller\Api\Improve\Design\PositionsController
     parent: PrestaShopBundle\Controller\Api\ApiController
     public: true
-
-  prestashop.core.api.improve.design.postions.controller:
-    alias: PrestaShopBundle\Controller\Api\Improve\Design\PositionsController
 
   prestashop.core.admin.multistore:
     class: PrestaShopBundle\Controller\Admin\MultistoreController


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove support for service:action syntax to reference controllers. Use serviceOrFqcn::method instead. Rename HttpKernelInterface::MASTER_REQUEST to MAIN_REQUEST
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI and UI tests are green
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/7130101047
| Fixed issue or discussion?     | Fixes #33999
| Related PRs       | -
| Sponsor company   | -

**BC breaks:** 

alias deleted :

- prestashop.core.api.stock.controller
- prestashop.core.api.supplier.controller
- prestashop.core.api.manufacturer.controller
- prestashop.core.api.category.controller
- prestashop.core.api.attribute.controller
- prestashop.core.api.feature.controller
- prestashop.core.api.i18n.controller
- prestashop.core.api.translation.controller
- prestashop.core.api.improve.design.postions.controller
