### PR TITLE
Partial fix for textarea field height issues in V1 product page

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -93,7 +93,7 @@ function resetEditor() {
     // Reset content to force refresh of editor
     editor.setContent(editor.getContent());
     setTimeout(() => {
-      editor.execCommand('mceInsertContent', false, '');
+      editor.execCommand('mceInsertContent', false, '', {skip_focus: true});
       editor.execCommand('mceAutoResize');
     }, 250);
   });

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -67,6 +67,7 @@ $(document).ready(() => {
   $('#form-nav').on('click', '.nav-item', () => {
     $('[data-toggle="tooltip"]').tooltip('hide');
     $('[data-toggle="popover"]').popover('hide');
+    resetEditor();
   });
 
   $('.summary-description-container a[data-toggle="tab"]').on('shown.bs.tab', resetEditor);
@@ -77,16 +78,24 @@ $(document).ready(() => {
  * Reset active tinyMce editor (triggered when switch language, or switching tabs)
  */
 function resetEditor() {
+  if (!window.tinyMCE) {
+    return;
+  }
+
   const languageEditorsSelector = '.summary-description-container div.translation-field.active textarea.autoload_rte';
   $(languageEditorsSelector).each((index, textarea) => {
-    if (window.tinyMCE) {
-      const editor = window.tinyMCE.get(textarea.id);
+    const editor = window.tinyMCE.get(textarea.id);
 
-      if (editor) {
-        // Reset content to force refresh of editor
-        editor.setContent(editor.getContent());
-      }
+    if (!editor) {
+      return;
     }
+
+    // Reset content to force refresh of editor
+    editor.setContent(editor.getContent());
+    setTimeout(() => {
+      editor.execCommand('mceInsertContent', false, '');
+      editor.execCommand('mceAutoResize');
+    }, 250);
   });
 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | See #35692 (that I closed earlier). This fix is only applicable to the old product page, so merging in the 8.1.x branch makes more sense. This fix also addresses the issue of a superfluous focus on the textarea field introduced by the previous PR.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/35680#issuecomment-2009101266 
| UI Tests          | N/A
| Fixed issue or discussion?     | Partial fix/workaround for #35680
| Related PRs       | Follow-up for #35692
| Sponsor company   | [WAM](https://www.linkedin.com/company/wam-intl/)

NB: This PR does not address the issue in the new product page. In fact, there's probably a better way to fix completely the issue with TinyMCE fields in hidden tabs by using TinyMCE's event handling capabilities, but that requires some thorough UI testing so I'll think about it in a few weeks when I'll have more time. In the meantime, this should be a nice temporary workaround for the old product page.