### PR TITLE
Jetbrain IDE configuration folder is now ignored from gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ npm-debug.log.*
 *.swp
 *.swo
 .cache/
+.idea/
 
 # Cache
 /cache/*


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allow JetBrains IDE configuration files to be ignored when contributing.
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Clone the projet with PHPStorm, expect on develop to see .idea/* files in git status and not when pulling this branch
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/35382
| Sponsor company   | Evolutive
