### PR TITLE
Functional tests - Add new test to check popular products in payment confirmation page (Classic & Hummingbird)

### DIFF
--- a/tests/UI/campaigns/functional/FO/classic/12_orderConfirmation/04_popularProduct.ts
+++ b/tests/UI/campaigns/functional/FO/classic/12_orderConfirmation/04_popularProduct.ts
@@ -28,11 +28,6 @@ import type {BrowserContext, Page} from 'playwright';
 // context
 const baseContext: string = 'functional_FO_classic_orderConfirmation_popularProduct';
 
-/*
-Scenario:
-- Create new order in FO
-
-*/
 describe('FO - Order confirmation : Popular product', async () => {
   let browserContext: BrowserContext;
   let page: Page;

--- a/tests/UI/campaigns/functional/FO/classic/12_orderConfirmation/04_popularProduct.ts
+++ b/tests/UI/campaigns/functional/FO/classic/12_orderConfirmation/04_popularProduct.ts
@@ -129,16 +129,14 @@ describe('FO - Order confirmation : Popular product', async () => {
   it('should check popular product title', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'checkPopularProducts', baseContext);
 
-    await homePage.changeLanguage(page, 'en');
-
-    const popularProductTitle = await orderConfirmationPage.getBlockTitle(page, 'popularproducts');
+    const popularProductTitle = await orderConfirmationPage.getBlockTitle(page);
     expect(popularProductTitle).to.equal('Popular Products');
   });
 
   it('should check the number of popular products', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'checkPopularProductsNumber', baseContext);
 
-    const productsNumber = await orderConfirmationPage.getProductsBlockNumber(page, 'popularproducts');
+    const productsNumber = await orderConfirmationPage.getProductsBlockNumber(page);
     expect(productsNumber).to.equal(8);
   });
 

