### PR TITLE
Use v8 documentation in CMS Page (HelperCard)

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/core/util/helper_card.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/util/helper_card.yml
@@ -42,11 +42,11 @@ services:
           'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-categorie'
           '_fallback': 'https://docs.prestashop-project.org/1.7-documentation/user-guide/selling/managing-catalog/managing-categories'
         'cms_pages':
-          'en': 'https://docs.prestashop-project.org/1.7-documentation/user-guide/improving-shop/customizing-store-design/pages-managing-static-content'
-          'fr': 'https://docs.prestashop-project.org/1.7-documentation/v/french/guide-utilisateur/optimiser-boutique/personnaliser-apparence-boutique/pages-gerer-contenu-statique'
+          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/customizing-store-design/pages-managing-static-content'
+          'fr': 'https://docs.prestashop-project.org/v.8-documentation/v/french-1/guide-utilisateur/optimiser-boutique/personnaliser-apparence-boutique/pages-gerer-contenu-statique'
           'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/optimizar-tienda/personalizar-diseno-tienda/paginas-gestionar-contenido-estatico'
           'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/migliorare-negozio/personalizzare-design-negozio/pagine-gestione-contenuti-statici'
-          '_fallback': 'https://docs.prestashop-project.org/1.7-documentation/user-guide/improving-shop/customizing-store-design/pages-managing-static-content'
+          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/customizing-store-design/pages-managing-static-content'
         'debug_mode':
           'en': 'https://docs.prestashop-project.org/1.7-documentation/user-guide/configuring-shop/advanced-parameters/performance#performance-debugmode'
           'fr': 'https://docs.prestashop-project.org/1.7-documentation/v/french/guide-utilisateur/configurer-boutique/parametres-avances/performance#parametresdeperformances-modedebug'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Use v8 links when available in Pages helper card
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?        | Open the Pages (CMS) Back Office link and see the helper card link associated to the call-to-action button.