### PR TITLE
Feat(infos): added hostname in system information

### DIFF
--- a/src/Adapter/Hosting/HostingInformation.php
+++ b/src/Adapter/Hosting/HostingInformation.php
@@ -89,6 +89,7 @@ class HostingInformation
     {
         return Tools::apacheModExists('mod_instaweb');
     }
+
     /**
      * @return string
      */

--- a/src/Adapter/Hosting/HostingInformation.php
+++ b/src/Adapter/Hosting/HostingInformation.php
@@ -89,4 +89,12 @@ class HostingInformation
     {
         return Tools::apacheModExists('mod_instaweb');
     }
+    
+    /**
+     * @return string
+     */
+    public function getHostname(): string
+    {
+        return gethostname();
+    }
 }

--- a/src/Adapter/Hosting/HostingInformation.php
+++ b/src/Adapter/Hosting/HostingInformation.php
@@ -89,7 +89,6 @@ class HostingInformation
     {
         return Tools::apacheModExists('mod_instaweb');
     }
-    
     /**
      * @return string
      */

--- a/src/Adapter/System/SystemInformation.php
+++ b/src/Adapter/System/SystemInformation.php
@@ -69,6 +69,7 @@ class SystemInformation
             'server' => $this->hostingInformation->getServerInformation(),
             'instaWebInstalled' => $this->hostingInformation->isApacheInstawebModule(),
             'uname' => $this->hostingInformation->getUname(),
+            'hostname' => $this->hostingInformation->getHostname(),
             'database' => $this->hostingInformation->getDatabaseInformation(),
             'overrides' => $this->shopInformation->getOverridesList(),
             'shop' => $this->shopInformation->getShopInformation(),

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -42,6 +42,11 @@
         <i class="material-icons">info_outline</i> {{ 'Server information'|trans }}
       </h3>
       <div class="card-body">
+        {% if system.hostname is not empty %}
+          <p class="mb-0">
+            <strong>{{ 'Server Hostname:'|trans }}</strong> {{ system.hostname }}
+          </p>
+        {% endif %}
         {% if system.uname is not empty %}
           <p class="mb-0">
             <strong>{{ 'Server information:'|trans }}</strong> {{ system.uname }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When I have Prestashop in a load-balancing system, I can see the database name, but not the server hostname to identify on which server I am. This feature display the hostname on backoffice
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| UI Tests     | https://github.com/florine2623/testing_pr/actions/runs/8417257291
| How to test?      | Go into System Information Tab in backoffice and see the hostname
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/33941
| Sponsor company   | Evolutive
