### PR TITLE
Fix uasort in dead code

### DIFF
--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -124,10 +124,10 @@ class AdminModulesControllerCore extends AdminController
     public function checkCategoriesNames($a, $b)
     {
         if ($a['name'] === $this->trans('Other Modules')) {
-            return true;
+            return 1;
         }
 
-        return (bool) ($a['name'] > $b['name']);
+        return $a['name'] > $b['name'] ? 1 : -1;
     }
 
     public function setMedia($isNewTheme = false)


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | This code is not used, but it's executed on module configuration page. In debug mode, it's throwing  `PHP Deprecated:  uasort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero in /var/www/vhosts/eshop-sinks.cz/httpdocs/controllers/admin/AdminModulesController.php on line 110`.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests green, the code is not use and visible in BO. If anyone used this public method somewhere, it returns the correctly sort list. Can be verified by putting `dump($this->list_modules_categories)` after the uasort.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/8567603126 ✅ 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 