--- a/tests/UI/campaigns/functional/FO/classic/12_orderConfirmation/04_popularProduct.ts
+++ b/tests/UI/campaigns/functional/FO/classic/12_orderConfirmation/04_popularProduct.ts
@@ -1,0 +1,206 @@
+// Import utils
+import helper from '@utils/helpers';
+import testContext from '@utils/testContext';
+
+// Import FO pages
+import {homePage} from '@pages/FO/classic/home';
+import {cartPage} from '@pages/FO/classic/cart';
+import {checkoutPage} from '@pages/FO/classic/checkout';
+import {orderConfirmationPage} from '@pages/FO/classic/checkout/orderConfirmation';
+import {quickViewModal} from '@pages/FO/classic/modal/quickView';
+import {blockCartModal} from '@pages/FO/classic/modal/blockCart';
+import {searchResultsPage} from '@pages/FO/classic/searchResults';
+import {categoryPage} from '@pages/FO/classic/category';
+
+// Import data
+import Products from '@data/demo/products';
+import Carriers from '@data/demo/carriers';
+
+import {
+  // Import data
+  dataPaymentMethods,
+  dataCustomers,
+} from '@prestashop-core/ui-testing';
+
+import {expect} from 'chai';
+import type {BrowserContext, Page} from 'playwright';
+
+// context
+const baseContext: string = 'functional_FO_classic_orderConfirmation_popularProduct';
+
+/*
+Scenario:
+- Create new order in FO
+
+*/
+describe('FO - Order confirmation : Popular product', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+
+  // before and after functions
+  before(async function () {
+    browserContext = await helper.createBrowserContext(this.browser);
+    page = await helper.newTab(browserContext);
+  });
+
+  after(async () => {
+    await helper.closeBrowserContext(browserContext);
+  });
+
+  it('should open the shop page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'openFoShop', baseContext);
+
+    await homePage.goToFo(page);
+    await homePage.changeLanguage(page, 'en');
+
+    const result = await homePage.isHomePage(page);
+    expect(result).to.equal(true);
+  });
+
+  it('should go to home page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToHomePage', baseContext);
+
+    await homePage.goToHomePage(page);
+
+    const result = await homePage.isHomePage(page);
+    expect(result).to.eq(true);
+  });
+
+  it(`should add the product ${Products.demo_6.name} to cart by quick view`, async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'addDemo3ByQuickView', baseContext);
+
+    await homePage.searchProduct(page, Products.demo_6.name);
+    await searchResultsPage.quickViewProduct(page, 1);
+
+    await quickViewModal.addToCartByQuickView(page);
+    await blockCartModal.proceedToCheckout(page);
+
+    const pageTitle = await cartPage.getPageTitle(page);
+    expect(pageTitle).to.equal(cartPage.pageTitle);
+  });
+
+  it('should validate shopping cart and go to checkout page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToCheckoutPage', baseContext);
+
+    await cartPage.clickOnProceedToCheckout(page);
+
+    const isCheckoutPage = await checkoutPage.isCheckoutPage(page);
+    expect(isCheckoutPage).to.equal(true);
+  });
+
+  it('should sign in by default customer', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'signInFO', baseContext);
+
+    await checkoutPage.clickOnSignIn(page);
+
+    const isCustomerConnected = await checkoutPage.customerLogin(page, dataCustomers.johnDoe);
+    expect(isCustomerConnected, 'Customer is not connected!').to.equal(true);
+  });
+
+  it('should go to delivery step', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToDeliveryStep', baseContext);
+
+    // Address step - Go to delivery step
+    const isStepAddressComplete = await checkoutPage.goToDeliveryStep(page);
+    expect(isStepAddressComplete, 'Step Address is not complete').to.equal(true);
+  });
+
+  it('should select the first carrier and go to payment step', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'checkShippingPrice1', baseContext);
+
+    await checkoutPage.chooseShippingMethod(page, Carriers.default.id);
+
+    const isPaymentStep = await checkoutPage.goToPaymentStep(page);
+    expect(isPaymentStep).to.eq(true);
+  });
+
+  it('should Pay by check and confirm order', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'confirmOrder', baseContext);
+
+    await checkoutPage.choosePaymentAndOrder(page, dataPaymentMethods.checkPayment.moduleName);
+
+    const pageTitle = await orderConfirmationPage.getPageTitle(page);
+    expect(pageTitle).to.equal(orderConfirmationPage.pageTitle);
+
+    const cardTitle = await orderConfirmationPage.getOrderConfirmationCardTitle(page);
+    expect(cardTitle).to.contains(orderConfirmationPage.orderConfirmationCardTitle);
+  });
+
+  it('should check popular product title', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'checkPopularProducts', baseContext);
+
+    await homePage.changeLanguage(page, 'en');
+
+    const popularProductTitle = await orderConfirmationPage.getBlockTitle(page, 'popularproducts');
+    expect(popularProductTitle).to.equal('Popular Products');
+  });
+
+  it('should check the number of popular products', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'checkPopularProductsNumber', baseContext);
+
+    const productsNumber = await orderConfirmationPage.getProductsBlockNumber(page, 'popularproducts');
+    expect(productsNumber).to.equal(8);
+  });
+
+  it('should quick view the first product in list', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'quickViewFirstProduct', baseContext);
+
+    await orderConfirmationPage.quickViewProduct(page, 1);
+
+    const isQuickViewModalVisible = await quickViewModal.isQuickViewProductModalVisible(page);
+    expect(isQuickViewModalVisible).to.equal(true);
+  });
+
+  it('should add the product to cart', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'addProductToCart', baseContext);
+
+    await quickViewModal.addToCartByQuickView(page);
+    await blockCartModal.proceedToCheckout(page);
+
+    const pageTitle = await cartPage.getPageTitle(page);
+    expect(pageTitle).to.eq(cartPage.pageTitle);
+  });
+
+  it('should proceed to checkout', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'proceedToCheckout', baseContext);
+
+    // Proceed to checkout the shopping cart
+    await cartPage.clickOnProceedToCheckout(page);
+
+    const isCheckoutPage = await checkoutPage.isCheckoutPage(page);
+    expect(isCheckoutPage).to.eq(true);
+  });
+
+  it('should go to delivery address step', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'confirmAddressStep', baseContext);
+
+    const isDeliveryStep = await checkoutPage.goToDeliveryStep(page);
+    expect(isDeliveryStep, 'Delivery Step boc is not displayed').to.eq(true);
+  });
+
+  it('should choose the shipping method', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'shippingMethodStep', baseContext);
+
+    const isPaymentStep = await checkoutPage.goToPaymentStep(page);
+    expect(isPaymentStep, 'Payment Step bloc is not displayed').to.eq(true);
+  });
+
+  it('should choose the payment type and confirm the order', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'choosePaymentMethod', baseContext);
+
+    await checkoutPage.choosePaymentAndOrder(page, dataPaymentMethods.wirePayment.moduleName);
+
+    const cardTitle = await orderConfirmationPage.getOrderConfirmationCardTitle(page);
+    // Check the confirmation message
+    expect(cardTitle).to.contains(orderConfirmationPage.orderConfirmationCardTitle);
+  });
+
+  it('should click on all products page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'clickOnAllProductsPage', baseContext);
+
+    await orderConfirmationPage.goToAllProductsPage(page);
+
+    const isCategoryPageVisible = await categoryPage.isCategoryPage(page);
+    expect(isCategoryPageVisible, 'Home category page was not opened').to.eq(true);
+  });
+});

