### PR TITLE
Add scope hard coded checks in places employee permissions were hard coded

### DIFF
--- a/app/config/admin/config.yml
+++ b/app/config/admin/config.yml
@@ -8,4 +8,3 @@ framework:
   router:
     resource: "%kernel.project_dir%/app/config/admin/routing.yml"
     strict_requirements: ~
-  error_controller: PrestaShopBundle\Controller\Admin\ErrorController::showAction

--- a/app/config/admin/config_prod.yml
+++ b/app/config/admin/config_prod.yml
@@ -1,3 +1,6 @@
 imports:
   - { resource: ../config_prod.yml }
   - { resource: config.yml }
+
+framework:
+  error_controller: PrestaShopBundle\Controller\Admin\ErrorController::showAction

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3495,6 +3495,8 @@ abstract class ModuleCore implements ModuleInterface
     public static function resetStaticCache()
     {
         static::$_INSTANCE = [];
+        static::$modules_cache = null;
+        static::$cachedModuleNames = null;
         Cache::clean('Module::isEnabled*');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "prestashop/gsitemap": "^4",
         "prestashop/pagesnotfound": "^2",
         "prestashop/productcomments": "^6.0",
-        "prestashop/ps_apiresources": "dev-filters-class",
+        "prestashop/ps_apiresources": "dev-module-endpoint",
         "prestashop/ps_banner": "^2",
         "prestashop/ps_bestsellers": "^1.0",
         "prestashop/ps_brandlist": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d2270fec6c8af9a94eead07a83dc65b",
+    "content-hash": "02928d8728ffeb508e357c9a8a7e6633",
     "packages": [
         {
             "name": "api-platform/core",
@@ -5579,16 +5579,16 @@
         },
         {
             "name": "prestashop/ps_apiresources",
-            "version": "dev-filters-class",
+            "version": "dev-module-endpoint",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jolelievre/ps_apiresources.git",
-                "reference": "c5872ad07215872dec33f313bf9ebdce5fce406c"
+                "reference": "959b5ffaed7e6b1855a0ab3e5fb36cd7eba6bcdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jolelievre/ps_apiresources/zipball/c5872ad07215872dec33f313bf9ebdce5fce406c",
-                "reference": "c5872ad07215872dec33f313bf9ebdce5fce406c",
+                "url": "https://api.github.com/repos/jolelievre/ps_apiresources/zipball/959b5ffaed7e6b1855a0ab3e5fb36cd7eba6bcdf",
+                "reference": "959b5ffaed7e6b1855a0ab3e5fb36cd7eba6bcdf",
                 "shasum": ""
             },
             "require": {
@@ -5640,9 +5640,9 @@
             "description": "PrestaShop - API Resources",
             "homepage": "https://github.com/PrestaShop/ps_apiresources",
             "support": {
-                "source": "https://github.com/jolelievre/ps_apiresources/tree/filters-class"
+                "source": "https://github.com/jolelievre/ps_apiresources/tree/module-endpoint"
             },
-            "time": "2024-03-25T16:42:36+00:00"
+            "time": "2024-03-26T12:51:38+00:00"
         },
         {
             "name": "prestashop/ps_banner",

--- a/src/Adapter/Module/QueryHandler/GetModuleInfosHandler.php
+++ b/src/Adapter/Module/QueryHandler/GetModuleInfosHandler.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Module\QueryHandler;
+
+use Module;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
+use PrestaShop\PrestaShop\Core\Domain\Module\Exception\ModuleNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Module\Query\GetModuleInfos;
+use PrestaShop\PrestaShop\Core\Domain\Module\QueryHandler\GetModuleInfosHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Module\QueryResult\ModuleInfos;
+
+#[AsQueryHandler]
+class GetModuleInfosHandler implements GetModuleInfosHandlerInterface
+{
+    public function handle(GetModuleInfos $query): ModuleInfos
+    {
+        $module = Module::getInstanceById($query->getModuleId()->getValue());
+        if (empty($module)) {
+            throw new ModuleNotFoundException('Cannot find Module with ID ' . $query->getModuleId()->getValue());
+        }
+
+        return new ModuleInfos(
+            (int) $module->id,
+            $module->name,
+            $module->version,
+            (bool) $module->active,
+        );
+    }
+}

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Adapter\Tools;
+use PrestaShop\PrestaShop\Core\Context\ApiClientContext;
 use PrestaShop\PrestaShop\Core\Module\ModuleManager;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
 use PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerFactory;
@@ -50,19 +51,20 @@ class ModuleManagerBuilder
      *
      * @var ModuleRepository
      */
-    public static $modulesRepository = null;
+    protected static $modulesRepository = null;
     /**
      * Singleton of ModuleManager.
      *
      * @var ModuleManager
      */
-    public static $moduleManager = null;
-    public static $adminModuleDataProvider = null;
-    public static $legacyLogger = null;
-    public static $moduleDataProvider = null;
-    public static $translator = null;
-    public static $instance = null;
-    public static $cacheProvider = null;
+    protected static $moduleManager = null;
+    protected static $adminModuleDataProvider = null;
+    protected static $legacyLogger = null;
+    protected static $moduleDataProvider = null;
+    protected static $translator = null;
+    protected static $instance = null;
+    protected static $cacheProvider = null;
+    protected static $apiClientContext;
 
     /**
      * @var bool
@@ -168,10 +170,12 @@ class ModuleManagerBuilder
 
         if (null === self::$adminModuleDataProvider) {
             self::$moduleDataProvider = new ModuleDataProvider(self::$legacyLogger, self::$translator);
+            self::$apiClientContext = new ApiClientContext(null);
             self::$adminModuleDataProvider = new AdminModuleDataProvider(
                 self::$moduleDataProvider,
                 self::$translator,
-                Context::getContext()->employee
+                Context::getContext()->employee,
+                self::$apiClientContext,
             );
             self::$adminModuleDataProvider->setRouter($this->getSymfonyRouter());
         }

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Addon\AddonManagerInterface;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use PrestaShop\PrestaShop\Core\Addon\Theme\Exception\ThemeAlreadyExistsException;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Context\ApiClientContext;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\FailedToEnableThemeModuleException;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\ThemeConstraintException;
 use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
@@ -56,108 +57,31 @@ use Tools;
 
 class ThemeManager implements AddonManagerInterface
 {
-    /**
-     * @var HookConfigurator
-     */
-    private $hookConfigurator;
+    public ?string $sandbox;
 
-    /**
-     * @var Shop
-     */
-    private $shop;
+    private readonly TranslationFinder $translationFinder;
 
-    /**
-     * @var Employee
-     */
-    private $employee;
+    private readonly LoggerInterface $logger;
 
-    /**
-     * @var ThemeValidator
-     */
-    private $themeValidator;
+    private readonly ApiClientContext $apiClientContext;
 
-    /**
-     * @var ConfigurationInterface
-     */
-    private $appConfiguration;
-
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    /**
-     * @var Finder
-     */
-    private $finder;
-
-    /**
-     * @var string|null
-     */
-    public $sandbox;
-
-    /**
-     * @var ThemeRepository
-     */
-    private $themeRepository;
-
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
-     * @var ImageTypeRepository
-     */
-    private $imageTypeRepository;
-
-    /**
-     * @var TranslationFinder
-     */
-    private $translationFinder;
-
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
-     * @param Shop $shop
-     * @param ConfigurationInterface $configuration
-     * @param ThemeValidator $themeValidator
-     * @param TranslatorInterface $translator
-     * @param Employee $employee
-     * @param Filesystem $filesystem
-     * @param Finder $finder
-     * @param HookConfigurator $hookConfigurator
-     * @param ThemeRepository $themeRepository
-     * @param ImageTypeRepository $imageTypeRepository
-     */
     public function __construct(
-        Shop $shop,
-        ConfigurationInterface $configuration,
-        ThemeValidator $themeValidator,
-        TranslatorInterface $translator,
-        Employee $employee,
-        Filesystem $filesystem,
-        Finder $finder,
-        HookConfigurator $hookConfigurator,
-        ThemeRepository $themeRepository,
-        ImageTypeRepository $imageTypeRepository,
-        LoggerInterface $logger = null
+        private Shop $shop,
+        private readonly ConfigurationInterface $configuration,
+        private readonly ThemeValidator $themeValidator,
+        private readonly TranslatorInterface $translator,
+        private readonly Employee $employee,
+        private readonly Filesystem $filesystem,
+        private Finder $finder,
+        private readonly HookConfigurator $hookConfigurator,
+        private readonly ThemeRepository $themeRepository,
+        private readonly ImageTypeRepository $imageTypeRepository,
+        LoggerInterface $logger = null,
+        ApiClientContext $apiClientContext = null,
     ) {
         $this->translationFinder = new TranslationFinder();
-        $this->shop = $shop;
-        $this->appConfiguration = $configuration;
-        $this->themeValidator = $themeValidator;
-        $this->translator = $translator;
-        $this->employee = $employee;
-        $this->filesystem = $filesystem;
-        $this->finder = $finder;
-        $this->hookConfigurator = $hookConfigurator;
-        $this->themeRepository = $themeRepository;
-        $this->imageTypeRepository = $imageTypeRepository;
         $this->logger = $logger ?? new NullLogger();
+        $this->apiClientContext = $apiClientContext ?? new ApiClientContext(null);
     }
 
     /**
@@ -192,7 +116,8 @@ class ThemeManager implements AddonManagerInterface
      */
     public function uninstall($name)
     {
-        if (!$this->employee->can('delete', 'AdminThemes')) {
+        $apiClientHasPermission = $this->apiClientContext->getApiClient() !== null && $this->apiClientContext->getApiClient()->hasScope('theme_write');
+        if (!$this->employee->can('delete', 'AdminThemes') && !$apiClientHasPermission) {
             return false;
         }
 
@@ -233,12 +158,13 @@ class ThemeManager implements AddonManagerInterface
      */
     public function enable($name, $force = false)
     {
-        if (!$force && !$this->employee->can('edit', 'AdminThemes')) {
+        $apiClientHasPermission = $this->apiClientContext->getApiClient() !== null && $this->apiClientContext->getApiClient()->hasScope('theme_write');
+        if (!$force && !$this->employee->can('edit', 'AdminThemes') && !$apiClientHasPermission) {
             return false;
         }
 
         /* if file exits, remove it and use YAML configuration file instead */
-        @unlink($this->appConfiguration->get('_PS_CONFIG_DIR_') . 'themes/' . $name . '/shop' . $this->shop->id . '.json');
+        @unlink($this->configuration->get('_PS_CONFIG_DIR_') . 'themes/' . $name . '/shop' . $this->shop->id . '.json');
 
         /** @var Theme $theme */
         $theme = $this->themeRepository->getInstanceByName($name);
@@ -286,7 +212,7 @@ class ThemeManager implements AddonManagerInterface
 
         $this->doDisableModules($theme->getModulesToDisable());
 
-        @unlink($this->appConfiguration->get('_PS_CONFIG_DIR_') . 'themes/' . $name . '/shop' . $this->shop->id . '.json');
+        @unlink($this->configuration->get('_PS_CONFIG_DIR_') . 'themes/' . $name . '/shop' . $this->shop->id . '.json');
 
         return true;
     }
@@ -352,7 +278,7 @@ class ThemeManager implements AddonManagerInterface
     private function doApplyConfiguration(array $configuration): self
     {
         foreach ($configuration as $key => $value) {
-            $this->appConfiguration->set($key, $value);
+            $this->configuration->set($key, $value);
         }
 
         return $this;
@@ -494,7 +420,7 @@ class ThemeManager implements AddonManagerInterface
             throw new ThemeConstraintException($errorMessage, ThemeConstraintException::INVALID_CONFIGURATION);
         }
 
-        $module_root_dir = $this->appConfiguration->get('_PS_MODULE_DIR_');
+        $module_root_dir = $this->configuration->get('_PS_MODULE_DIR_');
         $modules_parent_dir = $sandboxPath . '/dependencies/modules';
         if ($this->filesystem->exists($modules_parent_dir)) {
             $module_dirs = $this->finder->directories()
@@ -511,7 +437,7 @@ class ThemeManager implements AddonManagerInterface
             $this->filesystem->remove($modules_parent_dir);
         }
 
-        $themePath = $this->appConfiguration->get('_PS_ALL_THEMES_DIR_') . $theme->getName();
+        $themePath = $this->configuration->get('_PS_ALL_THEMES_DIR_') . $theme->getName();
         if ($this->filesystem->exists($themePath)) {
             $errorMessage = $this->translator->trans('There is already a theme named ' . $theme->getName() . ' in your themes/ folder. Remove it if you want to continue.', [], 'Admin.Design.Notification');
             $this->logger->error($errorMessage);
@@ -529,7 +455,7 @@ class ThemeManager implements AddonManagerInterface
     private function getSandboxPath()
     {
         if (!isset($this->sandbox)) {
-            $this->sandbox = $this->appConfiguration->get('_PS_CACHE_DIR_') . 'sandbox/' . uniqid() . '/';
+            $this->sandbox = $this->configuration->get('_PS_CACHE_DIR_') . 'sandbox/' . uniqid() . '/';
             $this->filesystem->mkdir($this->sandbox, PsFileSystem::DEFAULT_MODE_FOLDER);
         }
 
@@ -541,7 +467,7 @@ class ThemeManager implements AddonManagerInterface
      */
     public function saveTheme($theme)
     {
-        $jsonConfigFolder = $this->appConfiguration->get('_PS_CONFIG_DIR_') . 'themes/' . $theme->getName();
+        $jsonConfigFolder = $this->configuration->get('_PS_CONFIG_DIR_') . 'themes/' . $theme->getName();
         if (!$this->filesystem->exists($jsonConfigFolder) && !is_dir($jsonConfigFolder)) {
             mkdir($jsonConfigFolder, PsFileSystem::DEFAULT_MODE_FOLDER, true);
         }
@@ -569,7 +495,7 @@ class ThemeManager implements AddonManagerInterface
         $themeProvider = $kernel->getContainer()->get('prestashop.translation.theme_provider');
 
         $themeName = $theme->getName();
-        $themePath = $this->appConfiguration->get('_PS_ALL_THEMES_DIR_') . $themeName;
+        $themePath = $this->configuration->get('_PS_ALL_THEMES_DIR_') . $themeName;
         $translationFolder = $themePath . DIRECTORY_SEPARATOR . 'translations' . DIRECTORY_SEPARATOR;
 
         $languages = Language::getLanguages();

--- a/src/Core/Addon/Theme/ThemeManagerBuilder.php
+++ b/src/Core/Addon/Theme/ThemeManagerBuilder.php
@@ -31,6 +31,7 @@ use Db;
 use Employee;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Hook\HookInformationProvider;
+use PrestaShop\PrestaShop\Core\Context\ApiClientContext;
 use PrestaShop\PrestaShop\Core\Image\ImageTypeRepository;
 use PrestaShop\PrestaShop\Core\Module\HookConfigurator;
 use PrestaShop\PrestaShop\Core\Module\HookRepository;
@@ -42,17 +43,18 @@ use Symfony\Component\Finder\Finder;
 
 class ThemeManagerBuilder
 {
-    private $context;
-    private $db;
-    private $themeValidator;
-    private $logger;
+    private LoggerInterface $logger;
+    private ApiClientContext $apiClientContext;
 
-    public function __construct(Context $context, Db $db, ThemeValidator $themeValidator = null, LoggerInterface $logger = null)
-    {
-        $this->context = $context;
-        $this->db = $db;
-        $this->themeValidator = $themeValidator;
+    public function __construct(
+        private Context $context,
+        private readonly Db $db,
+        private ?ThemeValidator $themeValidator = null,
+        ?LoggerInterface $logger = null,
+        ?ApiClientContext $apiClientContext = null
+    ) {
         $this->logger = $logger ?? new NullLogger();
+        $this->apiClientContext = $apiClientContext ?: new ApiClientContext(null);
     }
 
     public function build()
@@ -83,7 +85,8 @@ class ThemeManagerBuilder
             ),
             $this->buildRepository($this->context->shop),
             new ImageTypeRepository($this->db),
-            $this->logger
+            $this->logger,
+            $this->apiClientContext,
         );
     }
 

--- a/src/Core/Context/ApiClient.php
+++ b/src/Core/Context/ApiClient.php
@@ -48,6 +48,11 @@ class ApiClient
         return $this->clientId;
     }
 
+    public function hasScope(string $scope): bool
+    {
+        return in_array($scope, $this->scopes);
+    }
+
     public function getScopes(): array
     {
         return $this->scopes;

--- a/src/Core/Domain/Module/Query/GetModuleInfos.php
+++ b/src/Core/Domain/Module/Query/GetModuleInfos.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Module\Query;
+
+use PrestaShop\PrestaShop\Core\Domain\Module\ValueObject\ModuleId;
+
+/**
+ * Get module information
+ */
+class GetModuleInfos
+{
+    private ModuleId $moduleId;
+
+    public function __construct(
+        int $moduleId,
+    ) {
+        $this->moduleId = new ModuleId($moduleId);
+    }
+
+    public function getModuleId(): ModuleId
+    {
+        return $this->moduleId;
+    }
+}

--- a/src/Core/Domain/Module/QueryHandler/GetModuleInfosHandlerInterface.php
+++ b/src/Core/Domain/Module/QueryHandler/GetModuleInfosHandlerInterface.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Module\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Module\Query\GetModuleInfos;
+use PrestaShop\PrestaShop\Core\Domain\Module\QueryResult\ModuleInfos;
+
+interface GetModuleInfosHandlerInterface
+{
+    public function handle(GetModuleInfos $query): ModuleInfos;
+}

--- a/src/Core/Domain/Module/QueryResult/ModuleInfos.php
+++ b/src/Core/Domain/Module/QueryResult/ModuleInfos.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Module\QueryResult;
+
+class ModuleInfos
+{
+    public function __construct(
+        private readonly int $moduleId,
+        private readonly string $technicalName,
+        private readonly string $version,
+        private readonly bool $enabled,
+    ) {
+    }
+
+    public function getModuleId(): int
+    {
+        return $this->moduleId;
+    }
+
+    public function getTechnicalName(): string
+    {
+        return $this->technicalName;
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_provider.yml
@@ -11,6 +11,7 @@ services:
       - "@prestashop.adapter.data_provider.module"
       - '@translator'
       - "@=service('prestashop.adapter.legacy.context').getContext().employee"
+      - '@PrestaShop\PrestaShop\Core\Context\ApiClientContext'
     calls:
       - [ setRouter, [ '@router' ] ]
     decorates: prestashop.core.admin.data_provider.module_interface

--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -10,6 +10,11 @@ services:
       - '@prestashop.adapter.legacy.logger'
       - '@prestashop.core.cache.clearer.cache_clearer_chain'
 
+  PrestaShop\PrestaShop\Adapter\Module\QueryHandler\GetModuleInfosHandler:
+    autowire: true
+    autoconfigure: true
+    public: false
+
   prestashop.adapter.module.self_configurator:
     class: PrestaShop\PrestaShop\Adapter\Module\Configuration\ModuleSelfConfigurator
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/addon.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/addon.yml
@@ -31,6 +31,7 @@ services:
       - '@prestashop.adapter.legacy_db'
       - '@prestashop.core.addon.theme.theme_validator'
       - '@logger'
+      - '@PrestaShop\PrestaShop\Core\Context\ApiClientContext'
 
   prestashop.core.addon.theme.theme_manager:
     class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManager

--- a/tests/Integration/Behaviour/Features/Context/Domain/ModuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ModuleFeatureContext.php
@@ -28,12 +28,30 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
+use Behat\Gherkin\Node\TableNode;
 use Module;
+use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Module\Command\BulkToggleModuleStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Module\Query\GetModuleInfos;
+use PrestaShop\PrestaShop\Core\Domain\Module\QueryResult\ModuleInfos;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 class ModuleFeatureContext extends AbstractDomainFeatureContext
 {
+    /**
+     * @Given module :moduleReference has following infos:
+     */
+    public function assertModuleInfos(string $moduleReference, TableNode $tableNode): void
+    {
+        /** @var ModuleInfos $moduleInfos */
+        $moduleInfos = $this->getQueryBus()->handle(new GetModuleInfos($this->referenceToId($moduleReference)));
+
+        $data = $tableNode->getRowsHash();
+        Assert::assertEquals($data['technical_name'], $moduleInfos->getTechnicalName());
+        Assert::assertEquals($data['version'], $moduleInfos->getVersion());
+        Assert::assertEquals(PrimitiveUtils::castStringBooleanIntoBoolean($data['enabled']), $moduleInfos->isEnabled());
+    }
+
     /**
      * @When /^I bulk (enable|disable) modules: "(.+)"$/
      */

--- a/tests/Integration/Behaviour/Features/Context/ModuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ModuleFeatureContext.php
@@ -48,6 +48,16 @@ class ModuleFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Given the module with technical name :technicalName exists
+     */
+    public function assertModuleExists(string $technicalName): void
+    {
+        $moduleId = (int) Module::getModuleIdByName($technicalName);
+        Assert::assertGreaterThan(0, $moduleId);
+        $this->getSharedStorage()->set($technicalName, $moduleId);
+    }
+
+    /**
      * @Given the module :module is enabled
      */
     public function isTheModuleEnabled(string $module): void

--- a/tests/Integration/Behaviour/Features/Scenario/Module/module.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Module/module.feature
@@ -23,3 +23,10 @@ Feature: Module
     When I bulk enable modules: "ps_featuredproducts"
     Then the module "ps_featuredproducts" is enabled
     And the module "ps_emailsubscription" is enabled
+
+  Scenario: Get module infos
+    Given the module with technical name ps_emailsubscription exists
+    Then module ps_emailsubscription has following infos:
+      | technical_name | ps_emailsubscription |
+      | version        | 2.8.2                |
+      | enabled        | true                 |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add scope hard-coded checks in places employee permissions were hard coded, this is not a perfect solution but a quick one The module and theme endpoints will simply have to match the chosen scope when they are implemented Only one write scope is checked, any more advanced scope policy will require a new development or a refacto to handle this more generically
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/8438552754
| UI Tests          | Fixes #35670
| Fixed issue or discussion?     | ~
| Related PRs       | https://github.com/PrestaShop/ps_apiresources/pull/20
| Sponsor company   | ~

### Breaking changes

- `PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder` public static fields were changed into protected ones as they were not used outside of the class
- `PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManager` internal fields were turned into readonly fields
