### PR TITLE
SF6: Use AbstractAuthenticator for TokenAuthenticator

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -1,6 +1,7 @@
 # To get started with security, check out the documentation:
 # https://symfony.com/doc/current/security.html
 security:
+  enable_authenticator_manager: true
   password_hashers:
     # auto hasher with default options for the User class (and children)
     PrestaShopBundle\Entity\ApiAccess: 'auto'
@@ -37,10 +38,9 @@ security:
       pattern: '^(%api_base_path%)(?!/docs)'
       stateless: true
       provider: 'oauth2'
-      guard:
-        authenticator:
-          - PrestaShop\PrestaShop\Core\Security\OAuth2\TokenAuthenticator
+      custom_authenticators:
+        - PrestaShop\PrestaShop\Core\Security\OAuth2\TokenAuthenticator
       request_matcher: PrestaShop\PrestaShop\Core\Security\OAuth2\ApiRequestMatcher
 
-    main:
-      anonymous: ~
+  access_control:
+    - { path: ^/, roles: PUBLIC_ACCESS }

--- a/src/Core/Security/OAuth2/TokenAuthenticator.php
+++ b/src/Core/Security/OAuth2/TokenAuthenticator.php
@@ -28,9 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Security\OAuth2;
 
-use Lcobucci\JWT\Encoding\JoseEncoder;
-use Lcobucci\JWT\Token\InvalidTokenStructure;
-use Lcobucci\JWT\Token\Parser;
 use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -65,14 +62,7 @@ class TokenAuthenticator extends AbstractAuthenticator
         if (null === $authorization) {
             return false;
         }
-        if (str_starts_with(strtolower($authorization), 'bearer ')) {
-            $token = substr($authorization, 7);
-            try {
-                (new Parser(new JoseEncoder()))->parse($token);
-            } catch (InvalidTokenStructure) {
-                return false;
-            }
-        } else {
+        if (!str_starts_with(strtolower($authorization), 'bearer ')) {
             return false;
         }
 

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminControllerTest.php
@@ -27,7 +27,6 @@
 namespace Tests\Integration\PrestaShopBundle\Controller\Admin;
 
 use Context;
-use Cookie;
 use Country;
 use Currency;
 use Employee;
@@ -228,8 +227,6 @@ class FrameworkBundleAdminControllerTest extends WebTestCase
      */
     public function testPagesAreAvailable(string $pageName, string $route): void
     {
-        $this->logIn();
-
         $uri = $this->router->generate($route);
 
         $this->client->catchExceptions(false);
@@ -337,16 +334,5 @@ class FrameworkBundleAdminControllerTest extends WebTestCase
             'admin_webservice_keys_create' => ['Webservice', 'admin_webservice_keys_create'],
             'admin_webservice_keys_index' => ['Webservice', 'admin_webservice_keys_index'],
         ];
-    }
-
-    /**
-     * Emulates a real employee logged to the Back Office.
-     * For survival tests only.
-     */
-    private function logIn(): void
-    {
-        $container = self::$kernel->getContainer();
-        $cookie = new Cookie('psAdmin', '', 3600);
-        $container->get('prestashop.adapter.legacy.context')->getContext()->cookie = $cookie;
     }
 }

