### PR TITLE
Add currency context for new admin API

### DIFF
--- a/app/config/admin-api/services.yml
+++ b/app/config/admin-api/services.yml
@@ -34,12 +34,18 @@ services:
   PrestaShopBundle\EventListener\API\Context\LanguageContextListener:
     tags:
       - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 5 }
+  # We set a high priority so this listener has a bigger one than ReadListener ApiPlatform (which has a priority of 4)
+  # but lower than the ShopContextListener because the listener depends on it
+  PrestaShopBundle\EventListener\API\Context\CurrencyContextListener:
+    tags:
+      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 5 }
 
   # We need to leave this under the LanguageContextListener for priorities.
   PrestaShopBundle\EventListener\API\Context\ApiLegacyContextListener:
     arguments:
       $legacyBuilders:
         - '@PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder'
+        - '@PrestaShop\PrestaShop\Core\Context\CurrencyContextBuilder'
     tags:
       - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 5 }
 

--- a/src/PrestaShopBundle/ApiPlatform/ContextParametersTrait.php
+++ b/src/PrestaShopBundle/ApiPlatform/ContextParametersTrait.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShopBundle\ApiPlatform;
 
 use PrestaShop\PrestaShop\Core\Context\ApiClientContext;
+use PrestaShop\PrestaShop\Core\Context\CurrencyContext;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Context\ShopContext;
 
@@ -36,6 +37,7 @@ trait ContextParametersTrait
 {
     protected readonly ShopContext $shopContext;
     protected readonly LanguageContext $languageContext;
+    protected readonly CurrencyContext $currencyContext;
     protected readonly ApiClientContext $apiClientContext;
 
     protected function getContextParameters(): array
@@ -52,6 +54,7 @@ trait ContextParametersTrait
                 'shopId' => $this->shopContext->getId(),
                 'shopIds' => $this->shopContext->getAssociatedShopIds(),
                 'langId' => $this->languageContext->getId(),
+                'currencyId' => $this->currencyContext->getId(),
                 'apiClientId' => $this->apiClientContext->getApiClient()?->getId(),
             ],
         ];

--- a/src/PrestaShopBundle/ApiPlatform/Processor/CommandProcessor.php
+++ b/src/PrestaShopBundle/ApiPlatform/Processor/CommandProcessor.php
@@ -32,6 +32,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Context\ApiClientContext;
+use PrestaShop\PrestaShop\Core\Context\CurrencyContext;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShopBundle\ApiPlatform\ContextParametersTrait;
@@ -51,6 +52,7 @@ class CommandProcessor implements ProcessorInterface
         protected readonly DomainSerializer $domainSerializer,
         protected readonly ShopContext $shopContext,
         protected readonly LanguageContext $languageContext,
+        protected readonly CurrencyContext $currencyContext,
         protected readonly ApiClientContext $apiClientContext,
     ) {
     }

--- a/src/PrestaShopBundle/ApiPlatform/Provider/QueryListProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/QueryListProvider.php
@@ -32,6 +32,7 @@ use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use PrestaShop\PrestaShop\Core\Context\ApiClientContext;
+use PrestaShop\PrestaShop\Core\Context\CurrencyContext;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Exception\TypeException;
@@ -61,6 +62,7 @@ class QueryListProvider implements ProviderInterface
         protected readonly ContainerInterface $container,
         protected readonly ShopContext $shopContext,
         protected readonly LanguageContext $languageContext,
+        protected readonly CurrencyContext $currencyContext,
         protected readonly ApiClientContext $apiClientContext,
         protected readonly FiltersBuilderInterface $filtersBuilder
     ) {

--- a/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php
@@ -32,6 +32,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Context\ApiClientContext;
+use PrestaShop\PrestaShop\Core\Context\CurrencyContext;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShopBundle\ApiPlatform\ContextParametersTrait;
@@ -51,6 +52,7 @@ class QueryProvider implements ProviderInterface
         protected readonly DomainSerializer $domainSerializer,
         protected readonly ShopContext $shopContext,
         protected readonly LanguageContext $languageContext,
+        protected readonly CurrencyContext $currencyContext,
         protected readonly ApiClientContext $apiClientContext,
     ) {
     }

