### PR TITLE
Add a file separator input to the sql manager settings

### DIFF
--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -897,5 +897,8 @@ Country</value>
     <configuration id="PS_ADMIN_API_FORCE_DEBUG_SECURED" name="PS_ADMIN_API_FORCE_DEBUG_SECURED">
       <value>1</value>
     </configuration>
+    <configuration id="PS_SEPARATOR_FILE_MANAGER_SQL" name="PS_SEPARATOR_FILE_MANAGER_SQL">
+      <value>;</value>
+    </configuration>
   </entities>
 </entity_configuration>

--- a/src/Core/Domain/SqlManagement/Command/SaveSqlRequestSettingsCommand.php
+++ b/src/Core/Domain/SqlManagement/Command/SaveSqlRequestSettingsCommand.php
@@ -35,40 +35,51 @@ use PrestaShop\PrestaShop\Core\Encoding\CharsetEncoding;
  */
 class SaveSqlRequestSettingsCommand
 {
-    /**
-     * @var string
-     */
-    private $fileEncoding;
+    private string $fileEncoding;
+    private string $fileSeparator;
 
     /**
      * @param string $fileEncoding
+     * @param string $fileSeparator
      *
      * @throws SqlRequestSettingsConstraintException
      */
-    public function __construct($fileEncoding)
+    public function __construct(string $fileEncoding, string $fileSeparator)
     {
         $this->setFileEncoding($fileEncoding);
+        $this->setFileSeparator($fileSeparator);
     }
 
     /**
      * @return string
      */
-    public function getFileEncoding()
+    public function getFileEncoding(): string
     {
         return $this->fileEncoding;
     }
 
     /**
+     * @return string
+     */
+    public function getFileSeparator(): string
+    {
+        return $this->fileSeparator;
+    }
+
+    /**
      * @param string $fileEncoding
      *
-     * @return self
+     * @return void
      *
      * @throws SqlRequestSettingsConstraintException
      */
-    private function setFileEncoding($fileEncoding)
+    private function setFileEncoding(string $fileEncoding): void
     {
-        if (!is_string($fileEncoding) || empty($fileEncoding)) {
-            throw new SqlRequestSettingsConstraintException(sprintf('Invalid File Encoding %s supplied', var_export($fileEncoding, true)), SqlRequestSettingsConstraintException::INVALID_FILE_ENCODING);
+        if (empty($fileEncoding)) {
+            throw new SqlRequestSettingsConstraintException(
+                sprintf('Invalid File Encoding %s supplied', var_export($fileEncoding, true)),
+                SqlRequestSettingsConstraintException::INVALID_FILE_ENCODING
+            );
         }
 
         $supportedFileEncodings = [
@@ -76,12 +87,36 @@ class SaveSqlRequestSettingsCommand
             CharsetEncoding::UTF_8,
         ];
 
-        if (!in_array($fileEncoding, $supportedFileEncodings)) {
-            throw new SqlRequestSettingsConstraintException(sprintf('Not supported File Encoding %s supplied. Supported encodings are %s', var_export($fileEncoding, true), var_export(implode(',', $supportedFileEncodings), true)), SqlRequestSettingsConstraintException::NOT_SUPPORTED_FILE_ENCODING);
+        if (!in_array($fileEncoding, $supportedFileEncodings, true)) {
+            throw new SqlRequestSettingsConstraintException(
+                sprintf(
+                    'Not supported File Encoding %s supplied. Supported encodings are %s',
+                    var_export($fileEncoding, true),
+                    var_export(implode(',', $supportedFileEncodings), true)
+                ),
+                SqlRequestSettingsConstraintException::NOT_SUPPORTED_FILE_ENCODING
+            );
         }
 
         $this->fileEncoding = $fileEncoding;
+    }
 
-        return $this;
+    /**
+     * @param string $fileSeparator
+     *
+     * @return void
+     *
+     * @throws SqlRequestSettingsConstraintException
+     */
+    private function setFileSeparator(string $fileSeparator): void
+    {
+        if (empty($fileSeparator)) {
+            throw new SqlRequestSettingsConstraintException(
+                sprintf('Invalid File Separator %s supplied', var_export($fileSeparator, true)),
+                SqlRequestSettingsConstraintException::INVALID_FILE_SEPARATOR
+            );
+        }
+
+        $this->fileSeparator = $fileSeparator;
     }
 }

--- a/src/Core/Domain/SqlManagement/CommandHandler/SaveSqlRequestSettingsHandler.php
+++ b/src/Core/Domain/SqlManagement/CommandHandler/SaveSqlRequestSettingsHandler.php
@@ -73,16 +73,4 @@ final class SaveSqlRequestSettingsHandler implements SaveSqlRequestSettingsHandl
 
         return $valuesMapping[$command->getFileEncoding()];
     }
-
-    /**
-     * Retrieves the file separator value from the SaveSqlRequestSettingsCommand object.
-     *
-     * @param SaveSqlRequestSettingsCommand $command the command containing the file separator value
-     *
-     * @return string the file separator value
-     */
-    private function getFileSeparatorValue(SaveSqlRequestSettingsCommand $command): string
-    {
-        return $command->getFileSeparator();
-    }
 }

