### PR TITLE
Set the most commonly used tax rules group for new products

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read  # for actions/checkout to fetch code
     name: PHP CS Fixer
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/admin-dev/themes/new-theme/js/pages/feature/feature-value/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/feature/feature-value/index.ts
@@ -27,7 +27,6 @@ import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sq
 import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
 import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
 import Grid from '@components/grid/grid';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
 import SortingExtension from '@components/grid/extension/sorting-extension';
 import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
@@ -46,6 +45,5 @@ $(() => {
   grid.addExtension(new SortingExtension());
   grid.addExtension(new SubmitRowActionExtension());
   grid.addExtension(new SubmitBulkExtension());
-  grid.addExtension(new LinkRowActionExtension());
   grid.addExtension(new BulkActionCheckboxExtension());
 });

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -774,7 +774,7 @@ class ProductCore extends ObjectModel
             $this->product_type = ProductType::TYPE_VIRTUAL;
         }
 
-        if($this->getIdTaxRulesGroupMostUsed() !== false && $this->id_tax_rules_group === null) {
+        if ($this->getIdTaxRulesGroupMostUsed() !== false && $this->id_tax_rules_group === null) {
             $this->id_tax_rules_group = (int) $this->getIdTaxRulesGroupMostUsed();
         }
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -774,6 +774,10 @@ class ProductCore extends ObjectModel
             $this->product_type = ProductType::TYPE_VIRTUAL;
         }
 
+        if($this->getIdTaxRulesGroupMostUsed() !== false && $this->id_tax_rules_group === null) {
+            $this->id_tax_rules_group = (int) $this->getIdTaxRulesGroupMostUsed();
+        }
+
         if (!parent::add($autodate, $null_values)) {
             return false;
         }

--- a/src/Core/Grid/Definition/Factory/FeatureGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/FeatureGridDefinitionFactory.php
@@ -121,7 +121,6 @@ class FeatureGridDefinitionFactory extends AbstractGridDefinitionFactory
                         'route' => 'admin_feature_values_index',
                         'route_param_name' => 'featureId',
                         'route_param_field' => 'id_feature',
