### PR TITLE
Fix OrderConfirmationController redirection url for slow validation payments

### DIFF
--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -90,10 +90,10 @@ class OrderConfirmationControllerCore extends FrontController
         // The confirmation link must contain a unique order secure key matching the key saved in database,
         // this prevents user to view other customer's order confirmations
         if (!$this->id_order || !$this->id_module || !$this->secure_key || empty($this->secure_key)) {
-            if(stristr($redirectLink, '?')) {
-                Tools::redirect($redirectLink . '&slowvalidation');
+            if(Tools::isSubmit('slowvalidation')){
+                Tools::redirect($this->context->link->getPageLink('history', null, null, ['slowvalidation' => '1']));
             } else {
-                Tools::redirect($redirectLink . '?slowvalidation');
+                Tools::redirect($redirectLink);
             }
         }
 

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -90,7 +90,7 @@ class OrderConfirmationControllerCore extends FrontController
         // The confirmation link must contain a unique order secure key matching the key saved in database,
         // this prevents user to view other customer's order confirmations
         if (!$this->id_order || !$this->id_module || !$this->secure_key || empty($this->secure_key)) {
-            Tools::redirect($redirectLink . (Tools::isSubmit('slowvalidation') ? '&slowvalidation' : ''));
+            Tools::redirect($redirectLink . (Tools::isSubmit('slowvalidation') ? (stristr($redirectLink,'?')?'&':'?').'slowvalidation' : ''));
         }
 
         if (!Validate::isLoadedObject($this->order) || $this->secure_key != $this->order->secure_key) {

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -90,7 +90,11 @@ class OrderConfirmationControllerCore extends FrontController
         // The confirmation link must contain a unique order secure key matching the key saved in database,
         // this prevents user to view other customer's order confirmations
         if (!$this->id_order || !$this->id_module || !$this->secure_key || empty($this->secure_key)) {
-            Tools::redirect($redirectLink . (Tools::isSubmit('slowvalidation') ? (stristr($redirectLink,'?')?'&':'?').'slowvalidation' : ''));
+            if(stristr($redirectLink, '?')) {
+                Tools::redirect($redirectLink . '&slowvalidation');
+            } else {
+                Tools::redirect($redirectLink . '?slowvalidation');
+            }
         }
 
         if (!Validate::isLoadedObject($this->order) || $this->secure_key != $this->order->secure_key) {

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -90,7 +90,7 @@ class OrderConfirmationControllerCore extends FrontController
         // The confirmation link must contain a unique order secure key matching the key saved in database,
         // this prevents user to view other customer's order confirmations
         if (!$this->id_order || !$this->id_module || !$this->secure_key || empty($this->secure_key)) {
-            if(Tools::isSubmit('slowvalidation')){
+            if (Tools::isSubmit('slowvalidation')) {
                 Tools::redirect($this->context->link->getPageLink('history', null, null, ['slowvalidation' => '1']));
             } else {
                 Tools::redirect($redirectLink);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I've changed slowvalidation redirect because if there's no query string in `$redirectLink` the user is redirected to `www.domain.com/order-history&slowvalidation` which result in a 404 not found. With this change will be redirected to `www.domain.com/order-history?slowvalidation`.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | @Hlavtox See the code, UI tests are sufficient.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/10079450307 ✅ 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 




