### PR TITLE
Fix: Pass correct language ID to getAttributesName instead of hardcoded 1

### DIFF
--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -421,6 +421,7 @@ class AdminProductWrapper
      */
     public function getSpecificPricesList($product, $defaultCurrency, $shops, $currencies, $countries, $groups)
     {
+        $context = Context::getContext();
         $content = [];
         $specific_prices = array_merge(
             SpecificPrice::getByProductId((int) $product->id),
@@ -478,7 +479,7 @@ class AdminProductWrapper
                 }
                 if ($specific_price['id_product_attribute']) {
                     $combination = new Combination((int) $specific_price['id_product_attribute']);
-                    $attributes = $combination->getAttributesName(1);
+                    $attributes = $combination->getAttributesName($context->language->id);
                     $attributes_name = '';
                     foreach ($attributes as $attribute) {
                         $attributes_name .= $attribute['name'] . ' - ';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | The language id param is set to 1 by default. This causes an issue in fetching the good name when changing the language in BO -> product page -> Price tab -> Specific price list. Using the language id in context should fix the issue.  
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      |  BO -> product page -> Prix tab -> Specific price list. Create a specific price for a declinaison.  In the list, the name of declinaison will be displayed well with this fix. Before that only the name in english language will be displayed.
| UI Tests          | https://github.com/mouleeg/ga.tests.ui.pr/actions/workflows/pr_test.yml https://github.com/florine2623/testing_pr/actions/runs/9740649087
| Fixed issue or discussion?     | #36458 
| Related PRs       | 
| Sponsor company   | 
