### PR TITLE
Remove file CACHEDIR.TAG - reverting changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ npm-debug.log.*
 !/download/index.php
 
 # Images
-/img/tmp/CACHEDIR.TAG
 /img/*
 !/img/.htaccess
 !/img/index.php

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ npm-debug.log.*
 !/download/index.php
 
 # Images
+/img/tmp/CACHEDIR.TAG
 /img/*
 !/img/.htaccess
 !/img/index.php

--- a/img/tmp/CACHEDIR.TAG
+++ b/img/tmp/CACHEDIR.TAG
@@ -1,1 +1,4 @@
-
+Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag created by PrestaShop.
+# For information about cache directory tags, see:
+#	http://www.brynosaurus.com/cachedir/

--- a/img/tmp/CACHEDIR.TAG
+++ b/img/tmp/CACHEDIR.TAG
@@ -1,4 +1,0 @@
-Signature: 8a477f597d28d172789f06886806bc55
-# This file is a cache directory tag created by PrestaShop.
-# For information about cache directory tags, see:
-#	http://www.brynosaurus.com/cachedir/

--- a/var/cache/CACHEDIR.TAG
+++ b/var/cache/CACHEDIR.TAG
@@ -1,1 +1,4 @@
-
+Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag created by PrestaShop.
+# For information about cache directory tags, see:
+#	http://www.brynosaurus.com/cachedir/

--- a/var/cache/CACHEDIR.TAG
+++ b/var/cache/CACHEDIR.TAG
@@ -1,4 +1,0 @@
-Signature: 8a477f597d28d172789f06886806bc55
-# This file is a cache directory tag created by PrestaShop.
-# For information about cache directory tags, see:
-#	http://www.brynosaurus.com/cachedir/


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove file CACHEDIR.TAG - reverting changes, check PR #34790 - EDIT 2024/01/09: I am reverting all changes with new feature/improvement CACHEDIR.TAG, check my last comment, I am not able to change behaviour like you requested. Someone else "must" do this.... I am sad with this. I hope someone else will do this job... Because CACHEDIR.TAG can be usefull at webhosting level with backup software. EDIT 2024/01/11 - new PR from @Hlavtox (https://github.com/PrestaShop/PrestaShop/pull/35030), so this PR 34816 should be merged to prevent "duplicity".
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | #34790
| Sponsor company   | https://www.openservis.cz/
