### PR TITLE
Fix: set by default enable action if module is disabled instead of configure action

### DIFF
--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -285,7 +286,13 @@ class AdminModuleDataProvider implements ModuleInterface
             if ($specific_action && array_key_exists($specific_action, $filteredUrls)) {
                 $urlActive = $specific_action;
             } else {
-                $urlActive = key($filteredUrls);
+                // if there is an 'enable' action available set it as first button action
+                // instead of 'configure' action which is the first action in the list
+                if (array_key_exists('enable', $filteredUrls)) {
+                    $urlActive = 'enable';
+                } else {
+                    $urlActive = key($filteredUrls);
+                }
             }
 
             $moduleAttributes->set('urls', $filteredUrls);

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -81,9 +81,9 @@ class AdminModuleDataProvider implements ModuleInterface
      * @var array<string> of defined and callable module actions
      */
     protected $moduleActions = [
+        Module::ACTION_ENABLE,
         Module::ACTION_INSTALL,
         Module::ACTION_CONFIGURE,
-        Module::ACTION_ENABLE,
         Module::ACTION_DISABLE,
         Module::ACTION_ENABLE_MOBILE,
         Module::ACTION_DISABLE_MOBILE,
@@ -285,13 +285,7 @@ class AdminModuleDataProvider implements ModuleInterface
             if ($specific_action && array_key_exists($specific_action, $filteredUrls)) {
                 $urlActive = $specific_action;
             } else {
-                // if there is an 'enable' action available set it as first button action
-                // instead of 'configure' action which is the first action in the list
-                if (array_key_exists('enable', $filteredUrls)) {
-                    $urlActive = 'enable';
-                } else {
-                    $urlActive = key($filteredUrls);
-                }
+                $urlActive = key($filteredUrls);
             }
 
             $moduleAttributes->set('urls', $filteredUrls);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | [See description below](#description)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See the issue https://github.com/PrestaShop/PrestaShop/issues/35665
| UI Tests          | https://github.com/Nakahiru/ga.tests.ui.pr/actions/runs/11213071238
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/35665
| Related PRs       | -
| Sponsor company   | -

## Description

This pull request fixes the issue at https://github.com/PrestaShop/PrestaShop/issues/35665. Since some PrestaShop versions, the action button (on the module list - module manager page) is not displaying the correct action. When a module is disabled, it shows the action `configure` instead of `enable` (in order to enable it again). This could potentially be misleading if a module is enabled or not.

### Before (without the pull request):
https://github.com/user-attachments/assets/0fd40f16-73f2-42d9-89d7-63271cd925dc

### After (with the pull request):
https://github.com/user-attachments/assets/b9b4cab4-2b55-4922-a867-c0f59675b6b7


