### PR TITLE
Update HTMLTemplateOrderSlip.php to fix #35802

### DIFF
--- a/classes/pdf/HTMLTemplateOrderSlip.php
+++ b/classes/pdf/HTMLTemplateOrderSlip.php
@@ -131,7 +131,7 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
             }
             unset($product);
         } else {
-            $this->order->products = null;
+            $this->order->products = [];
         }
 
         if ($this->order_slip->shipping_cost == 0) {


### PR DESCRIPTION
Fixes: #35802

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fixes issue #35802. This is a regression as this had been fixed before. 
| Type?             | bug fix
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Without this fix, no correction invoices can be downloaded from the shop
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/8632250955 ✅ 
| Fixed issue or discussion?     | Fixes #35802
| Related PRs       | none
| Sponsor company   | none