### PR TITLE
Fix issues on some catalog pages

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/feature/feature-value/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/feature/feature-value/index.ts
@@ -27,6 +27,7 @@ import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sq
 import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
 import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
 import Grid from '@components/grid/grid';
+import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
 import SortingExtension from '@components/grid/extension/sorting-extension';
 import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
@@ -45,5 +46,6 @@ $(() => {
   grid.addExtension(new SortingExtension());
   grid.addExtension(new SubmitRowActionExtension());
   grid.addExtension(new SubmitBulkExtension());
+  grid.addExtension(new LinkRowActionExtension());
   grid.addExtension(new BulkActionCheckboxExtension());
 });

--- a/src/Core/Grid/Definition/Factory/FeatureGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/FeatureGridDefinitionFactory.php
@@ -121,6 +121,7 @@ class FeatureGridDefinitionFactory extends AbstractGridDefinitionFactory
                         'route' => 'admin_feature_values_index',
                         'route_param_name' => 'featureId',
                         'route_param_field' => 'id_feature',
+                        'clickable_row' => true,
                     ])
                      )
                     ->add((new LinkRowAction('edit'))

--- a/src/Core/Grid/Definition/Factory/FeatureValueGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/FeatureValueGridDefinitionFactory.php
@@ -125,6 +125,7 @@ class FeatureValueGridDefinitionFactory extends AbstractFilterableGridDefinition
                                 'extra_route_params' => [
                                     'featureId' => 'id_feature',
                                 ],
+                                'clickable_row' => true,
                             ])
                     )
                     ->add(

--- a/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
+++ b/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
@@ -95,7 +95,6 @@ class LegacyLinkLinterCommand extends Command
         'admin_products_quantity',
         'admin_categories_get_categories_tree',
         'admin_catalog_price_rules_list_for_product',
-        'admin_features_horizontal_index',
         'admin_products_toggle_status_for_shop',
     ];
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
@@ -322,20 +322,16 @@ class FeatureController extends FrameworkBundleAdminController
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    private function getSettingsTipMessage(): string
+    private function getSettingsTipMessage()
     {
+        if ($this->isFeatureEnabled()) {
+            return null;
+        }
+
         $urlOpening = sprintf('<a href="%s">', $this->get('router')->generate('admin_performance'));
         $urlEnding = '</a>';
-
-        if ($this->isFeatureEnabled()) {
-            return $this->trans(
-                'The features are enabled on your store. Go to %sAdvanced Parameters > Performance%s to edit settings.',
-                'Admin.Catalog.Notification',
-                [$urlOpening, $urlEnding]
-            );
-        }
 
         return $this->trans(
             'The features are disabled on your store. Go to %sAdvanced Parameters > Performance%s to edit settings.',

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureValueController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureValueController.php
@@ -110,18 +110,18 @@ class FeatureValueController extends FrameworkBundleAdminController
             if (null !== $handlerResult->getIdentifiableObjectId()) {
                 $this->addFlash('success', $this->trans('Successful creation', 'Admin.Notifications.Success'));
 
-                if ($request->request->has(self::SAVE_AND_ADD_BUTTON_NAME)) {
-                    return $this->redirectToRoute('admin_feature_values_add', [
-                        'featureId' => $featureId,
-                    ]);
+                // Case 1 - save and stay, user entered the form from feature value list
+                if ($request->request->has(self::SAVE_AND_ADD_BUTTON_NAME) && $featureId) {
+                    return $this->redirectToRoute('admin_feature_values_add', ['featureId' => $featureId]);
+                // Case 2 - save and stay, user entered the form from feature list
+                } elseif ($request->request->has(self::SAVE_AND_ADD_BUTTON_NAME)) {
+                    return $this->redirectToRoute('admin_feature_values_add');
+                // Case 3 - save and exit, user entered the form from feature value list
+                } elseif ($featureId) {
+                    return $this->redirectToRoute('admin_feature_values_index', ['featureId' => $featureId]);
                 }
 
-                if ($featureId) {
-                    return $this->redirectToRoute('admin_feature_values_index', [
-                        'featureId' => $featureId,
-                    ]);
-                }
-
+                // Case 4 - save and exit, if user entered the form from feature list
                 return $this->redirectToRoute('admin_features_index');
             }
         } catch (Exception $e) {
@@ -130,10 +130,18 @@ class FeatureValueController extends FrameworkBundleAdminController
             return $this->redirectToRoute('admin_features_index');
         }
 
+        // Resolve a link to use when cancelling the form
+        if ($featureId) {
+            $cancelLink = $this->generateUrl('admin_feature_values_index', ['featureId' => $featureId]);
+        } else {
+            $cancelLink = $this->generateUrl('admin_features_index');
+        }
+
         return $this->render('@PrestaShop/Admin/Sell/Catalog/Features/FeatureValue/create.html.twig', [
             'featureId' => $featureId,
             'featureValueForm' => $featureValueForm->createView(),
             'layoutTitle' => $this->trans('New Feature Value', 'Admin.Navigation.Menu'),
+            'cancelLink' => $cancelLink,
         ]);
     }
 
@@ -182,6 +190,7 @@ class FeatureValueController extends FrameworkBundleAdminController
                 'Feature value',
                 'Admin.Navigation.Menu',
             ),
