### PR TITLE
Downgrade ps_googleanalytics

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1769,11 +1769,6 @@ class ToolsCore
      */
     public static function math_round($value, $places, $mode = PS_ROUND_HALF_UP)
     {
-        // since php 8.1 the round function won't tolerate null values
-        if (empty($value)) {
-            $value = 0.0;
-        }
-
         //If PHP_ROUND_HALF_UP exist (PHP 5.3) use it and pass correct mode value (PrestaShop define - 1)
         if (defined('PHP_ROUND_HALF_UP')) {
             return round($value, $places, $mode - 1);

--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
         "prestashop/ps_facetedsearch": "^3.2.1",
         "prestashop/ps_faviconnotificationbo": "^2",
         "prestashop/ps_featuredproducts": "^2",
-        "prestashop/ps_googleanalytics": "^5",
+        "prestashop/ps_googleanalytics": "^4.1",
         "prestashop/ps_imageslider": "^3",
         "prestashop/ps_languageselector": "^2",
         "prestashop/ps_linklist": "^6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4019cc93bf15cdf5093c1c3e7fca2a9",
+    "content-hash": "7e8a1e008299cbe49f4e417b815a4711",
     "packages": [
         {
             "name": "api-platform/core",
@@ -6770,20 +6770,20 @@
         },
         {
             "name": "prestashop/ps_googleanalytics",
-            "version": "v5.0.1",
+            "version": "v4.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_googleanalytics.git",
-                "reference": "efdc50414724aa990eeb87eff3bb1868986cdfda"
+                "reference": "7bfdf5f6e88658e7b0f6b5a01cbe384516eb7233"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_googleanalytics/zipball/efdc50414724aa990eeb87eff3bb1868986cdfda",
-                "reference": "efdc50414724aa990eeb87eff3bb1868986cdfda",
+                "url": "https://api.github.com/repos/PrestaShop/ps_googleanalytics/zipball/7bfdf5f6e88658e7b0f6b5a01cbe384516eb7233",
+                "reference": "7bfdf5f6e88658e7b0f6b5a01cbe384516eb7233",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.3"
+                "php": ">=5.6"
             },
             "require-dev": {
                 "prestashop/php-dev-tools": "3.*"
@@ -6809,9 +6809,9 @@
             "description": "PrestaShop module ps_googleanalytics",
             "homepage": "https://github.com/PrestaShop/ps_googleanalytics",
             "support": {
-                "source": "https://github.com/PrestaShop/ps_googleanalytics/tree/v5.0.1"
+                "source": "https://github.com/PrestaShop/ps_googleanalytics/tree/v4.2.2"
             },
-            "time": "2024-02-28T16:20:31+00:00"
+            "time": "2023-04-05T09:37:41+00:00"
         },
         {
             "name": "prestashop/ps_imageslider",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Downgrade googleanalytics, this PR will also check that we don't get behat errors anymore when ps_googleanalytics is not updated to V5.x
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI and UI tests green
| UI Tests          | incoming
| Fixed issue or discussion?     | none
| Related PRs       | none
| Sponsor company   | PrestaShop SA