### PR TITLE
Ensure order tax is updated when modifying order in backoffice

### DIFF
--- a/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
@@ -126,6 +126,9 @@ final class UpdateProductInOrderHandler extends AbstractOrderCommandHandler impl
 
             // Update invoice, quantity and amounts
             $order = $this->orderProductQuantityUpdater->update($order, $orderDetail, $command->getQuantity(), $orderInvoice);
+            
+            // Update the tax details
+            $this->orderDetailUpdater->updateOrderDetailsTaxes($order);            
 
             Hook::exec('actionOrderEdited', ['order' => $order]);
         } catch (Exception $e) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x
| Description?      | Fixes order_detail_tax not updating when editing orders from backoffice
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check steps to reproduce for issue #35875 before/after applying this patch.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #35875 
| Related PRs       | N/A
| Sponsor company   | 
