### PR TITLE
Add actionMailPreviewBuildTemplateVariables hook

### DIFF
--- a/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
+++ b/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
@@ -146,6 +146,20 @@ final class MailPreviewVariablesBuilder
         $templateVars['{color}'] = $this->configuration->get('PS_MAIL_COLOR');
         $templateVars = array_merge($templateVars, $this->buildOrderVariables($mailLayout));
 
+        if ($mailLayout->getModuleName() !== '') {
+            $moduleTemplateVars = Hook::exec(
+                'actionBuildTemplateVariables',
+                [
+                    'templateVars' => $templateVars,
+                ],
+                (int) Module::getModuleIdByName($mailLayout->getModuleName()),
+                true
+            );
+            if (isset($moduleTemplateVars[$mailLayout->getModuleName()])) {
+                $templateVars = array_merge($templateVars, $moduleTemplateVars[$mailLayout->getModuleName()]);
+            }
+        }
+
         return $templateVars;
     }
 

--- a/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
+++ b/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
@@ -31,6 +31,8 @@ use AddressFormat;
 use Carrier;
 use Cart;
 use Context;
+use Hook;
+use Module;
 use Order;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;

--- a/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
+++ b/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
@@ -150,7 +150,7 @@ final class MailPreviewVariablesBuilder
 
         if ($mailLayout->getModuleName() !== '') {
             $moduleTemplateVars = Hook::exec(
-                'actionBuildTemplateVariables',
+                'actionMailPreviewBuildTemplateVariables',
                 [
                     'templateVars' => $templateVars,
                 ],

--- a/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
+++ b/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
@@ -148,7 +148,7 @@ final class MailPreviewVariablesBuilder
         $templateVars['{color}'] = $this->configuration->get('PS_MAIL_COLOR');
         $templateVars = array_merge($templateVars, $this->buildOrderVariables($mailLayout));
 
-        if ($mailLayout->getModuleName() !== '') {
+        if (!empty($mailLayout->getModuleName())) {
             $moduleTemplateVars = Hook::exec(
                 'actionMailPreviewBuildTemplateVariables',
                 [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fire `actionMailPreviewBuildTemplateVariables` when previewing a module's email template, so modules can inject Smarty variables into their own preview.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see below
| Related PRs       |

## How to test

The hook is **scoped to the module owning the previewed template** — it fires only when previewing a mail whose template lives inside a module, and only that module receives the call. The previous "How to test" was ambiguous on that point (`ps_quality` can't trigger it because its own emails aren't the preview target).

Drop-in test module:

```php
// modules/testmailvars/testmailvars.php
<?php
if (!defined('_PS_VERSION_')) { exit; }

class TestMailVars extends Module
{
    public function __construct()
    {
        $this->name = 'testmailvars';
        $this->tab = 'front_office_features';
        $this->version = '1.0.0';
        $this->author = 'test';
        $this->need_instance = 0;
        $this->bootstrap = true;
        parent::__construct();
        $this->displayName = 'Test Mail Variables';
        $this->description = 'Injects a Smarty variable into its own mail preview via actionMailPreviewBuildTemplateVariables.';
    }

    public function install()
    {
        return parent::install()
            && $this->registerHook('actionMailPreviewBuildTemplateVariables');
    }

    public function hookActionMailPreviewBuildTemplateVariables(array $params): array
    {
        return [
            'injected_var' => 'HELLO_FROM_HOOK',
        ];
    }
}
```

```html
<!-- modules/testmailvars/mails/en/hello.html -->
<html><body>
  <p>Injected value: {injected_var}</p>
</body></html>
```

```txt
// modules/testmailvars/mails/en/hello.txt
Injected value: {injected_var}
```

### Steps

1. Copy the module folder into `modules/`.
2. BO → **Modules** → **Module manager** → search *Test Mail Variables* → **Install**.
3. BO → **Design** → **Email theme** → click the small magnifying glass at the bottom (*"Preview"*).
4. On the preview page, locate the **testmailvars → hello** row → click the **HTML** icon (or **TXT**).
5. Expected output in the previewed mail: **`Injected value: HELLO_FROM_HOOK`**.

Without the patch: `{injected_var}` is not substituted (or the placeholder shows as-is / empty).
With the patch: the value from the hook is interpolated.

### Follow-up out of scope

@Hlavtox suggested also firing this hook for **core** mail templates (not just module ones). Kept out of scope here to keep the diff minimal and the semantics tight (a core hook without `$module_id` scoping would broadcast to every listening module on every preview — worth its own PR and discussion).