--- a/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/01_internalAuthServer/02_resourceEndpoint.ts
+++ b/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/01_internalAuthServer/02_resourceEndpoint.ts
@@ -132,8 +132,6 @@ describe('API : Internal Auth Server - Resource Endpoint', async () => {
 
       const apiResponse = await apiContext.get('api/hook-status/1');
       expect(apiResponse.status()).to.eq(401);
-      expect(api.hasResponseHeader(apiResponse, 'WWW-Authenticate')).to.eq(true);
-      expect(api.getResponseHeader(apiResponse, 'WWW-Authenticate')).to.be.eq('Bearer');
     });
 
     it('should request the endpoint /admin-dev/api/hook-status/1 with invalid access token', async function () {

--- a/tests/Unit/Core/Security/TokenAuthenticatorTest.php
+++ b/tests/Unit/Core/Security/TokenAuthenticatorTest.php
@@ -82,9 +82,6 @@ class TokenAuthenticatorTest extends TestCase
         $this->request->headers->add(['Authorization' => 'toto']);
         $this->assertFalse($this->tokenAuthenticator->supports($this->request));
 
-        $this->request->headers->add(['Authorization' => 'bearer toto']);
-        $this->assertFalse($this->tokenAuthenticator->supports($this->request));
-
         $this->request->headers->add(['Authorization' => 'bearer ' . $this->buildTestToken()]);
         $this->assertTrue($this->tokenAuthenticator->supports($this->request));
     }

--- a/tests/Unit/Core/Security/TokenAuthenticatorTest.php
+++ b/tests/Unit/Core/Security/TokenAuthenticatorTest.php
@@ -26,18 +26,20 @@
 
 namespace Tests\Unit\Core\Security;
 
+use DateTimeImmutable;
+use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\JwtFacade;
+use Lcobucci\JWT\Signer\Hmac\Sha256;
+use Lcobucci\JWT\Signer\Key\InMemory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Security\OAuth2\AuthorisationServerInterface;
 use PrestaShop\PrestaShop\Core\Security\OAuth2\TokenAuthenticator;
-use PrestaShopBundle\Security\OAuth2\Entity\JwtTokenUser;
-use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 
 class TokenAuthenticatorTest extends TestCase
 {
@@ -73,29 +75,48 @@ class TokenAuthenticatorTest extends TestCase
         $this->assertSame('Bearer', $response->headers->get('WWW-Authenticate'));
     }
 
-    public function testGetCredentials(): void
+    public function testSupports(): void
     {
-        $credentials = $this->tokenAuthenticator->getCredentials($this->request);
-        $this->assertTrue($credentials instanceof ServerRequestInterface);
+        $this->assertFalse($this->tokenAuthenticator->supports($this->request));
+
+        $this->request->headers->add(['Authorization' => 'toto']);
+        $this->assertFalse($this->tokenAuthenticator->supports($this->request));
+
+        $this->request->headers->add(['Authorization' => 'bearer toto']);
+        $this->assertFalse($this->tokenAuthenticator->supports($this->request));
+
+        $this->request->headers->add(['Authorization' => 'bearer ' . $this->buildTestToken()]);
+        $this->assertTrue($this->tokenAuthenticator->supports($this->request));
     }
 
-    public function testGetUser(): void
+    private function buildTestToken(): string
     {
-        $this->authorizationServer->method('getUser')->willReturn(new JwtTokenUser('testUser', []));
-        $serverRequestMock = $this->createMock(ServerRequestInterface::class);
-        $user = $this->tokenAuthenticator->getUser(
-            $serverRequestMock,
-            $this->createMock(UserProviderInterface::class)
+        $key = InMemory::base64Encoded('hiG8DlOKvtih6AxlZn5XKImZ06yu8I3mkOzaJrEuW8yAv8Jnkw330uMt8AEqQ5LB');
+
+        $token = (new JwtFacade())->issue(
+            new Sha256(),
+            $key,
+            static fn (
+                Builder $builder,
+                DateTimeImmutable $issuedAt
+            ): Builder => $builder
+                ->issuedBy('https://api.my-awesome-app.io')
+                ->permittedFor('https://client-app.io')
+                ->expiresAt($issuedAt->modify('+10 minutes'))
         );
-        $this->assertInstanceOf(JwtTokenUser::class, $user);
+
+        return $token->toString();
     }
 
-    public function testCheckCredentials(): void
+    public function testAuthenticate(): void
     {
-        $this->authorizationServer->expects($this->once())->method('isTokenValid');
-        $this->tokenAuthenticator->checkCredentials(
-            $this->createMock(ServerRequestInterface::class),
-            $this->createMock(UserInterface::class)
-        );
+        $this->expectException(CustomUserMessageAuthenticationException::class);
+        $this->expectExceptionMessage('No API token provided');
+        $this->tokenAuthenticator->authenticate($this->request);
+
+        $this->request->headers->add(['Authorization' => 'bearer ' . $this->buildTestToken()]);
+        $this->expectException(CustomUserMessageAuthenticationException::class);
+        $this->expectExceptionMessage('Invalid credentials');
+        $this->tokenAuthenticator->authenticate($this->request);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Update anonymous access, see https://symfony.com/doc/current/security.html#allowing-unsecured-access-i-e-anonymous-users. Use AbstractAuthenticator instead of AbstractGuardAuthenticator (deprecated)
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI and UI tests are green
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/7197890031
| Fixed issue or discussion?     | Fixes #34762
| Related PRs       | -
| Sponsor company   | -
