### PR TITLE
MariaDB ci test to use healthcheck.sh to order

### DIFF
--- a/docker-compose.mariadb.yml
+++ b/docker-compose.mariadb.yml
@@ -13,6 +13,12 @@ services:
     environment:
       MARIADB_ROOT_PASSWORD: ${DB_PASSWD:-prestashop}
       MARIADB_DATABASE: ${DB_NAME:-prestashop}
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 5s
+      timeout: 1s
+      retries: 3
     restart: unless-stopped
     networks:
       - prestashop-network
@@ -49,12 +55,13 @@ services:
       BLACKFIRE_ENABLE: ${BLACKFIRE_ENABLE:-0}
       BLACKFIRE_SERVER_ID: ${BLACKFIRE_SERVER_ID:-0}
       BLACKFIRE_SERVER_TOKEN: ${BLACKFIRE_SERVER_TOKEN:-0}
-    command: /tmp/wait-for-it.sh --timeout=60 --strict mariadb:3306 -- /tmp/docker_run_git.sh
+    command: /tmp/docker_run_git.sh
     ports:
       - "8001:80"
       - "8002:443"
     depends_on:
-      - mariadb
+      mariadb:
+        condition: service_healthy
     volumes:
       - ./:/var/www/html:delegated
     networks:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | MariaDB ci test to use healthcheck.sh to order compose startup.
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `docker-compose -f docker-compose.mariadb.yml up`
| UI Tests          | per below
| Fixed issue or discussion?     | None
| Related PRs       | #36385
| Sponsor company   | MariaDB Foundation.

