### PR TITLE
Add a condition for handling errors from hook actionModuleInstallBefore

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -374,6 +374,11 @@ abstract class ModuleCore implements ModuleInterface
     public function install()
     {
         Hook::exec('actionModuleInstallBefore', ['object' => $this]);
+
+        if ($this->_errors) {
+            return false;
+        }
+
         // Check module name validation
         if (!Validate::isModuleName($this->name)) {
             $this->_errors[] = Context::getContext()->getTranslator()->trans('Unable to install the module (Module name is not valid).', [], 'Admin.Modules.Notification');


### PR DESCRIPTION
[fakemodule.zip](https://github.com/user-attachments/files/16388454/fakemodule.zip)
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | This condition allow the display of an error if the hook actionModuleInstallBefore add errors to the context.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a module that use the hook actionModuleInstallBefore (check example bellow). Install the module. Finally upload another module to see the error in the install modal.
| UI Tests          | https://github.com/matthieu-rolland/ga.tests.ui.pr/actions/runs/10095697357
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | Prestashop SA

```
public function hookActionModuleInstallBefore($params)
    {
        $params["object"]->_errors[] = "Test";
    }
```
