### PR TITLE
35591 b9 migrated attribute pages bug 9

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/attribute-group/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/attribute-group/index.ts
@@ -35,6 +35,7 @@ import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filt
 import ShowcaseCard from '@components/showcase-card/showcase-card';
 import ShowcaseCardCloseExtension from '@components/showcase-card/extension/showcase-card-close-extension';
 import PositionExtension from '@components/grid/extension/position-extension';
+import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 
 const {$} = window;
 
@@ -50,6 +51,7 @@ $(() => {
   grid.addExtension(new BulkActionCheckboxExtension());
   grid.addExtension(new FiltersSubmitButtonEnablerExtension());
   grid.addExtension(new PositionExtension(grid));
+  grid.addExtension(new LinkRowActionExtension());
 
   const showcaseCard = new ShowcaseCard('attributesShowcaseCard');
   showcaseCard.addExtension(new ShowcaseCardCloseExtension());

--- a/admin-dev/themes/new-theme/js/pages/attribute/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/attribute/index.ts
@@ -33,6 +33,7 @@ import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-
 import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
 import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
 import PositionExtension from '@components/grid/extension/position-extension';
+import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 
 const {$} = window;
 
@@ -48,4 +49,5 @@ $(() => {
   grid.addExtension(new BulkActionCheckboxExtension());
   grid.addExtension(new FiltersSubmitButtonEnablerExtension());
   grid.addExtension(new PositionExtension(grid));
+  grid.addExtension(new LinkRowActionExtension());
 });

--- a/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
@@ -159,6 +159,7 @@ final class AttributeGridDefinitionFactory extends AbstractFilterableGridDefinit
                                 'extra_route_params' => [
                                     'attributeId' => 'id_attribute',
                                 ],
+                                'clickable_row' => true,
                             ])
                         )
                         ->add(

--- a/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
@@ -120,6 +120,7 @@ final class AttributeGroupGridDefinitionFactory extends AbstractFilterableGridDe
                                 'route' => 'admin_attributes_index',
                                 'route_param_name' => 'attributeGroupId',
                                 'route_param_field' => 'id_attribute_group',
+                                'clickable_row' => true,
                             ])
                         )
                         ->add((new LinkRowAction('edit'))


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  related #35591 - fix bug 9 : Can't click on the row to view the attribut value list
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Indicate how to verify that this change works as expected.
| UI Tests          | Please run UI tests and paste here the link to the run. [Read this page to know why and how to use this tool.](https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/ui-tests/).
| Fixed issue or discussion?     | Fixes #36011
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
