### PR TITLE
Handle links in XML checksum generation and improve tests auto actions

### DIFF
--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -99,6 +99,11 @@ set -e
 if [ $PS_DEV_MODE -ne 1 ]; then
   echo "\n* Disabling DEV mode ...";
   sed -i -e "s/define('_PS_MODE_DEV_', true);/define('_PS_MODE_DEV_',\ false);/g" /var/www/html/config/defines.inc.php
+else
+  echo "\n* Enabling DEV mode ...";
+  sed -i -e "s/define('_PS_MODE_DEV_', false);/define('_PS_MODE_DEV_',\ true);/g" /var/www/html/config/defines.inc.php
+  echo "\n* Define PHP error logs ...";
+  echo "error_log=/var/www/html/var/logs/php.log" >> /usr/local/etc/php/php.ini
 fi
 
 if [ ! -f ./config/settings.inc.php ]; then

--- a/.github/actions/setup-env-export-logs/action.yml
+++ b/.github/actions/setup-env-export-logs/action.yml
@@ -13,21 +13,43 @@ inputs:
     required: false
     description: Database Server for PrestaShop (mysql/mariadb)
     default: mysql
+  ENABLE_SSL:
+    required: false
+    description: True to Run with SSL
+    default: 'true'
+  INSTALL_AUTO:
+    required: false
+    description: True To Auto Install
+    default: 'true'
+  PRESTASHOP_DIR:
+    required: false
+    description: Prestashop folder
+    default: '.'
 
 runs:
   using: 'composite'
   steps:
     - name: List dockers
       run: |
+        cd ${{ inputs.PRESTASHOP_DIR }}
         docker ps
       shell: bash
 
     - name: Export docker logs
       run: |
+        cd ${{ inputs.PRESTASHOP_DIR }}
         mkdir -p ./var/docker-logs
         docker logs ${{ inputs.DOCKER_PREFIX }}-${{ inputs.DB_SERVER }}-1 > ./var/docker-logs/${{ inputs.DB_SERVER }}.log
         docker logs ${{ inputs.DOCKER_PREFIX }}-prestashop-git-1 > ./var/docker-logs/prestashop.log
       shell: bash
+
+    - name: Export front output
+      shell: bash
+      env:
+        URL_FO: ${{ (inputs.ENABLE_SSL == 'false') && 'http://localhost:8001/' || 'https://localhost:8002/' }}
+        URL_PING: ${{ (inputs.INSTALL_AUTO == 'true') && 'en/' || 'install-dev/' }}
+      run: |
+        wget -O ${{ inputs.PRESTASHOP_DIR }}/var/logs/front.html ${{ env.URL_FO }}${{ env.URL_PING }}
 
     - name: Sanitize artifact name
       id: sanitize-artifact-name
@@ -39,5 +61,5 @@ runs:
       with:
         name: ${{ steps.sanitize-artifact-name.outputs.ARTIFACT_NAME }}
         path: |
-          ./var/logs
-          ./var/docker-logs
+          ${{ inputs.PRESTASHOP_DIR }}/var/logs
+          ${{ inputs.PRESTASHOP_DIR }}/var/docker-logs

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -35,6 +35,10 @@ inputs:
     required: false
     description: true to disable Make
     default: 'false'
+  PRESTASHOP_DIR:
+    required: false
+    description: Prestashop folder
+    default: '.'
 
 runs:
   using: 'composite'
@@ -51,16 +55,17 @@ runs:
           chmod +x mkcert-v*-linux-amd64
           sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
           ## Generate certificate
-          mkcert -key-file ./.docker/ssl.key -cert-file ./.docker/ssl.crt localhost
+          mkcert -key-file ${{ inputs.PRESTASHOP_DIR }}/.docker/ssl.key -cert-file ${{ inputs.PRESTASHOP_DIR }}/.docker/ssl.crt localhost
           ## Link certificate to Chrome Trust Store
           mkdir -p $HOME/.pki/nssdb
           certutil -d $HOME/.pki/nssdb -N
-          certutil -d sql:$HOME/.pki/nssdb -n localhost -A -t "TCu,Cu,Tu" -i ./.docker/ssl.crt
+          certutil -d sql:$HOME/.pki/nssdb -n localhost -A -t "TCu,Cu,Tu" -i ${{ inputs.PRESTASHOP_DIR }}/.docker/ssl.crt
           ## Add self-signed certificate to Chrome Trust Store
           mkcert -install
 
     # Run composer install outside of docker because inside it regularly has network issues
     - name: Composer Install
+      if: inputs.DISABLE_MAKE != 'true'
       run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
       shell: bash
 
@@ -86,6 +91,7 @@ runs:
         PS_LANGUAGE: 'en'
         ADMIN_PASSWD: 'Correct Horse Battery Staple'
       run: |
+        cd ${{ inputs.PRESTASHOP_DIR }}
         USER_ID=$(id -u) GROUP_ID=$(id -g) \
         docker compose -f ${{ (inputs.DB_SERVER == 'mysql') && 'docker-compose.yml' || 'docker-compose.mariadb.yml' }} up -d prestashop-git --build
         bash -c 'while [[ "$(curl -L -s -o /dev/null -w %{http_code} ${{ env.URL_FO }}${{ env.URL_PING }})" != "200" ]]; do sleep 5; done'

