### PR TITLE
Fix order and remove duplicates from smarty.config.inc.php

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -76,54 +76,49 @@ function smartyEscape($string, $esc_type = 'html', $char_set = null, $double_enc
 }
 
 // PrestaShop & Smarty functions
-smartyRegisterFunction($smarty, 'modifier', 'escape', 'smartyEscape');
-smartyRegisterFunction($smarty, 'modifier', 'truncate', 'smarty_modifier_truncate');
-smartyRegisterFunction($smarty, 'function', 'l', 'smartyTranslate', false);
-smartyRegisterFunction($smarty, 'function', 'hook', 'smartyHook');
 smartyRegisterFunction($smarty, 'function', 'dateFormat', array('Tools', 'dateFormat'));
+smartyRegisterFunction($smarty, 'function', 'hook', 'smartyHook');
+smartyRegisterFunction($smarty, 'function', 'l', 'smartyTranslate', false);
+smartyRegisterFunction($smarty, 'function', 'url', array('Link', 'getUrlSmarty'));
+
 smartyRegisterFunction($smarty, 'modifier', 'boolval', array('Tools', 'boolval'));
-smartyRegisterFunction($smarty, 'modifier', 'cleanHtml', 'smartyCleanHtml');
 smartyRegisterFunction($smarty, 'modifier', 'classname', 'smartyClassname');
 smartyRegisterFunction($smarty, 'modifier', 'classnames', 'smartyClassnames');
-smartyRegisterFunction($smarty, 'function', 'url', array('Link', 'getUrlSmarty'));
+smartyRegisterFunction($smarty, 'modifier', 'cleanHtml', 'smartyCleanHtml');
+smartyRegisterFunction($smarty, 'modifier', 'end', 'smarty_endWithoutReference');
+smartyRegisterFunction($smarty, 'modifier', 'escape', 'smartyEscape');
+smartyRegisterFunction($smarty, 'modifier', 'truncate', 'smarty_modifier_truncate');
 
 // Native PHP functions
 smartyRegisterFunction($smarty, 'modifier', 'addcslashes', 'addcslashes');
 smartyRegisterFunction($smarty, 'modifier', 'addslashes', 'addslashes');
 smartyRegisterFunction($smarty, 'modifier', 'array_slice', 'array_slice');
 smartyRegisterFunction($smarty, 'modifier', 'date', 'date');
-smartyRegisterFunction($smarty, 'modifier', 'end', 'smarty_endWithoutReference');
 smartyRegisterFunction($smarty, 'modifier', 'explode', 'explode');
 smartyRegisterFunction($smarty, 'modifier', 'floatval', 'floatval');
 smartyRegisterFunction($smarty, 'modifier', 'htmlentities', 'htmlentities');
+smartyRegisterFunction($smarty, 'modifier', 'htmlspecialchars', 'htmlspecialchars');
+smartyRegisterFunction($smarty, 'modifier', 'implode', 'implode');
+smartyRegisterFunction($smarty, 'modifier', 'in_array', 'in_array');
 smartyRegisterFunction($smarty, 'modifier', 'intval', 'intval');
 smartyRegisterFunction($smarty, 'modifier', 'json_decode', 'json_decode');
 smartyRegisterFunction($smarty, 'modifier', 'json_encode', 'json_encode');
+smartyRegisterFunction($smarty, 'modifier', 'lcfirst', 'lcfirst');
+smartyRegisterFunction($smarty, 'modifier', 'md5', 'md5');
 smartyRegisterFunction($smarty, 'modifier', 'mt_rand', 'mt_rand');
+smartyRegisterFunction($smarty, 'modifier', 'nl2br', 'nl2br');
+smartyRegisterFunction($smarty, 'modifier', 'print_r', 'print_r');
 smartyRegisterFunction($smarty, 'modifier', 'rand', 'rand');
-smartyRegisterFunction($smarty, 'modifier', 'strtolower', 'strtolower');
+smartyRegisterFunction($smarty, 'modifier', 'sizeof', 'sizeof');
 smartyRegisterFunction($smarty, 'modifier', 'str_replace', 'str_replace');
+smartyRegisterFunction($smarty, 'modifier', 'stripslashes', 'stripslashes');
+smartyRegisterFunction($smarty, 'modifier', 'strtolower', 'strtolower');
 smartyRegisterFunction($smarty, 'modifier', 'strval', 'strval');
+smartyRegisterFunction($smarty, 'modifier', 'substr', 'substr');
 smartyRegisterFunction($smarty, 'modifier', 'trim', 'trim');
 smartyRegisterFunction($smarty, 'modifier', 'ucfirst', 'ucfirst');
 smartyRegisterFunction($smarty, 'modifier', 'urlencode', 'urlencode');
