### PR TITLE
Fix min qty in front ProductController

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -510,6 +510,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product = $this->getTemplateVarProduct();
         $minimalProductQuantity = $this->getProductMinimalQuantity($product);
 
+        // If the product is already in the cart, we can set the minimal quantity to 1
+        if ($product['cart_quantity'] >= $minimalProductQuantity) {
+            $minimalProductQuantity = 1;
+        }
+
         ob_end_clean();
         header('Content-Type: application/json');
         $this->ajaxRender(json_encode([
@@ -1199,6 +1204,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product['new'] = (int) $this->product->new;
         $product['id_product_attribute'] = $this->getIdProductAttributeByGroupOrRequestOrDefault();
         $product['minimal_quantity'] = $this->getProductMinimalQuantity($product);
+        $product['cart_quantity'] = $this->context->cart->getProductQuantity($product['id_product'], $product['id_product_attribute'])['quantity'];
         $product['quantity_wanted'] = $this->getRequiredQuantity($product);
         $product['extraContent'] = $extraContentFinder->addParams(['product' => $this->product])->present();
         $product['ecotax_tax_inc'] = $this->product->getEcotax(null, true, true);
@@ -1318,6 +1324,10 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $requiredQuantity = (int) Tools::getValue('quantity_wanted', $this->getProductMinimalQuantity($product));
         if ($requiredQuantity < $product['minimal_quantity']) {
             $requiredQuantity = $product['minimal_quantity'];
+        }
+
+        if ($product['cart_quantity'] >= $requiredQuantity) {
+            return 0;
         }
 
         return $requiredQuantity;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fix min qty in front ProductController on ajax refresh action.<br>Now, we refreshing correctly the minimal required quantities on standard, virtual, combinaison and pack products.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #35888 
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/8651056510 https://github.com/florine2623/testing_pr/actions/runs/8749975555 ✅ 
| Fixed issue or discussion?     | Fixes #35888
| Related PRs       | https://github.com/PrestaShop/hummingbird/pull/609
| Sponsor company   | PrestaShop SA
