### PR TITLE
Introduce AllShopContext Attribute for Symfony layout

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/FeatureFlagController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/FeatureFlagController.php
@@ -30,6 +30,7 @@ namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Controller\Attribute\AllShopContext;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -38,6 +39,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Manages the "Configure > Advanced Parameters > Experimental Features" page.
  */
+#[AllShopContext]
 class FeatureFlagController extends FrameworkBundleAdminController
 {
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PermissionController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PermissionController.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\Command\UpdateTabPermis
 use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\Query\GetPermissionsForConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\QueryResult\ConfigurablePermissions;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Controller\Attribute\AllShopContext;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,6 +43,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Allows permissions configuration for employee profiles in "Configure > Advanced Parameters > Team > Permissions"
  */
+#[AllShopContext]
 class PermissionController extends FrameworkBundleAdminController
 {
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Domain\Profile\QueryResult\EditableProfile;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\ProfileFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Controller\Attribute\AllShopContext;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use PrestaShopBundle\Security\Attribute\DemoRestricted;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -51,6 +52,7 @@ use Symfony\Component\HttpFoundation\Response;
  * Class ProfileController is responsible for displaying the
  * "Configure > Advanced parameters > Team > Roles" page.
  */
+#[AllShopContext]
 class ProfileController extends FrameworkBundleAdminController
 {
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SecurityController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SecurityController.php
@@ -47,6 +47,7 @@ use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\Security\Session\CustomerFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\Security\Session\EmployeeFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Controller\Attribute\AllShopContext;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -56,6 +57,7 @@ use Symfony\Component\HttpFoundation\Response;
  * Class SecurityController is responsible for displaying the
  * "Configure > Advanced parameters > Security" page.
  */
+#[AllShopContext]
 class SecurityController extends FrameworkBundleAdminController
 {
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderStateController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderStateController.php
@@ -46,6 +46,7 @@ use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderStatesGridDefinition
 use PrestaShop\PrestaShop\Core\Search\Filters\OrderReturnStatesFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\OrderStatesFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Controller\Attribute\AllShopContext;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -54,6 +55,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Controller responsible of "Configure > Shop Parameters > Order states Settings" page.
  */
+#[AllShopContext]
 class OrderStateController extends FrameworkBundleAdminController
 {
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
@@ -44,6 +44,7 @@ use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintE
 use PrestaShop\PrestaShop\Core\Search\Filters\LanguageFilters;
 use PrestaShop\PrestaShop\Core\Util\Url\UrlFileCheckerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Controller\Attribute\AllShopContext;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use PrestaShopBundle\Security\Attribute\DemoRestricted;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -53,6 +54,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Class LanguageController manages "Improve > International > Localization > Languages".
  */
+#[AllShopContext]
 class LanguageController extends FrameworkBundleAdminController
 {
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TranslationsController.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Language\Copier\LanguageCopierConfig;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Controller\Attribute\AllShopContext;
 use PrestaShopBundle\Exception\InvalidModuleException;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -42,6 +43,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 /**
  * Admin controller for the International pages.
  */
+#[AllShopContext]
 class TranslationsController extends FrameworkBundleAdminController
 {
     public const CONTROLLER_NAME = 'ADMINTRANSLATIONS';

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CatalogPriceRuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CatalogPriceRuleController.php
@@ -44,6 +44,7 @@ use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CatalogPriceRuleGridDefin
 use PrestaShop\PrestaShop\Core\Search\Filters\CatalogPriceRuleFilters;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Controller\Attribute\AllShopContext;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use PrestaShopBundle\Security\Attribute\DemoRestricted;
 use PrestaShopBundle\Service\Grid\ResponseBuilder;
@@ -55,6 +56,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Responsible for Sell > Catalog > Discounts > Catalog Price Rules page
  */
+#[AllShopContext]
 class CatalogPriceRuleController extends FrameworkBundleAdminController
 {
     private const UNSPECIFIED_VALUE_FORMAT = '--';

--- a/src/PrestaShopBundle/Controller/Attribute/AllShopContext.php
+++ b/src/PrestaShopBundle/Controller/Attribute/AllShopContext.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\Controller\Attribute;
+
+use Attribute;
+
+/*
+ *  Attribute for controllers.
+ *  Allows you to specify if this, or a particular action, requires to be in context all shop.
+ *  Related to the multishop feature.
+ *  Analysed in ShopContextListener
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+class AllShopContext
+{
+}

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextListenerTest.php
@@ -36,6 +36,8 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShopBundle\EventListener\Admin\Context\ShopContextListener;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Exception\NoConfigurationException;
+use Symfony\Component\Routing\RouterInterface;
 use Tests\Unit\PrestaShopBundle\EventListener\ContextEventListenerTestCase;
 
 class ShopContextListenerTest extends ContextEventListenerTestCase
@@ -58,7 +60,8 @@ class ShopContextListenerTest extends ContextEventListenerTestCase
             $this->mockEmployeeContext(),
             $this->mockConfiguration(['PS_SHOP_DEFAULT' => self::DEFAULT_SHOP_ID, 'PS_SSL_ENABLED' => self::PS_SSL_ENABLED]),
             $this->mockLegacyContext(['shopContext' => '']),
-            $this->mockMultistoreFeature(false)
+            $this->mockMultistoreFeature(false),
+            $this->mockRouter()
         );
         $listener->onKernelRequest($event);
 
@@ -90,7 +93,8 @@ class ShopContextListenerTest extends ContextEventListenerTestCase
             $this->mockEmployeeContext($employeeData),
             $this->mockConfiguration(['PS_SHOP_DEFAULT' => self::DEFAULT_SHOP_ID, 'PS_SSL_ENABLED' => self::PS_SSL_ENABLED]),
             $this->mockLegacyContext(['shopContext' => $cookieValue]),
-            $this->mockMultistoreFeature(true)
+            $this->mockMultistoreFeature(true),
+            $this->mockRouter()
         );
         $listener->onKernelRequest($event);
 
@@ -164,7 +168,8 @@ class ShopContextListenerTest extends ContextEventListenerTestCase
             $this->mockEmployeeContext(),
             $this->mockConfiguration(['PS_SHOP_DEFAULT' => self::DEFAULT_SHOP_ID, 'PS_SSL_ENABLED' => self::PS_SSL_ENABLED]),
             $mockContext,
-            $this->mockMultistoreFeature(true)
+            $this->mockMultistoreFeature(true),
+            $this->mockRouter()
         );
 
         // Check that initially the cookie has a null value
@@ -257,6 +262,17 @@ class ShopContextListenerTest extends ContextEventListenerTestCase
             false,
             '',
         ];
+    }
+
+    private function mockRouter(): RouterInterface|MockObject
+    {
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->method('match')
+            ->willThrowException(new NoConfigurationException())
+        ;
+
+        return $router;
     }
 
     private function mockMultistoreFeature(bool $multiShopEnabled): MultistoreFeature|MockObject


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Introduce AllShopContext Attribute for Symfony layout. In the legacy layout we have a mechanism that forced the allshopContext into the legacy controller  `AdminLegacyLayoutControllerCore`.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/35828
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/8571357346
| Fixed issue or discussion?     | Fixes #https://github.com/PrestaShop/PrestaShop/issues/35828
| Related PRs       | -
| Sponsor company   | -