### PR TITLE
Remove deprecated ajaxDie method and deprecated hooks

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -114,7 +114,6 @@ class HookCore extends ObjectModel
         'displayAdminOrderContentShip' => ['from' => '1.7.7.0'],
 
         // Controller
-        'actionAjaxDieBefore' => ['from' => '1.6.1.1'],
         'actionGetProductPropertiesAfter' => ['from' => '1.7.8.0'],
     ];
 

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -737,22 +737,6 @@ abstract class ControllerCore
     }
 
     /**
-     * @deprecated deprecated since 1.7.5.0, use ajaxRender instead
-     * Dies and echoes output value
-     *
-     * @param string|null $value
-     * @param string|null $controller
-     * @param string|null $method
-     *
-     * @throws PrestaShopException
-     */
-    protected function ajaxDie($value = null, $controller = null, $method = null)
-    {
-        $this->ajaxRender($value, $controller, $method);
-        exit;
-    }
-
-    /**
      * @param string|null $value
      * @param string|null $controller
      * @param string|null $method
@@ -770,14 +754,6 @@ abstract class ControllerCore
             $method = $bt[1]['function'];
         }
 
-        /* @deprecated deprecated since 1.6.1.1 */
-        Hook::exec('actionAjaxDieBefore', ['controller' => $controller, 'method' => $method, 'value' => $value]);
-
-        /*
-         * @deprecated deprecated since 1.6.1.1
-         * use 'actionAjaxDie'.$controller.$method.'Before' instead
-         */
-        Hook::exec('actionBeforeAjaxDie' . $controller . $method, ['value' => $value]);
         Hook::exec('actionAjaxDie' . $controller . $method . 'Before', ['value' => &$value]);
         header('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
 

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -4564,11 +4564,6 @@
       <title>Triggers before product is added to cart</title>
       <description>Allows responding to add to cart events.</description>
     </hook>
-    <hook id="actionAjaxDieBefore">
-      <name>actionAjaxDieBefore</name>
-      <title>Triggers when returning AJAX response</title>
-      <description>Allows to modify AJAX response of controllers using ajaxRender method.</description>
-    </hook>
     <hook id="actionValidateCartRule">
       <name>actionValidateCartRule</name>
       <title>Alter cart rule validation process</title>

--- a/install-dev/data/xml/hook_alias.xml
+++ b/install-dev/data/xml/hook_alias.xml
@@ -321,10 +321,6 @@
       <alias>actionBeforeCartUpdateQty</alias>
       <name>actionCartUpdateQuantityBefore</name>
     </hook_alias>
-    <hook_alias id="actionBeforeAjaxDie">
-      <alias>actionBeforeAjaxDie</alias>
-      <name>actionAjaxDieBefore</name>
-    </hook_alias>
     <hook_alias id="actionBeforeAuthentication">
       <alias>actionBeforeAuthentication</alias>
       <name>actionAuthenticationBefore</name>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed deprecated hooks and methods related to ajaxDie.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Tests green.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/8984005226
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Related PRs
- https://github.com/PrestaShop/ps_themecusto/pull/62 + https://github.com/PrestaShop/ps_themecusto/pull/64 + update in composer
- https://github.com/PrestaShop/ps_googleanalytics/pull/158 + https://github.com/PrestaShop/ps_googleanalytics/pull/162 + update in composer
- https://github.com/PrestaShop/ps_emailsubscription/pull/108 + https://github.com/PrestaShop/ps_emailsubscription/pull/110 + update in composer

### Removed methods and changes
classes/controller/Controller.php - removed ajaxDie method, removed calls to actionAjaxDieBefore and actionBeforeAjaxDie
classes/Hook.php - deleted removed hook actionAjaxDieBefore

### Database changes required for upgraded installs
- remove actionBeforeAjaxDie from hook and hook_alias
- remove actionAjaxDieBefore from hook and hook_alias

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed deprecated AJAX-related hooks and methods to improve stability and maintainability.
- **Chores**
  - Cleaned up obsolete hook definitions and aliases from configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->