### PR TITLE
Correct warning with substr if $component is an array

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1189,16 +1189,16 @@ class FrontControllerCore extends Controller
      */
     public function addJqueryUI($component, $theme = 'base', $check_dependencies = true)
     {
-        // If the component does not start with ui. prefix, we need to add it
-        if (substr($component, 0, 3) !== 'ui.') {
-            $component = 'ui.' . $component;
-        }
-
         if (!is_array($component)) {
             $component = [$component];
         }
 
         foreach ($component as $ui) {
+            // If the component does not start with ui. prefix, we need to add it
+            if (!str_starts_with($ui, 'ui.')) {
+                $ui = 'ui.' . $ui;
+            }
+
             $ui_path = Media::getJqueryUIPath($ui, $theme, $check_dependencies);
             foreach ($ui_path['css'] as $uiPathCss => $uiMediaCss) {
                 $this->registerStylesheet(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | if addJqueryUI is called with an array of components, substr triggers a warning
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Call addJqueryUI with an array of components
| UI Tests      |https://github.com/florine2623/testing_pr/actions/runs/7408203932 ✅ 
| Sponsor company   | Evolutive