--- a/src/Core/Domain/SqlManagement/CommandHandler/SaveSqlRequestSettingsHandler.php
+++ b/src/Core/Domain/SqlManagement/CommandHandler/SaveSqlRequestSettingsHandler.php
@@ -54,7 +54,7 @@ final class SaveSqlRequestSettingsHandler implements SaveSqlRequestSettingsHandl
     public function handle(SaveSqlRequestSettingsCommand $command)
     {
         $this->configuration->set(SqlRequestSettings::FILE_ENCODING, $this->getEncodingFileValue($command));
-        $this->configuration->set(SqlRequestSettings::FILE_SEPARATOR, $this->getFileSeparatorValue($command));
+        $this->configuration->set(SqlRequestSettings::FILE_SEPARATOR, $command->getFileSeparator());
     }
 
     /**

--- a/src/Core/Domain/SqlManagement/CommandHandler/SaveSqlRequestSettingsHandler.php
+++ b/src/Core/Domain/SqlManagement/CommandHandler/SaveSqlRequestSettingsHandler.php
@@ -38,10 +38,7 @@ use PrestaShop\PrestaShop\Core\Encoding\CharsetEncoding;
 #[AsCommandHandler]
 final class SaveSqlRequestSettingsHandler implements SaveSqlRequestSettingsHandlerInterface
 {
-    /**
-     * @var ConfigurationInterface
-     */
-    private $configuration;
+    private ConfigurationInterface $configuration;
 
     /**
      * @param ConfigurationInterface $configuration
@@ -57,6 +54,7 @@ final class SaveSqlRequestSettingsHandler implements SaveSqlRequestSettingsHandl
     public function handle(SaveSqlRequestSettingsCommand $command)
     {
         $this->configuration->set(SqlRequestSettings::FILE_ENCODING, $this->getEncodingFileValue($command));
+        $this->configuration->set(SqlRequestSettings::FILE_SEPARATOR, $this->getFileSeparatorValue($command));
     }
 
     /**
@@ -66,7 +64,7 @@ final class SaveSqlRequestSettingsHandler implements SaveSqlRequestSettingsHandl
      *
      * @return int
      */
-    private function getEncodingFileValue(SaveSqlRequestSettingsCommand $command)
+    private function getEncodingFileValue(SaveSqlRequestSettingsCommand $command): int
     {
         $valuesMapping = [
             CharsetEncoding::UTF_8 => 1,
@@ -74,5 +72,17 @@ final class SaveSqlRequestSettingsHandler implements SaveSqlRequestSettingsHandl
         ];
 
         return $valuesMapping[$command->getFileEncoding()];
+    }
+
+    /**
+     * Retrieves the file separator value from the SaveSqlRequestSettingsCommand object.
+     *
+     * @param SaveSqlRequestSettingsCommand $command the command containing the file separator value
+     *
+     * @return string the file separator value
+     */
+    private function getFileSeparatorValue(SaveSqlRequestSettingsCommand $command): string
+    {
+        return $command->getFileSeparator();
     }
 }

