### PR TITLE
Fix issue with Product Customizations

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1129,7 +1129,8 @@ class CartCore extends ObjectModel
             isset($productRow['id_product_attribute']) ? (int) $productRow['id_product_attribute'] : 0,
             true,
             false,
-            true
+            true,
+            isset($productRow['id_customization']) ? (int) $productRow['id_customization'] : 0
         );
 
         $orderPrices['price_without_reduction_without_tax'] = Product::getPriceFromOrder(
@@ -1138,7 +1139,8 @@ class CartCore extends ObjectModel
             isset($productRow['id_product_attribute']) ? (int) $productRow['id_product_attribute'] : 0,
             false,
             false,
-            true
+            true,
+            isset($productRow['id_customization']) ? (int) $productRow['id_customization'] : 0
         );
 
         $orderPrices['price_with_reduction'] = Product::getPriceFromOrder(
@@ -1147,7 +1149,8 @@ class CartCore extends ObjectModel
             isset($productRow['id_product_attribute']) ? (int) $productRow['id_product_attribute'] : 0,
             true,
             true,
-            true
+            true,
+            isset($productRow['id_customization']) ? (int) $productRow['id_customization'] : 0
         );
 
         $orderPrices['price'] = $orderPrices['price_with_reduction_without_tax'] = Product::getPriceFromOrder(
@@ -1156,7 +1159,8 @@ class CartCore extends ObjectModel
             isset($productRow['id_product_attribute']) ? (int) $productRow['id_product_attribute'] : 0,
             false,
             true,
-            true
+            true,
+            isset($productRow['id_customization']) ? (int) $productRow['id_customization'] : 0
         );
 
         // If the product price was not found in the order, use cart prices as fallback

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4058,7 +4058,7 @@ class ProductCore extends ObjectModel
         bool $withTaxes,
         bool $useReduction,
         bool $withEcoTax,
-        int $ustomizationId = 0
+        int $customizationId = 0
     ): ?float {
         $sql = new DbQuery();
         $sql->select('od.*, t.rate AS tax_rate');

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4069,7 +4069,7 @@ class ProductCore extends ObjectModel
             $sql->where('od.`product_attribute_id` = ' . $combinationId);
         }
         if (Customization::isFeatureActive()) {
-            $sql->where('od.`id_customization` = ' . $ustomizationId);
+            $sql->where('od.`id_customization` = ' . $customizationId);
         }
         $sql->leftJoin('order_detail_tax', 'odt', 'odt.id_order_detail = od.id_order_detail');
         $sql->leftJoin('tax', 't', 't.id_tax = odt.id_tax');

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4057,7 +4057,8 @@ class ProductCore extends ObjectModel
         int $combinationId,
         bool $withTaxes,
         bool $useReduction,
-        bool $withEcoTax
+        bool $withEcoTax,
+        int $ustomizationId = 0
     ): ?float {
         $sql = new DbQuery();
         $sql->select('od.*, t.rate AS tax_rate');
@@ -4066,6 +4067,9 @@ class ProductCore extends ObjectModel
         $sql->where('od.`product_id` = ' . $productId);
         if (Combination::isFeatureActive()) {
             $sql->where('od.`product_attribute_id` = ' . $combinationId);
+        }
+        if (Customization::isFeatureActive()) {
+            $sql->where('od.`id_customization` = ' . $ustomizationId);
         }
         $sql->leftJoin('order_detail_tax', 'odt', 'odt.id_order_detail = od.id_order_detail');
         $sql->leftJoin('tax', 't', 't.id_tax = odt.id_tax');

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -207,7 +207,8 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
                 $command->getProductId()->getValue(),
                 null !== $command->getCombinationId() ? $command->getCombinationId()->getValue() : 0,
                 $command->getProductPriceTaxExcluded(),
-                $command->getProductPriceTaxIncluded()
+                $command->getProductPriceTaxIncluded(),
+                0
             );
             StockAvailable::synchronize($product->id);
 

--- a/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
@@ -119,7 +119,8 @@ final class UpdateProductInOrderHandler extends AbstractOrderCommandHandler impl
                 (int) $orderDetail->product_id,
                 (int) $orderDetail->product_attribute_id,
                 $command->getPriceTaxExcluded(),
-                $command->getPriceTaxIncluded()
+                $command->getPriceTaxIncluded(),
+                (int) $orderDetail->id_customization
             );
 
             // Update invoice, quantity and amounts

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -389,7 +389,7 @@ class OrderAmountUpdater
      *
      * @return array
      */
