### PR TITLE
Add pastetext to TinyMCE configuration

### DIFF
--- a/js/admin/tinymce.inc.js
+++ b/js/admin/tinymce.inc.js
@@ -47,10 +47,10 @@ function tinySetup(config) {
 
   var default_config = {
     selector: '.rte',
-    plugins: 'align colorpicker link image filemanager table media placeholder lists advlist code table autoresize',
+    plugins: 'align colorpicker link image filemanager table media placeholder lists advlist code table autoresize paste',
     browser_spellcheck: true,
     toolbar1:
-      'code,colorpicker,bold,italic,underline,strikethrough,blockquote,link,align,bullist,numlist,table,image,media,formatselect',
+      'code,colorpicker,bold,italic,underline,strikethrough,blockquote,link,align,bullist,numlist,table,image,media,formatselect,pastetext',
     toolbar2: '',
     external_filemanager_path: baseAdminDir + 'filemanager/',
     filemanager_title: 'File manager',
@@ -62,9 +62,9 @@ function tinySetup(config) {
     skin: 'prestashop',
     mobile: {
       theme: 'mobile',
-      plugins: ['lists', 'align', 'link', 'table', 'placeholder', 'advlist', 'code'],
+      plugins: ['lists', 'align', 'link', 'table', 'placeholder', 'advlist', 'code', 'paste'],
       toolbar:
-        'undo code colorpicker bold italic underline strikethrough blockquote link align bullist numlist table formatselect styleselect',
+        'undo code colorpicker bold italic underline strikethrough blockquote link align bullist numlist table formatselect styleselect pastetext',
     },
     menubar: false,
     statusbar: false,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add the paste text (paste text without formatting) in TinyMCE toolbar buttons.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Edit a product or a CMS page and see that a new button is now enabled.
| Fixed issue or discussion?     | Fix #36150 

**Before**
<img width="1022" alt="Capture d’écran 2024-05-14 à 17 02 09" src="https://github.com/PrestaShop/PrestaShop/assets/2631425/e8b6f463-b909-451a-8ef3-6c2ee611975c">

**After**
<img width="1022" alt="Capture d’écran 2024-05-14 à 17 03 29" src="https://github.com/PrestaShop/PrestaShop/assets/2631425/7aefc5fc-e286-4937-8126-2dd24d0653d8">