--- a/tests/UI/campaigns/functional/FO/hummingbird/12_orderConfirmation/04_popularProduct.ts
+++ b/tests/UI/campaigns/functional/FO/hummingbird/12_orderConfirmation/04_popularProduct.ts
@@ -131,16 +131,14 @@ describe('FO - Order confirmation : Popular product', async () => {
     it('should check popular product title', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkPopularProducts', baseContext);
 
-      await homePage.changeLanguage(page, 'en');
-
-      const popularProductTitle = await orderConfirmationPage.getBlockTitle(page, 'popularproducts');
+      const popularProductTitle = await orderConfirmationPage.getBlockTitle(page);
       expect(popularProductTitle).to.equal('Popular Products');
     });
 
     it('should check the number of popular products', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkPopularProductsNumber', baseContext);
 
-      const productsNumber = await orderConfirmationPage.getProductsBlockNumber(page, 'popularproducts');
+      const productsNumber = await orderConfirmationPage.getProductsBlockNumber(page);
       expect(productsNumber).to.equal(8);
     });
 

--- a/tests/UI/campaigns/functional/FO/hummingbird/12_orderConfirmation/04_popularProduct.ts
+++ b/tests/UI/campaigns/functional/FO/hummingbird/12_orderConfirmation/04_popularProduct.ts
@@ -1,0 +1,212 @@
+// Import utils
+import helper from '@utils/helpers';
+import testContext from '@utils/testContext';
+
+// Import common tests
+import {installHummingbird, uninstallHummingbird} from '@commonTests/BO/design/hummingbird';
+
+// Import FO pages
+import homePage from '@pages/FO/hummingbird/home';
+import cartPage from '@pages/FO/hummingbird/cart';
+import checkoutPage from '@pages/FO/hummingbird/checkout';
+import orderConfirmationPage from '@pages/FO/hummingbird/checkout/orderConfirmation';
+import quickViewModal from '@pages/FO/hummingbird/modal/quickView';
+import blockCartModal from '@pages/FO/hummingbird/modal/blockCart';
+import searchResultsPage from '@pages/FO/hummingbird/searchResults';
+import categoryPage from '@pages/FO/hummingbird/category';
+
+// Import data
+import Products from '@data/demo/products';
+import Carriers from '@data/demo/carriers';
+
+import {
+  // Import data
+  dataPaymentMethods,
+  dataCustomers,
+} from '@prestashop-core/ui-testing';
+
+import {expect} from 'chai';
+import type {BrowserContext, Page} from 'playwright';
+
+// context
+const baseContext: string = 'functional_FO_hummingbird_orderConfirmation_popularProduct';
+
+describe('FO - Order confirmation : Popular product', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+
+  // Pre-condition : Install Hummingbird
+  installHummingbird(`${baseContext}_preTest`);
+
+  // before and after functions
+  before(async function () {
+    browserContext = await helper.createBrowserContext(this.browser);
+    page = await helper.newTab(browserContext);
+  });
+
+  after(async () => {
+    await helper.closeBrowserContext(browserContext);
+  });
+
+  describe('Check Popular product block', async () => {
+    it('should open the shop page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'openFoShop', baseContext);
+
+      await homePage.goToFo(page);
+      await homePage.changeLanguage(page, 'en');
+
+      const result = await homePage.isHomePage(page);
+      expect(result).to.equal(true);
+    });
+
+    it('should go to home page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToHomePage', baseContext);
+
+      await homePage.goToHomePage(page);
+
+      const result = await homePage.isHomePage(page);
+      expect(result).to.eq(true);
+    });
+
+    it(`should add the product ${Products.demo_6.name} to cart by quick view`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'addDemo3ByQuickView', baseContext);
+
+      await homePage.searchProduct(page, Products.demo_6.name);
+      await searchResultsPage.quickViewProduct(page, 1);
+
+      await quickViewModal.addToCartByQuickView(page);
+      await blockCartModal.proceedToCheckout(page);
+
+      const pageTitle = await cartPage.getPageTitle(page);
+      expect(pageTitle).to.equal(cartPage.pageTitle);
+    });
+
+    it('should validate shopping cart and go to checkout page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToCheckoutPage', baseContext);
+
+      await cartPage.clickOnProceedToCheckout(page);
+
+      const isCheckoutPage = await checkoutPage.isCheckoutPage(page);
+      expect(isCheckoutPage).to.equal(true);
+    });
+
+    it('should sign in by default customer', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'signInFO', baseContext);
+
+      await checkoutPage.clickOnSignIn(page);
+
+      const isCustomerConnected = await checkoutPage.customerLogin(page, dataCustomers.johnDoe);
+      expect(isCustomerConnected, 'Customer is not connected!').to.equal(true);
+    });
+
+    it('should go to delivery step', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToDeliveryStep', baseContext);
+
+      // Address step - Go to delivery step
+      const isStepAddressComplete = await checkoutPage.goToDeliveryStep(page);
+      expect(isStepAddressComplete, 'Step Address is not complete').to.equal(true);
+    });
+
+    it('should select the first carrier and go to payment step', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkShippingPrice1', baseContext);
+
+      await checkoutPage.chooseShippingMethod(page, Carriers.default.id);
+
+      const isPaymentStep = await checkoutPage.goToPaymentStep(page);
+      expect(isPaymentStep).to.eq(true);
+    });
+
+    it('should Pay by check and confirm order', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'confirmOrder', baseContext);
+
+      await checkoutPage.choosePaymentAndOrder(page, dataPaymentMethods.checkPayment.moduleName);
+
+      const pageTitle = await orderConfirmationPage.getPageTitle(page);
+      expect(pageTitle).to.equal(orderConfirmationPage.pageTitle);
+
+      const cardTitle = await orderConfirmationPage.getOrderConfirmationCardTitle(page);
+      expect(cardTitle).to.contains(orderConfirmationPage.orderConfirmationCardTitle);
+    });
+
+    it('should check popular product title', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkPopularProducts', baseContext);
+
+      await homePage.changeLanguage(page, 'en');
+
+      const popularProductTitle = await orderConfirmationPage.getBlockTitle(page, 'popularproducts');
+      expect(popularProductTitle).to.equal('Popular Products');
+    });
+
+    it('should check the number of popular products', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkPopularProductsNumber', baseContext);
+
+      const productsNumber = await orderConfirmationPage.getProductsBlockNumber(page, 'popularproducts');
+      expect(productsNumber).to.equal(8);
+    });
+
+    it('should quick view the first product in list', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'quickViewFirstProduct', baseContext);
+
+      await orderConfirmationPage.quickViewProduct(page, 1);
+
+      const isQuickViewModalVisible = await quickViewModal.isQuickViewProductModalVisible(page);
+      expect(isQuickViewModalVisible).to.equal(true);
+    });
+
+    it('should add the product to cart', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'addProductToCart', baseContext);
+
+      await quickViewModal.addToCartByQuickView(page);
+      await blockCartModal.proceedToCheckout(page);
+
+      const pageTitle = await cartPage.getPageTitle(page);
+      expect(pageTitle).to.eq(cartPage.pageTitle);
+    });
+
+    it('should proceed to checkout', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'proceedToCheckout', baseContext);
+
+      // Proceed to checkout the shopping cart
+      await cartPage.clickOnProceedToCheckout(page);
+
+      const isCheckoutPage = await checkoutPage.isCheckoutPage(page);
+      expect(isCheckoutPage).to.eq(true);
+    });
+
+    it('should go to delivery address step', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'confirmAddressStep', baseContext);
+
+      const isDeliveryStep = await checkoutPage.goToDeliveryStep(page);
+      expect(isDeliveryStep, 'Delivery Step boc is not displayed').to.eq(true);
+    });
+
+    it('should choose the shipping method', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'shippingMethodStep', baseContext);
+
+      const isPaymentStep = await checkoutPage.goToPaymentStep(page);
+      expect(isPaymentStep, 'Payment Step bloc is not displayed').to.eq(true);
+    });
+
+    it('should choose the payment type and confirm the order', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'choosePaymentMethod', baseContext);
+
+      await checkoutPage.choosePaymentAndOrder(page, dataPaymentMethods.wirePayment.moduleName);
+
+      const cardTitle = await orderConfirmationPage.getOrderConfirmationCardTitle(page);
+      // Check the confirmation message
+      expect(cardTitle).to.contains(orderConfirmationPage.orderConfirmationCardTitle);
+    });
+
+    it('should click on all products page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'clickOnAllProductsPage', baseContext);
+
+      await orderConfirmationPage.goToAllProductsPage(page);
+
+      const isCategoryPageVisible = await categoryPage.isCategoryPage(page);
+      expect(isCategoryPageVisible, 'Home category page was not opened').to.eq(true);
+    });
+  });
+
+  // Post-condition : Uninstall Hummingbird
+  uninstallHummingbird(`${baseContext}_postTest`);
+});

