### PR TITLE
Fix: date_add field not updated when duplicating a product #34079

### DIFF
--- a/src/Adapter/Product/Update/ProductDuplicator.php
+++ b/src/Adapter/Product/Update/ProductDuplicator.php
@@ -262,7 +262,7 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
         // Then associate it to other shops and copy its values
         $newProductId = new ProductId((int) $duplicatedProduct->id);
         foreach ($shopIds as $shopId) {
-            $shopProduct = $this->productRepository->get($sourceProductId, $shopId);
+            $shopProduct = $this->productRepository->get($newProductId, $shopId);
             // The duplicated product is disabled and not indexed by default
             $shopProduct->indexed = false;
             $shopProduct->active = false;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description     | Reset product date_add on duplicate product
| Type?             | bug fix 
| Category?         | BO
| Fixed issue or discussion?     | Fixes #34079

