### PR TITLE
SF6- Remove deprecated code from FrameworkBundle

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -14,7 +14,7 @@ imports:
 framework:
   test: ~
   session:
-    storage_id: session.storage.mock_file
+    storage_factory_id: session.storage.factory.mock_file
   profiler:
     collect: false
 

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
 use PrestaShopBundle\Bridge\AdminController\LegacyControllerBridgeInterface;
 use PrestaShopBundle\Install\Language as InstallLanguage;
 use PrestaShopBundle\Translation\TranslatorComponent as Translator;
+use PrestaShopBundle\Translation\TranslatorInterface;
 use PrestaShopBundle\Translation\TranslatorLanguageLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -397,7 +398,7 @@ class ContextCore
             // symfony's container isn't available in front office, so we load and configure the translator component
             $this->translator = $this->getTranslatorFromLocale($this->language->locale);
         } else {
-            $this->translator = $sfContainer->get('translator');
+            $this->translator = $sfContainer->get(TranslatorInterface::class);
             // We need to set the locale here because in legacy BO pages, the translator is used
             // before the TranslatorListener does its job of setting the locale according to the Request object
             $this->translator->setLocale($this->language->locale);

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository;
 use PrestaShop\PrestaShop\Core\Localization\RTL\Processor as RtlStylesheetProcessor;
+use PrestaShopBundle\Translation\TranslatorInterface;
 use Symfony\Component\Intl\Countries;
 
 class LanguageCore extends ObjectModel implements LanguageInterface
@@ -1552,7 +1553,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     public static function updateMultilangTables(Language $language, array $tablesToUpdate)
     {
-        $translator = SymfonyContainer::getInstance()->get('translator');
+        $translator = SymfonyContainer::getInstance()->get(TranslatorInterface::class);
 
         foreach ($tablesToUpdate as $tableName) {
             $className = (new DataLangFactory(_DB_PREFIX_, $translator))
@@ -1612,7 +1613,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     public static function updateMultilangFromClass($table, $className, $lang)
     {
-        $translator = SymfonyContainer::getInstance()->get('translator');
+        $translator = SymfonyContainer::getInstance()->get(TranslatorInterface::class);
 
         try {
             $classObject = (new DataLangFactory(_DB_PREFIX_, $translator))
@@ -1649,7 +1650,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         $shopDefaultLanguage = new Language($shopDefaultLangId);
 
         $sfContainer = SymfonyContainer::getInstance();
-        $translator = $sfContainer->get('translator');
+        $translator = $sfContainer->get(TranslatorInterface::class);
         if (!$translator->isLanguageLoaded($shopDefaultLanguage->locale)) {
             $sfContainer->get('prestashop.translation.translator_language_loader')
                 ->setIsAdminContext(true)

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator;
 use PrestaShop\PrestaShop\Core\Util\Url\UrlCleaner;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class AdminControllerCore extends Controller
 {
@@ -2682,7 +2683,7 @@ class AdminControllerCore extends Controller
             }
 
             $username = $this->get('prestashop.user_provider')->getUsername();
-            $token = $this->get('security.csrf.token_manager')
+            $token = $this->get(CsrfTokenManagerInterface::class)
                 ->getToken($username)
                 ->getValue();
 

--- a/classes/lang/DataLang.php
+++ b/classes/lang/DataLang.php
@@ -62,7 +62,7 @@ class DataLangCore
 
         $this->translator = $translator instanceof TranslatorInterface
             ? $translator
-            : SymfonyContainer::getInstance()->get('translator');
+            : SymfonyContainer::getInstance()->get(TranslatorInterface::class);
 
         $isAdminContext = defined('_PS_ADMIN_DIR_');
 

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -4242,7 +4242,9 @@ class AdminImportControllerCore extends AdminController
      */
     private function getSession()
     {
-        return \PrestaShop\PrestaShop\Adapter\SymfonyContainer::getInstance()->get('session');
+        $requestStack = \PrestaShop\PrestaShop\Adapter\SymfonyContainer::getInstance()->get('request_stack');
+
+        return $requestStack->getSession();
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -55,7 +55,6 @@ use PrestaShop\PrestaShop\Core\Util\HelperCard\DocumentationLinkProviderInterfac
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
-use PrestaShopBundle\Translation\TranslatorInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -68,10 +67,8 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 class EmployeeController extends FrameworkBundleAdminController
 {
     public function __construct(
-         TranslatorInterface $translator,
         private readonly CsrfTokenManagerInterface $csrfTokenManager,
     ) {
-        parent::__construct($translator);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -55,16 +55,25 @@ use PrestaShop\PrestaShop\Core\Util\HelperCard\DocumentationLinkProviderInterfac
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
+use PrestaShopBundle\Translation\TranslatorInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 /**
  * Class EmployeeController handles pages under "Configure > Advanced Parameters > Team > Employees".
  */
 class EmployeeController extends FrameworkBundleAdminController
 {
+    public function __construct(
+         TranslatorInterface $translator,
+        private readonly CsrfTokenManagerInterface $csrfTokenManager,
+    ) {
+        parent::__construct($translator);
+    }
+
     /**
      * Show employees list & options page.
      *
@@ -378,7 +387,7 @@ class EmployeeController extends FrameworkBundleAdminController
                 // @see https://github.com/PrestaShop/PrestaShop/pull/32861
                 $redirectParameters = ['employeeId' => $result->getIdentifiableObjectId()];
                 if ($contextEmployeeProvider->getId() === $result->getIdentifiableObjectId()) {
-                    $newToken = $this->get('security.csrf.token_manager')
+                    $newToken = $this->csrfTokenManager
                         ->getToken($employeeForm->get('email')->getData())
                         ->getValue();
                     $redirectParameters['_token'] = $newToken;

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin;
 
+use Doctrine\Persistence\ManagerRegistry;
 use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridInterface;
@@ -34,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepositor
 use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
 use PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorInterface;
 use PrestaShop\PrestaShop\Core\Security\Permission;
+use PrestaShopBundle\Translation\TranslatorInterface;
 use Psr\Container\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
@@ -41,8 +43,6 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Contracts\Service\Attribute\Required;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Extends The Symfony framework bundle controller to add common functions for PrestaShop needs.
@@ -52,7 +52,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class FrameworkBundleAdminController extends AbstractController implements ContainerAwareInterface
 {
-    protected TranslatorInterface $translator;
     /**
      * @deprecated since 9.0
      */
@@ -75,6 +74,42 @@ class FrameworkBundleAdminController extends AbstractController implements Conta
         $this->container = $container;
 
         return $previous;
+    }
+
+    /**
+     * This method was removed in Symfony 6, for backward compatibility reasons this method is temporarily
+     * maintained so the modules can keep using it a little longer. It will be removed in the next major though
+     * along with this base controller class
+     *
+     * @deprecated since 9.0
+     */
+    protected function has(string $id): bool
+    {
+        return $this->container->has($id);
+    }
+
+    /**
+     * This method was removed in Symfony 6, for backward compatibility reasons this method is temporarily
+     * maintained so the modules can keep using it a little longer. It will be removed in the next major though
+     * along with this base controller class
+     *
+     * @deprecated since 9.0
+     */
+    protected function get(string $id): object
+    {
+        return $this->container->get($id);
+    }
+
+    /**
+     * This method was removed in Symfony 6, for backward compatibility reasons this method is temporarily
+     * maintained so the modules can keep using it a little longer. It will be removed in the next major though
+     * along with this base controller class
+     *
+     * @deprecated since 9.0
+     */
+    protected function getDoctrine(): ManagerRegistry
+    {
+        return $this->container->get('doctrine');
     }
 
     /**
@@ -121,7 +156,7 @@ class FrameworkBundleAdminController extends AbstractController implements Conta
             }
 
             if ($error->getMessagePluralization()) {
-                $errors[$formId][] = $this->translator->trans(
+                $errors[$formId][] = $this->getTranslator()->trans(
                     $error->getMessageTemplate(),
                     array_merge(
                         $error->getMessageParameters(),
@@ -130,7 +165,7 @@ class FrameworkBundleAdminController extends AbstractController implements Conta
                     'validators'
                 );
             } else {
-                $errors[$formId][] = $this->translator->trans(
+                $errors[$formId][] = $this->getTranslator()->trans(
                     $error->getMessageTemplate(),
                     $error->getMessageParameters(),
                     'validators'
@@ -306,7 +341,7 @@ class FrameworkBundleAdminController extends AbstractController implements Conta
      */
     protected function trans($key, $domain, array $parameters = [])
     {
-        return $this->translator->trans($key, $parameters, $domain);
+        return $this->getTranslator()->trans($key, $parameters, $domain);
     }
 
     /**
@@ -546,9 +581,8 @@ class FrameworkBundleAdminController extends AbstractController implements Conta
         );
     }
 
-    #[Required]
-    public function setTranslator(TranslatorInterface $translator)
+    protected function getTranslator(): TranslatorInterface
     {
-        $this->translator = $translator;
+        return $this->get(TranslatorInterface::class);
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -41,6 +41,8 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Contracts\Service\Attribute\Required;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Extends The Symfony framework bundle controller to add common functions for PrestaShop needs.
@@ -50,6 +52,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
  */
 class FrameworkBundleAdminController extends AbstractController implements ContainerAwareInterface
 {
+    protected TranslatorInterface $translator;
     /**
      * @deprecated since 9.0
      */
@@ -106,8 +109,6 @@ class FrameworkBundleAdminController extends AbstractController implements Conta
             return $errors;
         }
 
-        $translator = $this->get('translator');
-
         foreach ($form->getErrors(true) as $error) {
             if ($error->getCause() && method_exists($error->getCause(), 'getPropertyPath')) {
                 $formId = str_replace(
@@ -120,7 +121,7 @@ class FrameworkBundleAdminController extends AbstractController implements Conta
             }
 
             if ($error->getMessagePluralization()) {
-                $errors[$formId][] = $translator->trans(
+                $errors[$formId][] = $this->translator->trans(
                     $error->getMessageTemplate(),
                     array_merge(
                         $error->getMessageParameters(),
@@ -129,7 +130,7 @@ class FrameworkBundleAdminController extends AbstractController implements Conta
                     'validators'
                 );
             } else {
-                $errors[$formId][] = $translator->trans(
+                $errors[$formId][] = $this->translator->trans(
                     $error->getMessageTemplate(),
                     $error->getMessageParameters(),
                     'validators'
@@ -305,7 +306,7 @@ class FrameworkBundleAdminController extends AbstractController implements Conta
      */
     protected function trans($key, $domain, array $parameters = [])
     {
-        return $this->container->get('translator')->trans($key, $parameters, $domain);
+        return $this->translator->trans($key, $parameters, $domain);
     }
 
     /**
@@ -543,5 +544,11 @@ class FrameworkBundleAdminController extends AbstractController implements Conta
             $exceptionCode,
             $e->getMessage()
         );
+    }
+
+    #[Required]
+    public function setTranslator(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -28,9 +28,9 @@ namespace PrestaShopBundle\Controller\Admin\Improve;
 
 use DateTime;
 use Db;
+use Doctrine\ORM\EntityManagerInterface;
 use Exception;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
-use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Adapter\Module\Module as ModuleAdapter;
 use PrestaShop\PrestaShop\Core\Module\ModuleCollection;
 use PrestaShop\PrestaShop\Core\Module\ModuleManager;
@@ -63,6 +63,7 @@ class ModuleController extends ModuleAbstractController
     public function __construct(
         private readonly Environment $twig,
         private readonly ValidatorInterface $validator,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -139,7 +140,7 @@ class ModuleController extends ModuleAbstractController
         $moduleAccessedId = (int) $moduleAccessed->database->get('id');
 
         // Save history for this module
-        $moduleHistory = $this->getDoctrine()
+        $moduleHistory = $this->entityManager
             ->getRepository(ModuleHistory::class)
             ->findOneBy(
                 [
@@ -156,9 +157,8 @@ class ModuleController extends ModuleAbstractController
         $moduleHistory->setIdModule($moduleAccessedId);
         $moduleHistory->setDateUpd(new DateTime());
 
-        $em = $this->getDoctrine()->getManager();
-        $em->persist($moduleHistory);
-        $em->flush();
+        $this->entityManager->persist($moduleHistory);
+        $this->entityManager->flush();
 
         return $this->redirect(
             $legacyUrlGenerator->generate(

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -48,6 +48,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Twig\Environment;
 
 /**
@@ -59,8 +60,10 @@ class ModuleController extends ModuleAbstractController
 
     public const MAX_MODULES_DISPLAYED = 6;
 
-    public function __construct(private readonly Environment $twig)
-    {
+    public function __construct(
+        private readonly Environment $twig,
+        private readonly ValidatorInterface $validator,
+    ) {
     }
 
     /**
@@ -372,7 +375,7 @@ class ModuleController extends ModuleAbstractController
                 ),
             ];
 
-            $violations = $this->get('validator')->validate($fileUploaded, $constraints);
+            $violations = $this->validator->validate($fileUploaded, $constraints);
             if (0 !== count($violations)) {
                 $violationsMessages = [];
                 foreach ($violations as $violation) {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Controller\Admin\Sell\Catalog\Product;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Exception;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Adapter\Shop\Context;
@@ -110,17 +111,10 @@ class ProductController extends FrameworkBundleAdminController
      */
     private const BULK_PRODUCT_IDS_KEY = 'product_bulk';
 
-    /**
-     * @var ProductRepository
-     */
-    private $productRepository;
-
-    /**
-     * @param ProductRepository $productRepository
-     */
-    public function __construct(ProductRepository $productRepository)
-    {
-        $this->productRepository = $productRepository;
+    public function __construct(
+        private readonly ProductRepository $productRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
     }
 
     /**
@@ -989,7 +983,7 @@ class ProductController extends FrameworkBundleAdminController
     public function downloadVirtualFileAction(int $virtualProductFileId): BinaryFileResponse
     {
         $configuration = $this->getConfiguration();
-        $download = $this->getDoctrine()
+        $download = $this->entityManager
             ->getRepository(ProductDownload::class)
             ->findOneBy([
                 'id' => $virtualProductFileId,

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -107,6 +107,7 @@ use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use PrestaShopBundle\Service\Grid\ResponseBuilder;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -128,6 +129,10 @@ class OrderController extends FrameworkBundleAdminController
      * Options used for the number of products per page
      */
     public const PRODUCTS_PAGINATION_OPTIONS = [8, 20, 50, 100];
+
+    public function __construct(private readonly FormFactoryInterface $formFactory)
+    {
+    }
 
     /**
      * Shows list of orders
@@ -426,14 +431,13 @@ class OrderController extends FrameworkBundleAdminController
             return $this->redirectToRoute('admin_orders_index');
         }
 
-        $formFactory = $this->get('form.factory');
-        $updateOrderStatusForm = $formFactory->createNamed(
+        $updateOrderStatusForm = $this->formFactory->createNamed(
             'update_order_status',
             UpdateOrderStatusType::class, [
                 'new_order_status_id' => $orderForViewing->getHistory()->getCurrentOrderStatusId(),
             ]
         );
-        $updateOrderStatusActionBarForm = $formFactory->createNamed(
+        $updateOrderStatusActionBarForm = $this->formFactory->createNamed(
             'update_order_status_action_bar',
             UpdateOrderStatusType::class, [
                 'new_order_status_id' => $orderForViewing->getHistory()->getCurrentOrderStatusId(),
@@ -1119,9 +1123,7 @@ class OrderController extends FrameworkBundleAdminController
      */
     public function updateStatusAction(int $orderId, Request $request): RedirectResponse
     {
-        $formFactory = $this->get('form.factory');
-
-        $form = $formFactory->createNamed(
+        $form = $this->formFactory->createNamed(
             'update_order_status',
             UpdateOrderStatusType::class
         );
@@ -1129,7 +1131,7 @@ class OrderController extends FrameworkBundleAdminController
 
         if (!$form->isSubmitted() || !$form->isValid()) {
             // Check if the form is submit from the action bar
-            $form = $formFactory->createNamed(
+            $form = $this->formFactory->createNamed(
                 'update_order_status_action_bar',
                 UpdateOrderStatusType::class
             );

--- a/src/PrestaShopBundle/Controller/Api/StockController.php
+++ b/src/PrestaShopBundle/Controller/Api/StockController.php
@@ -43,23 +43,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class StockController extends ApiController
 {
-    /**
-     * @var StockRepository
-     */
-    public $stockRepository;
-
-    /**
-     * @var QueryStockParamsCollection
-     */
-    public $queryParams;
-
-    /**
-     * @var MovementsCollection;
-     */
-    public $movements;
-
-    public function __construct(private readonly TranslatorInterface $translator)
-    {
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+        private readonly StockRepository $stockRepository,
+        private readonly QueryStockParamsCollection $queryParams,
+        private readonly MovementsCollection $movements,
+    ) {
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Api/StockController.php
+++ b/src/PrestaShopBundle/Controller/Api/StockController.php
@@ -39,6 +39,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class StockController extends ApiController
 {
@@ -56,6 +57,10 @@ class StockController extends ApiController
      * @var MovementsCollection;
      */
     public $movements;
+
+    public function __construct(private readonly TranslatorInterface $translator)
+    {
+    }
 
     /**
      * @param Request $request
@@ -167,23 +172,21 @@ class StockController extends ApiController
             return $this->stockRepository->getDataExport($page, $limit, $queryParamsCollection);
         };
 
-        $translator = $this->container->get('translator');
-
         // headers columns
         $headersData = [
             'product_id' => 'Product ID',
             'combination_id' => 'Combination ID',
-            'product_reference' => $translator->trans('Product reference', [], 'Admin.Advparameters.Feature'),
-            'combination_reference' => $translator->trans('Combination reference', [], 'Admin.Advparameters.Feature'),
-            'product_name' => $translator->trans('Product name', [], 'Admin.Catalog.Feature'),
-            'combination_name' => $translator->trans('Combination name', [], 'Admin.Catalog.Feature'),
-            'supplier_name' => $translator->trans('Supplier', [], 'Admin.Global'),
-            'active' => $translator->trans('Status', [], 'Admin.Global'),
-            'product_physical_quantity' => $translator->trans('Physical quantity', [], 'Admin.Catalog.Feature'),
-            'product_reserved_quantity' => $translator->trans('Reserved quantity', [], 'Admin.Catalog.Feature'),
-            'product_available_quantity' => $translator->trans('Available quantity', [], 'Admin.Catalog.Feature'),
-            'product_low_stock_threshold' => $translator->trans('Low stock level', [], 'Admin.Catalog.Feature'),
-            'product_low_stock_alert' => $translator->trans('Send me an email when the quantity is below or equals this level', [], 'Admin.Catalog.Feature'),
+            'product_reference' => $this->translator->trans('Product reference', [], 'Admin.Advparameters.Feature'),
+            'combination_reference' => $this->translator->trans('Combination reference', [], 'Admin.Advparameters.Feature'),
+            'product_name' => $this->translator->trans('Product name', [], 'Admin.Catalog.Feature'),
+            'combination_name' => $this->translator->trans('Combination name', [], 'Admin.Catalog.Feature'),
+            'supplier_name' => $this->translator->trans('Supplier', [], 'Admin.Global'),
+            'active' => $this->translator->trans('Status', [], 'Admin.Global'),
+            'product_physical_quantity' => $this->translator->trans('Physical quantity', [], 'Admin.Catalog.Feature'),
+            'product_reserved_quantity' => $this->translator->trans('Reserved quantity', [], 'Admin.Catalog.Feature'),
+            'product_available_quantity' => $this->translator->trans('Available quantity', [], 'Admin.Catalog.Feature'),
+            'product_low_stock_threshold' => $this->translator->trans('Low stock level', [], 'Admin.Catalog.Feature'),
+            'product_low_stock_alert' => $this->translator->trans('Send me an email when the quantity is below or equals this level', [], 'Admin.Catalog.Feature'),
         ];
 
         return (new CsvResponse())
@@ -254,7 +257,7 @@ class StockController extends ApiController
         $messageMissingParameters = 'Each item of JSON-encoded array in the request body should contain ' .
             'a product id ("product_id"), a quantity delta ("delta"). ' .
             'The item of index #%d is invalid.';
-        $messageEmptyData = $this->container->get('translator')->trans(
+        $messageEmptyData = $this->translator->trans(
             'Value cannot be 0.',
             [],
             'Admin.Notifications.Error'

--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -40,6 +40,7 @@ use PrestaShopBundle\Form\Admin\Improve\International\Translations\ModifyTransla
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Service\TranslationService;
 use PrestaShopBundle\Translation\Exception\UnsupportedLocaleException;
+use PrestaShopBundle\Translation\TranslatorInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -55,6 +56,10 @@ class TranslationController extends ApiController
      * @var TranslationService
      */
     public $translationService;
+
+    public function __construct(private readonly TranslatorInterface $translator)
+    {
+    }
 
     /**
      * Show translations for 1 domain & 1 locale given & 1 theme given (optional).
@@ -348,13 +353,12 @@ class TranslationController extends ApiController
     private function translateMultilingualContent(array $modifiedDomains, Lang $lang)
     {
         if (in_array('AdminNavigationMenu', $modifiedDomains)) {
-            $translator = $this->container->get('translator');
 
             // reset translator
-            $translator->clearLanguage($lang->getLocale());
+            $this->translator->clearLanguage($lang->getLocale());
 
             // update menu items (tabs)
-            (new EntityTranslatorFactory($translator))
+            (new EntityTranslatorFactory($this->translator))
                 ->buildFromTableName('tab', $lang->getLocale())
                 ->translate($lang->getId(), \Context::getContext()->shop->id);
         }

--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -47,18 +47,11 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class TranslationController extends ApiController
 {
-    /**
-     * @var QueryTranslationParamsCollection
-     */
-    public $queryParams;
-
-    /**
-     * @var TranslationService
-     */
-    public $translationService;
-
-    public function __construct(private readonly TranslatorInterface $translator)
-    {
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+        private readonly QueryTranslationParamsCollection $queryParams,
+        private readonly TranslationService $translationService,
+    ) {
     }
 
     /**
@@ -353,7 +346,6 @@ class TranslationController extends ApiController
     private function translateMultilingualContent(array $modifiedDomains, Lang $lang)
     {
         if (in_array('AdminNavigationMenu', $modifiedDomains)) {
-
             // reset translator
             $this->translator->clearLanguage($lang->getLocale());
 

--- a/src/PrestaShopBundle/EventListener/AccessDeniedListener.php
+++ b/src/PrestaShopBundle/EventListener/AccessDeniedListener.php
@@ -31,7 +31,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -42,26 +42,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class AccessDeniedListener
 {
-    /**
-     * @var RouterInterface
-     */
-    private $router;
-
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
-     * @var Session
-     */
-    private $session;
-
-    public function __construct(RouterInterface $router, TranslatorInterface $translator, Session $session)
-    {
-        $this->router = $router;
-        $this->translator = $translator;
-        $this->session = $session;
+    public function __construct(
+        private readonly RouterInterface $router,
+        private readonly TranslatorInterface $translator,
+        private readonly FlashBagInterface $flashBag,
+    ) {
     }
 
     /**
@@ -104,7 +89,7 @@ class AccessDeniedListener
             ], Response::HTTP_FORBIDDEN);
         }
 
-        $this->session->getFlashBag()->add('error', $this->getErrorMessage($adminSecurity));
+        $this->flashBag->add('error', $this->getErrorMessage($adminSecurity));
 
         return new RedirectResponse(
             $this->computeRedirectionUrl($adminSecurity, $request)

--- a/src/PrestaShopBundle/EventListener/AccessDeniedListener.php
+++ b/src/PrestaShopBundle/EventListener/AccessDeniedListener.php
@@ -30,8 +30,10 @@ use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -45,7 +47,7 @@ class AccessDeniedListener
     public function __construct(
         private readonly RouterInterface $router,
         private readonly TranslatorInterface $translator,
-        private readonly FlashBagInterface $flashBag,
+        private readonly RequestStack $requestStack,
     ) {
     }
 
@@ -88,8 +90,9 @@ class AccessDeniedListener
                 'message' => $this->getErrorMessage($adminSecurity),
             ], Response::HTTP_FORBIDDEN);
         }
-
-        $this->flashBag->add('error', $this->getErrorMessage($adminSecurity));
+        /** @var Session $session */
+        $session = $this->requestStack->getSession();
+        $session->getFlashBag()->add('error', $this->getErrorMessage($adminSecurity));
 
         return new RedirectResponse(
             $this->computeRedirectionUrl($adminSecurity, $request)

--- a/src/PrestaShopBundle/EventListener/AccessDeniedListener.php
+++ b/src/PrestaShopBundle/EventListener/AccessDeniedListener.php
@@ -32,7 +32,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\Routing\RouterInterface;

--- a/src/PrestaShopBundle/EventListener/DemoModeEnabledListener.php
+++ b/src/PrestaShopBundle/EventListener/DemoModeEnabledListener.php
@@ -31,7 +31,7 @@ use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -46,7 +46,7 @@ class DemoModeEnabledListener
         private readonly ShopConfigurationInterface $shopConfiguration,
         private readonly RouterInterface $router,
         private readonly TranslatorInterface $translator,
-        private readonly Session $session,
+        private readonly FlashBagInterface $flashBag,
     ) {
     }
 
@@ -97,7 +97,7 @@ class DemoModeEnabledListener
      */
     private function showNotificationMessage(DemoRestricted $demoRestricted)
     {
-        $this->session->getFlashBag()->add(
+        $this->flashBag->add(
             'error',
             $this->translator->trans(
                 $demoRestricted->getMessage(),

--- a/src/PrestaShopBundle/EventListener/DemoModeEnabledListener.php
+++ b/src/PrestaShopBundle/EventListener/DemoModeEnabledListener.php
@@ -31,7 +31,9 @@ use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -46,7 +48,7 @@ class DemoModeEnabledListener
         private readonly ShopConfigurationInterface $shopConfiguration,
         private readonly RouterInterface $router,
         private readonly TranslatorInterface $translator,
-        private readonly FlashBagInterface $flashBag,
+        private readonly RequestStack $requestStack,
     ) {
     }
 
@@ -97,7 +99,9 @@ class DemoModeEnabledListener
      */
     private function showNotificationMessage(DemoRestricted $demoRestricted)
     {
-        $this->flashBag->add(
+        /** @var Session $session */
+        $session = $this->requestStack->getSession();
+        $session->getFlashBag()->add(
             'error',
             $this->translator->trans(
                 $demoRestricted->getMessage(),

--- a/src/PrestaShopBundle/EventListener/DemoModeEnabledListener.php
+++ b/src/PrestaShopBundle/EventListener/DemoModeEnabledListener.php
@@ -32,7 +32,6 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\Routing\RouterInterface;

--- a/src/PrestaShopBundle/EventListener/ModuleActivatedListener.php
+++ b/src/PrestaShopBundle/EventListener/ModuleActivatedListener.php
@@ -35,7 +35,9 @@ use PrestaShopBundle\Security\Annotation\ModuleActivated;
 use ReflectionClass;
 use ReflectionObject;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -49,14 +51,14 @@ class ModuleActivatedListener
     /**
      * @param RouterInterface $router
      * @param TranslatorInterface $translator
-     * @param FlashBagInterface $flashBag
+     * @param RequestStack $requestStack
      * @param Reader $annotationReader
      * @param ModuleRepository $moduleRepository
      */
     public function __construct(
         private readonly RouterInterface $router,
         private readonly TranslatorInterface $translator,
-        private readonly FlashBagInterface $flashBag,
+        private readonly RequestStack $requestStack,
         private readonly Reader $annotationReader,
         private readonly ModuleRepository $moduleRepository
     ) {
@@ -106,7 +108,9 @@ class ModuleActivatedListener
      */
     private function showNotificationMessage(ModuleActivated $moduleActivated)
     {
-        $this->flashBag->add(
+        /** @var Session $session */
+        $session = $this->requestStack->getSession();
+        $session->getFlashBag()->add(
             'error',
             $this->translator->trans(
                 $moduleActivated->getMessage(),

--- a/src/PrestaShopBundle/EventListener/ModuleActivatedListener.php
+++ b/src/PrestaShopBundle/EventListener/ModuleActivatedListener.php
@@ -35,7 +35,7 @@ use PrestaShopBundle\Security\Annotation\ModuleActivated;
 use ReflectionClass;
 use ReflectionObject;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -47,49 +47,19 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class ModuleActivatedListener
 {
     /**
-     * @var RouterInterface
-     */
-    private $router;
-
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
-     * @var Session
-     */
-    private $session;
-
-    /**
-     * @var Reader
-     */
-    private $annotationReader;
-
-    /**
-     * @var ModuleRepository
-     */
-    private $moduleRepository;
-
-    /**
      * @param RouterInterface $router
      * @param TranslatorInterface $translator
-     * @param Session $session
+     * @param FlashBagInterface $flashBag
      * @param Reader $annotationReader
      * @param ModuleRepository $moduleRepository
      */
     public function __construct(
-        RouterInterface $router,
-        TranslatorInterface $translator,
-        Session $session,
-        Reader $annotationReader,
-        ModuleRepository $moduleRepository
+        private readonly RouterInterface $router,
+        private readonly TranslatorInterface $translator,
+        private readonly FlashBagInterface $flashBag,
+        private readonly Reader $annotationReader,
+        private readonly ModuleRepository $moduleRepository
     ) {
-        $this->router = $router;
-        $this->translator = $translator;
-        $this->session = $session;
-        $this->annotationReader = $annotationReader;
-        $this->moduleRepository = $moduleRepository;
     }
 
     /**
@@ -136,7 +106,7 @@ class ModuleActivatedListener
      */
     private function showNotificationMessage(ModuleActivated $moduleActivated)
     {
-        $this->session->getFlashBag()->add(
+        $this->flashBag->add(
             'error',
             $this->translator->trans(
                 $moduleActivated->getMessage(),

--- a/src/PrestaShopBundle/EventListener/ModuleActivatedListener.php
+++ b/src/PrestaShopBundle/EventListener/ModuleActivatedListener.php
@@ -36,7 +36,6 @@ use ReflectionClass;
 use ReflectionObject;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\Routing\RouterInterface;

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportFormDataProvider.php
@@ -28,7 +28,7 @@ namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Import;
 
 use PrestaShop\PrestaShop\Core\Import\Configuration\ImportConfigInterface;
 use PrestaShop\PrestaShop\Core\Import\File\FileFinder;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Class ImportFormDataProvider is responsible for providing Import's 1st step form data.
@@ -36,25 +36,13 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 final class ImportFormDataProvider implements ImportFormDataProviderInterface
 {
     /**
-     * @var FileFinder
-     */
-    private $importFileFinder;
-
-    /**
-     * @var SessionInterface
-     */
-    private $session;
-
-    /**
      * @param FileFinder $importFileFinder
-     * @param SessionInterface $session
+     * @param RequestStack $requestStack
      */
     public function __construct(
-        FileFinder $importFileFinder,
-        SessionInterface $session
+        private readonly FileFinder $importFileFinder,
+        private readonly RequestStack $requestStack
     ) {
-        $this->importFileFinder = $importFileFinder;
-        $this->session = $session;
     }
 
     /**
@@ -90,16 +78,16 @@ final class ImportFormDataProvider implements ImportFormDataProviderInterface
                 'parameters' => [],
             ];
         } else {
-            $this->session->set('csv', $data['csv']);
-            $this->session->set('entity', $data['entity']);
-            $this->session->set('iso_lang', $data['iso_lang']);
-            $this->session->set('separator', $data['separator']);
-            $this->session->set('multiple_value_separator', $data['multiple_value_separator']);
-            $this->session->set('truncate', $data['truncate']);
-            $this->session->set('match_ref', $data['match_ref']);
-            $this->session->set('regenerate', $data['regenerate']);
-            $this->session->set('forceIDs', $data['forceIDs']);
-            $this->session->set('sendemail', $data['sendemail']);
+            $this->requestStack->getSession()->set('csv', $data['csv']);
+            $this->requestStack->getSession()->set('entity', $data['entity']);
+            $this->requestStack->getSession()->set('iso_lang', $data['iso_lang']);
+            $this->requestStack->getSession()->set('separator', $data['separator']);
+            $this->requestStack->getSession()->set('multiple_value_separator', $data['multiple_value_separator']);
+            $this->requestStack->getSession()->set('truncate', $data['truncate']);
+            $this->requestStack->getSession()->set('match_ref', $data['match_ref']);
+            $this->requestStack->getSession()->set('regenerate', $data['regenerate']);
+            $this->requestStack->getSession()->set('forceIDs', $data['forceIDs']);
+            $this->requestStack->getSession()->set('sendemail', $data['sendemail']);
         }
 
         return $errors;

--- a/src/PrestaShopBundle/Form/Extension/AlertsTrackingExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/AlertsTrackingExtension.php
@@ -33,6 +33,7 @@ use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
  * Appends alert messages from session flashbag to form vars.
@@ -60,10 +61,13 @@ class AlertsTrackingExtension extends AbstractTypeExtension
             return;
         }
 
+        /** @var Session $session */
+        $session = $this->requestStack->getSession();
+
         /*
          * Example: ['alerts' => ['success' => ['Success message'], 'error' => ['Invalid data']]]
          */
-        $view->vars['alerts'] = $this->requestStack->getSession()->getFlashBag()->peekAll();
+        $view->vars['alerts'] = $session->getFlashBag()->peekAll();
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Extension/AlertsTrackingExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/AlertsTrackingExtension.php
@@ -32,7 +32,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Appends alert messages from session flashbag to form vars.
@@ -43,17 +43,11 @@ use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 class AlertsTrackingExtension extends AbstractTypeExtension
 {
     /**
-     * @var FlashBagInterface
-     */
-    private $flashBag;
-
-    /**
-     * @param FlashBagInterface $flashBag
+     * @param RequestStack $requestStack
      */
     public function __construct(
-        FlashBagInterface $flashBag
+        private readonly RequestStack $requestStack
     ) {
-        $this->flashBag = $flashBag;
     }
 
     /**
@@ -69,7 +63,7 @@ class AlertsTrackingExtension extends AbstractTypeExtension
         /*
          * Example: ['alerts' => ['success' => ['Success message'], 'error' => ['Invalid data']]]
          */
-        $view->vars['alerts'] = $this->flashBag->peekAll();
+        $view->vars['alerts'] = $this->requestStack->getSession()->getFlashBag()->peekAll();
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/adapter/admin.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/admin.yml
@@ -2,12 +2,6 @@ services:
   _defaults:
     public: false
 
-  PrestaShop\PrestaShop\Adapter\Admin\PagePreference:
-    arguments:
-      - '@request_stack'
-      - !php/const _PS_MODE_DEV_
-    decorates: prestashop.core.admin.page_preference_interface
-
   prestashop.adapter.legacy_db:
     public: true
     class: 'Db'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/admin.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/admin.yml
@@ -4,7 +4,7 @@ services:
 
   PrestaShop\PrestaShop\Adapter\Admin\PagePreference:
     arguments:
-      - "@session"
+      - '@request_stack'
       - !php/const _PS_MODE_DEV_
     decorates: prestashop.core.admin.page_preference_interface
 

--- a/src/PrestaShopBundle/Resources/config/services/alias.yml
+++ b/src/PrestaShopBundle/Resources/config/services/alias.yml
@@ -26,3 +26,6 @@ services:
 
   PrestaShopBundle\Translation\TranslatorInterface:
     alias: translator
+
+  Symfony\Component\Security\Csrf\CsrfTokenManagerInterface:
+    alias: security.csrf.token_manager

--- a/src/PrestaShopBundle/Resources/config/services/alias.yml
+++ b/src/PrestaShopBundle/Resources/config/services/alias.yml
@@ -23,3 +23,6 @@ services:
 
   theme_validator:
     alias: prestashop.core.addon.theme.theme_validator
+
+  PrestaShopBundle\Translation\TranslatorInterface:
+    alias: translator

--- a/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
@@ -26,10 +26,11 @@ services:
     class: PrestaShopBundle\Controller\Api\StockController
     parent: PrestaShopBundle\Controller\Api\ApiController
     public: true
-    properties:
-      movements: "@prestashop.core.api.stock.movements_collection"
-      stockRepository: "@prestashop.core.api.stock.repository"
-      queryParams: "@prestashop.core.api.query_stock_params_collection"
+    arguments:
+      $translator: "@translator"
+      $stockRepository: "@prestashop.core.api.stock.repository"
+      $movements: "@prestashop.core.api.stock.movements_collection"
+      $queryParams: "@prestashop.core.api.query_stock_params_collection"
 
   PrestaShopBundle\Controller\Api\StockMovementController:
     class: PrestaShopBundle\Controller\Api\StockMovementController
@@ -86,9 +87,10 @@ services:
     class: PrestaShopBundle\Controller\Api\TranslationController
     parent: PrestaShopBundle\Controller\Api\ApiController
     public: true
-    properties:
-      translationService: "@prestashop.service.translation"
-      queryParams: "@prestashop.core.api.query_translation_params_collection"
+    arguments:
+      $translator: '@translator'
+      $translationService: "@prestashop.service.translation"
+      $queryParams: "@prestashop.core.api.query_translation_params_collection"
 
   PrestaShopBundle\Controller\Api\Improve\Design\PositionsController:
     class: PrestaShopBundle\Controller\Api\Improve\Design\PositionsController

--- a/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
@@ -52,9 +52,6 @@ services:
     tags:
       - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }
 
-  prestashop.access_denied.listener:
-    alias: PrestaShopBundle\EventListener\AccessDeniedListener
-
   PrestaShopBundle\EventListener\DemoModeEnabledListener:
     autowire: true
     autoconfigure: true
@@ -63,9 +60,6 @@ services:
     autowire: true
     tags:
       - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
-
-  prestashop.module_activated.listener:
-    alias: PrestaShopBundle\EventListener\ModuleActivatedListener
 
   prestashop.bundle.event_listener.filter_category_search_criteria:
     class: PrestaShopBundle\EventListener\FilterCategorySearchCriteriaListener

--- a/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
@@ -47,31 +47,25 @@ services:
     tags:
       - { name: kernel.event_listener, event: console.command, method: onConsoleCommand }
 
-  prestashop.access_denied.listener:
-    class: PrestaShopBundle\EventListener\AccessDeniedListener
-    arguments:
-      - "@router"
-      - "@translator"
-      - "@session"
+  PrestaShopBundle\EventListener\AccessDeniedListener:
+    autowire: true
     tags:
       - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }
+
+  prestashop.access_denied.listener:
+    alias: PrestaShopBundle\EventListener\AccessDeniedListener
 
   PrestaShopBundle\EventListener\DemoModeEnabledListener:
     autowire: true
     autoconfigure: true
-    arguments:
-      $session: "@session"
 
-  prestashop.module_activated.listener:
-    class: PrestaShopBundle\EventListener\ModuleActivatedListener
-    arguments:
-      - "@router"
-      - "@translator"
-      - "@session"
-      - "@annotation_reader"
-      - '@PrestaShop\PrestaShop\Core\Module\ModuleRepository'
+  PrestaShopBundle\EventListener\ModuleActivatedListener:
+    autowire: true
     tags:
       - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
+
+  prestashop.module_activated.listener:
+    alias: PrestaShopBundle\EventListener\ModuleActivatedListener
 
   prestashop.bundle.event_listener.filter_category_search_criteria:
     class: PrestaShopBundle\EventListener\FilterCategorySearchCriteriaListener

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form.yml
@@ -11,7 +11,7 @@ services:
       $defaultCurrencyId: '@=service("prestashop.adapter.legacy.configuration").get("PS_CURRENCY_DEFAULT")'
       $defaultLanguageId: '@=service("prestashop.adapter.legacy.configuration").get("PS_LANG_DEFAULT")'
       $formRenderer: '@twig.form.renderer'
-      $flashBag: '@session.flash_bag'
+      $requestStack: '@request_stack'
       $locale: '@prestashop.core.localization.locale.context_locale'
       $multistoreController: '@prestashop.core.admin.multistore'
       $validate: "@prestashop.adapter.validate"

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
@@ -132,7 +132,7 @@ services:
     class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Import\ImportFormDataProvider'
     arguments:
       - '@prestashop.core.import.file_finder'
-      - '@session'
+      - '@request_stack'
 
   prestashop.admin.import_data_configuration.form_data_provider:
     class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Import\ImportDataConfigurationFormDataProvider'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/grid.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/grid.yml
@@ -10,7 +10,7 @@ services:
       - '@prestashop.core.admin.admin_filter.repository'
       - '@=service("prestashop.adapter.legacy.context").getContext().employee.id'
       - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
-      - '@session'
+      - '@request_stack'
 
   prestashop.bundle.grid.controller_response_builder:
     class: PrestaShopBundle\Service\Grid\ControllerResponseBuilder

--- a/src/PrestaShopBundle/Security/Admin/SessionRenewer.php
+++ b/src/PrestaShopBundle/Security/Admin/SessionRenewer.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Security\Admin;
 
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Csrf\TokenStorage\ClearableTokenStorageInterface;
 
 /**
@@ -40,23 +40,13 @@ use Symfony\Component\Security\Csrf\TokenStorage\ClearableTokenStorageInterface;
 final class SessionRenewer
 {
     /**
-     * @var ClearableTokenStorageInterface
-     */
-    private $storage;
-
-    /**
-     * @var SessionInterface
-     */
-    private $session;
-
-    /**
      * @param ClearableTokenStorageInterface $storage
-     * @param SessionInterface $session
+     * @param RequestStack $requestStack
      */
-    public function __construct(ClearableTokenStorageInterface $storage, SessionInterface $session)
-    {
-        $this->storage = $storage;
-        $this->session = $session;
+    public function __construct(
+        private readonly ClearableTokenStorageInterface $storage,
+        private readonly RequestStack $requestStack
+    ) {
     }
 
     /**
@@ -66,11 +56,11 @@ final class SessionRenewer
      */
     public function renew(): void
     {
-        if (!$this->session->isStarted()) {
-            $this->session->start();
+        if (!$this->requestStack->getSession()->isStarted()) {
+            $this->requestStack->getSession()->start();
         }
 
-        $this->session->migrate(true);
+        $this->requestStack->getSession()->migrate(true);
         $this->storage->clear();
     }
 }

--- a/src/PrestaShopBundle/Service/Grid/ResponseBuilder.php
+++ b/src/PrestaShopBundle/Service/Grid/ResponseBuilder.php
@@ -34,6 +34,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Router;
 
 class ResponseBuilder
@@ -94,7 +95,9 @@ class ResponseBuilder
             } else {
                 foreach ($filtersForm->getErrors(true) as $error) {
                     $fieldLabel = $error->getOrigin()->getConfig()->getOption('label') ?: $error->getOrigin()->getName();
-                    $this->requestStack->getSession()->getFlashBag()->add('error', sprintf('%s: %s', $fieldLabel, $error->getMessage()));
+                    /** @var Session $session */
+                    $session = $this->requestStack->getSession();
+                    $session->getFlashBag()->add('error', sprintf('%s: %s', $fieldLabel, $error->getMessage()));
                 }
             }
         }

--- a/src/PrestaShopBundle/Service/Grid/ResponseBuilder.php
+++ b/src/PrestaShopBundle/Service/Grid/ResponseBuilder.php
@@ -33,50 +33,27 @@ use PrestaShopBundle\Entity\Repository\AdminFilterRepository;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Router;
 
 class ResponseBuilder
 {
-    /** @var AdminFilterRepository */
-    private $adminFilterRepository;
-
-    /** @var int|null */
-    private $employeeId;
-
-    /** @var GridFilterFormFactoryInterface */
-    private $filterFormFactory;
-
-    /** @var Router */
-    private $router;
-
-    /** @var int */
-    private $shopId;
-
-    /** @var Session */
-    private $session;
-
     /**
      * @param GridFilterFormFactoryInterface $filterFormFactory
      * @param Router $router
      * @param AdminFilterRepository $adminFilterRepository
      * @param int|null $employeeId
      * @param int $shopId
+     * @param RequestStack $requestStack
      */
     public function __construct(
-        GridFilterFormFactoryInterface $filterFormFactory,
-        Router $router,
-        AdminFilterRepository $adminFilterRepository,
-        ?int $employeeId,
-        int $shopId,
-        Session $session
+        private readonly GridFilterFormFactoryInterface $filterFormFactory,
+        private readonly Router $router,
+        private readonly AdminFilterRepository $adminFilterRepository,
+        private readonly ?int $employeeId,
+        private readonly int $shopId,
+        private readonly RequestStack $requestStack
     ) {
-        $this->filterFormFactory = $filterFormFactory;
-        $this->router = $router;
-        $this->adminFilterRepository = $adminFilterRepository;
-        $this->employeeId = $employeeId;
-        $this->shopId = $shopId;
-        $this->session = $session;
     }
 
     /**
@@ -117,7 +94,7 @@ class ResponseBuilder
             } else {
                 foreach ($filtersForm->getErrors(true) as $error) {
                     $fieldLabel = $error->getOrigin()->getConfig()->getOption('label') ?: $error->getOrigin()->getName();
-                    $this->session->getFlashBag()->add('error', sprintf('%s: %s', $fieldLabel, $error->getMessage()));
+                    $this->requestStack->getSession()->getFlashBag()->add('error', sprintf('%s: %s', $fieldLabel, $error->getMessage()));
                 }
             }
         }

--- a/tests/Integration/Adapter/SqlManager/QueryHandler/GetSqlRequestExecutionResultHandlerTest.php
+++ b/tests/Integration/Adapter/SqlManager/QueryHandler/GetSqlRequestExecutionResultHandlerTest.php
@@ -71,8 +71,8 @@ class GetSqlRequestExecutionResultHandlerTest extends KernelTestCase
     {
         self::bootKernel();
 
-        $this->queryBus = self::$container->get('prestashop.core.query_bus');
-        $this->commandBus = self::$container->get('prestashop.core.command_bus');
+        $this->queryBus = self::getContainer()->get('prestashop.core.query_bus');
+        $this->commandBus = self::getContainer()->get('prestashop.core.command_bus');
     }
 
     public function testSensitiveDataAreHidden(): void

--- a/tests/Integration/Classes/controller/AdminControllerTest.php
+++ b/tests/Integration/Classes/controller/AdminControllerTest.php
@@ -53,6 +53,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Tests\Integration\Utility\ContextMockerTrait;
 use Tools;
 
@@ -284,7 +285,7 @@ class AdminControllerTest extends TestCase
                 if ($param === 'prestashop.user_provider') {
                     return $this->getMockedUserProvider();
                 }
-                if ($param === 'security.csrf.token_manager') {
+                if ($param === CsrfTokenManagerInterface::class) {
                     return $this->getMockedCsrfTokenManager();
                 }
                 if ($param === 'PrestaShop\PrestaShop\Core\Image\AvifExtensionChecker') {

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceControllerTest.php
@@ -59,7 +59,7 @@ class WebserviceControllerTest extends WebTestCase
 
         $this->client = self::createClient();
         $this->router = self::$kernel->getContainer()->get('router');
-        $this->session = self::$kernel->getContainer()->get('session');
+        $this->session = self::$kernel->getContainer()->get('request_stack')->getSession();
 
         $this->webserviceKey = new WebserviceKey();
         $this->webserviceKey->key = 'DFS51LTKBBMBAF5QQRG523JMQYEHA4X7';

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceControllerTest.php
@@ -45,10 +45,6 @@ class WebserviceControllerTest extends WebTestCase
      */
     protected $router;
     /**
-     * @var Session
-     */
-    protected $session;
-    /**
      * @var WebserviceKey
      */
     protected $webserviceKey;
@@ -59,7 +55,6 @@ class WebserviceControllerTest extends WebTestCase
 
         $this->client = self::createClient();
         $this->router = self::$kernel->getContainer()->get('router');
-        $this->session = self::$kernel->getContainer()->get('request_stack')->getSession();
 
         $this->webserviceKey = new WebserviceKey();
         $this->webserviceKey->key = 'DFS51LTKBBMBAF5QQRG523JMQYEHA4X7';
@@ -113,7 +108,9 @@ class WebserviceControllerTest extends WebTestCase
         $this->assertTrue($response->isRedirection());
 
         // Check session
-        $all = $this->session->getFlashBag()->all();
+        /** @var Session $session */
+        $session = $this->client->getRequest()->getSession();
+        $all = $session->getFlashBag()->all();
         $this->assertArrayHasKey('success', $all);
         $this->assertSame('The status has been successfully updated.', $all['success'][0]);
 
@@ -145,7 +142,9 @@ class WebserviceControllerTest extends WebTestCase
         $this->assertTrue($response->isRedirection());
 
         // Check session
-        $all = $this->session->getFlashBag()->all();
+        /** @var Session $session */
+        $session = $this->client->getRequest()->getSession();
+        $all = $session->getFlashBag()->all();
         $this->assertArrayHasKey('success', $all);
         $this->assertSame('The status has been successfully updated.', $all['success'][0]);
 

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsControllerTest.php
@@ -78,7 +78,7 @@ class PositionsControllerTest extends WebTestCase
         $this->moduleId = Module::getModuleIdByName('ps_emailsubscription');
         $this->hookId = Hook::getIdByName('displayFooterBefore');
         $this->router = self::$kernel->getContainer()->get('router');
-        $this->session = self::$kernel->getContainer()->get('session');
+        $this->session = self::$kernel->getContainer()->get('request_stack')->getSession();
     }
 
     public function testUnhooksListAction(): void

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsControllerTest.php
@@ -56,10 +56,6 @@ class PositionsControllerTest extends WebTestCase
      * @var Router
      */
     protected $router;
-    /**
-     * @var Session
-     */
-    protected $session;
 
     protected function setUp(): void
     {
@@ -78,7 +74,6 @@ class PositionsControllerTest extends WebTestCase
         $this->moduleId = Module::getModuleIdByName('ps_emailsubscription');
         $this->hookId = Hook::getIdByName('displayFooterBefore');
         $this->router = self::$kernel->getContainer()->get('router');
-        $this->session = self::$kernel->getContainer()->get('request_stack')->getSession();
     }
 
     public function testUnhooksListAction(): void
@@ -110,7 +105,9 @@ class PositionsControllerTest extends WebTestCase
             $response->getStatusCode()
         );
 
-        $messages = $this->session->getFlashBag()->all();
+        /** @var Session $session */
+        $session = $this->client->getRequest()->getSession();
+        $messages = $session->getFlashBag()->all();
         $this->assertArrayHasKey(
             'error',
             $messages
@@ -142,14 +139,15 @@ class PositionsControllerTest extends WebTestCase
                 'hookId' => $this->hookId,
             ]
         );
-
         $response = $this->client->getResponse();
         $this->assertEquals(
             Response::HTTP_FOUND,
             $response->getStatusCode()
         );
 
-        $messages = $this->session->getFlashBag()->all();
+        /** @var Session $session */
+        $session = $this->client->getRequest()->getSession();
+        $messages = $session->getFlashBag()->all();
         $this->assertArrayNotHasKey(
             'error',
             $messages

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryControllerTest.php
@@ -79,7 +79,7 @@ class DeliveryControllerTest extends WebTestCase
         self::$kernel->getContainer()->set('prestashop.adapter.legacy.configuration', $configurationMock);
         $this->router = self::$kernel->getContainer()->get('router');
         $this->tokenManager = self::$kernel->getContainer()->get('security.csrf.token_manager');
-        $this->session = self::$kernel->getContainer()->get('session');
+        $this->session = self::$kernel->getContainer()->get('request_stack')->getSession();
     }
 
     public function testSlipAction(): void

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryControllerTest.php
@@ -51,10 +51,6 @@ class DeliveryControllerTest extends WebTestCase
      * @var CsrfTokenManager
      */
     protected $tokenManager;
-    /**
-     * @var Session
-     */
-    protected $session;
 
     protected function setUp(): void
     {
@@ -79,7 +75,6 @@ class DeliveryControllerTest extends WebTestCase
         self::$kernel->getContainer()->set('prestashop.adapter.legacy.configuration', $configurationMock);
         $this->router = self::$kernel->getContainer()->get('router');
         $this->tokenManager = self::$kernel->getContainer()->get('security.csrf.token_manager');
-        $this->session = self::$kernel->getContainer()->get('request_stack')->getSession();
     }
 
     public function testSlipAction(): void
@@ -138,9 +133,11 @@ class DeliveryControllerTest extends WebTestCase
             $response->getStatusCode()
         );
 
+        /** @var Session $session */
+        $session = $this->client->getRequest()->getSession();
         $this->assertArrayHasKey(
             'success',
-            $this->session->getFlashBag()->all()
+            $session->getFlashBag()->all()
         );
     }
 
@@ -165,9 +162,11 @@ class DeliveryControllerTest extends WebTestCase
             Response::HTTP_FOUND,
             $response->getStatusCode()
         );
+        /** @var Session $session */
+        $session = $this->client->getRequest()->getSession();
         $this->assertArrayHasKey(
             'error',
-            $this->session->getFlashBag()->all()
+            $session->getFlashBag()->all()
         );
         $this->assertStringContainsString('/sell/orders/delivery-slips/?_token', $response->getTargetUrl());
     }
@@ -193,9 +192,11 @@ class DeliveryControllerTest extends WebTestCase
             $response->getStatusCode()
         );
 
+        /** @var Session $session */
+        $session = $this->client->getRequest()->getSession();
         $this->assertArrayHasKey(
             'error',
-            $this->session->getFlashBag()->all()
+            $session->getFlashBag()->all()
         );
         $this->assertStringContainsString('/sell/orders/delivery-slips/?_token', $response->getTargetUrl());
     }

--- a/tests/Integration/PrestaShopBundle/Controller/Api/ApiTestCase.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/ApiTestCase.php
@@ -59,7 +59,6 @@ abstract class ApiTestCase extends WebTestCase
         self::$kernel = static::bootKernel();
         self::$client = self::$kernel->getContainer()->get('test.client');
         self::$client->setServerParameters([]);
-        self::$container = self::$client->getContainer();
         $this->router = self::getContainer()->get('router');
     }
 

--- a/tests/Integration/PrestaShopBundle/Controller/Api/StockManagementControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/StockManagementControllerTest.php
@@ -73,7 +73,7 @@ class StockManagementControllerTest extends ApiTestCase
             ->getMock();
 
         $stockMovementRepository->method('saveStockMvt')->willReturn(true);
-        self::$container->set('prestashop.core.api.stock_movement.repository', $stockMovementRepository);
+        self::getContainer()->set('prestashop.core.api.stock_movement.repository', $stockMovementRepository);
 
         $this->restoreQuantityEditionFixtures();
     }

--- a/tests/Unit/PrestaShopBundle/Service/Grid/ResponseBuilderTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Grid/ResponseBuilderTest.php
@@ -41,6 +41,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Router;
@@ -205,12 +206,14 @@ class ResponseBuilderTest extends TestCase
         $mockRequest->setMethod('POST');
         $mockRequest->request = new InputBag();
 
+        $requestStack = $this->createMock(RequestStack::class);
         $session = $this->createMock(Session::class);
         if (!$isValid) {
             $mockFlashBag = $this->createMock(FlashBagInterface::class);
             $mockFlashBag->method('add')->with('error', sprintf('%s: %s', self::ERROR_LABEL, self::ERROR_MESSAGE));
             $session->method('getFlashBag')->willReturn($mockFlashBag);
         }
+        $requestStack->method('getSession')->willReturn($session);
 
         $responseBuilder = new ResponseBuilder(
             $mockFilterFormFactory,
@@ -218,7 +221,7 @@ class ResponseBuilderTest extends TestCase
             $this->createMock(AdminFilterRepository::class),
             1,
             1,
-            $session
+            $requestStack
         );
 
         return $responseBuilder->buildSearchResponse(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | SF6- Remove deprecated code from FrameworkBundle, please see https://github.com/symfony/symfony/blob/6.4/UPGRADE-6.0.md#frameworkbundle
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | yes
| How to test?      | CI and tests are green
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/7355236904
| Fixed issue or discussion?     | Fixes #33997
| Related PRs       | -
| Sponsor company   | -


**Deprecated:**

We kept a compatibility layer in the FrameworkBundleAdminController for functions (these functions are normally no longer available in symfony 6)

- get
- has
- getDoctrine

**Importants BC break:**

- `translator` service is no longer public, but we can retrieve the `PrestaShopBundle\Translation\TranslatorInterface` public alias
- `security.csrf.token_manager` is no longer public, but we can retrieve the` Symfony\Component\Security\Csrf\CsrfTokenManagerInterface` public alias
- `session` and `session.flash_bag` services no longer exist, use RequestStack or Request instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated service dependencies across the application to use dependency injection and request stack access for session, translation, and CSRF token management.
  - Replaced direct service container calls with constructor-injected services in controllers, listeners, and service classes.
  - Updated configuration files to align with new dependency injection patterns and autowiring.

- **Bug Fixes**
  - Improved reliability of session and flash message handling by consistently accessing session data via the current request context.

- **Tests**
  - Refactored tests to use request stack and updated service access patterns to match application changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->