### PR TITLE
Fix potentialy SQL duplicate entry error in CartRule::copyConditions()

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -274,7 +274,7 @@ class CartRuleCore extends ObjectModel
 		(SELECT ' . (int) $id_cart_rule_destination . ', id_country FROM `' . _DB_PREFIX_ . 'cart_rule_country` WHERE `id_cart_rule` = ' . (int) $id_cart_rule_source . ')');
         Db::getInstance()->execute('
 		INSERT INTO `' . _DB_PREFIX_ . 'cart_rule_combination` (`id_cart_rule_1`, `id_cart_rule_2`)
-		(SELECT ' . (int) $id_cart_rule_destination . ', IF(id_cart_rule_1 != ' . (int) $id_cart_rule_source . ', id_cart_rule_1, id_cart_rule_2) FROM `' . _DB_PREFIX_ . 'cart_rule_combination`
+		(SELECT DISTINCT ' . (int) $id_cart_rule_destination . ', IF(id_cart_rule_1 != ' . (int) $id_cart_rule_source . ', id_cart_rule_1, id_cart_rule_2) FROM `' . _DB_PREFIX_ . 'cart_rule_combination`
 		WHERE `id_cart_rule_1` = ' . (int) $id_cart_rule_source . ' OR `id_cart_rule_2` = ' . (int) $id_cart_rule_source . ')');
 
         // Todo : should be changed soon, be must be copied too


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When placing a customer's order, if a coupon is partially used and we go through the CartRule::copyConditions() function, the following SQL error could occur: `SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '14414-13934' for key 'PRIMARY'`. Added SELECT DISTINCT to prevent duplicate entries.<br>This error results in the order being without order state.
| Type?             | bug fix
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | Stigmi
