### PR TITLE
Fix product csv import wiping category assignments, fixes #34601

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1556,10 +1556,9 @@ class AdminImportControllerCore extends AdminController
 
             if (is_array($category_data)) {
                 foreach ($category_data as $tmp) {
-                    if ($product->category && is_array($product->category)) {
-                        continue;
+                    if (!$product->category || is_array($product->category)) {
+                        $product->category[] = $tmp;
                     }
-                    $product->category[] = $tmp;
                 }
             }
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Product csv import with "load from reference" and without categories wiped all category assignments except for the default category. This tries to fix the import so that if categories were not defined they are not changed for existing product.
| Type?             | bug fix
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check the issue for two example csv files and description on what to test
| UI Tests          | -
| Fixed issue or discussion?     | Fixes #34601
| Related PRs       | -
| Sponsor company   | -

And some more comments on this PR.

php stan fixes changed the logic for this and currently importing product csv with ref and description will wipe category assignments from product. The logic on the importer on what it does is really strange and should be rewritten completely.

This change has been tested with the following import files


Dont touch categories
```csv
Reference,Description
demo_1,Lorem ipsum dolor sit amet
```
=> OK, product categories did not change

Update categories (with existing categories)
```csv
Reference,Description,Categories
demo_1,Lorem ipsum dolor sit amet,Clothes;Accessories
```
=> OK, new categories are assigned to the product (and the default category is not `Clothes`)

Update categories and create new category in the same import
```csv
Reference,Description,Categories
demo_1,Lorem ipsum dolor sit amet,Clothes;Accessories;NewCategory
```

=> OK, New category was created and product categories updated.

PHPStan error was also fixed in a different way.
