### PR TITLE
Fix Link->getModuleLink() function for other shop contexts

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -871,6 +871,10 @@ class DispatcherCore
             $id_shop = (int) Context::getContext()->shop->id;
         }
 
+        if (!isset($this->routes[$id_shop])) {
+            $this->loadRoutes($id_shop);
+        }
+
         return isset($this->routes[$id_shop][$id_lang][$route_id]);
     }
 

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -703,7 +703,7 @@ class LinkCore
 
         // If the module has its own route ... just use it !
         if (Dispatcher::getInstance()->hasRoute('module-' . $module . '-' . $controller, $idLang, $idShop)) {
-            return $this->getPageLink('module-' . $module . '-' . $controller, $ssl, $idLang, $params);
+            return $this->getPageLink('module-' . $module . '-' . $controller, $ssl, $idLang, $params, false, $idShop);
         } else {
             return $url . Dispatcher::getInstance()->createUrl('module', $idLang, $params, $this->allow, '', $idShop);
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x
| Description?      | Whe you try to get a shop 2 module link from shop 1 context, you dont get the correct route
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In a PrestaShop with multiple shops, try to do $this->context->link->getModuleLink('my_module', 'my_controller', [], null, null, $another_shop_id);
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/7396352066
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | Webimpacto Consulting, S.L

If you have a Prestashop with multiple shops, when you create a module with a new controller, you can add its routes with the hook moduleRoutes or actionAfterLoadRoutes.

If you try to show, in the Shop 1 context, a link to the Shop 2 module controller, you will try to get the link with $this->context->link->getModuleLink('my_module', 'my_controller', [], null, null, 2).
This wont work.

Thats because of 2 problems:

The getModuleLink function will return the wrong url the first time you use it, because inside the Dispatcher variables, the $routes[2] its not loaded. This first time all shop 2 routes will be loaded with the createUrl() function, but it will return an incorrect url.

This could be solved if the hasRoute() method would load the requested store routes (which seems obvious, because otherwise it will always return false when requesting an id_shop not loaded).

The other problem is that, in the getModuleLink(), the idShop value is used in the hasRoute(), and in the createUrl(), but its not used in the getPageLink(). So, if the Dispatcher has the module route, it will generate the Page Link with the current context id shop.

I added code to solve both of them