### PR TITLE
Fix `cart_quantity` in front ProductController

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1204,7 +1204,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product['new'] = (int) $this->product->new;
         $product['id_product_attribute'] = $this->getIdProductAttributeByGroupOrRequestOrDefault();
         $product['minimal_quantity'] = $this->getProductMinimalQuantity($product);
-        $product['cart_quantity'] = $this->context->cart->getProductQuantity($product['id_product'], $product['id_product_attribute'])['quantity'];
+        $product['cart_quantity'] = $this->context->cart->getProductQuantity($this->product->id_product, $product['id_product_attribute'])['quantity'];
         $product['quantity_wanted'] = $this->getRequiredQuantity($product);
         $product['extraContent'] = $extraContentFinder->addParams(['product' => $this->product])->present();
         $product['ecotax_tax_inc'] = $this->product->getEcotax(null, true, true);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fix `cart_quantity` in front ProductController. This is used when we select a combination in product page.<br>In fact, this cause a wrong value in `cart_quantity` to retrieve the current quantity of this combination in cart.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Set a minimal quantity in a combination product (for one combination only!)<br>2. Go to the shop, and add in cart the combination product setting with a new minimum quantity.<br>3. When we close the confirmation modal, we need to see that the input quantity is set to 1 instead of the minimal quantity
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/9745909412
| Fixed issue or discussion?     | Related to observation made by @tblivet in #36456 
| Related PRs       | #35902
| Sponsor company   | PrestaShop SA
