### PR TITLE
Fix quantity misadjustment on status change from Canceled to any non-loggable

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -239,8 +239,14 @@ class OrderHistoryCore extends ObjectModel
                         && in_array($new_os->id, $error_or_canceled_statuses)
                         && !in_array($old_os->id, $error_or_canceled_statuses)
                     ) {
-                        // if waiting for payment => payment error/canceled
+                        // Status is changed from not loggable status as Processing in progress etc. to Payment error/Canceled
                         StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], (int) $product['product_quantity'], $order->id_shop);
+                    } elseif (!$new_os->logable && !$old_os->logable
+                        && !in_array($new_os->id, $error_or_canceled_statuses)
+                        && in_array($old_os->id, $error_or_canceled_statuses)
+                    ) {
+                        // Status is changed from Payment error/Canceled to not loggable status as Processing in progress etc.
+                        StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], -(int) $product['product_quantity'], $order->id_shop);
                     }
                 }
                 // From here, there is 2 cases : $old_os exists, and we can test shipped state evolution,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes the stock issue where the physical quantity was incorrectly increased when an order's status changed from a _Canceled_ or _Payment error_ state to any non-loggable state. More details below.
| Type?             | bug fix
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In description below
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #36024 
| Related PRs       |
| Sponsor company   | @AvalancheMedia

## How to test? 
### 1. Check the stock quantity for a selected product
![image](https://github.com/PrestaShop/PrestaShop/assets/10909419/a3e6c786-ea87-4944-baec-1efcf9e7e30b)

### 2. Create an order for the selected product
Make sure the order is in a non-loggable state, such as _Awaiting Bank Wire Payment_. Check the stock quantity for the ordered product.
![image](https://github.com/PrestaShop/PrestaShop/assets/10909419/49a4f83b-78ff-4a26-9e49-3fbcedac560e)

### 3. Change order status to _Canceled_ or _Payment error_
Recheck the stock quantity for the ordered product. At this stage everything should be correct, the stock has returned to the state before the order was created.
![image](https://github.com/PrestaShop/PrestaShop/assets/10909419/5d7c2ba4-e24d-4602-b2e8-fec961aa1976)

### 4. Change order status to any non-loggable status for example _Awaiting bank wire payment_.

#### Expected behavior:
The amount of stock should return to the same as in the second step.
![image](https://github.com/PrestaShop/PrestaShop/assets/10909419/d549f05c-0629-49fe-b753-0943ee11ab2e)

#### Behavior before bug fix:
The physical quantity was incorrectly increased by the quantity of ordered product.
![image](https://github.com/PrestaShop/PrestaShop/assets/10909419/1c811a87-b1f4-4c7a-a69c-bb6eec40689c)

### 5. Change order status again to _Canceled_ or _Payment error_

#### Expected behavior:
The stock quantity should return to the same level as it was in the third step.
![image](https://github.com/PrestaShop/PrestaShop/assets/10909419/5d7c2ba4-e24d-4602-b2e8-fec961aa1976)

#### Behavior before bug fix:
Now you've somehow generated some additional stock :)
![image](https://github.com/PrestaShop/PrestaShop/assets/10909419/221b3a23-5653-42ca-90e7-96c39fd45a65)
