### PR TITLE
Add xdebug install into the dockerfile

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -8,6 +8,8 @@ EXPOSE 443
 ARG GROUP_ID
 ARG USER_ID
 ARG NODE_VERSION
+ARG INSTALL_XDEBUG
+
 
 RUN groupmod -g $GROUP_ID www-data \
   && usermod -u $USER_ID -g $GROUP_ID www-data
@@ -20,6 +22,14 @@ RUN apt update && apt install -y mailutils
 ENV NODE_VERSION       $NODE_VERSION
 
 RUN php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');" && php /tmp/composer-setup.php --no-ansi --install-dir=/usr/local/bin --filename=composer && rm -rf /tmp/composer-setup.php
+
+RUN if [ "$INSTALL_XDEBUG" = "true" ]; then \
+        pecl install xdebug-3.1.3 \
+        && docker-php-ext-enable xdebug \
+        && echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+        && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+        && echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
+    fi
 
 COPY .docker/docker_run_git.sh /tmp/
 CMD ["/tmp/docker_run_git.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
         - USER_ID=${USER_ID:-1000}
         - GROUP_ID=${GROUP_ID:-1000}
         - NODE_VERSION=${NODE_VERSION:-16.20.1}
+        - INSTALL_XDEBUG=${INSTALL_XDEBUG:-false}
     environment:
       DISABLE_MAKE: ${DISABLE_MAKE:-0}
       PS_INSTALL_AUTO: ${PS_INSTALL_AUTO:-1}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | In order to ease development on docker, it could be convenient to add xdebug in the dockerfile to make it's use easy while using docker.
| Type?             | improvement 
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI & tests green
| UI Tests          | https://github.com/tleon/ga.tests.ui.pr/actions/runs/8803315130
| Sponsor company   | PrestaShop SA
