### PR TITLE
Sort order products by date_add in admin order view

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -211,7 +211,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $this->getOrderCustomer($order, $orderInvoiceAddress),
             $this->getOrderShippingAddress($order),
             $orderInvoiceAddress,
-            $this->getOrderProducts($query->getOrderId(), $query->getProductsSorting()->getValue()),
+            $this->getOrderProducts($query->getOrderId(), $query->getProductsSorting()->getSortingFields(), $query->getProductsSorting()->getSortingOrder()),
             $this->getOrderHistory($order),
             $this->getOrderDocuments($order),
             $this->getOrderShipping($order),
@@ -859,17 +859,18 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
 
     /**
      * @param OrderId $orderId
-     * @param string $productsOrder
+     * @param array $productsSortingFields
+     * @param string $productsSortingOrder
      *
      * @return OrderProductsForViewing
      *
-     * @throws OrderException
      * @throws InvalidSortingException
+     * @throws OrderException
      */
-    private function getOrderProducts(OrderId $orderId, string $productsOrder): OrderProductsForViewing
+    private function getOrderProducts(OrderId $orderId, array $productsSortingFields, string $productsSortingOrder): OrderProductsForViewing
     {
         return $this->getOrderProductsForViewingHandler->handle(
-            GetOrderProductsForViewing::all($orderId->getValue(), $productsOrder)
+            GetOrderProductsForViewing::all($orderId->getValue(), $productsSortingFields, $productsSortingOrder)
         );
     }
 

--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -179,9 +179,8 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
         $sorter = new Sorter();
         $products = $sorter->natural(
             $products,
-            $query->getProductsSorting()->getValue(),
-            'product_reference',
-            'product_supplier_reference'
+            $query->getProductsSorting()->getSortingOrder(),
+            ...$query->getProductsSorting()->getSortingFields()
         );
 
         $productsForViewing = [];

--- a/src/Core/Domain/Order/Query/GetOrderForViewing.php
+++ b/src/Core/Domain/Order/Query/GetOrderForViewing.php
@@ -48,15 +48,16 @@ class GetOrderForViewing
 
     /**
      * @param int $orderId
-     * @param string $productsSorting
+     * @param array $productsSortingFields
+     * @param string $productsSortingOrder
      *
-     * @throws OrderException
      * @throws InvalidSortingException
+     * @throws OrderException
      */
