### PR TITLE
Fix using vouchers with invalid gift products

### DIFF
--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -239,9 +239,12 @@ class AdminCartRulesControllerCore extends AdminController
                 $_POST['gift_product_attribute'] = (int) Tools::getValue('ipa_' . $id_product);
             }
 
-            // Do not allow products with required customization
-            if (!empty($_POST['gift_product']) && count(Product::getRequiredCustomizableFieldsStatic((int) $_POST['gift_product']))) {
-                $this->errors[] = $this->trans('Product with required customization fields cannot be used as a gift.', [], 'Admin.Catalog.Notification');
+            // Check if the gift fulfills all requirements to be used as a gift.
+            if (!empty($_POST['gift_product'])) {
+                $giftEligibility = CartRule::checkGiftEligibility($_POST['gift_product'], $_POST['gift_product_attribute'], true);
+                if (!empty($giftEligibility)) {
+                    $this->errors[] = $giftEligibility;
+                }
             }
 
             // Idiot-proof control


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Avoids creating and applying gifts that result in a cart not orderable or straight fatal errors. It adds validation both when creating the voucher, when automatically applying it in cart and when manually applying it by a code.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Test by using related issues.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #35240, Fixes #15224
| Related PRs       | 
| Sponsor company   | 

### Known issues
The same as active, quantity and date properties of a cart rule, this validation does not work when the gift product is broken AFTER the rule has been added to cart. We currently can't know if it's a cart with valid order or not. This will be fixed all at once in the future.