### PR TITLE
Fix error in PHP 8:  count(): Argument #1 ($value) must be of type Countable|array, string given

### DIFF
--- a/classes/RequestSql.php
+++ b/classes/RequestSql.php
@@ -322,7 +322,7 @@ class RequestSqlCore extends ObjectModel
                 $tab = [];
                 foreach ($tables as $table) {
                     if ($this->attributExistInTable($attr, $table['table'])) {
-                        $tab = $table['table'];
+                        $tab[] = $table['table'];
                     }
                 }
                 if (count($tab) == 1) {


### PR DESCRIPTION
fix error in PHP 8:  count(): Argument #1 ($value) must be of type Countable|array, string given

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | fix error in PHP 8:  count(): Argument #1 ($value) must be of type Countable|array, string given
| Type?             | bug fix 
| Category?         |  BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Save request SQL in BO with one jointure
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/10139772353 ✅ 
| Fixed issue or discussion?     | Fixes #36083 
| Related PRs       | 
| Sponsor company   | 
