### PR TITLE
Add hostname to BO Information sections

### DIFF
--- a/src/Adapter/Hosting/HostingInformation.php
+++ b/src/Adapter/Hosting/HostingInformation.php
@@ -81,6 +81,14 @@ class HostingInformation
     {
         return function_exists('php_uname') ? php_uname('s') . ' ' . php_uname('v') . ' ' . php_uname('m') : '';
     }
+    
+    /**
+     * @return string
+     */
+    public function getHostname()
+    {
+        return gethostname();
+    }
 
     /**
      * @return bool

--- a/src/Adapter/Hosting/HostingInformation.php
+++ b/src/Adapter/Hosting/HostingInformation.php
@@ -81,7 +81,7 @@ class HostingInformation
     {
         return function_exists('php_uname') ? php_uname('s') . ' ' . php_uname('v') . ' ' . php_uname('m') : '';
     }
-    
+
     /**
      * @return string
      */

--- a/src/Adapter/System/SystemInformation.php
+++ b/src/Adapter/System/SystemInformation.php
@@ -69,6 +69,7 @@ class SystemInformation
             'server' => $this->hostingInformation->getServerInformation(),
             'instaWebInstalled' => $this->hostingInformation->isApacheInstawebModule(),
             'uname' => $this->hostingInformation->getUname(),
+            'hostname' => $this->hostingInformation->getHostname(),
             'database' => $this->hostingInformation->getDatabaseInformation(),
             'overrides' => $this->shopInformation->getOverridesList(),
             'shop' => $this->shopInformation->getShopInformation(),

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -48,6 +48,9 @@
           </p>
         {% endif %}
         <p class="mb-0">
+          <strong>{{ 'Server hostname:'|trans }}</strong> {{ system.hostname }}
+        </p>
+        <p class="mb-0">
           <strong>{{ 'Server software version:'|trans }}</strong> {{ system.server.version }}
         </p>
         <p class="mb-0">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | This PR have more usefull use cases from my real experiences. 1) customers can get easily hostname for remote connection to database for example. 2) customers sometimes don't know, where their hosting is :-D So, it can helps them to regonize it (Or it can helps their administrators). 3) If hosting company will migrate customer eshop to other server, customer will know it. etc etc etc - now we are showing for example Linux version, so why don't show hostname of server? ;) It can be useful.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Login to BO, then go to Configure - Advanced Parameters - Information and there you can see new information "Hostname: XXXX" (box "Server information")
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/

![Untitled](https://github.com/PrestaShop/PrestaShop/assets/8518736/215a28f6-911a-4344-b1d1-45fa9392e2e3)