-    public function __construct(int $orderId, string $productsSorting = QuerySorting::ASC)
+    public function __construct(int $orderId, array $productsSortingFields = ['date_add'], string $productsSortingOrder = QuerySorting::DESC)
     {
         $this->orderId = new OrderId($orderId);
-        $this->productsSorting = new QuerySorting($productsSorting);
+        $this->productsSorting = new QuerySorting($productsSortingFields, $productsSortingOrder);
     }
 
     /**

--- a/src/Core/Domain/Order/Query/GetOrderProductsForViewing.php
+++ b/src/Core/Domain/Order/Query/GetOrderProductsForViewing.php
@@ -63,23 +63,25 @@ class GetOrderProductsForViewing
      * @param int $orderId
      * @param int $offset
      * @param int $limit
-     * @param string $productsSorting
+     * @param array $productsSortingFields
+     * @param string $productsSortingOrder
      *
      * @return GetOrderProductsForViewing
      *
-     * @throws OrderException
      * @throws InvalidSortingException
+     * @throws OrderException
      */
     public static function paginated(
         int $orderId,
         int $offset,
         int $limit,
-        string $productsSorting = QuerySorting::ASC
-    ) {
+        array $productsSortingFields = ['date_add'],
+        string $productsSortingOrder = QuerySorting::DESC
+    ): GetOrderProductsForViewing {
         $query = new self();
 
         $query->orderId = new OrderId($orderId);
-        $query->productsSorting = new QuerySorting($productsSorting);
+        $query->productsSorting = new QuerySorting($productsSortingFields, $productsSortingOrder);
         $query->offset = $offset;
         $query->limit = $limit;
 
@@ -90,18 +92,19 @@ class GetOrderProductsForViewing
      * Builds query for getting all results
      *
      * @param int $orderId
-     * @param string $productsSorting
+     * @param array $productsSortingFields
+     * @param string $productsSortingOrder
      *
      * @return GetOrderProductsForViewing
      *
-     * @throws OrderException
      * @throws InvalidSortingException
+     * @throws OrderException
      */
-    public static function all(int $orderId, string $productsSorting = QuerySorting::ASC)
+    public static function all(int $orderId, array $productsSortingFields, string $productsSortingOrder = QuerySorting::DESC): GetOrderProductsForViewing
     {
         $query = new self();
         $query->orderId = new OrderId($orderId);
-        $query->productsSorting = new QuerySorting($productsSorting);
+        $query->productsSorting = new QuerySorting($productsSortingFields, $productsSortingOrder);
 
         return $query;
     }

--- a/src/Core/Domain/ValueObject/QuerySorting.php
+++ b/src/Core/Domain/ValueObject/QuerySorting.php
@@ -36,42 +36,75 @@ class QuerySorting
 {
     public const ASC = 'ASC';
     public const DESC = 'DESC';
+    public const AVAILABLE_SORTING_FIELDS = ['id_product', 'date_add', 'product_reference', 'product_supplier_reference'];
+    public const AVAILABLE_SORTING_ORDER = [self::ASC, self::DESC];
+
+    /**
+     * @var array
+     */
+    private $sortingFields;
 
     /**
      * @var string
      */
-    private $sorting;
+    private $sortingOrder;
 
     /**
-     * @param string $sorting
+     * @param array $sortingFields
+     * @param string $sortingOrder
      *
      * @throws InvalidSortingException
      */
-    public function __construct(string $sorting)
+    public function __construct(array $sortingFields, string $sortingOrder)
     {
-        $sorting = strtoupper($sorting);
-        $this->assertSortingSupported($sorting);
+        $this->assertSortingFieldsSupported($sortingFields);
 
-        $this->sorting = $sorting;
+        $sortingOrder = strtoupper($sortingOrder);
+        $this->assertSortingOrderSupported($sortingOrder);
+
+        $this->sortingFields = $sortingFields;
+        $this->sortingOrder = $sortingOrder;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSortingFields(): array
+    {
+        return $this->sortingFields;
     }
 
     /**
      * @return string
      */
-    public function getValue(): string
+    public function getSortingOrder(): string
     {
-        return $this->sorting;
+        return $this->sortingOrder;
     }
 
     /**
-     * @param string $sorting
+     * @param string $sortingOrder
      *
      * @throws InvalidSortingException
      */
-    private function assertSortingSupported(string $sorting): void
+    private function assertSortingOrderSupported(string $sortingOrder): void
     {
-        if (!in_array($sorting, [self::ASC, self::DESC], true)) {
-            throw new InvalidSortingException();
+        if (!in_array($sortingOrder, self::AVAILABLE_SORTING_ORDER, true)) {
+            throw new InvalidSortingException(sprintf('Invalid sorting order parameter `%s`. You must use one of these options: %s', $sortingOrder, implode(', ', self::AVAILABLE_SORTING_ORDER)));
+        }
+    }
+
+    /**
+     * @param array $sortingFields
+     *
+     * @throws InvalidSortingException
+     */
+    private function assertSortingFieldsSupported(array $sortingFields): void
+    {
+        foreach ($sortingFields as $sortingField) {
+            if (!in_array($sortingField, self::AVAILABLE_SORTING_FIELDS, true)) {
+                throw new InvalidSortingException(sprintf('Invalid sorting field parameter `%s`. You must use one of these options: %s', $sortingField, implode(', ', self::AVAILABLE_SORTING_ORDER)));
+            }
         }
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -417,7 +417,7 @@ class OrderController extends FrameworkBundleAdminController
     {
         try {
             /** @var OrderForViewing $orderForViewing */
-            $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId, QuerySorting::DESC));
+            $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId, ['date_add'], QuerySorting::DESC));
         } catch (OrderException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
 
@@ -715,7 +715,7 @@ class OrderController extends FrameworkBundleAdminController
     public function addProductAction(int $orderId, Request $request): Response
     {
         /** @var OrderForViewing $orderForViewing */
-        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId, QuerySorting::DESC));
+        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId, ['date_add'], QuerySorting::DESC));
 
         $previousProducts = [];
         foreach ($orderForViewing->getProducts()->getProducts() as $orderProductForViewing) {
@@ -762,7 +762,7 @@ class OrderController extends FrameworkBundleAdminController
          * We keep it for now to avoid Breaking Change
          */
         /** @var OrderForViewing $orderForViewing */
-        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId, QuerySorting::DESC));
+        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId, ['date_add'], QuerySorting::DESC));
 
         $updatedProducts = [];
         foreach ($orderForViewing->getProducts()->getProducts() as $orderProductForViewing) {
@@ -1027,7 +1027,7 @@ class OrderController extends FrameworkBundleAdminController
         }
 
         /** @var OrderForViewing $orderForViewing */