-smartyRegisterFunction($smarty, 'modifier', 'htmlspecialchars', 'htmlspecialchars');
-smartyRegisterFunction($smarty, 'modifier', 'implode', 'implode');
-smartyRegisterFunction($smarty, 'modifier', 'explode', 'explode');
-smartyRegisterFunction($smarty, 'modifier', 'print_r', 'print_r');
 smartyRegisterFunction($smarty, 'modifier', 'var_dump', 'var_dump');
-smartyRegisterFunction($smarty, 'modifier', 'lcfirst', 'lcfirst');
-smartyRegisterFunction($smarty, 'modifier', 'nl2br', 'nl2br');
-smartyRegisterFunction($smarty, 'modifier', 'sizeof', 'sizeof');
-smartyRegisterFunction($smarty, 'modifier', 'in_array', 'in_array');
-smartyRegisterFunction($smarty, 'modifier', 'substr', 'substr');
-smartyRegisterFunction($smarty, 'modifier', 'intval', 'intval');
-smartyRegisterFunction($smarty, 'modifier', 'date', 'date');
-smartyRegisterFunction($smarty, 'modifier', 'trim', 'trim');
-smartyRegisterFunction($smarty, 'modifier', 'json_encode', 'json_encode');
-smartyRegisterFunction($smarty, 'modifier', 'in_array', 'in_array');
-smartyRegisterFunction($smarty, 'modifier', 'stripslashes', 'stripslashes');
-smartyRegisterFunction($smarty, 'modifier', 'md5', 'md5');
 
 function smarty_modifier_htmlentitiesUTF8($string)
 {
@@ -189,7 +184,7 @@ function smartyHook($params, &$smarty)
         unset(
             $hook_params['h'],
             $hook_params['excl']
-        );
+            );
 
         return $result;
     }

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -161,7 +161,7 @@ function smartyHook($params, &$smarty)
     $id_module = null;
     $hook_params = $params;
     $hook_params['smarty'] = $smarty;
-    if (!empty ($params['mod'])) {
+    if (!empty($params['mod'])) {
         $module = Module::getInstanceByName($params['mod']);
         unset($hook_params['mod']);
         if ($module && $module->id) {
@@ -172,7 +172,7 @@ function smartyHook($params, &$smarty)
             return '';
         }
     }
-    if (!empty ($params['excl'])) {
+    if (!empty($params['excl'])) {
         $result = '';
         $modules = Hook::getHookModuleExecList($hook_params['h']);
 

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -92,6 +92,7 @@ smartyRegisterFunction($smarty, 'modifier', 'truncate', 'smarty_modifier_truncat
 // Native PHP functions
 smartyRegisterFunction($smarty, 'modifier', 'addcslashes', 'addcslashes');
 smartyRegisterFunction($smarty, 'modifier', 'addslashes', 'addslashes');
+smartyRegisterFunction($smarty, 'modifier', 'array_merge', 'array_merge');
 smartyRegisterFunction($smarty, 'modifier', 'array_slice', 'array_slice');
 smartyRegisterFunction($smarty, 'modifier', 'date', 'date');
 smartyRegisterFunction($smarty, 'modifier', 'explode', 'explode');

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -184,7 +184,7 @@ function smartyHook($params, &$smarty)
         unset(
             $hook_params['h'],
             $hook_params['excl']
-            );
+        );
 
         return $result;
     }

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -113,6 +113,7 @@ smartyRegisterFunction($smarty, 'modifier', 'rand', 'rand');
 smartyRegisterFunction($smarty, 'modifier', 'sizeof', 'sizeof');
 smartyRegisterFunction($smarty, 'modifier', 'str_replace', 'str_replace');
 smartyRegisterFunction($smarty, 'modifier', 'stripslashes', 'stripslashes');
+smartyRegisterFunction($smarty, 'modifier', 'strstr', 'strstr');
 smartyRegisterFunction($smarty, 'modifier', 'strtolower', 'strtolower');
 smartyRegisterFunction($smarty, 'modifier', 'strval', 'strval');
 smartyRegisterFunction($smarty, 'modifier', 'substr', 'substr');
@@ -160,7 +161,7 @@ function smartyHook($params, &$smarty)
     $id_module = null;
     $hook_params = $params;
     $hook_params['smarty'] = $smarty;
-    if (!empty($params['mod'])) {
+    if (!empty ($params['mod'])) {
         $module = Module::getInstanceByName($params['mod']);
         unset($hook_params['mod']);
         if ($module && $module->id) {
@@ -171,7 +172,7 @@ function smartyHook($params, &$smarty)
             return '';
         }
     }
-    if (!empty($params['excl'])) {
+    if (!empty ($params['excl'])) {
         $result = '';
         $modules = Hook::getHookModuleExecList($hook_params['h']);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixed for 8.1.x in #33555, but it appears #33582 didn't go as planned - no order and duplicates again
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | -
| UI Tests          | https://github.com/SharakPL/ga.tests.ui.pr/actions/runs/8278518875
| Fixed issue or discussion?     | -
| Related PRs       | #33555
| Sponsor company   | -