### PR TITLE
Add most used rule group to new products

### DIFF
--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -271,6 +271,7 @@ class ProductRepository extends AbstractMultiShopObjectModelRepository
         $product->id_shop_default = $shopId->getValue();
         $product->name = $localizedNames;
         $product->link_rewrite = $localizedLinkRewrites;
+        $product->id_tax_rules_group = $this->taxRulesGroupRepository->getIdTaxRulesGroupMostUsed();
 
         $this->productValidator->validateCreation($product);
         $this->addObjectModelToShops($product, [$shopId], CannotAddProductException::class);

--- a/src/Adapter/TaxRulesGroup/Repository/TaxRulesGroupRepository.php
+++ b/src/Adapter/TaxRulesGroup/Repository/TaxRulesGroupRepository.php
@@ -39,6 +39,7 @@ use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupNotFo
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\ValueObject\TaxRulesGroupId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Repository\AbstractMultiShopObjectModelRepository;
+use Product;
 use TaxRulesGroup;
 
 /**
@@ -196,5 +197,15 @@ class TaxRulesGroupRepository extends AbstractMultiShopObjectModelRepository
             CannotUpdateStoreException::class,
             $errorCode
         );
+    }
+
+    /**
+     * Get most used Tax.
+     *
+     * @return int
+     */
+    public function getIdTaxRulesGroupMostUsed()
+    {
+        return (int) Product::getIdTaxRulesGroupMostUsed();
     }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_prices.feature
@@ -11,15 +11,15 @@ Feature: Update product price fields from Back Office (BO) when default country 
       | name[en-US] | magic staff |
       | type        | standard    |
     And product product1 should have following prices information:
-      | price              | 0     |
-      | price_tax_included | 0     |
-      | ecotax             | 0     |
-      | tax rules group    |       |
-      | on_sale            | false |
-      | wholesale_price    | 0     |
-      | unit_price         | 0     |
-      | unit_price_ratio   | 0     |
-      | unity              |       |
+      | price              | 0               |
+      | price_tax_included | 0               |
+      | ecotax             | 0               |
+      | tax rules group    | US-FL Rate (6%) |
+      | on_sale            | false           |
+      | wholesale_price    | 0               |
+      | unit_price         | 0               |
+      | unit_price_ratio   | 0               |
+      | unity              |                 |
 
   Scenario: I update product prices
     And tax rules group named "US-AL Rate (4%)" exists
@@ -142,85 +142,85 @@ Feature: Update product price fields from Back Office (BO) when default country 
       | price      | 200 |
       | unit_price | 300 |
     And product product1 should have following prices information:
-      | price                   | 200      |
-      | price_tax_included      | 200      |
-      | ecotax                  | 0        |
-      | tax rules group         |          |
-      | on_sale                 | false    |
-      | wholesale_price         | 0        |
-      | unit_price              | 300      |
-      | unit_price_tax_included | 300      |
-      | unit_price_ratio        | 0.666666 |
-      | unity                   |          |
+      | price                   | 200             |
+      | price_tax_included      | 212             |
+      | ecotax                  | 0               |
+      | tax rules group         | US-FL Rate (6%) |
+      | on_sale                 | false           |
+      | wholesale_price         | 0               |
+      | unit_price              | 300             |
+      | unit_price_tax_included | 318             |
+      | unit_price_ratio        | 0.666666        |
+      | unity                   |                 |
     When I update product "product1" with following values:
       | price      | 0 |
     Then product product1 should have following prices information:
-      | price                   | 0     |
-      | price_tax_included      | 0     |
-      | ecotax                  | 0     |
-      | tax rules group         |       |
-      | on_sale                 | false |
-      | wholesale_price         | 0     |
-      | unit_price              | 0     |
-      | unit_price_tax_included | 0     |
-      | unit_price_ratio        | 0     |
-      | unity                   |       |
+      | price                   | 0               |
+      | price_tax_included      | 0               |
+      | ecotax                  | 0               |
+      | tax rules group         | US-FL Rate (6%) |
+      | on_sale                 | false           |
+      | wholesale_price         | 0               |
+      | unit_price              | 0               |
+      | unit_price_tax_included | 0               |
+      | unit_price_ratio        | 0               |
+      | unity                   |                 |
     # Even if you try to update unit price it remains zero because price is still zero
     When I update product "product1" with following values:
       | unit_price | 300 |
     Then product product1 should have following prices information:
-      | price                   | 0     |
-      | price_tax_included      | 0     |
-      | ecotax                  | 0     |
-      | tax rules group         |       |
-      | on_sale                 | false |
-      | wholesale_price         | 0     |
-      | unit_price              | 0     |
-      | unit_price_tax_included | 0     |
-      | unit_price_ratio        | 0     |
-      | unity                   |       |
+      | price                   | 0               |
+      | price_tax_included      | 0               |
+      | ecotax                  | 0               |
+      | tax rules group         | US-FL Rate (6%) |
+      | on_sale                 | false           |
+      | wholesale_price         | 0               |
+      | unit_price              | 0               |
+      | unit_price_tax_included | 0               |
+      | unit_price_ratio        | 0               |
+      | unity                   |                 |
 
   Scenario: I update product unit price when product price is 0 even if unit price was being modified
     When I update product "product1" with following values:
       | price      | 200 |
       | unit_price | 300 |
     And product product1 should have following prices information:
-      | price                   | 200      |
-      | price_tax_included      | 200      |
-      | ecotax                  | 0        |
-      | tax rules group         |          |
-      | on_sale                 | false    |
-      | wholesale_price         | 0        |
-      | unit_price              | 300      |
-      | unit_price_tax_included | 300      |
-      | unit_price_ratio        | 0.666666 |
-      | unity                   |          |
+      | price                   | 200             |
+      | price_tax_included      | 212             |
+      | ecotax                  | 0               |
+      | tax rules group         | US-FL Rate (6%) |
+      | on_sale                 | false           |
+      | wholesale_price         | 0               |
+      | unit_price              | 300             |
+      | unit_price_tax_included | 318             |
+      | unit_price_ratio        | 0.666666        |
+      | unity                   |                 |
     When I update product "product1" with following values:
       | price      | 0   |
       | unit_price | 300 |
     And product product1 should have following prices information:
-      | price                   | 0     |
-      | price_tax_included      | 0     |
-      | ecotax                  | 0     |
-      | tax rules group         |       |
-      | on_sale                 | false |
-      | wholesale_price         | 0     |
-      | unit_price              | 0     |
-      | unit_price_tax_included | 0     |
-      | unit_price_ratio        | 0     |
-      | unity                   |       |
+      | price                   | 0               |
+      | price_tax_included      | 0               |
+      | ecotax                  | 0               |
+      | tax rules group         | US-FL Rate (6%) |
+      | on_sale                 | false           |
+      | wholesale_price         | 0               |
+      | unit_price              | 0               |
+      | unit_price_tax_included | 0               |
+      | unit_price_ratio        | 0               |
+      | unity                   |                 |
 
   Scenario: I update product tax the price tax included and unit price tax included is impacted
     When I update product "product1" with following values:
       | price      | 20  |
       | unit_price | 500 |
     Then product product1 should have following prices information:
-      | price                   | 20   |
-      | price_tax_included      | 20   |
-      | unit_price              | 500  |
-      | unit_price_tax_included | 500  |
-      | unit_price_ratio        | 0.04 |
-      | tax rules group         |      |
+      | price                   | 20              |
+      | price_tax_included      | 21.20           |
+      | unit_price              | 500             |
+      | unit_price_tax_included | 530             |
+      | unit_price_ratio        | 0.04            |
+      | tax rules group         | US-FL Rate (6%) |
     When I update product "product1" with following values:
       | tax rules group | US-AL Rate (4%) |
     Then product product1 should have following prices information:

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_prices_ecotax.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_prices_ecotax.feature
@@ -9,15 +9,15 @@ Feature: Update product price fields from Back Office (BO).
       | name[en-US] | washing machine |
       | type        | standard        |
     And product ecoProduct should have following prices information:
-      | price              | 0     |
-      | price_tax_included | 0     |
-      | ecotax             | 0     |
-      | tax rules group    |       |
-      | on_sale            | false |
-      | wholesale_price    | 0     |
-      | unit_price         | 0     |
-      | unit_price_ratio   | 0     |
-      | unity              |       |
+      | price              | 0               |
+      | price_tax_included | 0               |
+      | ecotax             | 0               |
+      | tax rules group    | US-FL Rate (6%) |
+      | on_sale            | false           |
+      | wholesale_price    | 0               |
+      | unit_price         | 0               |
+      | unit_price_ratio   | 0               |
+      | unity              |                 |
     And shop configuration for "PS_USE_ECOTAX" is set to 1
     And I identify tax rules group named "US-AL Rate (4%)" as "us-al-tax-rate"
     And I identify tax rules group named "US-KS Rate (5.3%)" as "us-ks-tax-rate"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_prices_without_states.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_prices_without_states.feature
@@ -16,15 +16,15 @@ Feature: Update product price fields from Back Office (BO) when default country 
       | name[en-US] | magic staff |
       | type        | standard    |
     And product product1 should have following prices information:
-      | price              | 0     |
-      | price_tax_included | 0     |
-      | ecotax             | 0     |
-      | tax rules group    |       |
-      | on_sale            | false |
-      | wholesale_price    | 0     |
-      | unit_price         | 0     |
-      | unit_price_ratio   | 0     |
-      | unity              |       |
+      | price              | 0               |
+      | price_tax_included | 0               |
+      | ecotax             | 0               |
+      | tax rules group    | US-FL Rate (6%) |
+      | on_sale            | false           |
+      | wholesale_price    | 0               |
+      | unit_price         | 0               |
+      | unit_price_ratio   | 0               |
+      | unity              |                 |
     And I add new tax "fr-tax-6" with following properties:
       | name         | FR Tax (6%)   |
       | rate         | 6             |
@@ -106,12 +106,12 @@ Feature: Update product price fields from Back Office (BO) when default country 
       | price      | 20  |
       | unit_price | 500 |
     Then product product1 should have following prices information:
-      | price                   | 20   |
-      | price_tax_included      | 20   |
-      | unit_price              | 500  |
-      | unit_price_tax_included | 500  |
-      | unit_price_ratio        | 0.04 |
-      | tax rules group         |      |
+      | price                   | 20              |
+      | price_tax_included      | 20              |
+      | unit_price              | 500             |
+      | unit_price_tax_included | 500             |
+      | unit_price_ratio        | 0.04            |
+      | tax rules group         | US-FL Rate (6%) |
     When I update product "product1" with following values:
       | tax rules group | FR Tax (6%)     |
     Then product product1 should have following prices information:


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Sets the most used tax rule group to new products like it was on the old page. Right now, with the new product page, it sets it to "No tax" instead of the most used rule group like it should.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create new product using new product page, check that it gets assigned the most used tax rule group like on old product page. Open any old product, check it still remembers the tax rule you set to it.
| UI Tests          | 🟢 https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/8062969058
| Fixed issue or discussion?     | Fixes #35235
| Related PRs       | 
| Sponsor company   | 

**Before**
![before](https://github.com/PrestaShop/PrestaShop/assets/6097524/2bc99a13-2688-4874-a3d9-58c0515eaab1)

**After**
![after](https://github.com/PrestaShop/PrestaShop/assets/6097524/d95ba3cb-f799-45b5-be57-8a8eff541a7c)