```
$ docker-compose -f docker-compose.mariadb.yml up
Creating network "prestashop-network" with the default driver
Creating volume "prestashop_db-data" with default driver
Building prestashop-git
STEP 1/14: FROM prestashop/base:8.1-apache
✔ docker.io/prestashop/base:8.1-apache
....
--> 0fcbdf11b4ab
STEP 14/14: CMD ["/tmp/docker_run_git.sh"]
COMMIT prestashop_prestashop-git
--> cab84fc27857
Successfully tagged localhost/prestashop_prestashop-git:latest
cab84fc278571ec9b103a7665c33bfcf0b924470d32cf0e10a14676c8a5f2c7d
WARNING: Image for service prestashop-git was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
Pulling maildev (maildev/maildev:)...
31e352740f53: Already exists
2629b68d4311: Download complete
7476c7de0ad2: Download complete
ddb7cc70f260: Download complete
02aff18a2536: Download complete
18afe6373474: Download complete
8a920dba53d6: Download complete
Creating prestashop_mariadb_1 ... done
Creating prestashop_maildev_1 ... done
Creating prestashop_prestashop-git_1 ... done
Attaching to prestashop_maildev_1, prestashop_mariadb_1, prestashop_prestashop-git_1
mariadb_1         | 2024-06-28 01:21:32+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:11.4.2+maria~ubu2404 started.
mariadb_1         | 2024-06-28 01:21:32+00:00 [Warn] [Entrypoint]: /sys/fs/cgroup///memory.pressure not writable, functionality unavailable to MariaDB
mariadb_1         | 2024-06-28 01:21:32+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
maildev_1         | MailDev using directory /tmp/maildev-1
mariadb_1         | 2024-06-28 01:21:32+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:11.4.2+maria~ubu2404 started.
mariadb_1         | 2024-06-28 01:21:32+00:00 [Note] [Entrypoint]: Initializing database files
mariadb_1         | 2024-06-28  1:21:32 0 [Warning] mariadbd: io_uring_queue_init() failed with errno 95
mariadb_1         | 2024-06-28  1:21:32 0 [Warning] InnoDB: liburing disabled: falling back to innodb_use_native_aio=OFF
maildev_1         | MailDev webapp running at http://0.0.0.0:1080/
prestashop-git_1  | 
prestashop-git_1  | * HTTPS is not enabled.
mariadb_1         | 
mariadb_1         | 
mariadb_1         | PLEASE REMEMBER TO SET A PASSWORD FOR THE MariaDB root USER !
mariadb_1         | To do so, start the server, then issue the following command:
mariadb_1         | 
mariadb_1         | '/usr/bin/mariadb-secure-installation'
mariadb_1         | 
mariadb_1         | which will also give you the option of removing the test
mariadb_1         | databases and anonymous user created by default.  This is
mariadb_1         | strongly recommended for production servers.
mariadb_1         | 
mariadb_1         | See the MariaDB Knowledgebase at https://mariadb.com/kb
mariadb_1         | 
mariadb_1         | Please report any problems at https://mariadb.org/jira
mariadb_1         | 
mariadb_1         | The latest information about MariaDB is available at https://mariadb.org/.
mariadb_1         | 
mariadb_1         | Consider joining MariaDB's strong and vibrant community:
mariadb_1         | https://mariadb.org/get-involved/
mariadb_1         | 
maildev_1         | MailDev SMTP Server running at 0.0.0.0:1025
mariadb_1         | 2024-06-28 01:21:33+00:00 [Note] [Entrypoint]: Database files initialized
mariadb_1         | 2024-06-28 01:21:33+00:00 [Note] [Entrypoint]: Starting temporary server
mariadb_1         | 2024-06-28 01:21:33+00:00 [Note] [Entrypoint]: Waiting for server startup
mariadb_1         | 2024-06-28  1:21:33 0 [Note] Starting MariaDB 11.4.2-MariaDB-ubu2404 source revision 3fca5ed772fb75e3e57c507edef2985f8eba5b12 as process 95
mariadb_1         | 2024-06-28  1:21:33 0 [Note] InnoDB: Compressed tables use zlib 1.3
mariadb_1         | 2024-06-28  1:21:33 0 [Note] InnoDB: Number of transaction pools: 1
mariadb_1         | 2024-06-28  1:21:33 0 [Note] InnoDB: Using AVX512 instructions
prestashop-git_1  | 
prestashop-git_1  | * Install node 16.20.1...
mariadb_1         | 2024-06-28  1:21:33 0 [Note] mariadbd: O_TMPFILE is not supported on /tmp (disabling future attempts)
mariadb_1         | 2024-06-28  1:21:33 0 [Warning] mariadbd: io_uring_queue_init() failed with errno 95
mariadb_1         | 2024-06-28  1:21:33 0 [Warning] InnoDB: liburing disabled: falling back to innodb_use_native_aio=OFF
mariadb_1         | 2024-06-28  1:21:33 0 [Note] InnoDB: Initializing buffer pool, total size = 128.000MiB, chunk size = 2.000MiB
mariadb_1         | 2024-06-28  1:21:33 0 [Note] InnoDB: Completed initialization of buffer pool
mariadb_1         | 2024-06-28  1:21:33 0 [Note] InnoDB: Buffered log writes (block size=512 bytes)
mariadb_1         | 2024-06-28  1:21:33 0 [Note] InnoDB: End of log at LSN=46332
mariadb_1         | 2024-06-28  1:21:33 0 [Note] InnoDB: Opened 3 undo tablespaces
mariadb_1         | 2024-06-28  1:21:33 0 [Note] InnoDB: 128 rollback segments in 3 undo tablespaces are active.
mariadb_1         | 2024-06-28  1:21:33 0 [Note] InnoDB: Setting file './ibtmp1' size to 12.000MiB. Physically writing the file full; Please wait ...
mariadb_1         | 2024-06-28  1:21:33 0 [Note] InnoDB: File './ibtmp1' size is now 12.000MiB.
mariadb_1         | 2024-06-28  1:21:33 0 [Note] InnoDB: log sequence number 46332; transaction id 14
mariadb_1         | 2024-06-28  1:21:33 0 [Note] Plugin 'FEEDBACK' is disabled.
mariadb_1         | 2024-06-28  1:21:33 0 [Note] Plugin 'wsrep-provider' is disabled.
mariadb_1         | 2024-06-28  1:21:35 0 [Warning] 'user' entry 'root@34cb534bdc90' ignored in --skip-name-resolve mode.
mariadb_1         | 2024-06-28  1:21:35 0 [Warning] 'proxies_priv' entry '@% root@34cb534bdc90' ignored in --skip-name-resolve mode.
mariadb_1         | 2024-06-28  1:21:35 0 [Note] mariadbd: Event Scheduler: Loaded 0 events
mariadb_1         | 2024-06-28  1:21:35 0 [Note] mariadbd: ready for connections.
mariadb_1         | Version: '11.4.2-MariaDB-ubu2404'  socket: '/run/mysqld/mysqld.sock'  port: 0  mariadb.org binary distribution
mariadb_1         | 2024-06-28 01:21:35+00:00 [Note] [Entrypoint]: Temporary server started.
mariadb_1         | 2024-06-28 01:21:35+00:00 [Note] [Entrypoint]: Creating database prestashop
mariadb_1         | 2024-06-28 01:21:35+00:00 [Note] [Entrypoint]: Securing system users (equivalent to running mysql_secure_installation)
mariadb_1         | 
mariadb_1         | 2024-06-28 01:21:35+00:00 [Note] [Entrypoint]: Stopping temporary server
mariadb_1         | 2024-06-28  1:21:35 0 [Note] mariadbd (initiated by: unknown): Normal shutdown
mariadb_1         | 2024-06-28  1:21:35 0 [Note] InnoDB: FTS optimize thread exiting.
mariadb_1         | 2024-06-28  1:21:35 0 [Note] InnoDB: Starting shutdown...
mariadb_1         | 2024-06-28  1:21:35 0 [Note] InnoDB: Dumping buffer pool(s) to /var/lib/mysql/ib_buffer_pool
mariadb_1         | 2024-06-28  1:21:35 0 [Note] InnoDB: Buffer pool(s) dump completed at 240628  1:21:35
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: Removed temporary tablespace data file: "./ibtmp1"
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: Shutdown completed; log sequence number 47907; transaction id 15
mariadb_1         | 2024-06-28  1:21:36 0 [Note] mariadbd: Shutdown complete
mariadb_1         | 
mariadb_1         | 2024-06-28 01:21:36+00:00 [Note] [Entrypoint]: Temporary server stopped
mariadb_1         | 
mariadb_1         | 2024-06-28 01:21:36+00:00 [Note] [Entrypoint]: MariaDB init process done. Ready for start up.
mariadb_1         | 
mariadb_1         | 2024-06-28  1:21:36 0 [Note] Starting MariaDB 11.4.2-MariaDB-ubu2404 source revision 3fca5ed772fb75e3e57c507edef2985f8eba5b12 as process 1
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: Compressed tables use zlib 1.3
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: Number of transaction pools: 1
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: Using AVX512 instructions
mariadb_1         | 2024-06-28  1:21:36 0 [Note] mariadbd: O_TMPFILE is not supported on /tmp (disabling future attempts)
mariadb_1         | 2024-06-28  1:21:36 0 [Warning] mariadbd: io_uring_queue_init() failed with errno 95
mariadb_1         | 2024-06-28  1:21:36 0 [Warning] InnoDB: liburing disabled: falling back to innodb_use_native_aio=OFF
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: Initializing buffer pool, total size = 128.000MiB, chunk size = 2.000MiB
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: Completed initialization of buffer pool
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: Buffered log writes (block size=512 bytes)
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: End of log at LSN=47907
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: Opened 3 undo tablespaces
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: 128 rollback segments in 3 undo tablespaces are active.
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: Setting file './ibtmp1' size to 12.000MiB. Physically writing the file full; Please wait ...
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: File './ibtmp1' size is now 12.000MiB.
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: log sequence number 47907; transaction id 15
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: Loading buffer pool(s) from /var/lib/mysql/ib_buffer_pool
mariadb_1         | 2024-06-28  1:21:36 0 [Note] Plugin 'FEEDBACK' is disabled.
mariadb_1         | 2024-06-28  1:21:36 0 [Note] Plugin 'wsrep-provider' is disabled.
mariadb_1         | 2024-06-28  1:21:36 0 [Note] InnoDB: Buffer pool(s) load completed at 240628  1:21:36
mariadb_1         | 2024-06-28  1:21:38 0 [Note] Server socket created on IP: '0.0.0.0'.
mariadb_1         | 2024-06-28  1:21:38 0 [Note] Server socket created on IP: '::'.
mariadb_1         | 2024-06-28  1:21:38 0 [Note] mariadbd: Event Scheduler: Loaded 0 events
mariadb_1         | 2024-06-28  1:21:38 0 [Note] mariadbd: ready for connections.
mariadb_1         | Version: '11.4.2-MariaDB-ubu2404'  socket: '/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
prestashop-git_1  |   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
prestashop-git_1  |                                  Dload  Upload   Total   Spent    Left  Speed
100 14984  100 14984    0     0  38598      0 --:--:-- --:--:-- --:--:-- 38519
prestashop-git_1  | => Downloading nvm as script to '/usr/local/nvm'
prestashop-git_1  | 
prestashop-git_1  | => Appending nvm source string to /root/.bashrc
prestashop-git_1  | => Appending bash_completion source string to /root/.bashrc
prestashop-git_1  | => Installing Node.js version 16.20.1
prestashop-git_1  | Downloading and installing node v16.20.1...
....
```

The healthcheck.sh in the container can perform  a few more extensive functions than the wait-for-it script.
