### PR TITLE
Carrier - #36259 Ranges selector component

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.ts
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.ts
@@ -41,6 +41,7 @@ import Grid from '@components/grid/grid';
 import ModifyAllShopsCheckbox from '@components/modify-all-shops-checkbox';
 import MultipleChoiceTable from '@js/components/multiple-choice-table';
 import MultistoreConfigField from '@js/components/form/multistore-config-field';
+import CarrierRanges from '@js/components/form/carrier-ranges';
 import PreviewOpener from '@components/form/preview-opener';
 import Router from '@components/router';
 import ShopSelector from '@components/shop-selector/shop-selector';
@@ -164,6 +165,7 @@ const initPrestashopComponents = (): void => {
     TranslatableInput,
     EntitySearchInput,
     EmailInput,
+    CarrierRanges,
   };
 };
 export default initPrestashopComponents;

--- a/admin-dev/themes/new-theme/js/components/components-map.ts
+++ b/admin-dev/themes/new-theme/js/components/components-map.ts
@@ -146,4 +146,7 @@ export default {
   emailInput: {
     inputSelector: '.email-input',
   },
+  carrierRanges: {
+    addRangeButton: '.js-add-carrier-ranges-btn',
+  },
 };

--- a/admin-dev/themes/new-theme/js/components/form/carrier-ranges.ts
+++ b/admin-dev/themes/new-theme/js/components/form/carrier-ranges.ts
@@ -1,0 +1,71 @@
+/**
+* Copyright since 2007 PrestaShop SA and Contributors
+* PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.md.
+* It is also available through the world-wide-web at this URL:
+* https://opensource.org/licenses/OSL-3.0
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to https://devdocs.prestashop.com/ for more information.
+*
+* @author    PrestaShop SA and Contributors <contact@prestashop.com>
+* @copyright Since 2007 PrestaShop SA and Contributors
+* @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+*/
+
+import ComponentsMap from '@components/components-map';
+import {createApp} from 'vue';
+import {createI18n} from 'vue-i18n';
+import CarrierRangesModal from '@pages/carrier/form/components/CarrierRangesModal.vue';
+import EventEmitter from '@components/event-emitter';
+import ReplaceFormatter from '@PSVue/plugins/vue-i18n/replace-formatter';
+import CarrierFormEventMap from '@pages/carrier/form/carrier-form-event-map';
+
+export default class CarrierRanges {
+  private readonly eventEmitter: typeof EventEmitter;
+
+  constructor() {
+    this.eventEmitter = window.prestashop.instance.eventEmitter;
+    this.initRangesSelectionModal();
+  }
+
+  initRangesSelectionModal(): void {
+    // Create the modal container
+    const $showModal = $(ComponentsMap.carrierRanges.addRangeButton);
+    const $modalContainer = $('<div id="carrier-ranges-modal-selection"></div>');
+    $showModal.after($modalContainer);
+
+    // Retreive translations from the button
+    const i18n = createI18n({
+      locale: 'en',
+      formatter: new ReplaceFormatter(),
+      messages: {en: $showModal.data('translations')},
+    });
+
+    // Initialize the Vue app with the CarrierRangesModal component
+    const vueApp = createApp(CarrierRangesModal, {
+      i18n,
+      eventEmitter: this.eventEmitter,
+    }).use(i18n);
+
+    // Mount the Vue app to the modal container
+    vueApp.mount('#carrier-ranges-modal-selection');
+
+    // Open the modal when the button "Add range" is clicked
+    $showModal.click((e: JQuery.ClickEvent) => {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      this.eventEmitter.emit(CarrierFormEventMap.openRangeSelectionModal);
+    });
+  }
+}

--- a/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-event-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-event-map.ts
@@ -22,11 +22,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-$(() => {
-  window.prestashop.component.initComponents([
-    'TranslatableInput',
-    'EventEmitter',
-    'CarrierRanges',
-  ]);
-});
+export default {
+  openRangeSelectionModal: 'openRangeSelectionModal',
+};

