### PR TITLE
Do not initialize context when the shop is already initialized in CLI

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2881,6 +2881,11 @@ class AdminControllerCore extends Controller
             return;
         }
 
+        // Do not initialize context when the store is already initialized in CLI
+        if (Tools::isPHPCLI() && $this->context) {
+            return;
+        }
+
         // Change shop context ?
         if (Shop::isFeatureActive() && Tools::getValue('setShopContext') !== false) {
             $this->context->cookie->shopContext = Tools::getValue('setShopContext');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Do not initialize context when the shop is already initialized in CLI to avoid fatal error : `Shop context types other than "single shop" are not supported.`
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Try to update product qty with CLI.
| UI Tests          | ~TODO.
| Fixed issue or discussion?     | ~TODO
| Related PRs       | ~TODO
| Sponsor company   | ~