### PR TITLE
Validate cart rule actions on load

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -478,14 +478,19 @@ class FrontControllerCore extends Controller
                 $cart->id_address_delivery = 0;
                 $cart->id_address_invoice = 0;
             }
-
-            // Needed if the merchant want to give a free product to every visitors
             $this->context->cart = $cart;
-            CartRule::autoAddToCart($this->context);
         } else {
             $this->context->cart = $cart;
             $this->context->cart->checkAndUpdateAddresses();
         }
+
+        /*
+         * We also need to run automatic cart rule actions.
+         * autoAddToCart is required to automatically assigning newly created cart rules with no code (automatic).
+         * autoRemoveFromCart is needed to verify, if the cart rules already in a cart are still valid.
+         */
+        CartRule::autoRemoveFromCart($this->context);
+        CartRule::autoAddToCart($this->context);
 
         $this->context->smarty->assign('request_uri', Tools::safeOutput(urldecode($_SERVER['REQUEST_URI'])));
 
@@ -509,8 +514,6 @@ class FrontControllerCore extends Controller
         if (!Tools::isPHPCLI() && Country::GEOLOC_FORBIDDEN == $this->restrictedCountry) {
             $this->displayRestrictedCountryPage();
         }
-
-        $this->context->cart = $cart;
 
         Hook::exec(
             'actionFrontControllerInitAfter',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | This PR slightly improves the validation of cart rules in the shopping cart. It doesn't fix all the issues, but it's a first step in always making the validation reliable. There have been a lot of issues reported regarding this and PR fixes some of them partially, this is why I'm not marking any Issues as "Fixes". Partial backport of https://github.com/PrestaShop/PrestaShop/pull/34875 after discussing it with @kpodemski. **It does not fix ACTIVE, TOTAL QUANTITY AND DATE VALIDITY OF THE VOUCHER.** Test it on some other properties of the cart rule.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Detailed steps are listed below.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/7654840172 🟢 
| Fixed issue or discussion?     | This PR is related to #19393, #32303, #23933 but fixes only part of the issues.
| Related PRs       | 
| Sponsor company   | 

### Test scenario 1

1. Make a cart rule with a minimal order value of 100 EUR.
2. Meet the conditions. Add it to the cart.
3. Change the minimal quantity to 200 EUR.
4. Go to the cart, hit F5...
5. WITHOUT PR - Cart rule is not removed from cart. It’s removed when you +- the quantity on any product.
5. WITH PR - Cart rule is removed immediately.

### Test scenario 2

1. Create customer group ID 4.
2. Create a new customer, put him to group 4, set default group 4.
3. Create a cart rule that will apply automatically, cart rule will give a free gift, set group restriction only to 1, 2, 3.
4. Log in as the customer you created.
5. Add something to cart and go to cart.
5. Now, go edit that customer in BO, tick that he belongs to group 1.
7. Go back to cart, hit F5. Cart rule will be applied and gift added to cart.
8. Go back to edit customer, un-tick group 1, save.
9. Go back to cart, hit F5...
10. WITHOUT PR - Gift is not removed from cart. It’s removed when you +- the quantity on any product.
8. WITH PR - Gift is removed immediately.