### PR TITLE
Add new selector for quickview modal using Bootstrap 5 (Hummingbird)

### DIFF
--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -182,7 +182,7 @@ function updateProduct(event, eventType, updateUrl) {
         + preview,
       method: 'POST',
       data: {
-        quickview: $('.modal.quickview.in').length,
+        quickview: $('.modal.quickview.in, .modal.quickview.show').length,
         ajax: 1,
         action: 'refresh',
         quantity_wanted:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR adds a selector on the quickview modal to accommodate Hummingbird, which uses Bootstrap v5 and introduces new selectors for modal display.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |  ⬇️
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/9679998967 ✅ 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | @PrestaShopCorp

- Install Hummingbird on a shop.
- Open a quickview modal for a product that has combinations.
- Use the developer inspector to inspect "XHR" in network section.
- Change the combination; a new request should appear.
- When inspecting this request, you should find `quickview = 1` (previously, `0` was returned before the PR).
![image](https://github.com/PrestaShop/PrestaShop/assets/110676325/b5f54f82-ecfa-4f3e-9900-d8c1e6b45725)
