### PR TITLE
Handle hook prefix to allow dashboard module to be saved

### DIFF
--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -425,7 +425,7 @@ class AdminDashboardControllerCore extends AdminController
         $hook = Tools::getValue('hook');
         $configs = Tools::getValue('configs');
 
-        if (!in_array(str_replace('hook', '', $hook), self::DASHBOARD_ALLOWED_HOOKS)) {
+        if (!in_array(lcfirst(str_replace('hook', '', $hook)), self::DASHBOARD_ALLOWED_HOOKS)) {
             $return['has_errors'] = true;
             $return['errors'][] = 'This hook is not allowed here.';
             die(json_encode($return));

--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -425,7 +425,7 @@ class AdminDashboardControllerCore extends AdminController
         $hook = Tools::getValue('hook');
         $configs = Tools::getValue('configs');
 
-        if (!in_array($hook, self::DASHBOARD_ALLOWED_HOOKS)) {
+        if (!in_array(str_replace('hook', '', $hook), self::DASHBOARD_ALLOWED_HOOKS)) {
             $return['has_errors'] = true;
             $return['errors'][] = 'This hook is not allowed here.';
             die(json_encode($return));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | As hook name is passed with the "hook" prefix, we need to handle it when checking array without prefix.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See issue.
| UI Tests | https://github.com/matthieu-rolland/ga.tests.ui.pr/actions/runs/9860630202
| Fixed issue or discussion?     | Fixes #34326