### PR TITLE
Disable autofill of password for SMTP

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php
@@ -65,6 +65,7 @@ class SmtpConfigurationType extends TranslatorAwareType
                 'empty_data' => '',
                 'label' => $this->trans('SMTP password', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('Leave blank if not applicable.', 'Admin.Advparameters.Help'),
+                /* Some browsers (for example Google Chrome) are totally ignoring "off" value, so we use "new-password" - which is working well for this purpose */
                 'attr' => [
                     'autocomplete' => 'new-password',
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php
@@ -67,7 +67,7 @@ class SmtpConfigurationType extends TranslatorAwareType
                 'help' => $this->trans('Leave blank if not applicable.', 'Admin.Advparameters.Help'),
                 'attr' => [
                     'autocomplete' => 'new-password',
-                ]
+                ],
             ])
             ->add('encryption', ChoiceType::class, [
                 'choices' => [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php
@@ -65,6 +65,9 @@ class SmtpConfigurationType extends TranslatorAwareType
                 'empty_data' => '',
                 'label' => $this->trans('SMTP password', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('Leave blank if not applicable.', 'Admin.Advparameters.Help'),
+                'attr' => [
+                    'autocomplete' => 'new-password',
+                ]
             ])
             ->add('encryption', ChoiceType::class, [
                 'choices' => [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Input "password" (SMTP settings) is filled by Chrome autofill and this make problems, because it stills repeatly fills password in every loading of this page, so customer save his current password, but after reloading page, there can be another password (from autofill) and mails will stop working... Autofill for SMTP password must be disabled, it prevents mistakes and problems.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to E-mail settings and check, if password isn't autofilled after apply this PR.
| UI Tests          | 
| Fixed issue or discussion?     |
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
