### PR TITLE
Add Length  constraint to MetaType

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaType.php
@@ -177,6 +177,9 @@ class MetaType extends AbstractType
                                 'Admin.Notifications.Error'
                             ),
                         ]),
+                        new Length([
+                            'max' => self::META_DESCRIPTION_MAX_CHARS,
+                        ]),
                     ],
                     'attr' => [
                         'class' => 'js-taggable-field',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch           | 8.1.x
| Description      | I added a constraint for the maximum length of 255 (as per the field structure in the database), this prevents an exception from being created when saving. This exception was not descriptive and it was not clear what the problem was in saving a text that was too long.
| Type             | bug fix
| Category         | BO
| BC breaks        | yes
| Deprecations     |  no
| How to test     | If you go to the SEO & Url section and add more than 255 characters in the Meta Keywords field to any page, saving you will be redirected to the grid with an exception but without explanation.
| UI Tests          | not necessary.
| Fixed issue or discussion?     | none
| Related PRs       | not necessary.
| Sponsor company   | Me :).
