### PR TITLE
Revert MacOs runner because of its instability

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read  # for actions/checkout to fetch code
     name: PHP CS Fixer
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Revert MacOs runner because of its instability (initially was added in https://github.com/PrestaShop/PrestaShop/pull/35249)
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green
| UI Tests          | ~
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
