### PR TITLE
Support 8 bits PNG file

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -309,6 +309,10 @@ class ImageManagerCore
             imagealphablending($destImage, false);
             imagesavealpha($destImage, true);
             $transparent = imagecolorallocatealpha($destImage, 255, 255, 255, 127);
+            // if png color type is 3, the file is paletted (256 colors). Change palette to reduce file size
+            if (self::getPNGColorType($sourceFile) == 3) {
+                imagetruecolortopalette($destImage, false, 255);
+            }
             imagefilledrectangle($destImage, 0, 0, $destinationWidth, $destinationHeight, $transparent);
         } else {
             $white = imagecolorallocate($destImage, 255, 255, 255);
@@ -898,5 +902,27 @@ class ImageManagerCore
         }
 
         return $path;
+    }
+
+    /**
+     * The function `getPNGColorType` returns the color type byte from a PNG file
+     *
+     * @param string $fileName
+     *
+     * @return @return int|bool
+     */
+    public static function getPNGColorType($fileName)
+    {
+        $handle = fopen($fileName, 'r');
+        if (false === $handle) {
+            return false;
+        }
+
+        // set pointer to the color type byte and read it
+        fseek($handle, 25);
+        $colorTypeByte = fread($handle, 1);
+        fclose($handle);
+
+        return ord($colorTypeByte);
     }
 }

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -305,8 +305,8 @@ class ImageManagerCore
         $destImage = imagecreatetruecolor($destinationWidth, $destinationHeight);
 
         // If the output is PNG, fill with transparency. Else fill with white background.
-        if ($destinationFileType == 'png' || $destinationFileType == 'webp' || $destinationFileType == 'avif') {
-            // if png color type is 3, the file is paletted (256 colors). Change palette to reduce file size
+        if (in_array($destinationFileType, ['png', 'webp', 'avif'])) {
+            // if png color type is 3, the file is paletted (256 colors or less). Change palette to reduce file size
             if ($destinationFileType == 'png' && self::getPNGColorType($sourceFile) == 3) {
                 imagetruecolortopalette($destImage, false, 255);
             } else {

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -909,7 +909,7 @@ class ImageManagerCore
      *
      * @param string $fileName
      *
-     * @return @return int|bool
+     * @return int|bool
      */
     public static function getPNGColorType($fileName)
     {

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -306,13 +306,14 @@ class ImageManagerCore
 
         // If the output is PNG, fill with transparency. Else fill with white background.
         if ($destinationFileType == 'png' || $destinationFileType == 'webp' || $destinationFileType == 'avif') {
-            imagealphablending($destImage, false);
-            imagesavealpha($destImage, true);
-            $transparent = imagecolorallocatealpha($destImage, 255, 255, 255, 127);
             // if png color type is 3, the file is paletted (256 colors). Change palette to reduce file size
             if (self::getPNGColorType($sourceFile) == 3) {
                 imagetruecolortopalette($destImage, false, 255);
+            } else {
+                imagealphablending($destImage, false);
             }
+            imagesavealpha($destImage, true);
+            $transparent = imagecolorallocatealpha($destImage, 255, 255, 255, 127);
             imagefilledrectangle($destImage, 0, 0, $destinationWidth, $destinationHeight, $transparent);
         } else {
             $white = imagecolorallocate($destImage, 255, 255, 255);

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -307,7 +307,7 @@ class ImageManagerCore
         // If the output is PNG, fill with transparency. Else fill with white background.
         if ($destinationFileType == 'png' || $destinationFileType == 'webp' || $destinationFileType == 'avif') {
             // if png color type is 3, the file is paletted (256 colors). Change palette to reduce file size
-            if (self::getPNGColorType($sourceFile) == 3) {
+            if ($destinationFileType == 'png' && self::getPNGColorType($sourceFile) == 3) {
                 imagetruecolortopalette($destImage, false, 255);
             } else {
                 imagealphablending($destImage, false);

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -914,16 +914,10 @@ class ImageManagerCore
      */
     public static function getPNGColorType($fileName)
     {
-        $handle = fopen($fileName, 'r');
-        if (false === $handle) {
+        if (!is_readable($fileName)) {
             return false;
         }
 
-        // set pointer to the color type byte and read it
-        fseek($handle, 25);
-        $colorTypeByte = fread($handle, 1);
-        fclose($handle);
-
-        return ord($colorTypeByte);
+        return ord(@file_get_contents($fileName, false, null, 25, 1));
     }
 }

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -307,7 +307,7 @@ class ImageManagerCore
         // If the output is PNG, fill with transparency. Else fill with white background.
         if (in_array($destinationFileType, ['png', 'webp', 'avif'])) {
             // if png color type is 3, the file is paletted (256 colors or less). Change palette to reduce file size
-            if ($destinationFileType == 'png' && self::getPNGColorType($sourceFile) == 3) {
+            if ($destinationFileType == 'png' && $sourceFileType == IMAGETYPE_PNG && self::getPNGColorType($sourceFile) == 3) {
                 imagetruecolortopalette($destImage, false, 255);
             } else {
                 imagealphablending($destImage, false);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | 8bits png file are converted to 32bits. With this PR 8bits file remains in 8bits.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes / no
| UI Tests     | https://github.com/florine2623/testing_pr/actions/runs/9402884811 ✅ 
| How to test?      | See issue
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/35601
| Sponsor company   | Creabilis.com
