### PR TITLE
Remove outdated PHP conditions

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -380,22 +380,6 @@ class CookieCore
             throw new PrestaShopException('Error during setting a cookie. Combined size of name and value cannot exceed 4096 characters. Larger cookie is not compliant with RFC 2965 and will not be accepted by the browser.');
         }
 
-        /*
-         * The alternative signature supporting an options array is only available since
-         * PHP 7.3.0, before there is no support for SameSite attribute.
-         */
-        if (PHP_VERSION_ID < 70300) {
-            return setcookie(
-                $this->_name,
-                $content,
-                $time,
-                $this->_path,
-                $this->_domain . '; SameSite=' . $this->_sameSite,
-                $this->_secure,
-                true
-            );
-        }
-
         return setcookie(
             $this->_name,
             $content,

--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -297,7 +297,7 @@ abstract class DbCore
     {
         $class = '';
         /* @phpstan-ignore-next-line */
-        if (PHP_VERSION_ID >= 50200 && extension_loaded('pdo_mysql')) {
+        if (extension_loaded('pdo_mysql')) {
             $class = 'DbPDO';
         } elseif (extension_loaded('mysqli')) {
             $class = 'DbMySQLi';

--- a/src/Core/Session/SessionHandler.php
+++ b/src/Core/Session/SessionHandler.php
@@ -95,27 +95,13 @@ class SessionHandler implements SessionHandlerInterface
             return;
         }
 
-        /*
-         * The alternative signature supporting an options array is only available since
-         * PHP 7.3.0, before there is no support for SameSite attribute.
-         */
-        if (PHP_VERSION_ID < 70300) {
-            session_set_cookie_params(
-                $this->lifetime,
-                $this->path . ';SameSite=' . $this->sameSite,
-                '',
-                $this->isSecure,
-                true
-            );
-        } else {
-            session_set_cookie_params([
-                'lifetime' => $this->lifetime,
-                'path' => $this->path,
-                'secure' => $this->isSecure,
-                'httponly' => true,
-                'samesite' => $this->sameSite,
-            ]);
-        }
+        session_set_cookie_params([
+            'lifetime' => $this->lifetime,
+            'path' => $this->path,
+            'secure' => $this->isSecure,
+            'httponly' => true,
+            'samesite' => $this->sameSite,
+        ]);
 
         $this->session = new Session(new PhpBridgeSessionStorage());
         $this->session->start();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There are some conditions for unsupported PHP versions, they can be safely removed.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/8983619075
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 
