### PR TITLE
Fix default Finnish date_format

### DIFF
--- a/app/Resources/all_languages.json
+++ b/app/Resources/all_languages.json
@@ -201,8 +201,8 @@
   "fi": {
     "name": "Suomi (Finnish)",
     "iso_code": "fi",
-    "date_format_lite": "Y-m-d",
-    "date_format_full": "Y-m-d H:i:s",
+    "date_format_lite": "d.m.Y",
+    "date_format_full": "d.m.Y H:i:s",
     "is_rtl": "0",
     "language_code": "fi-fi",
     "locale": "fi-FI"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Change default date format to Finnish format of `d.m.Y`
| Type?             | improvement
| Category?         | LO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install Finnish language and check that the date format is d.m.Y . See https://www.localeplanet.com/icu/fi-FI/index.html
| UI Tests          | -
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -
