### PR TITLE
Fix backup tool creating nulls

### DIFF
--- a/classes/PrestaShopBackup.php
+++ b/classes/PrestaShopBackup.php
@@ -294,31 +294,21 @@ class PrestaShopBackupCore
             if (!in_array($schema[0]['Table'], $ignoreInsertTable)) {
                 $data = Db::getInstance()->query('SELECT * FROM `' . $schema[0]['Table'] . '`');
                 $sizeof = Db::getInstance()->numRows();
-                $lines = explode("\n", $schema[0]['Create Table']);
 
                 if ($data && $sizeof > 0) {
-                    // Export the table data
+                    // First we write the beginning of an insert query
                     fwrite($fp, 'INSERT INTO `' . $schema[0]['Table'] . "` VALUES\n");
+
+                    // We start a counter, because we want to separate the queries by batches of 200 lines
                     $i = 1;
                     while ($row = Db::getInstance()->nextRow($data)) {
                         $s = '(';
 
-                        foreach ($row as $field => $value) {
-                            $tmp = "'" . pSQL($value, true) . "',";
-                            if ($tmp != "'',") {
-                                $s .= $tmp;
+                        foreach ($row as $value) {
+                            if ($value === null) {
+                                $s .= "NULL,";
                             } else {
-                                foreach ($lines as $line) {
-                                    if (strpos($line, '`' . $field . '`') !== false) {
-                                        if (preg_match('/(.*NOT NULL.*)/Ui', $line)) {
-                                            $s .= "'',";
-                                        } else {
-                                            $s .= 'NULL,';
-                                        }
-
-                                        break;
-                                    }
-                                }
+                                $s .= "'" . pSQL($value, true) . "',";
                             }
                         }
                         $s = rtrim($s, ',');

--- a/classes/PrestaShopBackup.php
+++ b/classes/PrestaShopBackup.php
@@ -306,7 +306,7 @@ class PrestaShopBackupCore
 
                         foreach ($row as $value) {
                             if ($value === null) {
-                                $s .= "NULL,";
+                                $s .= 'NULL,';
                             } else {
                                 $s .= "'" . pSQL($value, true) . "',";
                             }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | This PR fixes an issue when the prestashop backup was adding NULLs to columns, where there is an empty string. If you restore this database, you get errors in admin. More info below.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create backup in prestashop backoffice, restore it in phpMyAdmin, see that backoffice product page works normally. :-)
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #33818
| Related PRs       | 
| Sponsor company   | 

### Description
- We have some issues when there are NULL values in database - https://github.com/PrestaShop/PrestaShop/issues/34454. They can get there multiple ways. One of the ways is the builtin backup tool that adds NULLs to columns, where there is an empty string.
- The original logic was following. It put the value into pSQL method. The method converts NULLs to empty string. So, it checked if the column is NULLable in the database and added NULL or empty string. This is bad, because it will make every empty string a NULL. :-)
- So, fix was simple. Check if the column is NULL before running it through pSQL method.