### PR TITLE
PrestashopDatabaseException on cart confirmation with free delivery cart rules in debug mode #32748 

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -737,7 +737,7 @@ class CartRuleCore extends ObjectModel
                     FROM `' . _DB_PREFIX_ . 'cart_cart_rule` ccr
                     INNER JOIN `' . _DB_PREFIX_ . 'cart` c ON c.id_cart = ccr.id_cart
                     LEFT JOIN `' . _DB_PREFIX_ . 'orders` o ON o.id_cart = c.id_cart
-                    WHERE c.id_customer = ' . $cart->id_customer . ' AND c.id_cart = ' . $cart->id . ' AND ccr.id_cart_rule = ' . (int) $this->id . ' AND o.id_order IS NULL
+                    WHERE c.id_customer = ' . $cart->id_customer . ' AND c.id_cart = ' . (int) $cart->id . ' AND ccr.id_cart_rule = ' . (int) $this->id . ' AND o.id_order IS NULL
                 ');
             } else {
                 // When checking the cart rules present in that cart the request result is accurate


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x
| Description?      |  PrestashopDatabaseException on cart confirmation with free delivery cart rules in debug mode #32748 
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | yes
| How to test?      | See also #32748 
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/11889887087 ✅ 
| Fixed issue or discussion?     | Fixes #32748
| Related PRs       | none
| Sponsor company   | @202ecommerce
