### PR TITLE
Remove deprecated jquery method

### DIFF
--- a/themes/_core/js/checkout-steps.js
+++ b/themes/_core/js/checkout-steps.js
@@ -33,7 +33,7 @@ export default class Steps {
     this.$steps = $(prestashop.selectors.checkout.step);
     this.$steps.off('click');
 
-    this.$clickableSteps = $(currentStepSelector).prevAll().andSelf();
+    this.$clickableSteps = $(currentStepSelector).prevAll().addBack();
     this.$clickableSteps.addClass('-clickable');
   }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Jquery https://api.jquery.com/andSelf/ is deprecated and is throwing errors if you remove jquery migrate. https://api.jquery.com/addBack/ is a replacement. Apart from jquery UI, this was the only code that is not working in clean latest jquery version.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 
