### PR TITLE
Fix precision of tax calculator

### DIFF
--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -174,16 +174,34 @@ class Calculator
             throw new \Exception('Cart must be processed before getting its total');
         }
 
-        $amount = $this->getRowTotalWithoutDiscount();
+        /*
+         * First, we get the total price of items in the cart with no discounts.
+         * We will round everything once again, because some prices in the sum may not be rounded
+         * to keep their precision.
+         */
+        $amount = $this->rounded($this->getRowTotalWithoutDiscount(), $this->computePrecision);
+
+        /*
+         * Now, we subtract the amount of discounts from this sum.
+         */
         $amount = $amount->sub($this->rounded($this->getDiscountTotal(), $this->computePrecision));
+
+        /*
+         * Next thing, we add a rounded value for shipping fees.
+         */
         $shippingFees = $this->fees->getInitialShippingFees();
         if (null !== $shippingFees) {
             $amount = $amount->add($this->rounded($shippingFees, $this->computePrecision));
         }
+
+        /*
+         * And absolutely last, we add wrapping fees if they are present.
+         */
         $wrappingFees = $this->fees->getFinalWrappingFees();
         if (null !== $wrappingFees) {
             $amount = $amount->add($this->rounded($wrappingFees, $this->computePrecision));
         }
+
 
         return $amount;
     }
@@ -204,6 +222,9 @@ class Calculator
     }
 
     /**
+     * This method returns sum of all cart lines - products.
+     * It returns the prices with their original price, without applying any cart rules on them.
+     *
      * @return AmountImmutable
      *
      * @throws \Exception
@@ -212,7 +233,19 @@ class Calculator
     {
         $amount = new AmountImmutable();
         foreach ($this->cartRows as $cartRow) {
-            $amount = $amount->add($cartRow->getInitialTotalPrice());
+            /*
+             * We round the tax included price only, to keep the calculations using
+             * the displayed prices the user sees. If he sees 999 EUR, we will use this
+             * rounded values for calculations, no magic 999.5 EUR behind this.
+             *
+             * For tax excluded price however, we keep the non-rounded value, because we could
+             * have a big difference at the end of the calculation. We will round the tax
+             * excluded price as a last thing.
+             *
+             * If we decide one day to support using tax excluded price as the primary one, we
+             * can reverse this the other way around.
+             */
+            $amount = $amount->add($this->roundedTaxIncluded($cartRow->getInitialTotalPrice(), $this->computePrecision));
         }
 
         return $amount;
@@ -312,7 +345,7 @@ class Calculator
     }
 
     /**
-     * calculate only product rows.
+     * Calculate only product rows.
      */
     public function calculateRows()
     {
@@ -322,7 +355,7 @@ class Calculator
     }
 
     /**
-     * calculate only cart rules (rows and fees have to be calculated first).
+     * Calculate only cart rules (rows and fees have to be calculated first).
      */
     public function calculateCartRules()
     {
@@ -363,6 +396,9 @@ class Calculator
     }
 
     /**
+     * Rounds both values in the amount by given precision. Useful for total sums,
+     * where no additional precision is required and we want the final price.
+     *
      * @param AmountImmutable $amount
      * @param int $computePrecision
      *
@@ -373,6 +409,24 @@ class Calculator
         return new AmountImmutable(
             Tools::ps_round($amount->getTaxIncluded(), $computePrecision),
             Tools::ps_round($amount->getTaxExcluded(), $computePrecision)
+        );
+    }
+
+    /**
+     * Rounds only tax included price by given precision and leaves the tax
+     * excluded price with original precision. Useful for inter-calculations
+     * when we have one primary price to use.
+     *
+     * @param AmountImmutable $amount
+     * @param int $computePrecision
+     *
+     * @return AmountImmutable
+     */
+    private function roundedTaxIncluded(AmountImmutable $amount, int $computePrecision)
+    {
+        return new AmountImmutable(
+            Tools::ps_round($amount->getTaxIncluded(), $computePrecision),
+            $amount->getTaxExcluded()
         );
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fixes the issue when product total can be different than order total. Basically, the only change is rounding the product sum during adding them, not in the end. More information here - https://github.com/PrestaShop/PrestaShop/issues/36369#issuecomment-2206906692
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Read below
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/9783293566
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/36369
| Related PRs       | 
| Sponsor company   | [TRENDO s.r.o.](https://www.trendo.cz/)

### How to test
Do full manual tests with cart rules.
Verify my scenario is fixed and no other is broken.

### Comment
Verify by @kpodemski please.
I am now sure that the product price is 100% correctly calculated and rounded. The same with other prices.
One last thing I am not sure is if there is not a possibility of tax excluded price still being wrong in some cases.
In getTotal method, imagine we have 1659 CZK / 2007 CZK for total products.
Then, we have shipping fees with the same amount 1659 CZK / 2007 CZK.
Then the displayed tax excluded price will be 3318 CZK, but it should be 3317 CZK.
Yes, they are returned rounded #taxIncluded: 2007.0, #taxExcluded: 1659.0... yet another bug.
The amount is rounded all the way back in `Cart::getPackageShippingCost`.