### PR TITLE
Fix cart calculator tax rounding issues

### DIFF
--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -224,7 +224,7 @@ class CartRuleCalculator
                 new \Currency($cart->id_currency)
             );
 
-            // get total of concerned rows
+            // Get total sum of concerned rows
             $totalTaxIncl = $totalTaxExcl = 0;
             foreach ($concernedRows as $concernedRow) {
                 $totalTaxIncl += $concernedRow->getFinalTotalPrice()->getTaxIncluded();
@@ -234,16 +234,11 @@ class CartRuleCalculator
             // The reduction cannot exceed the products total, except when we do not want it to be limited (for the partial use calculation)
             $discountConverted = min($discountConverted, $cartRule->reduction_tax ? $totalTaxIncl : $totalTaxExcl);
 
-            // apply weighted discount :
+            // apply weighted discount:
             // on each line we apply a part of the discount corresponding to discount*rowWeight/total
             foreach ($concernedRows as $concernedRow) {
-                // get current line tax rate
-                $taxRate = 0;
-                if ($concernedRow->getFinalTotalPrice()->getTaxExcluded() != 0) {
-                    $taxRate = ($concernedRow->getFinalTotalPrice()->getTaxIncluded()
-                                - $concernedRow->getFinalTotalPrice()->getTaxExcluded())
-                               / $concernedRow->getFinalTotalPrice()->getTaxExcluded();
-                }
+                // Get current line tax rate
+                $taxRate = $this->getTaxRateFromRow($concernedRow);
                 $weightFactor = 0;
                 if ($cartRule->reduction_tax) {
                     // if cart rule amount is set tax included : calculate weight tax included
@@ -263,10 +258,38 @@ class CartRuleCalculator
                     $discountAmountTaxIncl = $discountAmountTaxExcl * (1 + $taxRate);
                 }
                 $amount = new AmountImmutable($discountAmountTaxIncl, $discountAmountTaxExcl);
+
+                // Update the unit prices of the items, they will be needed for possible next rules to be calculated
                 $concernedRow->applyFlatDiscount($amount);
+
+                // Apply the discount amount
                 $cartRuleData->addDiscountApplied($amount);
             }
         }
+    }
+
+    /**
+     * @param CartRow $row
+     *
+     * @return float tax rate of the given row
+     */
+    protected function getTaxRateFromRow($row)
+    {
+        // If the product was free, we return zero
+        if (empty($row->getFinalTotalPrice()->getTaxExcluded())) {
+            return 0.0;
+        }
+
+        // Calculate the rate
+        $taxRate = ($row->getFinalTotalPrice()->getTaxIncluded() - $row->getFinalTotalPrice()->getTaxExcluded())
+                    / $row->getFinalTotalPrice()->getTaxExcluded();
+
+        // If we got some nonsense number below zero, we return zero
+        if (empty($taxRate) || $taxRate < 0) {
+            return 0.0;
+        }
+
+        return $taxRate;
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | My clients were reporting errors when editing some orders in backoffice. When trying to add a discount, it would throw DivisionByZero error, because the calculator would resolve the current row tax rate to `-1`. This catches it and resets it to zero if needed.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests green. I have applied to my stores and it works correctly now.
| UI Tests          | 
| Fixed issue or discussion?     | No issue created, it would not be reproducible anyway. It depends on very specific settings - rounding, product prices, multiple cart rules etc. UPDATE: There was an issue. :-) Fixes https://github.com/PrestaShop/PrestaShop/issues/15041
| Related PRs       | 
| Sponsor company   | 

### The issue
There is a following row in `ps_order_detail`
- total_price_tax_excl 579.000000
- unit_price_tax_exc 578.512396

### Result in tax calculator
![sn__mek_obrazovky_2024-04-17_134902](https://github.com/PrestaShop/PrestaShop/assets/6097524/0804a641-a4cc-452a-8219-b70e389bd597)

Then when the CartRuleCalculator does `$discountAmountTaxExcl = $discountAmountTaxIncl / (1 + $taxRate);`, it throws fatal error Division by zero.