-        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId, QuerySorting::DESC));
+        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId, ['date_add'], QuerySorting::DESC));
 
         $products = $orderForViewing->getProducts()->getProducts();
         $product = array_reduce($products, function ($result, OrderProductForViewing $item) use ($orderDetailId) {
@@ -1573,7 +1573,7 @@ class OrderController extends FrameworkBundleAdminController
     public function getProductsListAction(int $orderId): Response
     {
         /** @var OrderForViewing $orderForViewing */
-        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId, QuerySorting::DESC));
+        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId, ['date_add'], QuerySorting::ASC));
 
         $currencyDataProvider = $this->container->get('prestashop.adapter.data_provider.currency');
         $orderCurrency = $currencyDataProvider->getCurrencyById($orderForViewing->getCurrencyId());

--- a/tests/Unit/Core/Domain/ValueObject/QuerySortingTest.php
+++ b/tests/Unit/Core/Domain/ValueObject/QuerySortingTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Core\Domain\ValueObject;
+
+use Generator;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Exception\InvalidSortingException;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\QuerySorting;
+
+class QuerySortingTest extends TestCase
+{
+    /**
+     * @dataProvider getValidValuesForClassCreation
+     *
+     * @param array $sortingFields
+     * @param string $sortingOrder
+     *
+     * @throws InvalidSortingException
+     */
+    public function testItCreatesClassWithValidValues(array $sortingFields, string $sortingOrder): void
+    {
+        $querySorting = new QuerySorting($sortingFields, $sortingOrder);
+
+        Assert::assertEquals($querySorting->getSortingFields(), $sortingFields);
+        Assert::assertEquals($querySorting->getSortingOrder(), $sortingOrder);
+    }
+
+    /**
+     * @dataProvider getInvalidSortingFields
+     *
+     * @param array $sortingFields
+     *
+     * @throws InvalidSortingException
+     */
+    public function testItThrowsExceptionWhenInvalidSortingFieldsIsProvided(array $sortingFields): void
+    {
+        $this->expectException(InvalidSortingException::class);
+        new QuerySorting($sortingFields, QuerySorting::ASC);
+    }
+
+    /**
+     * @dataProvider getInvalidSortingOrder
+     *
+     * @param string $sortingOrder
+     */
+    public function testItThrowsExceptionWhenInvalidSortingOrderIsProvided(string $sortingOrder): void
+    {
+        $this->expectException(InvalidSortingException::class);
+        new QuerySorting(['date_add'], $sortingOrder);
+    }
+
+    /**
+     * @return Generator
+     */
+    public function getInvalidSortingOrder(): Generator
+    {
+        yield ['BAD_VALUE'];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function getInvalidSortingFields(): Generator
+    {
+        yield [['bad_value']];
+        yield [['date_add', 'bad_value']];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function getValidValuesForClassCreation(): Generator
+    {
+        yield [['id_product'], 'ASC'];
+        yield [['date_add', 'product_reference'], 'ASC'];
+        yield [['id_product', 'product_supplier_reference', 'product_reference'], 'DESC'];
+    }
+}


### PR DESCRIPTION
… detail order view

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | In BO order detail view, when adding a product to the order, the product list is refreshed/displayed and ordered by reference. This PR improve the `QuerySorting` and display products by `date_add` to keep the product sort order.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See opened issue link below
| Fixed issue or discussion?     | Fixes #35504 
| Sponsor company   | Softizy