--- a/.github/actions/ui-test/action.yml
+++ b/.github/actions/ui-test/action.yml
@@ -62,6 +62,9 @@ runs:
         BROWSER: ${{ inputs.BROWSER }}
         ENABLE_SSL: ${{ inputs.ENABLE_SSL }}
         URL_FO: ${{ (inputs.ENABLE_SSL == 'false') && 'http://localhost:8001/' || 'https://localhost:8002/' }}
+        URL_BO: ${{ (inputs.ENABLE_SSL == 'false') && 'http://localhost:8001/admin-dev/' || 'https://localhost:8002/admin-dev/' }}
+        URL_API: ${{ (inputs.ENABLE_SSL == 'false') && 'http://localhost:8001/admin-api/' || 'https://localhost:8002/admin-api/' }}
+        URL_INSTALL: ${{ (inputs.ENABLE_SSL == 'false') && 'http://localhost:8001/install-dev/' || 'https://localhost:8002/install-dev/' }}
         DB_SERVER: ${{ inputs.DB_SERVER }}
       shell: bash
       run: npm run test:${{ inputs.TEST_CAMPAIGN }}

--- a/.github/workflows/cron_nightly_tests_reusable.yml
+++ b/.github/workflows/cron_nightly_tests_reusable.yml
@@ -203,6 +203,8 @@ jobs:
           DOCKER_PREFIX: prestashop
           ARTIFACT_NAME: setup-nightly-${{ matrix.BRANCH }}-${{ matrix.CAMPAIGN }}-${{ inputs.DB_SERVER }}
           DB_SERVER: ${{ inputs.DB_SERVER }}
+          ENABLE_SSL: ${{ env.ENABLE_SSL }}
+          INSTALL_AUTO: ${{ env.INSTALL_AUTO }}
         if: failure()
 
       # Keycloak is only needed for API campaign

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -80,6 +80,8 @@ jobs:
           DOCKER_PREFIX: prestashop
           ARTIFACT_NAME: setup-sanity-${{ matrix.php }}-${{ matrix.browser }}-${{ matrix.db }}
           DB_SERVER: ${{ matrix.db }}
+          ENABLE_SSL: 'true'
+          INSTALL_AUTO: 'false'
         if: failure()
 
       - name: Run Tests

--- a/.github/workflows/symfony-console.yml
+++ b/.github/workflows/symfony-console.yml
@@ -104,6 +104,8 @@ jobs:
         with:
           DOCKER_PREFIX: prestashop
           ARTIFACT_NAME: setup-symfony-console-${{ matrix.app-id }}
+          ENABLE_SSL: 'true'
+          INSTALL_AUTO: 'false'
         if: failure()
 
       # Retest the console after shop install

--- a/tools/build/CreateRelease.php
+++ b/tools/build/CreateRelease.php
@@ -58,6 +58,10 @@ $releaseOptions = [
         'description' => 'Do not put the installer in the release. Interesting if release will be upload remotely by FTP or for public release. Default: false.',
         'longopt' => 'no-installer',
     ],
