### PR TITLE
Fix hyphen end of name in mail order confirmation

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -457,7 +457,7 @@ abstract class PaymentModuleCore extends Module
                     'id_product' => $product['id_product'],
                     'id_product_attribute' => $product['id_product_attribute'],
                     'reference' => $product['reference'],
-                    'name' => (!empty($product['attributes']) ? ' - ' . $product['attributes'] : ''),
+                    'name' => $product['name'] . (!empty($product['attributes']) ? ' - ' . $product['attributes'] : ''),
                     'price' => Tools::getContextLocale($this->context)->formatPrice($product_price * $product['quantity'], $this->context->currency->iso_code),
                     'quantity' => $product['quantity'],
                     'customization' => [],

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -457,7 +457,7 @@ abstract class PaymentModuleCore extends Module
                     'id_product' => $product['id_product'],
                     'id_product_attribute' => $product['id_product_attribute'],
                     'reference' => $product['reference'],
-                    'name' => $product['name'] . (isset($product['attributes']) && $product['attributes'] != '' ? ' - ' . $product['attributes'] : ''),
+                    'name' => (!empty($product['attributes']) ? ' - ' . $product['attributes'] : ''),
                     'price' => Tools::getContextLocale($this->context)->formatPrice($product_price * $product['quantity'], $this->context->currency->iso_code),
                     'quantity' => $product['quantity'],
                     'customization' => [],

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -457,7 +457,7 @@ abstract class PaymentModuleCore extends Module
                     'id_product' => $product['id_product'],
                     'id_product_attribute' => $product['id_product_attribute'],
                     'reference' => $product['reference'],
-                    'name' => $product['name'] . (isset($product['attributes']) ? ' - ' . $product['attributes'] : ''),
+                    'name' => $product['name'] . (isset($product['attributes']) && $product['attributes']!='' ? ' - ' . $product['attributes'] : ''),
                     'price' => Tools::getContextLocale($this->context)->formatPrice($product_price * $product['quantity'], $this->context->currency->iso_code),
                     'quantity' => $product['quantity'],
                     'customization' => [],

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -457,7 +457,7 @@ abstract class PaymentModuleCore extends Module
                     'id_product' => $product['id_product'],
                     'id_product_attribute' => $product['id_product_attribute'],
                     'reference' => $product['reference'],
-                    'name' => $product['name'] . (isset($product['attributes']) && $product['attributes']!='' ? ' - ' . $product['attributes'] : ''),
+                    'name' => $product['name'] . (isset($product['attributes']) && $product['attributes'] != '' ? ' - ' . $product['attributes'] : ''),
                     'price' => Tools::getContextLocale($this->context)->formatPrice($product_price * $product['quantity'], $this->context->currency->iso_code),
                     'quantity' => $product['quantity'],
                     'customization' => [],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch           | develop
| Description      | When a product doesn't have a combination an hyphen is added to the name in order_conf mail. Solution, test that attributes is not an empty string to add hyphen to product name.
| Type             | bug fix
| Category         | FO
| BC breaks        | no
| Deprecations     | no
| How to test      | Create an order with products with and without combination. The order confirmation mail contains hyphen at the end of product without combination
| UI Tests | https://github.com/florine2623/testing_pr/actions/runs/10111983173
| Fixed issue  | Fixes #35942.
| Sponsor company   | @ComonSoft
