### PR TITLE
Mail - Reply-To can be the same as the To address (spam indicator - negative points)

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -513,7 +513,7 @@ class MailCore extends ObjectModel
                 $replyTo = $from;
             }
 
-            if (isset($replyTo) && $replyTo) {
+            if (!empty($replyTo) && $replyTo != $toPlugin) {
                 $message->setReplyTo($replyTo, ($replyToName !== '' ? $replyToName : null));
             }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Check below.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to module "ps_emailalerts" settings, enable "new order" confirmation and fill same email address like for whole shop (main eshop email). Make any order and check your email. There shouldn't be "Reply to".
| UI Tests          |
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/

### Description:
For example: if we use module ps_emailalerts and enable option informing me about New order and set up same email adress like e-shop address, we got "Reply to" same like "To".
It's spam indicator. I know, it's "valid use case", but some customers have problems, because they got for this emails any negative spam points.
Google for "REPLYTO_EQ_TO_ADDR".
(This can be related to more modules, not only ps_emailalerts, so we need to deal with it with file Mail.php)

### Screenshots:
Default rule from Rspamd:
![A](https://github.com/user-attachments/assets/2d09e252-4a1e-428d-984c-4750e5e44eef)
Example of same Reply to:
![B](https://github.com/user-attachments/assets/77bc3d9b-19cf-412c-97c5-c1c41014b2b7)
Real impact:
![C](https://github.com/user-attachments/assets/b06175f2-09d7-4f67-b0ca-12da4927a293)

**After apply this PR(commit) problem disappeared**


