### PR TITLE
Prevent inline styles to be replaced by CDN

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1057,7 +1057,7 @@ class FrontControllerCore extends Controller
         ];
         $params = array_merge($default_params, $params);
 
-        if (Tools::hasMediaServer() && !Configuration::get('PS_CSS_THEME_CACHE') && !$params["inline"]) {
+        if (Tools::hasMediaServer() && !Configuration::get('PS_CSS_THEME_CACHE') && !$params['inline']) {
             $relativePath = Tools::getCurrentUrlProtocolPrefix() . Tools::getMediaServer($relativePath)
                 . ($this->stylesheetManager->getFullPath($relativePath) ?? $relativePath);
             $params['server'] = 'remote';

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1057,7 +1057,7 @@ class FrontControllerCore extends Controller
         ];
         $params = array_merge($default_params, $params);
 
-        if (Tools::hasMediaServer() && !Configuration::get('PS_CSS_THEME_CACHE')) {
+        if (Tools::hasMediaServer() && !Configuration::get('PS_CSS_THEME_CACHE') && !$params["inline"]) {
             $relativePath = Tools::getCurrentUrlProtocolPrefix() . Tools::getMediaServer($relativePath)
                 . ($this->stylesheetManager->getFullPath($relativePath) ?? $relativePath);
             $params['server'] = 'remote';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR will fix a bug that occurs when we use both inline style and have configured a Media Server without CSS minify. 
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Register a new inline style inside a custom module. Check that the code is inline. After that enable a Media Server, disable the CSS minifier if was enabled. Check the code and you will see a <link> tag with your resource and your inline style doesn't exist anymore.

# Scenario

We have an inline style, regularly registered by a module and we want to keep it in HTML code

## What happens

If we add a Media Server it will be automatically replaced with a `<link>` tag with the CDN url.

## Excepted behaviour

The inline style is useful to keep the CSS code inside HTML tag and to don't make a new HTTP request, mostly for critical CSS. If we had a CDN we can't do this.

## What I have done

With a new condition inside current "if" we can also check that the style we are checking to add as a remote CDN resource is not an inline. With this small check we prevent that inline styles are passed to CDN everytime.