### PR TITLE
Fix: available_quantity coming from Cart::getProducts() is 0 for packs

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -755,6 +755,16 @@ class CartCore extends ObjectModel
                     $reduction_type_row = ['reduction_type' => 0];
                 }
 
+                if (Pack::isPack($product['id_product'])) {
+                    $product['quantity_available'] = Product::getQuantity(
+                        $product['id_product'],
+                        $product['id_product_attribute'],
+                        null,
+                        null,
+                        $product['id_customization'],
+                    );
+                }
+
                 $products[$key] = array_merge($product, $reduction_type_row);
             }
         }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -756,13 +756,12 @@ class CartCore extends ObjectModel
                 }
 
                 if (Pack::isPack($product['id_product'])) {
-                    $product['quantity_available'] = Product::getQuantity(
-                        $product['id_product'],
-                        $product['id_product_attribute'],
-                        null,
-                        null,
-                        $product['id_customization'],
-                    );
+                    /*
+                    * In case of packs, we need to properly calculate the quantity in stock. We can't just use the quantity from the query, because stocks can be set to use the quantity of the products in them. The quantity in stock_available then has no meaning and could be always zero.
+                    *
+                    * When calling Pack::getQuantity here, you MUST use null for $cart parameter. Otherwise it will subtract the quantity that is already in the cart. Basically resulting in a nonsense - half of quantity you have. We need the REAL quantity.
+                    */
+                    $row['quantity_available'] = Pack::getQuantity((int) $product['id_product'], (int) $product['id_product_attribute'], true, null, (int) $product['id_customization']);
                 }
 
                 $products[$key] = array_merge($product, $reduction_type_row);

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -761,7 +761,7 @@ class CartCore extends ObjectModel
                     *
                     * When calling Pack::getQuantity here, you MUST use null for $cart parameter. Otherwise it will subtract the quantity that is already in the cart. Basically resulting in a nonsense - half of quantity you have. We need the REAL quantity.
                     */
-                    $row['quantity_available'] = Pack::getQuantity((int) $product['id_product'], (int) $product['id_product_attribute'], true, null, (int) $product['id_customization']);
+                    $product['quantity_available'] = Pack::getQuantity((int) $product['id_product'], (int) $product['id_product_attribute'], true, null, (int) $product['id_customization']);
                 }
 
                 $products[$key] = array_merge($product, $reduction_type_row);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.1.x
| Description?      | When you create a product pack and set it's stock type to Decrement products in pack only. (PackStockType::STOCK_TYPE_PRODUCTS_ONLY), it doesn't work in cart.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | 0. Open `themes\classic\templates\checkout\_partials\cart-detailed-product-line.tpl` and add Stock: `{$product.quantity_available}` somewhere you can see it.<br> 1. Create pack of two standard products, 1 piece of each.<br> 2. Set stock quantity of these two products to 100 each.<br> 3. Go back to the pack, set quantity of the pack to 1, so you can add it to cart. (...another bug), set `Pack quantities` to `Decrement products in pack only`.<br> 4. Go to FO, add this package to cart, go to cart and check the stock is 100
| Fixed issue or discussion?     | Fixes #35366
| Sponsor company   | Codencode

Auto test - https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/7992846654
