### PR TITLE
Fix alias hooks and add the missing ones

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -4514,5 +4514,25 @@
       <title>Triggers after loading routes</title>
       <description>Allow modules to modify routes in any way or add their own multilanguage routes.</description>
     </hook>
+    <hook id="actionSubmitAccountBefore">
+      <name>actionSubmitAccountBefore</name>
+      <title>Triggers before customer registers</title>
+      <description>Triggers after submitting registration form, before the registration process itself. Allows to modify result of this action.</description>
+    </hook>
+    <hook id="actionAuthenticationBefore">
+      <name>actionAuthenticationBefore</name>
+      <title>Triggers before customer logs in</title>
+      <description>Triggers after successful validation of login form, before the login process itself.</description>
+    </hook>
+    <hook id="actionCartUpdateQuantityBefore">
+      <name>actionCartUpdateQuantityBefore</name>
+      <title>Triggers before product is added to cart</title>
+      <description>Allows responding to add to cart events.</description>
+    </hook>
+    <hook id="actionAjaxDieBefore">
+      <name>actionAjaxDieBefore</name>
+      <title>Triggers when returning AJAX response</title>
+      <description>Allows to modify AJAX response of controllers using ajaxRender method.</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook_alias.xml
+++ b/install-dev/data/xml/hook_alias.xml
@@ -333,10 +333,6 @@
       <alias>actionBeforeSubmitAccount</alias>
       <name>actionSubmitAccountBefore</name>
     </hook_alias>
-    <hook_alias id="actionAfterDeleteProductInCart">
-      <alias>actionAfterDeleteProductInCart</alias>
-      <name>actionDeleteProductInCartAfter</name>
-    </hook_alias>
     <hook_alias id="displayInvoice">
       <alias>displayInvoice</alias>
       <name>displayAdminOrderTop</name>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | There are several issues when there is an alias for a hook, but this module is not present in the database. It should be fixed in the core probably, but this mitigates the issue.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests green are sufficient as this is only fixtures.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/7710845416
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/667
| Sponsor company   | 

| Alias name | Hook name | Result
| ----------------- | ----------------- | -----------------
| actionBeforeAuthentication | actionAuthenticationBefore | Missing from hook.xml
| actionBeforeSubmitAccount | actionSubmitAccountBefore | Missing from hook.xml
| actionBeforeCartUpdateQty | actionCartUpdateQuantityBefore | Missing from hook.xml
| actionBeforeAjaxDie | actionAjaxDieBefore | Missing from hook.xml
| actionAfterDeleteProductInCart | actionDeleteProductInCartAfter | Missing from hook.xml, but not used anymore


























































