### PR TITLE
Don't create useless file "index.php" in every image folder

### DIFF
--- a/classes/Image.php
+++ b/classes/Image.php
@@ -54,9 +54,6 @@ class ImageCore extends ObjectModel
     /** @var string image extension */
     public $image_format = 'jpg';
 
-    /** @var string path to index.php file to be copied to new image folders */
-    public $source_index;
-
     /** @var string image folder */
     protected $folder;
 
@@ -101,7 +98,6 @@ class ImageCore extends ObjectModel
     {
         parent::__construct($id, $idLang, $id_shop, $translator);
         $this->image_dir = _PS_PRODUCT_IMG_DIR_;
-        $this->source_index = _PS_PRODUCT_IMG_DIR_ . 'index.php';
     }
 
     /**
@@ -782,13 +778,6 @@ class ImageCore extends ObjectModel
             // Apparently sometimes mkdir cannot set the rights, and sometimes chmod can't. Trying both.
             $success = @mkdir(_PS_PRODUCT_IMG_DIR_ . $this->getImgFolder(), self::$access_rights, true);
             $chmod = @chmod(_PS_PRODUCT_IMG_DIR_ . $this->getImgFolder(), self::$access_rights);
-
-            // Create an index.php file in the new folder
-            if (($success || $chmod)
-                && !file_exists(_PS_PRODUCT_IMG_DIR_ . $this->getImgFolder() . 'index.php')
-                && file_exists($this->source_index)) {
-                return @copy($this->source_index, _PS_PRODUCT_IMG_DIR_ . $this->getImgFolder() . 'index.php');
-            }
         }
 
         return true;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | File "index.php" in every image folder is now unusable, because we have .htaccess in main image folder (https://github.com/PrestaShop/PrestaShop/blob/develop/img/.htaccess), which don't allow *.php files. So index.php is useless and should be removed.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/7738644236
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
