### PR TITLE
Fix product page textarea height on tab or lang change

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -79,18 +79,19 @@ $(() => {
 function resetEditor() {
   const languageEditorsSelector = '.summary-description-container div.translation-field.active textarea.autoload_rte';
   $(languageEditorsSelector).each((index, textarea) => {
-    if (window.tinyMCE) {
-      const editor = window.tinyMCE.get(textarea.id);
-      if (!editor) {
-        return;
-      }
-      // Reset content to force refresh of editor
-      editor.setContent(editor.getContent());
-      setTimeout(() => {
-        editor.execCommand('mceInsertContent', false, '');
-        editor.execCommand('mceAutoResize');
-      }, 250);
+    if (!window.tinyMCE) {
+      return;
     }
+    const editor = window.tinyMCE.get(textarea.id);
+    if (!editor) {
+      return;
+    }
+    // Reset content to force refresh of editor
+    editor.setContent(editor.getContent());
+    setTimeout(() => {
+      editor.execCommand('mceInsertContent', false, '');
+      editor.execCommand('mceAutoResize');
+    }, 250);
   });
 }
 

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -82,10 +82,13 @@ function resetEditor() {
     if (!window.tinyMCE) {
       return;
     }
+
     const editor = window.tinyMCE.get(textarea.id);
+
     if (!editor) {
       return;
     }
+
     // Reset content to force refresh of editor
     editor.setContent(editor.getContent());
     setTimeout(() => {

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -80,7 +80,7 @@ function resetEditor() {
   $(languageEditorsSelector).each((index, textarea) => {
     if (window.tinyMCE) {
       const editor = window.tinyMCE.get(textarea.id);
-      if (editor) {
+      if (!editor) {
         return;
       }
       // Reset content to force refresh of editor

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -69,6 +69,7 @@ $(() => {
     resetEditor();
   });
 
+  $('.summary-description-container a[data-toggle="tab"]').on('shown.bs.tab', resetEditor);
   form.switchLanguage($('#form_switch_language').val());
 });
 
@@ -88,7 +89,7 @@ function resetEditor() {
       setTimeout(() => {
         editor.execCommand('mceInsertContent', false, '');
         editor.execCommand('mceAutoResize');
-      }, 300);
+      }, 250);
     }
   });
 }

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -66,9 +66,9 @@ $(() => {
   $('#form-nav').on('click', '.nav-item', () => {
     $('[data-toggle="tooltip"]').tooltip('hide');
     $('[data-toggle="popover"]').popover('hide');
+    resetEditor();
   });
 
-  $('.summary-description-container a[data-toggle="tab"]').on('shown.bs.tab', resetEditor);
   form.switchLanguage($('#form_switch_language').val());
 });
 
@@ -80,11 +80,15 @@ function resetEditor() {
   $(languageEditorsSelector).each((index, textarea) => {
     if (window.tinyMCE) {
       const editor = window.tinyMCE.get(textarea.id);
-
       if (editor) {
-        // Reset content to force refresh of editor
-        editor.setContent(editor.getContent());
+        return;
       }
+      // Reset content to force refresh of editor
+      editor.setContent(editor.getContent());
+      setTimeout(() => {
+        editor.execCommand('mceInsertContent', false, '');
+        editor.execCommand('mceAutoResize');
+      }, 300);
     }
   });
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There is an issue when a TinyMCE field is reset while invisible and reverts to min size, typically when the user is in another tab of the product page. The reset happens whenever the user changes language or switches tabs.<br>This pull request runs the ``mceAutoResize`` command (provided by the TinyMCE API) to update the height appropriately when switching tabs/lang.We run the ``mceAutoResize`` command blindly instead of checking whether a TinyMCE field exists in the selected tab, since checking that might incur a performance penalty and there are only two TinyMCE fields in the entire product page anyway.<br> Just mentioning the use of ``setTimeout()`` that might seem a bit hacky, but it does the trick.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See video in #35680 and steps to reproduce the issue described in https://github.com/PrestaShop/PrestaShop/issues/35680#issuecomment-2009101266.
| UI Tests          | N/A
| Fixed issue or discussion?     | Fixes #35680
| Related PRs       | N/A
| Sponsor company   | [WAM](https://www.linkedin.com/company/wam-intl/)