--- a/tests/UI/pages/FO/classic/checkout/orderConfirmation.ts
+++ b/tests/UI/pages/FO/classic/checkout/orderConfirmation.ts
@@ -1,9 +1,9 @@
 // Import pages
 import FOBasePage from '@pages/FO/FObasePage';
+import {quickViewModal} from '@pages/FO/classic/modal/quickView';
 
 import type {Page} from 'playwright';
 import type {ProductOrderConfirmation} from '@data/types/product';
-import {quickViewModal} from "@pages/FO/classic/modal/quickView";
 
 /**
  * Order confirmation page, contains functions that can be used on the page
@@ -63,21 +63,21 @@ class OrderConfirmationPage extends FOBasePage {
 
   protected shippingMethodRow: string;
 
-  private readonly productsBlock: (blockId: string) => string;
+  protected productsBlock: string;
 
-  private readonly productsBlockTitle: (blockId: string) => string;
+  protected productsBlockTitle: string;
 
-  private readonly productsBlockDiv: (blockId: string) => string;
+  protected productsBlockDiv: string;
 
-  private readonly allProductsLink: string;
+  protected allProductsLink: string;
 
-  private readonly productArticle: (row: number) => string;
+  protected productArticle: (row: number) => string;
 
-  private readonly productImg: (row: number) => string;
+  protected productImg: (row: number) => string;
 
-  private readonly productDescriptionDiv: (row: number) => string;
+  protected productDescriptionDiv: (row: number) => string;
 
-  private readonly productQuickViewLink: (row: number) => string;
+  protected productQuickViewLink: (row: number) => string;
 
   /**
    * @constructs
@@ -116,11 +116,11 @@ class OrderConfirmationPage extends FOBasePage {
     this.productRowPrices = (row: number) => `${this.productRowNth(row)} div.qty div`;
 
     // Selectors for popular products block
-    this.productsBlock = (blockName: string) => `#content-hook-order-confirmation-footer section[data-type="${blockName}"]`;
-    this.productsBlockTitle = (blockName: string) => `${this.productsBlock(blockName)} h2`;
-    this.productsBlockDiv = (blockName: string) => `${this.productsBlock(blockName)} div.products div.js-product`;
+    this.productsBlock = '#content-hook-order-confirmation-footer section[data-type="popularproducts"]';
+    this.productsBlockTitle = `${this.productsBlock} h2`;
+    this.productsBlockDiv = `${this.productsBlock} div.products div.js-product`;
     this.allProductsLink = '#content-hook-order-confirmation-footer a.all-product-link';
-    this.productArticle = (row: number) => `${this.productsBlock('popularproducts')} .products `
+    this.productArticle = (row: number) => `${this.productsBlock} .products `
       + `div:nth-child(${row}) article`;
     this.productImg = (row: number) => `${this.productArticle(row)} img`;
     this.productDescriptionDiv = (row: number) => `${this.productArticle(row)} div.product-description`;
@@ -301,21 +301,19 @@ class OrderConfirmationPage extends FOBasePage {
   /**
    * Get products block title
    * @param page {Page} Browser tab
-   * @param blockName {string} The block name in the page
    * @returns {Promise<string>}
    */
