### PR TITLE
Added id_shop param to actionAfterLoadRoutes Hook

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -705,7 +705,7 @@ class DispatcherCore
          *
          * Use getRoutes, addRoute, removeRoute methods for this purpose.
          */
-        Hook::exec('actionAfterLoadRoutes', ['dispatcher' => $this]);
+        Hook::exec('actionAfterLoadRoutes', ['dispatcher' => $this, 'id_shop' => $id_shop]);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Added id_shop param to the actionAfterLoadRoutes Hook. This parameter is required to properly modify routes in multistore context.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | -
| UI Tests          | -
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | Webimpacto Consulting, S.L

When you use the hook actionAfterLoadRoutes to add new routes for several stores and languages, it causes that the "routes" variable of the Dispatcher get filled with several stores. 

This causes the createUrl() function of Dispatcher to not work properly to create a url for another store, since the array $this->routes[$another_shop] is not empty, it doesnt load the routes for that store.

This can be avoided if (when we use the hook actionAfterLoadRoutes) we only add routes of the id_shop that is being loaded.