### PR TITLE
Change runners to be based on macos environment

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read  # for actions/checkout to fetch code
     name: PHP CS Fixer
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Github release a new type of runners based on M1 chips, supposedly faster so we test in this PR if it is indeed faster, which workflows are compatible and which workflows could benefit from this
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green
| UI Tests          | ~
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~


### Results:
- integration and behat tests can't run because they depend on `mirromutth/mysql-action@v1.1` only compatible on ubuntu
- all cron actions were left unmodified as they are not run in this CI so we prefer avoiding side effects on next cron actions
- `yamllint` is not available on macos env (by default at least)
- PHPUnit tests fail on a very specific test in `ToolsTest::testReplaceAccentedChars` there is one character that is not replaced as expected
- Block merge commit uses `Morishiri/block-merge-commits-action@v1.0.1` which requires ubuntu
- All workflows using docker failed, mostly because docker is not available by default but we didn't try to install it (note: mkcert step also failed)
- PHPStan workflows takes **twice** longer
- PHPCsFixer is **3.5 times** faster though
- JS unit tests are a bit slower
- All lint processes are longer, not in their execution but simply because the setup of. PHP is 30s instead of 3s on ubuntu, on short workflows like these ones this is huge
- For UI tests specific workflows: Typescript checks take the same time, ESlint seems to be faster on macos though (30s vs 48s for the pur lint step), steps identifiers is about the same time

### FInal decision
Only CSFixer job as moved to macos runner