### PR TITLE
Form type `MaterialChoiceTableType` introduce `display_total_items` form `option`

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -297,6 +297,7 @@ class CustomerType extends TranslatorAwareType
                 ),
                 'empty_data' => [],
                 'choices' => $this->groupByIdChoiceProvider->getChoices(),
+                'display_total_items' => true,
             ])
             ->add('default_group_id', GroupType::class, [
                 'label' => $this->trans('Default customer group', 'Admin.Orderscustomers.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableType.php
@@ -45,6 +45,7 @@ class MaterialChoiceTableType extends AbstractType
         $resolver->setDefaults([
             'expanded' => true,
             'multiple' => true,
+            'display_total_items' => false,
         ]);
     }
 
@@ -62,6 +63,7 @@ class MaterialChoiceTableType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['isCheckSelectAll'] = count($form->getViewData()) === count($options['choices']);
+        $view->vars['displayTotalItems'] = (bool) $options['display_total_items'];
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -589,7 +589,7 @@
                     {% endif %}
                   >
                   <i class="md-checkbox-control"></i>
-                  {{ 'Select all'|trans({}, 'Admin.Actions') }}
+                  {{ 'Select all'|trans({}, 'Admin.Actions') }} {% if form.vars.displayTotalItems %} ({{ form|length }}) {% endif %}
                 </label>
               </div>
             </th>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -813,7 +813,7 @@
                   {% endif %}
                 >
                 <i class="md-checkbox-control"></i>
-                {{ 'Select all'|trans({}, 'Admin.Actions') }}
+                {{ 'Select all'|trans({}, 'Admin.Actions') }} {% if form.vars.displayTotalItems %} ({{ form|length }}) {% endif %}
               </label>
             </div>
           </th>

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableTypeTest.php
@@ -38,7 +38,7 @@ class MaterialChoiceTableTypeTest extends TestCase
     /**
      * @dataProvider providerBuildView
      */
-    public function testBuildView(array $viewData, array $choices, bool $expectedReturn): void
+    public function testBuildView(array $viewData, array $choices, bool $displayTotalItems, array $expectedReturn): void
     {
         $mockForm = $this
             ->getMockBuilder(FormInterface::class)
@@ -58,10 +58,11 @@ class MaterialChoiceTableTypeTest extends TestCase
             $mockForm,
             [
                 'choices' => $choices,
+                'display_total_items' => $displayTotalItems,
             ]
         );
 
-        $this->assertEquals($expectedReturn, $formView->vars['isCheckSelectAll']);
+        $this->assertEquals($expectedReturn, [$formView->vars['isCheckSelectAll'], $formView->vars['displayTotalItems']]);
     }
 
     public function providerBuildView(): array
@@ -70,12 +71,14 @@ class MaterialChoiceTableTypeTest extends TestCase
             [
                 [1, 2, 3],
                 [1, 2, 3],
-                true,
+                false,
+                [true, false],
             ],
             [
                 [1, 2],
                 [1, 2, 3],
-                false,
+                true,
+                [false, true],
             ],
         ];
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `MaterialChoiceTableType` introduce `display_total_items` form `option`.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See https://github.com/PrestaShop/PrestaShop/discussions/35551
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/8173704811
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/35551
| Related PRs       | N/A
| Sponsor company   | Evolutive
