### PR TITLE
Fix smarty foreach loop on boolean variable $quick_access in BO

### DIFF
--- a/admin-dev/themes/new-theme/template/components/layout/mobile_quickaccess.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/mobile_quickaccess.tpl
@@ -24,13 +24,15 @@
  *}
 <div class="component-search-quickaccess d-none">
   <p class="component-search-title">{l s='Quick Access' d='Admin.Navigation.Header'}</p>
-  {foreach $quick_access as $quick}
-    <a class="dropdown-item quick-row-link{if $link->matchQuickLink({$quick.link})}{assign "matchQuickLink" $quick.id_quick_access} active{/if}"
-       href="{$quick.link|escape:'html':'UTF-8'}"
-      {if $quick.new_window} target="_blank"{/if}
-       data-item="{$quick.name}"
-    >{$quick.name}</a>
-  {/foreach}
+  {if $quick_access}
+    {foreach $quick_access as $quick}
+      <a class="dropdown-item quick-row-link{if $link->matchQuickLink({$quick.link})}{assign "matchQuickLink" $quick.id_quick_access} active{/if}"
+         href="{$quick.link|escape:'html':'UTF-8'}"
+        {if $quick.new_window} target="_blank"{/if}
+         data-item="{$quick.name}"
+      >{$quick.name}</a>
+    {/foreach}
+  {/if}
   <div class="dropdown-divider"></div>
   {if isset($matchQuickLink)}
     <a id="quick-remove-link"

--- a/admin-dev/themes/new-theme/template/components/layout/quick_access.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/quick_access.tpl
@@ -28,13 +28,15 @@
     {l s='Quick Access' d='Admin.Navigation.Header'}
   </button>
   <div class="dropdown-menu">
-    {foreach $quick_access as $quick}
-      <a class="dropdown-item quick-row-link {if isset($quick.class)}{$quick.class}{/if}{if $link->matchQuickLink({$quick.link})}{assign "matchQuickLink" $quick.id_quick_access} active{/if}"
-         href="{$quick.link|escape:'html':'UTF-8'}"
-        {if $quick.new_window} target="_blank"{/if}
-         data-item="{$quick.name}"
-      >{$quick.name}</a>
-    {/foreach}
+    {if $quick_access}
+      {foreach $quick_access as $quick}
+        <a class="dropdown-item quick-row-link {if isset($quick.class)}{$quick.class}{/if}{if $link->matchQuickLink({$quick.link})}{assign "matchQuickLink" $quick.id_quick_access} active{/if}"
+           href="{$quick.link|escape:'html':'UTF-8'}"
+          {if $quick.new_window} target="_blank"{/if}
+           data-item="{$quick.name}"
+        >{$quick.name}</a>
+      {/foreach}
+    {/if}
     <div class="dropdown-divider"></div>
     {if isset($matchQuickLink)}
       <a id="quick-remove-link"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x
| Description?      |  This PR fixes a smarty foreach loop on boolean variable $quick_access when there are not quick access entities created.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable debug mode; Empty all quick access pages in Backoffice; Browser main backoffice pages: orders, products etc.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #35136 
| Related PRs       | 
| Sponsor company   | www.hostinato.it
