### PR TITLE
Fix shipping cost on order details page - backport from v9

### DIFF
--- a/src/Adapter/Presenter/Order/OrderDetailLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderDetailLazyArray.php
@@ -229,7 +229,7 @@ class OrderDetailLazyArray extends AbstractLazyArray
                     ($shipping['weight'] > 0) ? sprintf('%.3f', $shipping['weight']) . ' ' .
                         Configuration::get('PS_WEIGHT_UNIT') : '-';
                 $shippingCost =
-                    (!$order->getTaxCalculationMethod()) ? $shipping['shipping_cost_tax_excl']
+                    ($order->getTaxCalculationMethod()) ? $shipping['shipping_cost_tax_excl']
                         : $shipping['shipping_cost_tax_incl'];
                 $orderShipping[$shippingId]['shipping_cost'] =
                     ($shippingCost > 0) ? $this->locale->formatPrice($shippingCost, (Currency::getIsoCodeById((int) $order->id_currency)))


### PR DESCRIPTION
Bug fix for order shipping cost displaying wrong price.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Backport of [already accepted fix](https://github.com/PrestaShop/PrestaShop/pull/29520) since it is related to how prices are being shown on the order detail page
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No need to tests.
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/7864683272
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/19132.
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company | impSolutions
