### PR TITLE
Fix diacritics pdf invoice support for ro-RO

### DIFF
--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -86,6 +86,7 @@ class PDFGeneratorCore extends TCPDF
         'lt' => 'dejavusans',
         'lv' => 'dejavusans',
         'tr' => 'dejavusans',
+        'ro' => 'dejavusans',
         'ko' => 'cid0kr',
         'zh' => 'cid0cs',
         'tw' => 'cid0cs',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix diacritics pdf invoice support for ro-RO that I have been manually doing for years now. (As a suggestion you can add a font selector in front with check for supported shop language)
| Type?             | bug fix 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set the shop on romanian and if you set transation with diacritics (Reference = Referință) it show as "Referință" instead of "Referin??"
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/7812236746
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 