### PR TITLE
Increase composer timeout globally in docker init script

### DIFF
--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -60,8 +60,10 @@ if [ "${DISABLE_MAKE}" != "1" ]; then
   fi
 
   echo "\n* Running composer ...";
-  export COMPOSER_PROCESS_TIMEOUT=600
-  runuser -g www-data -u www-data -- /usr/local/bin/composer install --ansi --prefer-dist --no-interaction --no-progress
+  # Execute composer as default user so that we can set the env variables to increase timeout, also disable default_socket_timeout for php
+  COMPOSER_PROCESS_TIMEOUT=600 COMPOSER_IPRESOLVE=4 php -ddefault_socket_timeout=-1 /usr/local/bin/composer install --ansi --prefer-dist --no-interaction --no-progress
+  # Update the owner of composer installed folders to be www-data
+  chown -R www-data:www-data vendor modules themes
 
   echo "\n* Build assets ...";
   runuser -g www-data -u www-data -- /usr/bin/make assets

--- a/.github/actions/setup-env-export-logs/action.yml
+++ b/.github/actions/setup-env-export-logs/action.yml
@@ -25,10 +25,15 @@ runs:
         docker logs ${{ inputs.DOCKER_PREFIX }}-prestashop-git-1 > ./var/docker-logs/prestashop.log
       shell: bash
 
+    - name: Sanitize artifact name
+      id: sanitize-artifact-name
+      run: echo "ARTIFACT_NAME=$( echo -e '${{ inputs.ARTIFACT_NAME }}' | tr ':' '-' )" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Save logs in case of error
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.ARTIFACT_NAME }}
+        name: ${{ steps.sanitize-artifact-name.outputs.ARTIFACT_NAME }}
         path: |
           ./var/logs
           ./var/docker-logs

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -54,6 +54,11 @@ runs:
           ## Add self-signed certificate to Chrome Trust Store
           mkcert -install
 
+    # Run composer install outside of docker because inside it regularly has network issues
+    - name: Composer Install
+      run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
+      shell: bash
+
     # Docker to create the shop
     - name: Build and Run shop with docker
       shell: bash


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Optimization for docker init based on https://getcomposer.org/doc/articles/troubleshooting.md#operation-timed-out-ipv6-issues-
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green
| UI Tests          | Without cache: https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/9397485839<br />With cache: https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/9397858829
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
