### PR TITLE
Update redirect_type enum values

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1642,7 +1642,7 @@ CREATE TABLE `PREFIX_product` (
   `text_fields` tinyint(4) NOT NULL DEFAULT '0',
   `active` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `redirect_type` ENUM(
-    '', '404', '410', '301-product', '302-product',
+    '404', '410', '301-product', '302-product',
     '301-category', '302-category', '200-displayed',
     '404-displayed', '410-displayed', 'default'
   ) NOT NULL DEFAULT 'default',
@@ -1702,7 +1702,7 @@ CREATE TABLE IF NOT EXISTS `PREFIX_product_shop` (
   `text_fields` tinyint(4) NOT NULL DEFAULT '0',
   `active` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `redirect_type` ENUM(
-    '', '404', '410', '301-product', '302-product',
+    '404', '410', '301-product', '302-product',
     '301-category', '302-category', '200-displayed',
     '404-displayed', '410-displayed', 'default'
   ) NOT NULL DEFAULT 'default',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove unnecessary redirect_type in product and product_shop tables, see https://github.com/PrestaShop/PrestaShop/blob/ada985284ce331b28539adfc3b374879e1749b2c/src/Core/Domain/Product/ValueObject/RedirectType.php
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Check that the redirection feature of a product has not changed
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/8797906754
| Fixed issue or discussion?     | -
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/689
| Sponsor company   | -

### BC breaks

Empty string is no longer valid in `redirect_type` for `product` and `product_shop` tables
