### PR TITLE
Added route checking and loading in hasRoute function

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -871,6 +871,10 @@ class DispatcherCore
             $id_shop = (int) Context::getContext()->shop->id;
         }
 
+        if (!isset($this->routes[$id_shop])) {
+            $this->loadRoutes($id_shop);
+        }
+
         return isset($this->routes[$id_shop][$id_lang][$route_id]);
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x
| Description?      | In the hasRoute function, loads the routes of the selected store if they are not already loaded.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In a PrestaShop with multiple shops, try to do $this->context->link->getModuleLink('my_module', 'my_controller', [], null, null, $another_shop_id);
| UI Tests          | -
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | Webimpacto Consulting, S.L

If you have a Prestashop with multiple shops, when you create a module with a new controller, you can add its routes with the hook moduleRoutes or actionAfterLoadRoutes.

If you try in shop 1 to get that module controller's link from shop 2, you would use the $this->context->link->getModuleLink('my_module', 'my_controller', [], null, null, 2) function. It will return the wrong url the first time you use it, because inside the Dispatcher variables, the $routes[2] its not loaded. This first time all shop 2 routes will be loaded with the createUrl() function, but it will return an incorrect url.

This could be solved if the hasRoute() method would load the requested store routes (which seems obvious, because otherwise it will always return false when requesting an id_shop not loaded).