### PR TITLE
Display multiple carriers properly in checkout

### DIFF
--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -23,25 +23,21 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DeliveryOptionsFinderCore
 {
     private $context;
-    private $objectPresenter;
     private $translator;
     private $priceFormatter;
 
     public function __construct(
         Context $context,
         TranslatorInterface $translator,
-        ObjectPresenter $objectPresenter,
         PriceFormatter $priceFormatter
     ) {
         $this->context = $context;
-        $this->objectPresenter = $objectPresenter;
         $this->translator = $translator;
         $this->priceFormatter = $priceFormatter;
     }
@@ -115,9 +111,9 @@ class DeliveryOptionsFinderCore
                 }
             }
 
-            /* 
+            /*
              * Add names and delivery delays.
-             * 
+             *
              * When the delivery option consists of more carriers, we join up their names and delays.
              * If it's only one carrier, we just use it.
              */
@@ -138,7 +134,7 @@ class DeliveryOptionsFinderCore
                 $formattedDeliveryOption['delay'] = $carrier['instance']->delay[$this->context->language->id];
             }
 
-            /* 
+            /*
              * If carriers are related to a module, check for additionnal data to display.
              * We will call these hooks all the carriers in the delivery option, so
              * all modules can display their extra data - pickup branches etc.

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -121,7 +121,6 @@ class OrderControllerCore extends FrontController
         $deliveryOptionsFinder = new DeliveryOptionsFinder(
             $this->context,
             $this->getTranslator(),
-            $this->objectPresenter,
             new PriceFormatter()
         );
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allows checkout to properly display delivery options consisted of multiple carriers.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/15369, Fixes https://github.com/PrestaShop/PrestaShop/issues/9998, Fixes https://github.com/PrestaShop/PrestaShop/issues/13080
| Related PRs       | 
| Sponsor company   | 

### How does it look
![Snímek obrazovky 2024-04-26 142443](https://github.com/PrestaShop/PrestaShop/assets/6097524/a79d4b62-5b01-49b9-a36a-c07899c32738)

### How to test
- Create product A that can be sent only with carrier A
- Create product B that can be sent only with carrier B
- Go to FO, add both to cart.
- Go to checkout and see that you can see that the delivery option is consisted of both carriers. ✅

### Note
- If you send the order, prestashop will split the order into two. You will see two orders in backoffice, one order with Carrier A, second order with Carrier B.
- There are other bugs in it, which will probably be resolved in a different way. No need to report it - https://github.com/PrestaShop/PrestaShop/issues/15491.
- I want to fix the rest of the issues by using multiple package numbers instead of splitting orders into two. That way there will be no issues with discounts, order prices, editing the order etc.
