### PR TITLE
Stop requesting core.js source map in production

### DIFF
--- a/themes/webpack.config.js
+++ b/themes/webpack.config.js
@@ -51,7 +51,7 @@ module.exports = (env, argv) => {
     externals: {
       prestashop: 'prestashop',
     },
-    devtool: 'source-map',
+    devtool: mode === 'production' ? false : 'source-map',
     optimization: {
       minimize: true,
       minimizer: [new TerserPlugin({


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Prestashop ships without **themes/core.js.map** file but still requests this map from core.js:<br>`//# sourceMappingURL=core.js.map`<br><br>It causes 403 in browser's console:<br>![obraz](https://github.com/PrestaShop/PrestaShop/assets/5007456/ebe6898e-c0c4-4dca-9c79-b1d824320d10)<br><br>This PR prevents source map generation in production.
| Type?             | improvement
| Category?         | FO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | -
| UI Tests          | 🟢 https://github.com/SharakPL/ga.tests.ui.pr/actions/runs/8172238439
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -