### PR TITLE
Taking into account legacy public actions in Symfony layout

### DIFF
--- a/app/config/admin/services.yml
+++ b/app/config/admin/services.yml
@@ -92,6 +92,10 @@ services:
     tags:
       - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: '%legacy_employee_listener_priority%' }
 
+  PrestaShopBundle\EventListener\Admin\Context\DefaultLanguageContextListener:
+    tags:
+      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: '%legacy_language_listener_priority%' }
+
   # Language depends on Employee so its priority is lower, however it has higher priority than Currency and Country because they depend on Language
   PrestaShopBundle\EventListener\Admin\Context\LanguageContextListener:
     arguments:
@@ -105,6 +109,10 @@ services:
       $isSymfonyLayout: false
     tags:
       - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: '%legacy_language_listener_priority%' }
+
+  PrestaShopBundle\EventListener\Admin\Context\DefaultShopContextListener:
+    tags:
+      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: '%legacy_default_listener_priority%' }
 
   PrestaShopBundle\EventListener\Admin\Context\ShopContextListener:
     arguments:

--- a/app/config/admin/services.yml
+++ b/app/config/admin/services.yml
@@ -1,10 +1,15 @@
 # Dedicated services for Admin app
 parameters:
-  # All admin context listeners should be executed before the router listener, this way even if no symfony route is found they context are initialized
+  # We set priorities lower than the RouterListener (32) so that the LegacyRouterChecker class is called first.
+  # The correct behaviour of Context Listeners on legacy routes depends on LegacyRouterChecker.
+  employee_listener_priority: 31
+  language_listener_priority: 30
+  default_listener_priority: 29
+  # All admin context listeners should be executed before the router listener, this way even if no symfony route is found the contexts are initialized correctly
   # and can be used in admin legacy pages as well (router listener priority is 32)
-  employee_listener_priority: 35
-  language_listener_priority: 34
-  default_listener_priority: 33
+  legacy_employee_listener_priority: 35
+  legacy_language_listener_priority: 34
+  legacy_default_listener_priority: 33
 
 services:
   _defaults:
@@ -75,25 +80,70 @@ services:
 
   # Employee context must have a higher priority because Shop and Language depend on it
   PrestaShopBundle\EventListener\Admin\Context\EmployeeContextListener:
+    arguments:
+      $isSymfonyLayout: true
     tags:
       - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: '%employee_listener_priority%' }
 
+  PrestaShopBundle\EventListener\Admin\Context\EmployeeContextListener.legacy:
+    class: PrestaShopBundle\EventListener\Admin\Context\EmployeeContextListener
+    arguments:
+      $isSymfonyLayout: false
+    tags:
+      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: '%legacy_employee_listener_priority%' }
+
   # Language depends on Employee so its priority is lower, however it has higher priority than Currency and Country because they depend on Language
   PrestaShopBundle\EventListener\Admin\Context\LanguageContextListener:
+    arguments:
+      $isSymfonyLayout: true
     tags:
       - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: '%language_listener_priority%' }
 
+  PrestaShopBundle\EventListener\Admin\Context\LanguageContextListener.legacy:
+    class: PrestaShopBundle\EventListener\Admin\Context\LanguageContextListener
+    arguments:
+      $isSymfonyLayout: false
+    tags:
+      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: '%legacy_language_listener_priority%' }
+
   PrestaShopBundle\EventListener\Admin\Context\ShopContextListener:
+    arguments:
+      $isSymfonyLayout: true
     tags:
       - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: '%default_listener_priority%' }
+
+  PrestaShopBundle\EventListener\Admin\Context\ShopContextListener.legacy:
+    class: PrestaShopBundle\EventListener\Admin\Context\ShopContextListener
+    arguments:
+      $isSymfonyLayout: false
+    tags:
+      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: '%legacy_default_listener_priority%' }
 
   PrestaShopBundle\EventListener\Admin\Context\CurrencyContextListener:
+    arguments:
+      $isSymfonyLayout: true
     tags:
       - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: '%default_listener_priority%' }
 
+  PrestaShopBundle\EventListener\Admin\Context\CurrencyContextListener.legacy:
+    class: PrestaShopBundle\EventListener\Admin\Context\CurrencyContextListener
+    arguments:
+      $isSymfonyLayout: false
+    tags:
+      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: '%legacy_default_listener_priority%' }
+
   PrestaShopBundle\EventListener\Admin\Context\CountryContextListener:
+    arguments:
+      $isSymfonyLayout: true
     tags:
       - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: '%default_listener_priority%' }
+
+  PrestaShopBundle\EventListener\Admin\Context\CountryContextListener.legacy:
+    class: PrestaShopBundle\EventListener\Admin\Context\CountryContextListener
+    arguments:
+      $isSymfonyLayout: false
+    tags:
+      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: '%legacy_default_listener_priority%' }
 
   # This listener must run after the router listener since it's based on the request attributes that are defined by the router
   PrestaShopBundle\EventListener\Admin\Context\LegacyControllerContextListener:

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -4395,7 +4395,7 @@ class AdminControllerCore extends Controller
      *
      * @return bool
      */
-    protected function isAnonymousAllowed()
+    public function isAnonymousAllowed()
     {
         return $this->allowAnonymous;
     }

