### PR TITLE
Fix wiping module cache

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -330,7 +330,6 @@ abstract class ModuleCore implements ModuleInterface
         // If the module has the name we load the corresponding data from the cache
         // Also we can assign some properties like path
         if ($this->name != null) {
-
             // Assign paths and uris
             $this->_path = __PS_BASE_URI__ . 'modules/' . $this->name . '/';
             $this->local_path = _PS_MODULE_DIR_ . $this->name . '/';
@@ -339,7 +338,7 @@ abstract class ModuleCore implements ModuleInterface
             if (static::$modules_cache === null) {
                 static::$modules_cache = [];
 
-                /* 
+                /*
                  * We select all activation statuses and data from module table and store it for future use.
                  * In case of multiple shops, we will always use the cached data.
                  */
@@ -356,7 +355,7 @@ abstract class ModuleCore implements ModuleInterface
                             'name' => $row['name'],
                         ];
                     }
-                    
+
                     // And store activation status
                     static::$modules_cache[$row['name']]['active'][] = $row['id_shop'];
                 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Improves loading performance by avoiding wiping module cache in some cases. Details below.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Test page load in FO with profiler. You will see fewer SQL requests.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/10685330569
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   |

### Details
Check profiler on any shop and you will see that there will be this query several times.

```sql
SELECT m.`id_module`, m.`name`, ms.`id_module`as `mshop`
                FROM `ps_module` m
                LEFT JOIN `ps_module_shop` ms
                ON m.`id_module` = ms.`id_module`
                AND ms.`id_shop` = XX
```

This query is coming from constructor in Module class. It's purpose is to load module ID and if it's active from database and store it into `static::$modules_cache`, so it can be later assigned from this cache to the module instance, on it's creation.
 https://github.com/PrestaShop/PrestaShop/blob/c10bd6317b22f45742cbae3b1017b4b505b310cf/classes/module/Module.php#L338

However, in the beginning of page load, until controller is initialized, this cache is wiped several times (5 in my case), because of this line. 

https://github.com/PrestaShop/PrestaShop/blob/c10bd6317b22f45742cbae3b1017b4b505b310cf/classes/module/Module.php#L362

This line was introduced in https://github.com/PrestaShop/PrestaShop/pull/3485, because in the beginning of the request process, when there is no `$this->context->shop->id` initialized yet, the cache could be retrieved for a default shop ID, instead of the one we are using.

https://github.com/PrestaShop/PrestaShop/blob/c10bd6317b22f45742cbae3b1017b4b505b310cf/classes/module/Module.php#L334

This may have worked, but it creates duplicate queries and is kinda a hackjob. `!$this->context->controller instanceof Controller` doesn't really mean the shop_id is ready.

### So, what I did to improve this and keep it working like it should
What I did was to change the query a bit so it loads the active statuses for all shops.

```
SELECT m.`id_module`, m.`name`, ms.`id_shop` as `id_shop`
FROM `ps_module` m
LEFT JOIN `ps_module_shop` ms ON m.`id_module` = ms.`id_module`
```

Then I store the active properties into the cache for all shops.

So, then whatever shop ID is used when constructing the module, it won't need to run this query again.

### Real world performance
On https://eshop-franke.cz/, I got down from 110 to 105 queries and few ms saved. Small piece in a puzzle.

![Snímek obrazovky 2024-05-23 143707](https://github.com/PrestaShop/PrestaShop/assets/6097524/99bcdbb7-32d4-409f-82e7-8f7e959603ed)
