### PR TITLE
Added check if current order status exists on status update

### DIFF
--- a/src/Adapter/Order/CommandHandler/UpdateOrderStatusHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateOrderStatusHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -62,7 +63,7 @@ final class UpdateOrderStatusHandler extends AbstractOrderHandler implements Upd
 
         $currentOrderState = $order->getCurrentOrderState();
 
-        if ($currentOrderState->id == $orderState->id) {
+        if ($currentOrderState && $currentOrderState->id == $orderState->id) {
             throw new OrderException('The order has already been assigned this status.');
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x
| Description?      | Can not update order status if order does not have order status: `Warning: Attempt to read property "id" on null` UpdateOrderStatusHandler.php:56. Order could be missing order status because of wrongly implemented hook in modules as example`hookUpdateOrderStatus`
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | Create order without state and try to update it status;
| UI Tests          | [https://github.com/ihah/ga.tests.ui.pr/actions/runs/8432404962](https://github.com/ihah/ga.tests.ui.pr/actions/runs/8432404962)
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -
