### PR TITLE
Fix: Catalog - Stocks - multiple filters not working

### DIFF
--- a/src/PrestaShopBundle/Controller/Api/StockController.php
+++ b/src/PrestaShopBundle/Controller/Api/StockController.php
@@ -72,10 +72,12 @@ class StockController extends ApiController
             $queryParams = $request->query->all();
 
             if (isset($queryParams['keywords'])) {
+                // 'keywords' exists in the parameters, so it must be converted into an array
                 $queryParams['keywords'] = explode(',', $queryParams['keywords']);
+                $request->query->replace($queryParams);
             }
 
-            $queryParamsCollection = $this->queryParams->fromArray($queryParams);
+            $queryParamsCollection = $this->queryParams->fromRequest($request);
         } catch (InvalidPaginationParamsException $exception) {
             return $this->handleException(new BadRequestHttpException($exception->getMessage(), $exception));
         }

--- a/src/PrestaShopBundle/Controller/Api/StockController.php
+++ b/src/PrestaShopBundle/Controller/Api/StockController.php
@@ -71,8 +71,8 @@ class StockController extends ApiController
         try {
             $queryParams = $request->query->all();
 
-            if (isset($queryParams['keywords'])) {
-                // 'keywords' exists in the parameters, so it must be converted into an array
+            if (isset($queryParams['keywords']) && !is_array($queryParams['keywords'])) {
+                // 'keywords' exists in the parameters and is not array, so it must be converted into an array
                 $queryParams['keywords'] = explode(',', $queryParams['keywords']);
                 $request->query->replace($queryParams);
             }

--- a/src/PrestaShopBundle/Controller/Api/StockController.php
+++ b/src/PrestaShopBundle/Controller/Api/StockController.php
@@ -69,7 +69,13 @@ class StockController extends ApiController
         }
 
         try {
-            $queryParamsCollection = $this->queryParams->fromRequest($request);
+            $queryParams = $request->query->all();
+
+            if (isset($queryParams['keywords'])) {
+                $queryParams['keywords'] = explode(',', $queryParams['keywords']);
+            }
+
+            $queryParamsCollection = $this->queryParams->fromArray($queryParams);
         } catch (InvalidPaginationParamsException $exception) {
             return $this->handleException(new BadRequestHttpException($exception->getMessage(), $exception));
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | In search in Catalog - Stocks when I add multiple filters, no products are shown. If I use only one keyword in search it is working.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| UI Tests | https://github.com/florine2623/testing_pr/actions/runs/8173612011 ✅ 
| How to test?      | Go to Catalog > Stock and perform a 2-word search
| Fixed issue or discussion?     | Fixes #35280
| Sponsor company   | Codencode snc
