### PR TITLE
Fixed sort error after generation of credit slip just for delivery fees; refs #33890

### DIFF
--- a/classes/pdf/HTMLTemplateOrderSlip.php
+++ b/classes/pdf/HTMLTemplateOrderSlip.php
@@ -124,7 +124,7 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
             }
             unset($product);
         } else {
-            $this->order->products = null;
+            $this->order->products = [];
         }
 
         if ($this->order_slip->shipping_cost == 0) {


### PR DESCRIPTION
| Questions | Answers |
| ----------------- | ------------------------------------------------------- |
| Branch? | develop
| Description? | When I want to generate a PDF for credit slips for refund only delivery fees, I have an 500 error on my server. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed issue or discussion? | Fixes #33890 |
| UI Tests | https://github.com/florine2623/testing_pr/actions/workflows/pr_test.yml
| Sponsor company | 202 ecommerce |