### PR TITLE
Allow JSON format for OpenApi doc

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -121,6 +121,7 @@ api_platform:
   docs_formats:
     # This is used to allow using the Swagger UI in HTML presentation
     html: [ 'text/html' ]
+    json: [ 'application/json' ]
   mapping:
     paths:
       - '%kernel.project_dir%/src/PrestaShopBundle/ApiPlatform/Resources'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allow JSON format for OpenApi doc, with the upgrade of ApiPLatform to version 3 we removed the JSON format from authorized format for the doc, thus the link in the BO was now broken
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green
| UI Tests          | ~
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
