### PR TITLE
Availability in structured data for products that are not available to order

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -452,6 +452,9 @@ class ProductLazyArray extends AbstractLazyArray
         // Availability for displaying discontinued products, if enabled
         if ($this->product['active'] != 1) {
             return 'https://schema.org/Discontinued';
+        // if it's not avaiblable for order
+        } elseif (!$this->product['available_for_order']) {
+            return 'https://schema.org/OutOfStock';                       
         // If product is in stock or stock management is disabled (= we have everything in stock)
         } elseif ($this->product['quantity'] > 0 || !$this->configuration->get('PS_STOCK_MANAGEMENT')) {
             return 'https://schema.org/InStock';


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | If stock management is turned off and the product is not available for ordering, InStock availability is displayed in structured data. This pull request fixes this problem.
| Type?             | bug fix 
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Stock management must be turned off, create a new product, turn off available_for_order and see what the structured data looks like