--- a/admin-dev/themes/new-theme/js/pages/carrier/form/components/CarrierRangesModal.vue
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/components/CarrierRangesModal.vue
@@ -1,0 +1,374 @@
+<!--**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *-->
+<template>
+  <div data-role="carrier-ranges-edit-modal">
+    <modal
+      v-if="isModalShown"
+      :modal-title="$t('modal.title')"
+      :confirm-label="$t('modal.apply')"
+      :cancel-label="$t('modal.cancel')"
+      :confirmation="true"
+      :close-on-click-outside="false"
+      @close="cancelChanges"
+      @confirm="applyChanges"
+      @mouseleave="mouseLeave"
+    >
+      <template #header>
+        <h5 class="modal-title">
+          {{ $t('modal.title') }}
+        </h5>
+        <button
+          @click.prevent="addRange()"
+          type="button"
+          class="btn btn-sm btn-outline-primary"
+        >
+          <i class="material-icons">add_box</i>
+          {{ $t('modal.addRange') }}
+        </button>
+      </template>
+      <template #body>
+        <div
+          class="alert alert-danger"
+          v-if="overlappingAlert"
+          role="alert"
+        >
+          {{ $t('modal.overlappingAlert') }}
+        </div>
+        <div class="table-container">
+          <table
+            class="table table-carrier-ranges-modal"
+            @drop="dragDrop"
+          >
+            <thead>
+              <tr>
+                <th/>
+                <th>{{ $t('modal.col.min') }}</th>
+                <th>{{ $t('modal.col.max') }} </th>
+                <th>{{ $t('modal.col.action') }}</th>
+              </tr>
+            </thead>
+            <tbody :key="refreshKey">
+              <template
+                :key="i"
+                v-for="r,i in ranges"
+              >
+                <tr
+                  :data-row="i"
+                  draggable="true"
+                  @dragstart="dragStart(i)"
+                  @dragover.stop.prevent="(e) => dragOver(e, i)"
+                  @dragend="dragEnd"
+                >
+                  <td>
+                    <button
+                      type="button"
+                      class="btn-drag"
+                    >
+                      <i class="material-icons">drag_indicator</i>
+                    </button>
+                    <button
+                      type="button"
+                      class="btn-add"
+                      @click.prevent="addRange(i)"
+                    >
+                      <i class="material-icons">add</i>
+                    </button>
+                  </td>
+                  <td>
+                    <div class="input-group">
+                      <div class="input-group-prepend">
+                        <span class="input-group-text">€</span>
+                      </div>
+                      <input
+                        type="number"
+                        class="form-control form-min"
+                        inputmode="decimal"
+                        placeholder="0"
+                        v-model="r.min"
+                      >
+                    </div>
+                  </td>
+                  <td>
+                    <div class="input-group">
+                      <div class="input-group-prepend">
+                        <span class="input-group-text">€</span>
+                      </div>
+                      <input
+                        type="number"
+                        class="form-control form-max"
+                        inputmode="decimal"
+                        placeholder="∞"
+                        v-model="r.max"
+                      >
+                    </div>
+                  </td>
+                  <td align="center">
+                    <button
+                      type="button"
+                      @click.prevent="deleteRange(i)"
+                      class="btn-delete"
+                    >
+                      <i class="material-icons">delete</i>
+                    </button>
+                  </td>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+        </div>
+      </template>
+    </modal>
+  </div>
+</template>
+
+<script lang="ts">
+  import Modal from '@PSVue/components/Modal';
+  import {defineComponent} from 'vue';
+  import CarrierFormEventMap from '@pages/carrier/form/carrier-form-event-map';
+
+  interface Range {
+    min: number|null,
+    max: number|null,
+  }
+
+  interface CarrierRangesModalStates {
+    isModalShown: boolean, // define if the modal is shown
+    ranges: Range[], // define the ranges currently displayed
+    savedRanges: Range[], // define the ranges saved before the changes
+    dragIndex: null|number, // store the index of the range being dragged
+    refreshKey: number, // force the refresh of the table by incrementing this key
+    errors: boolean, // define if there are errors in the ranges
+    overlappingAlert: boolean, // define if there are overlapping ranges (and display an alert)
+  }
+
+  export default defineComponent({
+    name: 'CarrierRangesModal',
+    components: {Modal},
+    data(): CarrierRangesModalStates {
+      return {
+        isModalShown: false,
+        ranges: [],
+        savedRanges: [],
+        dragIndex: null,
+        refreshKey: 0,
+        errors: false,
+        overlappingAlert: false,
+      };
+    },
+    props: {
+      eventEmitter: {
+        type: Object,
+        required: true,
+      },
+    },
+    mounted() {
+      // If we need to open this modal
+      this.eventEmitter.on(CarrierFormEventMap.openRangeSelectionModal, () => this.openModal());
+    },
+    methods: {
+      openModal() {
+        // We add a class to the body to prevent scrolling
+        document.querySelector('body')?.classList.add('overflow-hidden');
+        this.isModalShown = true;
+
+        // We save the ranges to be able to cancel the changes
+        this.savedRanges.splice(0, this.savedRanges.length);
+        this.ranges.forEach((range) => this.savedRanges.push({min: range.min, max: range.max}));
+
+        // We add an empty range if there is none
+        if (this.ranges.length === 0) {
+          this.ranges.push({min: null, max: null});
+        }
+
+        // We reset the errors
+        this.errors = false;
+        this.overlappingAlert = false;
+      },
+      closeModal() {
+        // We remove the class to allow scrolling
+        document.querySelector('body')?.classList.remove('overflow-hidden');
+        this.isModalShown = false;
+        this.refreshKey = 0;
+      },
+      cancelChanges() {
+        // We cancel the changes and close the modal
+        this.ranges.splice(0, this.ranges.length);
+        this.savedRanges.forEach((range) => this.ranges.push({min: range.min, max: range.max}));
+        // We remove empty ranges
+        this.ranges = this.ranges.filter((range) => range.min !== null || range.max !== null);
+        // Then, we close the modal
+        this.closeModal();
+      },
+      applyChanges() {
+        // We remove empty ranges
+        this.ranges = this.ranges.filter((range) => range.min !== null || range.max !== null);
+        // We validate the changes
+        this.validateChanges();
+
+        if (!this.errors) {
+          // We emit the new ranges
+          this.eventEmitter.emit('updateRanges', this.ranges);
+          // We close the modal
+          this.closeModal();
+        }
+      },
+      validateChanges() {
+        const table = <HTMLElement> document.querySelector('.table-carrier-ranges-modal');
+        // Reset errors
+        this.errors = false;
+        this.overlappingAlert = false;
+        // We remove the error class from all inputs already in error
+        table.querySelectorAll('input.is-invalid').forEach((input) => {
+          input.classList.remove('is-invalid');
+        });
+
+        // We sort the ranges by min values
+        this.ranges.sort((a, b) => (a.min || 0) - (b.min || 0));
+
+        // We check ranges
+        let saveMax: null|number = null;
+        this.ranges.forEach((range, index) => {
+          // Check overlapping
+          if (saveMax !== null && range.min !== null && range.min < saveMax) {
+            table.querySelectorAll(`tr[data-row="${index - 1}"] input.form-max`)
+              .forEach((input) => {
+                input.classList.add('is-invalid');
+              });
+            table.querySelectorAll(`tr[data-row="${index}"] input.form-min`)
+              .forEach((input) => {
+                input.classList.add('is-invalid');
+              });
+            this.errors = true;
+            this.overlappingAlert = true;
+          }
+
+          // Check min < max for each range
+          if (range.max !== null && range.min !== null && range.max <= range.min) {
+            table.querySelectorAll(`tr[data-row="${index}"] input.form-max`)
+              .forEach((input) => {
+                input.classList.add('is-invalid');
+              });
+            this.errors = true;
+          }
+
+          saveMax = range.max;
+        });
+      },
+      addRange(index: undefined|number) {
+        // Add new range at the index specified, at the bottom if not specified
+        // (with "min" already set to the previous "max")
+        if (index === undefined) {
+          this.ranges.push({min: this.ranges[this.ranges.length - 1]?.max, max: null});
+        } else {
+          this.ranges.splice(index + 1, 0, {min: this.ranges[index]?.max, max: null});
+        }
+      },
+      deleteRange(rangeIndex: number) {
+        // We remove the selected range
+        this.ranges.splice(rangeIndex, 1);
+        // We add an empty range if there is none
+        if (this.ranges.length === 0) {
+          this.ranges.push({min: null, max: null});
+        }
+      },
+      dragStart(rangeIndex: number) {
+        // We save the current range index to know which one is being dragged
+        this.dragIndex = rangeIndex;
+      },
+      dragOver(event: DragEvent, rangeIndex: number) {
+        // We retrieve the row being dragged and the row being hovered
+        const table = <HTMLElement> document.querySelector('.table-carrier-ranges-modal');
+        const row = <HTMLElement> table.querySelector(`tr[data-row="${this.dragIndex}"]`);
+        const rowHover = <HTMLElement> table.querySelector(`tr[data-row="${rangeIndex}"]`);
+
+        // We move the dragged row before or after the hovered row depending on the position of the mouse on it
+        if (row !== null && rowHover !== null) {
+          if (event.offsetY > rowHover.offsetHeight / 2) {
+            rowHover.parentNode?.insertBefore(row, rowHover.nextSibling);
+          } else {
+            rowHover.parentNode?.insertBefore(row, rowHover);
+          }
+        }
+      },
+      dragEnd() {
+        // We reorder the ranges according to the new order when the drag ending
+        const rangesNewOrder:Range[] = [];
+        const rows = document.querySelectorAll('.table-carrier-ranges-modal tbody tr[data-row]');
+        rows.forEach((row) => {
+          const rowId = row.getAttribute('data-row');
+
+          if (rowId !== null) {
+            rangesNewOrder.push(this.ranges[parseInt(rowId, 10)]);
+          }
+        });
+
+        // We update the ranges and +1 to the refreshKey to force the refresh
+        this.ranges.splice(0, this.ranges.length, ...rangesNewOrder);
+        this.dragIndex = null;
+        this.refreshKey += 1;
+      },
+    },
+  });
+</script>
+
+<style lang="scss" type="text/scss" scoped>
+  @import '~@scss/config/_settings.scss';
+
+  .modal {
+    .modal-footer {
+      justify-content: space-between;
+    }
+
+    .table {
+      margin-bottom: 0;
+      border-bottom: 0;
+
+      tr td {
+        border: 0;
+      }
+    }
+
+    .btn-delete, .btn-drag, .btn-add {
+      border: none;
+      background: none;
+
+      i {
+        font-size: 1.2em;
+      }
+    }
+
+    .btn-drag {
+      cursor: move!important;
+      outline: none;
+      user-select: none;
+    }
+
+    .table-container {
+      max-height: 60vh;
+      overflow-y: auto;
+    }
+  }
+
+</style>

