### PR TITLE
query improvement: generate cart product quantity cache keys with one single query

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -761,6 +761,8 @@ class CartCore extends ObjectModel
                 $products[$key] = array_merge($product, $reduction_type_row);
             }
         }
+
+        $this->getQuantitiesForAllProducts($products_ids, $this->id);
         // Thus you can avoid one query per product, because there will be only one query for all the products of the cart
         Product::cacheProductsFeatures($products_ids);
         Cart::cacheSomeAttributesLists($pa_ids, (int) $this->getAssociatedLanguage()->getId());
@@ -4782,5 +4784,47 @@ class CartCore extends ObjectModel
           FROM (' . $firstUnionSql . ' UNION ' . $secondUnionSql . ') as q';
 
         return Db::getInstance()->getRow($parentSql);
+    }
+
+    /*
+     * REFACTOR FUNCTIONS TO BE MOVED LATER
+     */
+
+    /**
+     * This function does the query to fetch quantities like in the getPriceStatic method,
+     * but one query for all products instead of one query per product.
+     * Then we recreate the same cache keys used by getPriceStatic
+     */
+    private function getQuantitiesForAllProducts(array $productIds, int $idCart): void
+    {
+        if (empty($productIds)) {
+            return;
+        }
+
+        // check first key to see if it has been generated already
+        $productIdCheck = $productIds[0];
+        $checkCacheId = 'Product::getPriceStatic_' . (int) $productIdCheck . '-' . (int) $idCart;
+
+        if (Cache::isStored($checkCacheId)) {
+            return;
+        }
+
+        $product_ids_str = implode(", ", $productIds);
+        $sql = "SELECT `id_product`, SUM(`quantity`) as quantity
+          FROM `ps_cart_product`
+          WHERE `id_cart` = 6
+          AND `id_product` IN ($product_ids_str)
+          GROUP BY `id_product`";
+
+        $res = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+
+        if (empty($res)) {
+            return;
+        }
+
+        foreach ($res as $resdata) {
+            $cache_id = 'Product::getPriceStatic_' . (int) $resdata['id_product'] . '-' . (int) $idCart;
+            Cache::store($cache_id, $resdata['quantity']);
+        }
     }
 }


### PR DESCRIPTION
…le query

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Get cart quantities for all products in a single sql query instead of one query per product, then generate the cache keys so that individual queries are not remade;
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | add several products in cart, when displaying the cart page, you should execute one query less per product (in my use case: 100 products in cart, 99 queries less to execute)
| UI Tests          | 
| Fixed issue or discussion?     | linked to #35969 but it does not fix the whole thing
| Related PRs       | 
| Sponsor company   | PrestaShop SA