### PR TITLE
Update hook.xml

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -6,6 +6,11 @@
     <field name="description"/>
   </fields>
   <entities>
+    <hook id="actionMailAlterMessageBeforeSend">
+      <name>actionMailAlterMessageBeforeSend</name>
+      <title>Modify Swift Message before sending</title>
+      <description>This hook is called before the Swift Message is sent in Mail.php</description>
+    </hook>
     <hook id="actionValidateOrder">
       <name>actionValidateOrder</name>
       <title>New orders</title>


### PR DESCRIPTION
Add missing core hook in Mail.php: actionMailAlterMessageBeforeSend

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There is a missing core hook that is not being register in database: actionMailAlterMessageBeforeSend. Used in Mail.php before sending the Swift Message
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check that hook is in the database after clean installation.
| UI Tests          | https://github.com/manudas/ga.tests.ui.pr/actions/runs/8130177992 https://github.com/florine2623/testing_pr/actions/runs/8174113247 ✅ 

| Fixed issue or discussion?     |  https://github.com/PrestaShop/PrestaShop/issues/35545
| Related PRs       | none
| Sponsor company   | none
