### PR TITLE
Improve GD test precision - check JPEG support

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -209,6 +209,7 @@ class ConfigurationTestCore
     public static function test_gd()
     {
         if (function_exists('gd_info')) {
+            $gd = gd_info();
             return !empty($gd['JPEG Support']) || !empty($gd['JPG Support']);
         }
 

--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -208,7 +208,11 @@ class ConfigurationTestCore
 
     public static function test_gd()
     {
-        return function_exists('imagecreatetruecolor');
+        if (function_exists('gd_info')) {
+            return !empty($gd['JPEG Support']) || !empty($gd['JPG Support']);
+        }
+
+        return false;
     }
 
     public static function test_json()

--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -210,7 +210,7 @@ class ConfigurationTestCore
     {
         if (function_exists('gd_info')) {
             $gd = gd_info();
-            return !empty($gd['JPEG Support']) || !empty($gd['JPG Support']);
+            return !empty($gd['JPEG Support']);
         }
 
         return false;

--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -210,6 +210,7 @@ class ConfigurationTestCore
     {
         if (function_exists('gd_info')) {
             $gd = gd_info();
+
             return !empty($gd['JPEG Support']);
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Improved GD test precision - check JPEG support <br> This pull request enhances the test_gd function to provide more accurate information about JPEG support in the GD library. Instead of solely relying on the existence of the imagecreatetruecolor function, the code now utilizes gd_info to determine JPEG capabilities.
| Type?             | improvement 
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/10200783127 ✅ 
| Fixed issue or discussion?     | Fixes #35493
| Related PRs       | -
| Sponsor company   | -
