### PR TITLE
Fixing issue #36401 duplicated invalid text

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
@@ -262,7 +262,7 @@ abstract class AbstractCategoryType extends TranslatorAwareType
             ])
             ->add('meta_keyword', TranslatableType::class, [
                 'label' => $this->trans('Meta keywords', 'Admin.Global'),
-                'help' => $this->trans('To add tags, press the \'enter\' key. You can also use the \'comma\' key. Invalid characters: <>;=#{}', 'Admin.Shopparameters.Help')
+                'help' => $this->trans('To add tags, press the \'enter\' key. You can also use the \'comma\' key.', 'Admin.Shopparameters.Help')
                     . '<br>' . $genericCharactersHint,
                 'required' => false,
                 'options' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Admin.Shopparameters.Help variable already had the hardcoded text resulting in duplicate, I simply removed the hardcoded text
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | go to catalog -> catagories -> edit or new -> view meta keywords<br/><br/>Invalid characters: <>;=#{} is no longer duplicated
| UI Tests          | (TO DO)Please run UI tests and paste here the link to the run. [Read this page to know why and how to use this tool](https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/ui-tests/).
| Fixed issue or discussion?     | Fixes #36401 

