### PR TITLE
Nightly: Add nightly.zip for prestashop/flashLight use

### DIFF
--- a/.github/workflows/cron_nightly_build.yml
+++ b/.github/workflows/cron_nightly_build.yml
@@ -67,7 +67,14 @@ jobs:
         run: php tools/build/CreateRelease.php --destination-dir=${{ env.RELEASE_DIR }}
 
       - name: Rename build
-        run: today=`date +%Y-%m-%d-`; for i in *; do mv $i $today$GH_BRANCH-$i; done
+        run: today=`date +%Y-%m-%d`; for i in *; do mv $i $today-$GH_BRANCH-$i; done
+        working-directory: ${{ env.RELEASE_DIR }}
+
+      - name: Create nightly.zip for develop
+        if: matrix.BRANCH == 'develop'
+        run: |
+          today=`date +%Y-%m-%d`
+          cp $today-$GH_BRANCH*.zip nightly.zip
         working-directory: ${{ env.RELEASE_DIR }}
 
       - name: Auth Cloud Sdk
@@ -78,6 +85,10 @@ jobs:
 
       - name: Setup Cloud Sdk
         uses: google-github-actions/setup-gcloud@v1
+
+      - name: Delete last Nightly zip from develop
+        if: matrix.BRANCH == 'develop'
+        run: gsutil rm -rf gs://prestashop-core-nightly/nightly.zip
 
       - name: Upload to Google Cloud Storage (GCS)
         run: gsutil cp -r "${{ env.RELEASE_DIR }}/**" gs://prestashop-core-nightly


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The idea here is to have always a nightly.zip on GCP bucket on develop branch for prestashop/flashlight use.
| Type?             | new feature
| Category?         | PM
| BC breaks?        |no
| Deprecations?     | no
| How to test?      | no tests needed
| UI Tests          | No need
| Fixed issue or discussion?     | N/A
| Related PRs       | 
| Sponsor company   | PrestaShopCorp

