### PR TITLE
Follow symlinks for traductions - Deployer best practice

### DIFF
--- a/src/PrestaShopBundle/Translation/TranslatorLanguageLoader.php
+++ b/src/PrestaShopBundle/Translation/TranslatorLanguageLoader.php
@@ -108,6 +108,7 @@ class TranslatorLanguageLoader
                 ->files()
                 ->name('*.' . $locale . '.xlf')
                 ->notName($this->isAdminContext ? '^Shop*' : '^Admin*')
+				->followLinks()
                 ->in($directory);
 
             foreach ($finder as $file) {
@@ -156,6 +157,7 @@ class TranslatorLanguageLoader
         $modulesCatalogueFinder = Finder::create()
             ->files()
             ->name($filenamePattern)
+			->followLinks()
             ->in($translationDir);
 
         foreach ($modulesCatalogueFinder as $file) {

--- a/src/PrestaShopBundle/Translation/TranslatorLanguageLoader.php
+++ b/src/PrestaShopBundle/Translation/TranslatorLanguageLoader.php
@@ -108,7 +108,7 @@ class TranslatorLanguageLoader
                 ->files()
                 ->name('*.' . $locale . '.xlf')
                 ->notName($this->isAdminContext ? '^Shop*' : '^Admin*')
-				->followLinks()
+                ->followLinks()
                 ->in($directory);
 
             foreach ($finder as $file) {
@@ -157,7 +157,7 @@ class TranslatorLanguageLoader
         $modulesCatalogueFinder = Finder::create()
             ->files()
             ->name($filenamePattern)
-			->followLinks()
+            ->followLinks()
             ->in($translationDir);
 
         foreach ($modulesCatalogueFinder as $file) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The Finder used to search translation files does not follow symlinks by default. This is a major issue when working with modern and robust solutions like Deployer. On these environments, each GIT release is in a specific folder, and the "living" files (traductions, images...) are in a common shared folder. Symlinks are then created to point to the shared folder. Currently, all translation files are ignored by PrestaShop, as they are symlinks. This PR aims to integrate them.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Move a traduction file from app/Resources/translations or from your theme to somewhere else, and make a symlink to it (ie: ln -fs /moved_file /original/location)
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #36161
| Related PRs       | 
| Sponsor company   | KIWIK (kiwik.com)
