### PR TITLE
Prevent key duplication during apply rule to product specific price

### DIFF
--- a/classes/SpecificPriceRule.php
+++ b/classes/SpecificPriceRule.php
@@ -308,7 +308,21 @@ class SpecificPriceRuleCore extends ObjectModel
             return false;
         }
 
-        $specific_price = new SpecificPrice();
+        $idSpecificPrice = (int) SpecificPrice::exists(
+            (int) $id_product,
+            (int) $id_product_attribute,
+            (int) $rule->id_shop,
+            (int) $rule->id_group,
+            (int) $rule->id_country,
+            (int) $rule->id_currency,
+            0,
+            (int) $rule->from_quantity,
+            (string) $rule->from,
+            (string) $rule->to,
+            (int) $rule->id
+        );
+
+        $specific_price = new SpecificPrice($idSpecificPrice);
         $specific_price->id_specific_price_rule = (int) $rule->id;
         $specific_price->id_product = (int) $id_product;
         $specific_price->id_product_attribute = (int) $id_product_attribute;
@@ -325,6 +339,6 @@ class SpecificPriceRuleCore extends ObjectModel
         $specific_price->from = $rule->from;
         $specific_price->to = $rule->to;
 
-        return $specific_price->add();
+        return $specific_price->save();
     }
 }

--- a/classes/SpecificPriceRule.php
+++ b/classes/SpecificPriceRule.php
@@ -319,7 +319,7 @@ class SpecificPriceRuleCore extends ObjectModel
             (int) $rule->from_quantity,
             (string) $rule->from,
             (string) $rule->to,
-            (int) $rule->id
+            $rule->id != 0
         );
 
         $specific_price = new SpecificPrice($idSpecificPrice);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Prevent key duplication during apply rule to product specific price
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Make sure that edit and add product speficif prices work fine
| UI Tests          | N/A
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/18568
| Related PRs       | N/A
| Sponsor company   | Evolutive
