### PR TITLE
New products block module - Configure settings of "Number of days for which the product is considered 'new'" field

### DIFF
--- a/tests/UI/campaigns/modules/ps_newproducts/02_configuration/03_configureSettingsNumberOfDays.ts
+++ b/tests/UI/campaigns/modules/ps_newproducts/02_configuration/03_configureSettingsNumberOfDays.ts
@@ -1,0 +1,151 @@
+// Import utils
+import helper from '@utils/helpers';
+import testContext from '@utils/testContext';
+
+// Import commonTests
+import loginCommon from '@commonTests/BO/loginBO';
+
+// Import pages
+// Import FO pages
+import {homePage} from '@pages/FO/classic/home';
+// Import BO pages
+import dashboardPage from '@pages/BO/dashboard';
+import {moduleManager as moduleManagerPage} from '@pages/BO/modules/moduleManager';
+import psNewProducts from '@pages/BO/modules/psNewProducts';
+
+// Import data
+import Modules from '@data/demo/modules';
+
+import {expect} from 'chai';
+import type {BrowserContext, Page} from 'playwright';
+
+const baseContext: string = 'modules_ps_newproducts_configuration_configureSettingsNumberOfDays';
+
+describe('New products block module - Configure settings of "Number of days for which the product is considered \'new\'" field',
+  async () => {
+    let browserContext: BrowserContext;
+    let page: Page;
+    let defaultValue: string;
+
+    // before and after functions
+    before(async function () {
+      browserContext = await helper.createBrowserContext(this.browser);
+      page = await helper.newTab(browserContext);
+    });
+
+    after(async () => {
+      await helper.closeBrowserContext(browserContext);
+    });
+
+    it('should login in BO', async function () {
+      await loginCommon.loginBO(this, page);
+    });
+
+    it('should go to \'Modules > Module Manager\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToModuleManagerPage', baseContext);
+
+      await dashboardPage.goToSubMenu(
+        page,
+        dashboardPage.modulesParentLink,
+        dashboardPage.moduleManagerLink,
+      );
+      await moduleManagerPage.closeSfToolBar(page);
+
+      const pageTitle = await moduleManagerPage.getPageTitle(page);
+      expect(pageTitle).to.contains(moduleManagerPage.pageTitle);
+    });
+
+    it(`should search the module ${Modules.psNewProducts.name}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'searchModule', baseContext);
+
+      const isModuleVisible = await moduleManagerPage.searchModule(page, Modules.psNewProducts);
+      expect(isModuleVisible).to.eq(true);
+    });
+
+    it(`should go to the configuration page of the module '${Modules.psNewProducts.name}'`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToConfigurationPage', baseContext);
+
+      await moduleManagerPage.goToConfigurationPage(page, Modules.psNewProducts.tag);
+
+      const pageTitle = await psNewProducts.getPageSubtitle(page);
+      expect(pageTitle).to.eq(psNewProducts.pageSubTitle);
+
+      defaultValue = await psNewProducts.getNumDaysConsideredAsNew(page);
+    });
+
+    [
+      {
+        setting: 3,
+        blockIsVisible: true,
+      },
+      {
+        setting: -1,
+        blockIsVisible: false,
+      },
+      {
+        setting: 1000000000,
+        blockIsVisible: false,
+      },
+      // @todo : https://github.com/PrestaShop/PrestaShop/issues/35796
+      /*
+      {
+        setting: '1 500',
+        blockIsVisible: false,
+      },
+      */
+      // @todo : https://github.com/PrestaShop/PrestaShop/issues/35796
+      /*
+      {
+        setting: 0,
+        blockIsVisible: false,
+      },
+      */
+      // @todo : https://github.com/PrestaShop/PrestaShop/issues/35796
+      /*
+      {
+        setting: '@',
+        blockIsVisible: false,
+      },
+      */
+    ].forEach((arg: { setting: number|string, blockIsVisible: boolean }, index: number) => {
+      it(`should change the configuration (${arg.setting}) in the module`, async function () {
+        await testContext.addContextItem(this, 'testIdentifier', `changeConfiguration${index}`, baseContext);
+
+        const textResult = await psNewProducts.setNumDaysConsideredAsNew(page, arg.setting);
+        expect(textResult).to.contains(psNewProducts.updateSettingsSuccessMessage);
+      });
+
+      it('should go to the front office', async function () {
+        await testContext.addContextItem(this, 'testIdentifier', `goToTheFo${index}`, baseContext);
+
+        page = await psNewProducts.viewMyShop(page);
+        await homePage.changeLanguage(page, 'en');
+
+        const isHomePage = await homePage.isHomePage(page);
+        expect(isHomePage).to.eq(true);
+      });
+
+      it('should check the block "New Products" is visible', async function () {
+        await testContext.addContextItem(this, 'testIdentifier', `checkBlockNewProductsVisible${index}`, baseContext);
+
+        const hasProductsBlock = await homePage.hasProductsBlock(page, 'newproducts');
+        expect(hasProductsBlock).to.be.equal(arg.blockIsVisible);
+      });
+
+      it('should return to the back office', async function () {
+        await testContext.addContextItem(this, 'testIdentifier', `returnToBO${index}`, baseContext);
+
+        page = await homePage.closePage(browserContext, page, 0);
+
+        const pageTitle = await psNewProducts.getPageSubtitle(page);
+        expect(pageTitle).to.eq(psNewProducts.pageSubTitle);
+      });
+    });
+
+    it('should reset the configuration in the module', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'setDefaultValue', baseContext);
+
+      const textResult = await psNewProducts.setNumDaysConsideredAsNew(page, defaultValue);
+      expect(textResult).to.contains(psNewProducts.updateSettingsSuccessMessage);
+    });
+  });

--- a/tests/UI/pages/BO/modules/psNewProducts/index.ts
+++ b/tests/UI/pages/BO/modules/psNewProducts/index.ts
@@ -14,6 +14,8 @@ class PsNewProducts extends ModuleConfiguration {
 
   private readonly productsToDisplayInput: string;
 
+  private readonly numDaysConsideredAsNewInput: string;
+
   private readonly saveSettingsForm: string;
 
   /**
@@ -28,6 +30,7 @@ class PsNewProducts extends ModuleConfiguration {
 
     // Selectors
     this.productsToDisplayInput = '#NEW_PRODUCTS_NBR';
+    this.numDaysConsideredAsNewInput = '#PS_NB_DAYS_NEW_PRODUCT';
     this.saveSettingsForm = '#module_form_submit_btn';
   }
 
@@ -46,12 +49,34 @@ class PsNewProducts extends ModuleConfiguration {
   }
 
   /**
+   * Set Number of days for which the product is considered 'new'
+   * @param page {Page} Browser tab
+   * @param value {number|string}
+   * @returns {Promise<string>}
+   */
+  async setNumDaysConsideredAsNew(page: Page, value: number|string): Promise<string> {
+    await page.locator(this.numDaysConsideredAsNewInput).fill(value.toString());
+    await this.clickAndWaitForLoadState(page, this.saveSettingsForm);
+
+    return this.getAlertSuccessBlockContent(page);
+  }
+
+  /**
    * Get Products to display
    * @param page {Page} Browser tab
    * @returns {Promise<string>}
    */
   async getNumProductsToDisplay(page: Page): Promise<string> {
     return this.getAttributeContent(page, this.productsToDisplayInput, 'value');
+  }
+
+  /**
+   * Get Number of days for which the product is considered 'new'
+   * @param page {Page} Browser tab
+   * @returns {Promise<string>}
+   */
+  async getNumDaysConsideredAsNew(page: Page): Promise<string> {
+    return this.getAttributeContent(page, this.numDaysConsideredAsNewInput, 'value');
   }
 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | New products block module - Configure settings of "Number of days for which the product is considered 'new'" field
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: 
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/8522353703
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp

## Linked issues 
* https://github.com/PrestaShop/PrestaShop/issues/35796