### PR TITLE
Fix notice on nulls

### DIFF
--- a/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
+++ b/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
@@ -74,6 +74,11 @@ class TinyMceMaxLengthValidator extends ConstraintValidator
             throw new InvalidArgumentException('Max must be int. Input was: ' . \gettype($constraint->max));
         }
 
+        // If the provided value is not a string, nothing to validate here
+        if (!is_string($value)) {
+            return;
+        }
+
         $replaceArray = [
             "\n",
             "\r",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Empty textareas are passed into the validator as nulls. This PR fixes `PHP Deprecated:  strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated in /srv/www/cycli.cz/public/www/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php on line 83 `flooding the logs.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests green
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/8566855416
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 
