### PR TITLE
Open EntitySearchInput to public components in backoffice

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.ts
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.ts
@@ -49,6 +49,7 @@ import TextWithLengthCounter from '@components/form/text-with-length-counter';
 import TinyMCEEditor from '@js/components/tinymce-editor';
 import TranslatableField from '@js/components/translatable-field';
 import TranslatableInput from '@js/components/translatable-input';
+import EntitySearchInput from '@js/components/entity-search-input';
 
 // Grid extensions
 import AsyncToggleColumnExtension from '@components/grid/extension/column/common/async-toggle-column-extension';
@@ -160,6 +161,7 @@ const initPrestashopComponents = (): void => {
     TinyMCEEditor,
     TranslatableField,
     TranslatableInput,
+    EntitySearchInput
   };
 };
 export default initPrestashopComponents;

--- a/admin-dev/themes/new-theme/js/pages/product/edit/manager/related-products-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/manager/related-products-manager.ts
@@ -35,7 +35,7 @@ export default class RelatedProductsManager {
 
   constructor(eventEmitter: EventEmitter) {
     this.eventEmitter = eventEmitter;
-    this.entitySearchInput = new EntitySearchInput($(ProductMap.relatedProducts.searchInput), {
+    this.entitySearchInput = new window.prestashop.component.EntitySearchInput($(ProductMap.relatedProducts.searchInput), {
       onRemovedContent: () => {
         this.eventEmitter.emit(ProductEventMap.updateSubmitButtonState);
       },


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Enables the “EntitySearchType” component to be used outside the sources of the new administration theme (mainly for module developers). The solution isn't perfect for the user's (prestawork) needs, but it's within the Prestashop standards.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Modifications that may have an impact on use are made to the component initialization for the “Related product” field (Product V2) to demonstrate its use.
| UI Tests          | [X]
| Fixed issue or discussion?     | Fixes #34667
