### PR TITLE
Fix PassVsprintfValidator - matching invalid sprintf parameters when classic parameters present

### DIFF
--- a/src/PrestaShopBundle/Translation/Constraints/PassVsprintfValidator.php
+++ b/src/PrestaShopBundle/Translation/Constraints/PassVsprintfValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -45,7 +46,10 @@ class PassVsprintfValidator extends ConstraintValidator
             throw new UnexpectedTypeException($translation, 'PrestaShopBundle\Entity\Translation');
         }
 
-        if ($this->countArgumentsOfTranslation($translation->getKey()) != $this->countArgumentsOfTranslation($translation->getTranslation())) {
+        if (
+            $this->countArgumentsOfTranslation($translation->getKey()) !=
+            $this->countArgumentsOfTranslation($translation->getTranslation())
+        ) {
             $this->context->buildViolation($constraint->message)
                 ->addViolation();
         }
@@ -56,7 +60,13 @@ class PassVsprintfValidator extends ConstraintValidator
         if (empty($property)) {
             return 0;
         }
+
         $matches = [];
+
+        // First we remove all classic parameters (%var%)
+        $property = preg_replace(Translator::$regexClassicParams, '~', $property);
+
+        // Then we count the number of sprintf parameters
         if (preg_match_all(Translator::$regexSprintfParams, $property, $matches) === false) {
             throw new Exception('Preg_match failed');
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | https://github.com/PrestaShop/PrestaShop/issues/36360
| Type?             | bug fix
| Category?         |  BO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Following the test on the github issue
| UI Tests          |  https://github.com/SequoiaLabs/ga.tests.ui.pr/actions/runs/9512764351
| Fixed issue or discussion?     | Fixes #36360
| Sponsor company   | SequoiaLabs
