### PR TITLE
Fix A pack set to Decrement products in pack only. cannot be added to cart

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -434,14 +434,8 @@ class CartControllerCore extends FrontController
              * If the product can't be in the cart in this quantity, we raise an error.
              * For the purpose of this error message, we must get the real quantity in stock.
              * No subtracting of quantity in the cart here.
-             *
-             * @todo StockAvailable::getQuantityAvailableByProduct does not work for packs
-             * which depend on quantity of products inside.
              */
-            $availableProductQuantity = StockAvailable::getQuantityAvailableByProduct(
-                $this->id_product,
-                $this->id_product_attribute
-            );
+            $availableProductQuantity = Product::getQuantity($this->id_product, $this->id_product_attribute);
             $this->errors[] = $this->trans(
                 'You can only buy %quantity% "%product%". Please adjust the quantity in your cart to continue.',
                 [
@@ -533,14 +527,8 @@ class CartControllerCore extends FrontController
                  * If the product can't be in the cart in this quantity, we raise an error.
                  * For the purpose of this error message, we must get the real quantity in stock.
                  * No subtracting of quantity in the cart here.
-                 *
-                 * @todo StockAvailable::getQuantityAvailableByProduct does not work for packs
-                 * which depend on quantity of products inside.
                  */
-                $availableProductQuantity = StockAvailable::getQuantityAvailableByProduct(
-                    $this->id_product,
-                    $this->id_product_attribute
-                );
+                $availableProductQuantity = Product::getQuantity($this->id_product, $this->id_product_attribute);
                 $this->{$ErrorKey}[] = $this->trans(
                     'You can only buy %quantity% "%product%". Please adjust the quantity in your cart to continue.',
                     [
@@ -552,6 +540,7 @@ class CartControllerCore extends FrontController
             }
         }
 
+        // Check validity of all cart rules in cart and check if there are some automatic ones that should be applied
         CartRule::autoRemoveFromCart();
         CartRule::autoAddToCart();
 
@@ -617,14 +606,8 @@ class CartControllerCore extends FrontController
 
         /*
          * We check if this product is out-of-stock.
-         *
-         * @todo StockAvailable::getQuantityAvailableByProduct does not work for packs
-         * which depend on quantity of products inside.
          */
-        $availableProductQuantity = StockAvailable::getQuantityAvailableByProduct(
-            $this->id_product,
-            $this->id_product_attribute
-        );
+        $availableProductQuantity = Product::getQuantity($this->id_product, $this->id_product_attribute);
         if ($availableProductQuantity < $qtyToCheck) {
             return true;
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.1.x
| Description?      | When you create a product pack and set it's stock type to Decrement products in pack only. (PackStockType::STOCK_TYPE_PRODUCTS_ONLY) and the quantity of the pack is zero, it cannot be added to cart. The PR also fixes `available_quantity` variable in cart products.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Auto test | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/8038868360
| How to test? | 1. Create pack of two standard products, 1 piece of each. <br>2. Set stock quantity of these two products to 100 each. <br>3. Go back to the pack, set quantity of the pack to 0, set Pack quantities to Decrement products in pack only. <br>4. Go to FO and try to add it to cart.
| Fixed issue or discussion?     | Fixes #35367, Fixes #35366
| Sponsor company   | Codencode snc

### Known issues
When you put both pack and the single products into cart, the ordering is successfully blocked, the error message is not correct and reports the available quantity of the pack. Fixing this will need another batch of thoughts and some BC breaks probably. A workaround would be something like `if available_quantity >= quantityincart`, then error message `"With the current products in your cart, pack is not available in this quantity."`. Saying the true reason would be better, but much more complicated.

![Snímek obrazovky 2024-02-25 155450](https://github.com/PrestaShop/PrestaShop/assets/6097524/367b6a7f-61a8-45b4-ab89-837273bd0eba)