### PR TITLE
Do not show vouchers that should be hidden

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/informations.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/informations.tpl
@@ -87,7 +87,7 @@
 	</div>
 </div>
 
-<div class="form-group" id="cart-rules-highlight"{if !$currentTab->getFieldValue($currentObject, 'code')} style="display: none;"{/if}>
+<div class="form-group">
 	<label class="control-label col-lg-3">
 		<span class="label-tooltip" data-toggle="tooltip"
 		title="{l|escape s='If the voucher is not yet in the cart, it will be displayed in the cart summary.' d='Admin.Catalog.Help'}">
@@ -150,9 +150,4 @@
 </div>
 <script type="text/javascript">
 	$(".textarea-autosize").autosize();
-	$(document).ready(function() {
-    $('#code').bind('keyup change', function() {
-      $('#cart-rules-highlight').toggle($(this).val() !== "");
-    });
-  });
 </script>

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -531,7 +531,7 @@ class CartRuleCore extends ObjectModel
         $query = new DbQuery();
         $query->select('cr.*, crl.name');
         $query->from('cart_rule', 'cr');
-        $query->where('cr.id_customer = ' . $customerId . ' OR (cr.`id_customer` = 0 AND (cr.`highlight` = 1 OR cr.`code` = ""))');
+        $query->where('cr.id_customer = ' . $customerId);
         $query->leftJoin('cart_rule_lang', 'crl', 'cr.id_cart_rule = crl.id_cart_rule AND crl.id_lang = ' . (int) Configuration::get('PS_LANG_DEFAULT'));
         $query->orderBy('cr.active DESC, cr.id_customer DESC');
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -366,8 +366,6 @@ function gencode(size)
   for (var i = 1; i <= size; ++i) {
     getE('code').value += chars.charAt(Math.floor(randomNumbers[i]/2**32 * chars.length));
   }
-
-  getE('cart-rules-highlight').style.display = '';
 }
 
 var tpl_viewing_window = null;

--- a/tests/Integration/Classes/CartRuleTest.php
+++ b/tests/Integration/Classes/CartRuleTest.php
@@ -172,6 +172,169 @@ class CartRuleTest extends TestCase
         $this->assertEquals(2, count($customerCartRules));
     }
 
