### PR TITLE
FIX on upload attachments file with POST method

### DIFF
--- a/classes/webservice/WebserviceSpecificManagementAttachments.php
+++ b/classes/webservice/WebserviceSpecificManagementAttachments.php
@@ -341,7 +341,7 @@ class WebserviceSpecificManagementAttachmentsCore implements WebserviceSpecificM
             $attachment->file = $file['id'];
             $attachment->file_name = $file['file_name'];
             $attachment->mime = $file['mime_type'];
-            if ($attachment->name[$defaultLanguage] === null) {
+            if ($attachment->name === null) {
                 $attachment->name[$defaultLanguage] = $_POST['name'] ?? $file['file_name'];
             }
 


### PR DESCRIPTION
This is my first PR on GitHub, I want to help the Prestashop Community.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x
| Description?      | I was trying to implement the attachments webservices endpoints and during my test with Postman I encountered an error when I do a POST method with a document through  https://url/api/attachments/file/ : "! [CDATA[[PHP Warning #2] Trying to access array offset on value of type null (/var/www/prestashop/classes/webservices/WebservicesSpecificManagementAttachments.php, line 344)]]"<br><br>But the document is upload on the server and is available on files sections on Prestshop BO.<br><br>After some analysis and tests I found the origine of the issue, name is nullable. And the attribute name is null when you post your file. With this fix, the upload response contains the good attachment object and I can continue to work with the file if i want to change the name or some attributes.<br><br>For me this issue was introduce with this commit : <br><br>https://github.com/PrestaShop/PrestaShop/commit/8731bab209a580f9248817a0ebf42028e5ba9774
| Type?             | bug fix 
| Category?         |  WS
| BC breaks?        |  no
| Deprecations?     | no
| UI Tests | https://github.com/florine2623/testing_pr/actions/runs/12051230379 ✅ 
| How to test?      | Issue #35922
|Fixed issue or discussion?      | Fixes #35922 


Error in postman 
![error_PS_WS](https://github.com/PrestaShop/PrestaShop/assets/167074009/dcc01efb-c996-40c1-8b35-fe59b994294c)

After the FIX 
![fixed](https://github.com/PrestaShop/PrestaShop/assets/167074009/b954d83b-a1e5-42d8-917b-99896cc77ecd)




