### PR TITLE
Prevent creating duplicate customers in some scenarios

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1210,6 +1210,11 @@ class CustomerCore extends ObjectModel
             return false;
         }
 
+        // If a customer with the same email already exists, wrong call
+        if (Customer::customerExists($this->email)) {
+            return false;
+        }
+
         $this->is_guest = false;
 
         /*

--- a/controllers/front/GuestTrackingController.php
+++ b/controllers/front/GuestTrackingController.php
@@ -113,6 +113,13 @@ class GuestTrackingControllerCore extends FrontController
                     [],
                     'Shop.Notifications.Error'
                 );
+            // Check if a different customer with the same email was not already created in a different window or through backoffice
+            } elseif (Customer::customerExists($customer->email)) {
+                $this->errors[] = $this->trans(
+                    'You can\'t transform your account into a customer account, because a registered customer with the same email already exists.',
+                    [],
+                    'Shop.Notifications.Error'
+                );
             // Attempt to convert the customer
             } elseif ($customer->transformToCustomer($this->context->language->id, $password)) {
                 $this->success[] = $this->trans(

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -181,9 +181,19 @@ class OrderConfirmationControllerCore extends FrontController
                 return;
             }
 
+            // Prevent error
+            // A) either on page refresh
+            // B) if we already transformed him in other window or through backoffice
             if ($this->customer->is_guest == 0) {
                 $this->errors[] = $this->trans(
                     'A customer account has already been created from this guest account. Please sign in.',
+                    [],
+                    'Shop.Notifications.Error'
+                );
+            // Check if a different customer with the same email was not already created in a different window or through backoffice
+            } elseif (Customer::customerExists($this->customer->email)) {
+                $this->errors[] = $this->trans(
+                    'You can\'t transform your account into a customer account, because a registered customer with the same email already exists.',
                     [],
                     'Shop.Notifications.Error'
                 );


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | When converting guest to customer, we check if a customer exists during displaying the prompt, we check if the customer is a guest during processing of the requests, but we forget to check, if ANOTHER guest account with the same email wasn't already transformed in some other window or in backoffice.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Read below
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/9744074711/job/26888923702 ✅ 
| Fixed issue or discussion?     | Fixes #36421
| Related PRs       | 
| Sponsor company   | 

### How to reproduce - guest tracking
- Create order as a guest. Let's say this is order and customer A.
- Create another order as a guest with the same email. Let's say this is order and customer B.
- Go to order tracking of order B. Check that you see the guest transformation box. Keep it open.
- In BO, transform the guest A a customer.
- Now, go back to order tracking of order B and transform the customer. It won't work with my PR, it will work without by PR.

### How to reproduce - order confirmation page
- Create order as a guest. Let's say this is order and customer C.
- Create another order as a guest with the same email. Let's say this is order and customer D. Keep the order confirmation open.
- In BO, transform the guest C a customer.
- Now, go back to confirmation of order D and transform the customer. It won't work with my PR, it will work without by PR.


