### PR TITLE
Fix(merchandise-return): deprecation alert is displayed on the return form

### DIFF
--- a/pdf/order-return.summary-tab.tpl
+++ b/pdf/order-return.summary-tab.tpl
@@ -31,7 +31,7 @@
 		<th class="header small" valign="middle">{l s='Date' d='Shop.Pdf' pdf='true'}</th>
 	</tr>
 	<tr>
-		<td class="center small white">{'%06d'|sprintf:$order_return->id}</td>
+		<td class="center small white">{sprintf('%06d', $order_return->id)}</td>
 		<td class="center small white">{dateFormat date=$order_return->date_add full=0}</td>
 	</tr>
 </table>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | See [related issue](https://github.com/PrestaShop/PrestaShop/issues/35362) description
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| UI Tests     | https://github.com/florine2623/testing_pr/actions/runs/8283185085
| How to test?      | See [related issue](https://github.com/PrestaShop/PrestaShop/issues/35362) description
| Fixed issue or discussion?     | Fixes #35362
| Sponsor company   | Softizy
