### PR TITLE
Bug fixes for issues 23646 and 28713 (maybe other bugs also) about managing stock updates for packs.

### DIFF
--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -246,21 +246,16 @@ class StockManager implements StockInterface
         // in "not shipped state" so the reserved quantity would not be updated on the Available Stock.
         if ($idOrder) {
             $productsAttributesQuery = '
-                SELECT od.product_id as id_product, od.product_attribute_id as id_product_attribute
-                FROM ' . _DB_PREFIX_ . 'orders o
-                INNER JOIN ' . _DB_PREFIX_ . 'order_detail od ON od.id_order = o.id_order
-                WHERE o.id_shop = ' . (int) $shopId . '
-                AND od.product_id IN (SELECT product_id FROM ' . _DB_PREFIX_ . 'order_detail WHERE id_order = ' . (int) $idOrder .')';
+                SELECT od.product_id as id_product, od.product_attribute_id as id_product_attribute 
+                FROM ps_order_detail od 
+                WHERE od.id_order = ' . (int) $idOrder;
             
             $productsAttributes = Db::getInstance()->executeS($productsAttributesQuery);
 
             $productsAttributesQuery = '
-                SELECT pp.id_product_item as id_product, pp.id_product_attribute_item as id_product_attribute
-                FROM ' . _DB_PREFIX_ . 'orders o
-                INNER JOIN ' . _DB_PREFIX_ . 'order_detail od ON od.id_order = o.id_order
-                JOIN ' . _DB_PREFIX_ . 'pack pp ON pp.id_product_pack = od.product_id
-                WHERE o.id_shop = ' . (int) $shopId . '
-                AND pp.id_product_item IN (SELECT id_product_item from ps_pack pp join ps_order_detail od on (od.product_id = pp.id_product_pack) where od.id_order = ' . (int) $idOrder . ')';
+                SELECT pp.id_product_item as id_product, pp.id_product_attribute_item as id_product_attribute 
+                FROM ps_pack pp 
+                INNER JOIN ps_order_detail od ON pp.id_product_pack = od.product_id AND od.id_order = ' . (int) $idOrder;
 
             $productsAttributes = array_merge($productsAttributes, Db::getInstance()->executeS($productsAttributesQuery));
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Bug fix for issues 23646 and 28713. Fixing issues with updates on reserved quantity and physical quantities on stock when the order contains packs.
| Type?             | bug fix that has included full refactoring of updateReservedQuantity and updatePhysicalQuantity methods
| Category?         |  BO
| BC breaks?        | yes / no - Sorry not sure what this means
| Deprecations?     | no
| How to test?      | Test complex orders that include individual products and packs of products and check that reserved and physical quantities are correctly updated in stock status for all references on all order state changes including order canceled and refunded. Also test manual stock movements from the backoffice Catalog -> Stock
| UI Tests          | Sorry, I don't have time to run these tests myself. I have been quite significant amount of manual testing on my test servers.
| Fixed issue or discussion?     | Fixes #23646, Fixes #28713
| Related PRs       | none
| Sponsor company   | OcioHogar Home design, S.L. The changes are already installed in production on this site: www.vagheggi.es since end December.

### Additional information 

    https://github.com/PrestaShop/PrestaShop/issues/23646
    https://github.com/PrestaShop/PrestaShop/issues/28713

    Root cause for both bugs: The functions updateReservedProductQuantity and updatePhysicalProductQuantity at src/Adapter/StockManager.php were
    not considering at all the case of products sold within packs.
    On other areas of Prestashop the "available_quantity" is correctly updated in all cases before invoking these functions on order state change,
    I haven't found any bug about the updates on the "available_quantity" however given that the updateReservedProductQuantity was not calculating
    correctly the Reserved quantity for products within packs, then the physical quantity was being incremented when receiving the order (instead of when doing the shipment).

    I have done an almost brand new implementation of both functions that is now considering the products included within packs in the order.

    The new implementation is considering also this issue reported on the same functions:
    https://github.com/PrestaShop/PrestaShop/issues/14703

    The implementation basically attempts to use separate SQL queries to avoid unique SQL queries that would translate into a too complex query plan slow to manage which is
    the issue on that performance bug.

    I have tested a lot locally with orders that include the same product as part of a pack and also as a standalone product within the same order. Also tested with
    products with combinations included in a pack and as standalone product within the order.

    Tested also stock modifications from backoffice Catalog and from product pages.