### PR TITLE
[DB] add index to attribute_group is_color_group column

### DIFF
--- a/src/PrestaShopBundle/Entity/AttributeGroup.php
+++ b/src/PrestaShopBundle/Entity/AttributeGroup.php
@@ -33,7 +33,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * AttributeGroup.
  *
- * @ORM\Table()
+ * @ORM\Table(indexes={@ORM\Index(name="is_color_group", columns={"is_color_group"})})
  * @ORM\Entity(repositoryClass="PrestaShopBundle\Entity\Repository\AttributeGroupRepository")
  */
 class AttributeGroup


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Column is_color_group of ps_attribute_group  table is used on WHERE clause, hence must be indexed (mysql log complain)
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Update doctrine schema, browse Prestashop store, check mysql variables "Select full join" (should increments slower ^^)
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 