### PR TITLE
Error 500 fix for Admin Categories If description null (backport from develop)

### DIFF
--- a/src/Core/Grid/Data/Factory/AbstractCategoryDataFactory.php
+++ b/src/Core/Grid/Data/Factory/AbstractCategoryDataFactory.php
@@ -74,7 +74,9 @@ abstract class AbstractCategoryDataFactory implements GridDataFactoryInterface
     protected function modifyRecords(array $records): array
     {
         foreach ($records as $key => $record) {
-            $records[$key]['description'] = mb_substr(strip_tags(stripslashes($record['description'])), 0, self::DESCRIPTION_MAX_LENGTH);
+            if ($record['description'] !== null) {
+                $records[$key]['description'] = mb_substr(strip_tags(stripslashes($record['description'])), 0, self::DESCRIPTION_MAX_LENGTH);
+            }
         }
 
         return $records;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Error fix for stripslashes(): Argument #1 ($string) must be of type string, null given. The parameter is null after migration. Please can we use the if condition and check if it's not null? Because if it is null gives a 500 error. ORIGINAL IDEA BY @uguranium  - we should backport it to 8.1.x branch, because it's very common problem, so 8.1. customers must benefit from this fix as well, not in develop, but now.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | https://github.com/nicosomb/ga.tests.ui.pr/actions/runs/9032410643
| Fixed issue or discussion?     | 
| Related PRs       | #30922
| Sponsor company   | https://www.openservis.cz/
