### PR TITLE
Migrate "Design > Image Settings"

### DIFF
--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -158,6 +158,7 @@ module.exports = {
     country: './js/pages/country',
     country_form: './js/pages/country/form',
     create_product: './js/pages/product/create/create-product',
+    image_settings: './js/pages/image-settings',
     create_product_default_theme: './scss/pages/product/create_product_default_theme.scss',
     cart: './js/pages/cart',
   },

--- a/admin-dev/themes/new-theme/js/components/grid/extension/action/row/image_type/delete-image-type-row-action-extension.ts
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/action/row/image_type/delete-image-type-row-action-extension.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+import {Grid} from '@js/types/grid';
+import GridMap from '@components/grid/grid-map';
+
+const {$} = window;
+
+/**
+ * Class DeleteCustomerRowActionExtension handles submitting of row action
+ */
+export default class DeleteImageTypeRowActionExtension {
+  /**
+   * Extend grid
+   *
+   * @param {Grid} grid
+   */
+  extend(grid: Grid): void {
+    grid
+      .getContainer()
+      .on('click', GridMap.rows.imageTypeDeleteAction, (event) => {
+        event.preventDefault();
+
+        const $button = $(event.currentTarget);
+        const $deleteImageTypeModal = $(GridMap.rows.deleteImageTypeModal(grid.getId()));
+        $deleteImageTypeModal.modal('show');
+
+        $deleteImageTypeModal.on('click', GridMap.rows.submitDeleteImageType, () => {
+          const $form = $deleteImageTypeModal.find('form');
+          $form.attr('action', $button.data('delete-url'));
+          $form.submit();
+        });
+      });
+  }
+}