--- a/src/PrestaShopBundle/Form/Admin/Type/CarrierRangesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CarrierRangesType.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Type;
+
+use PrestaShopBundle\Translation\TranslatorInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * CarrierRangesType is a form type used to create Carrier ranges fo form.
+ *
+ * $builder
+ *     ->add('ranges', CarrierRangesType::class, [
+ *         'label' => 'Ranges',
+ *     ])
+ * ;
+ */
+class CarrierRangesType extends TranslatorAwareType
+{
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+    ) {
+        parent::__construct($translator, $locales);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('show_modal', IconButtonType::class, [
+                'label' => ' ' . $options['button_label'],
+                'icon' => 'add_box',
+                'attr' => [
+                    'class' => 'js-add-carrier-ranges-btn btn btn-outline-primary',
+                    'data-translations' => json_encode([
+                        'modal.title' => $this->trans('Ranges', 'Admin.Shipping.Feature'),
+                        'modal.addRange' => $this->trans('Add range', 'Admin.Shipping.Feature'),
+                        'modal.apply' => $this->trans('Apply', 'Admin.Actions'),
+                        'modal.cancel' => $this->trans('Cancel', 'Admin.Actions'),
+                        'modal.col.min' => $this->trans('Minimum', 'Admin.Shipping.Feature'),
+                        'modal.col.max' => $this->trans('Maximum', 'Admin.Shipping.Feature'),
+                        'modal.col.action' => $this->trans('Action', 'Admin.Shipping.Feature'),
+                        'modal.overlappingAlert' => $this->trans('Make sure there are no overlapping ranges. Remember, the minimum is part of the range, but the maximum isn\'t. So, the upper limit of a range is the lower limit of the next range.', 'Admin.Shipping.Feature'),
+                    ]),
+                ],
+            ])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'label' => $this->trans('Ranges', 'Admin.Shipping.Feature'),
+            'button_label' => $this->trans('Add range', 'Admin.Shipping.Feature'),
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'carrier_ranges';
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR aim to add a new component to select ranges for the new migrated carrier form pages
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI 🟢 for now
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/9893553594
| Fixed issue or discussion?     | Fixes #36259 
| Related PRs       | ~
| Sponsor company   | PrestaShop SA

## Some screenshots
"Add ranges" button:
![Capture d’écran 2024-07-12 à 11 49 28](https://github.com/user-attachments/assets/3515d0fb-d13b-42a4-ac5c-ac0e69b1900f)

Modal:
![Capture d’écran 2024-07-12 à 11 49 34](https://github.com/user-attachments/assets/45761d10-4bf9-4a07-8cd7-17278d94febe)

Modal with invalid maximum for the range (on click "Apply"):
![Capture d’écran 2024-07-12 à 11 49 48](https://github.com/user-attachments/assets/8cd8e1eb-acf2-40b2-979a-7cd7838cee63)

Modal with overlapping ranges (on click "Apply"):
![Capture d’écran 2024-07-12 à 11 50 08](https://github.com/user-attachments/assets/3ba74219-3211-48e8-87ce-53990c87126a)

## More details
- At the left of each range, we have a grab icon that permit us to reorder ranges if needed.
- We have also a "+" button, to add below the range a new range.
- We can add a new range below all ranges by clicking on "Add range" button à the top right.
- When we add a new range, we set the minimum value with the maximum value from the first range at the top of the new range.
- To close this modal, we need to click on "Cancel" or "Apply", clicking outside have no effect to the modal.
- On "Apply", we reorder by minimum before checking the ranges validity.