+    'keep-tests' => [
+        'description' => 'Keep tests folder in the release. Default: false.',
+        'longopt' => 'keep-tests',
+    ],
     'help' => [
         'description' => 'Show help',
         'opt' => 'h',
@@ -90,6 +94,7 @@ if (isset($userOptions['h'])
 
 $destinationDir = '';
 $useZip = $useInstaller = true;
+$keepTests = false;
 
 if (isset($userOptions['version'])) {
     $version = $userOptions['version'];
@@ -109,8 +114,12 @@ if (isset($userOptions['no-installer'])) {
     $useInstaller = false;
 }
 
+if (isset($userOptions['keep-tests'])) {
+    $keepTests = true;
+}
+
 try {
-    $releaseCreator = new ReleaseCreator($version, $useInstaller, $useZip, $destinationDir);
+    $releaseCreator = new ReleaseCreator($version, $useInstaller, $useZip, $destinationDir, $keepTests);
     $releaseCreator->createRelease();
 } catch (Exception $e) {
     $consoleWrite->displayText(

--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -87,7 +87,7 @@ class ReleaseCreator
      *
      * @var array
      */
-    protected $foldersRemoveList = ['.docker'];
+    protected $foldersRemoveList = [];
 
     /**
      * Pattern of files or directories to remove.
@@ -95,15 +95,12 @@ class ReleaseCreator
      * @var array
      */
     protected $patternsRemoveList = [
-        'tests(\-legacy)?$',
         'tools/contrib$',
         'travis\-scripts$',
         'CONTRIBUTING\.md$',
         'composer\.json$',
         'diff\-hooks\.php',
-        '((?<!_dev\/)package\.json)$',
         '(.*)?\.composer$',
-        '(.*)?\.git(.*)?$',
         '.*\.map$',
         '.*\.psd$',
         '.*\.md$',
@@ -141,7 +138,6 @@ class ReleaseCreator
         '\.eslintignore$',
         '\.eslintrc\.js$',
         '\.php_cs\.dist$',
-        'docker-compose\.yml$',
         'tools/assets$',
         '\.webpack$',
     ];
@@ -206,12 +202,13 @@ class ReleaseCreator
     /**
      * Set the release wanted version, and some options.
      *
-     * @param string $version
+     * @param string|null $version
      * @param bool $useInstaller
      * @param bool $useZip
      * @param string $destinationDir
+     * @param bool $keepTests
      */
-    public function __construct($version = null, $useInstaller = true, $useZip = true, $destinationDir = '')
+    public function __construct(?string $version = null, bool $useInstaller = true, bool $useZip = true, string $destinationDir = '', bool $keepTests = false)
     {
         $this->consoleWriter = new ConsoleWriter();
         $tmpDir = sys_get_temp_dir();
@@ -224,6 +221,14 @@ class ReleaseCreator
         $this->projectPath = realpath(__DIR__ . '/../../..');
         $this->version = $version ? $version : $this->getCurrentVersion();
         $this->zipFileName = "prestashop_$this->version.zip";
+        // Keep files for tests (tests, git and docker folders)
+        if (!$keepTests) {
+            $this->patternsRemoveList[] = 'tests(\-legacy)?$';
+            $this->patternsRemoveList[] = '(.*)?\.git(.*)?$';
+            $this->patternsRemoveList[] = '.docker';
+            $this->patternsRemoveList[] = 'docker-compose\.yml$';
+            $this->patternsRemoveList[] = '((?<!_dev\/)package\.json)$';
+        }
 
         if (empty($this->version)) {
             throw new Exception('Version is not provided and cannot be found in project.');

--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -883,11 +883,17 @@ class ReleaseCreator
 
         foreach ($files as $key => $value) {
             if (is_numeric($key)) {
-                $md5 = md5_file($value);
                 $count = substr_count($value, DIRECTORY_SEPARATOR) - $subCount + 1;
                 $file_name = str_replace($this->tempProjectPath, '', $value);
                 $file_name = pathinfo($file_name, PATHINFO_BASENAME);
-                $content .= str_repeat("\t", $count) . "<md5file name=\"$file_name\">$md5</md5file>" . PHP_EOL;
+
+                if (is_link($value)) {
+                    $linkTarget = readlink($value);
+                    $content .= str_repeat("\t", $count) . "<link name=\"$file_name\">$linkTarget</link>" . PHP_EOL;
+                } else {
+                    $md5 = md5_file($value);
+                    $content .= str_repeat("\t", $count) . "<md5file name=\"$file_name\">$md5</md5file>" . PHP_EOL;
+                }
             } else {
                 $count = substr_count($key, DIRECTORY_SEPARATOR) - $subCount + 1;
                 $dir_name = str_replace($this->tempProjectPath, '', $key);

--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -252,9 +252,9 @@ class ReleaseCreator
                 "--- Release will be zipped.{$this->lineSeparator}",
                 ConsoleWriter::COLOR_GREEN
             );
-        } elseif ($this->useInstaller) {
+        } else {
             $this->consoleWriter->displayText(
-                "--- Release will have the installer.{$this->lineSeparator}",
+                "--- Release will be a folder without installer.{$this->lineSeparator}",
                 ConsoleWriter::COLOR_GREEN
             );
         }
@@ -540,6 +540,10 @@ class ReleaseCreator
             && composer config autoloader-suffix {$autoloaderSuffix} \
             && composer install --no-dev --optimize-autoloader --no-interaction 2>&1";
         exec($command, $output, $returnCode);
+        if (!empty($output)) {
+            $logPath = __DIR__ . '/../../../var/logs/composer-install.log';
+            file_put_contents($logPath, implode(PHP_EOL, $output));
+        }
 
         if ($returnCode !== 0) {
             throw new BuildException('Unable to run composer install.');
@@ -562,6 +566,10 @@ class ReleaseCreator
         $argProjectPath = escapeshellarg($this->tempProjectPath);
         $command = "cd {$argProjectPath} && make assets 2>&1";
         exec($command, $output, $returnCode);
+        if (!empty($output)) {
+            $logPath = __DIR__ . '/../../../var/logs/build-assets.log';
+            file_put_contents($logPath, implode(PHP_EOL, $output));
+        }
 
         if ($returnCode !== 0) {
             throw new BuildException('Unable to build assets.');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The core may now contain some symbolic links (like `admin-api/bundles/apiplatform`) we cannot compute the md5 value of the symlink especially if it's a link to a folder so we introduce a new type of XML export dedicated for symbolic links The upgrade module will have to handle this correctly For now we simply use an md5 of the link value but it may not be enough and will have to be improved<br>Also add a few improvement in UI tests action workflows like extra inputs for better reusability
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run `php tools/build/CreateRelease.php --version="9.0.0"` there should be no longer some warnings and in the checksum a new `<link />` tag should now be present
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/10158372361
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