--- a/admin-dev/themes/new-theme/js/components/grid/grid-map.ts
+++ b/admin-dev/themes/new-theme/js/components/grid/grid-map.ts
@@ -52,6 +52,9 @@ export default {
     linkRowActionClickableFirst:
       '.js-link-row-action[data-clickable-row=1]:first',
     clickableTd: 'td.clickable',
+    imageTypeDeleteAction: '.js-delete-image-type-row-action',
+    deleteImageTypeModal: (id: string): string => `#${id}_grid_delete_image_type_modal`,
+    submitDeleteImageType: '.js-submit-delete-image-type',
   },
   actions: {
     showQuery: '.js-common_show_query-grid-action',

--- a/admin-dev/themes/new-theme/js/pages/image-settings/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/image-settings/index.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+import Grid from '@components/grid/grid';
+import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
+import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
+import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
+import SortingExtension from '@components/grid/extension/sorting-extension';
+import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
+import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
+import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
+import ChoiceExtension from '@components/grid/extension/choice-extension';
+import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
+import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
+import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
+import DeleteImageTypeRowActionExtension
+  from '@components/grid/extension/action/row/image_type/delete-image-type-row-action-extension';
+import ConfirmModal from '@components/modal/confirm-modal';
+
+const {$} = window;
+
+$(() => {
+  // Init image type grid
+  const grid = new Grid('image_type');
+  grid.addExtension(new FiltersResetExtension());
+  grid.addExtension(new ReloadListActionExtension());
+  grid.addExtension(new ExportToSqlManagerExtension());
+  grid.addExtension(new SortingExtension());
+  grid.addExtension(new LinkRowActionExtension());
+  grid.addExtension(new SubmitBulkExtension());
+  grid.addExtension(new BulkActionCheckboxExtension());
+  grid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  grid.addExtension(new ChoiceExtension());
+  grid.addExtension(new ColumnTogglingExtension());
+  grid.addExtension(new SubmitRowActionExtension());
+  grid.addExtension(new DeleteImageTypeRowActionExtension());
+
+  // Regenerate thumbnails system
+  const $regenerateThumbnailsForm = $('form[name=regenerate_thumbnails]');
+  const $regenerateThumbnailsButton = $('#regenerate-thumbnails-button');
+  const $selectImage = $('#regenerate_thumbnails_image');
+  const $selectImageType = $('#regenerate_thumbnails_image-type');
+  const $parentImageFormat = $selectImageType.parents('.form-group');
+  const formatsByTypes = $selectImage.data('formats');
+
+  // First hide the image format select
+  $parentImageFormat.hide();
+
+  // On image type change, show the image format by the type selected
+  $selectImage.on('change', () => {
+    const selectedImage: string = ($selectImage.val() ?? 'all').toString();
+
+    // Reset format selector
+    $selectImageType.val(0);
+    $selectImageType.children('option').hide();
+
+    // If all is selected, hide the format selector
+    if (selectedImage === 'all') {
+      $parentImageFormat.hide();
+    } else {
+      // Else show the format selector...
+      $parentImageFormat.show();
+      // and the formats by the type selected
+      formatsByTypes[selectedImage].forEach((formatId: number) => {
+        $selectImageType.children(`option[value="${formatId}"]`).show();
+      });
+      // Don't forget to show the "all" option
+      $selectImageType.children('option[value="0"]').show();
+    }
+  });
+
+  // On submit regenerate thumbnails form, show a confirmation modal.
+  $regenerateThumbnailsButton.on('click', (event) => {
+    event.preventDefault();
+
+    // Display confirmation modal
+    const modal = new (ConfirmModal as any)(
+      {
+        id: '#regeneration-confirm-modal',
+        confirmTitle: $regenerateThumbnailsButton.data('confirm-title'),
+        confirmMessage: $regenerateThumbnailsButton.data('confirm-message'),
+        closeButtonLabel: $regenerateThumbnailsButton.data('confirm-cancel'),
+        confirmButtonLabel: $regenerateThumbnailsButton.data('confirm-apply'),
+        closable: true,
+      },
+      () => {
+        // If ok, submit the form
+        $regenerateThumbnailsForm.submit();
+      },
+    );
+    modal.show();
+  });
+});

--- a/classes/lang/KeysReference/FeatureFlagLang.php
+++ b/classes/lang/KeysReference/FeatureFlagLang.php
@@ -84,3 +84,6 @@ trans('Enable / Disable the new front container.', 'Admin.Advparameters.Help');
 // Carts index feature flag
 trans('Carts', 'Admin.Advaparameters.Feature');
 trans('Enable or Disable the migrated carts page.', 'Admin.Advparameters.Help');
+
+trans('Image settings', 'Admin.Advparameters.Feature');
+trans('Enable / Disable the new image settings page.', 'Admin.Advparameters.Help');

--- a/install-dev/data/xml/feature_flag.xml
+++ b/install-dev/data/xml/feature_flag.xml
@@ -24,5 +24,6 @@
     <feature_flag id="symfony_layout" name="symfony_layout" type="env,query,dotenv,db" label_wording="Symfony layout" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable symfony layout (in opposition to legacy layout)." description_domain="Admin.Advparameters.Help" state="1" stability="beta" />
     <feature_flag id="front_container_v2" name="front_container_v2" type="env,dotenv,db" label_wording="New front container" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the new front container." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
     <feature_flag id="carts" name="carts" type="env,dotenv,db" label_wording="Carts" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the migrated carts page." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
+    <feature_flag id="image_settings" name="image_settings" type="env,dotenv,db" label_wording="Image settings" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the new image settings page." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
   </entities>
 </entity_feature_flag>

--- a/src/Adapter/Admin/ImageConfiguration.php
+++ b/src/Adapter/Admin/ImageConfiguration.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Admin;
+
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+
+/**
+ * Manages the configuration data about image.
+ */
+class ImageConfiguration implements DataConfigurationInterface
+{
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration()
+    {
+        return [
+            'formats' => $this->configuration->get('PS_IMAGE_FORMAT'),
+            'base-format' => $this->configuration->get('PS_IMAGE_QUALITY'),
+            'avif-quality' => (int) $this->configuration->get('PS_AVIF_QUALITY'),
+            'jpeg-quality' => (int) $this->configuration->get('PS_JPEG_QUALITY'),
+            'png-quality' => (int) $this->configuration->get('PS_PNG_QUALITY'),
+            'webp-quality' => (int) $this->configuration->get('PS_WEBP_QUALITY'),
+            'generation-method' => (int) $this->configuration->get('PS_IMAGE_GENERATION_METHOD'),
+            'picture-max-size' => (int) $this->configuration->get('PS_PRODUCT_PICTURE_MAX_SIZE'),
+            'picture-max-width' => (int) $this->configuration->get('PS_PRODUCT_PICTURE_WIDTH'),
+            'picture-max-height' => (int) $this->configuration->get('PS_PRODUCT_PICTURE_HEIGHT'),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateConfiguration(array $configuration)
+    {
+        $errors = [];
+
+        if ($this->validateConfiguration($configuration)) {
+            $this->configuration->set('PS_IMAGE_FORMAT', $configuration['formats']);
+            $this->configuration->set('PS_IMAGE_QUALITY', $configuration['base-format']);
+            $this->configuration->set('PS_AVIF_QUALITY', (int) $configuration['avif-quality']);
+            $this->configuration->set('PS_JPEG_QUALITY', (int) $configuration['jpeg-quality']);
+            $this->configuration->set('PS_PNG_QUALITY', (int) $configuration['png-quality']);
+            $this->configuration->set('PS_WEBP_QUALITY', (int) $configuration['webp-quality']);
+            $this->configuration->set('PS_IMAGE_GENERATION_METHOD', (int) $configuration['generation-method']);
+            $this->configuration->set('PS_PRODUCT_PICTURE_MAX_SIZE', (int) $configuration['picture-max-size']);
+            $this->configuration->set('PS_PRODUCT_PICTURE_WIDTH', (int) $configuration['picture-max-width']);
+            $this->configuration->set('PS_PRODUCT_PICTURE_HEIGHT', (int) $configuration['picture-max-height']);
+        }
+
+        return $errors;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateConfiguration(array $configuration)
+    {
+        return isset(
+            $configuration['formats'],
+            $configuration['base-format'],
+            $configuration['avif-quality'],
+            $configuration['jpeg-quality'],
+            $configuration['png-quality'],
+            $configuration['webp-quality'],
+            $configuration['generation-method'],
+            $configuration['picture-max-size'],
+            $configuration['picture-max-width'],
+            $configuration['picture-max-height'],
+        );
+    }
+}

--- a/src/Adapter/ImageThumbnailsRegenerator.php
+++ b/src/Adapter/ImageThumbnailsRegenerator.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter;
+
+use Db;
+use Image;
+use ImageManager as LegacyImageManager;
+use ImageType as LegacyImageType;
+use Module as LegacyModule;
+use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageRepository;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageNotDeletedException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeException;
+use PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration;
+use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Class responsible for regenerating images by image type.
+ */
+class ImageThumbnailsRegenerator
+{
+    private int $maxExecutionTime = 7200;
+    private int $startTime = 0;
+
+    public function __construct(
+      private readonly ProductImageRepository $productImageRepository,
+      private readonly ImageFormatConfiguration $imageFormatConfiguration,
+      private readonly LanguageRepositoryInterface $langRepository,
+      private readonly ConfigurationInterface $configuration,
+      private readonly TranslatorInterface $translator,
+    ) {
+        // Save start time to calculate remaining time and to avoid timeout on long running processes
+        $this->startTime = time();
+        ini_set('max_execution_time', $this->maxExecutionTime); // ini_set may be disabled, we need the real value
+        $this->maxExecutionTime = (int) ini_get('max_execution_time');
+    }
+
+    /**
+     * Delete previous resized images.
+     *
+     * @param string $dir
+     * @param array $types
+     * @param bool $isProduct
+     *
+     * @return bool
+     */
+    public function deletePreviousImages(string $dir, array $types, bool $isProduct = false): bool
+    {
+        if (!is_dir($dir)) {
+            return false;
+        }
+        $toDel = scandir($dir, SCANDIR_SORT_NONE);
+
+        foreach ($toDel as $d) {
+            foreach ($types as $imageType) {
+                if (preg_match('/^[0-9]+\-' . ($isProduct ? '[0-9]+\-' : '') . $imageType->getName() . '(|2x)\.(jpg|png|webp|avif)$/', $d)
+                    || (count($types) > 1 && preg_match('/^[0-9]+\-[_a-zA-Z0-9-]*\.(jpg|png|webp|avif)$/', $d))
+                    || preg_match('/^([[:lower:]]{2})\-default\-' . $imageType->getName() . '(|2x)\.(jpg|png|webp|avif)$/', $d)) {
+                    if (file_exists($dir . $d)) {
+                        unlink($dir . $d);
+                    }
+                }
+            }
+        }
+
+        // Delete product images using new filesystem.
+        if ($isProduct) {
+            $productsImages = $this->productImageRepository->getAllImages();
+            foreach ($productsImages as $image) {
+                if (file_exists($dir . $image->getImgFolder())) {
+                    $toDel = scandir($dir . $image->getImgFolder(), SCANDIR_SORT_NONE);
+                    foreach ($toDel as $d) {
+                        foreach ($types as $imageType) {
+                            if (preg_match('/^[0-9]+\-' . $imageType->getName() . '(|2x)\.(jpg|png|webp|avif)$/', $d)
+                                || (count($types) > 1 && preg_match('/^[0-9]+\-[_a-zA-Z0-9-]*\.(jpg|png|webp|avif)$/', $d))) {
+                                if (file_exists($dir . $image->getImgFolder() . $d)) {
+                                    unlink($dir . $image->getImgFolder() . $d);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Regenerate images.
+     *
+     * @param string $dir
+     * @param array $type
+     * @param bool $productsImages
+     *
+     * @return bool|array
+     */
+    public function regenerateNewImages(string $dir, array $type, bool $productsImages = false): bool|array
+    {
+        if (!is_dir($dir)) {
+            return false;
+        }
+
+        $errors = [];
+
+        /*
+         * Let's resolve which formats we will use for image generation.
+         *
+         * In case of .jpg images, the actual format inside is decided by ImageManager.
+         */
+        $configuredImageFormats = $this->imageFormatConfiguration->getGenerationFormats();
+
+        if (!$productsImages) {
+            $formated_medium = LegacyImageType::getFormattedName('medium');
+            foreach (scandir($dir, SCANDIR_SORT_NONE) as $image) {
+                if (preg_match('/^[0-9]*\.jpg$/', $image)) {
+                    foreach ($type as $k => $imageType) {
+                        // Customizable writing dir
+                        $newDir = $dir;
+                        if (!file_exists($newDir)) {
+                            continue;
+                        }
+
+                        if (($dir == _PS_CAT_IMG_DIR_) && ($imageType->getName() == $formated_medium) && is_file(_PS_CAT_IMG_DIR_ . str_replace('.', '_thumb.', $image))) {
+                            $image = str_replace('.', '_thumb.', $image);
+                        }
+
+                        foreach ($configuredImageFormats as $imageFormat) {
+                            // If thumbnail does not exist
+                            if (!file_exists($newDir . substr($image, 0, -4) . '-' . stripslashes($imageType->getName()) . '.' . $imageFormat)) {
+                                // Check if original image exists
+                                if (!file_exists($dir . $image) || !filesize($dir . $image)) {
+                                    $errors[] = $this->translator->trans('Source file does not exist or is empty (%filepath%)', ['%filepath%' => $dir . $image], 'Admin.Design.Notification');
+                                } else {
+                                    if (!LegacyImageManager::resize(
+                                        $dir . $image,
+                                        $newDir . substr(str_replace('_thumb.', '.', $image), 0, -4) . '-' . stripslashes($imageType->getName()) . '.' . $imageFormat,
+                                        (int) $imageType->getWidth(),
+                                        (int) $imageType->getHeight(),
+                                        $imageFormat
+                                        )) {
+                                        $errors[] = $this->translator->trans('Failed to resize image file (%filepath%)', ['%filepath%' => $dir . $image], 'Admin.Design.Notification');
+                                    }
+                                }
+                            }
+                        }
+
+                        // stop 4 seconds before the timeout, just enough time to process the end of the page on a slow server
+                        if (time() - $this->startTime > $this->maxExecutionTime - 4) {
+                            return ['timeout'];
+                        }
+                    }
+                }
+            }
+        } else {
+            foreach ($this->productImageRepository->getAllImages() as $imageObj) {
+                $existing_img = $dir . $imageObj->getExistingImgPath() . '.jpg';
+                if (file_exists($existing_img) && filesize($existing_img)) {
+                    foreach ($type as $imageType) {
+                        foreach ($configuredImageFormats as $imageFormat) {
+                            if (!file_exists($dir . $imageObj->getExistingImgPath() . '-' . stripslashes($imageType->getName()) . '.' . $imageFormat)) {
+                                if (!LegacyImageManager::resize(
+                                    $existing_img,
+                                    $dir . $imageObj->getExistingImgPath() . '-' . stripslashes($imageType->getName()) . '.' . $imageFormat,
+                                    (int) $imageType->getWidth(),
+                                    (int) $imageType->getHeight(),
+                                    $imageFormat
+                                )) {
+                                    $errors[] = $this->translator->trans(
+                                        'Original image is corrupt (%filename%) for product ID %id% or bad permission on folder.',
+                                        [
+                                            '%filename%' => $existing_img,
+                                            '%id%' => (int) $imageObj->id_product,
+                                        ],
+                                        'Admin.Design.Notification'
+                                    );
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    $errors[] = $this->translator->trans(
+                        'Original image is missing or empty (%filename%) for product ID %id%',
+                        [
+                            '%filename%' => $existing_img,
+                            '%id%' => (int) $imageObj->id_product,
+                        ],
+                        'Admin.Design.Notification'
+                    );
+                }
+                if (time() - $this->startTime > $this->maxExecutionTime - 4) { // stop 4 seconds before the tiemout, just enough time to process the end of the page on a slow server
+                    return ['timeout'];
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    /* Hook watermark optimization */
+    public function regenerateWatermark(string $dir, array $formats = null): bool|string
+    {
+        $result = Db::getInstance()->executeS('
+		SELECT m.`name` FROM `' . _DB_PREFIX_ . 'module` m
+		LEFT JOIN `' . _DB_PREFIX_ . 'hook_module` hm ON hm.`id_module` = m.`id_module`
+		LEFT JOIN `' . _DB_PREFIX_ . 'hook` h ON hm.`id_hook` = h.`id_hook`
+		WHERE h.`name` = \'actionWatermark\' AND m.`active` = 1');
+
+        if ($result && count($result)) {
+            $productsImages = $this->productImageRepository->getAllImages();
+            foreach ($productsImages as $imageObj) {
+                if (file_exists($dir . $imageObj->getExistingImgPath() . '.jpg')) {
+                    foreach ($result as $module) {
+                        $moduleInstance = LegacyModule::getInstanceByName($module['name']);
+                        if ($moduleInstance && is_callable([$moduleInstance, 'hookActionWatermark'])) {
+                            call_user_func([$moduleInstance, 'hookActionWatermark'], ['id_image' => $imageObj->id, 'id_product' => $imageObj->id_product, 'image_type' => $formats]);
+                        }
+
+                        if (time() - $this->startTime > $this->maxExecutionTime - 4) { // stop 4 seconds before the tiemout, just enough time to process the end of the page on a slow server
+                            return 'timeout';
+                        }
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Regenerate no-pictures images.
+     *
+     * @param string $dir
+     * @param array $type
+     * @param array $languages
+     *
+     * @return bool
+     */
+    public function regenerateNoPictureImages(string $dir, array $type, array $languages): bool
+    {
+        $defaultLang = $this->langRepository->findOneBy(['id' => (int) $this->configuration->get('PS_LANG_DEFAULT')]);
+        $errors = false;
+
+        /*
+         * Let's resolve which formats we will use for image generation.
+         *
+         * In case of .jpg images, the actual format inside is decided by ImageManager.
+         */
+        $configuredImageFormats = $this->imageFormatConfiguration->getGenerationFormats();
+
+        foreach ($type as $image_type) {
+            foreach ($languages as $language) {
+                $file = $dir . $language->getIsoCode() . '.jpg';
+                if (!file_exists($file)) {
+                    $file = _PS_PRODUCT_IMG_DIR_ . $defaultLang->getIsoCode() . '.jpg';
+                }
+                foreach ($configuredImageFormats as $imageFormat) {
+                    if (!file_exists($dir . $language->getIsoCode() . '-default-' . stripslashes($image_type->getName()) . '.' . $imageFormat)) {
+                        if (!LegacyImageManager::resize(
+                            $file,
+                            $dir . $language->getIsoCode() . '-default-' . stripslashes($image_type->getName()) . '.' . $imageFormat,
+                            (int) $image_type->getWidth(),
+                            (int) $image_type->getHeight(),
+                            $imageFormat
+                        )) {
+                            $errors = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Function aim to delete all images from defined image type
+     *
+     * @throws ImageTypeException
+     */
+    public function deleteImagesFromType($imageTypeName, $path): void
+    {
+        foreach (glob($path . '*', GLOB_BRACE) as $file) {
+            if (is_dir($file)) {
+                $this->deleteImagesFromType($imageTypeName, $file . '/');
+            } else {
+                if (
+                    preg_match('/\/(\d+|\w{2}-default)-' . $imageTypeName . '\.(jpg|png|webp|avif)$/', $file)
+                ) {
+                    if (!unlink($file)) {
+                        throw new ImageNotDeletedException(sprintf('Unable to delete image "%s"', $file));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Adapter/Product/Image/Repository/ProductImageRepository.php
+++ b/src/Adapter/Product/Image/Repository/ProductImageRepository.php
@@ -90,6 +90,22 @@ class ProductImageRepository extends AbstractMultiShopObjectModelRepository
     }
 
     /**
+     * @return Image[]
+     */
+    public function getAllImages(): array
+    {
+        $qb = $this->connection->createQueryBuilder()
+            ->select('i.id_image')
+            ->from($this->dbPrefix . 'image', 'i')
+            ->addOrderBy('i.id_image', 'ASC')
+       ;
+
+        return array_map(static function (string $id): Image {
+            return new Image((int) $id);
+        }, $qb->executeQuery()->fetchFirstColumn());
+    }
+
+    /**
      * @param ProductId $productId
      *
      * @return Image[]

--- a/src/Core/ConstraintValidator/Constraints/TypedRegex.php
+++ b/src/Core/ConstraintValidator/Constraints/TypedRegex.php
@@ -60,6 +60,7 @@ class TypedRegex extends Constraint
     public const TYPE_WEBSERVICE_KEY = 'webservice_key';
     public const TYPE_LINK_REWRITE = 'link_rewrite';
     public const TYPE_ZIP_CODE_FORMAT = 'zip_code_format';
+    public const TYPE_IMAGE_TYPE_NAME = 'image_type_name';
     public const CLEAN_HTML_NO_IFRAME = 'clean_html_no_iframe';
     public const CLEAN_HTML_ALLOW_IFRAME = 'clean_html_allow_iframe';
 

--- a/src/Core/ConstraintValidator/TypedRegexValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexValidator.php
@@ -163,6 +163,8 @@ class TypedRegexValidator extends ConstraintValidator
                 }
 
                 return '/^[_a-zA-Z0-9\-]+$/';
+            case TypedRegex::TYPE_IMAGE_TYPE_NAME:
+                return '/^[a-zA-Z0-9_ -]+$/';
             default:
                 $definedTypes = implode(', ', array_values((new ReflectionClass(TypedRegex::class))->getConstants()));
                 throw new InvalidArgumentException(sprintf('Type "%s" is not defined. Defined types are: %s', $type, $definedTypes));

--- a/src/Core/Domain/ImageSettings/Command/AddImageTypeCommand.php
+++ b/src/Core/Domain/ImageSettings/Command/AddImageTypeCommand.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command;
+
+/**
+ * Adds new image type with provided data.
+ */
+class AddImageTypeCommand
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly int $width,
+        private readonly int $height,
+        private readonly bool $products,
+        private readonly bool $categories,
+        private readonly bool $manufacturers,
+        private readonly bool $suppliers,
+        private readonly bool $stores
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getWidth(): int
+    {
+        return $this->width;
+    }
+
+    public function getHeight(): int
+    {
+        return $this->height;
+    }
+
+    public function isProducts(): bool
+    {
+        return $this->products;
+    }
+
+    public function isCategories(): bool
+    {
+        return $this->categories;
+    }
+
+    public function isManufacturers(): bool
+    {
+        return $this->manufacturers;
+    }
+
+    public function isSuppliers(): bool
+    {
+        return $this->suppliers;
+    }
+
+    public function isStores(): bool
+    {
+        return $this->stores;
+    }
+}

--- a/src/Core/Domain/ImageSettings/Command/BulkDeleteImageTypeCommand.php
+++ b/src/Core/Domain/ImageSettings/Command/BulkDeleteImageTypeCommand.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject\ImageTypeId;
+
+/**
+ * Deletes image types on bulk action
+ */
+class BulkDeleteImageTypeCommand
+{
+    /**
+     * @var array<int, ImageTypeId>
+     */
+    private array $imageTypeIds;
+
+    /**
+     * @param array<int, int> $imageTypeIds
+     */
+    public function __construct(array $imageTypeIds)
+    {
+        $this->setImageTypeIds($imageTypeIds);
+    }
+
+    /**
+     * @return array<int, ImageTypeId>
+     */
+    public function getImageTypeIds(): array
+    {
+        return $this->imageTypeIds;
+    }
+
+    /**
+     * @param array<int, int> $imageTypeIds
+     */
+    private function setImageTypeIds(array $imageTypeIds): void
+    {
+        foreach ($imageTypeIds as $imageTypeId) {
+            $this->imageTypeIds[] = new ImageTypeId((int) $imageTypeId);
+        }
+    }
+}

--- a/src/Core/Domain/ImageSettings/Command/DeleteImageTypeCommand.php
+++ b/src/Core/Domain/ImageSettings/Command/DeleteImageTypeCommand.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject\ImageTypeId;
+
+/**
+ * Delete image type
+ */
+class DeleteImageTypeCommand
+{
+    private ImageTypeId $imageTypeId;
+
+    /**
+     * @param int $imageTypeId
+     */
+    public function __construct(int $imageTypeId)
+    {
+        $this->imageTypeId = new ImageTypeId($imageTypeId);
+    }
+
+    /**
+     * @return ImageTypeId
+     */
+    public function getImageTypeId(): ImageTypeId
+    {
+        return $this->imageTypeId;
+    }
+}

--- a/src/Core/Domain/ImageSettings/Command/DeleteImagesFromTypeCommand.php
+++ b/src/Core/Domain/ImageSettings/Command/DeleteImagesFromTypeCommand.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject\ImageTypeId;
+
+/**
+ * Delete images from defined image type
+ */
+class DeleteImagesFromTypeCommand
+{
+    private ImageTypeId $imageTypeId;
+
+    /**
+     * @param int $imageTypeId
+     */
+    public function __construct(int $imageTypeId)
+    {
+        $this->imageTypeId = new ImageTypeId($imageTypeId);
+    }
+
+    /**
+     * @return ImageTypeId
+     */
+    public function getImageTypeId(): ImageTypeId
+    {
+        return $this->imageTypeId;
+    }
+}

--- a/src/Core/Domain/ImageSettings/Command/EditImageSettingsCommand.php
+++ b/src/Core/Domain/ImageSettings/Command/EditImageSettingsCommand.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command;
+
+/**
+ * Command that edits zone
+ */
+class EditImageSettingsCommand
+{
+    private array $formats;
+    private string $baseFormat;
+    private int $avifQuality;
+    private int $jpegQuality;
+    private int $pngQuality;
+    private int $webpQuality;
+    private int $generationMethod;
+    private int $pictureMaxSize;
+    private int $pictureMaxWidth;
+    private int $pictureMaxHeight;
+
+    public function setFormats(array $formats): void
+    {
+        $this->formats = $formats;
+    }
+
+    public function getFormats(): string
+    {
+        // Always have jpg format in all cases.
+        $this->formats[] = 'jpg';
+        $this->formats = array_unique($this->formats);
+
+        // Prepare data for database.
+        return implode(',', $this->formats);
+    }
+
+    public function setBaseFormat(string $baseFormat): void
+    {
+        $this->baseFormat = $baseFormat;
+    }
+
+    public function getBaseFormat(): string
+    {
+        return $this->baseFormat;
+    }
+
+    public function setAvifQuality(int $avifQuality): void
+    {
+        $this->avifQuality = $avifQuality;
+    }
+
+    public function getAvifQuality(): int
+    {
+        return $this->avifQuality;
+    }
+
+    public function setJpegQuality(int $jpegQuality): void
+    {
+        $this->jpegQuality = $jpegQuality;
+    }
+
+    public function getJpegQuality(): int
+    {
+        return $this->jpegQuality;
+    }
+
+    public function setPngQuality(int $pngQuality): void
+    {
+        $this->pngQuality = $pngQuality;
+    }
+
+    public function getPngQuality(): int
+    {
+        return $this->pngQuality;
+    }
+
+    public function setWebpQuality(int $webpQuality): void
+    {
+        $this->webpQuality = $webpQuality;
+    }
+
+    public function getWebpQuality(): int
+    {
+        return $this->webpQuality;
+    }
+
+    public function setGenerationMethod(int $generationMethod): void
+    {
+        $this->generationMethod = $generationMethod;
+    }
+
+    public function getGenerationMethod(): int
+    {
+        return $this->generationMethod;
+    }
+
+    public function setPictureMaxSize(int $pictureMaxSize): void
+    {
+        $this->pictureMaxSize = $pictureMaxSize;
+    }
+
+    public function getPictureMaxSize(): int
+    {
+        return $this->pictureMaxSize;
+    }
+
+    public function setPictureMaxWidth(int $pictureMaxWidth): void
+    {
+        $this->pictureMaxWidth = $pictureMaxWidth;
+    }
+
+    public function getPictureMaxWidth(): int
+    {
+        return $this->pictureMaxWidth;
+    }
+
+    public function setPictureMaxHeight(int $pictureMaxHeight): void
+    {
+        $this->pictureMaxHeight = $pictureMaxHeight;
+    }
+
+    public function getPictureMaxHeight(): int
+    {
+        return $this->pictureMaxHeight;
+    }
+}

--- a/src/Core/Domain/ImageSettings/Command/EditImageTypeCommand.php
+++ b/src/Core/Domain/ImageSettings/Command/EditImageTypeCommand.php
@@ -36,14 +36,14 @@ use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject\ImageTypeId;
 class EditImageTypeCommand
 {
     private ImageTypeId $imageTypeId;
-    private string $name;
-    private int $width;
-    private int $height;
-    private bool $products;
-    private bool $categories;
-    private bool $manufacturers;
-    private bool $suppliers;
-    private bool $stores;
+    private ?string $name = null;
+    private ?int $width = null;
+    private ?int $height = null;
+    private ?bool $products = null;
+    private ?bool $categories = null;
+    private ?bool $manufacturers = null;
+    private ?bool $suppliers = null;
+    private ?bool $stores = null;
 
     public function __construct(int $imageTypeId)
     {
@@ -55,7 +55,7 @@ class EditImageTypeCommand
         return $this->imageTypeId;
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -67,7 +67,7 @@ class EditImageTypeCommand
         return $this;
     }
 
-    public function getWidth(): int
+    public function getWidth(): ?int
     {
         return $this->width;
     }
@@ -79,7 +79,7 @@ class EditImageTypeCommand
         return $this;
     }
 
-    public function getHeight(): int
+    public function getHeight(): ?int
     {
         return $this->height;
     }
@@ -91,7 +91,7 @@ class EditImageTypeCommand
         return $this;
     }
 
-    public function isProducts(): bool
+    public function isProducts(): ?bool
     {
         return $this->products;
     }
@@ -103,7 +103,7 @@ class EditImageTypeCommand
         return $this;
     }
 
-    public function isCategories(): bool
+    public function isCategories(): ?bool
     {
         return $this->categories;
     }
@@ -115,7 +115,7 @@ class EditImageTypeCommand
         return $this;
     }
 
-    public function isManufacturers(): bool
+    public function isManufacturers(): ?bool
     {
         return $this->manufacturers;
     }
@@ -127,7 +127,7 @@ class EditImageTypeCommand
         return $this;
     }
 
-    public function isSuppliers(): bool
+    public function isSuppliers(): ?bool
     {
         return $this->suppliers;
     }
@@ -139,7 +139,7 @@ class EditImageTypeCommand
         return $this;
     }
 
-    public function isStores(): bool
+    public function isStores(): ?bool
     {
         return $this->stores;
     }

--- a/src/Core/Domain/ImageSettings/Command/EditImageTypeCommand.php
+++ b/src/Core/Domain/ImageSettings/Command/EditImageTypeCommand.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject\ImageTypeId;
+
+/**
+ * Command that edits zone
+ */
+class EditImageTypeCommand
+{
+    private ImageTypeId $imageTypeId;
+    private string $name;
+    private int $width;
+    private int $height;
+    private bool $products;
+    private bool $categories;
+    private bool $manufacturers;
+    private bool $suppliers;
+    private bool $stores;
+
+    public function __construct(int $imageTypeId)
+    {
+        $this->imageTypeId = new ImageTypeId($imageTypeId);
+    }
+
+    public function getImageTypeId(): ImageTypeId
+    {
+        return $this->imageTypeId;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getWidth(): int
+    {
+        return $this->width;
+    }
+
+    public function setWidth(int $width): self
+    {
+        $this->width = $width;
+
+        return $this;
+    }
+
+    public function getHeight(): int
+    {
+        return $this->height;
+    }
+
+    public function setHeight(int $height): self
+    {
+        $this->height = $height;
+
+        return $this;
+    }
+
+    public function isProducts(): bool
+    {
+        return $this->products;
+    }
+
+    public function setProducts(bool $products): self
+    {
+        $this->products = $products;
+
+        return $this;
+    }
+
+    public function isCategories(): bool
+    {
+        return $this->categories;
+    }
+
+    public function setCategories(bool $categories): self
+    {
+        $this->categories = $categories;
+
+        return $this;
+    }
+
+    public function isManufacturers(): bool
+    {
+        return $this->manufacturers;
+    }
+
+    public function setManufacturers(bool $manufacturers): self
+    {
+        $this->manufacturers = $manufacturers;
+
+        return $this;
+    }
+
+    public function isSuppliers(): bool
+    {
+        return $this->suppliers;
+    }
+
+    public function setSuppliers(bool $suppliers): self
+    {
+        $this->suppliers = $suppliers;
+
+        return $this;
+    }
+
+    public function isStores(): bool
+    {
+        return $this->stores;
+    }
+
+    public function setStores(bool $stores): self
+    {
+        $this->stores = $stores;
+
+        return $this;
+    }
+}

--- a/src/Core/Domain/ImageSettings/Command/RegenerateThumbnailsCommand.php
+++ b/src/Core/Domain/ImageSettings/Command/RegenerateThumbnailsCommand.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command;
+
+/**
+ * Regenerate thumbnails command
+ */
+class RegenerateThumbnailsCommand
+{
+    public function __construct(
+        private readonly string $image,
+        private readonly int $imageTypeId,
+        private readonly bool $erasePreviousImages,
+    ) {
+    }
+
+    public function getImage(): string
+    {
+        return $this->image;
+    }
+
+    public function getImageTypeId(): int
+    {
+        return $this->imageTypeId;
+    }
+
+    public function erasePreviousImages(): bool
+    {
+        return $this->erasePreviousImages;
+    }
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/AddImageTypeHandler.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/AddImageTypeHandler.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\AddImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject\ImageTypeId;
+use PrestaShopBundle\Entity\ImageType;
+use PrestaShopBundle\Entity\Repository\ImageTypeRepository;
+
+/**
+ * Handles @see AddImageTypeCommand
+ */
+#[AsCommandHandler]
+final class AddImageTypeHandler implements AddImageTypeHandlerInterface
+{
+    public function __construct(
+        private readonly ImageTypeRepository $imageTypeRepository
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(AddImageTypeCommand $command): ImageTypeId
+    {
+        $imageType = new ImageType();
+        $imageType->setName($command->getName());
+        $imageType->setWidth($command->getWidth());
+        $imageType->setHeight($command->getHeight());
+        $imageType->setProducts($command->isProducts());
+        $imageType->setCategories($command->isCategories());
+        $imageType->setManufacturers($command->isManufacturers());
+        $imageType->setSuppliers($command->isSuppliers());
+        $imageType->setStores($command->isStores());
+
+        $this->imageTypeRepository->save($imageType);
+
+        return new ImageTypeId((int) $imageType->getId());
+    }
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/AddImageTypeHandlerInterface.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/AddImageTypeHandlerInterface.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\AddImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject\ImageTypeId;
+
+/**
+ * Interface for service that creates new image type
+ */
+interface AddImageTypeHandlerInterface
+{
+    /**
+     * @param AddImageTypeCommand $command
+     *
+     * @return ImageTypeId
+     */
+    public function handle(AddImageTypeCommand $command): ImageTypeId;
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/BulkDeleteImageTypeHandler.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/BulkDeleteImageTypeHandler.php
@@ -41,7 +41,7 @@ use PrestaShopBundle\Entity\Repository\ImageTypeRepository;
  * Handles command that bulk delete image types
  */
 #[AsCommandHandler]
-class BulkImageTypeHandler extends AbstractBulkCommandHandler implements BulkImageTypeHandlerInterface
+class BulkDeleteImageTypeHandler extends AbstractBulkCommandHandler implements BulkDeleteImageTypeHandlerInterface
 {
     public function __construct(
         private readonly ImageTypeRepository $imageTypeRepository

--- a/src/Core/Domain/ImageSettings/CommandHandler/BulkDeleteImageTypeHandlerInterface.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/BulkDeleteImageTypeHandlerInterface.php
@@ -29,9 +29,9 @@ namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\BulkDeleteImageTypeCommand;
 
 /**
- * Defines contract for BulkImageTypeHandler
+ * Defines contract for BulkDeleteImageTypeHandler
  */
-interface BulkImageTypeHandlerInterface
+interface BulkDeleteImageTypeHandlerInterface
 {
     /**
      * @param BulkDeleteImageTypeCommand $command

--- a/src/Core/Domain/ImageSettings/CommandHandler/BulkImageTypeHandler.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/BulkImageTypeHandler.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\AbstractBulkCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\BulkDeleteImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\BulkImageTypeException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject\ImageTypeId;
+use PrestaShopBundle\Entity\Repository\ImageTypeRepository;
+
+/**
+ * Handles command that bulk delete image types
+ */
+#[AsCommandHandler]
+class BulkImageTypeHandler extends AbstractBulkCommandHandler implements BulkImageTypeHandlerInterface
+{
+    public function __construct(
+        private readonly ImageTypeRepository $imageTypeRepository
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(BulkDeleteImageTypeCommand $command): void
+    {
+        $this->handleBulkAction($command->getImageTypeIds(), ImageTypeException::class);
+    }
+
+    protected function buildBulkException(array $caughtExceptions): BulkImageTypeException
+    {
+        return new BulkImageTypeException(
+            $caughtExceptions,
+            'Errors occurred during image type bulk delete action',
+        );
+    }
+
+    /**
+     * @param ImageTypeId $id
+     * @param mixed $command
+     *
+     * @return void
+     *
+     * @throws ImageTypeNotFoundException
+     */
+    protected function handleSingleAction(mixed $id, mixed $command): void
+    {
+        $imageType = $this->imageTypeRepository->find($id->getValue());
+
+        if (null === $imageType) {
+            throw new ImageTypeNotFoundException(sprintf('Unable to find image type with id "%d" for deletion', $id->getValue()));
+        }
+
+        $this->imageTypeRepository->delete($imageType);
+    }
+
+    protected function supports($id): bool
+    {
+        return $id instanceof ImageTypeId;
+    }
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/BulkImageTypeHandlerInterface.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/BulkImageTypeHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\BulkDeleteImageTypeCommand;
+
+/**
+ * Defines contract for BulkImageTypeHandler
+ */
+interface BulkImageTypeHandlerInterface
+{
+    /**
+     * @param BulkDeleteImageTypeCommand $command
+     */
+    public function handle(BulkDeleteImageTypeCommand $command): void;
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/DeleteImageTypeHandler.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/DeleteImageTypeHandler.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\DeleteImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeNotFoundException;
+use PrestaShopBundle\Entity\ImageType;
+use PrestaShopBundle\Entity\Repository\ImageTypeRepository;
+
+/**
+ * Handles command that delete image type
+ */
+#[AsCommandHandler]
+final class DeleteImageTypeHandler implements DeleteImageTypeHandlerInterface
+{
+    public function __construct(
+        private readonly ImageTypeRepository $imageTypeRepository
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(DeleteImageTypeCommand $command): void
+    {
+        /** @var ?ImageType $imageType */
+        $imageType = $this->imageTypeRepository->find($command->getImageTypeId()->getValue());
+
+        if (!$imageType) {
+            throw new ImageTypeNotFoundException(sprintf('Unable to find image type with id "%d" for deletion', $command->getImageTypeId()->getValue()));
+        }
+
+        $this->imageTypeRepository->delete($imageType);
+    }
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/DeleteImageTypeHandlerInterface.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/DeleteImageTypeHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\DeleteImageTypeCommand;
+
+/**
+ * Defines contract for DeleteImageTypeHandler
+ */
+interface DeleteImageTypeHandlerInterface
+{
+    /**
+     * @param DeleteImageTypeCommand $command
+     */
+    public function handle(DeleteImageTypeCommand $command): void;
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/DeleteImagesFromTypeHandler.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/DeleteImagesFromTypeHandler.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\ImageThumbnailsRegenerator;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\DeleteImagesFromTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeNotFoundException;
+use PrestaShopBundle\Entity\ImageType;
+use PrestaShopBundle\Entity\Repository\ImageTypeRepository;
+
+/**
+ * Handles command that delete images from defined image type
+ */
+#[AsCommandHandler]
+final class DeleteImagesFromTypeHandler implements DeleteImagesFromTypeHandlerInterface
+{
+    public function __construct(
+        private readonly ImageTypeRepository $imageTypeRepository,
+        private readonly ImageThumbnailsRegenerator $imageThumbnailsRegenerator
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(DeleteImagesFromTypeCommand $command): void
+    {
+        // Get image type by id
+        /** @var ?ImageType $imageType */
+        $imageType = $this->imageTypeRepository->find($command->getImageTypeId()->getValue());
+
+        if (!$imageType) {
+            throw new ImageTypeNotFoundException(sprintf('Unable to find image type with id "%d" for deletion', $command->getImageTypeId()->getValue()));
+        }
+
+        // Delete all images linked to image type
+        $this->imageThumbnailsRegenerator->deleteImagesFromType($imageType->getName(), _PS_IMG_DIR_ . '{c,m,su,p,st}/');
+    }
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/DeleteImagesFromTypeHandlerInterface.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/DeleteImagesFromTypeHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\DeleteImagesFromTypeCommand;
+
+/**
+ * Defines contract for DeleteImagesFromTypeHandler
+ */
+interface DeleteImagesFromTypeHandlerInterface
+{
+    /**
+     * @param DeleteImagesFromTypeCommand $command
+     */
+    public function handle(DeleteImagesFromTypeCommand $command): void;
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/EditImageSettingsHandler.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/EditImageSettingsHandler.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Admin\ImageConfiguration;
+use PrestaShop\PrestaShop\Adapter\Domain\AbstractObjectModelHandler;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\EditImageSettingsCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeException;
+
+#[AsCommandHandler]
+final class EditImageSettingsHandler extends AbstractObjectModelHandler implements EditImageSettingsHandlerInterface
+{
+    public function __construct(
+        private readonly ImageConfiguration $imageConfiguration
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws ImageTypeException
+     */
+    public function handle(EditImageSettingsCommand $command): void
+    {
+        $this->imageConfiguration->updateConfiguration([
+            'formats' => $command->getFormats(),
+            'base-format' => $command->getBaseFormat(),
+            'avif-quality' => $command->getAvifQuality(),
+            'jpeg-quality' => $command->getJpegQuality(),
+            'png-quality' => $command->getPngQuality(),
+            'webp-quality' => $command->getWebpQuality(),
+            'generation-method' => $command->getGenerationMethod(),
+            'picture-max-size' => $command->getPictureMaxSize(),
+            'picture-max-width' => $command->getPictureMaxWidth(),
+            'picture-max-height' => $command->getPictureMaxHeight(),
+        ]);
+    }
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/EditImageSettingsHandlerInterface.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/EditImageSettingsHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\EditImageSettingsCommand;
+
+/**
+ * Defines contract for EditImageSettingsHandler
+ */
+interface EditImageSettingsHandlerInterface
+{
+    /**
+     * @param EditImageSettingsCommand $command
+     */
+    public function handle(EditImageSettingsCommand $command): void;
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/EditImageTypeHandler.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/EditImageTypeHandler.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Domain\AbstractObjectModelHandler;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\EditImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeNotFoundException;
+use PrestaShopBundle\Entity\ImageType;
+use PrestaShopBundle\Entity\Repository\ImageTypeRepository;
+
+#[AsCommandHandler]
+final class EditImageTypeHandler extends AbstractObjectModelHandler implements EditImageTypeHandlerInterface
+{
+    public function __construct(
+        private readonly ImageTypeRepository $imageTypeRepository
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws ImageTypeException
+     */
+    public function handle(EditImageTypeCommand $command): void
+    {
+        /** @var ImageType $imageType */
+        $imageType = $this->imageTypeRepository->find($command->getImageTypeId()->getValue());
+
+        if (null == $imageType->getId()) {
+            throw new ImageTypeNotFoundException(sprintf('Image type with id "%d" was not found', $command->getImageTypeId()->getValue()));
+        }
+
+        if (null !== $command->getName()) {
+            $imageType->setName($command->getName());
+        }
+
+        if (null !== $command->getWidth()) {
+            $imageType->setWidth($command->getWidth());
+        }
+
+        if (null !== $command->getHeight()) {
+            $imageType->setHeight($command->getHeight());
+        }
+
+        if (null !== $command->isProducts()) {
+            $imageType->setProducts($command->isProducts());
+        }
+
+        if (null !== $command->isCategories()) {
+            $imageType->setCategories($command->isCategories());
+        }
+
+        if (null !== $command->isManufacturers()) {
+            $imageType->setManufacturers($command->isManufacturers());
+        }
+
+        if (null !== $command->isSuppliers()) {
+            $imageType->setSuppliers($command->isSuppliers());
+        }
+
+        if (null !== $command->isStores()) {
+            $imageType->setStores($command->isStores());
+        }
+
+        $this->imageTypeRepository->save($imageType);
+    }
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/EditImageTypeHandlerInterface.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/EditImageTypeHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\EditImageTypeCommand;
+
+/**
+ * Defines contract for EditImageTypeHandler
+ */
+interface EditImageTypeHandlerInterface
+{
+    /**
+     * @param EditImageTypeCommand $command
+     */
+    public function handle(EditImageTypeCommand $command): void;
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/RegenerateThumbnailsHandler.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/RegenerateThumbnailsHandler.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Domain\AbstractObjectModelHandler;
+use PrestaShop\PrestaShop\Adapter\ImageThumbnailsRegenerator;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\RegenerateThumbnailsCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\RegenerateThumbnailsTimeoutException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\RegenerateThumbnailsWriteException;
+use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
+use PrestaShopBundle\Entity\Repository\ImageTypeRepository;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+#[AsCommandHandler]
+final class RegenerateThumbnailsHandler extends AbstractObjectModelHandler implements RegenerateThumbnailsHandlerInterface
+{
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+        private readonly ImageTypeRepository $imageTypeRepository,
+        private readonly LanguageRepositoryInterface $langRepository,
+        private readonly ImageThumbnailsRegenerator $imageThumbnailsRegenerator,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws ImageTypeException
+     */
+    public function handle(RegenerateThumbnailsCommand $command): void
+    {
+        // Get all languages
+        $languages = $this->langRepository->findAll();
+
+        // Set images to regenerate with all theirs specific directories
+        $process = [
+            ['type' => 'categories', 'dir' => _PS_CAT_IMG_DIR_],
+            ['type' => 'manufacturers', 'dir' => _PS_MANU_IMG_DIR_],
+            ['type' => 'suppliers', 'dir' => _PS_SUPP_IMG_DIR_],
+            ['type' => 'products', 'dir' => _PS_PRODUCT_IMG_DIR_],
+            ['type' => 'stores', 'dir' => _PS_STORE_IMG_DIR_],
+        ];
+
+        // Launching generation process
+        foreach ($process as $proc) {
+            // Check if this kind of image is selected, if not, skip
+            if ($command->getImage() !== 'all' && $command->getImage() !== $proc['type']) {
+                continue;
+            }
+
+            // Getting formats generation (all if 'all' selected)
+            if ($command->getImageTypeId() === 0) {
+                $formats = $this->imageTypeRepository->findAll();
+            } else {
+                $formats = $this->imageTypeRepository->findBy(['id' => $command->getImageTypeId()]);
+            }
+
+            // If user asked to erase images, let's do it first
+            if ($command->erasePreviousImages()) {
+                $this->imageThumbnailsRegenerator->deletePreviousImages($proc['dir'], $formats, $proc['type'] === 'products');
+            }
+
+            // Regenerate images
+            $errors = $this->imageThumbnailsRegenerator->regenerateNewImages($proc['dir'], $formats, $proc['type'] == 'products');
+            if (is_array($errors) && count($errors) > 0) {
+                if (in_array('timeout', $errors)) {
+                    throw new RegenerateThumbnailsTimeoutException($this->translator->trans('Only part of the images have been regenerated. The server timed out before finishing.', [], 'Admin.Design.Notification'));
+                } else {
+                    throw new RegenerateThumbnailsWriteException($this->translator->trans('Cannot write images for this type: %1$s. Please check the %2$s folder\'s writing permissions.', [$proc['type'], $proc['dir']], 'Admin.Design.Notification'));
+                }
+            } else {
+                if ($proc['type'] == 'products') {
+                    if ($this->imageThumbnailsRegenerator->regenerateWatermark($proc['dir'], $formats) === 'timeout') {
+                        throw new RegenerateThumbnailsTimeoutException($this->translator->trans('Server timed out. The watermark may not have been applied to all images.', [], 'Admin.Design.Notification'));
+                    }
+                }
+                if (count($errors) === 0) {
+                    if ($this->imageThumbnailsRegenerator->regenerateNoPictureImages($proc['dir'], $formats, $languages)) {
+                        throw new RegenerateThumbnailsTimeoutException($this->translator->trans('Cannot write images for this type: %1$s. Please check the %2$s folder\'s writing permissions.', [$proc['type'], $proc['dir']], 'Admin.Design.Notification'));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/RegenerateThumbnailsHandlerInterface.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/RegenerateThumbnailsHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\RegenerateThumbnailsCommand;
+
+/**
+ * Defines contract for RegenerateThumbnailsHandler
+ */
+interface RegenerateThumbnailsHandlerInterface
+{
+    /**
+     * @param RegenerateThumbnailsCommand $command
+     */
+    public function handle(RegenerateThumbnailsCommand $command): void;
+}

--- a/src/Core/Domain/ImageSettings/Exception/BulkImageTypeException.php
+++ b/src/Core/Domain/ImageSettings/Exception/BulkImageTypeException.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception;
+
+use PrestaShop\PrestaShop\Core\Domain\Exception\BulkCommandExceptionInterface;
+use Throwable;
+
+/**
+ * Base class to use for bulk operations, it stores a list of exception indexed by the image type ID that was impacted.
+ * It should be used as a base class for all the bulk action exceptions.
+ */
+class BulkImageTypeException extends ImageTypeException implements BulkCommandExceptionInterface
+{
+    /**
+     * @param Throwable[] $exceptions
+     * @param string $message
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        private readonly array $exceptions,
+        string $message = 'Errors occurred during image type bulk action',
+        int $code = 0,
+        Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExceptions(): array
+    {
+        return $this->exceptions;
+    }
+}

--- a/src/Core/Domain/ImageSettings/Exception/ImageNotDeletedException.php
+++ b/src/Core/Domain/ImageSettings/Exception/ImageNotDeletedException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception;
+
+/**
+ * Is thrown when an image cannot be deleted
+ */
+class ImageNotDeletedException extends ImageTypeException
+{
+}

--- a/src/Core/Domain/ImageSettings/Exception/ImageTypeException.php
+++ b/src/Core/Domain/ImageSettings/Exception/ImageTypeException.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception;
+
+use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
+
+/**
+ * Base exception for Image Type subdomain
+ */
+class ImageTypeException extends DomainException
+{
+}

--- a/src/Core/Domain/ImageSettings/Exception/ImageTypeNotFoundException.php
+++ b/src/Core/Domain/ImageSettings/Exception/ImageTypeNotFoundException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception;
+
+/**
+ * Is thrown when required image type cannot be found
+ */
+class ImageTypeNotFoundException extends ImageTypeException
+{
+}

--- a/src/Core/Domain/ImageSettings/Exception/RegenerateThumbnailsException.php
+++ b/src/Core/Domain/ImageSettings/Exception/RegenerateThumbnailsException.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception;
+
+use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
+
+/**
+ * Base exception for Image regeneration
+ */
+class RegenerateThumbnailsException extends DomainException
+{
+}

--- a/src/Core/Domain/ImageSettings/Exception/RegenerateThumbnailsTimeoutException.php
+++ b/src/Core/Domain/ImageSettings/Exception/RegenerateThumbnailsTimeoutException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception;
+
+/**
+ * Is thrown when a timeout occurs during thumbnails regeneration
+ */
+class RegenerateThumbnailsTimeoutException extends RegenerateThumbnailsException
+{
+}

--- a/src/Core/Domain/ImageSettings/Exception/RegenerateThumbnailsWriteException.php
+++ b/src/Core/Domain/ImageSettings/Exception/RegenerateThumbnailsWriteException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception;
+
+/**
+ * Is thrown when a write access fail occurs during thumbnails regeneration
+ */
+class RegenerateThumbnailsWriteException extends RegenerateThumbnailsException
+{
+}

--- a/src/Core/Domain/ImageSettings/Query/GetImageSettingsForEditing.php
+++ b/src/Core/Domain/ImageSettings/Query/GetImageSettingsForEditing.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Query;
+
+/**
+ * Gets image settings for editing in back office
+ */
+class GetImageSettingsForEditing
+{
+}

--- a/src/Core/Domain/ImageSettings/Query/GetImageTypeForEditing.php
+++ b/src/Core/Domain/ImageSettings/Query/GetImageTypeForEditing.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Query;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject\ImageTypeId;
+
+/**
+ * Gets image type for editing in back office
+ */
+class GetImageTypeForEditing
+{
+    private ImageTypeId $imageTypeId;
+
+    /**
+     * @param int $imageTypeId
+     */
+    public function __construct(int $imageTypeId)
+    {
+        $this->imageTypeId = new ImageTypeId($imageTypeId);
+    }
+
+    /**
+     * @return ImageTypeId
+     */
+    public function getImageTypeId(): ImageTypeId
+    {
+        return $this->imageTypeId;
+    }
+}

--- a/src/Core/Domain/ImageSettings/QueryHandler/GetImageSettingsForEditingHandler.php
+++ b/src/Core/Domain/ImageSettings/QueryHandler/GetImageSettingsForEditingHandler.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryHandler;
+
+use PrestaShop\PrestaShop\Adapter\Admin\ImageConfiguration;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Query\GetImageSettingsForEditing;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryResult\EditableImageSettings;
+
+/**
+ * Handles command that gets image settings for editing
+ *
+ * @internal
+ */
+#[AsQueryHandler]
+final class GetImageSettingsForEditingHandler implements GetImageSettingsForEditingHandlerInterface
+{
+    public function __construct(
+        private readonly ImageConfiguration $imageConfiguration
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(GetImageSettingsForEditing $query): EditableImageSettings
+    {
+        $config = $this->imageConfiguration->getConfiguration();
+
+        return new EditableImageSettings(
+            $config['formats'],
+            $config['base-format'],
+            $config['avif-quality'],
+            $config['jpeg-quality'],
+            $config['png-quality'],
+            $config['webp-quality'],
+            $config['generation-method'],
+            $config['picture-max-size'],
+            $config['picture-max-width'],
+            $config['picture-max-height']
+        );
+    }
+}

--- a/src/Core/Domain/ImageSettings/QueryHandler/GetImageSettingsForEditingHandlerInterface.php
+++ b/src/Core/Domain/ImageSettings/QueryHandler/GetImageSettingsForEditingHandlerInterface.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Query\GetImageSettingsForEditing;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryResult\EditableImageSettings;
+
+/**
+ * Defines contract for GetImageSettingsForEditingHandlerInterface
+ */
+interface GetImageSettingsForEditingHandlerInterface
+{
+    /**
+     * @param GetImageSettingsForEditing $query
+     *
+     * @return EditableImageSettings
+     */
+    public function handle(GetImageSettingsForEditing $query): EditableImageSettings;
+}

--- a/src/Core/Domain/ImageSettings/QueryHandler/GetImageTypeForEditingHandler.php
+++ b/src/Core/Domain/ImageSettings/QueryHandler/GetImageTypeForEditingHandler.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Query\GetImageTypeForEditing;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryResult\EditableImageType;
+use PrestaShopBundle\Entity\Repository\ImageTypeRepository;
+
+/**
+ * Handles command that gets image type for editing
+ *
+ * @internal
+ */
+#[AsQueryHandler]
+final class GetImageTypeForEditingHandler implements GetImageTypeForEditingHandlerInterface
+{
+    public function __construct(
+        private readonly ImageTypeRepository $imageTypeRepository
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(GetImageTypeForEditing $query): EditableImageType
+    {
+        $imageType = $this->imageTypeRepository->find($query->getImageTypeId()->getValue());
+
+        if (null === $imageType) {
+            throw new ImageTypeNotFoundException(sprintf('Image type with id "%d" not found', $query->getImageTypeId()->getValue()));
+        }
+
+        return new EditableImageType(
+            $query->getImageTypeId(),
+            (string) $imageType->getName(),
+            (int) $imageType->getWidth(),
+            (int) $imageType->getHeight(),
+            (bool) $imageType->isProducts(),
+            (bool) $imageType->isCategories(),
+            (bool) $imageType->isManufacturers(),
+            (bool) $imageType->isSuppliers(),
+            (bool) $imageType->isStores()
+        );
+    }
+}

--- a/src/Core/Domain/ImageSettings/QueryHandler/GetImageTypeForEditingHandlerInterface.php
+++ b/src/Core/Domain/ImageSettings/QueryHandler/GetImageTypeForEditingHandlerInterface.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Query\GetImageTypeForEditing;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryResult\EditableImageType;
+
+/**
+ * Defines contract for GetImageTypeForEditingHandlerInterface
+ */
+interface GetImageTypeForEditingHandlerInterface
+{
+    /**
+     * @param GetImageTypeForEditing $query
+     *
+     * @return EditableImageType
+     */
+    public function handle(GetImageTypeForEditing $query): EditableImageType;
+}

--- a/src/Core/Domain/ImageSettings/QueryResult/EditableImageSettings.php
+++ b/src/Core/Domain/ImageSettings/QueryResult/EditableImageSettings.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryResult;
+
+/**
+ * Transfers image settings data for editing
+ */
+class EditableImageSettings
+{
+    public function __construct(
+        private readonly string $formats,
+        private readonly string $baseFormat,
+        private readonly int $avifQuality,
+        private readonly int $jpegQuality,
+        private readonly int $pngQuality,
+        private readonly int $webpQuality,
+        private readonly int $generationMethod,
+        private readonly int $pictureMaxSize,
+        private readonly int $pictureMaxWidth,
+        private readonly int $pictureMaxHeight
+    ) {
+    }
+
+    public function getFormats(): array
+    {
+        return array_map('trim', explode(',', $this->formats));
+    }
+
+    public function getBaseFormat(): string
+    {
+        return $this->baseFormat;
+    }
+
+    public function getAvifQuality(): int
+    {
+        return $this->avifQuality;
+    }
+
+    public function getJpegQuality(): int
+    {
+        return $this->jpegQuality;
+    }
+
+    public function getPngQuality(): int
+    {
+        return $this->pngQuality;
+    }
+
+    public function getWebpQuality(): int
+    {
+        return $this->webpQuality;
+    }
+
+    public function getGenerationMethod(): int
+    {
+        return $this->generationMethod;
+    }
+
+    public function getPictureMaxSize(): int
+    {
+        return $this->pictureMaxSize;
+    }
+
+    public function getPictureMaxWidth(): int
+    {
+        return $this->pictureMaxWidth;
+    }
+
+    public function getPictureMaxHeight(): int
+    {
+        return $this->pictureMaxHeight;
+    }
+}

--- a/src/Core/Domain/ImageSettings/QueryResult/EditableImageType.php
+++ b/src/Core/Domain/ImageSettings/QueryResult/EditableImageType.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryResult;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject\ImageTypeId;
+
+/**
+ * Transfers image type data for editing
+ */
+class EditableImageType
+{
+    public function __construct(
+        private readonly ImageTypeId $imageTypeId,
+        private readonly string $name,
+        private readonly int $width,
+        private readonly int $height,
+        private readonly bool $products,
+        private readonly bool $categories,
+        private readonly bool $manufacturers,
+        private readonly bool $suppliers,
+        private readonly bool $stores,
+    ) {
+    }
+
+    public function getImageTypeId(): ImageTypeId
+    {
+        return $this->imageTypeId;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getWidth(): int
+    {
+        return $this->width;
+    }
+
+    public function getHeight(): int
+    {
+        return $this->height;
+    }
+
+    public function isProducts(): bool
+    {
+        return $this->products;
+    }
+
+    public function isCategories(): bool
+    {
+        return $this->categories;
+    }
+
+    public function isManufacturers(): bool
+    {
+        return $this->manufacturers;
+    }
+
+    public function isSuppliers(): bool
+    {
+        return $this->suppliers;
+    }
+
+    public function isStores(): bool
+    {
+        return $this->stores;
+    }
+}

--- a/src/Core/Domain/ImageSettings/ValueObject/ImageTypeId.php
+++ b/src/Core/Domain/ImageSettings/ValueObject/ImageTypeId.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeException;
+
+/**
+ * Defines Image Type ID with it's constraints
+ */
+class ImageTypeId
+{
+    private int $imageTypeId;
+
+    /**
+     * @param int $imageTypeId
+     *
+     * @throws ImageTypeException
+     */
+    public function __construct(int $imageTypeId)
+    {
+        $this->assertIntegerIsGreaterThanZero($imageTypeId);
+        $this->imageTypeId = $imageTypeId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getValue(): int
+    {
+        return $this->imageTypeId;
+    }
+
+    /**
+     * @param int $imageTypeId
+     *
+     * @throws ImageTypeException
+     */
+    private function assertIntegerIsGreaterThanZero(int $imageTypeId): void
+    {
+        if (0 >= $imageTypeId) {
+            throw new ImageTypeException(sprintf('Image type id %d is invalid. Image type id have to be number bigger than zero.', $imageTypeId));
+        }
+    }
+}

--- a/src/Core/FeatureFlag/FeatureFlagSettings.php
+++ b/src/Core/FeatureFlag/FeatureFlagSettings.php
@@ -54,4 +54,5 @@ class FeatureFlagSettings
     public const FEATURE_FLAG_SYMFONY_LAYOUT = 'symfony_layout';
     public const FEATURE_FLAG_FRONT_CONTAINER_V2 = 'front_container_v2';
     public const FEATURE_FLAG_CARTS = 'carts';
+    public const FEATURE_FLAG_IMAGE_SETTINGS = 'image_settings';
 }

--- a/src/Core/Form/ChoiceProvider/ImageTypeChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/ImageTypeChoiceProvider.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
+
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShopBundle\Entity\Repository\ImageTypeRepository;
+
+class ImageTypeChoiceProvider implements FormChoiceProviderInterface
+{
+    public function __construct(
+        private readonly ImageTypeRepository $imageTypeRepository
+    ) {
+    }
+
+    public function getChoices(): array
+    {
+        $imageTypes = [];
+        $dbImageTypes = $this->imageTypeRepository->findAll();
+
+        foreach ($dbImageTypes as $dbImageType) {
+            $imageTypes[$dbImageType->getName()] = $dbImageType->getId();
+        }
+
+        return $imageTypes;
+    }
+
+    public function buildChoicesByTypes(): array
+    {
+        $imageTypes = ['products' => [], 'categories' => [], 'manufacturers' => [], 'suppliers' => [], 'stores' => []];
+        $dbImageTypes = $this->imageTypeRepository->findAll();
+
+        foreach ($dbImageTypes as $dbImageType) {
+            if ($dbImageType->isProducts()) {
+                $imageTypes['products'][] = $dbImageType->getId();
+            }
+            if ($dbImageType->isCategories()) {
+                $imageTypes['categories'][] = $dbImageType->getId();
+            }
+            if ($dbImageType->isManufacturers()) {
+                $imageTypes['manufacturers'][] = $dbImageType->getId();
+            }
+            if ($dbImageType->isSuppliers()) {
+                $imageTypes['suppliers'][] = $dbImageType->getId();
+            }
+            if ($dbImageType->isStores()) {
+                $imageTypes['stores'][] = $dbImageType->getId();
+            }
+        }
+
+        return $imageTypes;
+    }
+}

--- a/src/Core/Form/IdentifiableObject/DataHandler/ImageTypeFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/ImageTypeFormDataHandler.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\AddImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\EditImageTypeCommand;
+
+class ImageTypeFormDataHandler implements FormDataHandlerInterface
+{
+    public function __construct(
+        private CommandBusInterface $commandBus
+    ) {
+    }
+
+    public function create(array $data)
+    {
+        $this->commandBus->handle(new AddImageTypeCommand(
+            $data['name'],
+            (int) $data['width'],
+            (int) $data['height'],
+            (bool) $data['products'],
+            (bool) $data['categories'],
+            (bool) $data['manufacturers'],
+            (bool) $data['suppliers'],
+            (bool) $data['stores'],
+        ));
+    }
+
+    public function update($id, array $data)
+    {
+        $command = new EditImageTypeCommand((int) $id);
+        $command
+            ->setName($data['name'])
+            ->setWidth((int) $data['width'])
+            ->setHeight((int) $data['height'])
+            ->setProducts((bool) $data['products'])
+            ->setCategories((bool) $data['categories'])
+            ->setManufacturers((bool) $data['manufacturers'])
+            ->setSuppliers((bool) $data['suppliers'])
+            ->setStores((bool) $data['stores'])
+        ;
+
+        $this->commandBus->handle($command);
+    }
+}

--- a/src/Core/Form/IdentifiableObject/DataProvider/ImageTypeFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ImageTypeFormDataProvider.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Query\GetImageTypeForEditing;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryResult\EditableImageType;
+
+/**
+ * Provides data for image type add/edit form.
+ */
+final class ImageTypeFormDataProvider implements FormDataProviderInterface
+{
+    public function __construct(
+        private readonly CommandBusInterface $queryBus,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData($id): array
+    {
+        /** @var EditableImageType $result */
+        $result = $this->queryBus->handle(new GetImageTypeForEditing($id));
+
+        return [
+            'id' => $id,
+            'name' => $result->getName(),
+            'width' => $result->getWidth(),
+            'height' => $result->getHeight(),
+            'products' => $result->isProducts(),
+            'categories' => $result->isCategories(),
+            'manufacturers' => $result->isManufacturers(),
+            'suppliers' => $result->isSuppliers(),
+            'stores' => $result->isStores(),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultData(): array
+    {
+        return [
+            'name' => '',
+            'width' => null,
+            'height' => null,
+            'products' => false,
+            'categories' => false,
+            'manufacturers' => false,
+            'suppliers' => false,
+            'stores' => false,
+        ];
+    }
+}

--- a/src/Core/Grid/Action/Row/Type/ImageType/DeleteImageTypeRowAction.php
+++ b/src/Core/Grid/Action/Row/Type/ImageType/DeleteImageTypeRowAction.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\ImageType;
+
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\AbstractRowAction;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class DeleteImageTypeRowAction extends AbstractRowAction
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'delete_image_type';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver
+            ->setRequired([
+                'id_field',
+                'route',
+            ])
+            ->setAllowedTypes('id_field', 'string')
+            ->setAllowedTypes('route', 'string')
+        ;
+    }
+}

--- a/src/Core/Grid/Column/Type/Common/PixelDataColumn.php
+++ b/src/Core/Grid/Column/Type/Common/PixelDataColumn.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Column\Type\Common;
+
+use PrestaShop\PrestaShop\Core\Grid\Column\AbstractColumn;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Class PixelDataColumn displays data in pixel.
+ */
+class PixelDataColumn extends AbstractColumn
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'pixel_data';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver
+            ->setRequired([
+                'field',
+            ])
+            ->setAllowedTypes('field', 'string')
+        ;
+    }
+}

--- a/src/Core/Grid/Definition/Factory/ImageTypeGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ImageTypeGridDefinitionFactory.php
@@ -1,0 +1,310 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\ImageType\DeleteImageTypeRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\PixelDataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\StatusColumn;
+use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
+use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
+use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
+use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+/**
+ * Class CustomerGridDefinitionFactory defines customers grid structure.
+ */
+final class ImageTypeGridDefinitionFactory extends AbstractGridDefinitionFactory
+{
+    use BulkDeleteActionTrait;
+
+    public const GRID_ID = 'image_type';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getId()
+    {
+        return self::GRID_ID;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getName()
+    {
+        return $this->trans('Image Settings', [], 'Admin.Navigation.Menu');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getColumns()
+    {
+        $columns = (new ColumnCollection())
+            ->add(
+                (new BulkActionColumn('bulk'))
+                    ->setOptions([
+                        'bulk_field' => 'id_image_type',
+                    ])
+            )
+            ->add(
+                (new DataColumn('id_image_type'))
+                    ->setName($this->trans('ID', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'id_image_type',
+                    ])
+            )
+            ->add(
+                (new DataColumn('name'))
+                    ->setName($this->trans('Name', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'name',
+                    ])
+            )
+            ->add(
+                (new PixelDataColumn('width'))
+                    ->setName($this->trans('Width', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'width',
+                    ])
+            )
+            ->add(
+                (new PixelDataColumn('height'))
+                    ->setName($this->trans('Height', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'height',
+                    ])
+            )
+            ->add(
+                (new StatusColumn('products'))
+                    ->setName($this->trans('Products', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'products',
+                        'alignment' => 'center',
+                    ])
+            )
+            ->add(
+                (new StatusColumn('categories'))
+                    ->setName($this->trans('Categories', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'categories',
+                        'alignment' => 'center',
+                    ])
+            )
+            ->add(
+                (new StatusColumn('manufacturers'))
+                    ->setName($this->trans('Brands', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'manufacturers',
+                        'alignment' => 'center',
+                    ])
+            )
+            ->add(
+                (new StatusColumn('suppliers'))
+                    ->setName($this->trans('Suppliers', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'suppliers',
+                        'alignment' => 'center',
+                    ])
+            )
+            ->add(
+                (new StatusColumn('stores'))
+                    ->setName($this->trans('Stores', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'stores',
+                        'alignment' => 'center',
+                    ])
+            )
+            ->add(
+                (new ActionColumn('actions'))
+                    ->setName($this->trans('Actions', [], 'Admin.Global'))
+                    ->setOptions([
+                        'actions' => $this->getRowActions(),
+                    ])
+            )
+        ;
+
+        return $columns;
+    }
+
+    /**
+     * @return RowActionCollection
+     */
+    private function getRowActions(): RowActionCollection
+    {
+        $rowActionCollection = new RowActionCollection();
+        $rowActionCollection
+            ->add(
+                (new LinkRowAction('edit'))
+                    ->setName($this->trans('Edit', [], 'Admin.Actions'))
+                    ->setIcon('edit')
+                    ->setOptions([
+                        'route' => 'admin_image_settings_edit',
+                        'route_param_name' => 'imageTypeId',
+                        'route_param_field' => 'id_image_type',
+                        'clickable_row' => true,
+                    ])
+            )
+            ->add(
+                (new DeleteImageTypeRowAction('delete'))
+                    ->setName($this->trans('Delete', [], 'Admin.Actions'))
+                    ->setIcon('delete')
+                    ->setOptions([
+                        'route' => 'admin_image_settings_delete',
+                        'id_field' => 'id_image_type',
+                    ])
+            );
+
+        return $rowActionCollection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFilters()
+    {
+        $filters = (new FilterCollection())
+            ->add(
+                (new Filter('id_image_type', NumberType::class))
+                    ->setTypeOptions([
+                        'attr' => [
+                            'placeholder' => $this->trans('Search ID', [], 'Admin.Actions'),
+                        ],
+                        'required' => false,
+                    ])
+                    ->setAssociatedColumn('id_image_type')
+            )
+            ->add(
+                (new Filter('name', TextType::class))
+                    ->setTypeOptions([
+                        'attr' => [
+                            'placeholder' => $this->trans('Search Name', [], 'Admin.Actions'),
+                        ],
+                        'required' => false,
+                    ])
+                    ->setAssociatedColumn('name')
+            )
+            ->add(
+                (new Filter('width', TextType::class))
+                    ->setTypeOptions([
+                        'attr' => [
+                            'placeholder' => $this->trans('Search Width', [], 'Admin.Actions'),
+                        ],
+                        'required' => false,
+                    ])
+                    ->setAssociatedColumn('width')
+            )
+            ->add(
+                (new Filter('height', TextType::class))
+                    ->setTypeOptions([
+                        'attr' => [
+                            'placeholder' => $this->trans('Search Height', [], 'Admin.Actions'),
+                        ],
+                        'required' => false,
+                    ])
+                    ->setAssociatedColumn('height')
+            )
+            ->add(
+                (new Filter('products', YesAndNoChoiceType::class))
+                    ->setAssociatedColumn('products')
+            )
+            ->add(
+                (new Filter('categories', YesAndNoChoiceType::class))
+                    ->setAssociatedColumn('categories')
+            )
+            ->add(
+                (new Filter('manufacturers', YesAndNoChoiceType::class))
+                    ->setAssociatedColumn('manufacturers')
+            )
+            ->add(
+                (new Filter('suppliers', YesAndNoChoiceType::class))
+                    ->setAssociatedColumn('suppliers')
+            )
+            ->add(
+                (new Filter('stores', YesAndNoChoiceType::class))
+                    ->setAssociatedColumn('stores')
+            )
+            ->add(
+                (new Filter('actions', SearchAndResetType::class))
+                    ->setTypeOptions([
+                        'reset_route' => 'admin_common_reset_search_by_filter_id',
+                        'reset_route_params' => [
+                            'filterId' => self::GRID_ID,
+                        ],
+                        'redirect_route' => 'admin_image_settings_index',
+                    ])
+                    ->setAssociatedColumn('actions')
+            );
+
+        return $filters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGridActions()
+    {
+        return (new GridActionCollection())
+            ->add(
+                (new SimpleGridAction('common_refresh_list'))
+                    ->setName($this->trans('Refresh list', [], 'Admin.Advparameters.Feature'))
+                    ->setIcon('refresh')
+            )
+            ->add(
+                (new SimpleGridAction('common_show_query'))
+                    ->setName($this->trans('Show SQL query', [], 'Admin.Actions'))
+                    ->setIcon('code')
+            )
+            ->add(
+                (new SimpleGridAction('common_export_sql_manager'))
+                    ->setName($this->trans('Export to SQL Manager', [], 'Admin.Actions'))
+                    ->setIcon('storage')
+            );
+    }
+
+    /*
+     * {@inheritdoc}
+     */
+    protected function getBulkActions()
+    {
+        return (new BulkActionCollection())
+            ->add(
+                $this->buildBulkDeleteAction('admin_image_settings_bulk_delete')
+            );
+    }
+}

--- a/src/Core/Grid/Query/ImageTypeQueryBuilder.php
+++ b/src/Core/Grid/Query/ImageTypeQueryBuilder.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use InvalidArgumentException;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShop\PrestaShop\Core\Search\Filters\ImageTypeFilters;
+
+/**
+ * Class ApiAccessQueryBuilder builds search & count queries for api access grid.
+ */
+class ImageTypeQueryBuilder extends AbstractDoctrineQueryBuilder
+{
+    private DoctrineSearchCriteriaApplicator $searchCriteriaApplicator;
+
+    /**
+     * @param Connection $connection
+     * @param string $dbPrefix
+     * @param DoctrineSearchCriteriaApplicator $searchCriteriaApplicator
+     */
+    public function __construct(
+        Connection $connection,
+        string $dbPrefix,
+        DoctrineSearchCriteriaApplicator $searchCriteriaApplicator
+    ) {
+        parent::__construct($connection, $dbPrefix);
+
+        $this->searchCriteriaApplicator = $searchCriteriaApplicator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        if (!$searchCriteria instanceof ImageTypeFilters) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Expected %s, but got %s',
+                    ImageTypeFilters::class, get_class($searchCriteria)
+                )
+            );
+        }
+
+        $queryBuilder = $this->getQueryBuilder($searchCriteria)
+            ->select('it.*')
+            ->from($this->dbPrefix . 'image_type', 'it');
+
+        $this->searchCriteriaApplicator
+            ->applyPagination($searchCriteria, $queryBuilder)
+            ->applySorting($searchCriteria, $queryBuilder);
+
+        return $queryBuilder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        if (!$searchCriteria instanceof ImageTypeFilters) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Expected %s, but got %s',
+                    ImageTypeFilters::class, get_class($searchCriteria)
+                )
+            );
+        }
+
+        return $this->getQueryBuilder($searchCriteria)
+            ->select('COUNT(it.id_image_type)')
+            ->from($this->dbPrefix . 'image_type', 'it');
+    }
+
+    /**
+     * Get generic query builder.
+     *
+     * @return QueryBuilder
+     */
+    private function getQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $this->applyFilters($qb, $searchCriteria);
+
+        return $qb;
+    }
+
+    /**
+     * @param QueryBuilder $builder
+     * @param SearchCriteriaInterface $criteria
+     */
+    private function applyFilters(QueryBuilder $builder, SearchCriteriaInterface $criteria): void
+    {
+        $allowedFilters = [
+            'id_image_type',
+            'name',
+            'width',
+            'height',
+            'products',
+            'categories',
+            'manufacturers',
+            'suppliers',
+            'stores',
+        ];
+
+        foreach ($criteria->getFilters() as $filterName => $filterValue) {
+            if (!in_array($filterName, $allowedFilters)) {
+                continue;
+            }
+
+            if ($filterName === 'name') {
+                $builder->andwhere('it.' . $filterName . ' like :' . $filterName);
+                $builder->setparameter($filterName, '%' . $filterValue . '%');
+            } else {
+                $builder->andWhere('it.' . $filterName . ' = :' . $filterName);
+                $builder->setParameter($filterName, $filterValue);
+            }
+        }
+    }
+}

--- a/src/Core/Search/Filters/ImageTypeFilters.php
+++ b/src/Core/Search/Filters/ImageTypeFilters.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Search\Filters;
+
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ImageTypeGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Search\Filters;
+
+/**
+ * Class CustomerFilters provides default filters for customers grid.
+ */
+final class ImageTypeFilters extends Filters
+{
+    /** @var string */
+    protected $filterId = ImageTypeGridDefinitionFactory::GRID_ID;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDefaults()
+    {
+        return [
+            'limit' => 50,
+            'offset' => 0,
+            'orderBy' => 'id_image_type',
+            'sortOrder' => 'ASC',
+            'filters' => [],
+        ];
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ImageSettingsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ImageSettingsController.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Controller\Admin\Improve\Design;
+
+use Exception;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\BulkDeleteImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\DeleteImagesFromTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\DeleteImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\RegenerateThumbnailsCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Query\GetImageTypeForEditing;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryResult\EditableImageType;
+use PrestaShop\PrestaShop\Core\Search\Filters\ImageTypeFilters;
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Form\Admin\Improve\Design\ImageSettings\DeleteImageTypeType;
+use PrestaShopBundle\Form\Admin\Improve\Design\ImageSettings\RegenerateThumbnailsType;
+use PrestaShopBundle\Security\Attribute\AdminSecurity;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Responsible for Image Settings actions in Back Office
+ */
+class ImageSettingsController extends FrameworkBundleAdminController
+{
+    /**
+     * Displays image settings listing page.
+     *
+     * @param Request $request
+     * @param ImageTypeFilters $filters
+     *
+     * @return Response
+     */
+    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))")]
+    public function indexAction(Request $request, ImageTypeFilters $filters): Response
+    {
+        // Get image type grid
+        $imageTypeGridFactory = $this->get('prestashop.core.grid.factory.image_type');
+        $imageTypeGrid = $imageTypeGridFactory->getGrid($filters);
+
+        // Create form for deleting image type if needed (in modal)
+        $deleteForm = $this->createForm(DeleteImageTypeType::class);
+
+        // Create form to set some image settings
+        $configFormBuilder = $this->get('prestashop.admin.image_settings.form_handler');
+        $configForm = $configFormBuilder->getForm();
+
+        // Create form to regenerate thumbnails
+        $regenThumbnailsForm = $this->createForm(RegenerateThumbnailsType::class);
+
+        return $this->render('@PrestaShop/Admin/Improve/Design/ImageSettings/index.html.twig', [
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+            'imageTypeGrid' => $this->presentGrid($imageTypeGrid),
+            'enableSidebar' => true,
+            'deleteImageTypeForm' => $deleteForm->createView(),
+            'layoutHeaderToolbarBtn' => [
+                'add' => [
+                    'href' => $this->generateUrl('admin_image_settings_create'),
+                    'desc' => $this->trans('Add new image type', 'Admin.Design.Feature'),
+                    'icon' => 'add_circle_outline',
+                ],
+            ],
+            'configForm' => $configForm->createView(),
+            'regenThumbnailsForm' => $regenThumbnailsForm->createView(),
+        ]);
+    }
+
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))")]
+    public function saveSettingsAction(Request $request): Response
+    {
+        try {
+            // Create form to set some image settings
+            $configFormHandler = $this->get('prestashop.admin.image_settings.form_handler');
+            $configForm = $configFormHandler->getForm();
+            $configForm->handleRequest($request);
+
+            if ($configForm->isSubmitted()) {
+                if ($configForm->isValid()) {
+                    $configFormHandler->save($configForm->getData());
+                    $this->addFlash('success', $this->trans('The settings have been successfully updated.', 'Admin.Notifications.Success'));
+                } else {
+                    $this->addFlashFormErrors($configForm);
+                }
+            }
+        } catch (Exception $e) {
+            $this->addFlash('error', $e->getMessage());
+        }
+
+        return $this->redirectToRoute('admin_image_settings_index');
+    }
+
+    /**
+     * Show "Add new" image type form and handles its submit.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    #[AdminSecurity("is_granted('create', request.get('_legacy_controller'))", redirectRoute: 'admin_image_settings_index')]
+    public function createAction(Request $request): Response
+    {
+        $formBuilder = $this->get('prestashop.core.form.identifiable_object.builder.image_type_form_builder');
+        $formHandler = $this->get('prestashop.core.form.identifiable_object.handler.image_type_form_handler');
+
+        $form = $formBuilder->getForm();
+        $form->handleRequest($request);
+
+        try {
+            $handleResult = $formHandler->handle($form);
+
+            if ($handleResult->isSubmitted() && $handleResult->isValid()) {
+                $this->addFlash('success', $this->trans('Successful creation', 'Admin.Notifications.Success'));
+
+                return $this->redirectToRoute('admin_image_settings_index');
+            }
+        } catch (Exception $e) {
+            $this->addFlash('error', $e->getMessage());
+        }
+
+        return $this->render('@PrestaShop/Admin/Improve/Design/ImageSettings/ImageType/create.html.twig', [
+            'form' => $form->createView(),
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+            'enableSidebar' => true,
+            'layoutTitle' => $this->trans('Add new', 'Admin.Actions'),
+        ]);
+    }
+
+    /**
+     * Displays image type for edit and handles its submit.
+     *
+     * @param int $imageTypeId
+     * @param Request $request
+     *
+     * @return Response
+     */
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_image_settings_index')]
+    public function editAction(int $imageTypeId, Request $request): Response
+    {
+        try {
+            /** @var EditableImageType $editableImageType */
+            $editableImageType = $this->getQueryBus()->handle(new GetImageTypeForEditing($imageTypeId));
+
+            $formBuilder = $this->get('prestashop.core.form.identifiable_object.builder.image_type_form_builder');
+            $formHandler = $this->get('prestashop.core.form.identifiable_object.handler.image_type_form_handler');
+
+            $form = $formBuilder->getFormFor($imageTypeId);
+            $form->handleRequest($request);
+
+            $result = $formHandler->handleFor($imageTypeId, $form);
+
+            if ($result->isSubmitted() && $result->isValid()) {
+                $this->addFlash('success', $this->trans('Update successful', 'Admin.Notifications.Success'));
+
+                return $this->redirectToRoute('admin_image_settings_index');
+            }
+        } catch (Exception $e) {
+            $this->addFlash('error', $e->getMessage());
+
+            if ($e instanceof ImageTypeNotFoundException) {
+                return $this->redirectToRoute('admin_image_settings_index');
+            }
+        }
+
+        return $this->render('@PrestaShop/Admin/Improve/Design/ImageSettings/ImageType/edit.html.twig', [
+            'form' => $form->createView(),
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+            'enableSidebar' => true,
+            'layoutTitle' => $this->trans('Edit: %value%', 'Admin.Actions', ['%value%' => $editableImageType->getName()]),
+        ]);
+    }
+
+    /**
+     * Delete image type.
+     *
+     * @param int $imageTypeId
+     *
+     * @return RedirectResponse
+     */
+    #[AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute: 'admin_image_settings_index')]
+    public function deleteAction(Request $request, int $imageTypeId): RedirectResponse
+    {
+        try {
+            $deleteForm = $this->createForm(DeleteImageTypeType::class);
+            $deleteForm->handleRequest($request);
+
+            // If we need to delete images files too
+            if ($deleteForm->get('delete_images_files_too')->getNormData()) {
+                $this->getCommandBus()->handle(new DeleteImagesFromTypeCommand($imageTypeId));
+            }
+
+            // Delete image type
+            $this->getCommandBus()->handle(new DeleteImageTypeCommand($imageTypeId));
+            $this->addFlash('success', $this->trans('Successful deletion', 'Admin.Notifications.Success'));
+        } catch (Exception $e) {
+            $this->addFlash('error', $e->getMessage());
+        }
+
+        return $this->redirectToRoute('admin_image_settings_index');
+    }
+
+    /**
+     * Deletes image type in bulk action
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    #[AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute: 'admin_image_settings_index')]
+    public function bulkDeleteAction(Request $request): RedirectResponse
+    {
+        $ids = $this->getBulkIdsFromRequest($request);
+
+        try {
+            $this->getCommandBus()->handle(new BulkDeleteImageTypeCommand($ids));
+
+            $this->addFlash(
+                'success',
+                $this->trans('The selection has been successfully deleted.', 'Admin.Notifications.Success')
+            );
+        } catch (Exception $e) {
+            $this->addFlash('error', $e->getMessage());
+        }
+
+        return $this->redirectToRoute('admin_image_settings_index');
+    }
+
+    /**
+     * Collects IDs from request.
+     *
+     * @param Request $request
+     *
+     * @return array
+     */
+    private function getBulkIdsFromRequest(Request $request): array
+    {
+        $ids = $request->request->all('image_type_bulk');
+
+        return array_map('intval', $ids);
+    }
+
+    /**
+     * Regenerate thumbnails.
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_image_settings_index')]
+    public function regenerateThumbnailsAction(Request $request): RedirectResponse
+    {
+        try {
+            $regenThumbnailsForm = $this->createForm(RegenerateThumbnailsType::class);
+            $regenThumbnailsForm->handleRequest($request);
+
+            $this->getCommandBus()->handle(new RegenerateThumbnailsCommand(
+                $regenThumbnailsForm->get('image')->getData(),
+                $regenThumbnailsForm->get('image-type')->getData(),
+                $regenThumbnailsForm->get('erase-previous-images')->getData()
+             ));
+            $this->addFlash('success', $this->trans('The thumbnails were successfully regenerated.', 'Admin.Notifications.Success'));
+        } catch (Exception $e) {
+            $this->addFlash('error', $e->getMessage());
+        }
+
+        return $this->redirectToRoute('admin_image_settings_index');
+    }
+}

--- a/src/PrestaShopBundle/Entity/ImageType.php
+++ b/src/PrestaShopBundle/Entity/ImageType.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+
+/**
+ * @ORM\Entity(repositoryClass="PrestaShopBundle\Entity\Repository\ImageTypeRepository")
+ * @ORM\Table()
+ * @UniqueEntity("name")
+ */
+class ImageType
+{
+    /**
+     * @var int
+     *
+     * @ORM\Id
+     * @ORM\Column(name="id_image_type", type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="name", type="string", length=64, unique=true)
+     */
+    private $name;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="width", type="integer")
+     */
+    private $width;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="height", type="integer")
+     */
+    private $height;
+
+    /**
+     * @var bool
+     *
+     * @ORM\Column(name="products", type="boolean")
+     */
+    private $products;
+
+    /**
+     * @var bool
+     *
+     * @ORM\Column(name="categories", type="boolean")
+     */
+    private $categories;
+
+    /**
+     * @var bool
+     *
+     * @ORM\Column(name="manufacturers", type="boolean")
+     */
+    private $manufacturers;
+
+    /**
+     * @var bool
+     *
+     * @orm\column(name="suppliers", type="boolean")
+     */
+    private $suppliers;
+
+    /**
+     * @var bool
+     *
+     * @orm\column(name="stores", type="boolean")
+     */
+    private $stores;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getWidth(): int
+    {
+        return $this->width;
+    }
+
+    public function setWidth(int $width): self
+    {
+        $this->width = $width;
+
+        return $this;
+    }
+
+    public function getHeight(): int
+    {
+        return $this->height;
+    }
+
+    public function setHeight(int $height): self
+    {
+        $this->height = $height;
+
+        return $this;
+    }
+
+    public function isProducts(): bool
+    {
+        return $this->products;
+    }
+
+    public function setProducts(bool $products): self
+    {
+        $this->products = $products;
+
+        return $this;
+    }
+
+    public function isCategories(): bool
+    {
+        return $this->categories;
+    }
+
+    public function setCategories(bool $categories): self
+    {
+        $this->categories = $categories;
+
+        return $this;
+    }
+
+    public function isManufacturers(): bool
+    {
+        return $this->manufacturers;
+    }
+
+    public function setManufacturers(bool $manufacturers): self
+    {
+        $this->manufacturers = $manufacturers;
+
+        return $this;
+    }
+
+    public function isSuppliers(): bool
+    {
+        return $this->suppliers;
+    }
+
+    public function setSuppliers(bool $suppliers): self
+    {
+        $this->suppliers = $suppliers;
+
+        return $this;
+    }
+
+    public function isStores(): bool
+    {
+        return $this->stores;
+    }
+
+    public function setStores(bool $stores): self
+    {
+        $this->stores = $stores;
+
+        return $this;
+    }
+}

--- a/src/PrestaShopBundle/Entity/Repository/ImageTypeRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/ImageTypeRepository.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Entity\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use PrestaShopBundle\Entity\ImageType;
+
+class ImageTypeRepository extends EntityRepository
+{
+    /**
+     * Get an image type by its name.
+     *
+     * @param string $typeName
+     *
+     * @return ImageType|null return null if feature flag cannot be found
+     */
+    public function getByName(string $typeName): ?ImageType
+    {
+        return $this->findOneBy(['name' => $typeName]);
+    }
+
+    /**
+     * Save an image type into database.
+     *
+     * @param ImageType $imageType
+     *
+     * @return ImageType
+     */
+    public function save(ImageType $imageType): ImageType
+    {
+        $this->getEntityManager()->persist($imageType);
+        $this->getEntityManager()->flush();
+
+        return $imageType;
+    }
+
+    /**
+     * Delete an image type into database.
+     *
+     * @param ImageType $imageType
+     *
+     * @return void
+     */
+    public function delete(ImageType $imageType): void
+    {
+        $this->getEntityManager()->remove($imageType);
+        $this->getEntityManager()->flush();
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/DeleteImageTypeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/DeleteImageTypeType.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Improve\Design\ImageSettings;
+
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class DeleteImageTypeType extends TranslatorAwareType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('delete_images_files_too', SwitchType::class, [
+                'label' => $this->trans('Delete the images linked to this image setting', 'Admin.Design.Notification'),
+                'required' => false,
+                'show_choices' => false,
+                'inline_switch' => true,
+                'data' => false,
+            ])
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageSettingsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageSettingsFormDataProvider.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Improve\Design\ImageSettings;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\EditImageSettingsCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Query\GetImageSettingsForEditing;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryResult\EditableImageSettings;
+use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
+
+/**
+ * Provides data for image settings form
+ */
+final class ImageSettingsFormDataProvider implements FormDataProviderInterface
+{
+    public function __construct(
+        private readonly CommandBusInterface $queryBus,
+        private readonly CommandBusInterface $commandBus,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(): array
+    {
+        /** @var EditableImageSettings $settings */
+        $settings = $this->queryBus->handle(new GetImageSettingsForEditing());
+
+        return [
+            'formats' => $settings->getFormats(),
+            'base-format' => $settings->getBaseFormat(),
+            'avif-quality' => $settings->getAvifQuality(),
+            'jpeg-quality' => $settings->getJpegQuality(),
+            'png-quality' => $settings->getPngQuality(),
+            'webp-quality' => $settings->getWebpQuality(),
+            'generation-method' => $settings->getGenerationMethod(),
+            'picture-max-size' => $settings->getPictureMaxSize(),
+            'picture-max-width' => $settings->getPictureMaxWidth(),
+            'picture-max-height' => $settings->getPictureMaxHeight(),
+        ];
+    }
+
+    public function setData(array $data)
+    {
+        $command = new EditImageSettingsCommand();
+        $command->setFormats($data['formats']);
+        $command->setBaseFormat($data['base-format']);
+        $command->setAvifQuality($data['avif-quality']);
+        $command->setJpegQuality($data['jpeg-quality']);
+        $command->setPngQuality($data['png-quality']);
+        $command->setWebpQuality($data['webp-quality']);
+        $command->setGenerationMethod($data['generation-method']);
+        $command->setPictureMaxSize($data['picture-max-size']);
+        $command->setPictureMaxWidth($data['picture-max-width']);
+        $command->setPictureMaxHeight($data['picture-max-height']);
+        $this->commandBus->handle($command);
+
+        return [];
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageSettingsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageSettingsType.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Improve\Design\ImageSettings;
+
+use PrestaShop\PrestaShop\Core\Image\AvifExtensionChecker;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Range;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class ImageSettingsType extends TranslatorAwareType
+{
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        private readonly AvifExtensionChecker $avifExtensionChecker,
+    ) {
+        parent::__construct($translator, $locales);
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        // Check if AVIF is enabled on the server
+        $avifEnabled = $this->avifExtensionChecker->isAvailable();
+        $helpFormats = $this->trans('Choose which image formats you want to be generated. Base image will always have .jpg extension, other formats will have .webp or .avif.', 'Admin.Design.Help');
+
+        if (!$avifEnabled) {
+            $helpFormats .= '<br/><strong>' . $this->trans('AVIF is disabled because it\'s not supported on your server, check your configuration if you want to use it.', 'Admin.Design.Help') . '</strong>';
+        }
+
+        // Build the settings form
+        $builder
+            ->add('formats', ChoiceType::class, [
+                'label' => $this->trans('Image formats to generate', 'Admin.Design.Feature'),
+                'help' => $helpFormats,
+                'expanded' => true,
+                'multiple' => true,
+                'choices' => [
+                    $this->trans('Base JPEG/PNG', 'Admin.Design.Feature') => 'jpg',
+                    $this->trans('WebP', 'Admin.Design.Feature') => 'webp',
+                    $this->trans('AVIF', 'Admin.Design.Feature') => 'avif',
+                ],
+                'choice_attr' => function (string $choice, string $key) use ($avifEnabled): array {
+                    return ['disabled' => $choice === 'jpg' || $choice === 'avif' && !$avifEnabled];
+                },
+            ])
+            ->add('base-format', ChoiceType::class, [
+                'label' => $this->trans('Base format', 'Admin.Design.Feature'),
+                'expanded' => true,
+                'choices' => [
+                    $this->trans('Use JPEG', 'Admin.Design.Feature') => 'jpg',
+                    $this->trans('Use PNG only if the base image is in PNG format', 'Admin.Design.Feature') => 'png',
+                    $this->trans('Use PNG', 'Admin.Design.Feature') => 'png_all',
+                ],
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ])
+            ->add('avif-quality', IntegerType::class, [
+                'label' => $this->trans('AVIF compression', 'Admin.Design.Feature'),
+                'required' => $avifEnabled,
+                'disabled' => !$avifEnabled,
+                'attr' => [
+                    'min' => 0,
+                    'max' => 100,
+                ],
+                'constraints' => $avifEnabled ? [new NotBlank(), new Range(['min' => 0, 'max' => 100])] : [],
+                'help' => $this->trans('Ranges from 0 (worst quality, smallest file) to 100 (best quality, biggest file).', 'Admin.Design.Help') . ' ' . $this->trans('Recommended: %d.', 'Admin.Design.Help', [90]),
+            ])
+            ->add('jpeg-quality', IntegerType::class, [
+                'label' => $this->trans('JPEG compression', 'Admin.Design.Feature'),
+                'required' => true,
+                'attr' => [
+                    'min' => 0,
+                    'max' => 100,
+                ],
+                'constraints' => [
+                    new NotBlank(),
+                    new Range([
+                        'min' => 0,
+                        'max' => 100,
+                    ]),
+                ],
+                'help' => $this->trans('Ranges from 0 (worst quality, smallest file) to 100 (best quality, biggest file).', 'Admin.Design.Help') . ' ' . $this->trans('Recommended: %d.', 'Admin.Design.Help', [90]),
+            ])
+            ->add('png-quality', IntegerType::class, [
+                'label' => $this->trans('PNG compression', 'Admin.Design.Feature'),
+                'required' => true,
+                'attr' => [
+                    'min' => 0,
+                    'max' => 9,
+                ],
+                'constraints' => [
+                    new NotBlank(),
+                    new Range([
+                        'min' => 0,
+                        'max' => 9,
+                    ]),
+                ],
+                'help' => $this->trans('PNG compression is lossless: unlike JPG, you do not lose image quality with a high compression ratio. However, photographs will compress very badly.', 'Admin.Design.Help') . ' ' . $this->trans('Ranges from 0 (biggest file) to 9 (smallest file, slowest decompression).', 'Admin.Design.Help') . ' ' . $this->trans('Recommended: %d.', 'Admin.Design.Help', [7]),
+            ])
+            ->add('webp-quality', IntegerType::class, [
+                'label' => $this->trans('WebP compression', 'Admin.Design.Feature'),
+                'required' => true,
+                'attr' => [
+                    'min' => 0,
+                    'max' => 100,
+                ],
+                'constraints' => [
+                    new NotBlank(),
+                    new Range([
+                        'min' => 0,
+                        'max' => 100,
+                    ]),
+                ],
+                'help' => $this->trans('Ranges from 0 (worst quality, smallest file) to 100 (best quality, biggest file).', 'Admin.Design.Help') . ' ' . $this->trans('Recommended: %d.', 'Admin.Design.Help', [80]),
+            ])
+            ->add('generation-method', ChoiceType::class, [
+                'label' => $this->trans('Generate images based on one side of the source image', 'Admin.Design.Feature'),
+                'choices' => [
+                    $this->trans('Automatic (longest side)', 'Admin.Design.Feature') => 0,
+                    $this->trans('Width', 'Admin.Global') => 1,
+                    $this->trans('Height', 'Admin.Global') => 2,
+                ],
+                'constraints' => [
+                    new NotBlank(),
+                ],
+            ])
+            ->add('picture-max-size', IntegerType::class, [
+                'label' => $this->trans('Maximum file size of product customization pictures', 'Admin.Design.Feature'),
+                'help' => $this->trans('The maximum file size of pictures that customers can upload to customize a product (in bytes).', 'Admin.Design.Help'),
+                'attr' => [
+                    'min' => 0,
+                ],
+                'constraints' => [
+                    new NotBlank(),
+                    new Range([
+                        'min' => 0,
+                    ]),
+                ],
+            ])
+            ->add('picture-max-width', IntegerType::class, [
+                'label' => $this->trans('Product picture width', 'Admin.Design.Feature'),
+                'help' => $this->trans('Width of product customization pictures that customers can upload (in pixels).', 'Admin.Design.Help'),
+                'attr' => [
+                    'min' => 0,
+                ],
+                'constraints' => [
+                    new NotBlank(),
+                    new Range([
+                        'min' => 0,
+                    ]),
+                ],
+            ])
+            ->add('picture-max-height', IntegerType::class, [
+                'label' => $this->trans('Product picture height', 'Admin.Design.Feature'),
+                'help' => $this->trans('Height of product customization pictures that customers can upload (in pixels).', 'Admin.Design.Help'),
+                'attr' => [
+                    'min' => 0,
+                ],
+                'constraints' => [
+                    new NotBlank(),
+                    new Range([
+                        'min' => 0,
+                    ]),
+                ],
+            ])
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageTypeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageTypeType.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Improve\Design\ImageSettings;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Range;
+
+class ImageTypeType extends TranslatorAwareType
+{
+    /** Minimum size for width and height in pixels of the image type */
+    private const MIN_PX_SIZE = 1;
+
+    /** Maximum size for width and height in pixels for the image type */
+    private const MAX_PX_SIZE = 9999;
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label' => $this->trans('Name for the image type', 'Admin.Design.Feature'),
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                    new TypedRegex([
+                        'type' => TypedRegex::TYPE_IMAGE_TYPE_NAME,
+                    ]),
+                ],
+                'help' => $this->trans('Letters, underscores and hyphens only (e.g. "small_custom", "cart_medium", "large", "thickbox_extra-large").', 'Admin.Design.Help'),
+            ])
+            ->add('width', IntegerType::class, [
+                'label' => $this->trans('Width', 'Admin.Global'),
+                'attr' => [
+                    'min' => self::MIN_PX_SIZE,
+                    'max' => self::MAX_PX_SIZE,
+                ],
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                    new Range([
+                        'min' => self::MIN_PX_SIZE,
+                        'max' => self::MAX_PX_SIZE,
+                        'notInRangeMessage' => $this->trans(
+                            'This field must be between %min% and %max%',
+                            'Admin.Notifications.Error',
+                            ['%min%' => self::MIN_PX_SIZE, '%max%' => self::MAX_PX_SIZE]
+                        ),
+                    ]),
+                ],
+                'help' => $this->trans('Maximum image width in pixels.', 'Admin.Design.Help'),
+            ])
+            ->add('height', IntegerType::class, [
+                'label' => $this->trans('Height', 'Admin.Global'),
+                'attr' => [
+                    'min' => self::MIN_PX_SIZE,
+                    'max' => self::MAX_PX_SIZE,
+                ],
+                'required' => true,
+                'constraints' => [
+                    new NotBlank(),
+                    new Range([
+                        'min' => self::MIN_PX_SIZE,
+                        'max' => self::MAX_PX_SIZE,
+                        'notInRangeMessage' => $this->trans(
+                            'This field must be between %min% and %max%',
+                            'Admin.Notifications.Error',
+                            ['%min%' => self::MIN_PX_SIZE, '%max%' => self::MAX_PX_SIZE]
+                        ),
+                    ]),
+                ],
+                'help' => $this->trans('Maximum image height in pixels.', 'Admin.Design.Help'),
+            ])
+            ->add('products', SwitchType::class, [
+                'label' => $this->trans('Products', 'Admin.Global'),
+                'help' => $this->trans('This type will be used for Product images.', 'Admin.Design.Help'),
+                'required' => false,
+            ])
+            ->add('categories', SwitchType::class, [
+                'label' => $this->trans('Categories', 'Admin.Global'),
+                'help' => $this->trans('This type will be used for Category images.', 'Admin.Design.Help'),
+                'required' => false,
+            ])
+            ->add('manufacturers', SwitchType::class, [
+                'label' => $this->trans('Brands', 'Admin.Global'),
+                'help' => $this->trans('This type will be used for Brand images.', 'Admin.Design.Help'),
+                'required' => false,
+            ])
+            ->add('suppliers', SwitchType::class, [
+                'label' => $this->trans('Suppliers', 'Admin.Global'),
+                'help' => $this->trans('This type will be used for Supplier images.', 'Admin.Design.Help'),
+                'required' => false,
+            ])
+            ->add('stores', SwitchType::class, [
+                'label' => $this->trans('Stores', 'Admin.Global'),
+                'help' => $this->trans('This type will be used for Store images.', 'Admin.Design.Help'),
+                'required' => false,
+            ])
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/RegenerateThumbnailsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/RegenerateThumbnailsType.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Improve\Design\ImageSettings;
+
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImageTypeChoiceProvider;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class RegenerateThumbnailsType extends TranslatorAwareType
+{
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        private readonly ImageTypeChoiceProvider $imageTypeChoiceProvider
+    ) {
+        parent::__construct($translator, $locales);
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('image', ChoiceType::class, [
+                'label' => $this->trans('Select an image', 'Admin.Design.Feature'),
+                'attr' => [
+                    'data-formats' => json_encode($this->imageTypeChoiceProvider->buildChoicesByTypes()),
+                ],
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'choices' => [
+                    $this->trans('All', 'Admin.Global') => 'all',
+                    $this->trans('Categories', 'Admin.Global') => 'categories',
+                    $this->trans('Brands', 'Admin.Global') => 'manufacturers',
+                    $this->trans('Suppliers', 'Admin.Global') => 'suppliers',
+                    $this->trans('Products', 'Admin.Global') => 'products',
+                    $this->trans('Stores', 'Admin.Global') => 'stores',
+                ],
+            ])
+            ->add('image-type', ChoiceType::class, [
+                'label' => $this->trans('Select a format', 'Admin.Design.Feature'),
+                'constraints' => [
+                    new NotBlank(),
+                ],
+                'choices' => [
+                    $this->trans('All', 'Admin.Global') => 0,
+                    ...$this->imageTypeChoiceProvider->getChoices(),
+                ],
+            ])
+            ->add('erase-previous-images', SwitchType::class, [
+                'label' => $this->trans('Erase previous images', 'Admin.Design.Feature'),
+                'help' => $this->trans('Select "No" only if your server timed out and you need to resume the regeneration.', 'Admin.Design.Help'),
+                'required' => false,
+                'data' => false,
+            ])
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/_design.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/_design.yml
@@ -13,3 +13,7 @@ _cms_page:
 _mail_theme:
   resource: "mail_theme.yml"
   prefix: /mail_theme/
+
+_image_settings:
+  resource: "image_settings.yml"
+  prefix: /image-settings

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/image_settings.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/image_settings.yml
@@ -1,0 +1,81 @@
+admin_image_settings_index:
+  path: /
+  methods: [ GET ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\Design\ImageSettingsController::indexAction'
+    _legacy_controller: AdminImages
+    _legacy_link: AdminImages
+    _legacy_feature_flag: image_settings
+
+admin_image_settings_filter:
+  path: /
+  methods: [ POST ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\CommonController::searchGridAction'
+    _legacy_controller: AdminImages
+    _legacy_link: AdminImages
+    _legacy_feature_flag: image_settings
+    gridDefinitionFactoryServiceId: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ImageTypeGridDefinitionFactory
+    redirectRoute: admin_image_settings_index
+
+admin_image_settings_save_settings:
+  path: /save-settings
+  methods: [ POST ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\Design\ImageSettingsController::saveSettingsAction'
+    _legacy_controller: AdminImages
+    _legacy_link: AdminImages
+    _legacy_feature_flag: image_settings
+
+admin_image_settings_regenerate_thumbnails:
+  path: /regenerate-thumbnails
+  methods: [ POST ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\Design\ImageSettingsController::regenerateThumbnailsAction'
+    _legacy_controller: AdminImages
+    _legacy_link: AdminImages
+    _legacy_feature_flag: image_settings
+
+admin_image_settings_create:
+  path: /new
+  methods: [ GET, POST ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\Design\ImageSettingsController::createAction'
+    _legacy_controller: AdminImages
+    _legacy_link: AdminImages
+    _legacy_feature_flag: image_settings
+
+admin_image_settings_edit:
+  path: /{imageTypeId}/edit
+  methods: [ GET, POST ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\Design\ImageSettingsController::editAction'
+    _legacy_controller: AdminImages
+    _legacy_link: AdminImages
+    _legacy_parameters:
+      id_image_type: imageTypeId
+    _legacy_feature_flag: image_settings
+  requirements:
+    imageTypeId: \d+
+
+admin_image_settings_delete:
+  path: /{imageTypeId}/delete
+  methods: [ POST, DELETE ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\Design\ImageSettingsController::deleteAction'
+    _legacy_controller: AdminImages
+    _legacy_link: AdminImages
+    _legacy_parameters:
+      id_image_type: imageTypeId
+    _legacy_feature_flag: image_settings
+  requirements:
+    imageTypeId: \d+
+
+admin_image_settings_bulk_delete:
+  path: /bulk-delete
+  methods: [ POST, DELETE ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\Design\ImageSettingsController::bulkDeleteAction'
+    _legacy_controller: AdminImages
+    _legacy_link: AdminImages
+    _legacy_feature_flag: image_settings

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -294,3 +294,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+
+  PrestaShop\PrestaShop\Adapter\Admin\ImageConfiguration:
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
@@ -116,3 +116,6 @@ services:
 
   prestashop.adapter.file.robots_text_file_generator:
     class: 'PrestaShop\PrestaShop\Adapter\File\RobotsTextFileGenerator'
+
+  PrestaShop\PrestaShop\Adapter\ImageThumbnailsRegenerator:
+    autowire: true

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
@@ -293,3 +293,9 @@ services:
     class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Security\FormDataProvider'
     arguments:
       - '@prestashop.adapter.security.password_policy.configuration'
+
+  prestashop.admin.improve.design.image_settings.form_data_provider:
+    class: 'PrestaShopBundle\Form\Admin\Improve\Design\ImageSettings\ImageSettingsFormDataProvider'
+    arguments:
+      - '@prestashop.core.query_bus'
+      - '@prestashop.core.command_bus'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -570,3 +570,13 @@ services:
       - 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Security\PasswordPolicyType'
       - 'SecurityPagePasswordPolicy'
       - 'password_policy'
+
+  prestashop.admin.image_settings.form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\Handler'
+    arguments:
+      - '@form.factory'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.admin.improve.design.image_settings.form_data_provider'
+      - 'PrestaShopBundle\Form\Admin\Improve\Design\ImageSettings\ImageSettingsType'
+      - 'ImageSettingsPage'
+      - 'image_settings'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -651,3 +651,8 @@ services:
       - { method: setTranslator, arguments: [ '@translator' ] }
     tags:
       - { name: form.type }
+
+  PrestaShopBundle\Form\Admin\Improve\Design\ImageSettings\ImageTypeType: ~
+  PrestaShopBundle\Form\Admin\Improve\Design\ImageSettings\DeleteImageTypeType: ~
+  PrestaShopBundle\Form\Admin\Improve\Design\ImageSettings\ImageSettingsType: ~
+  PrestaShopBundle\Form\Admin\Improve\Design\ImageSettings\RegenerateThumbnailsType: ~

--- a/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
@@ -131,3 +131,8 @@ services:
     factory: [ '@doctrine.orm.default_entity_manager', getRepository ]
     arguments:
       - PrestaShopBundle\Entity\ApiAccess
+
+  PrestaShopBundle\Entity\Repository\ImageTypeRepository:
+    factory: [ '@doctrine.orm.default_entity_manager', getRepository ]
+    arguments:
+      - PrestaShopBundle\Entity\ImageType

--- a/src/PrestaShopBundle/Resources/config/services/core/domain/image_settings.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/domain/image_settings.yml
@@ -1,0 +1,16 @@
+services:
+  _defaults:
+    autowire: true
+    public: false
+    autoconfigure: true
+
+  PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\AddImageTypeHandler: ~
+  PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\EditImageTypeHandler: ~
+  PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\DeleteImageTypeHandler: ~
+  PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\BulkImageTypeHandler: ~
+  PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\DeleteImagesFromTypeHandler: ~
+  PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\EditImageSettingsHandler: ~
+  PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\RegenerateThumbnailsHandler: ~
+
+  PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryHandler\GetImageTypeForEditingHandler: ~
+  PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryHandler\GetImageSettingsForEditingHandler: ~

--- a/src/PrestaShopBundle/Resources/config/services/core/domain/image_settings.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/domain/image_settings.yml
@@ -7,7 +7,7 @@ services:
   PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\AddImageTypeHandler: ~
   PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\EditImageTypeHandler: ~
   PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\DeleteImageTypeHandler: ~
-  PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\BulkImageTypeHandler: ~
+  PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\BulkDeleteImageTypeHandler: ~
   PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\DeleteImagesFromTypeHandler: ~
   PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\EditImageSettingsHandler: ~
   PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\RegenerateThumbnailsHandler: ~

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -135,3 +135,6 @@ services:
       - '@prestashop.core.command_bus'
       - '@=service("prestashop.adapter.legacy.configuration").getInt("PS_SHOP_DEFAULT")'
       - "@=service('prestashop.adapter.shop.context').getContextShopID()"
+
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImageTypeChoiceProvider:
+    autowire: true

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
@@ -336,3 +336,10 @@ services:
     arguments:
       - 'PrestaShopBundle\Form\Admin\AdvancedParameters\AuthorizationServer\ApiAccessType'
       - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\ApiAccessFormDataProvider'
+
+  prestashop.core.form.identifiable_object.builder.image_type_form_builder:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder'
+    factory: [ '@prestashop.core.form.builder.form_builder_factory', 'create' ]
+    arguments:
+      - 'PrestaShopBundle\Form\Admin\Improve\Design\ImageSettings\ImageTypeType'
+      - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\ImageTypeFormDataProvider'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -278,3 +278,7 @@ services:
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\ApiAccessFormDataHandler:
     autowire: true
     public: false
+
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\ImageTypeFormDataHandler:
+    autowire: true
+    public: false

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -253,3 +253,7 @@ services:
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\ApiAccessFormDataProvider:
     autowire: true
     public: false
+
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\ImageTypeFormDataProvider:
+    autowire: true
+    public: false

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
@@ -309,3 +309,9 @@ services:
     factory: [ '@prestashop.core.form.identifiable_object.handler.form_handler_factory', 'create' ]
     arguments:
       - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\ApiAccessFormDataHandler'
+
+  prestashop.core.form.identifiable_object.handler.image_type_form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler'
+    factory: [ '@prestashop.core.form.identifiable_object.handler.form_handler_factory', 'create' ]
+    arguments:
+      - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\ImageTypeFormDataHandler'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -543,3 +543,10 @@ services:
     arguments:
       $searchCriteriaApplicator: '@prestashop.core.query.doctrine_search_criteria_applicator'
       $multistoreContextChecker: '@prestashop.adapter.shop.context'
+
+  PrestaShop\PrestaShop\Core\Grid\Query\ImageTypeQueryBuilder:
+    parent: 'prestashop.core.grid.abstract_query_builder'
+    public: false
+    autowire: true
+    arguments:
+      - '@prestashop.core.query.doctrine_search_criteria_applicator'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -678,3 +678,12 @@ services:
       - '@translator'
       - '@prestashop.core.localization.locale.context_locale'
       - '@prestashop.core.query_bus'
+
+  prestashop.core.grid.data_factory.image_type:
+    class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
+    public: false
+    arguments:
+      - '@PrestaShop\PrestaShop\Core\Grid\Query\ImageTypeQueryBuilder'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.core.grid.query.doctrine_query_parser'
+      - 'image_type'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -423,6 +423,11 @@ services:
     autowire: true
     public: true
 
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ImageTypeGridDefinitionFactory:
+    parent: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory
+    autowire: true
+    public: true
+
   # deprecated services
   # Alias for this abstract definition causes tests in vendor fail for some reason, so we stick to full definition instead
   prestashop.core.grid.definition.factory.abstract_grid_definition:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
@@ -534,3 +534,11 @@ services:
       - '@PrestaShop\PrestaShop\Core\Grid\Data\Factory\CartGridDataFactory'
       - '@prestashop.core.grid.filter.form_factory'
       - '@prestashop.core.hook.dispatcher'
+
+  prestashop.core.grid.factory.image_type:
+    class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
+    arguments:
+      - '@PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ImageTypeGridDefinitionFactory'
+      - '@prestashop.core.grid.data_factory.image_type'
+      - '@prestashop.core.grid.filter.form_factory'
+      - '@prestashop.core.hook.dispatcher'

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/delete_image_type.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/delete_image_type.html.twig
@@ -1,0 +1,47 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+{% set class = 'btn tooltip-link js-delete-image-type-row-action' %}
+
+{% if attributes.class is defined %}
+  {% set class = class ~ ' ' ~ attributes.class %}
+{% endif %}
+
+<a class="{{ class }} grid-{{ action.name|lower }}-row-link"
+   href="#"
+   data-delete-url="{{ path(action.options.route, {'imageTypeId': record[action.options.id_field] }) }}"
+  {% if attributes.tooltip_name %}
+    data-toggle="pstooltip"
+    data-placement="top"
+    data-original-title="{{ action.name }}"
+  {% endif %}
+>
+  {% if action.icon is not empty %}
+    <i class="material-icons">{{ action.icon }}</i>
+  {% endif %}
+  {% if not attributes.tooltip_name %}
+    {{ action.name }}
+  {% endif %}
+</a>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/pixel_data.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/pixel_data.html.twig
@@ -1,0 +1,27 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+{% if record[column.options.field] %}
+    {{ record[column.options.field] }} px
+{% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/Blocks/delete_image_type.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/Blocks/delete_image_type.html.twig
@@ -1,0 +1,58 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+{% embed '@PrestaShop/Admin/Helpers/bootstrap_popup.html.twig' with {
+  'id': grid.id ~ '_grid_delete_image_type_modal',
+  'title': "Are you sure you want to delete this image setting?"|trans({}, 'Admin.Design.Feature'),
+  'closable': true,
+  'closeLabel': "Cancel"|trans({}, 'Admin.Actions'),
+  'actions': [{
+    'type': 'button',
+    'label': "Delete"|trans({}, 'Admin.Actions'),
+    'class': 'btn btn-danger btn-lg js-submit-delete-image-type',
+  }],
+} %}
+  {% block content %}
+    <div class="modal-body">
+      <p>{{ 'If you delete this image format, the theme won\'t be able to use it anymore. This will result in a degraded experience on your front office.'|trans({}, 'Admin.Design.Notification') }}</p>
+      {{ form_start(deleteImageTypeForm) }}
+      <div class="form-wrapper w-100 p-0 mt-4">
+        {% block delete_image_type_form %}
+          <div class="d-flex align-items-center">
+            <div class="bold">
+              {{ form_label(deleteImageTypeForm.delete_images_files_too, null, {'label_attr': {'class': 'm-0'}}) }}
+            </div>
+            <div class="col-sm">
+              {{ form_widget(deleteImageTypeForm.delete_images_files_too) }}
+            </div>
+          </div>
+
+          {{ form_rest(deleteImageTypeForm) }}
+        {% endblock %}
+      </div>
+      {{ form_end(deleteImageTypeForm) }}
+    </div>
+  {% endblock %}
+{% endembed %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/ImageType/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/ImageType/create.html.twig
@@ -1,0 +1,29 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  {{ include('@PrestaShop/Admin/Improve/Design/ImageSettings/ImageType/form.html.twig') }}
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/ImageType/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/ImageType/edit.html.twig
@@ -1,0 +1,33 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  <div class="alert alert-warning">
+    {{ 'After modification, do not forget to regenerate thumbnails'|trans({}, 'Admin.Design.Notification') }}<br/>
+    {{ 'Make sure the theme you use doesn\'t rely on this image format before deleting it.'|trans({}, 'Admin.Design.Notification') }}
+  </div>
+  {{ include('@PrestaShop/Admin/Improve/Design/ImageSettings/ImageType/form.html.twig') }}
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/ImageType/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/ImageType/form.html.twig
@@ -1,0 +1,55 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+{% form_theme form '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
+
+{{ form_start(form) }}
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">image</i>
+      {{ 'Image type'|trans({}, 'Admin.Design.Feature') }}
+    </h3>
+
+    <div class="card-body">
+      <div class="form-wrapper">
+        {{ form_errors(form) }}
+        {% block form_image_type_widget %}
+          {{ form_widget(form) }}
+        {% endblock %}
+      </div>
+    </div>
+
+    <div class="card-footer">
+      <div class="d-inline-flex">
+        <a href="{{ path('admin_image_settings_index') }}" class="btn btn-outline-secondary">
+          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+        </a>
+      </div>
+      <div class="d-inline-flex float-right">
+        <button class="btn btn-primary" id="save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+      </div>
+    </div>
+  </div>
+{{ form_end(form) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/form-regenerate-thumbnails.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/form-regenerate-thumbnails.html.twig
@@ -1,0 +1,58 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+{% form_theme regenThumbnailsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
+
+{{ form_start(regenThumbnailsForm, {'action': path('admin_image_settings_regenerate_thumbnails')}) }}
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">image</i>
+      {{ 'Regenerate thumbnails'|trans({}, 'Admin.Design.Feature') }}
+    </h3>
+    <div class="alert alert-warning mx-3 mt-3 mb-0">
+      {{ 'Be careful! Depending on the options selected, former manually uploaded thumbnails might be erased and replaced by automatically generated thumbnails.'|trans({}, 'Admin.Design.Notification') }}
+      <br />
+      {{ 'Also, regenerating thumbnails for all existing images can take several minutes, please be patient.'|trans({}, 'Admin.Design.Notification') }}
+    </div>
+    <div class="card-body">
+      <div class="form-wrapper">
+        {% block form_regenerate_thumbnails_widget %}
+          {{ form_rest(regenThumbnailsForm) }}
+        {% endblock %}
+      </div>
+    </div>
+    <div class="card-footer clearfix">
+      <div class="d-inline-flex float-right">
+        <button
+          class="btn btn-primary btn-confirm-form"
+          id="regenerate-thumbnails-button"
+          data-confirm-message="{{ 'Regenerate thumbnails for the selected images? With the "erase" option enabled, the previously selected thumbnails will be deleted.'|trans({}, 'Admin.Design.Notification') }}"
+          data-confirm-title="{{ 'Regenerate thumbnails'|trans({}, 'Admin.Design.Feature') }}"
+          data-confirm-cancel="{{ 'Cancel'|trans({}, 'Admin.Actions') }}"
+          data-confirm-apply="{{ 'Regenerate thumbnails'|trans({}, 'Admin.Actions') }}"
+        >{{ 'Regenerate thumbnails'|trans({}, 'Admin.Actions') }}</button>
+      </div>
+    </div>
+  </div>
+{{ form_end(regenThumbnailsForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/form-settings.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/form-settings.html.twig
@@ -1,0 +1,51 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+{% form_theme configForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
+
+{{ form_start(configForm, {'action': path('admin_image_settings_save_settings')}) }}
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">settings</i>
+      {{ 'Images generation options'|trans({}, 'Admin.Design.Feature') }}
+    </h3>
+    <div class="alert alert-info mx-3 mt-3 mb-0">
+      {{ 'JPEG images have a small file size and standard quality. PNG images have a larger file size, a higher quality and support transparency. Note that in all cases the image files will have the .jpg extension.'|trans({}, 'Admin.Design.Help') }}
+      <br /><br/>
+      {{ 'WARNING: This feature may not be compatible with your theme, or with some of your modules. In particular, PNG mode is not compatible with the Watermark module. If you encounter any issues, turn it off by selecting "Use JPEG'|trans({}, 'Admin.Design.Help') }}
+    </div>
+    <div class="card-body">
+      <div class="form-wrapper">
+        {% block form_image_settings_widget %}
+          {{ form_rest(configForm) }}
+        {% endblock %}
+      </div>
+    </div>
+    <div class="card-footer clearfix">
+      <div class="d-inline-flex float-right">
+        <button class="btn btn-primary" id="save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+      </div>
+    </div>
+  </div>
+{{ form_end(configForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/index.html.twig
@@ -1,0 +1,47 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  <div class="alert alert-danger">
+    {{ 'By default, all images settings are already installed in your store. Do not delete them, you will need it!'|trans({}, 'Admin.Design.Help') }}
+  </div>
+
+  {% block image_types_listing %}
+     {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': imageTypeGrid} %}
+      {% block grid_panel_extra_content %}
+        {% include '@PrestaShop/Admin/Improve/Design/ImageSettings/Blocks/delete_image_type.html.twig' %}
+      {% endblock %}
+    {% endembed %}
+  {% endblock %}
+  {{ include('@PrestaShop/Admin/Improve/Design/ImageSettings/form-settings.html.twig') }}
+  {{ include('@PrestaShop/Admin/Improve/Design/ImageSettings/form-regenerate-thumbnails.html.twig') }}
+{% endblock %}
+
+{% block javascripts %}
+  {{ parent() }}
+  <script src="{{ asset('themes/default/js/bundle/pagination.js') }}"></script>
+  <script src="{{ asset('themes/new-theme/public/image_settings.bundle.js') }}"></script>
+{% endblock %}

--- a/tests/Integration/Behaviour/Features/Context/Domain/ImageSettings/ImageSettingsContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ImageSettings/ImageSettingsContext.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\ImageSettings;
+
+use Behat\Gherkin\Node\TableNode;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\EditImageSettingsCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Query\GetImageSettingsForEditing;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryResult\EditableImageSettings;
+use Tests\Integration\Behaviour\Features\Context\Domain\AbstractDomainFeatureContext;
+
+class ImageSettingsContext extends AbstractDomainFeatureContext
+{
+    /**
+     * @When I edit images settings with following properties:
+     */
+    public function editImageSettingsUsingCommand(TableNode $table)
+    {
+        $data = $this->fixDataType($table->getRowsHash());
+
+        $command = new EditImageSettingsCommand();
+        $command->setFormats($data['formats']);
+        $command->setBaseFormat($data['base-format']);
+        $command->setAvifQuality($data['avif-quality']);
+        $command->setJpegQuality($data['jpeg-quality']);
+        $command->setPngQuality($data['png-quality']);
+        $command->setWebpQuality($data['webp-quality']);
+        $command->setGenerationMethod($data['generation-method']);
+        $command->setPictureMaxSize($data['picture-max-size']);
+        $command->setPictureMaxWidth($data['picture-max-width']);
+        $command->setPictureMaxHeight($data['picture-max-height']);
+
+        $this->getCommandBus()->handle($command);
+    }
+
+    /**
+     * @When images settings should have the following properties:
+     */
+    public function assertImageSettingsProperties(TableNode $table)
+    {
+        $errors = [];
+        $expectedData = $this->fixDataType($table->getRowsHash());
+
+        /** @var EditableImageSettings $imageSettings */
+        $imageSettings = $this->getQueryBus()->handle(new GetImageSettingsForEditing());
+
+        if (isset($expectedData['formats'])) {
+            if ($imageSettings->getFormats() !== $expectedData['formats']) {
+                $errors[] = 'formats';
+            }
+        }
+
+        if (isset($expectedData['base-format'])) {
+            if ($imageSettings->getBaseFormat() !== $expectedData['base-format']) {
+                $errors[] = 'base-format';
+            }
+        }
+
+        if (isset($expectedData['avif-quality'])) {
+            if ($imageSettings->getAvifQuality() !== $expectedData['avif-quality']) {
+                $errors[] = 'avif-quality';
+            }
+        }
+
+        if (isset($expectedData['jpeg-quality'])) {
+            if ($imageSettings->getJpegQuality() !== $expectedData['jpeg-quality']) {
+                $errors[] = 'jpeg-quality';
+            }
+        }
+
+        if (isset($expectedData['png-quality'])) {
+            if ($imageSettings->getPngQuality() !== $expectedData['png-quality']) {
+                $errors[] = 'png-quality';
+            }
+        }
+
+        if (isset($expectedData['webp-quality'])) {
+            if ($imageSettings->getWebpQuality() !== $expectedData['webp-quality']) {
+                $errors[] = 'webp-quality';
+            }
+        }
+
+        if (isset($expectedData['generation-method'])) {
+            if ($imageSettings->getGenerationMethod() !== $expectedData['generation-method']) {
+                $errors[] = 'generation-method';
+            }
+        }
+
+        if (isset($expectedData['picture-max-size'])) {
+            if ($imageSettings->getPictureMaxSize() !== $expectedData['picture-max-size']) {
+                $errors[] = 'picture-max-size';
+            }
+        }
+
+        if (isset($expectedData['picture-max-width'])) {
+            if ($imageSettings->getPictureMaxWidth() !== $expectedData['picture-max-width']) {
+                $errors[] = 'picture-max-width';
+            }
+        }
+
+        if (isset($expectedData['picture-max-height'])) {
+            if ($imageSettings->getPictureMaxHeight() !== $expectedData['picture-max-height']) {
+                $errors[] = 'picture-max-height';
+            }
+        }
+
+        if (count($errors) > 0) {
+            throw new \RuntimeException(sprintf('Fields %s are not identical', implode(', ', $errors)));
+        }
+    }
+
+    /**
+     * Fix data properties.
+     */
+    private function fixDataType(array $data): array
+    {
+        // Cast to array for formats
+        if (array_key_exists('formats', $data) && !is_null($data['formats'])) {
+            $data['formats'] = explode(',', $data['formats']);
+        }
+
+        // Cast to int
+        foreach (
+            [
+                'avif-quality',
+                'jpeg-quality',
+                'png-quality',
+                'webp-quality',
+                'generation-method',
+                'picture-max-size',
+                'picture-max-width',
+                'picture-max-height',
+            ] as $key) {
+            if (array_key_exists($key, $data) && !is_null($data[$key])) {
+                $data[$key] = intval($data[$key]);
+            }
+        }
+
+        return $data;
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/ImageSettings/ImageTypeContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ImageSettings/ImageTypeContext.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\ImageSettings;
+
+use Behat\Gherkin\Node\TableNode;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\AddImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\BulkDeleteImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\DeleteImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\EditImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Query\GetImageTypeForEditing;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryResult\EditableImageType;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject\ImageTypeId;
+use Tests\Integration\Behaviour\Features\Context\Domain\AbstractDomainFeatureContext;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
+
+class ImageTypeContext extends AbstractDomainFeatureContext
+{
+    /**
+     * @When I create an image type :imageTypeName with following properties:
+     */
+    public function createImageTypeUsingCommand(string $imageTypeName, TableNode $table)
+    {
+        $data = $this->fixDataType($table->getRowsHash());
+
+        $command = new AddImageTypeCommand(
+            $imageTypeName,
+            $data['width'],
+            $data['height'],
+            $data['products'],
+            $data['categories'],
+            $data['manufacturers'],
+            $data['suppliers'],
+            $data['stores']
+        );
+
+        /** @var ImageTypeId $imageTypeId */
+        $imageTypeId = $this->getCommandBus()->handle($command);
+
+        $this->getSharedStorage()->set($imageTypeName, $imageTypeId->getValue());
+    }
+
+    /**
+     * @When I edit image type :imageTypeName with following properties:
+     */
+    public function editImageTypeUsingCommand(string $imageTypeName, TableNode $table)
+    {
+        $data = $this->fixDataType($table->getRowsHash());
+        $this->getSharedStorage()->exists($imageTypeName);
+
+        $command = new EditImageTypeCommand($this->getSharedStorage()->get($imageTypeName));
+        $command->setName($imageTypeName);
+        $command->setWidth($data['width']);
+        $command->setHeight($data['height']);
+        $command->setProducts($data['products']);
+        $command->setCategories($data['categories']);
+        $command->setManufacturers($data['manufacturers']);
+        $command->setSuppliers($data['suppliers']);
+        $command->setStores($data['stores']);
+
+        $this->getCommandBus()->handle($command);
+    }
+
+    /**
+     * @When I delete image type :imageTypeName.
+     */
+    public function deleteImageTypeUsingCommand(string $imageTypeName)
+    {
+        $this->getSharedStorage()->exists($imageTypeName);
+        $imageTypeId = $this->getSharedStorage()->get($imageTypeName);
+        $command = new DeleteImageTypeCommand($imageTypeId);
+        $this->getCommandBus()->handle($command);
+    }
+
+    /**
+     * @Then I bulk delete image types :imageTypesName.
+     */
+    public function bulkDeleteImageTypeUsingCommand(string $imageTypesName)
+    {
+        $imageTypesName = explode(',', $imageTypesName);
+        $imageTypesIds = [];
+        foreach ($imageTypesName as $imageTypeName) {
+            $this->getSharedStorage()->exists($imageTypeName);
+            $imageTypesIds[] = $this->getSharedStorage()->get($imageTypeName);
+        }
+        $command = new BulkDeleteImageTypeCommand($imageTypesIds);
+        $this->getCommandBus()->handle($command);
+    }
+
+    /**
+     * @Then image type :imageTypeName should have the following properties:
+     */
+    public function assertQueryImageTypeProperties(string $imageTypeName, TableNode $table)
+    {
+        $errors = [];
+        $expectedData = $table->getRowsHash();
+        $this->getSharedStorage()->exists($imageTypeName);
+
+        /** @var EditableImageType $imageType */
+        $imageType = $this->getQueryBus()->handle(new GetImageTypeForEditing($this->getSharedStorage()->get($imageTypeName)));
+
+        if (isset($expectedData['name'])) {
+            if ($imageType->getName() !== $imageTypeName) {
+                $errors[] = 'name';
+            }
+        }
+
+        if (isset($expectedData['width'])) {
+            if ($imageType->getWidth() != $expectedData['width']) {
+                $errors[] = 'width';
+            }
+        }
+
+        if (isset($expectedData['height'])) {
+            if ($imageType->getHeight() != $expectedData['height']) {
+                $errors[] = 'height';
+            }
+        }
+
+        if (isset($expectedData['products'])) {
+            if ($imageType->isProducts() !== filter_var($expectedData['products'], FILTER_VALIDATE_BOOL)) {
+                $errors[] = 'products';
+            }
+        }
+
+        if (isset($expectedData['categories'])) {
+            if ($imageType->isCategories() !== filter_var($expectedData['categories'], FILTER_VALIDATE_BOOL)) {
+                $errors[] = 'categories';
+            }
+        }
+
+        if (isset($expectedData['manufacturers'])) {
+            if ($imageType->isManufacturers() !== filter_var($expectedData['manufacturers'], FILTER_VALIDATE_BOOL)) {
+                $errors[] = 'manufacturers';
+            }
+        }
+
+        if (isset($expectedData['suppliers'])) {
+            if ($imageType->isSuppliers() !== filter_var($expectedData['suppliers'], FILTER_VALIDATE_BOOL)) {
+                $errors[] = 'suppliers';
+            }
+        }
+
+        if (isset($expectedData['stores'])) {
+            if ($imageType->isStores() !== filter_var($expectedData['stores'], FILTER_VALIDATE_BOOL)) {
+                $errors[] = 'stores';
+            }
+        }
+
+        if (count($errors) > 0) {
+            throw new \RuntimeException(sprintf('Fields %s are not identical', implode(', ', $errors)));
+        }
+    }
+
+    /**
+     * @When image type :imageTypeName should not exist.
+     */
+    public function assertImageTypeDoesNotExist(string $imageTypeName)
+    {
+        $this->getSharedStorage()->exists($imageTypeName);
+        $imageTypeId = $this->getSharedStorage()->get($imageTypeName);
+
+        try {
+            $this->getQueryBus()->handle(new GetImageTypeForEditing($this->getSharedStorage()->get($imageTypeName)));
+            throw new \RuntimeException(sprintf('Image type with id %s exists', $imageTypeId));
+        } catch (ImageTypeNotFoundException $ex) {
+            return;
+        }
+    }
+
+    /**
+     * Fix data properties.
+     */
+    private function fixDataType(array $data): array
+    {
+        // Cast to int
+        foreach (['width', 'height'] as $key) {
+            if (array_key_exists($key, $data) && !is_null($data[$key])) {
+                $data[$key] = intval($data[$key]);
+            }
+        }
+
+        // Cast to boolean
+        foreach (['products', 'categories', 'manufacturers', 'suppliers', 'stores'] as $key) {
+            if (array_key_exists($key, $data) && !is_null($data[$key])) {
+                $data[$key] = PrimitiveUtils::castStringBooleanIntoBoolean($data[$key]);
+            }
+        }
+
+        return $data;
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/ImageSettings/ImageTypeContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ImageSettings/ImageTypeContext.php
@@ -70,17 +70,37 @@ class ImageTypeContext extends AbstractDomainFeatureContext
     public function editImageTypeUsingCommand(string $imageTypeName, TableNode $table)
     {
         $data = $this->fixDataType($table->getRowsHash());
-        $this->getSharedStorage()->exists($imageTypeName);
 
         $command = new EditImageTypeCommand($this->getSharedStorage()->get($imageTypeName));
         $command->setName($imageTypeName);
-        $command->setWidth($data['width']);
-        $command->setHeight($data['height']);
-        $command->setProducts($data['products']);
-        $command->setCategories($data['categories']);
-        $command->setManufacturers($data['manufacturers']);
-        $command->setSuppliers($data['suppliers']);
-        $command->setStores($data['stores']);
+
+        if (isset($data['width'])) {
+            $command->setWidth($data['width']);
+        }
+
+        if (isset($data['height'])) {
+            $command->setHeight($data['height']);
+        }
+
+        if (isset($data['products'])) {
+            $command->setProducts($data['products']);
+        }
+
+        if (isset($data['categories'])) {
+            $command->setCategories($data['categories']);
+        }
+
+        if (isset($data['manufacturers'])) {
+            $command->setManufacturers($data['manufacturers']);
+        }
+
+        if (isset($data['suppliers'])) {
+            $command->setSuppliers($data['suppliers']);
+        }
+
+        if (isset($data['stores'])) {
+            $command->setStores($data['stores']);
+        }
 
         $this->getCommandBus()->handle($command);
     }
@@ -90,9 +110,7 @@ class ImageTypeContext extends AbstractDomainFeatureContext
      */
     public function deleteImageTypeUsingCommand(string $imageTypeName)
     {
-        $this->getSharedStorage()->exists($imageTypeName);
-        $imageTypeId = $this->getSharedStorage()->get($imageTypeName);
-        $command = new DeleteImageTypeCommand($imageTypeId);
+        $command = new DeleteImageTypeCommand($this->getSharedStorage()->get($imageTypeName));
         $this->getCommandBus()->handle($command);
     }
 
@@ -104,7 +122,6 @@ class ImageTypeContext extends AbstractDomainFeatureContext
         $imageTypesName = explode(',', $imageTypesName);
         $imageTypesIds = [];
         foreach ($imageTypesName as $imageTypeName) {
-            $this->getSharedStorage()->exists($imageTypeName);
             $imageTypesIds[] = $this->getSharedStorage()->get($imageTypeName);
         }
         $command = new BulkDeleteImageTypeCommand($imageTypesIds);
@@ -118,7 +135,6 @@ class ImageTypeContext extends AbstractDomainFeatureContext
     {
         $errors = [];
         $expectedData = $table->getRowsHash();
-        $this->getSharedStorage()->exists($imageTypeName);
 
         /** @var EditableImageType $imageType */
         $imageType = $this->getQueryBus()->handle(new GetImageTypeForEditing($this->getSharedStorage()->get($imageTypeName)));
@@ -181,12 +197,9 @@ class ImageTypeContext extends AbstractDomainFeatureContext
      */
     public function assertImageTypeDoesNotExist(string $imageTypeName)
     {
-        $this->getSharedStorage()->exists($imageTypeName);
-        $imageTypeId = $this->getSharedStorage()->get($imageTypeName);
-
         try {
             $this->getQueryBus()->handle(new GetImageTypeForEditing($this->getSharedStorage()->get($imageTypeName)));
-            throw new \RuntimeException(sprintf('Image type with id %s exists', $imageTypeId));
+            throw new \RuntimeException(sprintf('Image type %s still exists', $imageTypeName));
         } catch (ImageTypeNotFoundException $ex) {
             return;
         }

--- a/tests/Integration/Behaviour/Features/Scenario/ImageSettings/image_settings.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/ImageSettings/image_settings.feature
@@ -1,0 +1,110 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s image-settings --tags image-settings
+@restore-all-tables-before-feature
+@image-settings
+Feature: Image Settings
+  PrestaShop allows BO users to manage images types and settings for regeneration
+  As a BO user
+  I must be able to create, save, edit image types and edit image settings.
+
+  # Scenarios for image types
+  Scenario: Create an image type
+    When I create an image type "test-default" with following properties:
+      | width         | 123  |
+      | height        | 456  |
+      | products      | true |
+      | categories    | true |
+      | manufacturers | true |
+      | suppliers     | true |
+      | stores        | true |
+    Then image type "test-default" should have the following properties:
+      | width         | 123  |
+      | height        | 456  |
+      | products      | true |
+      | categories    | true |
+      | manufacturers | true |
+      | suppliers     | true |
+      | stores        | true |
+
+  Scenario: Edit an image type
+    When I edit image type "test-default" with following properties:
+      | width         | 456  |
+      | height        | 789  |
+      | products      | false |
+      | categories    | false |
+      | manufacturers | false |
+      | suppliers     | false |
+      | stores        | false |
+    Then image type "test-default" should have the following properties:
+      | width         | 456   |
+      | height        | 789   |
+      | products      | false |
+      | categories    | false |
+      | manufacturers | false |
+      | suppliers     | false |
+      | stores        | false |
+
+  Scenario: Delete an image type
+    When I delete image type "test-default".
+    Then image type "test-default" should not exist.
+
+  Scenario: Bulk delete some image types
+    When I create an image type "test1-default" with following properties:
+      | width         | 123  |
+      | height        | 456  |
+      | products      | true |
+      | categories    | true |
+      | manufacturers | true |
+      | suppliers     | true |
+      | stores        | true |
+    Then image type "test1-default" should have the following properties:
+      | width         | 123  |
+      | height        | 456  |
+      | products      | true |
+      | categories    | true |
+      | manufacturers | true |
+      | suppliers     | true |
+      | stores        | true |
+    Then I create an image type "test2-default" with following properties:
+      | width         | 456  |
+      | height        | 123  |
+      | products      | true |
+      | categories    | true |
+      | manufacturers | true |
+      | suppliers     | true |
+      | stores        | true |
+    Then image type "test2-default" should have the following properties:
+      | width         | 456  |
+      | height        | 123  |
+      | products      | true |
+      | categories    | true |
+      | manufacturers | true |
+      | suppliers     | true |
+      | stores        | true |
+    Then I bulk delete image types "test1-default,test2-default".
+    Then image type "test1-default" should not exist.
+    Then image type "test2-default" should not exist.
+
+  # Scenarios for image settings
+  Scenario: Edit images settings for regeneration
+    When I edit images settings with following properties:
+      | formats            | jpg,avif,webp |
+      | base-format        | jpg           |
+      | avif-quality       | 50            |
+      | jpeg-quality       | 60            |
+      | png-quality        | 5             |
+      | webp-quality       | 70            |
+      | generation-method  | 1             |
+      | picture-max-size   | 5000          |
+      | picture-max-width  | 123           |
+      | picture-max-height | 345           |
+    Then images settings should have the following properties:
+      | formats            | jpg,avif,webp |
+      | base-format        | jpg           |
+      | avif-quality       | 50            |
+      | jpeg-quality       | 60            |
+      | png-quality        | 5             |
+      | webp-quality       | 70            |
+      | generation-method  | 1             |
+      | picture-max-size   | 5000          |
+      | picture-max-width  | 123           |
+      | picture-max-height | 345           |

--- a/tests/Integration/Behaviour/Features/Scenario/ImageSettings/image_settings.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/ImageSettings/image_settings.feature
@@ -43,6 +43,38 @@ Feature: Image Settings
       | suppliers     | false |
       | stores        | false |
 
+  Scenario: Partial edit an image type
+    When I edit image type "test-default" with following properties:
+      | width         | 999 |
+    Then image type "test-default" should have the following properties:
+      | width         | 999   |
+      | height        | 789   |
+      | products      | false |
+      | categories    | false |
+      | manufacturers | false |
+      | suppliers     | false |
+      | stores        | false |
+    When I edit image type "test-default" with following properties:
+      | height        | 123 |
+    Then image type "test-default" should have the following properties:
+      | width         | 999   |
+      | height        | 123   |
+      | products      | false |
+      | categories    | false |
+      | manufacturers | false |
+      | suppliers     | false |
+      | stores        | false |
+    When I edit image type "test-default" with following properties:
+      | products      | true |
+    Then image type "test-default" should have the following properties:
+      | width         | 999   |
+      | height        | 123   |
+      | products      | true  |
+      | categories    | false |
+      | manufacturers | false |
+      | suppliers     | false |
+      | stores        | false |
+
   Scenario: Delete an image type
     When I delete image type "test-default".
     Then image type "test-default" should not exist.

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -601,3 +601,10 @@ default:
           contexts:
             - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
             - Tests\Integration\Behaviour\Features\Context\Domain\ApiAccessManagementFeatureContext
+        image-settings:
+          paths:
+            - "%paths.base%/Features/Scenario/ImageSettings"
+          contexts:
+            - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\ImageSettings\ImageTypeContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\ImageSettings\ImageSettingsContext

--- a/tests/Unit/Core/Domain/ImageSettings/QueryResult/EditableImageSettingsTest.php
+++ b/tests/Unit/Core/Domain/ImageSettings/QueryResult/EditableImageSettingsTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Domain\ImageSettings\QueryResult;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryResult\EditableImageSettings;
+
+class EditableImageSettingsTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $instance = new EditableImageSettings(
+            'jpg,avif',
+            'jpg',
+            90,
+            90,
+            8,
+            90,
+            2,
+            499,
+            123,
+            456,
+        );
+
+        $this->assertSame(['jpg', 'avif'], $instance->getFormats());
+        $this->assertSame('jpg', $instance->getBaseFormat());
+        $this->assertSame(90, $instance->getAvifQuality());
+        $this->assertSame(90, $instance->getJpegQuality());
+        $this->assertSame(8, $instance->getPngQuality());
+        $this->assertSame(90, $instance->getWebpQuality());
+        $this->assertSame(2, $instance->getGenerationMethod());
+        $this->assertSame(499, $instance->getPictureMaxSize());
+        $this->assertSame(123, $instance->getPictureMaxWidth());
+        $this->assertSame(456, $instance->getPictureMaxHeight());
+    }
+}

--- a/tests/Unit/Core/Domain/ImageSettings/QueryResult/EditableImageTypeTest.php
+++ b/tests/Unit/Core/Domain/ImageSettings/QueryResult/EditableImageTypeTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Domain\ImageSettings\QueryResult;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryResult\EditableImageType;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject\ImageTypeId;
+
+class EditableImageTypeTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $imageTypeId = new ImageTypeId(10);
+        $instance = new EditableImageType(
+            $imageTypeId,
+            'name',
+            123,
+            455,
+            true,
+            true,
+            true,
+            true,
+            true,
+        );
+
+        self::assertSame($imageTypeId, $instance->getImageTypeId());
+        self::assertSame('name', $instance->getName());
+        self::assertSame(123, $instance->getWidth());
+        self::assertSame(455, $instance->getHeight());
+        self::assertTrue($instance->isProducts());
+        self::assertTrue($instance->isCategories());
+        self::assertTrue($instance->isManufacturers());
+        self::assertTrue($instance->isSuppliers());
+        self::assertTrue($instance->isStores());
+    }
+}

--- a/tests/Unit/Core/Domain/ImageSettings/ValueObject/ImageTypeIdTest.php
+++ b/tests/Unit/Core/Domain/ImageSettings/ValueObject/ImageTypeIdTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\ImageSettings\ValueObject;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject\ImageTypeId;
+
+class ImageTypeIdTest extends TestCase
+{
+    /**
+     * @dataProvider getValidInput
+     */
+    public function testValidInput(int $imageTypeId): void
+    {
+        $vo = new ImageTypeId($imageTypeId);
+        $this->assertEquals($imageTypeId, $vo->getValue());
+    }
+
+    public function getValidInput(): iterable
+    {
+        yield [1000];
+        yield [1];
+    }
+
+    /**
+     * @dataProvider getInvalidInput
+     */
+    public function testInvalidInput($imageTypeId): void
+    {
+        $this->expectException(ImageTypeException::class);
+        new ImageTypeId($imageTypeId);
+    }
+
+    public function getInvalidInput(): iterable
+    {
+        yield [0];
+        yield [-1];
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Migration of "Design > Image Settings" pages in backoffice.<br>This new page is hidden behind a feature flag.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable "Image settings" feature flag.<br>2. Go to "Design > Image Settings" pages.<br>3. Use the pages as usual.
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/7678776674
| Fixed issue or discussion?     | #10563 
| Related PRs       | 
| Sponsor company   | PrestaShop SA

For now, I have created an adapter to regenerate images, but I think that we should find/create and use an optimized brand new way to do this task. Maybe, we can create an issue about this change!