--- a/src/Adapter/Security/Admin.php
+++ b/src/Adapter/Security/Admin.php
@@ -27,8 +27,8 @@
 namespace PrestaShop\PrestaShop\Adapter\Security;
 
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShopBundle\Routing\LegacyRouterChecker;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -88,7 +88,8 @@ class Admin
      */
     public function onKernelRequest(RequestEvent $event): void
     {
-        if ($this->security->getUser() !== null) {
+        $publicLegacyRoute = $event->getRequest()->attributes->get(LegacyRouterChecker::LEGACY_CONTROLLER_ANONYMOUS_ATTRIBUTE);
+        if ($this->security->getUser() !== null || $publicLegacyRoute) {
             return;
         }
 

--- a/src/Adapter/Security/Admin.php
+++ b/src/Adapter/Security/Admin.php
@@ -27,7 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Security;
 
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
-use PrestaShopBundle\Routing\LegacyRouterChecker;
+use PrestaShopBundle\Routing\LegacyControllerConstants;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -88,7 +88,7 @@ class Admin
      */
     public function onKernelRequest(RequestEvent $event): void
     {
-        $publicLegacyRoute = $event->getRequest()->attributes->get(LegacyRouterChecker::LEGACY_CONTROLLER_ANONYMOUS_ATTRIBUTE);
+        $publicLegacyRoute = $event->getRequest()->attributes->get(LegacyControllerConstants::ANONYMOUS_ATTRIBUTE);
         if ($this->security->getUser() !== null || $publicLegacyRoute) {
             return;
         }

--- a/src/Core/Context/LegacyControllerContextBuilder.php
+++ b/src/Core/Context/LegacyControllerContextBuilder.php
@@ -88,6 +88,8 @@ class LegacyControllerContextBuilder implements LegacyContextBuilderInterface
 
     public function buildLegacyContext(): void
     {
+        // In legacy pages the AdminController class already sets the context's controller, which is a more accurate
+        // candidate than our facade meant for backward compatibility, so we leave it untouched
         if ($this->contextStateManager->getContext()->controller) {
             return;
         }

--- a/src/Core/Context/LegacyControllerContextBuilder.php
+++ b/src/Core/Context/LegacyControllerContextBuilder.php
@@ -88,6 +88,10 @@ class LegacyControllerContextBuilder implements LegacyContextBuilderInterface
 
     public function buildLegacyContext(): void
     {
+        if ($this->contextStateManager->getContext()->controller) {
+            return;
+        }
+
         $this->assertArguments();
 
         if (null === $this->_legacyControllerContext) {

--- a/src/PrestaShopBundle/Controller/Admin/LegacyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/LegacyController.php
@@ -86,7 +86,7 @@ class LegacyController extends PrestaShopAdminController
             'is_module' => $request->attributes->get(LegacyRouterChecker::LEGACY_CONTROLLER_IS_MODULE_ATTRIBUTE),
         ];
 
-        $adminController = $this->initController($dispatcherHookParameters);
+        $adminController = $this->initController($request, $dispatcherHookParameters);
         // Redirect if necessary after post process
         if (!empty($adminController->getRedirectAfter())) {
             // After each request the cookie must be written to save its modified state during AdminController workflow
@@ -226,17 +226,16 @@ class LegacyController extends PrestaShopAdminController
      *
      * Note: some legacy controllers may already use die at this point (to echo content and finish the process) when postProcess is called.
      *
+     * @param Request $request
      * @param array $dispatcherHookParameters
      *
      * @return AdminController
      */
-    protected function initController(array $dispatcherHookParameters): AdminController
+    protected function initController(Request $request, array $dispatcherHookParameters): AdminController
     {
-        $controllerClass = $dispatcherHookParameters['controller_class'];
-
-        // Loading controller
+        // Retrieving the controller instantiated in LegacyRouterChecker
         /** @var AdminController $adminController */
-        $adminController = new $controllerClass();
+        $adminController = $request->attributes->get(LegacyRouterChecker::LEGACY_CONTROLLER_INSTANCE_ATTRIBUTE);
 
         // Fill default smarty variables as they can be used in partial templates rendered in init methods
         $this->assignSmartyVariables->fillDefault();
@@ -246,7 +245,6 @@ class LegacyController extends PrestaShopAdminController
 
         // This part comes from AdminController::run method, it has been stripped from permission checks since the permission is already
         // handled by this Symfony controller
-        $adminController->init();
         $adminController->setMedia(false);
         $adminController->postProcess();
 

--- a/src/PrestaShopBundle/Controller/Admin/LegacyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/LegacyController.php
@@ -194,30 +194,8 @@ class LegacyController extends PrestaShopAdminController
         } elseif (method_exists($adminController, 'displayAjax')) {
             $adminController->displayAjax();
         }
-        $outputContent = ob_get_clean();
 
-        // The output of the controller is either directly echoed or it can be properly appended in AdminController::content
-        // it depends on the implementation of the controllers.
-        if (!empty($outputContent) && !empty($adminController->content)) {
-            // Sometimes they are both done and are equal, in which case we only return one content to avoid duplicates.
-            if ($outputContent === $adminController->content) {
-                $responseContent = $outputContent;
-            } else {
-                // In case both contents are present and are different we concatenate them, first the echoed output and then the controller
-                // one since it is displayed last by smarty in the original workflow
-                // This concatenation approach is theoretical and naive and was not tested because of the lack of use cases, so it may need
-                // to be improved in the future
-                $responseContent = $outputContent . $adminController->content;
-            }
-        } elseif (!empty($outputContent)) {
-            $responseContent = $outputContent;
-        } elseif (!empty($adminController->content)) {
-            $responseContent = $adminController->content;
-        } else {
-            $responseContent = '';
-        }
-
-        return new Response($responseContent);
+        return new Response(ob_get_clean());
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/LegacyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/LegacyController.php
@@ -32,7 +32,7 @@ use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShopBundle\Entity\Repository\TabRepository;
-use PrestaShopBundle\Routing\LegacyRouterChecker;
+use PrestaShopBundle\Routing\LegacyControllerConstants;
 use PrestaShopBundle\Twig\Layout\MenuBuilder;
 use PrestaShopBundle\Twig\Layout\SmartyVariablesFiller;
 use Symfony\Component\HttpFoundation\Request;
@@ -82,8 +82,8 @@ class LegacyController extends PrestaShopAdminController
         // These parameters have already been set as request attributes by LegacyRouterChecker
         $dispatcherHookParameters = [
             'controller_type' => Dispatcher::FC_ADMIN,
-            'controller_class' => $request->attributes->get(LegacyRouterChecker::LEGACY_CONTROLLER_CLASS_ATTRIBUTE),
-            'is_module' => $request->attributes->get(LegacyRouterChecker::LEGACY_CONTROLLER_IS_MODULE_ATTRIBUTE),
+            'controller_class' => $request->attributes->get(LegacyControllerConstants::CLASS_ATTRIBUTE),
+            'is_module' => $request->attributes->get(LegacyControllerConstants::IS_MODULE_ATTRIBUTE),
         ];
 
         $adminController = $this->initController($request, $dispatcherHookParameters);
@@ -213,7 +213,7 @@ class LegacyController extends PrestaShopAdminController
     {
         // Retrieving the controller instantiated in LegacyRouterChecker
         /** @var AdminController $adminController */
-        $adminController = $request->attributes->get(LegacyRouterChecker::LEGACY_CONTROLLER_INSTANCE_ATTRIBUTE);
+        $adminController = $request->attributes->get(LegacyControllerConstants::INSTANCE_ATTRIBUTE);
 
         // Fill default smarty variables as they can be used in partial templates rendered in init methods
         $this->assignSmartyVariables->fillDefault();

--- a/src/PrestaShopBundle/EventListener/Admin/Context/CountryContextListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/CountryContextListener.php
@@ -30,6 +30,8 @@ namespace PrestaShopBundle\EventListener\Admin\Context;
 
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Context\CountryContextBuilder;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 /**
@@ -39,13 +41,19 @@ class CountryContextListener
 {
     public function __construct(
         private readonly CountryContextBuilder $countryContextBuilder,
-        private readonly ConfigurationInterface $configuration
+        private readonly ConfigurationInterface $configuration,
+        private readonly FeatureFlagStateCheckerInterface $featureFlagStateChecker,
+        private readonly bool $isSymfonyLayout,
     ) {
     }
 
     public function onKernelRequest(RequestEvent $event): void
     {
         if (!$event->isMainRequest()) {
+            return;
+        }
+
+        if ($this->isSymfonyLayout !== $this->featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_SYMFONY_LAYOUT)) {
             return;
         }
 

--- a/src/PrestaShopBundle/EventListener/Admin/Context/CurrencyContextListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/CurrencyContextListener.php
@@ -30,6 +30,8 @@ namespace PrestaShopBundle\EventListener\Admin\Context;
 
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Context\CurrencyContextBuilder;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 /**
@@ -40,12 +42,18 @@ class CurrencyContextListener
     public function __construct(
         private readonly CurrencyContextBuilder $currencyContextBuilder,
         private readonly ConfigurationInterface $configuration,
+        private readonly FeatureFlagStateCheckerInterface $featureFlagStateChecker,
+        private readonly bool $isSymfonyLayout,
     ) {
     }
 
     public function onKernelRequest(RequestEvent $event): void
     {
         if (!$event->isMainRequest()) {
+            return;
+        }
+
+        if ($this->isSymfonyLayout !== $this->featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_SYMFONY_LAYOUT)) {
             return;
         }
 

--- a/src/PrestaShopBundle/EventListener/Admin/Context/DefaultLanguageContextListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/DefaultLanguageContextListener.php
@@ -28,22 +28,20 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\EventListener\Admin\Context;
 
-use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
-use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
-use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 /**
- * Listener dedicated to set up Language context for the Back-Office/Admin application.
+ * Listener dedicated to set up default Language context for the Back-Office/Admin application.
+ * We need to initialize the LanguageContext earlier because it's used by components in the Symfony
+ * layout that will be displayed in the Not Found legacy page
  */
-class LanguageContextListener
+class DefaultLanguageContextListener
 {
     public function __construct(
         private readonly LanguageContextBuilder $languageContextBuilder,
-        private readonly EmployeeContext $employeeContext,
-        private readonly FeatureFlagStateCheckerInterface $featureFlagStateChecker,
-        private readonly bool $isSymfonyLayout,
+        private readonly ConfigurationInterface $configuration,
     ) {
     }
 
@@ -53,12 +51,8 @@ class LanguageContextListener
             return;
         }
 
-        if ($this->isSymfonyLayout !== $this->featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_SYMFONY_LAYOUT)) {
-            return;
-        }
-        if ($this->employeeContext->getEmployee()) {
-            // Use the employee language if available
-            $this->languageContextBuilder->setLanguageId($this->employeeContext->getEmployee()->getLanguageId());
-        }
+        $defaultLanguageId = (int) $this->configuration->get('PS_LANG_DEFAULT');
+        $this->languageContextBuilder->setDefaultLanguageId($defaultLanguageId);
+        $this->languageContextBuilder->setLanguageId($defaultLanguageId);
     }
 }

--- a/src/PrestaShopBundle/EventListener/Admin/Context/DefaultShopContextListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/DefaultShopContextListener.php
@@ -28,37 +28,35 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\EventListener\Admin\Context;
 
-use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
-use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
-use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
-use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
+use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 /**
- * Listener dedicated to set up Language context for the Back-Office/Admin application.
+ * Listener dedicated to set up default Shop context for the Back-Office/Admin application.
+ * We need to initialize the ShopContext earlier because it's used by components in the Symfony
+ * layout that will be displayed in the Not Found legacy page
  */
-class LanguageContextListener
+class DefaultShopContextListener
 {
     public function __construct(
-        private readonly LanguageContextBuilder $languageContextBuilder,
-        private readonly EmployeeContext $employeeContext,
-        private readonly FeatureFlagStateCheckerInterface $featureFlagStateChecker,
-        private readonly bool $isSymfonyLayout,
+        private readonly ShopContextBuilder $shopContextBuilder,
+        private readonly ShopConfigurationInterface $configuration,
     ) {
     }
 
+    /**
+     * @throws ShopException
+     */
     public function onKernelRequest(RequestEvent $event): void
     {
         if (!$event->isMainRequest()) {
             return;
         }
-
-        if ($this->isSymfonyLayout !== $this->featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_SYMFONY_LAYOUT)) {
-            return;
-        }
-        if ($this->employeeContext->getEmployee()) {
-            // Use the employee language if available
-            $this->languageContextBuilder->setLanguageId($this->employeeContext->getEmployee()->getLanguageId());
-        }
+        $shopConstraint = ShopConstraint::shop((int) $this->configuration->get('PS_SHOP_DEFAULT', null, ShopConstraint::allShops()));
+        $this->shopContextBuilder->setShopId($shopConstraint->getShopId()->getValue());
+        $this->shopContextBuilder->setShopConstraint($shopConstraint);
     }
 }

--- a/src/PrestaShopBundle/EventListener/Admin/Context/EmployeeContextListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/EmployeeContextListener.php
@@ -30,6 +30,8 @@ namespace PrestaShopBundle\EventListener\Admin\Context;
 
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\Context\EmployeeContextBuilder;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 use PrestaShopBundle\Security\Admin\Employee;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -43,12 +45,18 @@ class EmployeeContextListener
         private readonly EmployeeContextBuilder $employeeContextBuilder,
         private readonly LegacyContext $legacyContext,
         private readonly Security $security,
+        private readonly FeatureFlagStateCheckerInterface $featureFlagStateChecker,
+        private readonly bool $isSymfonyLayout,
     ) {
     }
 
     public function onKernelRequest(RequestEvent $event): void
     {
         if (!$event->isMainRequest()) {
+            return;
+        }
+
+        if ($this->isSymfonyLayout !== $this->featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_SYMFONY_LAYOUT)) {
             return;
         }
 

--- a/src/PrestaShopBundle/EventListener/Admin/Context/LanguageContextListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/LanguageContextListener.php
@@ -31,6 +31,8 @@ namespace PrestaShopBundle\EventListener\Admin\Context;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
 use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 /**
@@ -42,12 +44,18 @@ class LanguageContextListener
         private readonly LanguageContextBuilder $languageContextBuilder,
         private readonly EmployeeContext $employeeContext,
         private readonly ConfigurationInterface $configuration,
+        private readonly FeatureFlagStateCheckerInterface $featureFlagStateChecker,
+        private readonly bool $isSymfonyLayout,
     ) {
     }
 
     public function onKernelRequest(RequestEvent $event): void
     {
         if (!$event->isMainRequest()) {
+            return;
+        }
+
+        if ($this->isSymfonyLayout !== $this->featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_SYMFONY_LAYOUT)) {
             return;
         }
 

--- a/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextListener.php
@@ -35,6 +35,8 @@ use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
 use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 use PrestaShop\PrestaShop\Core\Util\Url\UrlCleaner;
 use PrestaShopBundle\Controller\Attribute\AllShopContext;
 use PrestaShopBundle\Routing\LegacyControllerConstants;
@@ -58,6 +60,8 @@ class ShopContextListener
         private readonly LegacyContext $legacyContext,
         private readonly MultistoreFeature $multistoreFeature,
         private readonly RouterInterface $router,
+        private readonly FeatureFlagStateCheckerInterface $featureFlagStateChecker,
+        private readonly bool $isSymfonyLayout,
     ) {
     }
 
@@ -70,6 +74,11 @@ class ShopContextListener
         if (!$event->isMainRequest()) {
             return;
         }
+
+        if ($this->isSymfonyLayout !== $this->featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_SYMFONY_LAYOUT)) {
+            return;
+        }
+
         $psSslEnabled = (bool) $this->configuration->get('PS_SSL_ENABLED', null, ShopConstraint::allShops());
 
         $this->shopContextBuilder->setSecureMode($psSslEnabled && $event->getRequest()->isSecure());

--- a/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextListener.php
@@ -37,7 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Util\Url\UrlCleaner;
 use PrestaShopBundle\Controller\Attribute\AllShopContext;
-use PrestaShopBundle\Routing\LegacyRouterChecker;
+use PrestaShopBundle\Routing\LegacyControllerConstants;
 use ReflectionClass;
 use ReflectionException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -45,7 +45,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Routing\Exception\NoConfigurationException;
 use Symfony\Component\Routing\RouterInterface;
-use PrestaShopBundle\Routing\LegacyRouterChecker;
 
 /**
  * Listener dedicated to set up Shop context for the Back-Office/Admin application.
@@ -117,13 +116,14 @@ class ShopContextListener
             return $shopConstraint;
         }
 
-        $isAllShopContext = $request->attributes->get(LegacyRouterChecker::LEGACY_CONTROLLER_IS_ALL_SHOP_CONTEXT);
+        $shopConstraint = ShopConstraint::allShops();
+        // Check if the displayed legacy controller forces All shops mode (check already performed by LegacyRouterChecker)
+        $isAllShopContext = $request->attributes->get(LegacyControllerConstants::IS_ALL_SHOP_CONTEXT_ATTRIBUTE);
 
         if ($isAllShopContext) {
             return $shopConstraint;
         }
 
-        $shopConstraint = ShopConstraint::allShops();
         $cookieShopConstraint = $this->getShopConstraintFromCookie();
         if ($cookieShopConstraint) {
             if ($cookieShopConstraint->getShopGroupId()) {

--- a/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextListener.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Util\Url\UrlCleaner;
 use PrestaShopBundle\Controller\Attribute\AllShopContext;
+use PrestaShopBundle\Routing\LegacyRouterChecker;
 use ReflectionClass;
 use ReflectionException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -44,6 +45,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Routing\Exception\NoConfigurationException;
 use Symfony\Component\Routing\RouterInterface;
+use PrestaShopBundle\Routing\LegacyRouterChecker;
 
 /**
  * Listener dedicated to set up Shop context for the Back-Office/Admin application.
@@ -112,6 +114,12 @@ class ShopContextListener
         $shopConstraint = $this->verifyRouteAttribute($request);
 
         if ($shopConstraint) {
+            return $shopConstraint;
+        }
+
+        $isAllShopContext = $request->attributes->get(LegacyRouterChecker::LEGACY_CONTROLLER_IS_ALL_SHOP_CONTEXT);
+
+        if ($isAllShopContext) {
             return $shopConstraint;
         }
 

--- a/src/PrestaShopBundle/EventListener/Admin/TokenizedUrlsListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/TokenizedUrlsListener.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\EventListener\Admin;
 
 use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 use PrestaShop\PrestaShop\Core\Util\Url\UrlCleaner;
+use PrestaShopBundle\Routing\LegacyRouterChecker;
 use PrestaShopBundle\Security\Admin\UserTokenManager;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
@@ -50,8 +51,9 @@ class TokenizedUrlsListener
     public function onKernelRequest(KernelEvent $event)
     {
         $request = $event->getRequest();
+        $publicLegacyRoute = $event->getRequest()->attributes->get(LegacyRouterChecker::LEGACY_CONTROLLER_ANONYMOUS_ATTRIBUTE);
 
-        if (TokenInUrls::isDisabled()) {
+        if (TokenInUrls::isDisabled() || $publicLegacyRoute) {
             return;
         }
 

--- a/src/PrestaShopBundle/EventListener/Admin/TokenizedUrlsListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/TokenizedUrlsListener.php
@@ -28,7 +28,7 @@ namespace PrestaShopBundle\EventListener\Admin;
 
 use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 use PrestaShop\PrestaShop\Core\Util\Url\UrlCleaner;
-use PrestaShopBundle\Routing\LegacyRouterChecker;
+use PrestaShopBundle\Routing\LegacyControllerConstants;
 use PrestaShopBundle\Security\Admin\UserTokenManager;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
@@ -51,7 +51,7 @@ class TokenizedUrlsListener
     public function onKernelRequest(KernelEvent $event)
     {
         $request = $event->getRequest();
-        $publicLegacyRoute = $event->getRequest()->attributes->get(LegacyRouterChecker::LEGACY_CONTROLLER_ANONYMOUS_ATTRIBUTE);
+        $publicLegacyRoute = $event->getRequest()->attributes->get(LegacyControllerConstants::ANONYMOUS_ATTRIBUTE);
 
         if (TokenInUrls::isDisabled() || $publicLegacyRoute) {
             return;

--- a/src/PrestaShopBundle/Routing/LegacyControllerConstants.php
+++ b/src/PrestaShopBundle/Routing/LegacyControllerConstants.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Routing;
+
+class LegacyControllerConstants
+{
+    public const CLASS_ATTRIBUTE = '_legacy_controller_class';
+    public const INSTANCE_ATTRIBUTE = '_legacy_controller_instance';
+    public const ANONYMOUS_ATTRIBUTE = '_legacy_controller_anonymous';
+    public const IS_MODULE_ATTRIBUTE = '_legacy_controller_is_module';
+    public const IS_ALL_SHOP_CONTEXT_ATTRIBUTE = '_legacy_controller_is_all_shop_context';
+}

--- a/src/PrestaShopBundle/Routing/LegacyRouterChecker.php
+++ b/src/PrestaShopBundle/Routing/LegacyRouterChecker.php
@@ -109,10 +109,10 @@ class LegacyRouterChecker
             // It's clearer to actually return a not found exception, for now the dispatcher is still used as fallback in index.php
             // but when it's cleared and only Symfony handles the whole routing then we can display a proper not found Symfony page
             if (!isset($controllers[strtolower($queryController)])) {
-                throw new NotFoundHttpException(sprintf('Unknown controller %s', $queryController));
+                $controllerClass = 'AdminNotFoundController';
+            } else {
+                $controllerClass = $controllers[strtolower($queryController)];
             }
-
-            $controllerClass = $controllers[strtolower($queryController)];
         }
         // We load the controller early in the process (during router matching actually), because the controller
         // configuration has many impacts on the contexts, the security listeners, ... And the relevant data can

--- a/src/PrestaShopBundle/Routing/LegacyRouterChecker.php
+++ b/src/PrestaShopBundle/Routing/LegacyRouterChecker.php
@@ -45,6 +45,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class LegacyRouterChecker
 {
     public const LEGACY_CONTROLLER_CLASS_ATTRIBUTE = '_legacy_controller_class';
+    public const LEGACY_CONTROLLER_INSTANCE_ATTRIBUTE = '_legacy_controller_instance_class';
+    public const LEGACY_CONTROLLER_ANONYMOUS_ATTRIBUTE = '_legacy_controller_anonymous_class';
     public const LEGACY_CONTROLLER_IS_MODULE_ATTRIBUTE = '_legacy_controller_is_module';
 
     public function __construct(
@@ -116,6 +118,12 @@ class LegacyRouterChecker
 
             $controllerClass = $controllers[strtolower($queryController)];
         }
+        // Loading controller
+        $adminController = new $controllerClass();
+        $adminController->init();
+
+        $request->attributes->set(self::LEGACY_CONTROLLER_INSTANCE_ATTRIBUTE, $adminController);
+        $request->attributes->set(self::LEGACY_CONTROLLER_ANONYMOUS_ATTRIBUTE, $adminController->isAnonymousAllowed());
         $request->attributes->set(self::LEGACY_CONTROLLER_CLASS_ATTRIBUTE, $controllerClass);
         $request->attributes->set(self::LEGACY_CONTROLLER_IS_MODULE_ATTRIBUTE, $isModule);
 

--- a/src/PrestaShopBundle/Routing/LegacyRouterChecker.php
+++ b/src/PrestaShopBundle/Routing/LegacyRouterChecker.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Routing;
 
 use Dispatcher;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
@@ -48,6 +49,7 @@ class LegacyRouterChecker
     public const LEGACY_CONTROLLER_INSTANCE_ATTRIBUTE = '_legacy_controller_instance_class';
     public const LEGACY_CONTROLLER_ANONYMOUS_ATTRIBUTE = '_legacy_controller_anonymous_class';
     public const LEGACY_CONTROLLER_IS_MODULE_ATTRIBUTE = '_legacy_controller_is_module';
+    public const LEGACY_CONTROLLER_IS_ALL_SHOP_CONTEXT = '_legacy_controller_is_all_shop_context';
 
     public function __construct(
         protected readonly FeatureFlagStateCheckerInterface $featureFlagStateChecker,
@@ -124,6 +126,7 @@ class LegacyRouterChecker
 
         $request->attributes->set(self::LEGACY_CONTROLLER_INSTANCE_ATTRIBUTE, $adminController);
         $request->attributes->set(self::LEGACY_CONTROLLER_ANONYMOUS_ATTRIBUTE, $adminController->isAnonymousAllowed());
+        $request->attributes->set(self::LEGACY_CONTROLLER_IS_ALL_SHOP_CONTEXT, $adminController->multishop_context === ShopConstraint::ALL_SHOPS);
         $request->attributes->set(self::LEGACY_CONTROLLER_CLASS_ATTRIBUTE, $controllerClass);
         $request->attributes->set(self::LEGACY_CONTROLLER_IS_MODULE_ATTRIBUTE, $isModule);
 

--- a/tests/UI/pages/BO/BObasePage.ts
+++ b/tests/UI/pages/BO/BObasePage.ts
@@ -256,9 +256,13 @@ export default class BOBasePage extends CommonPage {
 
   private readonly helpDocumentURL: string;
 
-  private readonly invalidTokenContinueLink: string;
+  private readonly invalidTokenContinueLinkLegacy: string;
 
-  private readonly invalidTokenCancelLink: string;
+  private readonly invalidTokenCancelLinkLegacy: string;
+
+  private readonly invalidTokenContinueLinkSymfony: string;
+
+  private readonly invalidTokenCancelLinkSymfony: string;
 
   public readonly debugModeToolbar: string;
 
@@ -613,8 +617,10 @@ export default class BOBasePage extends CommonPage {
     this.helpDocumentURL = `${this.rightSidebar} div.quicknav-scroller._fullspace object`;
 
     // Invalid token block
-    this.invalidTokenContinueLink = 'a.btn-continue';
-    this.invalidTokenCancelLink = 'a.btn-cancel';
+    this.invalidTokenContinueLinkLegacy = 'a.btn-continue';
+    this.invalidTokenCancelLinkLegacy = 'a.btn-cancel';
+    this.invalidTokenContinueLinkSymfony = '#security-compromised-page #csrf-white-container div a:nth-child(1)';
+    this.invalidTokenCancelLinkSymfony = '#security-compromised-page #csrf-white-container div a:nth-child(2)';
   }
 
   /*
@@ -1150,10 +1156,18 @@ export default class BOBasePage extends CommonPage {
    */
   async navigateToPageWithInvalidToken(page: Page, url: string, continueToPage: boolean = true): Promise<void> {
     await this.goTo(page, url);
-    if (await this.elementVisible(page, this.invalidTokenContinueLink, 10000)) {
+    // Legacy Layout
+    if (await this.elementVisible(page, this.invalidTokenContinueLinkLegacy, 10000)) {
       await this.clickAndWaitForURL(
         page,
-        continueToPage ? this.invalidTokenContinueLink : this.invalidTokenCancelLink,
+        continueToPage ? this.invalidTokenContinueLinkLegacy : this.invalidTokenCancelLinkLegacy,
+      );
+    }
+    // Symfony Layout
+    if (await this.elementVisible(page, this.invalidTokenContinueLinkSymfony, 10000)) {
+      await this.clickAndWaitForURL(
+        page,
+        continueToPage ? this.invalidTokenContinueLinkSymfony : this.invalidTokenCancelLinkSymfony,
       );
     }
   }

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/CountryContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/CountryContextListenerTest.php
@@ -48,6 +48,8 @@ class CountryContextListenerTest extends ContextEventListenerTestCase
         $listener = new CountryContextListener(
             $countryContextBuilder,
             $this->mockConfiguration(['PS_COUNTRY_DEFAULT' => 42]),
+            $this->mockFeatureFlagStateChecker(),
+            true,
         );
 
         $event = $this->createRequestEvent(new Request());

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/CurrencyContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/CurrencyContextListenerTest.php
@@ -48,6 +48,8 @@ class CurrencyContextListenerTest extends ContextEventListenerTestCase
         $listener = new CurrencyContextListener(
             $currencyContextBuilder,
             $this->mockConfiguration(['PS_CURRENCY_DEFAULT' => 42]),
+            $this->mockFeatureFlagStateChecker(),
+            true,
         );
 
         $event = $this->createRequestEvent(new Request());

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/EmployeeContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/EmployeeContextListenerTest.php
@@ -46,7 +46,9 @@ class EmployeeContextListenerTest extends ContextEventListenerTestCase
         $listener = new EmployeeContextListener(
             $employeeBuilder,
             $this->mockLegacyContext(['id_employee' => 42]),
-            $this->createMock(Security::class)
+            $this->createMock(Security::class),
+            $this->mockFeatureFlagStateChecker(),
+            true,
         );
 
         $event = $this->createRequestEvent(new Request());
@@ -63,7 +65,9 @@ class EmployeeContextListenerTest extends ContextEventListenerTestCase
         $listener = new EmployeeContextListener(
             $employeeBuilder,
             $this->mockLegacyContext(['id_employee' => null]),
-            $this->createMock(Security::class)
+            $this->createMock(Security::class),
+            $this->mockFeatureFlagStateChecker(),
+            true,
         );
         $listener->onKernelRequest($event);
         $this->assertEquals(null, $this->getPrivateField($employeeBuilder, 'employeeId'));
@@ -81,7 +85,9 @@ class EmployeeContextListenerTest extends ContextEventListenerTestCase
         $listener = new EmployeeContextListener(
             $employeeBuilder,
             $this->mockLegacyContext(['id_employee' => null]),
-            $securityMock
+            $securityMock,
+            $this->mockFeatureFlagStateChecker(),
+            true,
         );
 
         $event = $this->createRequestEvent(new Request());

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LanguageContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LanguageContextListenerTest.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
 use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
 use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
 use PrestaShop\PrestaShop\Core\Localization\Locale\RepositoryInterface;
+use PrestaShopBundle\EventListener\Admin\Context\DefaultLanguageContextListener;
 use PrestaShopBundle\EventListener\Admin\Context\LanguageContextListener;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\Unit\PrestaShopBundle\EventListener\ContextEventListenerTestCase;
@@ -56,7 +57,6 @@ class LanguageContextListenerTest extends ContextEventListenerTestCase
         $listener = new LanguageContextListener(
             $languageContextBuilder,
             $this->mockEmployeeContext(self::EMPLOYEE_CONTEXT_LANGUAGE_ID),
-            $this->mockConfiguration(),
             $this->mockFeatureFlagStateChecker(),
             true,
         );
@@ -74,12 +74,9 @@ class LanguageContextListenerTest extends ContextEventListenerTestCase
             $this->createMock(ContextStateManager::class),
             $this->createMock(ObjectModelLanguageRepository::class)
         );
-        $listener = new LanguageContextListener(
+        $listener = new DefaultLanguageContextListener(
             $languageContextBuilder,
-            $this->mockEmployeeContext(null),
             $this->mockConfiguration(['PS_LANG_DEFAULT' => self::DEFAULT_CONFIGURATION_LANGUAGE_ID]),
-            $this->mockFeatureFlagStateChecker(),
-            true,
         );
 
         $event = $this->createRequestEvent(new Request());

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LanguageContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LanguageContextListenerTest.php
@@ -57,6 +57,8 @@ class LanguageContextListenerTest extends ContextEventListenerTestCase
             $languageContextBuilder,
             $this->mockEmployeeContext(self::EMPLOYEE_CONTEXT_LANGUAGE_ID),
             $this->mockConfiguration(),
+            $this->mockFeatureFlagStateChecker(),
+            true,
         );
 
         $event = $this->createRequestEvent(new Request());
@@ -76,6 +78,8 @@ class LanguageContextListenerTest extends ContextEventListenerTestCase
             $languageContextBuilder,
             $this->mockEmployeeContext(null),
             $this->mockConfiguration(['PS_LANG_DEFAULT' => self::DEFAULT_CONFIGURATION_LANGUAGE_ID]),
+            $this->mockFeatureFlagStateChecker(),
+            true,
         );
 
         $event = $this->createRequestEvent(new Request());

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextListenerTest.php
@@ -61,7 +61,9 @@ class ShopContextListenerTest extends ContextEventListenerTestCase
             $this->mockConfiguration(['PS_SHOP_DEFAULT' => self::DEFAULT_SHOP_ID, 'PS_SSL_ENABLED' => self::PS_SSL_ENABLED]),
             $this->mockLegacyContext(['shopContext' => '']),
             $this->mockMultistoreFeature(false),
-            $this->mockRouter()
+            $this->mockRouter(),
+            $this->mockFeatureFlagStateChecker(),
+            true,
         );
         $listener->onKernelRequest($event);
 
