### PR TITLE
Fix: The new password policy is not present in the reset password page #35410

### DIFF
--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -23,8 +23,8 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-use PrestaShop\PrestaShop\Core\Util\InternationalizedDomainNameConverter;
 use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
+use PrestaShop\PrestaShop\Core\Util\InternationalizedDomainNameConverter;
 
 class PasswordControllerCore extends FrontController
 {

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -24,6 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 use PrestaShop\PrestaShop\Core\Util\InternationalizedDomainNameConverter;
+use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 
 class PasswordControllerCore extends FrontController
 {
@@ -163,6 +164,34 @@ class PasswordControllerCore extends FrontController
                     if (!Validate::isPlaintextPassword($passwd)) {
                         $this->errors[] = $this->trans('The password is not in a valid format.', [], 'Shop.Notifications.Error');
                     }
+                }
+
+                if (Validate::isAcceptablePasswordLength($passwd) === false) {
+                    $this->errors[] = $this->translator->trans(
+                        'Password must be between %d and %d characters long',
+                        [
+                            Configuration::get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH),
+                            Configuration::get(PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH),
+                        ],
+                        'Shop.Notifications.Error'
+                    );
+                }
+
+                if (Validate::isAcceptablePasswordScore($passwd) === false) {
+                    $wordingsForScore = [
+                        $this->translator->trans('Very weak', [], 'Shop.Theme.Global'),
+                        $this->translator->trans('Weak', [], 'Shop.Theme.Global'),
+                        $this->translator->trans('Average', [], 'Shop.Theme.Global'),
+                        $this->translator->trans('Strong', [], 'Shop.Theme.Global'),
+                        $this->translator->trans('Very strong', [], 'Shop.Theme.Global'),
+                    ];
+                    $this->errors[] = $this->translator->trans(
+                        'The minimum score must be: %s',
+                        [
+                            $wordingsForScore[(int) Configuration::get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_SCORE)],
+                        ],
+                        'Shop.Notifications.Error'
+                    );
                 }
             }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | if you try to do the password reset steps, you will get the reset page where to set a new password two times
from this page is not present the new password verification, in fact it is possible to set weak password
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. go at login<br> 2. push on the link "I don't remember the password" <br> 3. set an email to get the reset link <br> 4. push on the reset link<br> 5 set a new password, but weak like "casetta" <br> 6. Password verification will not appear
| Fixed issue or discussion?     | Fixes #35410
| Related PRs       | **Template modification is required** https://github.com/PrestaShop/classic-theme/pull/140
| Sponsor company   | Codencode snc