+    /*
+     * Tests if the customer sees only his specific vouchers in my account zone
+     * in front office.
+     */
+    public function testGetAllCustomersCartRulesInMyAccountZone(): void
+    {
+        // Reset table
+        self::setUpBeforeClass();
+
+        // Code, highlight, for everyone
+        $CodeHighlightEveryone = $this->createDummyCartRule(true, 0, true, true);
+        // Code, highlight, specific customer
+        $CodeHighlightSpecific = $this->createDummyCartRule(true, (int) $this->dummyCustomer->id, true, true);
+        // Code, no highlight, for everyone
+        $CodeNohighlightEveryone = $this->createDummyCartRule(true, 0, true);
+        // Code, no highlight, specific customer
+        $CodeNohighlightSpecific = $this->createDummyCartRule(true, (int) $this->dummyCustomer->id, true);
+        // No code, highlight, for everyone
+        $NocodeHighlightEveryone = $this->createDummyCartRule(true, 0, false, true);
+        // No code, highlight, specific customer
+        $NocodeHighlightSpecific = $this->createDummyCartRule(true, (int) $this->dummyCustomer->id, false, true);
+        // No code, no highlight, for everyone
+        $NocodeNohighlightEveryone = $this->createDummyCartRule(true, 0, false);
+        // No code, no highlight, specific customer
+        $NocodeNohighlightSpecific = $this->createDummyCartRule(true, (int) $this->dummyCustomer->id, false);
+        // Code, highlight, specific customer, disabled
+        $CodeHighlightSpecificDisabled = $this->createDummyCartRule(false, (int) $this->dummyCustomer->id, true, true);
+        // Code, highlight, specific customer, disabled
+        $CodeHighlightSpecificDisabled = $this->createDummyCartRule(false, (int) $this->dummyCustomer->id, true, true);
+
+        // Get customer's vouchers in frontoffice
+        $customerCartRules = CartRule::getCustomerCartRules(
+            $this->defaultLanguageId,
+            (int) $this->dummyCustomer->id,
+            true,
+            false
+        );
+
+        $this->assertEquals(
+            [
+                $CodeNohighlightSpecific->id,
+                $NocodeNohighlightSpecific->id,
+                $CodeHighlightSpecific->id,
+                $NocodeHighlightSpecific->id,
+            ],
+            array_column($customerCartRules, 'id_cart_rule')
+        );
+    }
+
+    /*
+     * Tests customer's voucher in backoffice. We should see even the disabled vouchers here.
+     */
+    public function testGetAllCustomersCartRulesInBackoffice(): void
+    {
+        // Reset table
+        self::setUpBeforeClass();
+
+        // Code, highlight, for everyone
+        $CodeHighlightEveryone = $this->createDummyCartRule(true, 0, true, true);
+        // Code, highlight, specific customer
+        $CodeHighlightSpecific = $this->createDummyCartRule(true, (int) $this->dummyCustomer->id, true, true);
+        // Code, no highlight, for everyone
+        $CodeNohighlightEveryone = $this->createDummyCartRule(true, 0, true);
+        // Code, no highlight, specific customer
+        $CodeNohighlightSpecific = $this->createDummyCartRule(true, (int) $this->dummyCustomer->id, true);
+        // No code, highlight, for everyone
+        $NocodeHighlightEveryone = $this->createDummyCartRule(true, 0, false, true);
+        // No code, highlight, specific customer
+        $NocodeHighlightSpecific = $this->createDummyCartRule(true, (int) $this->dummyCustomer->id, false, true);
+        // No code, no highlight, for everyone
+        $NocodeNohighlightEveryone = $this->createDummyCartRule(true, 0, false);
+        // No code, no highlight, specific customer
+        $NocodeNohighlightSpecific = $this->createDummyCartRule(true, (int) $this->dummyCustomer->id, false);
+        // Code, highlight, specific customer, disabled
+        $CodeHighlightSpecificDisabled = $this->createDummyCartRule(false, (int) $this->dummyCustomer->id, true, true);
+
+        $customerCartRules = CartRule::getAllCustomerCartRules(
+            (int) $this->dummyCustomer->id
+        );
+
+        $this->assertEquals(
+            [
+                $NocodeNohighlightSpecific->id,
+                $NocodeHighlightSpecific->id,
+                $CodeNohighlightSpecific->id,
+                $CodeHighlightSpecific->id,
+                $CodeHighlightSpecificDisabled->id,
+            ],
+            array_column($customerCartRules, 'id_cart_rule')
+        );
+    }
+
+    /*
+     * Tests if both logged in and logged out customer gets offered
+     * proper highlighted vouchers in cart.
+     */
+    public function testGetHighlightedVouchersInCart(): void
+    {
+        // Reset table
+        self::setUpBeforeClass();
+
+        // Code, highlight, for everyone
+        $CodeHighlightEveryone = $this->createDummyCartRule(true, 0, true, true);
+        // Code, highlight, specific customer
+        $CodeHighlightSpecific = $this->createDummyCartRule(true, (int) $this->dummyCustomer->id, true, true);
+        // Code, no highlight, for everyone
+        $CodeNohighlightEveryone = $this->createDummyCartRule(true, 0, true);
+        // Code, no highlight, specific customer
+        $CodeNohighlightSpecific = $this->createDummyCartRule(true, (int) $this->dummyCustomer->id, true);
+        // No code, highlight, for everyone
+        $NocodeHighlightEveryone = $this->createDummyCartRule(true, 0, false, true);
+        // No code, highlight, specific customer
+        $NocodeHighlightSpecific = $this->createDummyCartRule(true, (int) $this->dummyCustomer->id, false, true);
+        // No code, no highlight, for everyone
+        $NocodeNohighlightEveryone = $this->createDummyCartRule(true, 0, false);
+        // No code, no highlight, specific customer
+        $NocodeNohighlightSpecific = $this->createDummyCartRule(true, (int) $this->dummyCustomer->id, false);
+        // Code, highlight, specific customer, disabled
+        $CodeHighlightSpecificDisabled = $this->createDummyCartRule(false, (int) $this->dummyCustomer->id, true, true);
+        // Code, highlight, specific customer, disabled
+        $CodeHighlightSpecificDisabled = $this->createDummyCartRule(false, (int) $this->dummyCustomer->id, true, true);
+
+        // Get logged in customer's vouchers, we simulate getCustomerHighlightedDiscounts with no cart
+        $customerCartRules = CartRule::getCustomerCartRules(
+            $this->defaultLanguageId,
+            (int) $this->dummyCustomer->id,
+            true,
+            true,
+            true,
+            null,
+            false,
+            true
+        );
+        $this->assertEquals(
+            [
+                $CodeHighlightEveryone->id,
+                $NocodeHighlightEveryone->id,
+                $CodeHighlightSpecific->id,
+                $NocodeHighlightSpecific->id,
+            ],
+            array_column($customerCartRules, 'id_cart_rule')
+        );
+
+        // Get guest customer's vouchers, we simulate getCustomerHighlightedDiscounts with no cart
+        $customerCartRules = CartRule::getCustomerCartRules(
+            $this->defaultLanguageId,
+            0,
+            true,
+            true,
+            true,
+            null,
+            false,
+            true
+        );
+        $this->assertEquals(
+            [
+                $CodeHighlightEveryone->id,
+                $NocodeHighlightEveryone->id,
+            ],
+            array_column($customerCartRules, 'id_cart_rule')
+        );
+    }
+
     /**
      * Test sorting of the CartRules
      *
@@ -202,9 +365,7 @@ class CartRuleTest extends TestCase
         $this->assertEquals(
             [
                 $activeCustomerRule->id,
-                $activeGlobalRule->id,
                 $inactiveCustomerRule->id,
-                $inactiveGlobalRule->id,
             ],
             array_column($customerCartRules, 'id_cart_rule')
         );
@@ -220,7 +381,8 @@ class CartRuleTest extends TestCase
     public function createDummyCartRule(
         bool $active,
         int $customerId,
-        bool $code = true
+        bool $code = true,
+        bool $highlight = false
     ): CartRule {
         $randomNumber = rand(999, 9999);
         $cart_rule = new CartRule();
@@ -237,6 +399,7 @@ class CartRuleTest extends TestCase
         $cart_rule->date_from = date('Y-m-d H:i:s', time());
         $cart_rule->date_to = date('Y-m-d H:i:s', time() + 24 * 36000);
         $cart_rule->active = $active;
+        $cart_rule->highlight = $highlight;
         $cart_rule->add();
 
         return $cart_rule;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fixes exposed business logic and voucher display in both front and back office. Brings back the possibility to manually set what rules to highlight, like it was in 1.7.6 and older versions. Reverts some logic introduced in https://github.com/PrestaShop/PrestaShop/pull/22518. See table with change below. I covered everything with integration tests to make sure nobody breaks it again.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | You can use the table below to test it, but I added integration tests for all 8 types of vouchers (+ some disabled ones to be sure) in all 4 places. 👍
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/8052473905
| Fixed issue or discussion?     | Fixes #35408, Fixes #34592
| Related PRs       | 
| Sponsor company   | 

### Description

You can test the behavior with following vouchers. No functionality change in cart "highlight" section.

| Voucher | My account zone | Cart page | Cart page logged out | Backoffice customer detail
| --- | --- | --- | --- | ---
|   | This page should show only vouchers specific to this single customer. | This case should show only rules highlighted and either for current customer or for everyone. | This case should show only rules highlighted and for everyone. | This page should show only vouchers specific to this single customer.
|  |  |  |  | 
| Without PR  |   |   |  | 
| Code, highlight, for everyone | 🔴 YES - not a disaster, but wrong, it's not his specific voucher | 🟢YES | 🟢YES |  🔴YES - wrong, it's not his specific voucher
| Code, highlight, specific customer | 🟢 YES | 🟢YES | 🟢NO | 🟢YES
| Code, no highlight, for everyone | 🟢NO | 🟢NO | 🟢NO |  🟢NO
| Code, no highlight, specific customer | 🟢YES | 🟢NO | 🟢NO |  🟢YES
| No code, highlight, for everyone | 🔴YES - not a disaster, but wrong, it's not his specific voucher | 🟢YES | 🟢YES |  🔴YES - wrong, it's not his specific voucher
| No code, highlight, specific customer | 🟢YES | 🟢YES | 🟢NO |  🟢YES
| No code, no highlight, for everyone | 🔴YES - VERY WRONG, nobody should see this logic | 🟢NO | 🟢NO |  🔴YES - wrong, it's not his specific voucher
| No code, no highlight, specific customer | 🟢YES | 🟢NO | 🟢NO |  🟢YES
|  |  |  |  | 
| With PR |   |   |  | 
| Code, highlight, for everyone | 🟢NO | 🟢YES | 🟢YES |  🟢NO
| Code, highlight, specific customer | 🟢YES | 🟢YES | 🟢NO |  🟢YES
| Code, no highlight, for everyone | 🟢NO | 🟢NO | 🟢NO |  🟢NO
| Code, no highlight, specific customer | 🟢YES | 🟢NO | 🟢NO |  🟢YES
| No code, highlight, for everyone | 🟢NO | 🟢YES | 🟢YES |  🟢NO
| No code, highlight, specific customer | 🟢YES | 🟢YES | 🟢NO |  🟢YES
| No code, no highlight, for everyone | 🟢NO | 🟢NO | 🟢NO |  🟢NO
| No code, no highlight, specific customer | 🟢YES | 🟢NO | 🟢NO |  🟢YES