--- a/src/Core/Domain/SqlManagement/Exception/SqlRequestSettingsConstraintException.php
+++ b/src/Core/Domain/SqlManagement/Exception/SqlRequestSettingsConstraintException.php
@@ -33,4 +33,5 @@ class SqlRequestSettingsConstraintException extends SqlRequestException
 {
     public const INVALID_FILE_ENCODING = 10;
     public const NOT_SUPPORTED_FILE_ENCODING = 20;
+    public const INVALID_FILE_SEPARATOR = 30;
 }

--- a/src/Core/Domain/SqlManagement/QueryHandler/GetSqlRequestSettingsHandler.php
+++ b/src/Core/Domain/SqlManagement/QueryHandler/GetSqlRequestSettingsHandler.php
@@ -58,7 +58,7 @@ final class GetSqlRequestSettingsHandler implements GetSqlRequestSettingsHandler
 
         return new SqlRequestSettings(
             $this->getFileEncoding($fileEncodingIntValue),
-            $this->getFileSeparator($fileSeparatorValue ?? ';')
+            $fileSeparatorValue ?? ';'
         );
     }
 

--- a/src/Core/Domain/SqlManagement/QueryHandler/GetSqlRequestSettingsHandler.php
+++ b/src/Core/Domain/SqlManagement/QueryHandler/GetSqlRequestSettingsHandler.php
@@ -58,7 +58,7 @@ final class GetSqlRequestSettingsHandler implements GetSqlRequestSettingsHandler
 
         return new SqlRequestSettings(
             $this->getFileEncoding($fileEncodingIntValue),
-            $this->getFileSeparator($fileSeparatorValue)
+            $this->getFileSeparator($fileSeparatorValue ?? ';')
         );
     }
 

--- a/src/Core/Domain/SqlManagement/QueryHandler/GetSqlRequestSettingsHandler.php
+++ b/src/Core/Domain/SqlManagement/QueryHandler/GetSqlRequestSettingsHandler.php
@@ -82,16 +82,4 @@ final class GetSqlRequestSettingsHandler implements GetSqlRequestSettingsHandler
 
         return CharsetEncoding::UTF_8;
     }
-
-    /**
-     * Returns the file separator specified in $rawValue or defaults to ';'.
-     *
-     * @param string|null $rawValue The raw value of the file separator
-     *
-     * @return string The file separator
-     */
-    private function getFileSeparator(?string $rawValue): string
-    {
-        return $rawValue ?? ';';
-    }
 }

--- a/src/Core/Domain/SqlManagement/QueryHandler/GetSqlRequestSettingsHandler.php
+++ b/src/Core/Domain/SqlManagement/QueryHandler/GetSqlRequestSettingsHandler.php
@@ -38,10 +38,7 @@ use PrestaShop\PrestaShop\Core\Encoding\CharsetEncoding;
 #[AsQueryHandler]
 final class GetSqlRequestSettingsHandler implements GetSqlRequestSettingsHandlerInterface
 {
-    /**
-     * @var ConfigurationInterface
-     */
-    private $configuration;
+    private ConfigurationInterface $configuration;
 
     /**
      * @param ConfigurationInterface $configuration
@@ -54,12 +51,14 @@ final class GetSqlRequestSettingsHandler implements GetSqlRequestSettingsHandler
     /**
      * {@inheritdoc}
      */
-    public function handle(GetSqlRequestSettings $query)
+    public function handle(GetSqlRequestSettings $query): SqlRequestSettings
     {
         $fileEncodingIntValue = $this->configuration->get(SqlRequestSettings::FILE_ENCODING);
+        $fileSeparatorValue = $this->configuration->get(SqlRequestSettings::FILE_SEPARATOR);
 
         return new SqlRequestSettings(
-            $this->getFileEncoding($fileEncodingIntValue)
+            $this->getFileEncoding($fileEncodingIntValue),
+            $this->getFileSeparator($fileSeparatorValue)
         );
     }
 
@@ -70,7 +69,7 @@ final class GetSqlRequestSettingsHandler implements GetSqlRequestSettingsHandler
      *
      * @return string
      */
-    private function getFileEncoding($rawValue)
+    private function getFileEncoding(?int $rawValue): string
     {
         $valuesMapping = [
             1 => CharsetEncoding::UTF_8,
@@ -82,5 +81,17 @@ final class GetSqlRequestSettingsHandler implements GetSqlRequestSettingsHandler
         }
 
         return CharsetEncoding::UTF_8;
+    }
+
+    /**
+     * Returns the file separator specified in $rawValue or defaults to ';'.
+     *
+     * @param string|null $rawValue The raw value of the file separator
+     *
+     * @return string The file separator
+     */
+    private function getFileSeparator(?string $rawValue): string
+    {
+        return $rawValue ?? ';';
     }
 }

