### PR TITLE
Fix invoice download for non logged in customer

### DIFF
--- a/controllers/front/PdfInvoiceController.php
+++ b/controllers/front/PdfInvoiceController.php
@@ -62,7 +62,7 @@ class PdfInvoiceControllerCore extends FrontController
         }
 
         // Check if the user is not trying to download an invoice of an order of different customer
-        // Either the ID of the customer in context must match the customer in order OR a secure_key matching the one on the order must be provided 
+        // Either the ID of the customer in context must match the customer in order OR a secure_key matching the one on the order must be provided
         if ((isset($this->context->customer->id) && $order->id_customer != $this->context->customer->id) && (Tools::isSubmit('secure_key') && $order->secure_key != Tools::getValue('secure_key'))) {
             die($this->trans('The invoice was not found.', [], 'Shop.Notifications.Error'));
         }

--- a/controllers/front/PdfInvoiceController.php
+++ b/controllers/front/PdfInvoiceController.php
@@ -41,10 +41,12 @@ class PdfInvoiceControllerCore extends FrontController
 
     public function postProcess()
     {
+        // If the customer is not logged in AND no secure key was passed
         if (!$this->context->customer->isLogged() && !Tools::getValue('secure_key')) {
             Tools::redirect('index.php?controller=authentication&back=pdf-invoice');
         }
 
+        // If built-in invoicing is disabled
         if (!(int) Configuration::get('PS_INVOICE')) {
             die($this->trans('Invoices are disabled in this shop.', [], 'Shop.Notifications.Error'));
         }
@@ -54,11 +56,14 @@ class PdfInvoiceControllerCore extends FrontController
             $order = new Order((int) $id_order);
         }
 
+        // If the order doesn't exist
         if (!isset($order) || !Validate::isLoadedObject($order)) {
             die($this->trans('The invoice was not found.', [], 'Shop.Notifications.Error'));
         }
 
-        if ((isset($this->context->customer->id) && $order->id_customer != $this->context->customer->id) || (Tools::isSubmit('secure_key') && $order->secure_key != Tools::getValue('secure_key'))) {
+        // Check if the user is not trying to download an invoice of an order of different customer
+        // Either the ID of the customer in context must match the customer in order OR a secure_key matching the one on the order must be provided 
+        if ((isset($this->context->customer->id) && $order->id_customer != $this->context->customer->id) && (Tools::isSubmit('secure_key') && $order->secure_key != Tools::getValue('secure_key'))) {
             die($this->trans('The invoice was not found.', [], 'Shop.Notifications.Error'));
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | You can't download an invoice sometimes, if you are not logged in. This fixes it. Interesting that nobody in the huge community found it in like 13 years. :-)))
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/8110500915
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/35537
| Related PRs       | 
| Sponsor company   | 

### What's wrong
- When you want to download an invoice via a standardized link `https://www.domain.com/index.php?controller=pdf-invoice&id_order=XXXX&secure_key=XXXX`, it doesn't work sometimes.
- The condition now says this: `if there is a customer in context and it doesn't match the order customer OR the secure key doesn't match`, die.
- So now if you have a perfectly legit link with secure_key, but you are logged in as different customer or start a guest checkout, the link won't work.
- So the fix is easy, die only if both of these fail:
  - If there is a customer in context and it's not the customer of the order.
  - If there isn't a secure key in the link.

### How to test
- Make sure that some guest order exists in a shop and invoice is available for it.
- Go to FO, make sure you are logged out. Start a checkout as a guest (without password), no need to fill any addresses.
- Now go to guest tracking and try to track the order and try to download an invoice.
- You will get white screen and `The invoice was not found.`.
- Same situation is when you are logged in in FO as a different customer and you have the link to the invoice in the mail for example.