@@ -94,7 +96,9 @@ class ShopContextListenerTest extends ContextEventListenerTestCase
             $this->mockConfiguration(['PS_SHOP_DEFAULT' => self::DEFAULT_SHOP_ID, 'PS_SSL_ENABLED' => self::PS_SSL_ENABLED]),
             $this->mockLegacyContext(['shopContext' => $cookieValue]),
             $this->mockMultistoreFeature(true),
-            $this->mockRouter()
+            $this->mockRouter(),
+            $this->mockFeatureFlagStateChecker(),
+            true,
         );
         $listener->onKernelRequest($event);
 
@@ -169,7 +173,9 @@ class ShopContextListenerTest extends ContextEventListenerTestCase
             $this->mockConfiguration(['PS_SHOP_DEFAULT' => self::DEFAULT_SHOP_ID, 'PS_SSL_ENABLED' => self::PS_SSL_ENABLED]),
             $mockContext,
             $this->mockMultistoreFeature(true),
-            $this->mockRouter()
+            $this->mockRouter(),
+            $this->mockFeatureFlagStateChecker(),
+            true,
         );
 
         // Check that initially the cookie has a null value

--- a/tests/Unit/PrestaShopBundle/EventListener/ContextEventListenerTestCase.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/ContextEventListenerTestCase.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\Shop\Repository\ShopRepository;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 use ReflectionProperty;
 use Shop;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -80,6 +81,17 @@ abstract class ContextEventListenerTestCase extends KernelTestCase
         ;
 
         return $legacyContext;
