### PR TITLE
Groups list : display new group buttons even after saving options

### DIFF
--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -195,6 +195,11 @@ class AdminGroupsControllerCore extends AdminController
         }
 
         parent::initProcess();
+
+        // This is a composite page, we don't want the "options" display mode
+        if ($this->display == 'options') {
+            $this->display = '';
+        }
     }
 
     public function postProcess(): void


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  Display the "add a new group" button, even after saving the options form.<br>Fix inspired by [an existing code](https://github.com/PrestaShop/PrestaShop/blob/bab9734e939c5b90f3daf7658e64a75e5e8d2803/controllers/admin/AdminSearchConfController.php#L382C1-L385C10).
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to BO > Shop parameters > Customer settings > Groups<br>2. Save Default groups options<br>3. Note that the "Add a new group" button is present.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/8849782185 ✅ 
| Fixed issue or discussion?     | Fixes #30422
| Related PRs       | N/A
| Sponsor company   | N/A


https://github.com/PrestaShop/PrestaShop/assets/13508863/380647f0-180e-4ed5-b1aa-de30c6642087