-  async getBlockTitle(page: Page, blockName: string): Promise<string> {
-    return this.getTextContent(page, this.productsBlockTitle(blockName));
+  async getBlockTitle(page: Page): Promise<string> {
+    return this.getTextContent(page, this.productsBlockTitle);
   }
 
   /**
    * Get products block number
-   * @param blockName {string} The block name in the page
    * @param page {Page} Browser tab
    * @return {Promise<number>}
    */
-  async getProductsBlockNumber(page: Page, blockName: string): Promise<number> {
-    return page.locator(this.productsBlockDiv(blockName)).count();
+  async getProductsBlockNumber(page: Page): Promise<number> {
+    return page.locator(this.productsBlockDiv).count();
   }
 
   /**

--- a/tests/UI/pages/FO/classic/checkout/orderConfirmation.ts
+++ b/tests/UI/pages/FO/classic/checkout/orderConfirmation.ts
@@ -3,6 +3,7 @@ import FOBasePage from '@pages/FO/FObasePage';
 
 import type {Page} from 'playwright';
 import type {ProductOrderConfirmation} from '@data/types/product';
+import {quickViewModal} from "@pages/FO/classic/modal/quickView";
 
 /**
  * Order confirmation page, contains functions that can be used on the page
@@ -62,6 +63,22 @@ class OrderConfirmationPage extends FOBasePage {
 
   protected shippingMethodRow: string;
 
+  private readonly productsBlock: (blockId: string) => string;
+
+  private readonly productsBlockTitle: (blockId: string) => string;
+
+  private readonly productsBlockDiv: (blockId: string) => string;
+
+  private readonly allProductsLink: string;
+
+  private readonly productArticle: (row: number) => string;
+
+  private readonly productImg: (row: number) => string;
+
+  private readonly productDescriptionDiv: (row: number) => string;
+
+  private readonly productQuickViewLink: (row: number) => string;
+
   /**
    * @constructs
    * Setting up texts and selectors to use on order confirmation page
@@ -97,6 +114,17 @@ class OrderConfirmationPage extends FOBasePage {
     this.productRowImage = (row: number) => `${this.productRowNth(row)} span.image img`;
     this.productRowDetails = (row: number) => `${this.productRowNth(row)} div.details`;
     this.productRowPrices = (row: number) => `${this.productRowNth(row)} div.qty div`;
+
+    // Selectors for popular products block
+    this.productsBlock = (blockName: string) => `#content-hook-order-confirmation-footer section[data-type="${blockName}"]`;
+    this.productsBlockTitle = (blockName: string) => `${this.productsBlock(blockName)} h2`;
+    this.productsBlockDiv = (blockName: string) => `${this.productsBlock(blockName)} div.products div.js-product`;
+    this.allProductsLink = '#content-hook-order-confirmation-footer a.all-product-link';
+    this.productArticle = (row: number) => `${this.productsBlock('popularproducts')} .products `
+      + `div:nth-child(${row}) article`;
+    this.productImg = (row: number) => `${this.productArticle(row)} img`;
+    this.productDescriptionDiv = (row: number) => `${this.productArticle(row)} div.product-description`;
+    this.productQuickViewLink = (row: number) => `${this.productArticle(row)} a.quick-view`;
   }
 
   /*
@@ -268,6 +296,70 @@ class OrderConfirmationPage extends FOBasePage {
    */
   async getOrderTotal(page: Page): Promise<string> {
     return this.getTextContent(page, this.totalRow);
+  }
+
+  /**
+   * Get products block title
+   * @param page {Page} Browser tab
+   * @param blockName {string} The block name in the page
+   * @returns {Promise<string>}
+   */
+  async getBlockTitle(page: Page, blockName: string): Promise<string> {
+    return this.getTextContent(page, this.productsBlockTitle(blockName));
+  }
+
+  /**
+   * Get products block number
+   * @param blockName {string} The block name in the page
+   * @param page {Page} Browser tab
+   * @return {Promise<number>}
+   */
+  async getProductsBlockNumber(page: Page, blockName: string): Promise<number> {
+    return page.locator(this.productsBlockDiv(blockName)).count();
+  }
+
+  /**
+   * Go to all products page
+   * @param page {Page} Browser tab
+   * @return {Promise<void>}
+   */
+  async goToAllProductsPage(page: Page): Promise<void> {
+    await this.clickAndWaitForURL(page, this.allProductsLink);
+  }
+
+  /**
+   * Quick view product
+   * @param page {Page} Browser tab
+   * @param row {number} Row of product to quick view
+   * @return {Promise<void>}
+   */
+  async quickViewProduct(page: Page, row: number): Promise<void> {
+    await page.locator(this.productImg(row)).hover();
+    let displayed: boolean = false;
+
+    /* eslint-disable no-await-in-loop */
+    // Only way to detect if element is displayed is to get value of computed style 'product description' after hover
+    // and compare it with value 'block'
+    for (let i = 0; i < 10 && !displayed; i++) {
+      /* eslint-env browser */
+      displayed = await page.evaluate(
+        (selector: string): boolean => {
+          const element = document.querySelector(selector);
+
+          if (!element) {
+            return false;
+          }
+          return window.getComputedStyle(element, ':after').getPropertyValue('display') === 'block';
+        },
+        this.productDescriptionDiv(row),
+      );
+      await page.waitForTimeout(100);
+    }
+    /* eslint-enable no-await-in-loop */
+    await Promise.all([
+      this.waitForVisibleSelector(page, quickViewModal.quickViewModalDiv),
+      page.locator(this.productQuickViewLink(row)).evaluate((el: HTMLElement) => el.click()),
+    ]);
   }
 }
 

--- a/tests/UI/pages/FO/hummingbird/checkout/orderConfirmation.ts
+++ b/tests/UI/pages/FO/hummingbird/checkout/orderConfirmation.ts
@@ -36,6 +36,16 @@ class OrderConfirmation extends OrderConfirmationPage {
     this.productRowImage = (row: number) => `${this.productRowNth(row)} div.item__image img`;
     this.productRowDetails = (row: number) => `${this.productRowNth(row)} div.item__details`;
     this.productRowPrices = (row: number) => `${this.productRowNth(row)} div.item__prices`;
+
+    // Popular products section
+    this.productsBlock = '#content-wrapper section.featured-products';
+    this.productsBlockTitle = `${this.productsBlock} h2`;
+    this.productsBlockDiv = `${this.productsBlock} div.products div.card`;
+    this.allProductsLink = `${this.productsBlock} div.featured-products-footer a`;
+    this.productArticle = (number: number) => `${this.productsBlock} article:nth-child(${number})`;
+    this.productImg = (number: number) => `${this.productArticle(number)} img`;
+    this.productQuickViewLink = (number: number) => `${this.productArticle(number)} .product-miniature__quickview `
+      + 'button';
   }
 
   /**
@@ -50,6 +60,18 @@ class OrderConfirmation extends OrderConfirmationPage {
       details: await this.getTextContent(page, this.productRowDetails(row)),
       prices: await this.getTextContent(page, this.productRowPrices(row)),
     };
+  }
+
+  /**
+   * Quick view product
+   * @param page {Page} Browser tab
+   * @param id {number} Product row in the list
+   * @return {Promise<void>}
+   */
+  async quickViewProduct(page: Page, id: number): Promise<void> {
+    await page.locator(this.productImg(id)).hover();
+    await this.waitForVisibleSelector(page, this.productQuickViewLink(id));
+    await page.locator(this.productQuickViewLink(id)).click();
   }
 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add new test to check popular products in payment confirmation page (Classic & Hummingbird) 
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI and nightly are :green_apple: 
| UI Tests          | https://github.com/nesrineabdmouleh/testing_pr/actions/runs/8893227624
| Fixed issue or discussion?     | no
| Related PRs       | no
| Sponsor company   | 
