### PR TITLE
Fix lazy object rewrite mechanism

### DIFF
--- a/src/Adapter/Presenter/AbstractLazyArray.php
+++ b/src/Adapter/Presenter/AbstractLazyArray.php
@@ -411,7 +411,7 @@ abstract class AbstractLazyArray implements Iterator, ArrayAccess, Countable, Js
         $this->arrayAccessList->offsetSet($offset, [
             'type' => 'variable',
             'value' => $value,
-            'isRewritable' => $offsetData['isRewritable'] ?? false
+            'isRewritable' => $offsetData['isRewritable'] ?? false,
         ]);
     }
 

--- a/src/Adapter/Presenter/AbstractLazyArray.php
+++ b/src/Adapter/Presenter/AbstractLazyArray.php
@@ -411,6 +411,7 @@ abstract class AbstractLazyArray implements Iterator, ArrayAccess, Countable, Js
         $this->arrayAccessList->offsetSet($offset, [
             'type' => 'variable',
             'value' => $value,
+            'isRewritable' => $offsetData['isRewritable'] ?? false
         ]);
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix bug when rewriting a lazy array's value more than once (when rewriting the offset data, the value of the `isRewritable` param was not transmitted.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green (it's a bug that could happen if a module developer rewrite a lazy array twice, but there's no occurence of this in the core, so nothing to test), UI tests will be enough
| UI Tests          | https://github.com/matthieu-rolland/ga.tests.ui.pr/actions/runs/9858527568
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | PrestaShop SA