### PR TITLE
Unreleased version of Classic is required for v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "prestashop/blockreassurance": "^5.1",
         "prestashop/blockwishlist": "^3.0",
         "prestashop/circuit-breaker": "^4.0",
-        "prestashop/classic": "^2.1",
+        "prestashop/classic": "develop-dev",
         "prestashop/contactform": "^4",
         "prestashop/dashactivity": "^2",
         "prestashop/dashgoals": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "01650975359a616bc9bf67a47be4a21b",
+    "content-hash": "0883f16c21912e506e4db6998c4360fa",
     "packages": [
         {
             "name": "api-platform/core",
@@ -4941,22 +4941,23 @@
         },
         {
             "name": "prestashop/classic",
-            "version": "2.1.1",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/classic-theme.git",
-                "reference": "481b7af6c5d5f82b4db05ec4fd747a9cc5ff87e3"
+                "reference": "51ece31aadca2f7bc7c6135dbd99eca5689eaae6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/classic-theme/zipball/481b7af6c5d5f82b4db05ec4fd747a9cc5ff87e3",
-                "reference": "481b7af6c5d5f82b4db05ec4fd747a9cc5ff87e3",
+                "url": "https://api.github.com/repos/PrestaShop/classic-theme/zipball/51ece31aadca2f7bc7c6135dbd99eca5689eaae6",
+                "reference": "51ece31aadca2f7bc7c6135dbd99eca5689eaae6",
                 "shasum": ""
             },
             "require-dev": {
                 "symfony/console": "~4.4 || ^5.0",
                 "symfony/yaml": "~4.4 || ^5.0"
             },
+            "default-branch": true,
             "type": "prestashop-theme",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4969,14 +4970,14 @@
                 },
                 {
                     "name": "PrestaShop Community",
-                    "homepage": "https://contributors.prestashop.com/"
+                    "homepage": "https://contributors.prestashop-project.org/"
                 }
             ],
-            "description": "Classic theme for PrestaShop 1.7",
+            "description": "Classic theme for develop PrestaShop version",
             "support": {
-                "source": "https://github.com/PrestaShop/classic-theme/tree/2.1.1"
+                "source": "https://github.com/PrestaShop/classic-theme/tree/develop"
             },
-            "time": "2023-03-13T21:18:14+00:00"
+            "time": "2023-10-27T14:14:25+00:00"
         },
         {
             "name": "prestashop/contactform",
@@ -18161,6 +18162,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "prestashop/classic": 20,
         "prestashop/ps_apiresources": 20
     },
     "prefer-stable": true,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Classic v3 has some changes required for v9, for the time being, we could load the develop version.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Brand images on the brands list are not displayed correctly on v9 with Classic v2, you can see the page after updating Classic 
| UI Tests          | Please run UI tests and paste here the link to the run. [Read this page to know why and how to use this tool.](https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/ui-tests/).
| Fixed issue or discussion?     | not needed
| Related PRs       | n/a
| Sponsor company   | Your company or customer's name goes here (if applicable).
