### PR TITLE
fix flag new traduction

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -635,7 +635,7 @@ class ProductLazyArray extends AbstractLazyArray
         if ($this->getNew()) {
             $flags['new'] = [
                 'type' => 'new',
-                'label' => $this->translator->trans('New', [], 'Shop.Theme.Global'),
+                'label' => $this->translator->trans('New', [], 'Shop.Theme.Catalog'),
             ];
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x
| Description?      | Fix the **New** flag on product image translation from back office.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | The traduction will now show correctly on front page on the **New** products with badge **New** well translated if its French langue it show **Nouveau**,...
| UI Tests          | [Please run UI tests and paste here the link to the run. [Read this page to know why and how to use this tool.](https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/ui-tests/).](https://github.com/medMethnani/ga.tests.ui.pr/actions/runs/8915646840)
| Fixed issue or discussion?     | NONE
| Related PRs       | NONE
| Sponsor company   | Med METHNANI.
