### PR TITLE
AppKernel is now able to detect the admin folder

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -26,20 +26,21 @@
 
 use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Version;
 use PrestaShop\TranslationToolsBundle\TranslationToolsBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Resource\FileExistenceResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
-
 abstract class AppKernel extends Kernel
 {
-    const VERSION = Version::VERSION;
-    const MAJOR_VERSION_STRING = Version::MAJOR_VERSION_STRING;
-    const MAJOR_VERSION = Version::MAJOR_VERSION;
-    const MINOR_VERSION = Version::MINOR_VERSION;
-    const RELEASE_VERSION = Version::RELEASE_VERSION;
+    public const VERSION = Version::VERSION;
+    public const MAJOR_VERSION_STRING = Version::MAJOR_VERSION_STRING;
+    public const MAJOR_VERSION = Version::MAJOR_VERSION;
+    public const MINOR_VERSION = Version::MINOR_VERSION;
+    public const RELEASE_VERSION = Version::RELEASE_VERSION;
 
     /**
      * Lock stream is saved as static field, this way if multiple AppKernel are instanciated (this can happen in
@@ -59,7 +60,7 @@ abstract class AppKernel extends Kernel
      */
     public function registerBundles(): iterable
     {
-        $bundles = array(
+        $bundles = [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new Symfony\Bundle\SecurityBundle\SecurityBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
@@ -73,9 +74,9 @@ abstract class AppKernel extends Kernel
             new FOS\JsRoutingBundle\FOSJsRoutingBundle(),
             new Symfony\UX\TwigComponent\TwigComponentBundle(),
             new Twig\Extra\TwigExtraBundle\TwigExtraBundle(),
-        );
+        ];
 
-        if (in_array($this->getEnvironment(), array('dev', 'test'), true)) {
+        if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {
             $bundles[] = new Symfony\Bundle\DebugBundle\DebugBundle();
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
         }
@@ -106,7 +107,7 @@ abstract class AppKernel extends Kernel
      * Perform a lock on a file before cache clear is performed, this lock will be unlocked once the cache has been cleared.
      * Until then any other process will have to wait until the file is unlocked.
      *
-     * @return bool Returns boolean indicating if the lock file was successfully locked.
+     * @return bool returns boolean indicating if the lock file was successfully locked
      */
     public function locksCacheClear(): bool
     {
@@ -122,6 +123,7 @@ abstract class AppKernel extends Kernel
         if (false === $clearCacheLocked) {
             // Clear cache is already locked by another process, so we simply return
             fclose($lockStream);
+
             return false;
         }
 
@@ -194,8 +196,7 @@ abstract class AppKernel extends Kernel
         $activeModules = $this->getModuleRepository()->getActiveModules();
         // We only load translations and services of active modules (not simply installed)
         $moduleTranslationsPaths = [];
-        foreach ($activeModules as $activeModulePath)
-        {
+        foreach ($activeModules as $activeModulePath) {
             $modulePath = _PS_MODULE_DIR_ . $activeModulePath;
             $translationsPath = sprintf('%s/translations', $modulePath);
 
@@ -207,7 +208,7 @@ abstract class AppKernel extends Kernel
             ];
 
             foreach ($configFiles as $file) {
-                if(is_file($file)) {
+                if (is_file($file)) {
                     $loader->load($file);
                 }
             }
@@ -222,12 +223,53 @@ abstract class AppKernel extends Kernel
             $container->setParameter('container.autowiring.strict_mode', true);
             $container->setParameter('container.dumper.inline_class_loader', false);
             $container->setParameter('prestashop.module_dir', _PS_MODULE_DIR_);
-            /** @deprecated kernel.active_modules is deprecated. Use prestashop.active_modules instead. */
+            /* @deprecated kernel.active_modules is deprecated. Use prestashop.active_modules instead. */
             $container->setParameter('kernel.active_modules', $activeModules);
             $container->setParameter('prestashop.active_modules', $activeModules);
             $container->setParameter('prestashop.installed_modules', $installedModules);
             $container->addObjectResource($this);
             $container->setParameter('modules_translation_paths', $moduleTranslationsPaths);
+
+            // Define parameter for admin folder path
+            if (defined('PS_ADMIN_DIR') && is_dir(PS_ADMIN_DIR)) {
+                $adminDir = PS_ADMIN_DIR;
+            } elseif (defined('_PS_ADMIN_DIR_') && is_dir(_PS_ADMIN_DIR_)) {
+                $adminDir = _PS_ADMIN_DIR_;
+            } else {
+                // Look for potential admin folders, condition to meet:
+                //  - first level folders in the project folder
+                //  - contains a PHP file that define the const PS_ADMIN_DIR or _PS_ADMIN_DIR_
+                //  - the first folder found is used (alphabetical order, but files named index.php have the highest priority)
+                $finder = new Symfony\Component\Finder\Finder();
+                $finder->files()
+                    ->name('*.php')
+                    ->contains('/define\([\'\"](_)?PS_ADMIN_DIR(_)?[\'\"]/')
+                    ->depth('== 1')
+                    ->sort(function (SplFileInfo $a, SplFileInfo $b): int {
+                        // Prioritize files named index.php
+                        if ($a->getFilename() === 'index.php') {
+                            return -1;
+                        }
+
+                        return strcmp($a->getRealPath(), $b->getRealPath());
+                    })
+                    ->in($this->getProjectDir())
+                ;
+                foreach ($finder as $adminIndexFile) {
+                    $adminDir = $adminIndexFile->getPath();
+                    // Container freshness depends on this file existence
+                    $container->addResource(new FileExistenceResource($adminIndexFile->getRealPath()));
+                    break;
+                }
+            }
+
+            if (!isset($adminDir) || !is_dir($adminDir)) {
+                throw new CoreException('Could not detect admin folder, and const as not defined.');
+            }
+            $container->setParameter('prestashop.admin_dir', $adminDir);
+            $container->setParameter('prestashop.admin_folder_name', basename($adminDir));
+            // Container freshness depends on this folder existence
+            $container->addResource(new FileExistenceResource($adminDir));
         });
     }
 
@@ -331,8 +373,8 @@ abstract class AppKernel extends Kernel
      *
      * @return string
      */
-     public function getAppType(): string
-     {
-         return $this instanceof \AdminKernel ? 'admin' : 'front';
-     }
+    public function getAppType(): string
+    {
+        return $this instanceof \AdminKernel ? 'admin' : 'front';
+    }
 }

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -99,7 +99,7 @@ twig:
     '%kernel.project_dir%/modules': Modules
     '%mail_themes_dir%': MailThemes
     '%prestashop_views%': PrestaShopCore
-    '%kernel.project_dir%/admin-dev/themes/new-theme': AdminNewTheme
+    '%prestashop.admin_dir%/themes/new-theme': AdminNewTheme
   globals:
     ps: '@PrestaShopBundle\Twig\Layout\PrestaShopLayoutGlobalVariables'
     webpack_server: false


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | AppKernel is now able to detect the admin folder in case the PS_ADMIN_DIR is not defined, the admin dir path is now set in the `prestashop.admin_dir` parameter that must be favored from now on in DI
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI and UI tests green, see description below for manual checks
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/7962314884
| Fixed issue or discussion?     | Fixes #35354
| Related PRs       | ~
| Sponsor company   | ~

### Steps to reproduce
1. Install the nightly with a folder admin-dev present (if you rename it prior installation, it will fail)
2. Access your back office. It should load
3. Rename admin-dev as anything you want
4. Access your back ffice. It should load

### Alternative:
You can use `./bin/console debug:container --parameters` and check that `prestashop.admin_dir` and `prestashop.admin_folder_name` are correctly updated when the admin folder is renamed In dev environment it should be automatic thanks to the resource checking, but in prod you probably have to clean the cache after every modification