### PR TITLE
Take account of active and deleted fields when fetching a tax rules group id by name

### DIFF
--- a/classes/tax/TaxRulesGroup.php
+++ b/classes/tax/TaxRulesGroup.php
@@ -244,7 +244,8 @@ class TaxRulesGroupCore extends ObjectModel
         return (int) Db::getInstance()->getValue(
             'SELECT `id_tax_rules_group`
 			FROM `' . _DB_PREFIX_ . 'tax_rules_group` rg
-			WHERE `name` = \'' . pSQL($name) . '\''
+			WHERE `name` = \'' . pSQL($name) . '\'
+            ORDER BY `active` DESC, `deleted` ASC'
         );
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x
| Description?      | See below
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Localization works as before.
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/8341581695
| Fixed issue or discussion?     | Fixes #35641
| Related PRs       |
| Sponsor company   | 

# What the change is about
This change adds a sql 'ORDER BY' clause to the underlying query to improve the chance that an expected (valid) result will be returned.

It is only used (by the core) in the LocalizationPack class. It would be rare that this function be used elsewhere in community contributed code, but will not affect the operation of such code if it is used (but may prevent unexpected behaviour).

# Why I did this
While working on an pre-existing store customization there was unexpected behaviour when fetching a Tax Rules Group by name. There had been an assumption that the current active record would be returned, however the underlying SQL query merely returns the first matching record from the table. The store owner had made several changes and deletions resulting in multiple records using the same name, albeit disabled or deleted. The consequence of this is that the customization worked as intended when initially applied, but due to these changes no longer functioned correctly, and with no apparent cause.

Since the name is not enforced as being unique, this means that a prior disabled or deleted record will be returned, rather than the most recent active one.  This behaviour is inconsistent, so this PR attempts to mitigate assumptions that may be made regarding the behaviour. It does not address the issue of multiple, active and enabled records existing, although this situation is obvious from the BO (while matching deleted records will be invisible).
