### PR TITLE
RouteNotFoundException when I configure a disabled module

### DIFF
--- a/src/Adapter/Module/Repository/ModuleRepository.php
+++ b/src/Adapter/Module/Repository/ModuleRepository.php
@@ -53,6 +53,11 @@ class ModuleRepository extends AbstractObjectModelRepository
     private $activeModulesPaths;
 
     /**
+     * @var array
+     */
+    private $installedModulesPaths;
+
+    /**
      * @var string
      */
     protected $rootDir;
@@ -158,6 +163,27 @@ class ModuleRepository extends AbstractObjectModelRepository
         }
 
         return $installedModules;
+    }
+
+    /**
+     * Returns installed module file paths.
+     *
+     * @return array<string, string> File paths indexed by module name
+     */
+    public function getInstalledModulesPaths(): array
+    {
+        if (null === $this->installedModulesPaths) {
+            $this->installedModulesPaths = [];
+            $installedModules = $this->getInstalledModules();
+
+            foreach ($this->getModulesFromFolder() as $moduleName => $modulePath) {
+                if (in_array($moduleName, $installedModules)) {
+                    $this->installedModulesPaths[$moduleName] = $modulePath;
+                }
+            }
+        }
+
+        return $this->installedModulesPaths;
     }
 
     /**

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
@@ -60,7 +60,7 @@ class LoadServicesFromModulesPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $installedModules = $container->getParameter('prestashop.active_modules');
+        $installedModules = $container->getParameter('prestashop.installed_modules');
         $moduleDir = $container->getParameter('prestashop.module_dir');
 
         foreach ($installedModules as $moduleName) {

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/ModuleControllerRegisterPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/ModuleControllerRegisterPass.php
@@ -49,10 +49,10 @@ class ModuleControllerRegisterPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container): void
     {
-        $activeModules = $container->getParameter('prestashop.active_modules');
+        $installedModules = $container->getParameter('prestashop.installed_modules');
         $moduleDir = $container->getParameter('prestashop.module_dir');
 
-        foreach ($activeModules as $moduleName) {
+        foreach ($installedModules as $moduleName) {
             $fileIterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($moduleDir . $moduleName));
             $phpFiles = new RegexIterator($fileIterator, '/\.php$/');
 

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
@@ -47,8 +47,8 @@ class ModulesDoctrineCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $activeModules = $container->getParameter('prestashop.active_modules');
-        $compilerPassList = $this->getCompilerPassList($activeModules);
+        $installedModules = $container->getParameter('prestashop.installed_modules');
+        $compilerPassList = $this->getCompilerPassList($installedModules);
         /** @var CompilerPassInterface $compilerPass */
         foreach ($compilerPassList as $compilerResourcePath => $compilerPass) {
             $compilerPass->process($container);

--- a/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
@@ -2,7 +2,7 @@ services:
   prestashop.bundle.routing.module_route_loader:
     class: 'PrestaShopBundle\Routing\YamlModuleLoader'
     arguments:
-      - '@=service("prestashop.adapter.module.repository.module_repository").getActiveModulesPaths()'
+      - '@=service("prestashop.adapter.module.repository.module_repository").getInstalledModulesPaths()'
     tags: [ routing.loader ]
 
   prestashop.bundle.routing.converter.legacy_url_converter:

--- a/src/PrestaShopBundle/Routing/YamlModuleLoader.php
+++ b/src/PrestaShopBundle/Routing/YamlModuleLoader.php
@@ -39,16 +39,16 @@ class YamlModuleLoader extends Loader
     /**
      * @var array the list of activated modules
      */
-    private $activeModulesPaths;
+    private $installedModulesPaths;
 
     /**
      * @var bool we load the route collection only once per request
      */
     private $isLoaded = false;
 
-    public function __construct(array $activeModulesPaths)
+    public function __construct(array $installedModulesPaths)
     {
-        $this->activeModulesPaths = $activeModulesPaths;
+        $this->installedModulesPaths = $installedModulesPaths;
     }
 
     /**
@@ -62,7 +62,7 @@ class YamlModuleLoader extends Loader
 
         $routes = new RouteCollection();
 
-        foreach ($this->activeModulesPaths as $modulePath) {
+        foreach ($this->installedModulesPaths as $modulePath) {
             $routingFile = $modulePath . '/config/routes.yml';
             if (file_exists($routingFile)) {
                 $loadedRoutes = $this->import($routingFile, 'yaml');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I load the routes and services of the installed modules, not activated modules. This poses a problem when configuring a disabled module.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI and UI tests are green
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/7888375959
| Fixed issue or discussion?     | Fixes #35286
| Related PRs       | -
| Sponsor company   | -