### PR TITLE
Load parent assets in shop selector iframe page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/shops.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/shops.html.twig
@@ -26,6 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product.css') }}" type="text/css" media="all">
 {% endblock %}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix product shops selection modal in multishop
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install the shop with multiple shops, create a new product try to associated it with other shops, without the PR the modal content is not integrated and can't be used, with this fix it works as expected (see screenshots)
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/9497638564
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~


### Without fix
![Capture d’écran 2024-06-13 à 11 46 58](https://github.com/PrestaShop/PrestaShop/assets/13801017/5789bb3f-ed1d-46a2-8d75-428d1fbd0707)

### With fix
![Capture d’écran 2024-06-13 à 11 47 09](https://github.com/PrestaShop/PrestaShop/assets/13801017/6474b9bf-cc44-4a4f-9bf1-df867395b8f5)
