### PR TITLE
Fix a bug that doesn't update MPN field during combination import via file import

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -2504,7 +2504,8 @@ class AdminImportControllerCore extends AdminController
                                         $id_shop_list,
                                         '',
                                         $info['low_stock_threshold'],
-                                        $info['low_stock_alert']
+                                        $info['low_stock_alert'],
+                                        (string) $info['mpn']
                                     );
                                     $id_product_attribute_update = true;
                                     if (isset($info['supplier_reference']) && !empty($info['supplier_reference'])) {
@@ -2537,7 +2538,8 @@ class AdminImportControllerCore extends AdminController
                             $info['available_date'],
                             '',
                             $info['low_stock_threshold'],
-                            $info['low_stock_alert']
+                            $info['low_stock_alert'],
+                            (string) $info['mpn']
                         );
 
                         if (isset($info['supplier_reference']) && !empty($info['supplier_reference'])) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR fixes a bug that appear during combinations import via file import procedure.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Upload a file via combinations file import procedure to see the changes and MPN field created/updated.
| Fixed issue or discussion?     | Fixes #35721 

## What fixes this PR

This PR fixes a bug that occurs during combinations import via the official file import procedure.

## How I can reproduce the problem

To reproduce the problem you can simple follow this steps:

1. Go to advanced parameters -> import
2. Select "combinations" on select field
3. Upload a sample combinations file with the MPN field present in the combination row
4. Map the attributes of the files with the Combination attributes
5. Import the file and wait to finish
6. Open the product in the backoffice, you notice that all fields are updated or created but the MPN still remain empty. Everytime.

## Why this happens

After investigating, I've searched in the adminImportController to see what happens with the combinations.
This happens for a simple reason: The MPN field is not present, in the method call that really update the product combination.

## What i've done

I have added the missing MPN field in the method, casting it to string, to update the product.

## Final result

If you retest with this PR you see the MPN field updated.