### PR TITLE
Core(api) allow customer group endpoint to be created without shopid…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "prestashop/gsitemap": "^4",
         "prestashop/pagesnotfound": "^2",
         "prestashop/productcomments": "^6.0",
-        "prestashop/ps_apiresources": "dev-admin-api-renaming",
+        "prestashop/ps_apiresources": "dev-Issue-35687-command-on-single-shops-that-expects-shopids",
         "prestashop/ps_banner": "^2",
         "prestashop/ps_bestsellers": "^1.0",
         "prestashop/ps_brandlist": "^1.0",
@@ -254,7 +254,7 @@
     "repositories": {
         "ps_apiresources": {
             "type": "vcs",
-            "url": "https://github.com/jolelievre/ps_apiresources.git"
+            "url": "https://github.com/tleon/ps_apiresources.git"
         }
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80be213164c5e7dcc619167a1b9f5121",
+    "content-hash": "3b161cf4a13fd7f6b9271bb6d0e26b8f",
     "packages": [
         {
             "name": "api-platform/core",
@@ -5579,16 +5579,16 @@
         },
         {
             "name": "prestashop/ps_apiresources",
-            "version": "dev-admin-api-renaming",
+            "version": "dev-Issue-35687-command-on-single-shops-that-expects-shopids",
             "source": {
                 "type": "git",
-                "url": "https://github.com/jolelievre/ps_apiresources.git",
-                "reference": "58fe2edad43346d3b923b3b1616af412bf7d9374"
+                "url": "https://github.com/tleon/ps_apiresources.git",
+                "reference": "f7586dda75eb7c1d07544b8f0acc3c9c3f5094a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jolelievre/ps_apiresources/zipball/58fe2edad43346d3b923b3b1616af412bf7d9374",
-                "reference": "58fe2edad43346d3b923b3b1616af412bf7d9374",
+                "url": "https://api.github.com/repos/tleon/ps_apiresources/zipball/f7586dda75eb7c1d07544b8f0acc3c9c3f5094a9",
+                "reference": "f7586dda75eb7c1d07544b8f0acc3c9c3f5094a9",
                 "shasum": ""
             },
             "require": {
@@ -5640,9 +5640,9 @@
             "description": "PrestaShop - API Resources",
             "homepage": "https://github.com/PrestaShop/ps_apiresources",
             "support": {
-                "source": "https://github.com/jolelievre/ps_apiresources/tree/admin-api-renaming"
+                "source": "https://github.com/tleon/ps_apiresources/tree/Issue-35687-command-on-single-shops-that-expects-shopids"
             },
-            "time": "2024-03-29T12:27:52+00:00"
+            "time": "2024-04-02T15:29:56+00:00"
         },
         {
             "name": "prestashop/ps_banner",
@@ -17989,5 +17989,5 @@
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/PrestaShopBundle/ApiPlatform/ContextParametersTrait.php
+++ b/src/PrestaShopBundle/ApiPlatform/ContextParametersTrait.php
@@ -50,6 +50,7 @@ trait ContextParametersTrait
                     'isStrict' => $shopConstraint->isStrict(),
                 ],
                 'shopId' => $this->shopContext->getId(),
+                'shopIds' => $this->shopContext->getAssociatedShopIds(),
                 'langId' => $this->languageContext->getId(),
                 'apiClientId' => $this->apiClientContext->getApiClient()?->getId(),
             ],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Modify the ContextParametersTrait to allow shopIds to be grabed from the context in some endpoints
| Type?             |  improvement 
| Category?         |  BO 
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | See below tab
| UI Tests          | https://github.com/tleon/ga.tests.ui.pr/actions/runs/8470341627
| Fixed issue or discussion?     | Fixes #35687 
| Related PRs       | https://github.com/PrestaShop/ps_apiresources/pull/24
| Sponsor company   | PrestaShop SA


To test this you need to call the endpoint without specifying  the shop id in the request. If this PR works, the shop id should be grabed from the context.

endpoint : /customers/group
payload : 
```
{
    "localizedNames":[
        "test1"
    ],
    "reductionPercent" : 10.3,
    "displayPriceTaxExcluded": true,
    "showPrice":  true
}
```
method : POST
curl : 
```
curl --location 'http://localhost:8001/admin-api/customers/group' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <your_auth_token>' \
--data '{
    "localizedNames":[
        "test1"
    ],
    "reductionPercent" : 10.3,
    "displayPriceTaxExcluded": true,
    "showPrice":  true
}'
```