--- a/src/PrestaShopBundle/EventListener/API/Context/CurrencyContextListener.php
+++ b/src/PrestaShopBundle/EventListener/API/Context/CurrencyContextListener.php
@@ -8,6 +8,9 @@ use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
+/**
+ * Listener dedicated to set up Currency context for the Back-Office/Admin application.
+ */
 class CurrencyContextListener
 {
     public function __construct(

--- a/src/PrestaShopBundle/EventListener/API/Context/CurrencyContextListener.php
+++ b/src/PrestaShopBundle/EventListener/API/Context/CurrencyContextListener.php
@@ -17,8 +17,7 @@ class CurrencyContextListener
         private readonly CurrencyContextBuilder $currencyContextBuilder,
         private readonly ShopConfigurationInterface $configuration,
         private readonly ShopContext $shopContext
-    )
-    {
+    ) {
     }
 
     public function onKernelRequest(RequestEvent $event): void

--- a/src/PrestaShopBundle/EventListener/API/Context/CurrencyContextListener.php
+++ b/src/PrestaShopBundle/EventListener/API/Context/CurrencyContextListener.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace PrestaShopBundle\EventListener\API\Context;
+
+use PrestaShop\PrestaShop\Core\Context\CurrencyContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+class CurrencyContextListener
+{
+    public function __construct(
+        private readonly CurrencyContextBuilder $currencyContextBuilder,
+        private readonly ShopConfigurationInterface $configuration,
+        private readonly ShopContext $shopContext
+    )
+    {
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $defaultCurrencyId = $this->configuration->get('PS_CURRENCY_DEFAULT', null, ShopConstraint::shop($this->shopContext->getId()));
+
+        $this->currencyContextBuilder->setCurrencyId($defaultCurrencyId);
+
+        $currencyId = $event->getRequest()->get('currencyId', $defaultCurrencyId);
+        if ($currencyId) {
+            $this->currencyContextBuilder->setCurrencyId((int) $currencyId);
+        } else {
+            $this->currencyContextBuilder->setCurrencyId($defaultCurrencyId);
+        }
+    }
+}

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
@@ -67,6 +67,8 @@ class QueryProviderTest extends TestCase
 
     private LanguageContext $languageContext;
 
+    private CurrencyContext $currencyContext;
+
     private ShopContext $shopContext;
 
     private ApiClientContext $apiClientContext;

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
@@ -36,6 +36,7 @@ use PrestaShop\Module\APIResources\ApiPlatform\Resources\FoundProduct as FoundPr
 use PrestaShop\Module\APIResources\ApiPlatform\Resources\Hook;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Context\ApiClientContext;
+use PrestaShop\PrestaShop\Core\Context\CurrencyContext;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Domain\Hook\Query\GetHook;
@@ -94,6 +95,8 @@ class QueryProviderTest extends TestCase
             });
         $this->languageContext = $this->createMock(LanguageContext::class);
         $this->languageContext->method('getId')->willReturn(42);
+        $this->currencyContext = $this->createMock(CurrencyContext::class);
+        $this->currencyContext->method('getId')->willReturn(1);
         $this->shopContext = $this->createMock(ShopContext::class);
         $this->shopContext->method('getShopConstraint')->willReturn(ShopConstraint::shop(1));
         $this->shopContext->method('getId')->willReturn(1);
