### PR TITLE
Add optional blackfire installation in docker

### DIFF
--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -149,6 +149,22 @@ if [ $PS_USE_DOCKER_MAILDEV -eq 1 ]; then
     runuser -g www-data -u www-data -- php /var/www/html/bin/console prestashop:config set PS_MAIL_SMTP_PORT --value "1025"
 fi
 
+if [ $BLACKFIRE_ENABLE -eq 1 ]; then
+    if [ $BLACKFIRE_SERVER_ID -eq 0 ] || [ $BLACKFIRE_SERVER_TOKEN -eq 0 ]; then
+            echo "\n* BLACKFIRE_SERVER_ID and BLACKFIRE_SERVER_TOKEN environment variables missing."
+            echo "\n* Skipping blackfire install..."
+    else
+      echo "\n* Installing Blackfire..."
+      wget -q -O - https://packages.blackfire.io/gpg.key | dd of=/usr/share/keyrings/blackfire-archive-keyring.asc
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/blackfire-archive-keyring.asc] http://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list
+      apt update
+      apt install -y blackfire
+      blackfire agent:config --server-id=$BLACKFIRE_SERVER_ID --server-token=$BLACKFIRE_SERVER_TOKEN
+      service blackfire-agent restart
+      apt install -y blackfire-php
+    fi
+fi
+
 echo "\n***"
 echo "**"
 echo "** Front-office: http://${PS_DOMAIN}/"

--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -150,7 +150,7 @@ if [ $PS_USE_DOCKER_MAILDEV -eq 1 ]; then
 fi
 
 if [ $BLACKFIRE_ENABLE -eq 1 ]; then
-    if [ $BLACKFIRE_SERVER_ID -eq 0 ] || [ $BLACKFIRE_SERVER_TOKEN -eq 0 ]; then
+    if [ "$BLACKFIRE_SERVER_ID" = "0" ] || [ "$BLACKFIRE_SERVER_TOKEN" = "0" ]; then
             echo "\n* BLACKFIRE_SERVER_ID and BLACKFIRE_SERVER_TOKEN environment variables missing."
             echo "\n* Skipping blackfire install..."
     else

--- a/README.md
+++ b/README.md
@@ -80,12 +80,30 @@ docker compose down -v
 docker compose build --no-cache
 docker compose up --build --force-recreate
 ```
-**Note:** To add a PHPMyAdmin service to your Docker Compose setup, you can copy the existing `docker-compose.override.yml.dist` to `docker-compose.override.yml` and then start your Docker Compose setup (override file will be included as it is a convention)
+
+### PHPMyAdmin
+To add a PHPMyAdmin service to your Docker Compose setup, you can copy the existing `docker-compose.override.yml.dist` to `docker-compose.override.yml` and then start your Docker Compose setup (override file will be included as it is a convention)
 
 ```
 cp docker-compose.override.yml.dist docker-compose.override.yml
 docker compose up
 ```
+
+### BLACKFIRE
+By default, blackfire will not be installed. During the install process, the installation of blackfire is based on 3
+environment variables:
+
+```
+BLACKFIRE_ENABLE: 1
+BLACKFIRE_SERVER_ID: "your_server_id"
+BLACKFIRE_SERVER_TOKEN: "your_blackfire_server_token"
+```
+
+Those env variables are self-explanatory, you can either set them yourself or override the docker-compose default values:
+
+Open the file `docker-compose.override.yml` (copy it from `docker-compose.override.yml.dist`
+if it's not already done, see command just above in the PHPMyadmin section).
+Then uncomment the 3 docker lines and fill the BLACKFIRE_SERVER_ID and BLACKFIRE_SERVER_TOKEN with your account's server id and token.
 
 Documentation
 --------

--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ docker compose up
 ```
 
 ### BLACKFIRE
-By default, blackfire will not be installed. During the install process, the installation of blackfire is based on 3
-environment variables:
+By default, blackfire will not be installed. During the install process, the installation of blackfire is based on 3 environment variables:
 
 ```
 BLACKFIRE_ENABLE: 1

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -10,9 +10,6 @@ services:
       PMA_USER: root
       PMA_PASSWORD: prestashop
       MYSQL_ROOT_PASSWORD: prestashop
-      # BLACKFIRE_ENABLE: 1
-      # BLACKFIRE_SERVER_ID: "your_blackfire_server_id"
-      # BLACKFIRE_SERVER_TOKEN: "your_blackfire_server_token"
     restart: unless-stopped
     depends_on:
       - mysql

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -18,3 +18,8 @@ services:
       - mysql
     networks:
       - prestashop-network
+  prestashop-git:
+      environment:
+        # BLACKFIRE_ENABLE: 1
+        # BLACKFIRE_SERVER_ID: "your_server_id"
+        # BLACKFIRE_SERVER_TOKEN: "your_blackfire_server_token"

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -10,6 +10,9 @@ services:
       PMA_USER: root
       PMA_PASSWORD: prestashop
       MYSQL_ROOT_PASSWORD: prestashop
+      # BLACKFIRE_ENABLE: 1
+      # BLACKFIRE_SERVER_ID: "your_blackfire_server_id"
+      # BLACKFIRE_SERVER_TOKEN: "your_blackfire_server_token"
     restart: unless-stopped
     depends_on:
       - mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,9 @@ services:
       PS_USE_DOCKER_MAILDEV: ${PS_USE_DOCKER_MAILDEV:-1}
       ADMIN_MAIL: ${ADMIN_MAIL:-demo@prestashop.com}
       ADMIN_PASSWD: ${ADMIN_PASSWD:-Correct Horse Battery Staple}
+      BLACKFIRE_ENABLE: ${BLACKFIRE_ENABLE:-0}
+      BLACKFIRE_SERVER_ID: ${BLACKFIRE_SERVER_ID:-0}
+      BLACKFIRE_SERVER_TOKEN: ${BLACKFIRE_SERVER_TOKEN:-0}
     command: ["/tmp/wait-for-it.sh", "--timeout=60", "--strict", "mysql:3306", "--", "/tmp/docker_run_git.sh"]
     ports:
       - "8001:80"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR adds blackfire when installing prestashop via docker, it is optional and disabled by default.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Override the 3 blackfire environnement variable and check that blackfire is working (QA by dev, contacting me for getting a server id and token)
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/9388635380
| Fixed issue or discussion?     | #none
| Related PRs       | none
| Sponsor company   | PrestaShop