### PR TITLE
Update OrderInvoice.php

### DIFF
--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -444,10 +444,10 @@ class OrderInvoiceCore extends ObjectModel
             foreach ($shipping_breakdown as &$row) {
                 if (Configuration::get('PS_ATCP_SHIPWRAP')) {
                     $row['total_tax_excl'] = Tools::ps_round($row['total_amount'] / $row['rate'] * 100, Context::getContext()->getComputingPrecision(), $this->getOrder()->round_mode);
-                    $sum_of_tax_bases += $row['total_tax_excl'];
                 } else {
                     $row['total_tax_excl'] = $this->total_shipping_tax_excl;
                 }
+                $sum_of_tax_bases += $row['total_tax_excl'];
 
                 $row['total_amount'] = Tools::ps_round($row['total_amount'], Context::getContext()->getComputingPrecision(), $this->getOrder()->round_mode);
                 $sum_of_split_taxes += $row['total_amount'];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.0.x / 8.1.x
| Description?      | Error in calculation of $sum_of_tax_bases, leading to multiplying the shipping amount by two at the end.
| Type?             | bug fix / improvement / new feature / refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Examine result of getShippingTaxesBreakdown function and compare total_tax_excl to the actual total_shipping_tax_excl of the invoice, you will see that in case PS_ATCP_SHIPWRAP is not activated, the total_tax_excl is the double of total_shipping_tax_excl which of course is false. With my PR this is no more the case.
| UI Tests          | NA
| Fixed issue or discussion?     | Fix https://github.com/PrestaShop/PrestaShop/issues/35768
| Related PRs       | 
| Sponsor company   | Web Premiere
