### PR TITLE
Add new "Check the label 'Needs autoupgrade PR'" workflow

### DIFF
--- a/.github/workflows/check_need_autoupgrade_pr_label.yml
+++ b/.github/workflows/check_need_autoupgrade_pr_label.yml
@@ -1,0 +1,81 @@
+# This workflow allows you to check potential changes to the structure of the database,
+# and to apply the “Needs autoupgrade PR” label if this is the case
+name: Check the label 'Needs autoupgrade PR'
+
+on: pull_request_target
+
+jobs:
+  install_prestashop_and_dump:
+    name: Install Prestashop and create database dump
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: [ base, head ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch == 'base' && github.event.pull_request.base.ref || github.event.pull_request.head.ref }}
+
+      - name: Docker build
+        run: docker compose build prestashop-git
+
+      - name: Build dependency
+        run: docker compose run --rm prestashop-git composer install --ansi --prefer-dist --no-interaction --no-progress
+
+      - name: Create base database
+        run: docker compose run --rm mysql mysql -hmysql -uroot -pprestashop -e "CREATE DATABASE presta_${{ matrix.branch }};"
+
+      - name: Install shop
+        run: docker compose run --rm prestashop-git php install-dev/index_cli.php \
+          --step=database --db_server=mysql:3306 --db_name=presta_${{ matrix.branch }} \
+          --db_user=root --db_password=prestashop --prefix=ps_ --db_clear=1 \
+          --domain=localhost:8001 --firstname="Marc" --lastname="Beier" \
+          --password=Toto123! --email=demo@prestashop.com --language=fr --country=fr \
+          --newsletter=0 --send_email=0 --ssl=0
+
+      - name: Export dump
+        run: docker compose run --rm mysql sh -c "exec mysqldump -hmysql -uroot --no-data --compact -pprestashop presta_${{ matrix.branch }}" > dump_${{ matrix.branch }}.sql
+
+      - name: Upload dump
+        uses: actions/upload-artifact@v4
+        with:
+          name: dump_${{ matrix.branch }}
+          path: |
+            dump_${{ matrix.branch }}.sql
+
+  create_diff:
+    name: Create database dumps diff
+    needs: [ install_prestashop_and_dump ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+
+      - name: Create diff
+        run: git diff ./dump_head/dump_head.sql ./dump_base/dump_base.sql > sql-diff.txt | true
+
+      - name: Upload diff
+        uses: actions/upload-artifact@v4
+        with:
+          name: sql_diff
+          path: |
+            sql-diff.txt
+
+  update_label:
+    name: Update Needs autoupgrade PR label
+    needs: [ create_diff ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+
+      - run: |
+          if [ -s sql_diff/sql-diff.txt ]; then
+            gh pr edit "$NUMBER" --add-label "$LABELS"
+          else
+            gh pr edit "$NUMBER" --remove-label "$LABELS"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}
+          LABELS: Needs autoupgrade PR


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Added a new workflow to automatically add the "needs autoupgrade PR" label to know if a modification of the database structure has been detected. The workflow allows you to remove the label automatically if not necessary. The process is very fast (less than 2 mins) and is not blocking an PR. **This is to inform contributors as well as reviewers that a PR will have to be made on the autoupgrade module**.
| Type?             | improvement
| Category?         | PM
| BC breaks?        |no
| Deprecations?     | no
| How to test?      | Create a branch from it, make modifications to the database structure (db_structure.sql file or entities) and create a PR to the starting branch to trigger the CI (example here https://github.com/M0rgan01/PrestaShop/pull/14)
| UI Tests          | -
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -

![image](https://github.com/PrestaShop/PrestaShop/assets/36233446/a95ab214-8a89-4edb-b50c-41baefe34ede)
