### PR TITLE
Fix var_export() with missing 2nd return=true arg

### DIFF
--- a/src/Adapter/SqlManager/CommandHandler/DeleteSqlRequestHandler.php
+++ b/src/Adapter/SqlManager/CommandHandler/DeleteSqlRequestHandler.php
@@ -62,7 +62,7 @@ final class DeleteSqlRequestHandler implements DeleteSqlRequestHandlerInterface
             }
 
             if (false === $entity->delete()) {
-                throw new CannotDeleteSqlRequestException(sprintf('Could not delete SqlRequest with id %s', var_export($entityId)), CannotDeleteSqlRequestException::CANNOT_SINGLE_DELETE);
+                throw new CannotDeleteSqlRequestException(sprintf('Could not delete SqlRequest with id %s', var_export($entityId, true)), CannotDeleteSqlRequestException::CANNOT_SINGLE_DELETE);
             }
         } catch (PrestaShopException $e) {
             throw new SqlRequestException(sprintf('Unexpected error occurred when deleting SqlRequest with id %s', var_export($entityId, true)), 0, $e);

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
@@ -330,7 +330,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
             throw new RuntimeException(sprintf(
                 'Following customization fields were not found for product %s: %s',
                 $productReference,
-                var_export($notFoundExpectedFields)
+                var_export($notFoundExpectedFields, true)
             ));
         }
 
@@ -338,7 +338,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
             throw new RuntimeException(sprintf(
                 'Product "%s" contains unexpected customization fields: %s',
                 $productReference,
-                var_export($actualFields)
+                var_export($actualFields, true)
             ));
         }
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Fixing a typo / fix wrong exception messages. This code is tested by behat.
| Type?             | bug fix 
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | Behat tests should run correctly
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/9936425423
| Fixed issue or discussion?     | 
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).


A new feature I have implemented recently in PHPStan detected this typo errors

https://github.com/phpstan/phpstan-src/pull/3225