### PR TITLE
Add `displayHeader` and `displayFooter` in admin controller layout

### DIFF
--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -84,7 +84,9 @@ class AdminLegacyLayoutControllerCore extends AdminController
         $helpLink = '',
         $jsRouterMetadata = [],
         $metaTitle = '',
-        $useRegularH1Structure = true
+        $useRegularH1Structure = true,
+        $displayHeader = true,
+        $displayFooter = true
     ) {
         // Compatibility with legacy behavior.
         // Some controllers can only be used in "All stores" context.
@@ -125,6 +127,8 @@ class AdminLegacyLayoutControllerCore extends AdminController
         $this->className = 'LegacyLayout';
         $this->jsRouterMetadata = $jsRouterMetadata;
         $this->useRegularH1Structure = $useRegularH1Structure;
+        $this->display_header = $displayHeader;
+        $this->display_footer = $displayFooter;
     }
 
     /**

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -223,7 +223,9 @@ class LegacyContext
         $jsRouterMetadata = [],
         $metaTitle = '',
         $useRegularH1Structure = true,
-        $baseLayout = 'layout.tpl'
+        $baseLayout = 'layout.tpl',
+        $displayHeader = true,
+        $displayFooter = true
     ) {
         $originCtrl = new AdminLegacyLayoutControllerCore(
             $controllerName,
@@ -236,7 +238,9 @@ class LegacyContext
             $helpLink,
             $jsRouterMetadata,
             $metaTitle,
-            $useRegularH1Structure
+            $useRegularH1Structure,
+            $displayHeader,
+            $displayFooter
         );
         $originCtrl->layout = $baseLayout;
         $originCtrl->run();

--- a/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
@@ -26,6 +26,8 @@
 {% set showContentHeader = showContentHeader is defined ? showContentHeader : true  %}
 {% set layoutHeaderToolbarBtn = layoutHeaderToolbarBtn is defined ? layoutHeaderToolbarBtn : [] %}
 {% set metaTitle = meta_title is defined ? meta_title : (layoutTitle is defined ? layoutTitle : '') %}
+{% set displayHeader = displayHeader is defined ? displayHeader : true  %}
+{% set displayFooter = displayFooter is defined ? displayFooter : true  %}
 
 {# if the Symfony layout feature flag is enabled, we display the default layout or the light layout, #}
 {# otherwise we display the legacy layout #}
@@ -44,7 +46,9 @@
       js_router_metadata(),
       meta_title is defined ? meta_title : '',
       use_regular_h1_structure is defined ? use_regular_h1_structure : true,
-      legacyBaseLayout is defined ? legacyBaseLayout : 'layout.tpl'
+      legacyBaseLayout is defined ? legacyBaseLayout : 'layout.tpl',
+      displayHeader,
+      displayFooter
     )
   )
 ) %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Hability to disable/enable easly the header and footer in admin layout page without using lecagy controller bridge
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See description bellow 
| UI Tests          | N/A
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | Evolutive


# How to test

- Go to : 
`src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php`
- Edit : `OrderController::indexAction` and add the new vars **displayHeader** and **displayFooter**

```php
return $this->render(
     '@PrestaShop/Admin/Sell/Order/Order/index.html.twig',
     [
         'displayHeader' => false,
         'displayFooter' => false,
     ]
 );
```
| Before      | After |
| ----------- | ----------- |
| ![Capture d’écran du 2024-03-13 10-37-30](https://github.com/PrestaShop/PrestaShop/assets/16455155/15dbda6b-5fed-45f5-b754-310b35837479) | ![Capture d’écran du 2024-03-13 10-38-13](https://github.com/PrestaShop/PrestaShop/assets/16455155/adfe005c-e347-4af0-a531-336cf60493df)
 |

