### PR TITLE
Fix: BO - Import/Export - Can't import Store contact

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -3868,7 +3868,7 @@ class AdminImportControllerCore extends AdminController
             }
         }
 
-        if (is_array($store->hours)) {
+        if (is_array($store->hours) && isset($info['hours'])) {
             $newHours = [];
             foreach ($store->hours as $hour) {
                 $newHours[] = [$hour];

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -4628,7 +4628,8 @@ class AdminImportControllerCore extends AdminController
                     $doneCount += $this->aliasImport($offset, $limit, $validateOnly);
 
                     break;
-                case $this->entities[$import_type = $this->trans('Store contacts', [], 'Admin.Advparameters.Feature')]:
+                case $this->entities[$this->trans('Store contacts', [], 'Admin.Advparameters.Feature')]:
+                    $import_type = 'StoreContacts';
                     $doneCount += $this->storeContactImport($offset, $limit, $validateOnly);
                     $clearCache = true;
 

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -3863,7 +3863,6 @@ class AdminImportControllerCore extends AdminController
 
         /** @var Store $store */
         if (isset($store->image) && !empty($store->image)) {
-            
             // check to see if the image exists
             $headers = @get_headers($store->image);
             if ($headers && strpos($headers[0], '200')) {

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -3863,8 +3863,13 @@ class AdminImportControllerCore extends AdminController
 
         /** @var Store $store */
         if (isset($store->image) && !empty($store->image)) {
-            if (!(AdminImportController::copyImg($store->id, null, $store->image, 'stores', !$regenerate))) {
-                $this->warnings[] = $store->image . ' ' . $this->trans('cannot be copied.', [], 'Admin.Advparameters.Notification');
+            
+            // check to see if the image exists
+            $headers = @get_headers($store->image);
+            if ($headers && strpos($headers[0], '200')) {
+                if (!(AdminImportController::copyImg($store->id, null, $store->image, 'stores', !$regenerate))) {
+                    $this->warnings[] = $store->image . ' ' . $this->trans('cannot be copied.', [], 'Admin.Advparameters.Notification');
+                }
             }
         }
 


### PR DESCRIPTION
The problem depends on the fact that when importing store contacts, the 
```
PrestaShopLogger->object_type property
```
 is set with "Store contacts" which does not pass the validation of the **Validate::isValidObjectClassName()** method. So in this case I thought of valorising the **$import_type** variable with **StoreContacts** which passes the validation and the error no longer occurs.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| UI    | https://github.com/florine2623/testing_pr/actions/runs/8049269672 ✅ 
| Fixed issue or discussion?     | Fixes #35009
| Sponsor company   | Codencode snc 