### PR TITLE
fix hookdatacollector clone smarty component

### DIFF
--- a/src/PrestaShopBundle/DataCollector/HookDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/HookDataCollector.php
@@ -166,7 +166,7 @@ final class HookDataCollector extends DataCollector
     protected function getCasters()
     {
         $casters = parent::getCasters();
-        
+
         $casters['*'] = function ($vv, array $a, Stub $s, $isNested) {
             if (!$vv instanceof Stub) {
                 foreach ($a as $k => $v) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.1.x
| Description?      | Fix BO Symfony error " Warning: Undefined property: Symfony\Component\VarDumper\Caster\CutStub::$cache_locking" because Symfony want to clone a class with property reference (Smarty_Internal_Template --> & Smarty)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open BO, no error
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #30147
| Related PRs       | https://github.com/symfony/symfony/pull/54072
| Sponsor company   | SubitoLabs
