### PR TITLE
Fix deprecated

### DIFF
--- a/src/PrestaShopBundle/DataCollector/HookDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/HookDataCollector.php
@@ -26,13 +26,9 @@
 
 namespace PrestaShopBundle\DataCollector;
 
-use Smarty;
-use Smarty_Internal_Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
-use Symfony\Component\VarDumper\Caster\CutStub;
-use Symfony\Component\VarDumper\Cloner\Stub;
 
 /**
  * Collect all information about Legacy hooks and make it available
@@ -158,28 +154,5 @@ final class HookDataCollector extends DataCollector
         }
 
         return $hooksList;
-    }
-
-    /**
-     * @return callable[] The casters to add to the cloner
-     */
-    protected function getCasters()
-    {
-        $casters = parent::getCasters();
-        
-        $casters['*'] = function ($vv, array $a, Stub $s, $isNested) {
-            if (!$vv instanceof Stub) {
-                foreach ($a as $k => $v) {
-                    $isSmarty = $k === 'smarty' && $vv instanceof Smarty_Internal_Template && $v instanceof Smarty;
-                    if (\is_object($v) && !$v instanceof \DateTimeInterface && !$v instanceof Stub && !$isSmarty) {
-                        $a[$k] = new CutStub($v);
-                    }
-                }
-            }
-
-            return $a;
-        };
-
-        return $casters;
     }
 }

--- a/src/PrestaShopBundle/Security/Admin/EmployeeProvider.php
+++ b/src/PrestaShopBundle/Security/Admin/EmployeeProvider.php
@@ -67,7 +67,7 @@ class EmployeeProvider implements UserProviderInterface
     public function loadUserByUsername($username)
     {
         $cacheKey = sha1($username);
-        $cachedEmployee = $this->cache->getItem("app.employees_${cacheKey}");
+        $cachedEmployee = $this->cache->getItem("app.employees_{$cacheKey}");
 
         if ($cachedEmployee->isHit()) {
             return $cachedEmployee->get();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.1.x
| Description?      | fix deprecation notice https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated#:~:text=Deprecated%3A%20Using%20%24%7Bvar%7D%20in,not%20cause%20the%20deprecation%20notice. Since PHP 8.2, PHP emits a deprecation notice on the following pattern that the dollar sign ($) is placed at the outside of the curly braces:
| Type?             |  improvement 
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #30147
| Related PRs       | 
| Sponsor company   | SubitoLabs
