### PR TITLE
Order accessories by name

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4433,7 +4433,8 @@ class ProductCore extends ObjectModel
                 ' . Product::sqlStock('p', 0) . '
                 WHERE `id_product_1` = ' . (int) $this->id .
                 ($active ? ' AND product_shop.`active` = 1 AND product_shop.`visibility` != \'none\'' : '') . '
-                GROUP BY product_shop.id_product';
+                GROUP BY product_shop.id_product
+                ORDER BY pl.`name`';
 
         if (!$result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql)) {
             return [];


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Accessories in FO now show up in completely random order, mostly ordered by the index of the table (product ids), but it's not granted. Now, they will be always ordered at least by name, which makes the most sense from user point of ID.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/9660566504 ✅ 
| Fixed issue or discussion?     |
| Related PRs       | 
| Sponsor company   | 

> The order of the rows in the absence of ORDER BY clause may be:
> - different between any two storage engines;
> - if you use the same storage engine, it might be different between any two versions of the same storage engine; Example here, scroll down to "Ordering of Rows".
> - if the storage engine version is the same, but MySQL version is different, it might be different because of the query optimizer changes between those versions;
> - if everything is the same, it could be different due to the moon phase and that is OK.