### PR TITLE
Fix: set the product redirection to another product (301 & 302)

### DIFF
--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -305,9 +305,8 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
         // Otherwise, we fallback to category permament redirect
         if (RedirectType::TYPE_PRODUCT_PERMANENT == $form_data['redirect_type'] ||
             RedirectType::TYPE_PRODUCT_TEMPORARY == $form_data['redirect_type']) {
-            if (!empty($form_data['id_type_redirected']['data'][0])) {
-                $form_data['id_type_redirected'] = $form_data['id_type_redirected']['data'][0];
-            } else {
+            // Currently, $form_data['id_type_redirected'] already has the product ID
+            if (!is_numeric($form_data['id_type_redirected']) || $form_data['id_type_redirected'] <= 0) {
                 $form_data['redirect_type'] = RedirectType::TYPE_CATEGORY_PERMANENT;
             }
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | When you redirect a deactivated product to another product, whether permanent or temporary, the condition for finding the ID of the product to redirect is always a failure, because the ID has already replaced the array received in the same variable.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes 
| How to test?      | Disable a product, and create a redirection to another product in the product configuration
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/11896537511 ✅ 
| Fixed issue or discussion? | https://github.com/PrestaShop/PrestaShop/issues/36176
| Sponsor company   | Romain PIOT - MakeDigital.fr
