### PR TITLE
Fix strpos modifier

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -118,6 +118,7 @@ smartyRegisterFunction($smarty, 'modifier', 'rand', 'rand');
 smartyRegisterFunction($smarty, 'modifier', 'sizeof', 'sizeof');
 smartyRegisterFunction($smarty, 'modifier', 'str_replace', 'str_replace');
 smartyRegisterFunction($smarty, 'modifier', 'stripslashes', 'stripslashes');
+smartyRegisterFunction($smarty, 'modifier', 'strpos', 'strpos');
 smartyRegisterFunction($smarty, 'modifier', 'strstr', 'strstr');
 smartyRegisterFunction($smarty, 'modifier', 'strtolower', 'strtolower');
 smartyRegisterFunction($smarty, 'modifier', 'strval', 'strval');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fix [25-Mar-2024 17:20:41 Europe/Prague] PHP Deprecated:  Using php-function "strpos" as a modifier is deprecated and will be removed in a future release. Use Smarty::registerPlugin to explicitly register a custom modifier. in /srv/www/deskyhevea.cz/public/www/vendor/smarty/smarty/libs/sysplugins/smarty_internal_compile_private_modifier.php on line 114
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests green
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/8566870443
| Fixed issue or discussion?     | 
| Related PRs       |
| Sponsor company   | 
