### PR TITLE
Chore(api): make api based on grid instead of query builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "prestashop/gsitemap": "^4",
         "prestashop/pagesnotfound": "^2",
         "prestashop/productcomments": "^6.0",
-        "prestashop/ps_apiresources": "dev-external-server-refacto",
+        "prestashop/ps_apiresources": "dev-Issue-35686-make-api-based-on-grid",
         "prestashop/ps_banner": "^2",
         "prestashop/ps_bestsellers": "^1.0",
         "prestashop/ps_brandlist": "^1.0",
@@ -254,7 +254,7 @@
     "repositories": {
         "ps_apiresources": {
             "type": "vcs",
-            "url": "https://github.com/jolelievre/ps_apiresources.git"
+            "url": "https://github.com/tleon/ps_apiresources.git"
         }
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "30e0b178cb291349e58d42b4bf438e30",
+    "content-hash": "1728f58b8070fdf93219e8469336cd3f",
     "packages": [
         {
             "name": "api-platform/core",
@@ -5579,16 +5579,16 @@
         },
         {
             "name": "prestashop/ps_apiresources",
-            "version": "dev-external-server-refacto",
+            "version": "dev-Issue-35686-make-api-based-on-grid",
             "source": {
                 "type": "git",
-                "url": "https://github.com/jolelievre/ps_apiresources.git",
-                "reference": "f379b4c7932779de213ec6ee701be21e2d151dcb"
+                "url": "https://github.com/tleon/ps_apiresources.git",
+                "reference": "a2720b6365b33cf953e73a09822d55126e4b66f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jolelievre/ps_apiresources/zipball/f379b4c7932779de213ec6ee701be21e2d151dcb",
-                "reference": "f379b4c7932779de213ec6ee701be21e2d151dcb",
+                "url": "https://api.github.com/repos/tleon/ps_apiresources/zipball/a2720b6365b33cf953e73a09822d55126e4b66f1",
+                "reference": "a2720b6365b33cf953e73a09822d55126e4b66f1",
                 "shasum": ""
             },
             "require": {
@@ -5640,9 +5640,9 @@
             "description": "PrestaShop - API Resources",
             "homepage": "https://github.com/PrestaShop/ps_apiresources",
             "support": {
-                "source": "https://github.com/jolelievre/ps_apiresources/tree/external-server-refacto"
+                "source": "https://github.com/tleon/ps_apiresources/tree/Issue-35686-make-api-based-on-grid"
             },
-            "time": "2024-04-09T15:56:08+00:00"
+            "time": "2024-04-11T14:37:35+00:00"
         },
         {
             "name": "prestashop/ps_banner",
@@ -17989,5 +17989,5 @@
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/PrestaShopBundle/ApiPlatform/Exception/GridDataFactoryNotFoundException.php
+++ b/src/PrestaShopBundle/ApiPlatform/Exception/GridDataFactoryNotFoundException.php
@@ -34,6 +34,6 @@ use ApiPlatform\Exception\InvalidResourceException;
 /**
  * Is thrown when the Query builder property is not defined on a resource on which it should be.
  */
-class QueryBuilderNotFoundException extends InvalidResourceException
+class GridDataFactoryNotFoundException extends InvalidResourceException
 {
 }

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/PaginatedList.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/PaginatedList.php
@@ -34,12 +34,13 @@ use PrestaShop\PrestaShop\Core\Search\Filters;
 use PrestaShopBundle\ApiPlatform\Provider\QueryListProvider;
 
 /**
- * Class DoctrineQueryBuilderPaginatedList is a custom operation that provides extra parameters
+ * Class PaginatedList is a custom operation that provides extra parameters
  * to help configure an operation based on a GetCollection,
  * it is custom tailed for read operations and forces using the GET method.
+ * It gathers its data from the associated GridData using the GridDataFactoryInterface.
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
-class DQBPaginatedList extends AbstractCQRSOperation implements CollectionOperationInterface
+class PaginatedList extends AbstractCQRSOperation implements CollectionOperationInterface
 {
     public function __construct(
         ?string $uriTemplate = null,
@@ -113,7 +114,7 @@ class DQBPaginatedList extends AbstractCQRSOperation implements CollectionOperat
         array $extraProperties = [],
         array $scopes = [],
         ?array $ApiResourceMapping = null,
-        ?string $queryBuilder = null,
+        ?string $gridDataFactory = null,
         ?string $filtersClass = null,
         ?array $filtersMapping = null,
         ?bool $experimentalOperation = null,
@@ -123,9 +124,9 @@ class DQBPaginatedList extends AbstractCQRSOperation implements CollectionOperat
         $passedArguments['provider'] = $provider ?? QueryListProvider::class;
         $passedArguments['filtersClass'] = $filtersClass ?? Filters::class;
 
-        if (!empty($queryBuilder)) {
-            $this->checkArgumentAndExtraParameterValidity('queryBuilder', $queryBuilder, $passedArguments['extraProperties']);
-            $passedArguments['extraProperties']['queryBuilder'] = $queryBuilder;
+        if (!empty($gridDataFactory)) {
+            $this->checkArgumentAndExtraParameterValidity('gridDataFactory', $gridDataFactory, $passedArguments['extraProperties']);
+            $passedArguments['extraProperties']['gridDataFactory'] = $gridDataFactory;
         }
 
         if (!empty($filtersClass)) {
@@ -138,22 +139,22 @@ class DQBPaginatedList extends AbstractCQRSOperation implements CollectionOperat
             $passedArguments['extraProperties']['filtersMapping'] = $filtersMapping;
         }
 
-        unset($passedArguments['queryBuilder']);
+        unset($passedArguments['gridDataFactory']);
         unset($passedArguments['filtersClass']);
         unset($passedArguments['filtersMapping']);
 
         parent::__construct(...$passedArguments);
     }
 
-    public function getQueryBuilder(): ?string
+    public function getGridDataFactory(): ?string
     {
-        return $this->extraProperties['queryBuilder'] ?? null;
+        return $this->extraProperties['gridDataFactory'] ?? null;
     }
 
-    public function withQueryBuilder(string $queryBuilder): static
+    public function withGridDataFactory(string $gridDataFactory): static
     {
         $self = clone $this;
-        $self->extraProperties['queryBuilder'] = $queryBuilder;
+        $self->extraProperties['gridDataFactory'] = $gridDataFactory;
 
         return $self;
     }

--- a/src/PrestaShopBundle/ApiPlatform/Resources/Language.php
+++ b/src/PrestaShopBundle/ApiPlatform/Resources/Language.php
@@ -30,11 +30,11 @@ namespace PrestaShopBundle\ApiPlatform\Resources;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
-use PrestaShopBundle\ApiPlatform\Metadata\DQBPaginatedList;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
 
 #[ApiResource(
     operations: [
-        new DQBPaginatedList(
+        new PaginatedList(
             uriTemplate: '/languages',
             ApiResourceMapping: [
                 '[id_lang]' => '[langId]',
@@ -44,7 +44,7 @@ use PrestaShopBundle\ApiPlatform\Metadata\DQBPaginatedList;
                 '[date_format_full]' => '[dateTimeFormat]',
                 '[is_rtl]' => '[isRtl]',
             ],
-            queryBuilder: 'prestashop.core.grid.query.builder.language',
+            gridDataFactory: 'prestashop.core.grid.factory.language_decorator',
             filtersMapping: [
                 '[langId]' => '[id_lang]',
                 '[isoCode]' => '[iso_code]',
@@ -76,4 +76,6 @@ class Language
     public bool $isRtl;
 
     public bool $active;
+
+    public string $flag;
 }

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -656,7 +656,7 @@ services:
 
   prestashop.core.grid.data_factory.api_client:
     class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
-    public: false
+    public: true
     arguments:
       - '@PrestaShop\PrestaShop\Core\Grid\Query\ApiClientQueryBuilder'
       - '@prestashop.core.hook.dispatcher'

--- a/tests/Integration/ApiPlatform/EndPoint/LanguageEndpointTest.php
+++ b/tests/Integration/ApiPlatform/EndPoint/LanguageEndpointTest.php
@@ -78,6 +78,11 @@ class LanguageEndpointTest extends ApiTestCase
     public function testGetLanguages(): void
     {
         $paginatedLanguages = $this->listLanguages();
+        $items = $paginatedLanguages['items'];
+        // We delete the end of the flag path because it is a timestamp and could cause random fails in tests.
+        foreach ($items as $key => $item) {
+            $items[$key]['flag'] = substr($items[$key]['flag'], 0, strpos($items[$key]['flag'], '?'));
+        }
         $this->assertEquals(2, $paginatedLanguages['totalItems']);
         $this->assertEquals([
             [
@@ -90,6 +95,7 @@ class LanguageEndpointTest extends ApiTestCase
                 'dateTimeFormat' => 'm/d/Y H:i:s',
                 'isRtl' => false,
                 'active' => true,
+                'flag' => '/img/tmp/lang_mini_1_1.jpg',
             ],
             [
                 'langId' => static::$frenchLangId,
@@ -101,8 +107,9 @@ class LanguageEndpointTest extends ApiTestCase
                 'dateTimeFormat' => 'd/m/Y H:i:s',
                 'isRtl' => false,
                 'active' => true,
+                'flag' => '/img/tmp/lang_mini_' . static::$frenchLangId . '_1.jpg',
             ],
-        ], $paginatedLanguages['items']);
+        ], $items);
     }
 
     public function testFilterLanguages(): void

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/PaginatedListTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/PaginatedListTest.php
@@ -33,29 +33,29 @@ use ApiPlatform\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Search\Filters\LanguageFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\ProductFilters;
-use PrestaShopBundle\ApiPlatform\Metadata\DQBPaginatedList;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
 use PrestaShopBundle\ApiPlatform\Provider\QueryListProvider;
 
-class DQBPaginatedListTest extends TestCase
+class PaginatedListTest extends TestCase
 {
     public function testDefaultConstructor(): void
     {
         // Without any parameters
-        $operation = new DQBPaginatedList();
+        $operation = new PaginatedList();
         $this->assertEquals(QueryListProvider::class, $operation->getProvider());
-        $this->assertEquals(DQBPaginatedList::METHOD_GET, $operation->getMethod());
+        $this->assertEquals(PaginatedList::METHOD_GET, $operation->getMethod());
         $this->assertEquals([], $operation->getExtraProperties());
         $this->assertEquals(['json'], $operation->getFormats());
 
         // With positioned parameters
-        $operation = new DQBPaginatedList('/uri');
+        $operation = new PaginatedList('/uri');
         $this->assertEquals(QueryListProvider::class, $operation->getProvider());
         $this->assertEquals('/uri', $operation->getUriTemplate());
         $this->assertEquals([], $operation->getExtraProperties());
         $this->assertEquals(['json'], $operation->getFormats());
 
         // With named parameters
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             formats: ['json', 'html'],
             extraProperties: ['scopes' => ['test']]
         );
@@ -68,7 +68,7 @@ class DQBPaginatedListTest extends TestCase
     {
         // Filters mapping parameters in constructor
         $filtersClass = ProductFilters::class;
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             filtersClass: $filtersClass,
         );
 
@@ -76,14 +76,14 @@ class DQBPaginatedListTest extends TestCase
         $this->assertEquals($filtersClass, $operation->getFiltersClass());
 
         // Extra properties parameters in constructor
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             extraProperties: ['filtersClass' => $filtersClass],
         );
         $this->assertEquals(['filtersClass' => $filtersClass], $operation->getExtraProperties());
         $this->assertEquals($filtersClass, $operation->getFiltersClass());
 
         // Extra properties AND CQRS query mapping parameters in constructor, both values are equals no problem
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             extraProperties: ['filtersClass' => $filtersClass],
             filtersClass: $filtersClass,
         );
@@ -103,7 +103,7 @@ class DQBPaginatedListTest extends TestCase
         // When both values are specified, but they are different trigger an exception
         $caughtException = null;
         try {
-            new DQBPaginatedList(
+            new PaginatedList(
                 extraProperties: ['filtersClass' => $filtersClass],
                 filtersClass: $newMapping,
             );
@@ -120,7 +120,7 @@ class DQBPaginatedListTest extends TestCase
     {
         // Filters mapping parameters in constructor
         $filtersMapping = ['[langId]' => '[id_lang]'];
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             filtersMapping: $filtersMapping,
         );
 
@@ -128,14 +128,14 @@ class DQBPaginatedListTest extends TestCase
         $this->assertEquals($filtersMapping, $operation->getFiltersMapping());
 
         // Extra properties parameters in constructor
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             extraProperties: ['filtersMapping' => $filtersMapping],
         );
         $this->assertEquals(['filtersMapping' => $filtersMapping], $operation->getExtraProperties());
         $this->assertEquals($filtersMapping, $operation->getFiltersMapping());
 
         // Extra properties AND CQRS query mapping parameters in constructor, both values are equals no problem
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             extraProperties: ['filtersMapping' => $filtersMapping],
             filtersMapping: $filtersMapping,
         );
@@ -155,7 +155,7 @@ class DQBPaginatedListTest extends TestCase
         // When both values are specified, but they are different trigger an exception
         $caughtException = null;
         try {
-            new DQBPaginatedList(
+            new PaginatedList(
                 extraProperties: ['filtersMapping' => $filtersMapping],
                 filtersMapping: $newMapping,
             );
@@ -171,21 +171,21 @@ class DQBPaginatedListTest extends TestCase
     public function testScopes(): void
     {
         // Scopes parameters in constructor
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             scopes: ['test', 'test2']
         );
         $this->assertEquals(['scopes' => ['test', 'test2']], $operation->getExtraProperties());
         $this->assertEquals(['test', 'test2'], $operation->getScopes());
 
         // Extra properties parameters in constructor
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             extraProperties: ['scopes' => ['test']]
         );
         $this->assertEquals(['scopes' => ['test']], $operation->getExtraProperties());
         $this->assertEquals(['test'], $operation->getScopes());
 
         // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             extraProperties: ['scopes' => ['test', 'test1']],
             scopes: ['test', 'test2'],
         );
@@ -206,7 +206,7 @@ class DQBPaginatedListTest extends TestCase
     {
         // Api resource mapping parameters in constructor
         $resourceMapping = ['[id]' => '[queryId]'];
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             ApiResourceMapping: $resourceMapping,
         );
 
@@ -214,14 +214,14 @@ class DQBPaginatedListTest extends TestCase
         $this->assertEquals($resourceMapping, $operation->getApiResourceMapping());
 
         // Extra properties parameters in constructor
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             extraProperties: ['ApiResourceMapping' => $resourceMapping],
         );
         $this->assertEquals(['ApiResourceMapping' => $resourceMapping], $operation->getExtraProperties());
         $this->assertEquals($resourceMapping, $operation->getApiResourceMapping());
 
         // Extra properties AND Api resource mapping parameters in constructor, both values are equals no problem
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             extraProperties: ['ApiResourceMapping' => $resourceMapping],
             ApiResourceMapping: $resourceMapping,
         );
@@ -241,7 +241,7 @@ class DQBPaginatedListTest extends TestCase
         // When both values are specified, but they are different trigger an exception
         $caughtException = null;
         try {
-            new DQBPaginatedList(
+            new PaginatedList(
                 extraProperties: ['ApiResourceMapping' => $resourceMapping],
                 ApiResourceMapping: $newMapping,
             );
@@ -254,57 +254,57 @@ class DQBPaginatedListTest extends TestCase
         $this->assertEquals('Specifying an extra property ApiResourceMapping and a ApiResourceMapping argument that are different is invalid', $caughtException->getMessage());
     }
 
-    public function testQueryBuilder(): void
+    public function testGridDataFactory(): void
     {
-        // QueryBuilder parameters in constructor
-        $operation = new DQBPaginatedList(
-            queryBuilder: 'prestashop.core.api.query_builder.hook'
+        // GridDataFactory parameters in constructor
+        $operation = new PaginatedList(
+            gridDataFactory: 'prestashop.core.api.query_builder.hook'
         );
-        $this->assertEquals(['queryBuilder' => 'prestashop.core.api.query_builder.hook'], $operation->getExtraProperties());
-        $this->assertEquals('prestashop.core.api.query_builder.hook', $operation->getQueryBuilder());
+        $this->assertEquals(['gridDataFactory' => 'prestashop.core.api.query_builder.hook'], $operation->getExtraProperties());
+        $this->assertEquals('prestashop.core.api.query_builder.hook', $operation->getGridDataFactory());
 
         // Extra properties parameters in constructor
-        $operation = new DQBPaginatedList(
-            extraProperties: ['queryBuilder' => 'prestashop.core.api.query_builder.hook']
+        $operation = new PaginatedList(
+            extraProperties: ['gridDataFactory' => 'prestashop.core.api.query_builder.hook']
         );
-        $this->assertEquals(['queryBuilder' => 'prestashop.core.api.query_builder.hook'], $operation->getExtraProperties());
-        $this->assertEquals('prestashop.core.api.query_builder.hook', $operation->getQueryBuilder());
+        $this->assertEquals(['gridDataFactory' => 'prestashop.core.api.query_builder.hook'], $operation->getExtraProperties());
+        $this->assertEquals('prestashop.core.api.query_builder.hook', $operation->getGridDataFactory());
 
         // Use with method, returned object is a clone All values are replaced
-        $operation2 = $operation->withQueryBuilder('prestashop.core.api.query_builder.hook2');
+        $operation2 = $operation->withGridDataFactory('prestashop.core.api.query_builder.hook2');
         $this->assertNotEquals($operation2, $operation);
-        $this->assertEquals(['queryBuilder' => 'prestashop.core.api.query_builder.hook2'], $operation2->getExtraProperties());
-        $this->assertEquals('prestashop.core.api.query_builder.hook2', $operation2->getQueryBuilder());
+        $this->assertEquals(['gridDataFactory' => 'prestashop.core.api.query_builder.hook2'], $operation2->getExtraProperties());
+        $this->assertEquals('prestashop.core.api.query_builder.hook2', $operation2->getGridDataFactory());
         // Initial operation not modified of course
-        $this->assertEquals(['queryBuilder' => 'prestashop.core.api.query_builder.hook'], $operation->getExtraProperties());
-        $this->assertEquals('prestashop.core.api.query_builder.hook', $operation->getQueryBuilder());
+        $this->assertEquals(['gridDataFactory' => 'prestashop.core.api.query_builder.hook'], $operation->getExtraProperties());
+        $this->assertEquals('prestashop.core.api.query_builder.hook', $operation->getGridDataFactory());
     }
 
     public function testMultipleArguments(): void
     {
         $resourceMapping = ['[id]' => '[queryId]'];
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             extraProperties: [
                 'scopes' => ['master_scope'],
             ],
             scopes: ['scope1', 'scope2'],
             ApiResourceMapping: $resourceMapping,
-            queryBuilder: 'prestashop.core.api.query_builder.hook',
+            gridDataFactory: 'prestashop.core.api.query_builder.hook',
         );
 
         $this->assertEquals(QueryListProvider::class, $operation->getProvider());
         $this->assertEquals($resourceMapping, $operation->getApiResourceMapping());
         $this->assertEquals(['master_scope', 'scope1', 'scope2'], $operation->getScopes());
-        $this->assertEquals('prestashop.core.api.query_builder.hook', $operation->getQueryBuilder());
+        $this->assertEquals('prestashop.core.api.query_builder.hook', $operation->getGridDataFactory());
         $this->assertEquals([
             'scopes' => ['master_scope', 'scope1', 'scope2'],
             'ApiResourceMapping' => $resourceMapping,
-            'queryBuilder' => 'prestashop.core.api.query_builder.hook',
+            'gridDataFactory' => 'prestashop.core.api.query_builder.hook',
         ], $operation->getExtraProperties());
 
         // Using with clones the object, only one extra parameter is modified
         $operation2 = $operation->withScopes(['scope3']);
-        $operation3 = $operation2->withQueryBuilder('prestashop.core.api.query_builder.hook2');
+        $operation3 = $operation2->withGridDataFactory('prestashop.core.api.query_builder.hook2');
         $this->assertNotEquals($operation2, $operation);
         $this->assertNotEquals($operation2, $operation3);
         $this->assertNotEquals($operation3, $operation);
@@ -312,23 +312,23 @@ class DQBPaginatedListTest extends TestCase
         // Check first clone operation2
         $this->assertEquals(QueryListProvider::class, $operation2->getProvider());
         $this->assertEquals($resourceMapping, $operation2->getApiResourceMapping());
-        $this->assertEquals('prestashop.core.api.query_builder.hook', $operation2->getQueryBuilder());
+        $this->assertEquals('prestashop.core.api.query_builder.hook', $operation2->getGridDataFactory());
         $this->assertEquals(['scope3'], $operation2->getScopes());
         $this->assertEquals([
             'scopes' => ['scope3'],
             'ApiResourceMapping' => $resourceMapping,
-            'queryBuilder' => 'prestashop.core.api.query_builder.hook',
+            'gridDataFactory' => 'prestashop.core.api.query_builder.hook',
         ], $operation2->getExtraProperties());
 
         // Check second clone operation3
         $this->assertEquals(QueryListProvider::class, $operation3->getProvider());
         $this->assertEquals($resourceMapping, $operation3->getApiResourceMapping());
-        $this->assertEquals('prestashop.core.api.query_builder.hook2', $operation3->getQueryBuilder());
+        $this->assertEquals('prestashop.core.api.query_builder.hook2', $operation3->getGridDataFactory());
         $this->assertEquals(['scope3'], $operation3->getScopes());
         $this->assertEquals([
             'scopes' => ['scope3'],
             'ApiResourceMapping' => $resourceMapping,
-            'queryBuilder' => 'prestashop.core.api.query_builder.hook2',
+            'gridDataFactory' => 'prestashop.core.api.query_builder.hook2',
         ], $operation3->getExtraProperties());
 
         // The original object has not been modified
@@ -338,33 +338,33 @@ class DQBPaginatedListTest extends TestCase
         $this->assertEquals([
             'scopes' => ['master_scope', 'scope1', 'scope2'],
             'ApiResourceMapping' => $resourceMapping,
-            'queryBuilder' => 'prestashop.core.api.query_builder.hook',
+            'gridDataFactory' => 'prestashop.core.api.query_builder.hook',
         ], $operation->getExtraProperties());
     }
 
     public function testExperimentalOperation(): void
     {
         // Default value is false (no extra property added)
-        $operation = new DQBPaginatedList();
+        $operation = new PaginatedList();
         $this->assertEquals([], $operation->getExtraProperties());
         $this->assertEquals(false, $operation->getExperimentalOperation());
 
         // Scopes parameters in constructor
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             experimentalOperation: true,
         );
         $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
         $this->assertEquals(true, $operation->getExperimentalOperation());
 
         // Extra properties parameters in constructor
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             extraProperties: ['experimentalOperation' => false]
         );
         $this->assertEquals(['experimentalOperation' => false], $operation->getExtraProperties());
         $this->assertEquals(false, $operation->getExperimentalOperation());
 
         // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
-        $operation = new DQBPaginatedList(
+        $operation = new PaginatedList(
             extraProperties: ['experimentalOperation' => true],
             experimentalOperation: true,
         );
@@ -383,7 +383,7 @@ class DQBPaginatedListTest extends TestCase
         // When both values are specified, but they are different trigger an exception
         $caughtException = null;
         try {
-            new DQBPaginatedList(
+            new PaginatedList(
                 extraProperties: ['experimentalOperation' => true],
                 experimentalOperation: false,
             );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Change query list provider to work based on grid data instead of query builder
| Type?             |  improvement
| Category?         | BO 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | CI & tests 🟢
| UI Tests          | https://github.com/tleon/ga.tests.ui.pr/actions/runs/8570935742
| Fixed issue or discussion?     | Fixes #35686 
| Related PR | https://github.com/PrestaShop/ps_apiresources/pull/29
| Sponsor company   | PrestaShop SA