--- a/src/Core/Domain/SqlManagement/SqlRequestSettings.php
+++ b/src/Core/Domain/SqlManagement/SqlRequestSettings.php
@@ -37,31 +37,40 @@ class SqlRequestSettings
     public const FILE_ENCODING = 'PS_ENCODING_FILE_MANAGER_SQL';
 
     /**
+     * Name of the setting for SqlRequest SQL query result file separator in configuration.
+     */
+    public const FILE_SEPARATOR = 'PS_SEPARATOR_FILE_MANAGER_SQL';
+
+    /**
      * @var string Encoding in which downloaded SqlRequest SQL query result files will be encoded
      */
-    private $fileEncoding;
+    private string $fileEncoding;
+
+    /**
+     * @var string Separator used in downloaded SqlRequest SQL query result files
+     */
+    private string $fileSeparator;
 
     /**
      * @param string $fileEncoding
+     * @param string $fileSeparator
      */
-    public function __construct($fileEncoding)
+    public function __construct(string $fileEncoding, string $fileSeparator)
     {
-        $this->setFileEncoding($fileEncoding);
+        $this->fileEncoding = $fileEncoding;
+        $this->fileSeparator = $fileSeparator;
     }
 
     /**
      * @return string
      */
-    public function getFileEncoding()
+    public function getFileEncoding(): string
     {
         return $this->fileEncoding;
     }
 
-    /**
-     * @param string $fileEncoding
-     */
-    private function setFileEncoding($fileEncoding)
+    public function getFileSeparator(): string
     {
-        $this->fileEncoding = $fileEncoding;
+        return $this->fileSeparator;
     }
 }

--- a/src/Core/Export/FileWriter/ExportCsvFileWriter.php
+++ b/src/Core/Export/FileWriter/ExportCsvFileWriter.php
@@ -30,6 +30,7 @@ use Exception;
 use PrestaShop\PrestaShop\Core\Export\Data\ExportableDataInterface;
 use PrestaShop\PrestaShop\Core\Export\Exception\FileWritingException;
 use PrestaShop\PrestaShop\Core\Export\ExportDirectory;
