### PR TITLE
Exception on several scopes on an API Platform resource

### DIFF
--- a/src/PrestaShopBundle/EventListener/API/ScopeCheckerListener.php
+++ b/src/PrestaShopBundle/EventListener/API/ScopeCheckerListener.php
@@ -85,7 +85,7 @@ class ScopeCheckerListener
         foreach ($operationsScopes as $key => $scope) {
             $scopesSecurityRule .= 'is_granted("ROLE_' . strtoupper($scope) . '")';
             if ($key !== $arrayLength - 1) {
-                $scopesSecurityRule .= ' OR ';
+                $scopesSecurityRule .= ' or ';
             }
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When an API Platform resource define, more than one scope, a SyntaxError exception is thrown
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | You must add a scope to an already existing resource in the ps_apiresource module, for example `product_write` in the `PaginatedList` operation of `ProductList` class. You should get this error :  `Unexpected token \"name\" of value \"OR\" around position 33 for expression 'is_granted(\"ROLE_PRODUCT_READ\") OR is_granted(\"ROLE_PRODUCT_WRITE\")'.`
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/9908574916 ✅ 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   |