+    }
+
+    protected function mockFeatureFlagStateChecker(): FeatureFlagStateCheckerInterface|MockObject
+    {
+        $featureFlagStateChecker = $this->createMock(FeatureFlagStateCheckerInterface::class);
+        $featureFlagStateChecker
+            ->method('isEnabled')
+            ->willReturn(true)
+        ;
+
+        return $featureFlagStateChecker;
     }
 
     protected function createRequestEvent(Request $request): RequestEvent


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | We need to add a check in the Symfony listeners for anonymous requests from legacy controllers. I also removed the part recovering the content of the content variable of the legacy controllers, which added an unwanted rendering. To make this possible, we initialize the legacy controller in the LegacyRouterChecker Class, which is responsible for creating attributes that will later be useful in the listener Contexts and the LegacyController. This had side effects on the initialization of contexts, which were improperly initialized in the listeners and then overridden during initialization in the LegacyController. Therefore, we had to adapt the listeners and their priorities by duplicating them (listeners for the Symfony layout and listeners for the legacy layout).
| Type?             | bug fix
| Category?         | BO 
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | See  #35359
| UI Tests          | Symfony: https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/8802453146 / Legacy: https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/8802455158
| Fixed issue or discussion?     | Fixes #35359
| Related PRs       | -
| Sponsor company   | -

**BC breaks**
Method `AdminController->isAnonymousAllowed` is now `public`

