### PR TITLE
Remove whitespace so that tcpdf renders th headings correctly in all languages, fixes #35355

### DIFF
--- a/pdf/invoice.product-tab.tpl
+++ b/pdf/invoice.product-tab.tpl
@@ -36,18 +36,12 @@
       <th class="product header small" width="{$layout.tax_code.width}%">{l s='Tax Rate' d='Shop.Pdf' pdf='true'}</th>
     {/if}
     {if isset($layout.before_discount)}
-      <th class="product header small" width="{$layout.unit_price_tax_excl.width}%">
-        {l s='Base price' d='Shop.Pdf' pdf='true'}{if $isTaxEnabled}<br /> {l s='(Tax excl.)' d='Shop.Pdf' pdf='true'}{/if}
-      </th>
+      <th class="product header small" width="{$layout.unit_price_tax_excl.width}%">{l s='Base price' d='Shop.Pdf' pdf='true'}{if $isTaxEnabled}<br /> {l s='(Tax excl.)' d='Shop.Pdf' pdf='true'}{/if}</th>
     {/if}
 
-    <th class="product header-right small" width="{$layout.unit_price_tax_excl.width}%">
-      {l s='Unit Price' d='Shop.Pdf' pdf='true'}{if $isTaxEnabled}<br /> {l s='(Tax excl.)' d='Shop.Pdf' pdf='true'}{/if}
-    </th>
+    <th class="product header-right small" width="{$layout.unit_price_tax_excl.width}%">{l s='Unit Price' d='Shop.Pdf' pdf='true'}{if $isTaxEnabled}<br /> {l s='(Tax excl.)' d='Shop.Pdf' pdf='true'}{/if}</th>
     <th class="product header small" width="{$layout.quantity.width}%">{l s='Qty' d='Shop.Pdf' pdf='true'}</th>
-    <th class="product header-right small" width="{$layout.total_tax_excl.width}%">
-      {l s='Total' d='Shop.Pdf' pdf='true'}{if $isTaxEnabled}<br /> {l s='(Tax excl.)' d='Shop.Pdf' pdf='true'}{/if}
-    </th>
+    <th class="product header-right small" width="{$layout.total_tax_excl.width}%">{l s='Total' d='Shop.Pdf' pdf='true'}{if $isTaxEnabled}<br /> {l s='(Tax excl.)' d='Shop.Pdf' pdf='true'}{/if}</th>
   </tr>
   </thead>
 

--- a/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/11_checkInvoice.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/11_checkInvoice.ts
@@ -918,7 +918,7 @@ describe('BO - Orders - View and edit order: Check invoice', async () => {
         it('should check that the column \'Base price (Tax excl.)\' is visible', async function () {
           await testContext.addContextItem(this, 'testIdentifier', 'checkBasePriceColumnVisible', baseContext);
 
-          const basePriceColumnVisible = await utilsFile.isTextInPDF(filePath, 'Base,price,(Tax excl.)');
+          const basePriceColumnVisible = await utilsFile.isTextInPDF(filePath, 'Base price,(Tax excl.)');
           expect(basePriceColumnVisible, 'Base price is not visible!').to.eq(true);
         });
 


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | tcpdf seems to be really picky about whitespace. remove some to keep th headings aligned
| Type?             | bug fix
| Category?         | LO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | View PDF invoice of an order in Finnish language. Check that the product table headings are aligned
| UI Tests          | not ran
| Fixed issue or discussion?     | Fixes #35355 
| Related PRs       | 
| Sponsor company   | 
