### PR TITLE
Fix compatibility error on ARM processors when installing via docker  

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ volumes:
 services:
   mysql:
     image: mysql:5
+    platform: linux/amd64
     ports:
       - "3306"
     volumes:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | When running on a M1 macbook (or arm processor in general) docker would look for an ARM image for mysql 5, that doesn't exist, in this PR we specify the architecture
| Type?             | bug fix 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Checkout this PR on an arm macbook, then do `docker compose up`, it should work 
| UI Tests          | none
| Fixed issue or discussion?     | none #0000
| Related PRs       | none
| Sponsor company   | PrestaShop SA