### PR TITLE
avoid dashactivity, dashproduct - module can't be configured

### DIFF
--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -25,7 +25,7 @@
  */
 class AdminDashboardControllerCore extends AdminController
 {
-    private const DASHBOARD_ALLOWED_HOOKS = ['dashboardData', 'dashboardZoneOne', 'dashboardZoneTwo', 'displayDashboardToolbarIcons', 'displayDashboardToolbarTopMenu', 'displayDashboardTop'];
+    private const DASHBOARD_ALLOWED_HOOKS = ['hookDashboardData', 'hookDashboardZoneOne', 'hookDashboardZoneTwo', 'displayDashboardToolbarIcons', 'displayDashboardToolbarTopMenu', 'displayDashboardTop'];
 
     public function __construct()
     {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop & 8.1.x
| Description?      | Following lines 82, 85 and 89 of admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl ; and following line 227 of js/admin/dashboard.js ; and following lines 425 and 428 of controllers/admin/AdminDashboardController.php : DASHBOARD_ALLOWED_HOOKS must be with hook*
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to BO ; In Activity overview > Click on the configure button ; Edit any of the parameters ; See NO error This hook is not allowed here ; Refresh the page > See that the edition IS taken into account
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/8047242351
| Fixed issue or discussion?     | Fixes #34326
| Related PRs       | No
| Sponsor company   | No
