### PR TITLE
Check empty string in ProductController::assignAttributesCombinations()

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -888,7 +888,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         if (is_array($attributes_combinations) && count($attributes_combinations)) {
             foreach ($attributes_combinations as &$ac) {
                 foreach ($ac as &$val) {
-                    $val = str_replace(Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR'), '_', Tools::str2url(str_replace([',', '.'], '-', $val)));
+                    if ($val !== '') {
+                        $val = str_replace(Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR'), '_', Tools::str2url(str_replace([',', '.'], '-', $val)));
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x
| Description?      | Added a condition to skip the string processing for empty strings. Tested it on a 8.1.2 website, where I have products with 5k combinations from 4 attributes, making the `ProductController::assignAttributesCombinations()` method return an array with 20k elements. This optimization decreased the time needed by this method from 1.8 - 2.1 seconds to 1.4 - 1.6 seconds on my machine (Docker containers with PHP 8.1 on Manjaro Linux/i3-4170/16GB).
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Profile the product page for a product with lots of combinations, before and after the change.
| UI Tests          | https://github.com/the-ge/ga.tests.ui.pr/actions/runs/8851875393
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/36004
| Related PRs       | ---
| Sponsor company   | Tenita Gabriel PFA
