### PR TITLE
Presenter classes: use new php attributes instead of php doc

### DIFF
--- a/src/Adapter/Presenter/Category/CategoryLazyArray.php
+++ b/src/Adapter/Presenter/Category/CategoryLazyArray.php
@@ -33,6 +33,7 @@ use Language;
 use Link;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
+use PrestaShop\PrestaShop\Adapter\Presenter\LazyArrayAttribute;
 
 class CategoryLazyArray extends AbstractLazyArray
 {
@@ -72,10 +73,9 @@ class CategoryLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getUrl()
     {
         return $this->link->getCategoryLink(
@@ -85,14 +85,13 @@ class CategoryLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * This method returns standardized category image array created from CATEGORYID.jpg, with one exception.
      * One thumbnail size - CATEGORYID-small_default.jpg is generated from CATEGORYID_thumb.jpg instead.
      * This must be resolved in the future.
      *
      * @return array|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getImage()
     {
         /*
@@ -111,10 +110,9 @@ class CategoryLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getCover()
     {
         return $this->getImage();
@@ -124,10 +122,9 @@ class CategoryLazyArray extends AbstractLazyArray
      * @todo This should return category thumbnail image (miniatures of CATEGORYID_thumb.jpg) instead,
      * after support in ImageRetriever is implemented.
      *
-     * @arrayAccess
-     *
      * @return array|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getThumbnail()
     {
         return $this->getImage();

--- a/src/Adapter/Presenter/Manufacturer/ManufacturerLazyArray.php
+++ b/src/Adapter/Presenter/Manufacturer/ManufacturerLazyArray.php
@@ -31,6 +31,7 @@ use Link;
 use Manufacturer;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
+use PrestaShop\PrestaShop\Adapter\Presenter\LazyArrayAttribute;
 
 class ManufacturerLazyArray extends AbstractLazyArray
 {
@@ -70,30 +71,27 @@ class ManufacturerLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getText()
     {
         return $this->manufacturer['short_description'];
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getUrl()
     {
         return $this->link->getManufacturerLink($this->manufacturer['id']);
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getImage()
     {
         return $this->imageRetriever->getImage(
@@ -103,10 +101,9 @@ class ManufacturerLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return int
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getNbProducts()
     {
         if (!isset($this->manufacturer['nb_products'])) {

--- a/src/Adapter/Presenter/Order/OrderDetailLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderDetailLazyArray.php
@@ -33,6 +33,7 @@ use Currency;
 use HistoryController;
 use Order;
 use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
+use PrestaShop\PrestaShop\Adapter\Presenter\LazyArrayAttribute;
 use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
 use PrestaShopBundle\Translation\TranslatorComponent;
 use PrestaShopException;
@@ -75,132 +76,119 @@ class OrderDetailLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return int
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getId()
     {
         return $this->order->id;
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getReference()
     {
         return $this->order->reference;
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      *
      * @throws PrestaShopException
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getOrderDate()
     {
         return Tools::displayDate($this->order->date_add, false);
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getDetailsUrl()
     {
         return $this->context->link->getPageLink('order-detail', null, null, 'id_order=' . $this->order->id);
     }
 
     /**
-     * @arrayAccess
-     *
      * @return mixed
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getReorderUrl()
     {
         return HistoryController::getUrlToReorder((int) $this->order->id, $this->context);
     }
 
     /**
-     * @arrayAccess
-     *
      * @return mixed
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getInvoiceUrl()
     {
         return HistoryController::getUrlToInvoice($this->order, $this->context);
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getGiftMessage()
     {
         return nl2br($this->order->gift_message);
     }
 
     /**
-     * @arrayAccess
-     *
      * @return int
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getIsReturnable()
     {
         return (int) $this->order->isReturnable();
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getPayment()
     {
         return $this->order->payment;
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getModule()
     {
         return $this->order->module;
     }
 
     /**
-     * @arrayAccess
-     *
      * @return bool
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getRecyclable()
     {
         return (bool) $this->order->recyclable;
     }
 
     /**
-     * @arrayAccess
-     *
      * @return bool
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getIsValid()
     {
         return $this->order->valid;
     }
 
     /**
-     * @arrayAccess
-     *
      * @return bool
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getIsVirtual()
     {
         $cart = new Cart($this->order->id_cart);
@@ -209,10 +197,9 @@ class OrderDetailLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getShipping()
     {
         $order = $this->order;

--- a/src/Adapter/Presenter/Order/OrderLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderLazyArray.php
@@ -39,6 +39,7 @@ use Order;
 use OrderReturn;
 use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\Cart\CartPresenter;
+use PrestaShop\PrestaShop\Adapter\Presenter\LazyArrayAttribute;
 use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator;
@@ -91,10 +92,9 @@ class OrderLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return mixed
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getTotals()
     {
         $amounts = $this->getAmounts();
@@ -103,52 +103,47 @@ class OrderLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return int
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getIdAddressInvoice()
     {
         return $this->order->id_address_invoice;
     }
 
     /**
-     * @arrayAccess
-     *
      * @return int
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getIdAddressDelivery()
     {
         return $this->order->id_address_delivery;
     }
 
     /**
-     * @arrayAccess
-     *
      * @return mixed
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getSubtotals()
     {
         return $this->subTotals;
     }
 
     /**
-     * @arrayAccess
-     *
      * @return int
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getProductsCount()
     {
         return count($this->getProducts());
     }
 
     /**
-     * @arrayAccess
-     *
      * @return mixed
      *
      * @throws PrestaShopException
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getShipping()
     {
         $details = $this->getDetails();
@@ -157,10 +152,9 @@ class OrderLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getProducts()
     {
         $order = $this->order;
@@ -226,10 +220,9 @@ class OrderLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getAmounts()
     {
         $order = $this->order;
@@ -279,20 +272,18 @@ class OrderLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return OrderDetailLazyArray
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getDetails()
     {
         return new OrderDetailLazyArray($this->order);
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getHistory()
     {
         $order = $this->order;
@@ -320,10 +311,9 @@ class OrderLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getMessages()
     {
         $order = $this->order;
@@ -347,10 +337,9 @@ class OrderLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getCarrier()
     {
         $order = $this->order;
@@ -364,10 +353,9 @@ class OrderLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getAddresses()
     {
         $order = $this->order;
@@ -393,10 +381,9 @@ class OrderLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getFollowUp()
     {
         $order = $this->order;
@@ -410,10 +397,9 @@ class OrderLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getLabels()
     {
         return [

--- a/src/Adapter/Presenter/Order/OrderReturnLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderReturnLazyArray.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Adapter\Presenter\Order;
 
 use Link;
 use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
+use PrestaShop\PrestaShop\Adapter\Presenter\LazyArrayAttribute;
 use PrestaShopException;
 use ReflectionException;
 use Tools;
@@ -66,20 +67,18 @@ class OrderReturnLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return mixed
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getId()
     {
         return $this->orderReturn['id_order_return'];
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getDetailsUrl()
     {
         return $this->link->getPageLink(
@@ -91,10 +90,9 @@ class OrderReturnLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getReturnUrl()
     {
         return $this->link->getPageLink(
@@ -106,32 +104,29 @@ class OrderReturnLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getReturnNumber()
     {
         return $this->prefix . sprintf('%06d', $this->orderReturn['id_order_return']);
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      *
      * @throws PrestaShopException
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getReturnDate()
     {
         return Tools::displayDate($this->orderReturn['date_add'], false);
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getPrintUrl()
     {
         return ($this->orderReturn['state'] == 2)

--- a/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
@@ -32,6 +32,7 @@ use Context;
 use Currency;
 use Order;
 use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
+use PrestaShop\PrestaShop\Adapter\Presenter\LazyArrayAttribute;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShopBundle\Translation\TranslatorComponent;
 use TaxConfiguration;
@@ -69,10 +70,9 @@ class OrderSubtotalLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getProducts()
     {
         $totalProducts = ($this->includeTaxes) ? $this->order->total_products_wt : $this->order->total_products;
@@ -89,10 +89,9 @@ class OrderSubtotalLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getDiscounts()
     {
         $discountAmount = ($this->includeTaxes)
@@ -119,10 +118,9 @@ class OrderSubtotalLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getShipping()
     {
         $cart = new Cart($this->order->id_cart);
@@ -151,10 +149,9 @@ class OrderSubtotalLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getTax()
     {
         if (!Configuration::get('PS_TAX_DISPLAY')) {
@@ -180,10 +177,9 @@ class OrderSubtotalLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getGiftWrapping()
     {
         if ($this->order->gift) {

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -40,6 +40,7 @@ use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\HookManager;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
+use PrestaShop\PrestaShop\Adapter\Presenter\LazyArrayAttribute;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Core\Domain\Product\ProductCustomizabilitySettings;
@@ -157,20 +158,18 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return mixed
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getId()
     {
         return $this->product['id_product'];
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array|mixed
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getAttributes()
     {
         if (isset($this->product['attributes'])) {
@@ -181,60 +180,54 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return bool
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getShowPrice()
     {
         return $this->shouldShowPrice($this->settings, $this->product);
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getWeightUnit()
     {
         return $this->configuration->get('PS_WEIGHT_UNIT');
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getUrl()
     {
         return $this->getProductURL($this->product, $this->language);
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getLink()
     {
         return $this->getProductURL($this->product, $this->language);
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getCanonicalUrl()
     {
         return $this->getProductURL($this->product, $this->language, true);
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getAddToCartUrl()
     {
         if ($this->shouldEnableAddToCartButton($this->product, $this->settings)) {
@@ -248,12 +241,11 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array|bool
      *
      * @throws InvalidArgumentException
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getCondition()
     {
         if (empty($this->product['show_condition'])) {
@@ -285,10 +277,9 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getDeliveryInformation()
     {
         $productQuantity = $this->product['stock_quantity'] ?? $this->product['quantity'];
@@ -307,10 +298,9 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getEmbeddedAttributes()
     {
         $whitelist = $this->getProductAttributeWhitelist();
@@ -325,10 +315,9 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getFileSizeFormatted()
     {
         if (!isset($this->product['attachments'])) {
@@ -342,12 +331,11 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      *
      * @throws ReflectionException
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getAttachments()
     {
         // If this is a first call to this property
@@ -378,20 +366,18 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array|mixed
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getQuantityDiscounts()
     {
         return (isset($this->product['quantity_discounts'])) ? $this->product['quantity_discounts'] : [];
     }
 
     /**
-     * @arrayAccess
-     *
      * @return mixed|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getReferenceToDisplay()
     {
         $combinationData = $this->getCombinationSpecificData();
@@ -409,10 +395,9 @@ class ProductLazyArray extends AbstractLazyArray
     /**
      * Returns all product features, not grouped yet for performance reasons.
      *
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getFeatures()
     {
         /*
@@ -430,10 +415,9 @@ class ProductLazyArray extends AbstractLazyArray
     /**
      * Returns all product feature values nicely grouped by feature name.
      *
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getGroupedFeatures()
     {
         return $this->buildGroupedFeatures($this->getFeatures());
@@ -444,10 +428,9 @@ class ProductLazyArray extends AbstractLazyArray
      * https://support.google.com/merchants/answer/6324448
      * https://schema.org/ItemAvailability
      *
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getSeoAvailability()
     {
         // Availability for displaying discontinued products, if enabled
@@ -466,12 +449,11 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      *
      * @throws InvalidArgumentException
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getLabels()
     {
         return [
@@ -485,10 +467,9 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getEcotax()
     {
         if (isset($this->product['ecotax'])) {
@@ -503,10 +484,9 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getManufacturerName()
     {
         if (!isset($this->product['manufacturer_name'])) {
@@ -526,10 +506,9 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getCategory()
     {
         if (!isset($this->product['category'])) {
@@ -543,10 +522,9 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getCategoryName()
     {
         if (!isset($this->product['category_name'])) {
@@ -563,20 +541,18 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return bool
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getVirtual()
     {
         return !empty($this->product['is_virtual'] || !empty($this->product['virtual']));
     }
 
     /**
-     * @arrayAccess
-     *
      * @return int
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getNew()
     {
         if (!isset($this->product['new'])) {
@@ -587,12 +563,11 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      *
      * @throws InvalidArgumentException
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getFlags()
     {
         $flags = [];
@@ -663,10 +638,9 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getMainVariants()
     {
         $colors = $this->productColorsRetriever->getColoredVariants($this->product['id_product']);
@@ -696,10 +670,9 @@ class ProductLazyArray extends AbstractLazyArray
      * Also, on product page, $this->product['attributes'] contains a list of combinations, while in cart
      * it contains only attribute pairs like Color-Black etc.
      *
-     * @arrayAccess
-     *
      * @return array|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getCombinationSpecificData()
     {
         if (!isset($this->product['attributes']) || !is_array($this->product['attributes']) || empty($this->product['attributes'])) {
@@ -713,10 +686,9 @@ class ProductLazyArray extends AbstractLazyArray
      * This function returns current combination references, if set.
      * Otherwise, it returns the base product references.
      *
-     * @arrayAccess
-     *
      * @return array|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getSpecificReferences()
     {
         if (isset($this->product['cart_quantity'])) {
@@ -1184,10 +1156,9 @@ class ProductLazyArray extends AbstractLazyArray
     /**
      * Returns extra price associated with current combination, if provided
      *
-     * @arrayAccess
-     *
      * @return float
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getAttributePrice()
     {
         if (!isset($this->product['attribute_price'])) {

--- a/src/Adapter/Presenter/Product/ProductListingLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductListingLazyArray.php
@@ -26,16 +26,16 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Presenter\Product;
 
+use PrestaShop\PrestaShop\Adapter\Presenter\LazyArrayAttribute;
 use PrestaShop\PrestaShop\Core\Domain\Product\ProductCustomizabilitySettings;
 use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
 
 class ProductListingLazyArray extends ProductLazyArray
 {
     /**
-     * @arrayAccess
-     *
      * @return string|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getAddToCartUrl()
     {
         if ($this->product['id_product_attribute'] != 0 && !$this->settings->allow_add_variant_to_cart_from_listing) {

--- a/src/Adapter/Presenter/Store/StoreLazyArray.php
+++ b/src/Adapter/Presenter/Store/StoreLazyArray.php
@@ -31,6 +31,7 @@ use AddressFormat;
 use Language;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
+use PrestaShop\PrestaShop\Adapter\Presenter\LazyArrayAttribute;
 use Store;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -72,10 +73,9 @@ class StoreLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getImage()
     {
         return $this->imageRetriever->getImage(
@@ -85,10 +85,9 @@ class StoreLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getAddress()
     {
         // If we already have processed address, let's return it directly
@@ -111,10 +110,9 @@ class StoreLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getBusinessHours()
     {
         if (isset($this->store['business_hours'])) {

--- a/src/Adapter/Presenter/Supplier/SupplierLazyArray.php
+++ b/src/Adapter/Presenter/Supplier/SupplierLazyArray.php
@@ -30,6 +30,7 @@ use Language;
 use Link;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
+use PrestaShop\PrestaShop\Adapter\Presenter\LazyArrayAttribute;
 use Supplier;
 
 class SupplierLazyArray extends AbstractLazyArray
@@ -70,20 +71,18 @@ class SupplierLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return string
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getUrl()
     {
         return $this->link->getSupplierLink($this->supplier['id']);
     }
 
     /**
-     * @arrayAccess
-     *
      * @return array|null
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getImage()
     {
         return $this->imageRetriever->getImage(
@@ -93,10 +92,9 @@ class SupplierLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @arrayAccess
-     *
      * @return int
      */
+    #[LazyArrayAttribute(arrayAccess: true)]
     public function getNbProducts()
     {
         if (!isset($this->supplier['nb_products'])) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In presenters implemented the lazy array mechanism: replace @arrayAccess php docs with new php attributes that were implemented in #36477 
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green
| UI Tests          | [UI TESTS](https://github.com/matthieu-rolland/ga.tests.ui.pr/actions/runs/9837643115)
| Fixed issue or discussion?     | none
| Related PRs       | 
| Sponsor company   | PrestaShop SA