### PR TITLE
Optimize Product::getQuantity by removing duplicate queries

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -113,6 +113,7 @@ class CartCore extends ObjectModel
     protected static $cachePackageList = [];
     protected static $cacheDeliveryOptionList = [];
     protected static $cacheMultiAddressDelivery = [];
+    protected static $cacheOrderExists = null;
 
     /**
      * @see ObjectModel::$definition
@@ -239,6 +240,7 @@ class CartCore extends ObjectModel
         static::$cachePackageList = [];
         static::$cacheDeliveryOptionList = [];
         static::$cacheMultiAddressDelivery = [];
+        static::$cacheOrderExists = null;
     }
 
     /**
@@ -374,7 +376,8 @@ class CartCore extends ObjectModel
      */
     public function delete()
     {
-        if ($this->orderExists()) { //NOT delete a cart which is associated with an order
+        // Do NOT delete a cart which is associated with an order
+        if ($this->orderExists()) {
             return false;
         }
 
@@ -1800,10 +1803,14 @@ class CartCore extends ObjectModel
      */
     public function orderExists()
     {
-        return (bool) Db::getInstance()->getValue(
-            'SELECT count(*) FROM `' . _DB_PREFIX_ . 'orders` WHERE `id_cart` = ' . (int) $this->id,
-            false
-        );
+        if (self::$cacheOrderExists === null) {
+            self::$cacheOrderExists = (bool) Db::getInstance()->getValue(
+                'SELECT count(*) FROM `' . _DB_PREFIX_ . 'orders` WHERE `id_cart` = ' . (int) $this->id,
+                false
+            );
+        }
+
+        return self::$cacheOrderExists;
     }
 
     /**

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4349,7 +4349,7 @@ class ProductCore extends ObjectModel
         // has already been updated, this is only useful when the order has not yet been created.
         // @todo This logic should probably be moved somewhere else, this method should not do anything with orders.
         $nbProductInCart = 0;
-        if ($cart && empty(Order::getByCartId($cart->id))) {
+        if ($cart && !$cart->orderExists()) {
             /*
              * Now, we get the quantity of the product in cart. This method is clever and in deep_quantity,
              * it will get us the quantity products in all the packs, if there are some in the cart, not just standard products.


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Product::getQuantity was calling Order::getByCartId many times for each product displayed on the shop. On a page [like this](https://github.com/PrestaShop/PrestaShop/assets/6097524/13059b2f-2c8b-4046-97d4-0d6f7461e4d6), it saves 20 queries (541 -> 521).
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 



