### PR TITLE
Stabilise UI tests and nightly

### DIFF
--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -60,6 +60,9 @@ if [ "${DISABLE_MAKE}" != "1" ]; then
 
   echo "\n* Build assets ...";
   runuser -g www-data -u www-data -- /usr/bin/make assets
+
+  echo "\n* Wait for assets built...";
+  /usr/bin/make wait-assets
 else
   echo "\n* Build of assets was disabled...";
 fi

--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -56,7 +56,7 @@ if [ "${DISABLE_MAKE}" != "1" ]; then
   runuser -g www-data -u www-data -- php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');" && php /tmp/composer-setup.php --no-ansi --install-dir=/usr/local/bin --filename=composer && rm -rf /tmp/composer-setup.php
 
   echo "\n* Running composer ...";
-  runuser -g www-data -u www-data -- /usr/local/bin/composer install --no-interaction
+  runuser -g www-data -u www-data -- /usr/bin/make composer
   if [ $? -ne 0]; then
     echo Composer install failed
     exit 1

--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -57,6 +57,10 @@ if [ "${DISABLE_MAKE}" != "1" ]; then
 
   echo "\n* Running composer ...";
   runuser -g www-data -u www-data -- /usr/local/bin/composer install --no-interaction
+  if [ $? -ne 0]; then
+    echo Composer install failed
+    exit 1
+  fi
 
   echo "\n* Build assets ...";
   runuser -g www-data -u www-data -- /usr/bin/make assets

--- a/.github/actions/setup-env-export-logs/action.yml
+++ b/.github/actions/setup-env-export-logs/action.yml
@@ -1,0 +1,35 @@
+name: Export logs from the setup env action
+description: Export logs from the setup env action, usually on failure
+
+inputs:
+  DOCKER_PREFIX:
+    required: true
+    description: Docker prefix for prestashop containers
+  ARTIFACT_NAME:
+    required: false
+    description: Artifact exported name
+    default: setup-logs
+
+runs:
+  using: 'composite'
+  steps:
+    - name: List dockers
+      run: |
+        docker ps
+      shell: bash
+
+    - name: Export docker logs
+      run: |
+        ls -l ./var/logs
+        mkdir -p ./var/docker-logs
+        docker logs ${{ inputs.DOCKER_PREFIX }}-mysql-1 > ./var/docker-logs/mysql.log
+        docker logs ${{ inputs.DOCKER_PREFIX }}-prestashop-git-1 > ./var/docker-logs/prestashop.log
+      shell: bash
+
+    - name: Save logs in case of error
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.ARTIFACT_NAME }}
+        path: |
+          ./var/logs
+          ./var/docker-logs

--- a/.github/actions/setup-env-export-logs/action.yml
+++ b/.github/actions/setup-env-export-logs/action.yml
@@ -20,7 +20,6 @@ runs:
 
     - name: Export docker logs
       run: |
-        ls -l ./var/logs
         mkdir -p ./var/docker-logs
         docker logs ${{ inputs.DOCKER_PREFIX }}-mysql-1 > ./var/docker-logs/mysql.log
         docker logs ${{ inputs.DOCKER_PREFIX }}-prestashop-git-1 > ./var/docker-logs/prestashop.log

--- a/.github/workflows/api-module.yml
+++ b/.github/workflows/api-module.yml
@@ -63,11 +63,11 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Composer Install
-        run: composer install --ansi --prefer-dist --no-interaction --no-progress
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
 
       - name: Update phpunit version
         if: ${{ startsWith(matrix.php, '8.') }}
-        run: composer update -w --ignore-platform-reqs --no-interaction phpunit/phpunit
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer update -w --ignore-platform-reqs --no-interaction phpunit/phpunit
 
       # Front assets are needed for the theme to be installed and image types to be inserted in DB, admin assets required
       # because some built files (like preload.html.twig) are included and cause errors when absent

--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -63,7 +63,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Composer Install
-        run: composer install --ansi --prefer-dist --no-interaction --no-progress
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
 
       - name: Build theme assets
         run: make front-classic

--- a/.github/workflows/cron_js_routing.yml
+++ b/.github/workflows/cron_js_routing.yml
@@ -84,7 +84,7 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Install Composer dependencies
-        run: composer install --prefer-dist
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --prefer-dist
 
       - name: Build assets
         run: make assets

