### PR TITLE
Add cachedir tag during release

### DIFF
--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -279,6 +279,7 @@ class ReleaseCreator
             ->setFilesConstants()
             ->setupShopVersion()
             ->generateLicensesFile()
+            ->generateCachedirFiles()
             ->runComposerInstall()
             ->runBuildAssets()
             ->createPackage();
@@ -482,6 +483,40 @@ class ReleaseCreator
 
         if (!file_put_contents($this->tempProjectPath . '/LICENSES', $content)) {
             throw new BuildException('Unable to create LICENSES file.');
+        }
+        $this->consoleWriter->displayText(" DONE{$this->lineSeparator}", ConsoleWriter::COLOR_GREEN);
+
+        return $this;
+    }
+
+    /**
+     * Generate CACHEDIR.TAG files in some locations. This file is used in many applications
+     * to exclude directories from backups.
+     *
+     * @return $this
+     * @throws BuildException
+     */
+    protected function generateCachedirFiles()
+    {
+        $this->consoleWriter->displayText("Generating CACHEDIR.TAG files...", ConsoleWriter::COLOR_YELLOW);
+
+        // Prepare content of the file with the signature
+        $fileContent = 'Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag created by PrestaShop.
+# For information about cache directory tags, see:
+#	http://www.brynosaurus.com/cachedir/';
+
+        // Specify locations we want to create this file in
+        $fileLocations = [
+            '/img/tmp/',
+            '/var/cache/',
+        ];
+
+        foreach ($fileLocations as $fileLocation) {
+            $filePath = $this->tempProjectPath . $fileLocation . 'CACHEDIR.TAG';
+            if (!file_put_contents($filePath, $fileContent)) {
+                throw new BuildException('Unable to create ' . $filePath);
+            }
         }
         $this->consoleWriter->displayText(" DONE{$this->lineSeparator}", ConsoleWriter::COLOR_GREEN);
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Following https://github.com/PrestaShop/PrestaShop/pull/34816/, we decided to create these files during the build process. Original author of this idea is @ShaiMagal!
| Type?             | new feature
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Ping @florine2623. Create a release using `ReleaseCreator.php` and check the built ZIP, if there are `CACHEDIR.TAG` files in `var/cache`.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/7502484647 ✅ 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 
