### PR TITLE
Add carrier validation

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -276,11 +276,6 @@ abstract class PaymentModuleCore extends Module
             }
         }
 
-        if (!$this->isCarrierValid($package_list, $cart_delivery_option)) {
-            PrestaShopLogger::addLog('PaymentModule::validateOrder - Carrier is not valid', 3, null, 'Cart', (int) $id_cart, true);
-            die(Tools::displayError('Error processing order. Carrier is not valid.'));
-        }
-
         $order_list = [];
         $order_detail_list = [];
 
@@ -1293,26 +1288,5 @@ abstract class PaymentModuleCore extends Module
         }
 
         return $cart_rules_list;
-    }
-
-    protected function isCarrierValid($package_list, $cart_delivery_option): bool
-    {
-        foreach ($package_list as $packageKey => $packageByAddress) {
-            $carriers = explode(',', trim($cart_delivery_option[$packageKey], ','));
-
-            foreach ($carriers as $carrier) {
-                $carrierObject = new Carrier((int) $carrier);
-
-                if (!$carrierObject->id || !$carrierObject->active) {
-                    return false;
-                }
-                
-                if (empty(Db::getInstance()->executeS('SELECT `id_module` FROM `' . _DB_PREFIX_ . 'module_carrier` WHERE `id_reference` = ' . (int) $carrierObject->id_reference . ' AND `id_shop` = ' . (int) $this->context->shop->id . ' AND `id_module` = ' . (int) $this->id))) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
     }
 }

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -276,6 +276,11 @@ abstract class PaymentModuleCore extends Module
             }
         }
 
+        if (!$this->isCarrierValid($package_list)) {
+            PrestaShopLogger::addLog('PaymentModule::validateOrder - Carrier is not valid', 3, null, 'Cart', (int) $id_cart, true);
+            die(Tools::displayError('Error processing order. Carrier is not valid.'));
+        }
+
         $order_list = [];
         $order_detail_list = [];
 
@@ -1266,5 +1271,20 @@ abstract class PaymentModuleCore extends Module
         }
 
         return $cart_rules_list;
+    }
+
+    protected function isCarrierValid($package_list): bool
+    {
+        foreach ($package_list as $packageByAddress) {
+            foreach ($packageByAddress as $package) {
+                $carrier = new Carrier((int) $package['id_carrier']);
+
+                if (empty(Db::getInstance()->executeS('SELECT `id_module` FROM `' . _DB_PREFIX_ . 'module_carrier` WHERE `id_reference` = ' . (int) $carrier->id_reference . ' AND `id_shop` = ' . (int) $this->context->shop->id . ' AND `id_module` = ' . (int) $this->id))) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Fixes bug that allows users to bypass restrictions and select a payment method that should not be available for a given shipping method.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create two shipping methods and two payment methods. 2. Configure the system so the first shipping method only allows the first payment method, and the second shipping method allows only the second payment method. 3. Place a new order and proceed to the final step (payment method). Inspect the DOM for the form inside the div with the id "pay-with-payment-option-1-form". Modify the form's action URL from "/module/ps_cashondelivery/validation" to another payment method's URL, for example, "/module/ps_wirepayment/validation". 4. Submit the order.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #36619
| Related PRs       |
| Sponsor company   | 