### PR TITLE
Prevent uncheck cast

### DIFF
--- a/src/Adapter/EntityMapper.php
+++ b/src/Adapter/EntityMapper.php
@@ -98,7 +98,12 @@ class EntityMapper
                         if (isset($entity_defs['fields'][$key]['type']) && in_array($entity_defs['fields'][$key]['type'], [
                             \ObjectModel::TYPE_BOOL,
                         ])) {
-                            $entity->{$key} = (string) $value;
+                            if (is_array($value)) {
+                                array_walk($value, function (&$v) { $v = strval($v); });
+                                $entity->{$key} = $value;
+                            } else {
+                                $entity->{$key} = strval($value);
+                            }
                         } else {
                             $entity->{$key} = $value;
                         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Previous modification in EntityMapper introduced a breaking change when having a boolean field  with `'lang' => true` on an ObjectModel. This is due to an unchecked cast on a value being either a string, an number or an array, and will throw an `Error`: `Warning: Array to string conversion`, therefore introducing a breaking change from previous 8.x versions.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create an ObjectModel having a boolean field with `'lang' => true`, the object should be properly loaded from database without error
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #35003
| Related PRs       | Related to #33048 
| Sponsor company   | Novius
