### PR TITLE
Fix changelog 8.1.5

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -70,8 +70,6 @@ Changelog for PrestaShop 8
     - #34954: Fix Link->getModuleLink() function for other shop contexts (by @hherreros-webimpacto)
     - #35321: Fix display of categories from other shops (by @kpodemski)
     - #34873: Prevent uncheck cast (by @gross-nvs)
-    - #GHSA-vr7m-r9vm-m4wf:  (by @matthieu-rolland)
-    - #GHSA-xgpm-q3mq-46rq:  (by @matthieu-rolland)
   - Refactoring:
     - #35456: Comment cart and quantity methods (by @Hlavtox)
     - #35215: Fix alias hooks and add the missing ones (by @Hlavtox)


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | When generating the changelog, two security fixes from PrestaShop 8.1.3 were added by the tool... this PR removes them
| Type?             | improvement
| Category?         | ME
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | none
| UI Tests          | none
| Fixed issue or discussion?     | none
| Related PRs       | none
| Sponsor company   | PrestaShop SA