### PR TITLE
PR - Fix order detail price re-calculation

### DIFF
--- a/src/Adapter/Order/OrderDetailUpdater.php
+++ b/src/Adapter/Order/OrderDetailUpdater.php
@@ -199,7 +199,7 @@ class OrderDetailUpdater
                             'total_amount' => (float) $totalAmount,
                         ];
                         $orderDetail->unit_price_tax_incl = (float) $orderDetail->unit_price_tax_excl + $unitAmount;
-                        $orderDetail->total_price_tax_incl = (float) $orderDetail->total_price_tax_incl + $totalAmount;
+                        $orderDetail->total_price_tax_incl = (float) $orderDetail->total_price_tax_excl + $totalAmount;
                     }
 
                     Db::getInstance()->insert('order_detail_tax', $orderDetailTaxes, false);
@@ -207,7 +207,7 @@ class OrderDetailUpdater
 
                 // Update OrderDetail values
                 $orderDetail->unit_price_tax_incl = (float) $orderDetail->unit_price_tax_excl + $unitAmount;
-                $orderDetail->total_price_tax_incl = (float) $orderDetail->total_price_tax_incl + $totalAmount;
+                $orderDetail->total_price_tax_incl = (float) $orderDetail->total_price_tax_excl + $totalAmount;
                 if (!$orderDetail->update()) {
                     throw new OrderException('An error occurred while editing the product line.');
                 }

--- a/src/Adapter/Order/OrderDetailUpdater.php
+++ b/src/Adapter/Order/OrderDetailUpdater.php
@@ -164,17 +164,18 @@ class OrderDetailUpdater
         try {
             $orderDetailsData = $order->getProducts();
             foreach ($orderDetailsData as $orderDetailData) {
-                $orderDetail = new OrderDetail($orderDetailData['id_order_detail']);
+                $orderDetail = new OrderDetail((int) $orderDetailData['id_order_detail']);
 
                 // Clean existing order_detail_tax
                 Db::getInstance()->delete('order_detail_tax', 'id_order_detail = ' . (int) $orderDetail->id);
 
                 $taxCalculator = $this->getTaxCalculatorByAddress($taxAddress, $orderDetail);
                 $taxesAmount = $taxCalculator->getTaxesAmount($orderDetail->unit_price_tax_excl);
-                $unitAmount = $totalAmount = 0;
+                $sumUnitAmount = $sumTotalAmount = 0;
                 if (!empty($taxesAmount)) {
                     $orderDetailTaxes = [];
                     foreach ($taxesAmount as $taxId => $amount) {
+                        $unitAmount = $totalAmount = 0;
                         switch ($roundType) {
                             case Order::ROUND_ITEM:
                                 $unitAmount = (float) Tools::ps_round($amount, $computingPrecision);
@@ -198,16 +199,16 @@ class OrderDetailUpdater
                             'unit_amount' => (float) $unitAmount,
                             'total_amount' => (float) $totalAmount,
                         ];
-                        $orderDetail->unit_price_tax_incl = (float) $orderDetail->unit_price_tax_excl + $unitAmount;
-                        $orderDetail->total_price_tax_incl = (float) $orderDetail->total_price_tax_excl + $totalAmount;
+                        $sumUnitAmount += $unitAmount;
+                        $sumTotalAmount += $totalAmount;
                     }
 
                     Db::getInstance()->insert('order_detail_tax', $orderDetailTaxes, false);
                 }
 
                 // Update OrderDetail values
-                $orderDetail->unit_price_tax_incl = (float) $orderDetail->unit_price_tax_excl + $unitAmount;
-                $orderDetail->total_price_tax_incl = (float) $orderDetail->total_price_tax_excl + $totalAmount;
+                $orderDetail->unit_price_tax_incl = (float) $orderDetail->unit_price_tax_excl + $sumUnitAmount;
+                $orderDetail->total_price_tax_incl = (float) $orderDetail->total_price_tax_excl + $sumTotalAmount;
                 if (!$orderDetail->update()) {
                     throw new OrderException('An error occurred while editing the product line.');
                 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When editing an order delivery address in the BO, the product prices of that order are recalculated (to adjust the tax for the country). The code is incorrect and set a bad tax incl. price (`orderDetail->total_price_tax_incl`) due to a typo.<br>Please note that this has not been detected earlier because a SECOND update of this order is done later, in the same PHP process, when PrestaShop recalculates all the prices from the products found in the cart, in `OrderAmountUpdater::updateOrderDetails()`
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #36373
| Related PRs       |
| Sponsor company   | KIWIK (kiwik.com)


*Steps to reproduce*

0. BEFORE:
Have a way to log each SQL request made.
UNRECOMMENDED METHOD: For example, in your ENV environment:
```php
/classes/db/DbPDO.php
   protected function _query($sql)
    {
        try {
            file_put_contents(_PS_ROOT_DIR_.'/(pr-fix-order-detail-updater.log', \date('[Y-m-d H:i:s] ').print_r($sql, true).PHP_EOL, FILE_APPEND);
            return $this->link->query($sql);
        } catch (PDOException $exception) {
            throw new PrestaShopException($exception->getMessage(), (int) $exception->getCode(), $exception);
        }
    }
```

1. Have a cart with 2 products, each with an associated VAT tax for your country.
2. Place an order with that cart.
3. in BO, edit the order's delivery address.
4. For example, change the last digit of the phone number.
5. save
6. You will see in the SQL requests that a first batch of updates is done in `order_detail` with incorrect data, followed by a second batch later on with the correct data


Example of SQL requests (I only kept some fields for a better understanding)
```sql
-- WITHOUT PR
-- 1st update
UPDATE `ps_order_detail` SET `id_order_detail` = '8', ... `total_price_tax_incl` = '57.44' ... WHERE `id_order_detail` = 8;
UPDATE `ps_order_detail` SET `id_order_detail` = '9', ... `total_price_tax_incl` = '14.4'  ... WHERE `id_order_detail` = 9;
-- 2nd update
UPDATE `ps_order_detail` SET `id_order_detail` = '8', ... `total_price_tax_incl` = '43.08' ... WHERE `id_order_detail` = 8;
UPDATE `ps_order_detail` SET `id_order_detail` = '9', ... `total_price_tax_incl` = '10.8'  ... WHERE `id_order_detail` = 9;


-- WITH PR
-- 1st update
UPDATE `ps_order_detail` SET `id_order_detail` = '8', ... `total_price_tax_incl` = '43.08' ... WHERE `id_order_detail` = 8;
UPDATE `ps_order_detail` SET `id_order_detail` = '9', ... `total_price_tax_incl` = '10.8'  ... WHERE `id_order_detail` = 9;
-- 2nd update
UPDATE `ps_order_detail` SET `id_order_detail` = '8', ... `total_price_tax_incl` = '43.08' ... WHERE `id_order_detail` = 8;
UPDATE `ps_order_detail` SET `id_order_detail` = '9', ... `total_price_tax_incl` = '10.8' ...  WHERE `id_order_detail` = 9;
```


The changes occurs in:
```php
ChangeOrderDeliveryAddressHandler::handle()
  `-- OrderDetailUpdater::updateOrderDetailsTaxes()  // first (incorrect) update
  `-- OrderAmountUpdater::update()
        `-- OrderAmountUpdater::updateOrderDetails()  // second update (based on cart product prices)
```