### PR TITLE
Remove "debug code" from HTMLTemplateInvoice

### DIFF
--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -365,10 +365,6 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
             'legal_free_text' => $legal_free_text,
         ];
 
-        if (Tools::getValue('debug')) {
-            die(json_encode($data));
-        }
-
         $this->smarty->assign($data);
 
         $tpls = [
@@ -390,12 +386,11 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
     /**
      * Returns the tax tab content.
      *
-     * @return string|array Tax tab html content (Returns an array if debug params used in request)
+     * @return string|array Tax tab html content
      */
     public function getTaxTabContent()
     {
-        $debug = Tools::getValue('debug');
-
+   
         $address = new Address((int) $this->order->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
         $tax_exempt = Configuration::get('VATNUMBER_MANAGEMENT')
                             && !empty($address->vat_number)
@@ -411,14 +406,11 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
             'ecotax_tax_breakdown' => $this->order_invoice->getEcoTaxTaxesBreakdown(),
             'wrapping_tax_breakdown' => $this->order_invoice->getWrappingTaxesBreakdown(),
             'tax_breakdowns' => $this->getTaxBreakdown(),
-            'order' => $debug ? null : $this->order,
-            'order_invoice' => $debug ? null : $this->order_invoice,
-            'carrier' => $debug ? null : $carrier,
+            'order' => $this->order,
+            'order_invoice' => $this->order_invoice,
+            'carrier' => $carrier,
         ];
 
-        if ($debug) {
-            return $data;
-        }
 
         $this->smarty->assign($data);
 

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -390,7 +390,6 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
      */
     public function getTaxTabContent()
     {
-   
         $address = new Address((int) $this->order->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
         $tax_exempt = Configuration::get('VATNUMBER_MANAGEMENT')
                             && !empty($address->vat_number)
@@ -410,7 +409,6 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
             'order_invoice' => $this->order_invoice,
             'carrier' => $carrier,
         ];
-
 
         $this->smarty->assign($data);
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Imagine this situation, you are using GET parameter with name "debug" for your debugging (for your module etc - only for testing purposes when there is any error etc....) and you still get any strange json when rendering invoice and you don't know why and you aren't able to find it... After 2 hours waste of time you find this "great" code in HTMLTemplateInvoice.php. **Unacceptable. Please, remove it and save time of other developers. I already spend 2 hours of my life with this "feature"...**
| Type?             | refacto
| Category?         |  CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          |
 | Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/