### PR TITLE
New Dispatcher methods to set Controller/FrontController

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -814,7 +814,7 @@ class DispatcherCore
     /**
      * Sets the controller
      *
-     * @return null
+     * @return $this
      */
     public function setController(string $controller): self
     {
@@ -830,7 +830,7 @@ class DispatcherCore
     /**
      * Sets the front controller
      *
-     * @return null
+     * @return $this
      */
     public function setFrontController(int $front_controller): self
     {

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -826,6 +826,24 @@ class DispatcherCore
     }
 
     /**
+     * Sets the front controller
+     *
+     * @return null
+     */
+    public function setFrontController(string $front_controller)
+    {
+        if (!in_array($front_controller, [
+            self::FC_ADMIN,
+            self::FC_FRONT,
+            self::FC_MODULE
+        ])) {
+            throw new PrestaShopException('Dispatcher::setFrontController() fron_controller name is not valid');
+        }
+
+        $this->front_controller = $front_controller;
+    }
+
+    /**
      * Removes a route from a list of processed routes.
      *
      * @param string $route_id Name of the route

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -835,9 +835,9 @@ class DispatcherCore
         if (!in_array($front_controller, [
             self::FC_ADMIN,
             self::FC_FRONT,
-            self::FC_MODULE
+            self::FC_MODULE,
         ])) {
-            throw new PrestaShopException('Dispatcher::setFrontController() fron_controller name is not valid');
+            throw new PrestaShopException('Dispatcher::setFrontController() front_controller name is not valid');
         }
 
         $this->front_controller = $front_controller;

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -816,13 +816,15 @@ class DispatcherCore
      *
      * @return null
      */
-    public function setController(string $controller)
+    public function setController(string $controller): self
     {
         if (!Validate::isControllerName($controller)) {
             throw new PrestaShopException('Dispatcher::setController() controller name is not valid');
         }
 
         $this->controller = $controller;
+
+        return $this;
     }
 
     /**
@@ -830,7 +832,7 @@ class DispatcherCore
      *
      * @return null
      */
-    public function setFrontController(string $front_controller)
+    public function setFrontController(int $front_controller): self
     {
         if (!in_array($front_controller, [
             self::FC_ADMIN,
@@ -841,6 +843,8 @@ class DispatcherCore
         }
 
         $this->front_controller = $front_controller;
+
+        return $this;
     }
 
     /**

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -812,6 +812,20 @@ class DispatcherCore
     }
 
     /**
+     * Sets the controller
+     *
+     * @return null
+     */
+    public function setController(string $controller)
+    {
+        if (!Validate::isControllerName($controller)) {
+            throw new PrestaShopException('Dispatcher::setController() controller name is not valid');
+        }
+
+        $this->controller = $controller;
+    }
+
+    /**
      * Removes a route from a list of processed routes.
      *
      * @param string $route_id Name of the route


### PR DESCRIPTION
| Questions | Answers
| ----------------- | -------------------------------------------------------
| Branch? | develop
| Description? | Add setController/setFrontController methods to avoid bug in hookActionAfterLoadRoutes that protected variables can be set in Dispatcher
| Type? | bug fix
| Category? | CO
| BC breaks? | no
| Deprecations? | no
| How to test? | We have a module that wants to make an own Dispatch and needs to pass the information about the dispatched routes to the default PS Dispatcher in Hook actionAfterLoadRoutes. For this reason the protected variables "$controller" and "$front_controller" needs to be public or alternatively a setter methods is needed. Currently this can be only achieved with an Override of Dispatcher. You can read here how to test in deatil: https://github.com/PrestaShop/PrestaShop/issues/35971
| UI Tests | Please run UI tests and paste here the link to the run. [Read this page to know why and how to use this tool.](https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/ui-tests/).
| Fixed issue or discussion? | Fixes #35971
| Related PRs |
| Sponsor company | Gurkcity