### PR TITLE
Allow executing a batch of queries with DbCore->execute()

### DIFF
--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -573,7 +573,7 @@ abstract class DbCore
         if (is_array($sql)) {
             $result = true;
             foreach ($sql as $query) {
-                if (!$this->execute($query, $use_cache)) {
+                if (!$this->query($query)) {
                     $result = false;
                 }
             }

--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -561,6 +561,7 @@ abstract class DbCore
      * @param bool $use_cache
      *
      * @return bool
+     *
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR allow the use of an array of queries inside the execute() function of DbCore. It will allow developers to execute in a single call a batch of queries. Inspired by registerHook() function that works with a hook name or an array of hooks names.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Call the DbCore execute function passing an array of queries. Check that every query has been executed correctly. Alternatively, check that result is true.
| UI Tests          | NA
| Fixed issue or discussion?     | NA
| Related PRs       | NA
| Sponsor company   | Evolutive
