### PR TITLE
Add check all product are still active to set orderable cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4542,6 +4542,18 @@ class CartCore extends ObjectModel
         return true;
     }
 
+    public function checkAllProductsAreStillActive()
+    {
+        $productList = $this->getProducts(true);
+        foreach ($productList as $product) {
+            if (!$product['active']) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     /**
      * Set flag to split lines of products given away and also manually added to cart.
      */

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -231,7 +231,8 @@ class OrderControllerCore extends FrontController
 
         if ($this->context->cart->isAllProductsInStock() !== true ||
             $this->context->cart->checkAllProductsAreStillAvailableInThisState() !== true ||
-            $this->context->cart->checkAllProductsHaveMinimalQuantities() !== true) {
+            $this->context->cart->checkAllProductsHaveMinimalQuantities() !== true ||
+            $this->context->cart->checkAllProductsAreStillActive() !== true) {
             $responseData['errors'] = true;
             $responseData['cartUrl'] = $this->context->link->getPageLink('cart', null, null, ['action' => 'show']);
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This pull request addresses an issue where a cart validity check is performed only on the cart page when adding a (logically active) product to the cart, but not on the checkout page upon clicking the 'Finalize Order' button. Example of the problem: a user adds product X to the cart but leaves the store before completing the order. Two days later, the user returns to the store and still find his product X in the cart. Upon accessing the cart page, he encounters an error message stating "Product X is no longer available." However, if the user directly accesses the checkout URL without visiting the cart page first, he can proceed to finalize the order without any validation of product availability in the cart. This fix ensures consistency in cart validity checks between the cart and checkout pages, preventing users from purchasing products that are no longer active due to changes in availability subsequent to adding the product to the cart. Note: This issue particularly affects projects with a direct link to the checkout without prior visitation of the cart page, exacerbating the problem by allowing the purchase of products that are no longer active due to availability changes after adding them to the cart.
| Type?             | bug fix / improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |  1. Add a product to the cart. 2. Go to the checkout page. 3. Disable the product from the backoffice. 4. Come back to the checkout page. Click the "Finish order" button. The order will be finished instead of show a message notifying "Product is not available". 5. After my pull request changes, this problem has been fixed.
| UI Tests          | Please run UI tests and paste here the link to the run. [Read this page to know why and how to use this tool.](https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/ui-tests/).
| Fixed issue or discussion?     | Fixes #35634 
| Related PRs       | 
| Sponsor company   | csoon1992