-                        'clickable_row' => true,
                     ])
                      )
                     ->add((new LinkRowAction('edit'))

--- a/src/Core/Grid/Definition/Factory/FeatureValueGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/FeatureValueGridDefinitionFactory.php
@@ -125,7 +125,6 @@ class FeatureValueGridDefinitionFactory extends AbstractFilterableGridDefinition
                                 'extra_route_params' => [
                                     'featureId' => 'id_feature',
                                 ],
-                                'clickable_row' => true,
                             ])
                     )
                     ->add(

--- a/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
+++ b/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
@@ -95,6 +95,7 @@ class LegacyLinkLinterCommand extends Command
         'admin_products_quantity',
         'admin_categories_get_categories_tree',
         'admin_catalog_price_rules_list_for_product',
+        'admin_features_horizontal_index',
         'admin_products_toggle_status_for_shop',
     ];
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
@@ -315,16 +315,20 @@ class FeatureController extends FrameworkBundleAdminController
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    private function getSettingsTipMessage()
+    private function getSettingsTipMessage(): string
     {
-        if ($this->isFeatureEnabled()) {
-            return null;
-        }
-
         $urlOpening = sprintf('<a href="%s">', $this->get('router')->generate('admin_performance'));
         $urlEnding = '</a>';
+
+        if ($this->isFeatureEnabled()) {
+            return $this->trans(
+                'The features are enabled on your store. Go to %sAdvanced Parameters > Performance%s to edit settings.',
+                'Admin.Catalog.Notification',
+                [$urlOpening, $urlEnding]
+            );
+        }
 
         return $this->trans(
             'The features are disabled on your store. Go to %sAdvanced Parameters > Performance%s to edit settings.',

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureValueController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureValueController.php
@@ -107,18 +107,18 @@ class FeatureValueController extends FrameworkBundleAdminController
             if (null !== $handlerResult->getIdentifiableObjectId()) {
                 $this->addFlash('success', $this->trans('Successful creation', 'Admin.Notifications.Success'));
 
-                // Case 1 - save and stay, user entered the form from feature value list
-                if ($request->request->has(self::SAVE_AND_ADD_BUTTON_NAME) && $featureId) {
-                    return $this->redirectToRoute('admin_feature_values_add', ['featureId' => $featureId]);
-                // Case 2 - save and stay, user entered the form from feature list
-                } elseif ($request->request->has(self::SAVE_AND_ADD_BUTTON_NAME)) {
-                    return $this->redirectToRoute('admin_feature_values_add');
-                // Case 3 - save and exit, user entered the form from feature value list
-                } elseif ($featureId) {
-                    return $this->redirectToRoute('admin_feature_values_index', ['featureId' => $featureId]);
+                if ($request->request->has(self::SAVE_AND_ADD_BUTTON_NAME)) {
+                    return $this->redirectToRoute('admin_feature_values_add', [
+                        'featureId' => $featureId,
+                    ]);
                 }
 
-                // Case 4 - save and exit, if user entered the form from feature list
+                if ($featureId) {
+                    return $this->redirectToRoute('admin_feature_values_index', [
+                        'featureId' => $featureId,
+                    ]);
+                }
+
                 return $this->redirectToRoute('admin_features_index');
             }
         } catch (Exception $e) {
@@ -127,18 +127,10 @@ class FeatureValueController extends FrameworkBundleAdminController
             return $this->redirectToRoute('admin_features_index');
         }
 
-        // Resolve a link to use when cancelling the form
-        if ($featureId) {
-            $cancelLink = $this->generateUrl('admin_feature_values_index', ['featureId' => $featureId]);
-        } else {
-            $cancelLink = $this->generateUrl('admin_features_index');
-        }
-
         return $this->render('@PrestaShop/Admin/Sell/Catalog/Features/FeatureValue/create.html.twig', [
             'featureId' => $featureId,
             'featureValueForm' => $featureValueForm->createView(),
             'layoutTitle' => $this->trans('New Feature Value', 'Admin.Navigation.Menu'),
-            'cancelLink' => $cancelLink,
         ]);
     }
 
@@ -186,7 +178,6 @@ class FeatureValueController extends FrameworkBundleAdminController
                 'Feature value',
                 'Admin.Navigation.Menu',
             ),
