### PR TITLE
Fix error: CartRuleCore::checkProductRestrictionsFromCart(): Argument…

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -395,7 +395,7 @@ class CartRuleCore extends ObjectModel
         // Basic part of the query, we are selecting all cart rules
         $sql = '
             SELECT SQL_NO_CACHE * FROM `' . _DB_PREFIX_ . 'cart_rule` cr
-            LEFT JOIN `' . _DB_PREFIX_ . 'cart_rule_lang` crl 
+            LEFT JOIN `' . _DB_PREFIX_ . 'cart_rule_lang` crl
             ON (cr.`id_cart_rule` = crl.`id_cart_rule` AND crl.`id_lang` = ' . (int) $id_lang . ')';
 
         // We will definitely include vouchers for this specific customer
@@ -472,7 +472,7 @@ class CartRuleCore extends ObjectModel
             foreach ($result as $key => $cart_rule) {
                 if ($cart_rule['product_restriction']) {
                     $cr = new CartRule((int) $cart_rule['id_cart_rule']);
-                    $r = $cr->checkProductRestrictionsFromCart(Context::getContext()->cart, false, false);
+                    $r = $cr->checkProductRestrictionsFromCart($cart, false, false);
                     if ($r !== false) {
                         continue;
                     }


### PR DESCRIPTION
… #1 ($cart) must be of type CartCore, null given,

Fix error of cart null in customer ViewAction:
```
CartRuleCore::checkProductRestrictionsFromCart(): Argument #1 ($cart) must be of type CartCore, null given, called in /home/xxx/www/classes/CartRule.php on line 469

[TypeError 0]
```
The cart to analyse should be the customer cart and not the context cart.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x
| Description?      | When you want to see customer details who have carts with cartrules
| Type?             | bug fix / improvement / new feature / refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Hard to explains but: try to go on a customer view on backend, this customer should add a cart with cart rules and this cartrules must be not compatible with the cart of the context (customer group or something else)
| UI Tests          | https://github.com/friends-of-presta/ga.tests.ui.pr/actions/runs/17591531918
| Fixed issue or discussion?     | Fixes #35841
| Related PRs       | none
| Sponsor company   | PrestaSafe - Guillaume Batier
