### PR TITLE
Remove old Czech lower VAT 10% and 15%

### DIFF
--- a/localization/cz.xml
+++ b/localization/cz.xml
@@ -8,8 +8,6 @@
   </languages>
   <taxes>
     <tax id="1" name="DPH CZ 21%" rate="21" eu-tax-group="virtual"/>
-    <tax id="2" name="DPH CZ 15%" rate="15"/>
-    <tax id="3" name="DPH CZ 10%" rate="10"/>
     <tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="6" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -70,37 +68,6 @@
       <taxRule iso_code_country="se" id_tax="1"/>
       <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
-    <taxRulesGroup name="CZ Snížená sazba (15%)">
-      <taxRule iso_code_country="be" id_tax="2"/>
-      <taxRule iso_code_country="bg" id_tax="2"/>
-      <taxRule iso_code_country="cz" id_tax="2"/>
-      <taxRule iso_code_country="dk" id_tax="2"/>
-      <taxRule iso_code_country="de" id_tax="2"/>
-      <taxRule iso_code_country="ee" id_tax="2"/>
-      <taxRule iso_code_country="gr" id_tax="2"/>
-      <taxRule iso_code_country="hr" id_tax="2"/>
-      <taxRule iso_code_country="es" id_tax="2"/>
-      <taxRule iso_code_country="fr" id_tax="2"/>
-      <taxRule iso_code_country="mc" id_tax="2"/>
-      <taxRule iso_code_country="ie" id_tax="2"/>
-      <taxRule iso_code_country="it" id_tax="2"/>
-      <taxRule iso_code_country="cy" id_tax="2"/>
-      <taxRule iso_code_country="lv" id_tax="2"/>
-      <taxRule iso_code_country="lt" id_tax="2"/>
-      <taxRule iso_code_country="lu" id_tax="2"/>
-      <taxRule iso_code_country="hu" id_tax="2"/>
-      <taxRule iso_code_country="mt" id_tax="2"/>
-      <taxRule iso_code_country="nl" id_tax="2"/>
-      <taxRule iso_code_country="at" id_tax="2"/>
-      <taxRule iso_code_country="pl" id_tax="2"/>
-      <taxRule iso_code_country="pt" id_tax="2"/>
-      <taxRule iso_code_country="ro" id_tax="2"/>
-      <taxRule iso_code_country="si" id_tax="2"/>
-      <taxRule iso_code_country="sk" id_tax="2"/>
-      <taxRule iso_code_country="fi" id_tax="2"/>
-      <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
-    </taxRulesGroup>
     <taxRulesGroup name="CZ Snížená sazba (12%)">
       <taxRule iso_code_country="be" id_tax="32"/>
       <taxRule iso_code_country="bg" id_tax="32"/>
@@ -131,37 +98,6 @@
       <taxRule iso_code_country="fi" id_tax="32"/>
       <taxRule iso_code_country="se" id_tax="32"/>
       <taxRule iso_code_country="gb" id_tax="32"/>
-    </taxRulesGroup>
-    <taxRulesGroup name="CZ Snížená sazba (10%)">
-      <taxRule iso_code_country="be" id_tax="3"/>
-      <taxRule iso_code_country="bg" id_tax="3"/>
-      <taxRule iso_code_country="cz" id_tax="3"/>
-      <taxRule iso_code_country="dk" id_tax="3"/>
-      <taxRule iso_code_country="de" id_tax="3"/>
-      <taxRule iso_code_country="ee" id_tax="3"/>
-      <taxRule iso_code_country="gr" id_tax="3"/>
-      <taxRule iso_code_country="hr" id_tax="3"/>
-      <taxRule iso_code_country="es" id_tax="3"/>
-      <taxRule iso_code_country="fr" id_tax="3"/>
-      <taxRule iso_code_country="mc" id_tax="3"/>
-      <taxRule iso_code_country="ie" id_tax="3"/>
-      <taxRule iso_code_country="it" id_tax="3"/>
-      <taxRule iso_code_country="cy" id_tax="3"/>
-      <taxRule iso_code_country="lv" id_tax="3"/>
-      <taxRule iso_code_country="lt" id_tax="3"/>
-      <taxRule iso_code_country="lu" id_tax="3"/>
-      <taxRule iso_code_country="hu" id_tax="3"/>
-      <taxRule iso_code_country="mt" id_tax="3"/>
-      <taxRule iso_code_country="nl" id_tax="3"/>
-      <taxRule iso_code_country="at" id_tax="3"/>
-      <taxRule iso_code_country="pl" id_tax="3"/>
-      <taxRule iso_code_country="pt" id_tax="3"/>
-      <taxRule iso_code_country="ro" id_tax="3"/>
-      <taxRule iso_code_country="si" id_tax="3"/>
-      <taxRule iso_code_country="sk" id_tax="3"/>
-      <taxRule iso_code_country="fi" id_tax="3"/>
-      <taxRule iso_code_country="se" id_tax="3"/>
-      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="cz" id_tax="1"/>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | From 2024-01-01 were removed lower VAT 10% and 15% for Czech.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | #34529 
| Sponsor company   | https://www.openservis.cz/