+            'cancelLink' => $this->generateUrl('admin_feature_values_index', ['featureId' => $featureId]),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -815,20 +815,16 @@ class ManufacturerController extends FrameworkBundleAdminController
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    private function getSettingsTipMessage(): string
+    private function getSettingsTipMessage()
     {
+        if ($this->getConfiguration()->get('PS_DISPLAY_MANUFACTURERS')) {
+            return null;
+        }
+
         $urlOpening = sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences'));
         $urlEnding = '</a>';
-
-        if ($this->getConfiguration()->get('PS_DISPLAY_MANUFACTURERS')) {
-            return $this->trans(
-                'The display of your brands is enabled on your store. Go to %sShop Parameters > General%s to edit settings.',
-                'Admin.Catalog.Notification',
-                [$urlOpening, $urlEnding]
-            );
-        }
 
         return $this->trans(
             'The display of your brands is disabled on your store. Go to %sShop Parameters > General%s to edit settings.',

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -576,20 +576,16 @@ class SupplierController extends FrameworkBundleAdminController
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     protected function getSettingsTipMessage()
     {
+        if ($this->getConfiguration()->get('PS_DISPLAY_SUPPLIERS')) {
+            return null;
+        }
+
         $urlOpening = sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences'));
         $urlEnding = '</a>';
-
-        if ($this->getConfiguration()->get('PS_DISPLAY_SUPPLIERS')) {
-            return $this->trans(
-                'The display of your suppliers is enabled on your store. Go to %sShop Parameters > General%s to edit settings.',
-                'Admin.Catalog.Notification',
-                [$urlOpening, $urlEnding]
-            );
-        }
 
         return $this->trans(
             'The display of your suppliers is disabled on your store. Go to %sShop Parameters > General%s to edit settings.',

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/FeatureValue/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/FeatureValue/Blocks/form.html.twig
@@ -39,7 +39,7 @@
     </div>
 
     <div class="card-footer">
-      <a href="{{ path('admin_features_index', {'featureId': featureId}) }}" class="btn btn-outline-secondary">
+      <a href="{{ cancelLink }}" class="btn btn-outline-secondary">
         {{ 'Cancel'|trans({}, 'Admin.Actions') }}
       </a>
       <div class="float-right">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/index.html.twig
@@ -28,7 +28,9 @@
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% block content %}
-  {{ ps.infotip(settingsTipMessage, true) }}
+  {% if settingsTipMessage is not empty %}
+    {{ ps.infotip(settingsTipMessage, true) }}
+  {% endif %}
   {% block feature_group_showcase_card %}
       {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/showcase_card.html.twig' %}
   {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Blocks/View/products.html.twig
@@ -29,92 +29,96 @@
     ({{ viewableManufacturer.manufacturerProducts|length }})
   </h3>
   <div class="card-body">
-    {% for product in viewableManufacturer.manufacturerProducts %}
-      <div class="card">
-        <div class="card-header clearfix">
-          <a href="{{ path('admin_products_edit', {'productId': product.id}) }}">{{ product.name }}</a>
+    {% if viewableManufacturer.manufacturerProducts is not empty %}
+      {% for product in viewableManufacturer.manufacturerProducts %}
+        <div class="card">
+          <div class="card-header clearfix">
+            <a href="{{ path('admin_products_edit', {'productId': product.id}) }}">{{ product.name }}</a>
 
-          <div class="d-inline-block float-right">
-            <div class="btn-group-action text-right">
-              <div class="btn-group">
-                <a class="btn btn-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split p-0 no-rotate" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                </a>
-                <div class="dropdown-menu dropdown-menu-right">
-                  <a class="btn tooltip-link js-submit-row-action dropdown-item"
-                     href="{{ path('admin_products_edit', {'productId': product.id}) }}"
-                  >
-                    {{ 'Edit'|trans({}, 'Admin.Actions') }}
+            <div class="d-inline-block float-right">
+              <div class="btn-group-action text-right">
+                <div class="btn-group">
+                  <a class="btn btn-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split p-0 no-rotate" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   </a>
-                  <button class="btn tooltip-link js-form-submit-btn dropdown-item"
-                          type="button"
-                          data-form-submit-url="{{ path('admin_products_delete_from_all_shops', {'productId': product.id}) }}"
-                          data-form-confirm-message="{{ '%s%s?'|format('Delete item #'|trans({}, 'Admin.International.Feature'), product.id) }}"
-                  >
-                    {{ 'Delete'|trans({}, 'Admin.Actions') }}
-                  </button>
+                  <div class="dropdown-menu dropdown-menu-right">
+                    <a class="btn tooltip-link js-submit-row-action dropdown-item"
+                      href="{{ path('admin_products_edit', {'productId': product.id}) }}"
+                    >
+                      {{ 'Edit'|trans({}, 'Admin.Actions') }}
+                    </a>
+                    <button class="btn tooltip-link js-form-submit-btn dropdown-item"
+                            type="button"
+                            data-form-submit-url="{{ path('admin_products_delete_from_all_shops', {'productId': product.id}) }}"
+                            data-form-confirm-message="{{ '%s%s?'|format('Delete item #'|trans({}, 'Admin.International.Feature'), product.id) }}"
+                    >
+                      {{ 'Delete'|trans({}, 'Admin.Actions') }}
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div class="card-body">
-          {% if product.combinations is not empty %}
-            <table class="table">
-              <thead>
-                <tr>
-                  <th>{{ 'Attribute name'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                  <th>{{ 'Reference'|trans({}, 'Admin.Global') }}</th>
-                  <th>{{ 'EAN-13'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                  <th>{{ 'UPC'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                  <th>{{ 'MPN'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                  {% if not isAllShopContext and isStockManagementEnabled %}
-                    <th>{{ 'Available quantity'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                  {% endif %}
-                </tr>
-              </thead>
-              <tbody>
-                {% for combination in product.combinations %}
+          <div class="card-body">
+            {% if product.combinations is not empty %}
+              <table class="table">
+                <thead>
                   <tr>
-                    <td>{{ combination.attributes }}</td>
-                    <td>{{ combination.reference }}</td>
-                    <td>{{ combination.ean13 }}</td>
-                    <td>{{ combination.upc }}</td>
-                    <td>{{ combination.mpn }}</td>
+                    <th>{{ 'Attribute name'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                    <th>{{ 'Reference'|trans({}, 'Admin.Global') }}</th>
+                    <th>{{ 'EAN-13'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                    <th>{{ 'UPC'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                    <th>{{ 'MPN'|trans({}, 'Admin.Catalog.Feature') }}</th>
                     {% if not isAllShopContext and isStockManagementEnabled %}
-                      <td>{{ combination.quantity }}</td>
+                      <th>{{ 'Available quantity'|trans({}, 'Admin.Catalog.Feature') }}</th>
                     {% endif %}
                   </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          {% else %}
-            <table class="table">
-              <thead>
-                <tr>
-                  <th>{{ 'Ref:'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                  <th>{{ 'EAN-13:'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                  <th>{{ 'UPC:'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                  <th>{{ 'MPN:'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                  {% if isStockManagementEnabled %}
-                    <th>{{ 'Qty:'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                  {% endif %}
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>{{ product.reference }}</td>
-                  <td>{{ product.ean13 }}</td>
-                  <td>{{  product.upc }}</td>
-                  <td>{{  product.mpn }}</td>
-                  {% if isStockManagementEnabled %}
-                    <td>{{ product.quantity }}</td>
-                  {% endif %}
-                </tr>
-              </tbody>
-            </table>
-          {% endif %}
+                </thead>
+                <tbody>
+                  {% for combination in product.combinations %}
+                    <tr>
+                      <td>{{ combination.attributes }}</td>
+                      <td>{{ combination.reference }}</td>
+                      <td>{{ combination.ean13 }}</td>
+                      <td>{{ combination.upc }}</td>
+                      <td>{{ combination.mpn }}</td>
+                      {% if not isAllShopContext and isStockManagementEnabled %}
+                        <td>{{ combination.quantity }}</td>
+                      {% endif %}
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            {% else %}
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th>{{ 'Ref:'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                    <th>{{ 'EAN-13:'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                    <th>{{ 'UPC:'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                    <th>{{ 'MPN:'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                    {% if isStockManagementEnabled %}
+                      <th>{{ 'Qty:'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                    {% endif %}
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>{{ product.reference }}</td>
+                    <td>{{ product.ean13 }}</td>
+                    <td>{{  product.upc }}</td>
+                    <td>{{  product.mpn }}</td>
+                    {% if isStockManagementEnabled %}
+                      <td>{{ product.quantity }}</td>
+                    {% endif %}
+                  </tr>
+                </tbody>
+              </table>
+            {% endif %}
+          </div>
         </div>
-      </div>
-    {% endfor %}
+      {% endfor %}
+    {% else %}
+      {{ 'No products has been found for this brand.'|trans({}, 'Admin.Catalog.Notification') }}
+    {% endif %}
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/index.html.twig
@@ -28,7 +28,9 @@
 
 {% block content %}
   {% block manufacturers_listing %}
-    {{ ps.infotip(settingsTipMessage, true) }}
+    {% if settingsTipMessage is not empty %}
+      {{ ps.infotip(settingsTipMessage, true) }}
+    {% endif %}
     {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': manufacturerGrid} %}
   {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
@@ -28,7 +28,9 @@
 
 {% block content %}
   {% block supplier_grid %}
-    {{ ps.infotip(settingsTipMessage, true) }}
+    {% if settingsTipMessage is not empty %}
+      {{ ps.infotip(settingsTipMessage, true) }}
+    {% endif %}
     {% include'@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': supplierGrid} %}
   {% endblock %}
 {% endblock %}

--- a/tests/UI/campaigns/functional/BO/13_shopParameters/01_general/general/08_enableDisableSuppliers.ts
+++ b/tests/UI/campaigns/functional/BO/13_shopParameters/01_general/general/08_enableDisableSuppliers.ts
@@ -71,34 +71,36 @@ describe('BO - Shop Parameters - General : Enable/Disable display suppliers', as
         expect(result).to.contains(generalPage.successfulUpdateMessage);
       });
 
-      it('should go to \'Brands & Suppliers\' page', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', `goToBrandsPage_${index}`, baseContext);
+      if (test.args.action === 'Disable') {
+        it('should go to \'Brands & Suppliers\' page', async function () {
+          await testContext.addContextItem(this, 'testIdentifier', `goToBrandsPage_${index}`, baseContext);
 
-        await generalPage.goToSubMenu(
-          page,
-          generalPage.catalogParentLink,
-          generalPage.brandsAndSuppliersLink,
-        );
+          await generalPage.goToSubMenu(
+            page,
+            generalPage.catalogParentLink,
+            generalPage.brandsAndSuppliersLink,
+          );
 
-        const pageTitle = await brandsPage.getPageTitle(page);
-        expect(pageTitle).to.contains(brandsPage.pageTitle);
-      });
+          const pageTitle = await brandsPage.getPageTitle(page);
+          expect(pageTitle).to.contains(brandsPage.pageTitle);
+        });
 
-      it('should go to \'Suppliers\' tab', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', `goToSuppliersTab_${index}`, baseContext);
+        it('should go to \'Suppliers\' tab', async function () {
+          await testContext.addContextItem(this, 'testIdentifier', `goToSuppliersTab_${index}`, baseContext);
 
-        await brandsPage.goToSubTabSuppliers(page);
+          await brandsPage.goToSubTabSuppliers(page);
 
-        const pageTitle = await suppliersPage.getPageTitle(page);
-        expect(pageTitle).to.contains(suppliersPage.pageTitle);
-      });
+          const pageTitle = await suppliersPage.getPageTitle(page);
+          expect(pageTitle).to.contains(suppliersPage.pageTitle);
+        });
 
-      it(`should check that the message alert contains '${test.args.action}'`, async function () {
-        await testContext.addContextItem(this, 'testIdentifier', `checkAlertContains_${test.args.action}`, baseContext);
+        it(`should check that the message alert contains '${test.args.action}'`, async function () {
+          await testContext.addContextItem(this, 'testIdentifier', `checkAlertContains_${test.args.action}`, baseContext);
 
-        const text = await suppliersPage.getAlertInfoBlockParagraphContent(page);
-        expect(text).to.contains(test.args.action.toLowerCase());
-      });
+          const text = await suppliersPage.getAlertInfoBlockParagraphContent(page);
+          expect(text).to.contains(test.args.action.toLowerCase());
+        });
+      }
 
       it('should go to FO', async function () {
         await testContext.addContextItem(this, 'testIdentifier', `goToFO_${test.args.action}`, baseContext);
@@ -124,14 +126,16 @@ describe('BO - Shop Parameters - General : Enable/Disable display suppliers', as
         expect(exist).to.be.equal(test.args.exist);
       });
 
-      it('should go back to BO', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', `goBackToBo_${test.args.action}`, baseContext);
+      if (test.args.action === 'Enable') {
+        it('should go back to BO', async function () {
+          await testContext.addContextItem(this, 'testIdentifier', `goBackToBo_${test.args.action}`, baseContext);
 
-        page = await siteMapPage.closePage(browserContext, page, 0);
+          page = await siteMapPage.closePage(browserContext, page, 0);
 
-        const pageTitle = await suppliersPage.getPageTitle(page);
-        expect(pageTitle).to.contains(suppliersPage.pageTitle);
-      });
+          const pageTitle = await generalPage.getPageTitle(page);
+          expect(pageTitle).to.contains(generalPage.pageTitle);
+        });
+      }
     });
   });
 });

--- a/tests/UI/campaigns/functional/BO/13_shopParameters/01_general/general/09_enableDisableBrands.ts
+++ b/tests/UI/campaigns/functional/BO/13_shopParameters/01_general/general/09_enableDisableBrands.ts
@@ -68,25 +68,27 @@ describe('BO - Shop Parameters - General : Enable/Disable display brands', async
         expect(result).to.contains(generalPage.successfulUpdateMessage);
       });
 
-      it('should go to \'Brands & Suppliers\' page', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', `goToBrandsPage_${index}`, baseContext);
+      if (test.args.action === 'Disable') {
+        it('should go to \'Brands & Suppliers\' page', async function () {
+          await testContext.addContextItem(this, 'testIdentifier', `goToBrandsPage_${index}`, baseContext);
 
-        await generalPage.goToSubMenu(
-          page,
-          generalPage.catalogParentLink,
-          generalPage.brandsAndSuppliersLink,
-        );
+          await generalPage.goToSubMenu(
+            page,
+            generalPage.catalogParentLink,
+            generalPage.brandsAndSuppliersLink,
+          );
 
-        const pageTitle = await brandsPage.getPageTitle(page);
-        expect(pageTitle).to.contains(brandsPage.pageTitle);
-      });
+          const pageTitle = await brandsPage.getPageTitle(page);
+          expect(pageTitle).to.contains(brandsPage.pageTitle);
+        });
 
-      it(`should check that the message alert contains '${test.args.action}'`, async function () {
-        await testContext.addContextItem(this, 'testIdentifier', `checkAlertContains_${test.args.action}`, baseContext);
+        it(`should check that the message alert contains '${test.args.action}'`, async function () {
+          await testContext.addContextItem(this, 'testIdentifier', `checkAlertContains_${test.args.action}`, baseContext);
 
-        const text = await brandsPage.getAlertInfoBlockParagraphContent(page);
-        expect(text).to.contains(test.args.action.toLowerCase());
-      });
+          const text = await brandsPage.getAlertInfoBlockParagraphContent(page);
+          expect(text).to.contains(test.args.action.toLowerCase());
+        });
+      }
 
       it('should go to FO', async function () {
         await testContext.addContextItem(this, 'testIdentifier', `goToFO_${test.args.action}`, baseContext);
@@ -113,14 +115,16 @@ describe('BO - Shop Parameters - General : Enable/Disable display brands', async
         expect(exist).to.be.equal(test.args.exist);
       });
 
-      it('should go back to BO', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', `goBackToBo_${test.args.action}`, baseContext);
+      if (test.args.action === 'Disable') {
+        it('should go back to BO', async function () {
+          await testContext.addContextItem(this, 'testIdentifier', `goBackToBo_${test.args.action}`, baseContext);
 
-        page = await siteMapPage.closePage(browserContext, page, 0);
+          page = await siteMapPage.closePage(browserContext, page, 0);
 
-        const pageTitle = await brandsPage.getPageTitle(page);
-        expect(pageTitle).to.contains(brandsPage.pageTitle);
-      });
+          const pageTitle = await brandsPage.getPageTitle(page);
+          expect(pageTitle).to.contains(brandsPage.pageTitle);
+        });
+      }
     });
   });
 });


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests green + verify the list.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/7785727983 ✅ 
| Fixed issue or discussion?     | Fixes #34889
| Related PRs       | 
| Sponsor company   | 

### List of changes and things fixed
- Feature value form cancel link will now lead you to the page you came from, not to the listing.
- When saving feature value, it will now redirect you to the page you came from, not to the listing.
- Feature list is now clickable. Like on legacy page.
- Feature value list is now clickable. Like on legacy page.
- Removed unused horizontal controller.
- Removed message "Features are enabled" that displayed all the time and just wasted space.
![Snímek obrazovky 2023-12-21 171738](https://github.com/PrestaShop/PrestaShop/assets/6097524/18915338-b9ba-4730-ad29-abbf41ea7b36)
- Removed message "Brands are enabled" that displayed all the time and just wasted space.
![Snímek obrazovky 2023-12-21 171720](https://github.com/PrestaShop/PrestaShop/assets/6097524/79b11987-8e48-4425-98a2-18df277bf84a)
- Removed message "Suppliers are enabled" that displayed all the time and just wasted space.
![Snímek obrazovky 2023-12-21 171728](https://github.com/PrestaShop/PrestaShop/assets/6097524/5cee4082-d9f3-4a4a-a812-96c9e19a6ace)
- Added message `No products has been found for this brand.` when viewing a brand with no products. Ignore the big list of changes in the twig, it's just because it got tabbed.
![Snímek obrazovky 2023-12-21 171826](https://github.com/PrestaShop/PrestaShop/assets/6097524/df0fa9e4-acc7-4218-bf55-8060e24d311a)
