### PR TITLE
Match URLs with a trailing slash

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -766,6 +766,20 @@ class DispatcherCore
             $keywords = $transform_keywords;
         }
 
+        /*
+         * Now, we will add one optional / to the end of the regexp. This will allow to match
+         * both slashed and non-slashed variant of the URL. The user will be automatically redirected
+         * to the proper canonical variant in the controller, but he won't get a 404.
+         */
+        if (substr($regexp, -1) == '/') {
+            // If the expression ends with a slash, we make it optional.
+            $regexp .= '?';
+        } else {
+            // If not, we add the optional slash.
+            $regexp .= '/?';
+        }
+
+        // Add some static rules to the regexp for all routes
         $regexp = '#^/' . $regexp . '$#u';
 
         return [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fixes one of annoyances with the FO routing system and limits the possibility that user lands on 404 page. See description below.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Test that you can add or remove slash from end of the URLs and you will always end up on the correct page.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/9503827226
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | [TRENDO s.r.o.](https://www.trendo.cz/)

### Description
- All modern sites (including our migrated Symfony pages in BO) and shops will lead the user to correct page, if he puts `/` to the end of the URL or not. PrestaShop doesn't.
- Modules can get around it by making duplicated set of routing rules with a `/` at the end, but core pages can't. And it can't even be configured like optional keywords do.
- The routing system works by having an URL structure like `content/{id}-{rewrite}`. For this, it calculates a regex `#^/content/(?P<id_cms>[0-9]+)\-([_a-zA-Z0-9\x{0600}-\x{06FF}\pL\pS-]*?)/?$#u` that is used to match the URL.
- So you visit an URL:
  - Dispatcher loads a list of routes.
  - Goes through them one by one.
  - When the rule's regex matches, it stops and passes it to the controller it found, along with the data it extracted from the regex.

### The fix
- So, the fix is quite easy, we add one optional slash character to the end of the regex built.
- If it already has a hardcoded slash at the end (for example I do it in my modules), it makes it optional.
- It doesn't affect creating URLs in any way.
- If the user comes via the non-correct URL, he will be correctly redirected to the canonical URL variant in the controller.

### Live demo
You can test it on one of our stores live. See that both URLs work just fine:
- https://eshop-franke.cz/471-nerezove-drezy
- https://eshop-franke.cz/471-nerezove-drezy/

And see that links to our blog posts that have duplicate routes with and without slash also work fine:
- https://eshop-franke.cz/poradna/post/1-jak-vybrat-drez-do-kuchyne
- https://eshop-franke.cz/poradna/post/1-jak-vybrat-drez-do-kuchyne/