### PR TITLE
Bugfix/redirection product

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1210,6 +1210,11 @@ class CustomerCore extends ObjectModel
             return false;
         }
 
+        // If a customer with the same email already exists, wrong call
+        if (Customer::customerExists($this->email)) {
+            return false;
+        }
+
         $this->is_guest = false;
 
         /*

--- a/controllers/front/GuestTrackingController.php
+++ b/controllers/front/GuestTrackingController.php
@@ -113,6 +113,13 @@ class GuestTrackingControllerCore extends FrontController
                     [],
                     'Shop.Notifications.Error'
                 );
+            // Check if a different customer with the same email was not already created in a different window or through backoffice
+            } elseif (Customer::customerExists($customer->email)) {
+                $this->errors[] = $this->trans(
+                    'You can\'t transform your account into a customer account, because a registered customer with the same email already exists.',
+                    [],
+                    'Shop.Notifications.Error'
+                );
             // Attempt to convert the customer
             } elseif ($customer->transformToCustomer($this->context->language->id, $password)) {
                 $this->success[] = $this->trans(

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -181,9 +181,19 @@ class OrderConfirmationControllerCore extends FrontController
                 return;
             }
 
+            // Prevent error
+            // A) either on page refresh
+            // B) if we already transformed him in other window or through backoffice
             if ($this->customer->is_guest == 0) {
                 $this->errors[] = $this->trans(
                     'A customer account has already been created from this guest account. Please sign in.',
+                    [],
+                    'Shop.Notifications.Error'
+                );
+            // Check if a different customer with the same email was not already created in a different window or through backoffice
+            } elseif (Customer::customerExists($this->customer->email)) {
+                $this->errors[] = $this->trans(
+                    'You can\'t transform your account into a customer account, because a registered customer with the same email already exists.',
                     [],
                     'Shop.Notifications.Error'
                 );

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -421,6 +421,7 @@ class AdminProductWrapper
      */
     public function getSpecificPricesList($product, $defaultCurrency, $shops, $currencies, $countries, $groups)
     {
+        $context = Context::getContext();
         $content = [];
         $specific_prices = array_merge(
             SpecificPrice::getByProductId((int) $product->id),
@@ -478,7 +479,7 @@ class AdminProductWrapper
                 }
                 if ($specific_price['id_product_attribute']) {
                     $combination = new Combination((int) $specific_price['id_product_attribute']);
-                    $attributes = $combination->getAttributesName(1);
+                    $attributes = $combination->getAttributesName($context->language->id);
                     $attributes_name = '';
                     foreach ($attributes as $attribute) {
                         $attributes_name .= $attribute['name'] . ' - ';

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -305,9 +305,8 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
         // Otherwise, we fallback to category permament redirect
         if (RedirectType::TYPE_PRODUCT_PERMANENT == $form_data['redirect_type'] ||
             RedirectType::TYPE_PRODUCT_TEMPORARY == $form_data['redirect_type']) {
-            if (!empty($form_data['id_type_redirected']['data'][0])) {
-                $form_data['id_type_redirected'] = $form_data['id_type_redirected']['data'][0];
-            } else {
+            // Currently, $form_data['id_type_redirected'] already has the product ID
+            if (!is_numeric($form_data['id_type_redirected']) || $form_data['id_type_redirected'] <= 0) {
                 $form_data['redirect_type'] = RedirectType::TYPE_CATEGORY_PERMANENT;
             }
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | When you redirect a deactivated product to another product, whether permanent or temporary, the condition for finding the ID of the product to redirect is always a failure, because the ID has already replaced the array received in the same variable.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | Disable a product, and create a redirection to another product in the product configuration
| UI Tests          | 
| Sponsor company   | Romain PIOT - MakeDigital.fr
