### PR TITLE
Removed unused ProductController::assignAttributesCombinations() method and call

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -374,9 +374,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             // Assign template vars related to the price and tax
             $this->assignPriceAndTax();
 
-            // Assign attributes combinations to the template
-            $this->assignAttributesCombinations();
-
             // Add notification about this product being in cart
             $this->addCartQuantityNotification();
 
@@ -877,27 +874,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 'combinationImages' => [],
             ]);
         }
-    }
-
-    /**
-     * Get and assign attributes combinations informations.
-     */
-    protected function assignAttributesCombinations()
-    {
-        $attributes_combinations = Product::getAttributesInformationsByProduct($this->product->id);
-        if (is_array($attributes_combinations) && count($attributes_combinations)) {
-            foreach ($attributes_combinations as &$ac) {
-                foreach ($ac as &$val) {
-                    $val = str_replace(Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR'), '_', Tools::str2url(str_replace([',', '.'], '-', $val)));
-                }
-            }
-        } else {
-            $attributes_combinations = [];
-        }
-        $this->context->smarty->assign([
-            'attributesCombinations' => $attributes_combinations,
-            'attribute_anchor_separator' => Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR'),
-        ]);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x / 8.0.x / 1.7.8.x / 1.7.7.x
| Description?      | The `ProductController::assignAttributesCombinations()` method assigns an array of attribute combinations (with size being the count of attributes x count of product combinations, i.e. 4 x 5000 in my case) as a Smarty template variable. As the count of attributes and product combinations increase, this consumes more and more resources. Recent improvements directed at reducing resources consumed are https://github.com/PrestaShop/PrestaShop/issues/34453 and https://github.com/PrestaShop/PrestaShop/pull/36039. The thing is, the template variable this method assigns seems to have been last used in PrestaShop v1.6, so the method and the call to it should be removed altogether.
| Type?             | bug
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Acces the product page.
| UI Tests          | https://github.com/the-ge/ga.tests.ui.pr/actions/runs/8888692163
| Fixed issue or discussion?     | Fixes #36051
| Related PRs       | This PR makes https://github.com/PrestaShop/PrestaShop/pull/36039 superfluous.
| Sponsor company   | Tenita Gabriel PFA
