### PR TITLE
Fix CCC error for path with version

### DIFF
--- a/classes/assets/JavascriptManager.php
+++ b/classes/assets/JavascriptManager.php
@@ -102,6 +102,7 @@ class JavascriptManagerCore extends AbstractAssetManager
         $position = $this->getSanitizedPosition($position);
         $attribute = $this->getSanitizedAttribute($attribute);
 
+        $srcPath = $fullPath;
         $fullPath = $version ? $fullPath . '?' . $version : $fullPath;
 
         if ('remote' === $server) {
@@ -115,7 +116,7 @@ class JavascriptManagerCore extends AbstractAssetManager
         $this->list[$position][$type][$id] = [
             'id' => $id,
             'type' => $type,
-            'path' => $fullPath,
+            'path' => $srcPath,
             'uri' => $uri,
             'priority' => $priority,
             'attribute' => $attribute,

--- a/classes/assets/JavascriptManager.php
+++ b/classes/assets/JavascriptManager.php
@@ -102,7 +102,6 @@ class JavascriptManagerCore extends AbstractAssetManager
         $position = $this->getSanitizedPosition($position);
         $attribute = $this->getSanitizedAttribute($attribute);
 
-        $srcPath = $fullPath;
         $fullPath = $version ? $fullPath . '?' . $version : $fullPath;
 
         if ('remote' === $server) {
@@ -116,7 +115,7 @@ class JavascriptManagerCore extends AbstractAssetManager
         $this->list[$position][$type][$id] = [
             'id' => $id,
             'type' => $type,
-            'path' => $srcPath,
+            'path' => $fullPath,
             'uri' => $uri,
             'priority' => $priority,
             'attribute' => $attribute,

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -114,7 +114,6 @@ class StylesheetManagerCore extends AbstractAssetManager
     {
         $media = $this->getSanitizedMedia($media);
 
-        $srcPath = $fullPath;
         $fullPath = $version ? $fullPath . '?' . $version : $fullPath;
 
         if ('remote' === $server) {
@@ -128,7 +127,7 @@ class StylesheetManagerCore extends AbstractAssetManager
         $this->list[$type][$id] = [
             'id' => $id,
             'type' => $type,
-            'path' => $srcPath,
+            'path' => $fullPath,
             'uri' => $uri,
             'media' => $media,
             'priority' => $priority,

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -114,6 +114,7 @@ class StylesheetManagerCore extends AbstractAssetManager
     {
         $media = $this->getSanitizedMedia($media);
 
+        $srcPath = $fullPath;
         $fullPath = $version ? $fullPath . '?' . $version : $fullPath;
 
         if ('remote' === $server) {
@@ -127,7 +128,7 @@ class StylesheetManagerCore extends AbstractAssetManager
         $this->list[$type][$id] = [
             'id' => $id,
             'type' => $type,
-            'path' => $fullPath,
+            'path' => $srcPath,
             'uri' => $uri,
             'media' => $media,
             'priority' => $priority,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.1.x
| Description?      | Fix error in CCC style sheet and javascript when there is a version number added to uri. Fixes #35341.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | Activate in back office CCC for stylesheet and javascript, if you have js or css added with version number with modules, header nor bottom concatenated files are no more corrupted.
| Fixed issue or discussion?     | Fixes #35341
| Related PRs       | no
| Sponsor company   | @ComonSoft
