### PR TITLE
Filter product output in cart ajax method

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -135,13 +135,19 @@ class CartControllerCore extends FrontController
         $productQuantity = $updatedProduct['quantity'] ?? 0;
 
         if (!$this->errors) {
+            $presentedCart = $this->cart_presenter->present($this->context->cart, true);
+
+            // filter product output
+            $presentedCart['products'] = $this->get('prestashop.core.filter.front_end_object.product_collection')
+                ->filter($presentedCart['products']);
+
             $this->ajaxRender(json_encode([
                 'success' => true,
                 'id_product' => $this->id_product,
                 'id_product_attribute' => $this->id_product_attribute,
                 'id_customization' => $this->customization_id,
                 'quantity' => $productQuantity,
-                'cart' => $this->cart_presenter->present($this->context->cart, true),
+                'cart' => $presentedCart,
                 'errors' => empty($this->updateOperationError) ? '' : reset($this->updateOperationError),
             ]));
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Put back the filter on cart presenter's Product output in `displayAjaxUpdate`, this was removed due to incompatibility with the lazy array implementation, but this incompatibility has been fixed, so we can put it back
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green
| UI Tests          | https://github.com/matthieu-rolland/ga.tests.ui.pr/actions/runs/9854292465
| Fixed issue or discussion?     | 
| Related PRs       | #36408
| Sponsor company   | PrestaShop SA