--- a/.github/workflows/cron_nightly_tests_reusable.yml
+++ b/.github/workflows/cron_nightly_tests_reusable.yml
@@ -192,6 +192,12 @@ jobs:
           ENABLE_SSL: ${{ env.ENABLE_SSL }}
           INSTALL_AUTO: ${{ env.INSTALL_AUTO }}
           CP_API_CONFIG: ${{ (env.GH_BRANCH == '8.1.x') && 'true' || 'false' }}
+      - name: Setup Environment failure
+        uses: ./.github/actions/setup-env-export-logs
+        with:
+          DOCKER_PREFIX: prestashop
+          ARTIFACT_NAME: setup-nightly-${{ matrix.BRANCH }}-${{ matrix.CAMPAIGN }}
+        if: failure()
 
       # Keycloak is only needed for API campaign
       - name: Setup Keycloak

--- a/.github/workflows/cron_php_update_modules.yml
+++ b/.github/workflows/cron_php_update_modules.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install Composer dependencies
         run: |
           composer self-update --stable
-          composer install --prefer-dist
+          COMPOSER_PROCESS_TIMEOUT=600 composer install --prefer-dist
 
       - name: Install NPM dependencies
         working-directory: ./tests/UI

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -63,11 +63,11 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Composer Install
-        run: composer install --ansi --prefer-dist --no-interaction --no-progress
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
 
       - name: Update phpunit version
         if: ${{ startsWith(matrix.php, '8.') }}
-        run: composer update -w --ignore-platform-reqs --no-interaction phpunit/phpunit
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer update -w --ignore-platform-reqs --no-interaction phpunit/phpunit
 
       # Front assets are needed for the theme to be installed and image types to be inserted in DB, admin assets required especially
       # because some built files (like preload.html.twig) are included and cause errors when absent

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -74,7 +74,7 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Composer Install
-        run: composer install --ansi --prefer-dist --no-interaction --no-progress
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
 
       - name: Run Lint Yaml on `app`
         run: php bin/console lint:yaml app --parse-tags
@@ -134,7 +134,7 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Composer Install
-        run: composer install --ansi --prefer-dist --no-interaction --no-progress
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
 
       - name: Run Lint Twig
         run: php bin/console lint:twig src/PrestaShopBundle/Resources/views/

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -39,7 +39,7 @@ jobs:
         run: composer validate --strict
 
       - name: Composer Install
-        run: composer install --ansi --prefer-dist --no-interaction --no-progress
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
 
       - name: Run PHPCSFixer
         run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
@@ -80,7 +80,7 @@ jobs:
 
       - name: Composer Install
         run: |
-          composer install --ansi --prefer-dist --no-interaction --no-progress
+          COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
           rm composer.lock
           composer config platform.php ${{ matrix.php }}
 
@@ -121,11 +121,11 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Composer Install
-        run: composer install --ansi --prefer-dist --no-interaction --no-progress
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
 
       - name: Update phpunit version
         if: ${{ startsWith(matrix.php, '8.') }}
-        run: composer update -w --ignore-platform-reqs --no-interaction phpunit/phpunit
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer update -w --ignore-platform-reqs --no-interaction phpunit/phpunit
 
       - name: Run phpunit
         run: ./vendor/phpunit/phpunit/phpunit -c tests/Unit/phpunit.xml

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -34,6 +34,12 @@ jobs:
           PHP_VERSION: ${{ matrix.php }}
           ENABLE_SSL: 'true'
           INSTALL_AUTO: 'false'
+      - name: Setup Environment failure
+        uses: ./.github/actions/setup-env-export-logs
+        with:
+          DOCKER_PREFIX: prestashop
+          ARTIFACT_NAME: setup-sanity-${{ matrix.php }}-${{ matrix.browser }}
+        if: failure()
 
       - name: Run Tests
         uses: ./.github/actions/ui-test
@@ -52,7 +58,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: sanity-${{ matrix.php }}
+          name: sanity-${{ matrix.php }}-${{ matrix.browser }}
           path: |
             ./tests/UI/screenshots/
             ./var/logs

--- a/.github/workflows/symfony-console.yml
+++ b/.github/workflows/symfony-console.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Composer Install
-        run: composer install --ansi --prefer-dist --no-interaction --no-progress
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
 
       - name: Check bin/console can run without shop install and cache clear without app ID (only for admin job since it is the default value)
         if: matrix.app-id == 'admin'

