### PR TITLE
Improve GetCarrier query to have ordersCount 

### DIFF
--- a/src/Adapter/Carrier/QueryHandler/GetCarrierForEditingHandler.php
+++ b/src/Adapter/Carrier/QueryHandler/GetCarrierForEditingHandler.php
@@ -76,6 +76,7 @@ final class GetCarrierForEditingHandler implements GetCarrierForEditingHandlerIn
             (int) $carrier->range_behavior,
             $carrier->getAssociatedShops(),
             $logoPath,
+            $this->carrierRepository->ordersCount($query->getCarrierId()),
         );
     }
 }

--- a/src/Adapter/Carrier/Repository/CarrierRepository.php
+++ b/src/Adapter/Carrier/Repository/CarrierRepository.php
@@ -172,7 +172,7 @@ class CarrierRepository extends AbstractMultiShopObjectModelRepository
     public function getEditableOrNewVersion(CarrierId $carrierId): Carrier
     {
         // If the carrier don't have orders linked, we can return it as is
-        if (!$this->carrierHasOrders($carrierId)) {
+        if ($this->ordersCount($carrierId) === 0) {
             return $this->get($carrierId);
         }
 
@@ -278,7 +278,7 @@ class CarrierRepository extends AbstractMultiShopObjectModelRepository
         $qb->executeStatement();
     }
 
-    protected function carrierHasOrders(CarrierId $carrierId): bool
+    public function ordersCount(CarrierId $carrierId): int
     {
         $qb = $this->connection->createQueryBuilder();
 
@@ -289,6 +289,6 @@ class CarrierRepository extends AbstractMultiShopObjectModelRepository
             ->executeQuery()
             ->fetchOne();
 
-        return (bool) $count;
+        return $count;
     }
 }

--- a/src/Core/Domain/Carrier/QueryResult/EditableCarrier.php
+++ b/src/Core/Domain/Carrier/QueryResult/EditableCarrier.php
@@ -54,6 +54,7 @@ class EditableCarrier
         private int $rangeBehavior,
         private array $associatedShopIds,
         private ?string $logoPath = null,
+        private int $ordersCount = 0,
     ) {
     }
 
@@ -156,5 +157,10 @@ class EditableCarrier
     public function getAssociatedShopIds(): array
     {
         return $this->associatedShopIds;
+    }
+
+    public function getOrdersCount(): int
+    {
+        return $this->ordersCount;
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Carrier/CarrierFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Carrier/CarrierFeatureContext.php
@@ -353,6 +353,10 @@ class CarrierFeatureContext extends AbstractDomainFeatureContext
                 $carrier->getAssociatedShopIds(),
             );
         }
+
+        if (isset($data['ordersCount'])) {
+            Assert::assertEquals($data['ordersCount'], $carrier->getOrdersCount());
+        }
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_management.feature
@@ -51,6 +51,7 @@ Feature: Carrier management
       | isFree           | true                               |
       | shippingMethod   | weight                             |
       | rangeBehavior    | disabled                           |
+      | ordersCount      | 0                                  |
     Then carrier "carrier1" shouldn't have a logo
 
   Scenario: Partially editing carrier with name and with an order linked
@@ -93,8 +94,10 @@ Feature: Carrier management
       | name | Carrier 1 new |
     Then carrier "carrier1" should have the following properties:
       | name             | Carrier 1                          |
+      | ordersCount      | 1                                  |
     Then carrier "newCarrier1" should have the following properties:
       | name             | Carrier 1 new                      |
+      | ordersCount      | 0                                  |
 
   Scenario: Partially editing carrier with name and without an order linked
     When I create carrier "carrier1" with specified properties:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add `ordersCount` in get Carrier query
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI & Autos tests 🟢
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/9954791115
| Fixed issue or discussion?     | Fixes #36558
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
