### PR TITLE
Fix typo in pack wording that doesn't make sense

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
@@ -115,7 +115,7 @@ class StockType extends TranslatorAwareType
                 'choices' => $this->packStockTypeChoiceProvider->getChoices(),
                 'expanded' => true,
                 'label' => $this->trans('Pack stock behavior', 'Admin.Catalog.Feature'),
-                'label_help_box' => $this->trans('Controls how you want stock of the pack to be calculated. You can decide, if you want to manage the stocks of packs manually, or if it should be calculated automatically depending on stock of the products inside. In that case, the quantity of the pack inside is ignored.', 'Admin.Catalog.Help'),
+                'label_help_box' => $this->trans('Controls how you want stock of the pack to be calculated. You can decide, if you want to manage the stock of pack manually, or if it should be calculated automatically depending on stock of the products inside. In that case, the quantity of the pack is ignored.', 'Admin.Catalog.Help'),
                 'label_tag_name' => 'h3',
                 'required' => false,
                 'placeholder' => false,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fix typo in pack wording that doesn't make sense. There is no "pack inside".
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | ![Snímek obrazovky 2024-06-19 110616](https://github.com/PrestaShop/PrestaShop/assets/6097524/9182bd29-01c5-4be6-ab33-5b1405182578)
| Related PRs       | 
| Sponsor company   | 
