### PR TITLE
Fixes #36185 : Admin hooks of format "display#controller_name#Form" on legacy admin forms are not executed

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2618,7 +2618,7 @@ class AdminControllerCore extends Controller
         $helper->override_folder = $this->tpl_folder;
         $helper->currentIndex = self::$currentIndex;
         $helper->table = $this->table;
-        if ($helper->name_controller === null) {
+        if ($helper->name_controller === null || empty($helper->name_controller)) {
             $helper->name_controller = Tools::getValue('controller');
         }
         $helper->identifier = $this->identifier;


### PR DESCRIPTION
Fixes #36185

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See #36185 : Admin hooks of format "display#controller_name#Form" on legacy admin forms are not executed
| Type?             | bug fix
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #36185
| Fixed issue or discussion?     | Fixes #36185
| Related PRs       | --
| Sponsor company   | PliciWeb
