### PR TITLE
Updated query to remove subquery

### DIFF
--- a/src/Core/Grid/Query/AttributeGroupQueryBuilder.php
+++ b/src/Core/Grid/Query/AttributeGroupQueryBuilder.php
@@ -29,7 +29,6 @@ namespace PrestaShop\PrestaShop\Core\Grid\Query;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
-use PrestaShop\PrestaShop\Core\Multistore\MultistoreContextCheckerInterface;
 
 /**
  * Provides sql for attributes group list
@@ -47,11 +46,6 @@ final class AttributeGroupQueryBuilder extends AbstractDoctrineQueryBuilder
     private $searchCriteriaApplicator;
 
     /**
-     * @var MultistoreContextCheckerInterface
-     */
-    private $multistoreContextChecker;
-
-    /**
      * @var int[]
      */
     private $contextShopIds;
@@ -61,7 +55,6 @@ final class AttributeGroupQueryBuilder extends AbstractDoctrineQueryBuilder
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
      * @param int $contextLangId
-     * @param MultistoreContextCheckerInterface $multistoreContextChecker
      * @param int[] $contextShopIds
      */
     public function __construct(
@@ -69,13 +62,11 @@ final class AttributeGroupQueryBuilder extends AbstractDoctrineQueryBuilder
         $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
         $contextLangId,
-        MultistoreContextCheckerInterface $multistoreContextChecker,
         array $contextShopIds
     ) {
         parent::__construct($connection, $dbPrefix);
         $this->contextLangId = $contextLangId;
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
-        $this->multistoreContextChecker = $multistoreContextChecker;
         $this->contextShopIds = $contextShopIds;
     }
 
@@ -140,12 +131,12 @@ final class AttributeGroupQueryBuilder extends AbstractDoctrineQueryBuilder
         );
 
         $qb->leftJoin(
-            'ag',
-            $this->dbPrefix . 'attribute_group_shop',
-            'ags',
-            'ag.id_attribute_group = ags.id_attribute_group'
+            'a',
+            $this->dbPrefix . 'attribute_shop',
+            'ash',
+            'ash.id_attribute = a.id_attribute'
         );
-        $qb->andWhere('ags.id_shop IN (:contextShopIds)');
+        $qb->andWhere('ash.id_shop IN (:contextShopIds)');
         $qb->groupBy('ag.id_attribute_group');
 
         $this->applyFilters($filters, $qb);

--- a/src/Core/Grid/Query/AttributeGroupQueryBuilder.php
+++ b/src/Core/Grid/Query/AttributeGroupQueryBuilder.php
@@ -80,7 +80,7 @@ final class AttributeGroupQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters())
-            ->select('DISTINCT ag.id_attribute_group, agl.name, ag.position, COUNT(a.id_attribute) as `values`');
+            ->select('DISTINCT ag.id_attribute_group, agl.*, ag.*, COUNT(a.id_attribute) as `values`');
 
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -338,7 +338,6 @@ services:
     arguments:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
       - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
-      - '@prestashop.adapter.shop.context'
       - '@=service("prestashop.adapter.shop.context").getContextListShopID()'
     public: true
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | See bug 4 here https://github.com/PrestaShop/PrestaShop/issues/35591 
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no 
| How to test?      | See bug 4 here:  https://github.com/PrestaShop/PrestaShop/issues/35591
| UI Tests          |  https://github.com/nicosomb/ga.tests.ui.pr/actions/runs/8551008706
| Fixed issue or discussion?     | See #35591 
| Related PRs       | #35270 
| Sponsor company   | PrestaShop SA

The subquery was OK, but the native PrestaShop SQL manager seems to be buggy. As we can't fix it (it's a 3rd dependency), it's better to change the query on our side

The new query looks like: 

```
SELECT DISTINCT ag.id_attribute_group, agl.name, ag.position, COUNT(a.id_attribute) as `values` 
FROM ps_attribute a
LEFT JOIN ps_attribute_group ag ON a.id_attribute_group = ag.id_attribute_group 
LEFT JOIN ps_attribute_group_lang agl ON agl.id_attribute_group = ag.id_attribute_group AND agl.id_lang = 1 
LEFT JOIN ps_attribute_group_shop ags ON ag.id_attribute_group = ags.id_attribute_group 
WHERE ags.id_shop IN ('1') 
GROUP BY ag.id_attribute_group 
ORDER BY position desc LIMIT 50
``` 

instead of : 

```
SELECT DISTINCT ag.id_attribute_group, agl.name, ag.position, acount.values 
FROM ps_attribute_group ag 
LEFT JOIN (SELECT COUNT(DISTINCT a.id_attribute) AS `values`, a.id_attribute_group FROM ps_attribute a LEFT JOIN ps_attribute_shop attrShop ON a.id_attribute = attrShop.id_attribute WHERE attrShop.id_shop IN ('1') GROUP BY a.id_attribute_group) acount ON acount.id_attribute_group = ag.id_attribute_group 
LEFT JOIN ps_attribute_group_lang agl ON agl.id_attribute_group = ag.id_attribute_group AND agl.id_lang = 1 
LEFT JOIN ps_attribute_group_shop ags ON ag.id_attribute_group = ags.id_attribute_group 
WHERE ags.id_shop IN ('1') 
ORDER BY position desc LIMIT 50 
``` 