### PR TITLE
Stabilise CI and docker initialisation

### DIFF
--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -54,13 +54,13 @@ if [ "${DISABLE_MAKE}" != "1" ]; then
   mkdir -p /var/www/.composer
   chown -R www-data:www-data /var/www/.composer
   runuser -g www-data -u www-data -- php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');" && php /tmp/composer-setup.php --no-ansi --install-dir=/usr/local/bin --filename=composer && rm -rf /tmp/composer-setup.php
+  if [ ! -f /usr/local/bin/composer ]; then
+    echo Composer installation failed
+    exit 1
+  fi
 
   echo "\n* Running composer ...";
   COMPOSER_PROCESS_TIMEOUT=600 runuser -g www-data -u www-data -- /usr/local/bin/composer install --ansi --prefer-dist --no-interaction --no-progress
-  if [ $? -ne 0]; then
-    echo Composer install failed
-    exit 1
-  fi
 
   echo "\n* Build assets ...";
   runuser -g www-data -u www-data -- /usr/bin/make assets

--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -56,7 +56,7 @@ if [ "${DISABLE_MAKE}" != "1" ]; then
   runuser -g www-data -u www-data -- php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');" && php /tmp/composer-setup.php --no-ansi --install-dir=/usr/local/bin --filename=composer && rm -rf /tmp/composer-setup.php
 
   echo "\n* Running composer ...";
-  COMPOSER_PROCESS_TIMEOUT=600 runuser -g www-data -u www-data -- /usr/local/bin/composer install --no-interaction
+  COMPOSER_PROCESS_TIMEOUT=600 runuser -g www-data -u www-data -- /usr/local/bin/composer install --ansi --prefer-dist --no-interaction --no-progress
   if [ $? -ne 0]; then
     echo Composer install failed
     exit 1

--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -60,7 +60,8 @@ if [ "${DISABLE_MAKE}" != "1" ]; then
   fi
 
   echo "\n* Running composer ...";
-  COMPOSER_PROCESS_TIMEOUT=600 runuser -g www-data -u www-data -- /usr/local/bin/composer install --ansi --prefer-dist --no-interaction --no-progress
+  export COMPOSER_PROCESS_TIMEOUT=600
+  runuser -g www-data -u www-data -- /usr/local/bin/composer install --ansi --prefer-dist --no-interaction --no-progress
 
   echo "\n* Build assets ...";
   runuser -g www-data -u www-data -- /usr/bin/make assets

--- a/.github/workflows/create_diff_for_autoupgrade_pr_label.yml
+++ b/.github/workflows/create_diff_for_autoupgrade_pr_label.yml
@@ -33,7 +33,7 @@ jobs:
         run: COMPOSER_PROCESS_TIMEOUT=600 docker compose run --rm prestashop-git composer install --ansi --prefer-dist --no-interaction --no-progress --no-dev
 
       - name: Waiting for database
-        run: ./.docker/wait-for-it.sh --timeout=60 --strict localhost:3306
+        run: docker compose run --rm prestashop-git /tmp/wait-for-it.sh --timeout=60 --strict mysql:3306
 
       - name: Create base database
         run: docker compose run --rm mysql mysql -hmysql -uroot -pprestashop -e "CREATE DATABASE presta_${{ matrix.branch }};"

--- a/.github/workflows/create_diff_for_autoupgrade_pr_label.yml
+++ b/.github/workflows/create_diff_for_autoupgrade_pr_label.yml
@@ -30,7 +30,7 @@ jobs:
         run: docker compose build prestashop-git
 
       - name: Fetch dependencies
-        run: docker compose run --rm prestashop-git composer install --ansi --prefer-dist --no-interaction --no-progress
+        run: COMPOSER_PROCESS_TIMEOUT=600 docker compose run --rm prestashop-git composer install --ansi --prefer-dist --no-interaction --no-progress --no-dev
 
       - name: Waiting for database
         run: ./.docker/wait-for-it.sh --timeout=60 --strict localhost:3306

--- a/.github/workflows/cron_js_routing.yml
+++ b/.github/workflows/cron_js_routing.yml
@@ -84,7 +84,7 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Install Composer dependencies
-        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --prefer-dist
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
 
       - name: Build assets
         run: make assets

--- a/.github/workflows/cron_php_update_modules.yml
+++ b/.github/workflows/cron_php_update_modules.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install Composer dependencies
         run: |
           composer self-update --stable
-          COMPOSER_PROCESS_TIMEOUT=600 composer install --prefer-dist
+          COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
 
       - name: Install NPM dependencies
         working-directory: ./tests/UI

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -46,7 +46,7 @@ ini_set('default_charset', 'utf-8');
 /* in dev mode - check if composer was executed */
 if (is_dir(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'admin-dev') && (!is_dir(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'vendor') ||
         !file_exists(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php'))) {
-    die('Error : please install <a href="https://getcomposer.org/">composer</a>. Then run "php composer.phar install"');
+    die('Config check Error : please install <a href="https://getcomposer.org/">composer</a>. Then run "php composer.phar install"');
 }
 
 /* No settings file? goto installer... */

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -83,7 +83,7 @@ if (!defined('_PS_CORE_DIR_')) {
 /* in dev mode - check if composer was executed */
 if ((!is_dir(_PS_CORE_DIR_ . DIRECTORY_SEPARATOR . 'vendor') ||
     !file_exists(_PS_CORE_DIR_ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php'))) {
-    die('Error : please install <a href="https://getcomposer.org/">composer</a>. Then run "php composer.phar install"');
+    die('Init Install Error : please install <a href="https://getcomposer.org/">composer</a>. Then run "php composer.phar install"');
 }
 
 require_once _PS_CORE_DIR_ . '/config/defines.inc.php';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Stabilise CI and docker initialisation:<br>- increase composer timeout everywhere<br>- wait for composer install to be finished in docker initialization<br>- improve wait-for-it script to better check the status of the MySQL server
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | ~
| UI Tests          | With cache: https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/9319496351<br>Without cache: https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/9318935221
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
