### PR TITLE
Fix display of available hooks for a module

### DIFF
--- a/js/admin/modules-position.js
+++ b/js/admin/modules-position.js
@@ -179,7 +179,7 @@ $(function(){
 				dataType: 'json',
 				data: {
 					action: 'getPossibleHookingListForModule',
-					tab: 'AdminModulesPositions',
+					controller: 'AdminModulesPositions',
 					ajax: 1,
 					module_id: $this.val(),
 					token: token


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | [In this PR](https://github.com/PrestaShop/PrestaShop/pull/34525), @Hlavtox removed deprecated code and made some changes. `modules-position.js` needed to updated. 
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/35612
| UI Tests          | https://github.com/nicosomb/ga.tests.ui.pr/actions/runs/8970299797
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/issues/35612 
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/34525
| Sponsor company   | PrestaShop SA 