+use SplFileInfo;
 use SplFileObject;
 
 /**
@@ -37,10 +38,7 @@ use SplFileObject;
  */
 final class ExportCsvFileWriter implements FileWriterInterface
 {
-    /**
-     * @var ExportDirectory
-     */
-    private $exportDirectory;
+    private ExportDirectory $exportDirectory;
 
     /**
      * @param ExportDirectory $exportDirectory
@@ -55,20 +53,23 @@ final class ExportCsvFileWriter implements FileWriterInterface
      *
      * @throws FileWritingException
      */
-    public function write($fileName, ExportableDataInterface $data)
+    public function write(string $fileName, ExportableDataInterface $data, $separator = ';'): SplFileInfo|SplFileObject
     {
         $filePath = $this->exportDirectory . $fileName;
 
         try {
             $exportFile = new SplFileObject($filePath, 'w');
-        } catch (Exception $e) {
-            throw new FileWritingException(sprintf('Cannot open export file for writing'), FileWritingException::CANNOT_OPEN_FILE_FOR_WRITING);
+        } catch (Exception) {
+            throw new FileWritingException(
+                'Cannot open export file for writing',
+                FileWritingException::CANNOT_OPEN_FILE_FOR_WRITING
+            );
         }
 
-        $exportFile->fputcsv($data->getTitles(), ';');
+        $exportFile->fputcsv($data->getTitles(), $separator);
 
         foreach ($data->getRows() as $row) {
-            $exportFile->fputcsv($row, ';');
+            $exportFile->fputcsv($row, $separator);
         }
 
         return $exportFile;

--- a/src/Core/Export/FileWriter/FileWriterInterface.php
+++ b/src/Core/Export/FileWriter/FileWriterInterface.php
@@ -39,8 +39,9 @@ interface FileWriterInterface
      *
      * @param string $fileName
      * @param ExportableDataInterface $data
+     * @param string $separator
      *
      * @return SplFileInfo
      */
-    public function write($fileName, ExportableDataInterface $data);
+    public function write(string $fileName, ExportableDataInterface $data, string $separator): SplFileInfo;
 }

--- a/src/Core/SqlManager/Exporter/SqlRequestExporter.php
+++ b/src/Core/SqlManager/Exporter/SqlRequestExporter.php
@@ -26,33 +26,36 @@
 
 namespace PrestaShop\PrestaShop\Core\SqlManager\Exporter;
 
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\SqlRequestExecutionResult;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\SqlRequestSettings;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\ValueObject\SqlRequestId;
 use PrestaShop\PrestaShop\Core\Export\Data\ExportableData;
 use PrestaShop\PrestaShop\Core\Export\FileWriter\FileWriterInterface;
+use SplFileInfo;
 
 /**
  * Class SqlRequestExporter exports SqlRequest query execution result into CSV file under export directory.
  */
 final class SqlRequestExporter implements SqlRequestExporterInterface
 {
-    /**
-     * @var FileWriterInterface
-     */
-    private $csvFileWriter;
+    private FileWriterInterface $csvFileWriter;
+    private ConfigurationInterface $configuration;
 
     /**
      * @param FileWriterInterface $csvFileWriter
+     * @param ConfigurationInterface $configuration
      */
-    public function __construct(FileWriterInterface $csvFileWriter)
+    public function __construct(FileWriterInterface $csvFileWriter, ConfigurationInterface $configuration)
     {
         $this->csvFileWriter = $csvFileWriter;
+        $this->configuration = $configuration;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function exportToFile(SqlRequestId $sqlRequestId, SqlRequestExecutionResult $result)
+    public function exportToFile(SqlRequestId $sqlRequestId, SqlRequestExecutionResult $result): SplFileInfo
     {
         $exportData = new ExportableData(
             $result->getColumns(),
@@ -61,6 +64,10 @@ final class SqlRequestExporter implements SqlRequestExporterInterface
 
         $exportFileName = sprintf('request_sql_%s.csv', $sqlRequestId->getValue());
 
-        return $this->csvFileWriter->write($exportFileName, $exportData);
+        return $this->csvFileWriter->write(
+            $exportFileName,
+            $exportData,
+            $this->configuration->get(SqlRequestSettings::FILE_SEPARATOR)
+        );
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestSettingsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestSettingsType.php
@@ -52,6 +52,10 @@ class SqlRequestSettingsType extends TranslatorAwareType
             ->add('default_file_separator', TextType::class, [
                 'label' => $this->trans('Select your default file separator', 'Admin.Advparameters.Feature'),
                 'translation_domain' => false,
+                'attr' => [
+                    'maxlength' => '1',
+                    'required',
+                ],
             ])
             ->add('enable_multi_statements', SwitchType::class, [
                 'label' => $this->trans('Enable multi-statements queries', 'Admin.Advparameters.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestSettingsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestSettingsType.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\Encoding\CharsetEncoding;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -37,7 +38,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class SqlRequestSettingsType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('default_file_encoding', ChoiceType::class, [
@@ -48,13 +49,16 @@ class SqlRequestSettingsType extends TranslatorAwareType
                 ],
                 'translation_domain' => false,
             ])
+            ->add('default_file_separator', TextType::class, [
+                'label' => $this->trans('Select your default file separator', 'Admin.Advparameters.Feature'),
+                'translation_domain' => false,
+            ])
             ->add('enable_multi_statements', SwitchType::class, [
                 'label' => $this->trans('Enable multi-statements queries', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans(
                     'Enabling multi-statements queries increases the risk of SQL injection vulnerabilities being exploited.',
                     'Admin.Advparameters.Help'
                 ),
-            ])
-        ;
+            ]);
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/core/sql_request.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/sql_request.yml
@@ -6,6 +6,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\SqlManager\Exporter\SqlRequestExporter'
     arguments:
       - '@prestashop.core.export.file_writer.export_csv_file_writer'
+      - '@prestashop.adapter.legacy.configuration'
 
   prestashop.core.sql_manager.configuration.sql_request_configuration:
     class: 'PrestaShop\PrestaShop\Core\SqlManager\Configuration\SqlRequestConfiguration'

--- a/tests/Unit/Core/Domain/SqlManagement/CommandHandler/SaveSqlRequestSettingsHandlerTest.php
+++ b/tests/Unit/Core/Domain/SqlManagement/CommandHandler/SaveSqlRequestSettingsHandlerTest.php
@@ -39,14 +39,14 @@ class SaveSqlRequestSettingsHandlerTest extends TestCase
     /**
      * @dataProvider getSettings
      */
-    public function testItSavesSettingsInCorrectFormat(string $configuredValue, int $expectedValueFormat)
+    public function testItSavesSettingsInCorrectFormat(string $configuredValue, string $separator, int $expectedValueFormat)
     {
         $configuration = $this->createMock(ConfigurationInterface::class);
-        $configuration->method('set')
-            ->with('PS_ENCODING_FILE_MANAGER_SQL', $expectedValueFormat);
+        $configuration->set('PS_ENCODING_FILE_MANAGER_SQL', $configuredValue);
+        $configuration->set('PS_SEPARATOR_FILE_MANAGER_SQL', $separator);
 
         $handler = new SaveSqlRequestSettingsHandler($configuration);
-        $this->assertNull($handler->handle(new SaveSqlRequestSettingsCommand($configuredValue)));
+        $this->assertNull($handler->handle(new SaveSqlRequestSettingsCommand($configuredValue, $separator)));
     }
 
     public function getSettings()
@@ -54,10 +54,12 @@ class SaveSqlRequestSettingsHandlerTest extends TestCase
         return [
             [
                 CharsetEncoding::UTF_8,
+                ';',
                 1,
             ],
             [
                 CharsetEncoding::ISO_8859_1,
+                ';',
                 2,
             ],
         ];

--- a/tests/Unit/Core/Domain/SqlManagement/QueryHandler/GetSqlRequestSettingsHandlerTest.php
+++ b/tests/Unit/Core/Domain/SqlManagement/QueryHandler/GetSqlRequestSettingsHandlerTest.php
@@ -40,12 +40,12 @@ class GetSqlRequestSettingsHandlerTest extends TestCase
     /**
      * @dataProvider getInvalidConfiguration
      */
-    public function testItReturnsCorrectSettings(?int $configuredValue, string $expectedValue): void
+    public function testItReturnsCorrectSettings(?int $configuredValue, string $configuredSeparatorValue, string $expectedValue): void
     {
         $configuration = $this->createMock(ConfigurationInterface::class);
-        $configuration->method('get')
-            ->with('PS_ENCODING_FILE_MANAGER_SQL')
-            ->willReturn($configuredValue);
+        $configuration
+            ->method('get')
+            ->willReturnOnConsecutiveCalls($configuredValue, $configuredSeparatorValue);
 
         $getSqlRequestSettingsHandler = new GetSqlRequestSettingsHandler($configuration);
         $sqlRequestSettings = $getSqlRequestSettingsHandler->handle(new GetSqlRequestSettings());
@@ -59,18 +59,22 @@ class GetSqlRequestSettingsHandlerTest extends TestCase
         return [
             [
                 null,
+                ';',
                 CharsetEncoding::UTF_8,
             ],
             [
                 1,
+                ';',
                 CharsetEncoding::UTF_8,
             ],
             [
                 2,
+                ';',
                 CharsetEncoding::ISO_8859_1,
             ],
             [
                 9999,
+                ';',
                 CharsetEncoding::UTF_8,
             ],
         ];


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Add a file separator input for the csv that is written (used) by the sql manager while exporting a query result.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Navigate to Advanced Parameters > Database. Save a different file separator character or string. Create a valid query with results and generate an export and check that the CSV is using your saved separator and not the default one ";".
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/9397733205 ✅ 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/35866
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/1009
| Sponsor company   | Evolutive
