### PR TITLE
install script: use _PS_CACHE_DIR_ const as cache path

### DIFF
--- a/install-dev/index.php
+++ b/install-dev/index.php
@@ -25,6 +25,7 @@
  */
 
 require_once 'install_version.php';
+require_once '../config/defines.inc.php';
 
 if (
     !defined('PHP_VERSION_ID') // PHP_VERSION_ID is available since 5.2.7
@@ -32,9 +33,7 @@ if (
     || PHP_VERSION_ID > _PS_INSTALL_MAXIMUM_PHP_VERSION_ID_
     || !extension_loaded('SimpleXML') /** @phpstan-ignore-line */
     || !extension_loaded('zip') /** @phpstan-ignore-line */
-    || !is_writable(
-        __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'var'.DIRECTORY_SEPARATOR.'cache'
-    )
+    || !is_writable(_PS_CACHE_DIR_)
 ) {
     require_once dirname(__FILE__).'/missing_requirement.php';
     exit();

--- a/install-dev/missing_requirement.php
+++ b/install-dev/missing_requirement.php
@@ -138,7 +138,7 @@
             <i>To install PrestaShop <?php echo _PS_INSTALL_VERSION_ ?> you need to change your server's PHP version.</i>
         </li>
     <?php endif; ?>
-        <?php if (!is_writable(__DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'var'.DIRECTORY_SEPARATOR.'cache')): ?>
+        <?php if (!is_writable(_PS_CACHE_DIR_)): ?>
       <li>
           PrestaShop installation needs to write critical files in the folder var/cache.
           <i>Please review the permissions on your server.</i>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | cache path is hardcoded in the install script, we can change it (good practice to use a tmpfs mount btw....) in define.inc.php file
| Type?             | bug fix
| Category?         |  IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Change `_PS_CACHE_DIR_` default value and install PrestaShop, instruction below.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/8051808652
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | Subitolabs.

Go to `config/defines.inc.php`, change:

```
if (!defined('_PS_CACHE_DIR_')) {
    define('_PS_CACHE_DIR_', _PS_ROOT_DIR_.'/var/cache/' . _PS_ENV_ . DIRECTORY_SEPARATOR);
}
```

to

```
if (!defined('_PS_CACHE_DIR_')) {
    define('_PS_CACHE_DIR_', _PS_ROOT_DIR_.'/var/cache-test/' . _PS_ENV_ . DIRECTORY_SEPARATOR);
}
```
