### PR TITLE
Fix addJs/addCss on migrated pages with Symfony layout

### DIFF
--- a/src/Core/Context/LegacyControllerContextBuilder.php
+++ b/src/Core/Context/LegacyControllerContextBuilder.php
@@ -29,22 +29,19 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Context;
 
 use Doctrine\ORM\NoResultException;
-use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Util\Inflector;
 use PrestaShopBundle\Entity\Repository\TabRepository;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Tools;
 
-class LegacyControllerContextBuilder implements LegacyContextBuilderInterface
+class LegacyControllerContextBuilder
 {
     private ?string $controllerName = null;
     private ?string $redirectionUrl = null;
-    private ?LegacyControllerContext $_legacyControllerContext = null;
 
     public function __construct(
         private readonly EmployeeContext $employeeContext,
-        private readonly ContextStateManager $contextStateManager,
         private readonly array $controllersLockedToAllShopContext,
         private readonly TabRepository $tabRepository,
         private readonly ContainerInterface $container,
@@ -65,7 +62,7 @@ class LegacyControllerContextBuilder implements LegacyContextBuilderInterface
         $className = $this->getClassName($this->getControllerName());
         $table = $this->getTableFromClassName($this->getControllerName());
 
-        $legacyControllerContext = new LegacyControllerContext(
+        return new LegacyControllerContext(
             $this->container,
             $this->getControllerName(),
             $controllerType,
@@ -77,25 +74,6 @@ class LegacyControllerContextBuilder implements LegacyContextBuilderInterface
             $this->getCurrentIndex(),
             $table,
         );
-
-        $this->_legacyControllerContext = $legacyControllerContext;
-
-        return $legacyControllerContext;
-    }
-
-    public function buildLegacyContext(): void
-    {
-        // In legacy pages the AdminController class already sets the context's controller, which is a more accurate
-        // candidate than our facade meant for backward compatibility, so we leave it untouched
-        if ($this->contextStateManager->getContext()->controller) {
-            return;
-        }
-
-        if (null === $this->_legacyControllerContext) {
-            $this->_legacyControllerContext = $this->build();
-        }
-
-        $this->contextStateManager->setController($this->_legacyControllerContext);
     }
 
     public function setControllerName(string $controllerName): self

--- a/src/Core/Context/LegacyControllerContextInjector.php
+++ b/src/Core/Context/LegacyControllerContextInjector.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Context;
+
+use PrestaShop\PrestaShop\Adapter\ContextStateManager;
+
+/**
+ * This class is independent of the LegacyControllerContextBuilder, this way wa can inject LegacyControllerContext
+ * into it and use the lazyness of the service in our favor. This service will be called via the kernel.controller
+ * event from LegacyContextListener, by then LegacyControllerContextBuilder will have already been configured and
+ * the service can be lazy constructed.
+ *
+ * We must rely on the lazy Symfony service and inject this one in particular or the service used in Symfony and the
+ * one injected in legacy context won't be the same instance thus we wouldn't get the appropriate assets.
+ */
+class LegacyControllerContextInjector implements LegacyContextBuilderInterface
+{
+    public function __construct(
+        private readonly ContextStateManager $contextStateManager,
+        private readonly LegacyControllerContext $legacyControllerContext,
+    ) {
+    }
+
+    public function buildLegacyContext(): void
+    {
+        // In legacy pages the AdminController class already sets the context's controller, which is a more accurate
+        // candidate than our facade meant for backward compatibility, so we leave it untouched
+        if ($this->contextStateManager->getContext()->controller) {
+            return;
+        }
+
+        // We must fetch the service from the container to make sure Symfony service and legacy Context share the same
+        // instance, this is critical to make sure we load the appropriate asset files injected from legacy code
+        $this->contextStateManager->setController($this->legacyControllerContext);
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/core/context.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/context.yml
@@ -41,7 +41,9 @@ services:
     factory: [ '@PrestaShop\PrestaShop\Core\Context\CountryContextBuilder', 'build' ]
 
   PrestaShop\PrestaShop\Core\Context\LegacyControllerContextBuilder: ~
+  PrestaShop\PrestaShop\Core\Context\LegacyControllerContextInjector: ~
   PrestaShop\PrestaShop\Core\Context\LegacyControllerContext:
+    public: true
     lazy: true
     factory: [ '@PrestaShop\PrestaShop\Core\Context\LegacyControllerContextBuilder', 'build' ]
 

--- a/tests/Unit/Core/Context/LegacyControllerContextBuilderTest.php
+++ b/tests/Unit/Core/Context/LegacyControllerContextBuilderTest.php
@@ -31,7 +31,6 @@ namespace Tests\Unit\Core\Context;
 use Doctrine\ORM\NoResultException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Core\Context\Employee;
 use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
 use PrestaShop\PrestaShop\Core\Context\LegacyControllerContextBuilder;
@@ -58,7 +57,6 @@ class LegacyControllerContextBuilderTest extends TestCase
     {
         $builder = new LegacyControllerContextBuilder(
             $this->mockEmployeeContext(),
-            $this->createMock(ContextStateManager::class),
             ['AdminCarts'],
             $this->mockTabRepository(),
             $this->createMock(ContainerInterface::class),
@@ -192,7 +190,6 @@ class LegacyControllerContextBuilderTest extends TestCase
         ;
         $builder = new LegacyControllerContextBuilder(
             $this->mockEmployeeContext(),
-            $this->createMock(ContextStateManager::class),
             ['AdminCarts'],
             $tabRepository,
             $this->createMock(ContainerInterface::class),

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextListenerTest.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace Tests\Unit\PrestaShopBundle\EventListener\Admin\Context;
 
-use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
 use PrestaShop\PrestaShop\Core\Context\LegacyControllerContextBuilder;
 use PrestaShopBundle\Entity\Repository\TabRepository;
@@ -89,7 +88,6 @@ class LegacyControllerContextListenerTest extends ContextEventListenerTestCase
     {
         return new LegacyControllerContextBuilder(
             $this->createMock(EmployeeContext::class),
-            $this->createMock(ContextStateManager::class),
             ['AdminCarts'],
             $this->createMock(TabRepository::class),
             $this->createMock(ContainerInterface::class)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Split LegacyControllerContextBuilder so the part that build legacy context is called later and uses the same lazy service, this way we make sure migrated pages have the correct assets from legacy modules
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to the back office on a migrated page, check that the assets of the `ps_faviconnotificationbo` module are loaded in the page (ex: `/modules/ps_faviconnotificationbo/views/js/ps_faviconnotificationbo.js`) Without the PR the files are not included/loaded in the page With this PR they are present
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/9682990461
| Fixed issue or discussion?     | Fixes #36376
| Related PRs       | ~
| Sponsor company   | ~
