### PR TITLE
Add Export button missing on new Product Page V2

### DIFF
--- a/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
@@ -634,6 +634,14 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ])
             )
             ->add(
+                (new LinkGridAction('export'))
+                    ->setName($this->trans('Export', [], 'Admin.Actions'))
+                    ->setIcon('cloud_download')
+                    ->setOptions([
+                        'route' => 'admin_products_export',
+                    ])
+            )
+            ->add(
                 (new SimpleGridAction('common_refresh_list'))
                     ->setName($this->trans('Refresh list', [], 'Admin.Advparameters.Feature'))
                     ->setIcon('refresh')

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -718,9 +718,17 @@ class ProductController extends FrameworkBundleAdminController
         return $this->updateProductStatusByShopConstraint($productId, false, ShopConstraint::allShops());
     }
 
+    /**
+     * Export filtered products
+     *
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     *
+     * @param ProductFilters $filters
+     *
+     * @return CsvResponse
+     */
     public function exportAction(ProductFilters $filters)
     {
-
         if ($this->shouldRedirectToV1()) {
             return $this->redirectToRoute('admin_product_catalog');
         }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -729,10 +729,6 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function exportAction(ProductFilters $filters)
     {
-        if ($this->shouldRedirectToV1()) {
-            return $this->redirectToRoute('admin_product_catalog');
-        }
-
         $productGridFactory = $this->get('prestashop.core.grid.factory.product');
         $grid = $productGridFactory->getGrid($filters);
 

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products_v2/product.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products_v2/product.yml
@@ -34,6 +34,14 @@ admin_products_preview:
   requirements:
     productId: \d+
 
+admin_products_export:
+  path: /export
+  methods: [ GET ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::exportAction
+    _legacy_controller: AdminProducts
+    _legacy_link: AdminProducts:exportproduct
+
 admin_products_search:
   path: /
   methods: [ POST ]

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products_v2/product.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products_v2/product.yml
@@ -40,7 +40,7 @@ admin_products_export:
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::exportAction
     _legacy_controller: AdminProducts
-    _legacy_link: AdminProducts:exportproduct
+    _legacy_link: AdminProducts
 
 admin_products_search:
   path: /


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | This PR introduces the much-requested "Export" button to the new Product Page V2 in PrestaShop, addressing a significant gap in the platform's functionality. Previously, users experienced a workflow interruption due to the absence of an export feature directly from the product list, which is essential for exporting data to CSV or Excel formats for various operational needs. This update brings consistency across the platform's interfaces, significantly enhances operational efficiency, enables seamless data integration with external systems, supports advanced reporting and analytics, and meets user expectations for feature parity with previous versions. By reinstating the export feature, this PR ensures that PrestaShop remains a comprehensive tool for e-commerce businesses, catering to their evolving needs and maintaining its utility and user satisfaction.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| How to test?      | Turn new product page -> Go to the product list -> click config icon -> click "Export"
| Fixed issue or discussion?     | #35485
| Sponsor company   | Code Olympus