@@ -103,7 +106,7 @@ class QueryProviderTest extends TestCase
 
     public function testProvideHookStatus(): void
     {
-        $hookStatusProvider = new QueryProvider($this->queryBus, $this->serializer, $this->shopContext, $this->languageContext, $this->apiClientContext);
+        $hookStatusProvider = new QueryProvider($this->queryBus, $this->serializer, $this->shopContext, $this->languageContext, $this->currencyContext, $this->apiClientContext);
         $get = new Get();
         $get = $get
             ->withExtraProperties(['CQRSQuery' => GetHookStatus::class])
@@ -118,7 +121,7 @@ class QueryProviderTest extends TestCase
 
     public function testProvideHook(): void
     {
-        $hookStatusProvider = new QueryProvider($this->queryBus, $this->serializer, $this->shopContext, $this->languageContext, $this->apiClientContext);
+        $hookStatusProvider = new QueryProvider($this->queryBus, $this->serializer, $this->shopContext, $this->languageContext, $this->currencyContext, $this->apiClientContext);
         $get = new Get();
         $get = $get
             ->withExtraProperties(['CQRSQuery' => GetHook::class])
@@ -139,7 +142,7 @@ class QueryProviderTest extends TestCase
 
     public function testSearchProduct(): void
     {
-        $searchProductProvider = new QueryProvider($this->queryBus, $this->serializer, $this->shopContext, $this->languageContext, $this->apiClientContext);
+        $searchProductProvider = new QueryProvider($this->queryBus, $this->serializer, $this->shopContext, $this->languageContext, $this->currencyContext, $this->apiClientContext);
         $get = new GetCollection();
         $get = $get
             ->withExtraProperties(['CQRSQuery' => SearchProducts::class])
@@ -147,14 +150,14 @@ class QueryProviderTest extends TestCase
         $searchProducts = $searchProductProvider->provide($get, ['phrase' => 'mug', 'resultsLimit' => 10, 'isoCode' => 'EUR']);
         self::assertCount(1, $searchProducts);
 
-        $searchProductProvider = new QueryProvider($this->queryBus, $this->serializer, $this->shopContext, $this->languageContext, $this->apiClientContext);
+        $searchProductProvider = new QueryProvider($this->queryBus, $this->serializer, $this->shopContext, $this->languageContext, $this->currencyContext, $this->apiClientContext);
         $searchProducts = $searchProductProvider->provide($get, ['phrase' => 'search with order id', 'resultsLimit' => 10, 'isoCode' => 'EUR'], ['filters' => ['orderId' => 1]]);
         self::assertCount(0, $searchProducts);
     }
 
     public function testProvideNoQueryThrowsException(): void
     {
-        $hookStatusProvider = new QueryProvider($this->queryBus, $this->serializer, $this->shopContext, $this->languageContext, $this->apiClientContext);
+        $hookStatusProvider = new QueryProvider($this->queryBus, $this->serializer, $this->shopContext, $this->languageContext, $this->currencyContext, $this->apiClientContext);
         $get = new Get();
 
         $this->expectException(CQRSQueryNotFoundException::class);

--- a/tests/Unit/PrestaShopBundle/EventListener/API/Context/CurrencyContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/API/Context/CurrencyContextListenerTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\EventListener\API\Context;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PrestaShop\PrestaShop\Adapter\ContextStateManager;
+use PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository;
+use PrestaShop\PrestaShop\Core\Context\CurrencyContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\Unit\PrestaShopBundle\EventListener\ContextEventListenerTestCase;
+
+class CurrencyContextListenerTest extends ContextEventListenerTestCase
+{
+    private const DEFAULT_CURRENCY_ID = 42;
+    private const QUERY_CURRENCY_ID = 51;
+    private const SHOP_ID = 69;
+
+    public function testCurrencyContextBasedOnRequestParameter(): void
+    {
+        // Create request that mimic a call to external API
+        $event = $this->createRequestEvent(new Request(['currencyId' => self::QUERY_CURRENCY_ID]));
+
+        $currencyContextBuilder = new CurrencyContextBuilder(
+            $this->createMock(CurrencyRepository::class),
+            $this->createMock(ContextStateManager::class),
+            $this->createMock(LanguageContext::class)
+        );
+
+        $listener = new CurrencyContextListener(
+            $currencyContextBuilder,
+            $this->mockConfiguration(['PS_CURRENCY_DEFAULT' => self::DEFAULT_CURRENCY_ID], ShopConstraint::shop(self::SHOP_ID)),
+            $this->mockShopContext()
+        );
+
+        $listener->onKernelRequest($event);
+        $this->assertEquals(self::QUERY_CURRENCY_ID, $this->getPrivateField($currencyContextBuilder, 'currencyId'));
+    }
+
+    public function testCurrencyContextBasedOnShopConfiguration(): void
+    {
+        // Create request that mimic a call to external API (no currencyId parameter)
+        $event = $this->createRequestEvent(new Request());
+
+        $currencyContextBuilder = new CurrencyContextBuilder(
+            $this->createMock(CurrencyRepository::class),
+            $this->createMock(ContextStateManager::class),
+            $this->createMock(LanguageContext::class)
+        );
+
+        $listener = new CurrencyContextListener(
+            $currencyContextBuilder,
+            $this->mockConfiguration(['PS_CURRENCY_DEFAULT' => self::DEFAULT_CURRENCY_ID], ShopConstraint::shop(self::SHOP_ID)),
+            $this->mockShopContext()
+        );
+
+        $listener->onKernelRequest($event);
+        $this->assertEquals(self::DEFAULT_CURRENCY_ID, $this->getPrivateField($currencyContextBuilder, 'currencyId'));
+    }
+
+    private function mockShopContext(): ShopContext|MockObject
+    {
+        $shopContext = $this->createMock(ShopContext::class);
+        $shopContext->method('getId')->willReturn(self::SHOP_ID);
+
+        return $shopContext;
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add currency context for new admin API
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a new API ressource who need the currency context in its CQRSQuery, e.g.: GetOrderForViewing and call the endpoint.
| UI Tests          | https://github.com/clement-hvt/ga.tests.ui.pr/actions/runs/9766900904
| Fixed issue or discussion?     | Fixes #36483
| Related PRs       |
| Sponsor company   |
