### PR TITLE
Fix plural translation in form theme

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -768,9 +768,14 @@
       </div>
       <div class="d-inline-block">
         {% for error in errors %}
+          {% if error.cause.plural %}
+            {% set messageParameters = error.messageParameters|merge({'%count%': error.cause.plural}) %}
+          {% else %}
+            {% set messageParameters = error.messageParameters %}
+          {% endif %}
+
           <div class="text-danger">
-            <p> {{ error.messageTemplate|trans(error.messageParameters, 'form_error') }}
-            </p>
+            <p>{{ error.messageTemplate|trans(messageParameters, 'form_error') }}</p>
           </div>
         {%- endfor -%}
       </div>
@@ -786,8 +791,13 @@
       </button>
       <div class="alert-text">
         {% for error in errors %}
-            <p> {{ error.messageTemplate|trans(error.messageParameters, 'form_error') }}
-            </p>
+          {% if error.cause.plural %}
+            {% set messageParameters = error.messageParameters|merge({'%count%': error.cause.plural}) %}
+          {% else %}
+            {% set messageParameters = error.messageParameters %}
+          {% endif %}
+
+          <p>{{ error.messageTemplate|trans(messageParameters, 'form_error') }}</p>
         {%- endfor -%}
       </div>
     </div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Solves the problem of translating errors with plurals in the theme form. Based on code from `Symfony\Component\Validator\Violation\ConstraintViolationBuilder`(https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php#L116). <br><br> I'm not totally convinced by this code. Basically, in the "errors" object, we have a 'message' property which is already translated without the plural problem. I have the impression that we're going over our translation system a second time. Is this deliberate?
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | If based on issue only, add a GTIN with a size issue (> 13), e.g. 123456789123056789
| UI Tests          |  
| Fixed issue or discussion?     | Fixes #35813 
| Related PRs       | 
| Sponsor company   | 