### PR TITLE
BO login screen - don't show PrestaShop version before Employee successful login

### DIFF
--- a/admin-dev/themes/default/template/controllers/login/content.tpl
+++ b/admin-dev/themes/default/template/controllers/login/content.tpl
@@ -27,7 +27,6 @@
 		<h1 class="text-center">
 			<img id="logo" src="{$img_dir}prestashop@2x.png" width="123px" height="24px" alt="PrestaShop" />
 		</h1>
-		<div class="text-center">{$ps_version}</div>
 		<div id="error" class="hide alert alert-danger">
 		{if isset($errors)}
 			<h4>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Why we should show exact PS version before Employee will logged in? We show PS version to potentionally attacker. Please, skip comments like "Attacker doesn't know BO URL location" or "Attacker can have other options how to get PS version" -> thank you :-D It is small PR for future releases. We must go forward... One piece to the overall puzzle.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See, the PS version is no longer visible on the BO login page.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/

![Untitled](https://github.com/PrestaShop/PrestaShop/assets/8518736/c52b253b-56ef-42d4-ba7e-e5454157264d)

