### PR TITLE
Improved Github Actions when updating php modules

### DIFF
--- a/.github/workflows/cron_php_update_modules.yml
+++ b/.github/workflows/cron_php_update_modules.yml
@@ -64,9 +64,13 @@ jobs:
       - name: Update PrestaShop packages
         id: updated-packages
         run: |
-          FILE_CONTENT=$(cat cron_php_update_modules.txt)
-          echo PR_BODY=$FILE_CONTENT >> $GITHUB_OUTPUT
-          rm cron_php_update_modules.txt
+          if [[ -f cron_php_update_modules.txt ]]; then
+            FILE_CONTENT=$(cat cron_php_update_modules.txt)
+            echo PR_BODY=$FILE_CONTENT >> $GITHUB_OUTPUT
+            rm cron_php_update_modules.txt
+          else
+            echo 'Nothing to update'
+          fi
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When the cron_php_update_modules file doesn't exist, the github action shouldn't crash. It should be green with a message that there is no module to update
| Type?             |  improvement 
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| Sponsor company   | PrestaShop SA 