-            'cancelLink' => $this->generateUrl('admin_feature_values_index', ['featureId' => $featureId]),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -783,16 +783,20 @@ class ManufacturerController extends FrameworkBundleAdminController
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    private function getSettingsTipMessage()
+    private function getSettingsTipMessage(): string
     {
-        if ($this->getConfiguration()->get('PS_DISPLAY_MANUFACTURERS')) {
-            return null;
-        }
-
         $urlOpening = sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences'));
         $urlEnding = '</a>';
+
+        if ($this->getConfiguration()->get('PS_DISPLAY_MANUFACTURERS')) {
+            return $this->trans(
+                'The display of your brands is enabled on your store. Go to %sShop Parameters > General%s to edit settings.',
+                'Admin.Catalog.Notification',
+                [$urlOpening, $urlEnding]
+            );
+        }
 
         return $this->trans(
             'The display of your brands is disabled on your store. Go to %sShop Parameters > General%s to edit settings.',

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -532,16 +532,20 @@ class SupplierController extends FrameworkBundleAdminController
     }
 
     /**
-     * @return string|null
+     * @return string
      */
     protected function getSettingsTipMessage()
     {
-        if ($this->getConfiguration()->get('PS_DISPLAY_SUPPLIERS')) {
-            return null;
-        }
-
         $urlOpening = sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences'));
         $urlEnding = '</a>';
+
+        if ($this->getConfiguration()->get('PS_DISPLAY_SUPPLIERS')) {
+            return $this->trans(
+                'The display of your suppliers is enabled on your store. Go to %sShop Parameters > General%s to edit settings.',
+                'Admin.Catalog.Notification',
+                [$urlOpening, $urlEnding]
+            );
+        }
 
         return $this->trans(
             'The display of your suppliers is disabled on your store. Go to %sShop Parameters > General%s to edit settings.',

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/FeatureValue/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/FeatureValue/Blocks/form.html.twig
@@ -39,7 +39,7 @@
     </div>
 
     <div class="card-footer">
-      <a href="{{ cancelLink }}" class="btn btn-outline-secondary">
+      <a href="{{ path('admin_features_index', {'featureId': featureId}) }}" class="btn btn-outline-secondary">
         {{ 'Cancel'|trans({}, 'Admin.Actions') }}
       </a>
       <div class="float-right">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/index.html.twig
@@ -28,9 +28,7 @@
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% block content %}
-  {% if settingsTipMessage is not empty %}
-    {{ ps.infotip(settingsTipMessage, true) }}
-  {% endif %}
+  {{ ps.infotip(settingsTipMessage, true) }}
   {% block feature_group_showcase_card %}
       {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/showcase_card.html.twig' %}
   {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Blocks/View/products.html.twig
@@ -29,96 +29,92 @@
     ({{ viewableManufacturer.manufacturerProducts|length }})
   </h3>
   <div class="card-body">
-    {% if viewableManufacturer.manufacturerProducts is not empty %}
-      {% for product in viewableManufacturer.manufacturerProducts %}
-        <div class="card">
-          <div class="card-header clearfix">
-            <a href="{{ path('admin_products_edit', {'productId': product.id}) }}">{{ product.name }}</a>
+    {% for product in viewableManufacturer.manufacturerProducts %}
+      <div class="card">
+        <div class="card-header clearfix">
+          <a href="{{ path('admin_products_edit', {'productId': product.id}) }}">{{ product.name }}</a>
 
-            <div class="d-inline-block float-right">
-              <div class="btn-group-action text-right">
-                <div class="btn-group">
-                  <a class="btn btn-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split p-0 no-rotate" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <div class="d-inline-block float-right">
+            <div class="btn-group-action text-right">
+              <div class="btn-group">
+                <a class="btn btn-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split p-0 no-rotate" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                </a>
+                <div class="dropdown-menu dropdown-menu-right">
+                  <a class="btn tooltip-link js-submit-row-action dropdown-item"
+                     href="{{ path('admin_products_edit', {'productId': product.id}) }}"
+                  >
+                    {{ 'Edit'|trans({}, 'Admin.Actions') }}
                   </a>
-                  <div class="dropdown-menu dropdown-menu-right">
-                    <a class="btn tooltip-link js-submit-row-action dropdown-item"
-                      href="{{ path('admin_products_edit', {'productId': product.id}) }}"
-                    >
-                      {{ 'Edit'|trans({}, 'Admin.Actions') }}
-                    </a>
-                    <button class="btn tooltip-link js-form-submit-btn dropdown-item"
-                            type="button"
-                            data-form-submit-url="{{ path('admin_products_delete_from_all_shops', {'productId': product.id}) }}"
-                            data-form-confirm-message="{{ '%s%s?'|format('Delete item #'|trans({}, 'Admin.International.Feature'), product.id) }}"
-                    >
-                      {{ 'Delete'|trans({}, 'Admin.Actions') }}
-                    </button>
-                  </div>
+                  <button class="btn tooltip-link js-form-submit-btn dropdown-item"
+                          type="button"
+                          data-form-submit-url="{{ path('admin_products_delete_from_all_shops', {'productId': product.id}) }}"
+                          data-form-confirm-message="{{ '%s%s?'|format('Delete item #'|trans({}, 'Admin.International.Feature'), product.id) }}"
+                  >
+                    {{ 'Delete'|trans({}, 'Admin.Actions') }}
+                  </button>
                 </div>
               </div>
             </div>
           </div>
-          <div class="card-body">
-            {% if product.combinations is not empty %}
-              <table class="table">
-                <thead>
-                  <tr>
-                    <th>{{ 'Attribute name'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                    <th>{{ 'Reference'|trans({}, 'Admin.Global') }}</th>
-                    <th>{{ 'EAN-13'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                    <th>{{ 'UPC'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                    <th>{{ 'MPN'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                    {% if not isAllShopContext and isStockManagementEnabled %}
-                      <th>{{ 'Available quantity'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                    {% endif %}
-                  </tr>
-                </thead>
-                <tbody>
-                  {% for combination in product.combinations %}
-                    <tr>
-                      <td>{{ combination.attributes }}</td>
-                      <td>{{ combination.reference }}</td>
-                      <td>{{ combination.ean13 }}</td>
-                      <td>{{ combination.upc }}</td>
-                      <td>{{ combination.mpn }}</td>
-                      {% if not isAllShopContext and isStockManagementEnabled %}
-                        <td>{{ combination.quantity }}</td>
-                      {% endif %}
-                    </tr>
-                  {% endfor %}
-                </tbody>
-              </table>
-            {% else %}
-              <table class="table">
-                <thead>
-                  <tr>
-                    <th>{{ 'Ref:'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                    <th>{{ 'EAN-13:'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                    <th>{{ 'UPC:'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                    <th>{{ 'MPN:'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                    {% if isStockManagementEnabled %}
-                      <th>{{ 'Qty:'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                    {% endif %}
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>{{ product.reference }}</td>
-                    <td>{{ product.ean13 }}</td>
-                    <td>{{  product.upc }}</td>
-                    <td>{{  product.mpn }}</td>
-                    {% if isStockManagementEnabled %}
-                      <td>{{ product.quantity }}</td>
-                    {% endif %}
-                  </tr>
-                </tbody>
-              </table>
-            {% endif %}
-          </div>
         </div>
-      {% endfor %}
-    {% else %}
-      {{ 'No products has been found for this brand.'|trans({}, 'Admin.Catalog.Notification') }}
-    {% endif %}
+        <div class="card-body">
+          {% if product.combinations is not empty %}
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>{{ 'Attribute name'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                  <th>{{ 'Reference'|trans({}, 'Admin.Global') }}</th>
+                  <th>{{ 'EAN-13'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                  <th>{{ 'UPC'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                  <th>{{ 'MPN'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                  {% if not isAllShopContext and isStockManagementEnabled %}
+                    <th>{{ 'Available quantity'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                  {% endif %}
+                </tr>
+              </thead>
+              <tbody>
+                {% for combination in product.combinations %}
+                  <tr>
+                    <td>{{ combination.attributes }}</td>
+                    <td>{{ combination.reference }}</td>
+                    <td>{{ combination.ean13 }}</td>
+                    <td>{{ combination.upc }}</td>
+                    <td>{{ combination.mpn }}</td>
+                    {% if not isAllShopContext and isStockManagementEnabled %}
+                      <td>{{ combination.quantity }}</td>
+                    {% endif %}
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          {% else %}
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>{{ 'Ref:'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                  <th>{{ 'EAN-13:'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                  <th>{{ 'UPC:'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                  <th>{{ 'MPN:'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                  {% if isStockManagementEnabled %}
+                    <th>{{ 'Qty:'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                  {% endif %}
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>{{ product.reference }}</td>
+                  <td>{{ product.ean13 }}</td>
+                  <td>{{  product.upc }}</td>
+                  <td>{{  product.mpn }}</td>
+                  {% if isStockManagementEnabled %}
+                    <td>{{ product.quantity }}</td>
+                  {% endif %}
+                </tr>
+              </tbody>
+            </table>
+          {% endif %}
+        </div>
+      </div>
+    {% endfor %}
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/index.html.twig
@@ -28,9 +28,7 @@
 
 {% block content %}
   {% block manufacturers_listing %}
-    {% if settingsTipMessage is not empty %}
-      {{ ps.infotip(settingsTipMessage, true) }}
-    {% endif %}
+    {{ ps.infotip(settingsTipMessage, true) }}
     {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': manufacturerGrid} %}
   {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
@@ -28,9 +28,7 @@
 
 {% block content %}
   {% block supplier_grid %}
-    {% if settingsTipMessage is not empty %}
-      {{ ps.infotip(settingsTipMessage, true) }}
-    {% endif %}
+    {{ ps.infotip(settingsTipMessage, true) }}
     {% include'@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': supplierGrid} %}
   {% endblock %}
 {% endblock %}

--- a/tests/UI/campaigns/functional/BO/13_shopParameters/01_general/general/08_enableDisableSuppliers.ts
+++ b/tests/UI/campaigns/functional/BO/13_shopParameters/01_general/general/08_enableDisableSuppliers.ts
@@ -71,36 +71,34 @@ describe('BO - Shop Parameters - General : Enable/Disable display suppliers', as
         expect(result).to.contains(generalPage.successfulUpdateMessage);
       });
 
-      if (test.args.action === 'Disable') {
-        it('should go to \'Brands & Suppliers\' page', async function () {
-          await testContext.addContextItem(this, 'testIdentifier', `goToBrandsPage_${index}`, baseContext);
+      it('should go to \'Brands & Suppliers\' page', async function () {
+        await testContext.addContextItem(this, 'testIdentifier', `goToBrandsPage_${index}`, baseContext);
 
-          await generalPage.goToSubMenu(
-            page,
-            generalPage.catalogParentLink,
-            generalPage.brandsAndSuppliersLink,
-          );
+        await generalPage.goToSubMenu(
+          page,
+          generalPage.catalogParentLink,
+          generalPage.brandsAndSuppliersLink,
+        );
 
-          const pageTitle = await brandsPage.getPageTitle(page);
-          expect(pageTitle).to.contains(brandsPage.pageTitle);
-        });
+        const pageTitle = await brandsPage.getPageTitle(page);
+        expect(pageTitle).to.contains(brandsPage.pageTitle);
+      });
 
-        it('should go to \'Suppliers\' tab', async function () {
-          await testContext.addContextItem(this, 'testIdentifier', `goToSuppliersTab_${index}`, baseContext);
+      it('should go to \'Suppliers\' tab', async function () {
+        await testContext.addContextItem(this, 'testIdentifier', `goToSuppliersTab_${index}`, baseContext);
 
-          await brandsPage.goToSubTabSuppliers(page);
+        await brandsPage.goToSubTabSuppliers(page);
 
-          const pageTitle = await suppliersPage.getPageTitle(page);
-          expect(pageTitle).to.contains(suppliersPage.pageTitle);
-        });
+        const pageTitle = await suppliersPage.getPageTitle(page);
+        expect(pageTitle).to.contains(suppliersPage.pageTitle);
+      });
 
-        it(`should check that the message alert contains '${test.args.action}'`, async function () {
-          await testContext.addContextItem(this, 'testIdentifier', `checkAlertContains_${test.args.action}`, baseContext);
+      it(`should check that the message alert contains '${test.args.action}'`, async function () {
+        await testContext.addContextItem(this, 'testIdentifier', `checkAlertContains_${test.args.action}`, baseContext);
 
-          const text = await suppliersPage.getAlertInfoBlockParagraphContent(page);
-          expect(text).to.contains(test.args.action.toLowerCase());
-        });
-      }
+        const text = await suppliersPage.getAlertInfoBlockParagraphContent(page);
+        expect(text).to.contains(test.args.action.toLowerCase());
+      });
 
       it('should go to FO', async function () {
         await testContext.addContextItem(this, 'testIdentifier', `goToFO_${test.args.action}`, baseContext);
@@ -126,16 +124,14 @@ describe('BO - Shop Parameters - General : Enable/Disable display suppliers', as
         expect(exist).to.be.equal(test.args.exist);
       });
 
-      if (test.args.action === 'Enable') {
-        it('should go back to BO', async function () {
-          await testContext.addContextItem(this, 'testIdentifier', `goBackToBo_${test.args.action}`, baseContext);
+      it('should go back to BO', async function () {
+        await testContext.addContextItem(this, 'testIdentifier', `goBackToBo_${test.args.action}`, baseContext);
 
-          page = await siteMapPage.closePage(browserContext, page, 0);
+        page = await siteMapPage.closePage(browserContext, page, 0);
 
-          const pageTitle = await generalPage.getPageTitle(page);
-          expect(pageTitle).to.contains(generalPage.pageTitle);
-        });
-      }
+        const pageTitle = await suppliersPage.getPageTitle(page);
+        expect(pageTitle).to.contains(suppliersPage.pageTitle);
+      });
     });
   });
 });

--- a/tests/UI/campaigns/functional/BO/13_shopParameters/01_general/general/09_enableDisableBrands.ts
+++ b/tests/UI/campaigns/functional/BO/13_shopParameters/01_general/general/09_enableDisableBrands.ts
@@ -68,27 +68,25 @@ describe('BO - Shop Parameters - General : Enable/Disable display brands', async
         expect(result).to.contains(generalPage.successfulUpdateMessage);
       });
 
-      if (test.args.action === 'Disable') {
-        it('should go to \'Brands & Suppliers\' page', async function () {
-          await testContext.addContextItem(this, 'testIdentifier', `goToBrandsPage_${index}`, baseContext);
+      it('should go to \'Brands & Suppliers\' page', async function () {
+        await testContext.addContextItem(this, 'testIdentifier', `goToBrandsPage_${index}`, baseContext);
 
-          await generalPage.goToSubMenu(
-            page,
-            generalPage.catalogParentLink,
-            generalPage.brandsAndSuppliersLink,
-          );
+        await generalPage.goToSubMenu(
+          page,
+          generalPage.catalogParentLink,
+          generalPage.brandsAndSuppliersLink,
+        );
 
-          const pageTitle = await brandsPage.getPageTitle(page);
-          expect(pageTitle).to.contains(brandsPage.pageTitle);
-        });
+        const pageTitle = await brandsPage.getPageTitle(page);
+        expect(pageTitle).to.contains(brandsPage.pageTitle);
+      });
 
-        it(`should check that the message alert contains '${test.args.action}'`, async function () {
-          await testContext.addContextItem(this, 'testIdentifier', `checkAlertContains_${test.args.action}`, baseContext);
+      it(`should check that the message alert contains '${test.args.action}'`, async function () {
+        await testContext.addContextItem(this, 'testIdentifier', `checkAlertContains_${test.args.action}`, baseContext);
 
-          const text = await brandsPage.getAlertInfoBlockParagraphContent(page);
-          expect(text).to.contains(test.args.action.toLowerCase());
-        });
-      }
+        const text = await brandsPage.getAlertInfoBlockParagraphContent(page);
+        expect(text).to.contains(test.args.action.toLowerCase());
+      });
 
       it('should go to FO', async function () {
         await testContext.addContextItem(this, 'testIdentifier', `goToFO_${test.args.action}`, baseContext);
@@ -115,16 +113,14 @@ describe('BO - Shop Parameters - General : Enable/Disable display brands', async
         expect(exist).to.be.equal(test.args.exist);
       });
 
-      if (test.args.action === 'Disable') {
-        it('should go back to BO', async function () {
-          await testContext.addContextItem(this, 'testIdentifier', `goBackToBo_${test.args.action}`, baseContext);
+      it('should go back to BO', async function () {
+        await testContext.addContextItem(this, 'testIdentifier', `goBackToBo_${test.args.action}`, baseContext);
 
-          page = await siteMapPage.closePage(browserContext, page, 0);
+        page = await siteMapPage.closePage(browserContext, page, 0);
 
-          const pageTitle = await brandsPage.getPageTitle(page);
-          expect(pageTitle).to.contains(brandsPage.pageTitle);
-        });
-      }
+        const pageTitle = await brandsPage.getPageTitle(page);
+        expect(pageTitle).to.contains(brandsPage.pageTitle);
+      });
     });
   });
 });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Many users have noticed an issue where the group of tax rules (VAT) is not automatically selected when creating new products. This functionality appears to be working in older versions, such as 1.7.8.5.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| How to test?      | When creating a new product, check whether the most used tax groups rule is automatically determined
| Fixed issue or discussion?     | Fixes #35403
| Sponsor company   | Remitalis
