### PR TITLE
Fix order message not visible in admin

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -514,7 +514,7 @@ abstract class PaymentModuleCore extends Module
              */
             $messagesToStoreInTheThread = [];
 
-            /* 
+            /*
              * First, the message from $message method parameter. We will create new message object
              * and mark it, so we can also create a thread from this.
              */
@@ -532,8 +532,8 @@ abstract class PaymentModuleCore extends Module
                 }
             }
 
-            /* 
-             * Second, the message already set on the cart. The message object already exists, so we will just update
+            /*
+             * Second, the message already set on the cart. The Message object already exists, so we will just update
              * it with the new order ID we got.
              */
             $old_message = Message::getMessageByCartId((int) $this->context->cart->id);
@@ -545,8 +545,8 @@ abstract class PaymentModuleCore extends Module
             }
 
             /*
-             * And finally, we will create a customer thread, so we have the messages stored in the "new way"
-             * and we can see them in backoffice
+             * And finally, we will create a CustomerThread, so we have the messages stored in the "new way"
+             * and we can see them in backoffice.
              */
             if (!empty($messagesToStoreInTheThread)) {
                 $customerThread = new CustomerThread();

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -37,7 +37,7 @@ Feature: Order from Back Office (BO)
       | payment module name | dummy_payment              |
       | status              | Awaiting bank wire payment |
 
-  Scenario: Check customer message can be null
+  Scenario: Check customer message can be empty and will contain the second message
     When I create an empty cart "dummy_cart2" for customer "testCustomer"
     And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart2"
     And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart2"
@@ -46,7 +46,7 @@ Feature: Order from Back Office (BO)
       | message             |                             |
       | payment module name | dummy_payment               |
       | status              | Awaiting bank wire payment  |
-    Then order "bo_order2" must have no customer message
+    Then order "bo_order2" must have customer message with content "Manual order -- Employee: P. Daddy"
 
   Scenario: Check customer message is saved when creating an order
     When I create an empty cart "dummy_cart2" for customer "testCustomer"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Order message that is passed as `$message` attribute (example - message about manual order) into `PaymentModule::validateOrder` method is not saved into a customer thread, thus not visible in order detail in backoffice. Standard order note was migrated from the legacy `Message` object into `CustomerThread`/`CustomerMessage`, but this one is not. While I was at it, I removed some unused code in PaymentModule.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create order from backoffice and check that you can see both messages on order detail.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/9659035153 ✅ 
| Fixed issue or discussion?     | Fixes #9676
| Related PRs       | 
| Sponsor company   | 

### Known issues
Although the message is marked as private, it looks like any other message, because of styling issues. The styling of message that has `id_employee = 0` AND `private = true` will be resolved in another PR.

### How does it look
![Snímek obrazovky 2024-05-31 185245](https://github.com/PrestaShop/PrestaShop/assets/6097524/fec71252-59f9-4e8d-9ed7-dc16a77da192)