-    private function getProductFromCart(array $cartProducts, int $productId, int $productAttributeId,int $customizationId = 0): array
+    private function getProductFromCart(array $cartProducts, int $productId, int $productAttributeId, int $customizationId = 0): array
     {
         $cartProduct = array_reduce($cartProducts, function ($carry, $item) use ($productId, $productAttributeId, $customizationId) {
             if (null !== $carry) {

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -400,7 +400,7 @@ class OrderAmountUpdater
             $combinationMatch = $item['id_product_attribute'] == $productAttributeId;
             $customizationMatch = $item['id_customization'] == $customizationId;
 
-            return $productMatch && $customizationMatch && $customizationMatch ? $item : null;
+            return $productMatch && $combinationMatch && $customizationMatch ? $item : null;
         });
 
         // This shouldn't happen, if it does something was not done before updating the Order (removing an OrderDetail maybe)

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -398,9 +398,9 @@ class OrderAmountUpdater
 
             $productMatch = $item['id_product'] == $productId;
             $combinationMatch = $item['id_product_attribute'] == $productAttributeId;
-            $combinationMatch = $combinationMatch && $item['id_customization'] == $customizationId;
+            $customizationMatch = $combinationMatch && $item['id_customization'] == $customizationId;
 
-            return $productMatch && $combinationMatch ? $item : null;
+            return $productMatch && $customizationMatch ? $item : null;
         });
 
         // This shouldn't happen, if it does something was not done before updating the Order (removing an OrderDetail maybe)

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -371,7 +371,7 @@ class OrderAmountUpdater
         $cartProducts = $cart->getProducts(true, false, null, true, $this->keepOrderPrices);
         foreach ($order->getCartProducts() as $orderProduct) {
             $orderDetail = new OrderDetail($orderProduct['id_order_detail'], null, $this->contextStateManager->getContext());
-            $cartProduct = $this->getProductFromCart($cartProducts, (int) $orderDetail->product_id, (int) $orderDetail->product_attribute_id (int) $orderDetail->id_customization);
+            $cartProduct = $this->getProductFromCart($cartProducts, (int) $orderDetail->product_id, (int) $orderDetail->product_attribute_id, (int) $orderDetail->id_customization);
 
             $this->orderDetailUpdater->updateOrderDetail(
                 $orderDetail,

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -398,9 +398,9 @@ class OrderAmountUpdater
 
             $productMatch = $item['id_product'] == $productId;
             $combinationMatch = $item['id_product_attribute'] == $productAttributeId;
-            $customizationMatch = $combinationMatch && $item['id_customization'] == $customizationId;
+            $customizationMatch = $item['id_customization'] == $customizationId;
 
-            return $productMatch && $customizationMatch ? $item : null;
+            return $productMatch && $customizationMatch && $customizationMatch ? $item : null;
         });
 
         // This shouldn't happen, if it does something was not done before updating the Order (removing an OrderDetail maybe)

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -371,7 +371,7 @@ class OrderAmountUpdater
         $cartProducts = $cart->getProducts(true, false, null, true, $this->keepOrderPrices);
         foreach ($order->getCartProducts() as $orderProduct) {
             $orderDetail = new OrderDetail($orderProduct['id_order_detail'], null, $this->contextStateManager->getContext());
-            $cartProduct = $this->getProductFromCart($cartProducts, (int) $orderDetail->product_id, (int) $orderDetail->product_attribute_id);
+            $cartProduct = $this->getProductFromCart($cartProducts, (int) $orderDetail->product_id, (int) $orderDetail->product_attribute_id (int) $orderDetail->id_customization);
 
             $this->orderDetailUpdater->updateOrderDetail(
                 $orderDetail,
@@ -389,15 +389,16 @@ class OrderAmountUpdater
      *
      * @return array
      */
-    private function getProductFromCart(array $cartProducts, int $productId, int $productAttributeId): array
+    private function getProductFromCart(array $cartProducts, int $productId, int $productAttributeId,int $customizationId = 0): array
     {
-        $cartProduct = array_reduce($cartProducts, function ($carry, $item) use ($productId, $productAttributeId) {
+        $cartProduct = array_reduce($cartProducts, function ($carry, $item) use ($productId, $productAttributeId, $customizationId) {
             if (null !== $carry) {
                 return $carry;
             }
 
             $productMatch = $item['id_product'] == $productId;
             $combinationMatch = $item['id_product_attribute'] == $productAttributeId;
+            $combinationMatch = $combinationMatch && $item['id_customization'] == $customizationId;
 
             return $productMatch && $combinationMatch ? $item : null;
         });

--- a/src/Adapter/Order/OrderDetailUpdater.php
+++ b/src/Adapter/Order/OrderDetailUpdater.php
@@ -135,7 +135,7 @@ class OrderDetailUpdater
         int $combinationId,
         DecimalNumber $priceTaxExcluded,
         DecimalNumber $priceTaxIncluded,
-        int $customizationId
+        int $customizationId = 0
     ): void {
         list($roundType, $computingPrecision, $taxAddress) = $this->prepareOrderContext($order);
 
@@ -317,7 +317,7 @@ class OrderDetailUpdater
         int $roundType,
         int $computingPrecision,
         Address $taxAddress,
-        int $customizationId
+        int $customizationId = 0
     ): void {
         $identicalOrderDetails = $this->getOrderDetailsForProduct($order, $productId, $combinationId, $customizationId);
         if (empty($identicalOrderDetails)) {

--- a/src/Adapter/Order/OrderDetailUpdater.php
+++ b/src/Adapter/Order/OrderDetailUpdater.php
@@ -134,7 +134,8 @@ class OrderDetailUpdater
         int $productId,
         int $combinationId,
         DecimalNumber $priceTaxExcluded,
-        DecimalNumber $priceTaxIncluded
+        DecimalNumber $priceTaxIncluded,
+        int $customizationId
     ): void {
         list($roundType, $computingPrecision, $taxAddress) = $this->prepareOrderContext($order);
 
@@ -147,7 +148,8 @@ class OrderDetailUpdater
                 $priceTaxIncluded,
                 $roundType,
                 $computingPrecision,
-                $taxAddress
+                $taxAddress,
+                $customizationId
             );
         } finally {
             $this->contextStateManager->restorePreviousContext();
@@ -314,9 +316,10 @@ class OrderDetailUpdater
         DecimalNumber $priceTaxIncluded,
         int $roundType,
         int $computingPrecision,
-        Address $taxAddress
+        Address $taxAddress,
+        int $customizationId
     ): void {
-        $identicalOrderDetails = $this->getOrderDetailsForProduct($order, $productId, $combinationId);
+        $identicalOrderDetails = $this->getOrderDetailsForProduct($order, $productId, $combinationId, $customizationId);
         if (empty($identicalOrderDetails)) {
             return;
         }
@@ -361,13 +364,15 @@ class OrderDetailUpdater
     private function getOrderDetailsForProduct(
         Order $order,
         int $productId,
-        int $combinationId
+        int $combinationId,
+        int $customizationId = 0
     ): array {
         $identicalOrderDetails = [];
         $orderDetails = $order->getOrderDetailList();
         foreach ($orderDetails as $orderDetail) {
             if ((int) $orderDetail['product_id'] === $productId
-                && (int) $orderDetail['product_attribute_id'] === $combinationId) {
+                && (int) $orderDetail['product_attribute_id'] === $combinationId
+                && (int) $orderDetail['id_customization'] === $customizationId) {
                 $identicalOrderDetails[] = new OrderDetail($orderDetail['id_order_detail']);
             }
         }

--- a/src/Adapter/Product/PriceCalculator.php
+++ b/src/Adapter/Product/PriceCalculator.php
@@ -198,7 +198,8 @@ class PriceCalculator
         int $combinationId,
         bool $withTaxes,
         bool $useReduction,
-        bool $withEcoTax
+        bool $withEcoTax,
+        int $customizationId = 0
     ): ?float {
         return Product::getPriceFromOrder(
             $orderId,
@@ -206,7 +207,8 @@ class PriceCalculator
             $combinationId,
             $withTaxes,
             $useReduction,
-            $withEcoTax
+            $withEcoTax,
+            $customizationId
         );
     }
 }

--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -362,7 +362,8 @@ class CartRow
                     (int) $rowData['id_product_attribute'],
                     $computationParameters['withTaxes'],
                     true,
-                    $this->useEcotax
+                    $this->useEcotax,
+                    (int) $rowData['id_customization']
                 );
             }
             if (null === $productPrices[$productPrice]['value']) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | When purchasing the same customized item with two different customizations and two different costs, if I modify the cost of one of the two items in the order, the system updates the cost of both products.
| Type?             | bug fix
| Category?         |  BO
| BC breaks?        |  no
| Deprecations?    |  no
| UI Tests | https://github.com/florine2623/testing_pr/actions/runs/10141414428 ✅ 
| Fixed issue or discussion?     | Fixes #36286 (only issue 2)
| Sponsor company   | Codencode snc