### PR TITLE
Fix the reformating of legacy controller class name

### DIFF
--- a/src/PrestaShopBundle/Routing/LegacyRouterChecker.php
+++ b/src/PrestaShopBundle/Routing/LegacyRouterChecker.php
@@ -125,8 +125,8 @@ class LegacyRouterChecker
         $request->attributes->set(LegacyControllerConstants::IS_MODULE_ATTRIBUTE, $isModule);
 
         // Strip the ending Controller part
-        if (str_ends_with('Controller', $controllerName)) {
-            $controllerName = substr($controllerName, strrpos($controllerName, 'Controller'));
+        if (str_ends_with($controllerName, 'Controller')) {
+            $controllerName = substr($controllerName, 0, -strlen('Controller'));
         }
         $request->attributes->set(LegacyControllerConstants::CONTROLLER_NAME_ATTRIBUTE, $controllerName);
         $request->attributes->set(LegacyControllerConstants::CONTROLLER_ACTION_ATTRIBUTE, $this->getPermission($request, $controller->table ?? ''));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix the reformating of legacy controller class name ending with controller so it matches the rols in DB
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/9222988273
| Fixed issue or discussion?     | Fixes #36212
| Related PRs       | ~
| Sponsor company   | ~