--- a/.github/workflows/symfony-console.yml
+++ b/.github/workflows/symfony-console.yml
@@ -99,6 +99,12 @@ jobs:
           PHP_VERSION: 8.1
           ENABLE_SSL: 'true'
           INSTALL_AUTO: 'false'
+      - name: Setup Environment failure
+        uses: ./.github/actions/setup-env-export-logs
+        with:
+          DOCKER_PREFIX: prestashop
+          ARTIFACT_NAME: setup-symfony-console-${{ matrix.app-id }}
+        if: failure()
 
       # Retest the console after shop install
       - name: Check bin/console and cache:clear can run after shop install

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ composer: ## Install PHP dependencies
 assets:  ## Rebuilds all the static assets, running npm install-clean as needed
 	./tools/assets/build.sh
 
+wait-assets:
+	./tools/assets/wait-build.sh
+
 front-core: ## Building core theme assets
 	./tools/assets/build.sh front-core
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ help: ## Display this help menu
 install: composer assets  ## Install PHP dependencies and build the static assets
 
 composer: ## Install PHP dependencies
-	composer install
+	COMPOSER_PROCESS_TIMEOUT=600 composer install --no-interaction
 	./bin/console cache:clear --no-warmup
 
 assets:  ## Rebuilds all the static assets, running npm install-clean as needed

--- a/tools/assets/build.sh
+++ b/tools/assets/build.sh
@@ -19,6 +19,10 @@ function build {
     echo "Parameter is empty"
     exit 1
   fi
+  if [[ ! -d $1 ]]; then
+     echo $1 folder not found
+     exit 1
+  fi
 
   pushd $1
   if [[ -d "node_modules" ]]; then

--- a/tools/assets/build.sh
+++ b/tools/assets/build.sh
@@ -25,8 +25,10 @@ function build {
     rm -rf node_modules
   fi
 
+  touch buildLock
   npm ci
   npm run build
+  rm buildLock
   popd
 }
 

--- a/tools/assets/wait-build.sh
+++ b/tools/assets/wait-build.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+###
+# This script waits for assets to be built by checking the presence of the buildLock file
+#
+
+#http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+PROJECT_PATH=$(cd "$( dirname "$0" )/../../" && pwd)
+ADMIN_DIR="${PROJECT_PATH}/${ADMIN_DIR:-admin-dev}"
+
+if [[ ! -d $ADMIN_DIR ]]; then
+  echo "Could not find directory '$ADMIN_DIR'. Make sure to launch this script from the root directory of PrestaShop"
+  return 1
+fi
+
+if test $# -gt 0; then
+  case $1 in
+    admin-default)
+      echo ">>> Waiting for admin default theme..."
+      buildLocks="$ADMIN_DIR/themes/default/buildLock"
+    ;;
+    admin-new-theme)
+      echo ">>> Waiting for admin new theme..."
+      buildLocks="$ADMIN_DIR/themes/new-theme/buildLock"
+    ;;
+    front-core)
+      echo ">>> Waiting for core theme assets..."
+      buildLocks="$PROJECT_PATH/themes/buildLock"
+    ;;
+    front-classic)
+      echo ">>> Waiting for classic theme assets..."
+      buildLocks="$PROJECT_PATH/themes/classic/_dev/buildLock"
+    ;;
+    all)
+      echo ">>> Waiting for all assets..."
+      buildLocks="$ADMIN_DIR/themes/default/buildLock $ADMIN_DIR/themes/new-theme/buildLock $PROJECT_PATH/themes/classic/_dev/buildLock $PROJECT_PATH/themes/buildLock"
+    ;;
+    *)
+      echo "Unknown asset to wait $1"
+      exit 1
+    ;;
+  esac
+else
+  echo ">>> Waiting for all assets..."
+  buildLocks="$ADMIN_DIR/themes/default/buildLock $ADMIN_DIR/themes/new-theme/buildLock $PROJECT_PATH/themes/classic/_dev/buildLock $PROJECT_PATH/themes/buildLock"
+fi
+
+echo Checking for all these lock files $buildLocks
+for lockFile in $buildLocks; do
+  if [ -f $lockFile ]; then
+    echo Wait for $lockFile to be removed
+    sleep 1
+    while [ -f $lockFile ]; do
+      echo $lockFile still present wait a bit more
+      sleep 1
+    done
+  fi
+  echo $lockFile is no longer present
+done


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add log exports after environment setup, add waiting script in docker initialization to make sure assets are built before the web server is started, increase composer timeout
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green UI tests without cache OK
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/9212020695
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
