### PR TITLE
Add optional blackfire at install via Docker

### DIFF
--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -113,6 +113,22 @@ if [ $PS_DEMO_MODE -ne 0 ]; then
     sed -ie "s/define('_PS_MODE_DEMO_', false);/define('_PS_MODE_DEMO_',\ true);/g" /var/www/html/config/defines.inc.php
 fi
 
+if [ $BLACKFIRE_ENABLE -eq 1 ]; then
+    if [ "$BLACKFIRE_SERVER_ID" = "0" ] || [ "$BLACKFIRE_SERVER_TOKEN" = "0" ]; then
+            echo "\n* BLACKFIRE_SERVER_ID and BLACKFIRE_SERVER_TOKEN environment variables missing."
+            echo "\n* Skipping blackfire install..."
+    else
+      echo "\n* Installing Blackfire..."
+      wget -q -O - https://packages.blackfire.io/gpg.key | dd of=/usr/share/keyrings/blackfire-archive-keyring.asc
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/blackfire-archive-keyring.asc] http://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list
+      apt update
+      apt install -y blackfire
+      blackfire agent:config --server-id=$BLACKFIRE_SERVER_ID --server-token=$BLACKFIRE_SERVER_TOKEN
+      service blackfire-agent restart
+      apt install -y blackfire-php
+    fi
+fi
+
 echo "\n* Almost ! Starting web server now\n";
 
 exec apache2-foreground

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -1,0 +1,6 @@
+services:
+  prestashop-git:
+    environment:
+      #BLACKFIRE_ENABLE: 1
+      #BLACKFIRE_SERVER_ID: "your_server_id"
+      #BLACKFIRE_SERVER_TOKEN: "your_server_token"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,9 @@ services:
       PS_ERASE_DB: ${PS_ERASE_DB:-0}
       ADMIN_MAIL: ${ADMIN_MAIL:-demo@prestashop.com}
       ADMIN_PASSWD: ${ADMIN_PASSWD:-Correct Horse Battery Staple}
+      BLACKFIRE_ENABLE: ${BLACKFIRE_ENABLE:-0}
+      BLACKFIRE_SERVER_ID: ${BLACKFIRE_SERVER_ID:-0}
+      BLACKFIRE_SERVER_TOKEN: ${BLACKFIRE_SERVER_TOKEN:-0}
     command: ["/tmp/wait-for-it.sh", "--timeout=60", "--strict", "mysql:3306", "--", "/tmp/docker_run_git.sh"]
     ports:
       - "8001:80"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Add blackfire option for docker install
| Type?             | new feature
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1/ rename `docker-compose.override.yml.dist` into `docker-compose.override.yml` <br>2/ uncomment the 3 lines related to blackfire and fill in your servier id and server token<br>3/ from the root of the project, run `docker compose up`<br>4/ Blackfire should be working (ask me for help and token if needed)
| UI Tests          | not relevant here
| Fixed issue or discussion?     | 
| Related PRs       | none
| Sponsor company   | PrestaShop SA