### PR TITLE
Getjqueryuipath correct return value

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -208,6 +208,7 @@ class MediaCore
                 }
             }
         }
+
         if (@filemtime($fileUri)) {
             if (!empty($uiTmp)) {
                 foreach ($uiTmp as $ui) {
@@ -219,18 +220,13 @@ class MediaCore
                         $uiPath['css'][] = $ui['css'];
                     }
                 }
-                $uiPath['js'][] = Media::getJSPath($folder . $file);
-            } else {
-                $uiPath['js'] = Media::getJSPath($folder . $file);
             }
+
+            $uiPath['js'][] = Media::getJSPath($folder . $file);
         }
 
         //add i18n file for datepicker
         if ($component == 'ui.datepicker') {
-            if (!is_array($uiPath['js'])) {
-                $uiPath['js'] = [$uiPath['js']];
-            }
-
             $datePickerIsoCode = Context::getContext()->language->iso_code;
             if (array_key_exists($datePickerIsoCode, self::$jquery_ui_datepicker_iso_code)) {
                 $datePickerIsoCode = self::$jquery_ui_datepicker_iso_code[$datePickerIsoCode];

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -196,6 +196,7 @@ class MediaCore
                 $uiPath['css'] = array_merge($uiPath['css'], $compCss);
             }
         }
+
         if ($checkDependencies && array_key_exists($component, self::$jquery_ui_dependencies)) {
             foreach (self::$jquery_ui_dependencies[$component]['dependencies'] as $dependency) {
                 $uiTmp[] = Media::getJqueryUIPath($dependency, $theme, false);
@@ -212,12 +213,12 @@ class MediaCore
         if (@filemtime($fileUri)) {
             if (!empty($uiTmp)) {
                 foreach ($uiTmp as $ui) {
-                    if (!empty($ui['js'])) {
-                        $uiPath['js'][] = $ui['js'];
+                    if (!empty($ui['js'][0])) {
+                        $uiPath['js'][] = $ui['js'][0];
                     }
 
-                    if (!empty($ui['css'])) {
-                        $uiPath['css'][] = $ui['css'];
+                    if (!empty($ui['css'][0])) {
+                        $uiPath['css'][] = $ui['css'][0];
                     }
                 }
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Media::getJqueryUIPath can return a value that does not respect its own signature and may cause an error when a jQuery UI component with no dependency is called by FrontController::addJqueryUI
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see below
| Sponsor company   | Evolutive

* Deactivate ps_searchbar
* add $this->addJqueryUI(['ui.core']); to IndexController
* get error:
Warning: foreach() argument must be of type array|object, string given in /var/www/classes/controller/FrontController.php on line 1210
1	0.0001	469680	{main}( )	.../index.php:0
2	0.0304	2388720	DispatcherCore->dispatch( )	.../index.php:72
3	0.0361	2903928	ControllerCore->run( )	.../Dispatcher.php:492
4	0.0550	3803512	IndexControllerCore->initContent( )	.../Controller.php:330
5	0.0663	4349688	FrontControllerCore->addJqueryUI( $component = [0 => 'ui.core'], $theme = ???, $check_dependencies = ??? )	.../IndexController.php:40
* apply PR
* no more error