### PR TITLE
Filter experimental apis

### DIFF
--- a/.github/workflows/symfony-console.yml
+++ b/.github/workflows/symfony-console.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         app-id: [ admin, admin-api, front ]
+      fail-fast: false
     permissions:
       contents: read  # for actions/checkout to fetch code
     name: Symfony Console

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "prestashop/gsitemap": "^4",
         "prestashop/pagesnotfound": "^2",
         "prestashop/productcomments": "^6.0",
-        "prestashop/ps_apiresources": "dev-module-endpoint",
+        "prestashop/ps_apiresources": "dev-experimental-endpoint",
         "prestashop/ps_banner": "^2",
         "prestashop/ps_bestsellers": "^1.0",
         "prestashop/ps_brandlist": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "02928d8728ffeb508e357c9a8a7e6633",
+    "content-hash": "ef9ebfc365e2cf600ab13b3187f49561",
     "packages": [
         {
             "name": "api-platform/core",
@@ -5579,16 +5579,16 @@
         },
         {
             "name": "prestashop/ps_apiresources",
-            "version": "dev-module-endpoint",
+            "version": "dev-experimental-endpoint",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jolelievre/ps_apiresources.git",
-                "reference": "959b5ffaed7e6b1855a0ab3e5fb36cd7eba6bcdf"
+                "reference": "e4b444522ad0dc07b74614d1c5794f49bb67a846"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jolelievre/ps_apiresources/zipball/959b5ffaed7e6b1855a0ab3e5fb36cd7eba6bcdf",
-                "reference": "959b5ffaed7e6b1855a0ab3e5fb36cd7eba6bcdf",
+                "url": "https://api.github.com/repos/jolelievre/ps_apiresources/zipball/e4b444522ad0dc07b74614d1c5794f49bb67a846",
+                "reference": "e4b444522ad0dc07b74614d1c5794f49bb67a846",
                 "shasum": ""
             },
             "require": {
@@ -5597,7 +5597,7 @@
             "require-dev": {
                 "czproject/git-php": "^4.2",
                 "phpunit/phpunit": "^9.6",
-                "prestashop/php-dev-tools": "^4.2"
+                "prestashop/php-dev-tools": "^4.3"
             },
             "type": "prestashop-module",
             "autoload": {
@@ -5640,9 +5640,9 @@
             "description": "PrestaShop - API Resources",
             "homepage": "https://github.com/PrestaShop/ps_apiresources",
             "support": {
-                "source": "https://github.com/jolelievre/ps_apiresources/tree/module-endpoint"
+                "source": "https://github.com/jolelievre/ps_apiresources/tree/experimental-endpoint"
             },
-            "time": "2024-03-26T12:51:38+00:00"
+            "time": "2024-03-27T13:51:05+00:00"
         },
         {
             "name": "prestashop/ps_banner",

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -891,5 +891,8 @@ Country</value>
     <configuration id="PS_PRODUCT_BREADCRUMB_CATEGORY" name="PS_PRODUCT_BREADCRUMB_CATEGORY">
       <value>default</value>
     </configuration>
+    <configuration id="PS_ENABLE_EXPERIMENTAL_API_ENDPOINTS" name="PS_ENABLE_EXPERIMENTAL_API_ENDPOINTS">
+      <value>0</value>
+    </configuration>
   </entities>
 </entity_configuration>

--- a/src/Adapter/AuthorizationServer/AuthorizationServerConfiguration.php
+++ b/src/Adapter/AuthorizationServer/AuthorizationServerConfiguration.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\AuthorizationServer;
+
+use PrestaShop\PrestaShop\Adapter\Cache\Clearer\SymfonyCacheClearer;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class AuthorizationServerConfiguration implements DataConfigurationInterface
+{
+    public function __construct(
+        private readonly Configuration $configuration,
+        private readonly TranslatorInterface $translator,
+        private readonly SymfonyCacheClearer $cacheClearer,
+    ) {
+    }
+
+    public function getConfiguration()
+    {
+        return [
+            'enable_experimental_endpoints' => $this->configuration->getBoolean('PS_ENABLE_EXPERIMENTAL_API_ENDPOINTS'),
+        ];
+    }
+
+    public function updateConfiguration(array $configuration)
+    {
+        $errors = $this->getConfigurationErrors($configuration);
+        if (!empty($errors)) {
+            return $errors;
+        }
+
+        $this->configuration->set('PS_ENABLE_EXPERIMENTAL_API_ENDPOINTS', $configuration['enable_experimental_endpoints']);
+
+        // Clear cache so that Swagger and roles extraction are refreshed
+        $this->cacheClearer->clear();
+
+        return [];
+    }
+
+    public function validateConfiguration(array $configuration)
+    {
+        return empty($this->getConfigurationErrors($configuration));
+    }
+
+    private function getConfigurationErrors(array $configuration): array
+    {
+        $errors = [];
+        if (!is_bool($configuration['enable_experimental_endpoints'])) {
+            $errors[] = $this->translator->trans(
+                'The %s field is invalid.',
+                [$this->translator->trans('Enable experimental endpoints', [], 'Admin.Advparameters.Feature')],
+                'Admin.Notifications.Error'
+            );
+        }
+
+        return $errors;
+    }
+}

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/AbstractCQRSOperation.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/AbstractCQRSOperation.php
@@ -111,6 +111,7 @@ abstract class AbstractCQRSOperation extends HttpOperation
         array $scopes = [],
         ?array $CQRSQueryMapping = null,
         ?array $ApiResourceMapping = null,
+        ?bool $experimentalOperation = null,
     ) {
         $passedArguments = \get_defined_vars();
 
@@ -134,11 +135,17 @@ abstract class AbstractCQRSOperation extends HttpOperation
             $passedArguments['extraProperties']['ApiResourceMapping'] = $ApiResourceMapping;
         }
 
+        if (null !== $experimentalOperation) {
+            $this->checkArgumentAndExtraParameterValidity('experimentalOperation', $experimentalOperation, $passedArguments['extraProperties']);
+            $passedArguments['extraProperties']['experimentalOperation'] = $experimentalOperation;
+        }
+
         // Remove custom arguments
         unset($passedArguments['scopes']);
         unset($passedArguments['CQRSQuery']);
         unset($passedArguments['CQRSQueryMapping']);
         unset($passedArguments['ApiResourceMapping']);
+        unset($passedArguments['experimentalOperation']);
 
         // Unless especially specified we only handle JSON format by default
         $passedArguments['formats'] = $formats ?? ['json'];
@@ -194,6 +201,19 @@ abstract class AbstractCQRSOperation extends HttpOperation
     {
         $self = clone $this;
         $self->extraProperties['ApiResourceMapping'] = $CQRSQuery;
+
+        return $self;
+    }
+
+    public function getExperimentalOperation(): bool
+    {
+        return $this->extraProperties['experimentalOperation'] ?? false;
+    }
+
+    public function withExperimentalOperation(bool $experimentalOperation): static
+    {
+        $self = clone $this;
+        $self->extraProperties['experimentalOperation'] = $experimentalOperation;
 
         return $self;
     }

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSCommand.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSCommand.php
@@ -116,6 +116,7 @@ class CQRSCommand extends AbstractCQRSOperation
         ?array $CQRSQueryMapping = null,
         ?array $ApiResourceMapping = null,
         ?array $CQRSCommandMapping = null,
+        ?bool $experimentalOperation = null,
     ) {
         $passedArguments = \get_defined_vars();
 

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSCreate.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSCreate.php
@@ -114,6 +114,7 @@ class CQRSCreate extends CQRSCommand
         ?array $CQRSQueryMapping = null,
         ?array $ApiResourceMapping = null,
         ?array $CQRSCommandMapping = null,
+        ?bool $experimentalOperation = null,
     ) {
         $passedArguments = \get_defined_vars();
         $passedArguments['method'] = self::METHOD_POST;

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSDelete.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSDelete.php
@@ -115,6 +115,7 @@ class CQRSDelete extends AbstractCQRSOperation
         array $scopes = [],
         ?array $CQRSQueryMapping = null,
         ?array $ApiResourceMapping = null,
+        ?bool $experimentalOperation = null,
     ) {
         $passedArguments = \get_defined_vars();
         $passedArguments['method'] = self::METHOD_DELETE;

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSGet.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSGet.php
@@ -114,6 +114,7 @@ class CQRSGet extends AbstractCQRSOperation
         array $scopes = [],
         ?array $CQRSQueryMapping = null,
         ?array $ApiResourceMapping = null,
+        ?bool $experimentalOperation = null,
     ) {
         $passedArguments = \get_defined_vars();
         $passedArguments['method'] = self::METHOD_GET;

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSPartialUpdate.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSPartialUpdate.php
@@ -115,6 +115,7 @@ class CQRSPartialUpdate extends CQRSCommand
         ?array $CQRSQueryMapping = null,
         ?array $ApiResourceMapping = null,
         ?array $CQRSCommandMapping = null,
+        ?bool $experimentalOperation = null,
     ) {
         $passedArguments = \get_defined_vars();
         $passedArguments['method'] = self::METHOD_PATCH;

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSQueryCollection.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSQueryCollection.php
@@ -115,6 +115,7 @@ class CQRSQueryCollection extends AbstractCQRSOperation implements CollectionOpe
         array $scopes = [],
         ?array $CQRSQueryMapping = null,
         ?array $ApiResourceMapping = null,
+        ?bool $experimentalOperation = null,
     ) {
         $passedArguments = \get_defined_vars();
         $passedArguments['method'] = self::METHOD_GET;

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSUpdate.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSUpdate.php
@@ -115,6 +115,7 @@ class CQRSUpdate extends CQRSCommand
         ?array $CQRSQueryMapping = null,
         ?array $ApiResourceMapping = null,
         ?array $CQRSCommandMapping = null,
+        ?bool $experimentalOperation = null,
     ) {
         $passedArguments = \get_defined_vars();
         $passedArguments['method'] = self::METHOD_PUT;

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/DQBPaginatedList.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/DQBPaginatedList.php
@@ -116,6 +116,7 @@ class DQBPaginatedList extends AbstractCQRSOperation implements CollectionOperat
         ?string $queryBuilder = null,
         ?string $filtersClass = null,
         ?array $filtersMapping = null,
+        ?bool $experimentalOperation = null,
     ) {
         $passedArguments = \get_defined_vars();
         $passedArguments['method'] = self::METHOD_GET;

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/Resource/Factory/ExperimentalOperationsMetadataCollectionFactoryDecorator.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/Resource/Factory/ExperimentalOperationsMetadataCollectionFactoryDecorator.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\ApiPlatform\Metadata\Resource\Factory;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+
+/**
+ * This factory decorates the ApiPlatform default resource factory. It looks into each operation and checks
+ * if the extra property experimentalOperation is set to true, if its is then the operation should be filtered out
+ * in production environment. This means the operation is not visible in Swagger, and it's not used to generate the
+ * api routing, so it's not usable at all.
+ *
+ * Scope extraction is also impacted by this filtering, meaning if a scope is only associated to experimental operations
+ * it won't be available in prod mode at all.
+ *
+ * In dev mode all operations are kept though.
+ */
+class ExperimentalOperationsMetadataCollectionFactoryDecorator implements ResourceMetadataCollectionFactoryInterface
+{
+    public function __construct(
+        private readonly ResourceMetadataCollectionFactoryInterface $innerFactory,
+        private readonly bool $isDebug,
+    ) {
+    }
+
+    public function create(string $resourceClass): ResourceMetadataCollection
+    {
+        // We call the original method since we only want to alter the result of this method.
+        $resourceMetadataCollection = $this->innerFactory->create($resourceClass);
+
+        // In debug mode we filter nothing
+        if ($this->isDebug) {
+            return $resourceMetadataCollection;
+        }
+
+        /** @var ApiResource $resourceMetadata */
+        foreach ($resourceMetadataCollection as $resourceMetadata) {
+            $operations = $resourceMetadata->getOperations();
+            /** @var Operation $operation */
+            foreach ($operations as $key => $operation) {
+                $extraProperties = $operation->getExtraProperties();
+                if (isset($extraProperties['experimentalOperation']) && $extraProperties['experimentalOperation'] === true) {
+                    $operations->remove($key);
+                }
+            }
+        }
+
+        return $resourceMetadataCollection;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AuthorizationServer/ConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AuthorizationServer/ConfigurationType.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\AdvancedParameters\AuthorizationServer;
+
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class ConfigurationType extends TranslatorAwareType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        parent::buildForm($builder, $options);
+        $builder
+            ->add('enable_experimental_endpoints', SwitchType::class, [
+                'label' => $this->trans('Enable experimental endpoints', 'Admin.Advparameters.Feature'),
+                'help' => $this->trans('Experimental API endpoints are disabled by default in prod environment, this configuration allows to forcefully enable them (not recommended).', 'Admin.Advparameters.Feature'),
+                'required' => true,
+            ])
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/AuthorizationServer/FormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/AuthorizationServer/FormDataProvider.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\AuthorizationServer;
+
+use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
+
+class FormDataProvider implements FormDataProviderInterface
+{
+    public function __construct(
+        private readonly DataConfigurationInterface $dataConfiguration
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData()
+    {
+        return $this->dataConfiguration->getConfiguration();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setData(array $data)
+    {
+        return $this->dataConfiguration->updateConfiguration($data);
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/authorization_server.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/authorization_server.yml
@@ -6,6 +6,14 @@ admin_api_clients_index:
     _legacy_controller: AdminAuthorizationServer
     _legacy_link: AdminAuthorizationServer
 
+admin_api_clients_process_configuration:
+  path: /api-clients
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\AuthorizationServer\ApiClientController::processConfigurationAction
+    _legacy_controller: AdminAuthorizationServer
+    _legacy_link: AdminAuthorizationServer
+
 admin_api_clients_create:
   path: /api-clients/create
   methods: [ GET, POST, PATCH ]

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -298,3 +298,6 @@ services:
   PrestaShop\PrestaShop\Adapter\Admin\ImageConfiguration:
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+
+  PrestaShop\PrestaShop\Adapter\AuthorizationServer\AuthorizationServerConfiguration:
+    autowire: true

--- a/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
@@ -1,0 +1,59 @@
+# These are services related to ApiPlatform integration, like decorators or services that depend on the ApiPlatform framework
+services:
+  _defaults:
+    public: false
+
+  # Configuration to automatically inject normalizers into DomainSerializer
+  PrestaShopBundle\ApiPlatform\Normalizer\:
+    resource: "../../../../ApiPlatform/Normalizer/*"
+    tags: [ 'prestashop.api.normalizers' ]
+
+  # This is a custom serializer used by our custom providers/processors for ApiPlatform
+  PrestaShopBundle\ApiPlatform\DomainSerializer:
+    class: PrestaShopBundle\ApiPlatform\DomainSerializer
+    arguments:
+      - !tagged_iterator { tag: prestashop.api.normalizers, default_priority_method: getNormalizerPriority }
+
+  # Customer provider for CQRS queries
+  PrestaShopBundle\ApiPlatform\Provider\QueryProvider:
+    tags: [ 'api_platform.state_provider' ]
+    autowire: true
+    arguments:
+      - '@prestashop.core.query_bus'
+
+  # Custom processor for CQRS commands
+  PrestaShopBundle\ApiPlatform\Processor\CommandProcessor:
+    tags: [ 'api_platform.state_processor' ]
+    autowire: true
+    arguments:
+      - '@prestashop.core.command_bus'
+
+  # Custom provider for paginated listing
+  PrestaShopBundle\ApiPlatform\Provider\QueryListProvider:
+    tags: [ 'api_platform.state_provider' ]
+    autowire: true
+    arguments:
+      $filtersBuilder: '@prestashop.core.api.search.builder'
+      $requestStack: '@request_stack'
+
+  # This decorator allows modifying the available ApiPlatform resources based on their configuration (using a custom extra property)
+  PrestaShopBundle\ApiPlatform\Metadata\Resource\Factory\ExperimentalOperationsMetadataCollectionFactoryDecorator:
+    decorates: api_platform.metadata.resource.metadata_collection_factory
+    arguments:
+      $innerFactory: '@.inner'
+      $isDebug: '%kernel.debug%'
+
+  # This service depends on ResourceMetadataCollectionFactoryInterface (auto wired) and can extract the scopes defined on operations
+  PrestaShopBundle\ApiPlatform\Scopes\ApiResourceScopesExtractor:
+    autowire: true
+    arguments:
+      $moduleDir: '%prestashop.module_dir%'
+      $installedModules: '%prestashop.installed_modules%'
+      $enabledModules: '%prestashop.active_modules%'
+      $projectDir: '%kernel.project_dir%'
+
+  PrestaShopBundle\ApiPlatform\Scopes\CachedApiResourceScopesExtractor:
+    autowire: true
+    decorates: PrestaShopBundle\ApiPlatform\Scopes\ApiResourceScopesExtractor
+
+  PrestaShopBundle\ApiPlatform\Scopes\ApiResourceScopesExtractorInterface: '@PrestaShopBundle\ApiPlatform\Scopes\CachedApiResourceScopesExtractor'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
@@ -39,6 +39,7 @@ services:
   # This decorator allows modifying the available ApiPlatform resources based on their configuration (using a custom extra property)
   PrestaShopBundle\ApiPlatform\Metadata\Resource\Factory\ExperimentalOperationsMetadataCollectionFactoryDecorator:
     decorates: api_platform.metadata.resource.metadata_collection_factory
+    autowire: true
     arguments:
       $innerFactory: '@.inner'
       $isDebug: '%kernel.debug%'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
@@ -301,3 +301,8 @@ services:
     arguments:
       - '@prestashop.core.query_bus'
       - '@prestashop.core.command_bus'
+
+  prestashop.adapter.authorization_server.form_provider:
+    class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\AuthorizationServer\FormDataProvider'
+    arguments:
+      - '@PrestaShop\PrestaShop\Adapter\AuthorizationServer\AuthorizationServerConfiguration'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -580,3 +580,12 @@ services:
       - 'PrestaShopBundle\Form\Admin\Improve\Design\ImageSettings\ImageSettingsType'
       - 'ImageSettingsPage'
       - 'image_settings'
+
+  prestashop.adapter.autorization_server.form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\Handler'
+    arguments:
+      - '@form.factory'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.adapter.authorization_server.form_provider'
+      - 'PrestaShopBundle\Form\Admin\AdvancedParameters\AuthorizationServer\ConfigurationType'
+      - 'AuthorizationServer'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/oauth.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/oauth.yml
@@ -72,12 +72,3 @@ services:
   PrestaShopBundle\Controller\Api\OAuth2\AccessTokenController:
     autowire: true
     autoconfigure: true
-
-  PrestaShopBundle\ApiPlatform\Normalizer\:
-    resource: "../../../../ApiPlatform/Normalizer/*"
-    tags: [ 'prestashop.api.normalizers' ]
-
-  PrestaShopBundle\ApiPlatform\DomainSerializer:
-    class: PrestaShopBundle\ApiPlatform\DomainSerializer
-    arguments:
-      - !tagged_iterator { tag: prestashop.api.normalizers, default_priority_method: getNormalizerPriority }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -96,28 +96,6 @@ services:
     public: false
     tags: [ 'container.env_var_processor' ]
 
-  PrestaShopBundle\ApiPlatform\Provider\QueryProvider:
-    tags: [ 'api_platform.state_provider' ]
-    public: false
-    autowire: true
-    arguments:
-      - '@prestashop.core.query_bus'
-
-  PrestaShopBundle\ApiPlatform\Processor\CommandProcessor:
-    tags: [ 'api_platform.state_processor' ]
-    public: false
-    autowire: true
-    arguments:
-      - '@prestashop.core.command_bus'
-
-  PrestaShopBundle\ApiPlatform\Provider\QueryListProvider:
-    tags: [ 'api_platform.state_provider' ]
-    public: false
-    autowire: true
-    arguments:
-      $filtersBuilder: '@prestashop.core.api.search.builder'
-      $requestStack: '@request_stack'
-
   PrestaShopBundle\Security\Admin\SessionRenewer:
     arguments:
       $storage: "@security.csrf.token_storage"
@@ -135,19 +113,3 @@ services:
       - '@doctrine.orm.entity_manager'
 
   PrestaShop\PrestaShop\Core\Repository\TransactionManagerInterface: '@PrestaShopBundle\Service\Database\TransactionManager'
-
-  PrestaShopBundle\ApiPlatform\Scopes\ApiResourceScopesExtractor:
-    public: false
-    autowire: true
-    arguments:
-      $moduleDir: '%prestashop.module_dir%'
-      $installedModules: '%prestashop.installed_modules%'
-      $enabledModules: '%prestashop.active_modules%'
-      $projectDir: '%kernel.project_dir%'
-
-  PrestaShopBundle\ApiPlatform\Scopes\CachedApiResourceScopesExtractor:
-    public: false
-    autowire: true
-    decorates: PrestaShopBundle\ApiPlatform\Scopes\ApiResourceScopesExtractor
-
-  PrestaShopBundle\ApiPlatform\Scopes\ApiResourceScopesExtractorInterface: '@PrestaShopBundle\ApiPlatform\Scopes\CachedApiResourceScopesExtractor'

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/AuthorizationServer/ApiClient/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/AuthorizationServer/ApiClient/index.html.twig
@@ -59,6 +59,28 @@
   {% block api_client_listing %}
     {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': apiClientGrid} %}
   {% endblock %}
+
+  {# Configuration form #}
+  {{ form_start(configurationForm, {attr : {class: 'form'}, action: path('admin_api_clients_process_configuration') }) }}
+  {% block administration_form_general %}
+    <div class="card" id="configuration_fieldset_general">
+      <h3 class="card-header">
+        <i class="material-icons">settings</i>
+        {{ 'Configuration'|trans({}, 'Admin.Global') }}
+      </h3>
+      <div class="card-body">
+        <div class="form-wrapper">
+          {{ form_widget(configurationForm) }}
+        </div>
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button type="submit" class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
+    </div>
+  {% endblock %}
+  {{ form_end(configurationForm) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/tests/Integration/ApiPlatform/DisabledEndpointsTest.php
+++ b/tests/Integration/ApiPlatform/DisabledEndpointsTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\ApiPlatform;
+
+use PrestaShopBundle\ApiPlatform\Scopes\ApiResourceScopesExtractor;
+use Tests\Integration\ApiPlatform\EndPoint\ApiTestCase;
+
+/**
+ * These tests muste be executed independently because their variants have impact on the cache,
+ * that is also hy the cache must be cleared before, after the tests and in between them.
+ *
+ * @group isolatedProcess
+ */
+class DisabledEndpointsTest extends ApiTestCase
+{
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::clearCache();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::clearCache();
+    }
+
+    /**
+     * Since the variant configurations influence the cache we MUST clear it between each tests,
+     * and clear it again after to avoid impacting the following tests in the suite
+     */
+    protected static function clearCache(): void
+    {
+        $kernel = static::bootKernel();
+        $baseCommandLine = 'php -d memory_limit=-1 ' . $kernel->getProjectDir() . '/bin/console ';
+        $commandLine = $baseCommandLine . 'cache:clear --no-warmup --no-interaction --env=test --app-id=admin-api --quiet';
+        $result = 0;
+        system($commandLine, $result);
+        if ($result !== 0) {
+            throw new \RuntimeException('Could not clear the cache');
+        }
+    }
+
+    /**
+     * @dataProvider getConfigurations
+     *
+     * @param bool $isDebug
+     * @param bool $expectedEndpointStatus
+     * @param bool $forceExperimentalEndpoints
+     */
+    public function testDisabledEndpoints(bool $isDebug, bool $forceExperimentalEndpoints, bool $expectedEndpointStatus): void
+    {
+        // Boot kernel with appropriate configuration, exceptionally we force the environment, so we have
+        // distinct cache and adapted data/behaviour for each use case
+        $kernelOptions = ['debug' => $isDebug];
+        static::bootKernel($kernelOptions);
+
+        // Update the configuration
+        $this->updateConfiguration('PS_ENABLE_EXPERIMENTAL_API_ENDPOINTS', (int) $forceExperimentalEndpoints);
+
+        // Scope experimental_scope only exists when the endpoint is enabled
+        $bearerToken = $this->getBearerToken($expectedEndpointStatus ? ['experimental_scope'] : [], $kernelOptions);
+
+        static::createClient($kernelOptions)->request('GET', '/test/experimental/product/1', [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $bearerToken,
+            ],
+        ]);
+        self::assertResponseStatusCodeSame($expectedEndpointStatus ? 200 : 404);
+
+        /** @var ApiResourceScopesExtractor $scopesExtractor */
+        $scopesExtractor = static::createClient($kernelOptions)->getContainer()->get(ApiResourceScopesExtractor::class);
+        $resourceScopes = $scopesExtractor->getAllApiResourceScopes();
+        $foundScope = false;
+        foreach ($resourceScopes as $resourceScope) {
+            if (in_array('experimental_scope', $resourceScope->getScopes())) {
+                $foundScope = true;
+                break;
+            }
+        }
+        $this->assertEquals($expectedEndpointStatus, $foundScope);
+    }
+
+    public function getConfigurations(): iterable
+    {
+        yield 'debug mode on, force config is off (not relevant anyway), endpoint is enabled' => [
+            true,
+            false,
+            true,
+        ];
+
+        yield 'debug mode off, force config is off, endpoint is disabled' => [
+            false,
+            false,
+            false,
+        ];
+
+        yield 'debug mode off, force config is on, endpoint is enabled' => [
+            false,
+            true,
+            true,
+        ];
+    }
+}

--- a/tests/Integration/ApiPlatform/EndPoint/ApiTestCase.php
+++ b/tests/Integration/ApiPlatform/EndPoint/ApiTestCase.php
@@ -83,7 +83,7 @@ abstract class ApiTestCase extends ApiPlatformTestCase
         return parent::createClient($kernelOptions, $defaultOptions);
     }
 
-    protected function getBearerToken(array $scopes = []): string
+    protected function getBearerToken(array $scopes = [], array $kernelOptions = []): string
     {
         if (null === self::$clientSecret) {
             self::createApiClient($scopes);
@@ -101,7 +101,7 @@ abstract class ApiTestCase extends ApiPlatformTestCase
                 'content-type' => 'application/x-www-form-urlencoded',
             ],
         ];
-        $response = static::createClient()->request('POST', '/access_token', $options);
+        $response = static::createClient($kernelOptions)->request('POST', '/access_token', $options);
 
         return json_decode($response->getContent())->access_token;
     }

--- a/tests/Resources/ApiPlatform/Resources/ApiTest.php
+++ b/tests/Resources/ApiPlatform/Resources/ApiTest.php
@@ -47,6 +47,13 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
             scopes: ['product_read'],
             CQRSQueryMapping: ApiTest::QUERY_MAPPING,
         ),
+        new CQRSGet(
+            uriTemplate: '/test/experimental/product/{productId}',
+            CQRSQuery: GetProductForEditing::class,
+            scopes: ['experimental_scope'],
+            CQRSQueryMapping: ApiTest::QUERY_MAPPING,
+            experimentalOperation: true,
+        ),
     ],
 )]
 class ApiTest

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSCommandTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSCommandTest.php
@@ -474,4 +474,58 @@ class CQRSCommandTest extends TestCase
             'CQRSCommandMapping' => $commandMapping,
         ], $operation->getExtraProperties());
     }
+
+    public function testExperimentalOperation(): void
+    {
+        // Default value is false (no extra property added)
+        $operation = new CQRSCommand();
+        $this->assertEquals([], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Scopes parameters in constructor
+        $operation = new CQRSCommand(
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Extra properties parameters in constructor
+        $operation = new CQRSCommand(
+            extraProperties: ['experimentalOperation' => false]
+        );
+        $this->assertEquals(['experimentalOperation' => false], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
+        $operation = new CQRSCommand(
+            extraProperties: ['experimentalOperation' => true],
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Use with method, returned object is a clone All values are replaced
+        $operation2 = $operation->withExperimentalOperation(false);
+        $this->assertNotEquals($operation2, $operation);
+        $this->assertEquals(['experimentalOperation' => false], $operation2->getExtraProperties());
+        $this->assertEquals(false, $operation2->getExperimentalOperation());
+        // Initial operation not modified of course
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // When both values are specified, but they are different trigger an exception
+        $caughtException = null;
+        try {
+            new CQRSCommand(
+                extraProperties: ['experimentalOperation' => true],
+                experimentalOperation: false,
+            );
+        } catch (InvalidArgumentException $e) {
+            $caughtException = $e;
+        }
+
+        $this->assertNotNull($caughtException);
+        $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
+        $this->assertEquals('Specifying an extra property experimentalOperation and a experimentalOperation argument that are different is invalid', $caughtException->getMessage());
+    }
 }

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSCreateTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSCreateTest.php
@@ -327,4 +327,58 @@ class CQRSCreateTest extends TestCase
         $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
         $this->assertEquals('Specifying an extra property ApiResourceMapping and a ApiResourceMapping argument that are different is invalid', $caughtException->getMessage());
     }
+
+    public function testExperimentalOperation(): void
+    {
+        // Default value is false (no extra property added)
+        $operation = new CQRSCreate();
+        $this->assertEquals([], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Scopes parameters in constructor
+        $operation = new CQRSCreate(
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Extra properties parameters in constructor
+        $operation = new CQRSCreate(
+            extraProperties: ['experimentalOperation' => false]
+        );
+        $this->assertEquals(['experimentalOperation' => false], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
+        $operation = new CQRSCreate(
+            extraProperties: ['experimentalOperation' => true],
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Use with method, returned object is a clone All values are replaced
+        $operation2 = $operation->withExperimentalOperation(false);
+        $this->assertNotEquals($operation2, $operation);
+        $this->assertEquals(['experimentalOperation' => false], $operation2->getExtraProperties());
+        $this->assertEquals(false, $operation2->getExperimentalOperation());
+        // Initial operation not modified of course
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // When both values are specified, but they are different trigger an exception
+        $caughtException = null;
+        try {
+            new CQRSCreate(
+                extraProperties: ['experimentalOperation' => true],
+                experimentalOperation: false,
+            );
+        } catch (InvalidArgumentException $e) {
+            $caughtException = $e;
+        }
+
+        $this->assertNotNull($caughtException);
+        $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
+        $this->assertEquals('Specifying an extra property experimentalOperation and a experimentalOperation argument that are different is invalid', $caughtException->getMessage());
+    }
 }

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSDeleteTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSDeleteTest.php
@@ -279,4 +279,58 @@ class CQRSDeleteTest extends TestCase
         $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
         $this->assertEquals('Specifying an extra property ApiResourceMapping and a ApiResourceMapping argument that are different is invalid', $caughtException->getMessage());
     }
+
+    public function testExperimentalOperation(): void
+    {
+        // Default value is false (no extra property added)
+        $operation = new CQRSDelete();
+        $this->assertEquals([], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Scopes parameters in constructor
+        $operation = new CQRSDelete(
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Extra properties parameters in constructor
+        $operation = new CQRSDelete(
+            extraProperties: ['experimentalOperation' => false]
+        );
+        $this->assertEquals(['experimentalOperation' => false], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
+        $operation = new CQRSDelete(
+            extraProperties: ['experimentalOperation' => true],
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Use with method, returned object is a clone All values are replaced
+        $operation2 = $operation->withExperimentalOperation(false);
+        $this->assertNotEquals($operation2, $operation);
+        $this->assertEquals(['experimentalOperation' => false], $operation2->getExtraProperties());
+        $this->assertEquals(false, $operation2->getExperimentalOperation());
+        // Initial operation not modified of course
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // When both values are specified, but they are different trigger an exception
+        $caughtException = null;
+        try {
+            new CQRSDelete(
+                extraProperties: ['experimentalOperation' => true],
+                experimentalOperation: false,
+            );
+        } catch (InvalidArgumentException $e) {
+            $caughtException = $e;
+        }
+
+        $this->assertNotNull($caughtException);
+        $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
+        $this->assertEquals('Specifying an extra property experimentalOperation and a experimentalOperation argument that are different is invalid', $caughtException->getMessage());
+    }
 }

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSGetTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSGetTest.php
@@ -320,4 +320,58 @@ class CQRSGetTest extends TestCase
             'ApiResourceMapping' => $resourceMapping,
         ], $operation->getExtraProperties());
     }
+
+    public function testExperimentalOperation(): void
+    {
+        // Default value is false (no extra property added)
+        $operation = new CQRSGet();
+        $this->assertEquals([], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Scopes parameters in constructor
+        $operation = new CQRSGet(
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Extra properties parameters in constructor
+        $operation = new CQRSGet(
+            extraProperties: ['experimentalOperation' => false]
+        );
+        $this->assertEquals(['experimentalOperation' => false], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
+        $operation = new CQRSGet(
+            extraProperties: ['experimentalOperation' => true],
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Use with method, returned object is a clone All values are replaced
+        $operation2 = $operation->withExperimentalOperation(false);
+        $this->assertNotEquals($operation2, $operation);
+        $this->assertEquals(['experimentalOperation' => false], $operation2->getExtraProperties());
+        $this->assertEquals(false, $operation2->getExperimentalOperation());
+        // Initial operation not modified of course
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // When both values are specified, but they are different trigger an exception
+        $caughtException = null;
+        try {
+            new CQRSGet(
+                extraProperties: ['experimentalOperation' => true],
+                experimentalOperation: false,
+            );
+        } catch (InvalidArgumentException $e) {
+            $caughtException = $e;
+        }
+
+        $this->assertNotNull($caughtException);
+        $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
+        $this->assertEquals('Specifying an extra property experimentalOperation and a experimentalOperation argument that are different is invalid', $caughtException->getMessage());
+    }
 }

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSPartialUpdateTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSPartialUpdateTest.php
@@ -334,4 +334,58 @@ class CQRSPartialUpdateTest extends TestCase
         $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
         $this->assertEquals('Specifying an extra property ApiResourceMapping and a ApiResourceMapping argument that are different is invalid', $caughtException->getMessage());
     }
+
+    public function testExperimentalOperation(): void
+    {
+        // Default value is false (no extra property added)
+        $operation = new CQRSPartialUpdate();
+        $this->assertEquals([], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Scopes parameters in constructor
+        $operation = new CQRSPartialUpdate(
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Extra properties parameters in constructor
+        $operation = new CQRSPartialUpdate(
+            extraProperties: ['experimentalOperation' => false]
+        );
+        $this->assertEquals(['experimentalOperation' => false], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
+        $operation = new CQRSPartialUpdate(
+            extraProperties: ['experimentalOperation' => true],
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Use with method, returned object is a clone All values are replaced
+        $operation2 = $operation->withExperimentalOperation(false);
+        $this->assertNotEquals($operation2, $operation);
+        $this->assertEquals(['experimentalOperation' => false], $operation2->getExtraProperties());
+        $this->assertEquals(false, $operation2->getExperimentalOperation());
+        // Initial operation not modified of course
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // When both values are specified, but they are different trigger an exception
+        $caughtException = null;
+        try {
+            new CQRSPartialUpdate(
+                extraProperties: ['experimentalOperation' => true],
+                experimentalOperation: false,
+            );
+        } catch (InvalidArgumentException $e) {
+            $caughtException = $e;
+        }
+
+        $this->assertNotNull($caughtException);
+        $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
+        $this->assertEquals('Specifying an extra property experimentalOperation and a experimentalOperation argument that are different is invalid', $caughtException->getMessage());
+    }
 }

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSQueryCollectionTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSQueryCollectionTest.php
@@ -320,4 +320,58 @@ class CQRSQueryCollectionTest extends TestCase
             'ApiResourceMapping' => $resourceMapping,
         ], $operation->getExtraProperties());
     }
+
+    public function testExperimentalOperation(): void
+    {
+        // Default value is false (no extra property added)
+        $operation = new CQRSQueryCollection();
+        $this->assertEquals([], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Scopes parameters in constructor
+        $operation = new CQRSQueryCollection(
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Extra properties parameters in constructor
+        $operation = new CQRSQueryCollection(
+            extraProperties: ['experimentalOperation' => false]
+        );
+        $this->assertEquals(['experimentalOperation' => false], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
+        $operation = new CQRSQueryCollection(
+            extraProperties: ['experimentalOperation' => true],
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Use with method, returned object is a clone All values are replaced
+        $operation2 = $operation->withExperimentalOperation(false);
+        $this->assertNotEquals($operation2, $operation);
+        $this->assertEquals(['experimentalOperation' => false], $operation2->getExtraProperties());
+        $this->assertEquals(false, $operation2->getExperimentalOperation());
+        // Initial operation not modified of course
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // When both values are specified, but they are different trigger an exception
+        $caughtException = null;
+        try {
+            new CQRSQueryCollection(
+                extraProperties: ['experimentalOperation' => true],
+                experimentalOperation: false,
+            );
+        } catch (InvalidArgumentException $e) {
+            $caughtException = $e;
+        }
+
+        $this->assertNotNull($caughtException);
+        $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
+        $this->assertEquals('Specifying an extra property experimentalOperation and a experimentalOperation argument that are different is invalid', $caughtException->getMessage());
+    }
 }

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSUpdateTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSUpdateTest.php
@@ -330,4 +330,58 @@ class CQRSUpdateTest extends TestCase
         $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
         $this->assertEquals('Specifying an extra property ApiResourceMapping and a ApiResourceMapping argument that are different is invalid', $caughtException->getMessage());
     }
+
+    public function testExperimentalOperation(): void
+    {
+        // Default value is false (no extra property added)
+        $operation = new CQRSUpdate();
+        $this->assertEquals([], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Scopes parameters in constructor
+        $operation = new CQRSUpdate(
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Extra properties parameters in constructor
+        $operation = new CQRSUpdate(
+            extraProperties: ['experimentalOperation' => false]
+        );
+        $this->assertEquals(['experimentalOperation' => false], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
+        $operation = new CQRSUpdate(
+            extraProperties: ['experimentalOperation' => true],
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Use with method, returned object is a clone All values are replaced
+        $operation2 = $operation->withExperimentalOperation(false);
+        $this->assertNotEquals($operation2, $operation);
+        $this->assertEquals(['experimentalOperation' => false], $operation2->getExtraProperties());
+        $this->assertEquals(false, $operation2->getExperimentalOperation());
+        // Initial operation not modified of course
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // When both values are specified, but they are different trigger an exception
+        $caughtException = null;
+        try {
+            new CQRSUpdate(
+                extraProperties: ['experimentalOperation' => true],
+                experimentalOperation: false,
+            );
+        } catch (InvalidArgumentException $e) {
+            $caughtException = $e;
+        }
+
+        $this->assertNotNull($caughtException);
+        $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
+        $this->assertEquals('Specifying an extra property experimentalOperation and a experimentalOperation argument that are different is invalid', $caughtException->getMessage());
+    }
 }

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/DQBPaginatedListTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/DQBPaginatedListTest.php
@@ -341,4 +341,58 @@ class DQBPaginatedListTest extends TestCase
             'queryBuilder' => 'prestashop.core.api.query_builder.hook',
         ], $operation->getExtraProperties());
     }
+
+    public function testExperimentalOperation(): void
+    {
+        // Default value is false (no extra property added)
+        $operation = new DQBPaginatedList();
+        $this->assertEquals([], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Scopes parameters in constructor
+        $operation = new DQBPaginatedList(
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Extra properties parameters in constructor
+        $operation = new DQBPaginatedList(
+            extraProperties: ['experimentalOperation' => false]
+        );
+        $this->assertEquals(['experimentalOperation' => false], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getExperimentalOperation());
+
+        // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
+        $operation = new DQBPaginatedList(
+            extraProperties: ['experimentalOperation' => true],
+            experimentalOperation: true,
+        );
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // Use with method, returned object is a clone All values are replaced
+        $operation2 = $operation->withExperimentalOperation(false);
+        $this->assertNotEquals($operation2, $operation);
+        $this->assertEquals(['experimentalOperation' => false], $operation2->getExtraProperties());
+        $this->assertEquals(false, $operation2->getExperimentalOperation());
+        // Initial operation not modified of course
+        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getExperimentalOperation());
+
+        // When both values are specified, but they are different trigger an exception
+        $caughtException = null;
+        try {
+            new DQBPaginatedList(
+                extraProperties: ['experimentalOperation' => true],
+                experimentalOperation: false,
+            );
+        } catch (InvalidArgumentException $e) {
+            $caughtException = $e;
+        }
+
+        $this->assertNotNull($caughtException);
+        $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
+        $this->assertEquals('Specifying an extra property experimentalOperation and a experimentalOperation argument that are different is invalid', $caughtException->getMessage());
+    }
 }

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Scopes/ApiResourceScopesExtractorTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Scopes/ApiResourceScopesExtractorTest.php
@@ -30,6 +30,7 @@ namespace Tests\Unit\PrestaShopBundle\ApiPlatform\Scopes;
 
 use ApiPlatform\Metadata\Resource\Factory\AttributesResourceMetadataCollectionFactory;
 use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\EnvironmentInterface;
 use PrestaShopBundle\ApiPlatform\Scopes\ApiResourceScopes;
 use PrestaShopBundle\ApiPlatform\Scopes\ApiResourceScopesExtractor;
 
@@ -73,8 +74,12 @@ class ApiResourceScopesExtractorTest extends TestCase
 
     private function buildExtractor(): ApiResourceScopesExtractor
     {
+        $environment = $this->createMock(EnvironmentInterface::class);
+        $environment->method('getName')->willReturn('test');
+
         return new ApiResourceScopesExtractor(
             new AttributesResourceMetadataCollectionFactory(),
+            $environment,
             $this->moduleDir,
             ['fake_module', 'disabled_fake_module'],
             ['fake_module'],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Filter experimental APIs via a collection decorator, it allows configuring some operations so that they are not enabled in prod mode because too unstable
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In swagger you check the presence of the endpoints related with cart-rule (only one at best), and in the API client form the scope `cart_rule_write`:<br>- In dev mode both are **present**<br>- In prod mode with config `Enable experimental endpoints` **off** both are **absent**<br>- In prod mode with config `Enable experimental endpoints` **on** both are **present**
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/8455915492
| Fixed issue or discussion?     | Fixes #35684
| Related PRs       | https://github.com/PrestaShop/ps_apiresources/pull/23
| Sponsor company   | ~
