### PR TITLE
Fix: tax rules country selection

### DIFF
--- a/controllers/admin/AdminTaxRulesGroupController.php
+++ b/controllers/admin/AdminTaxRulesGroupController.php
@@ -571,7 +571,6 @@ class AdminTaxRulesGroupControllerCore extends AdminController
     protected function updateTaxRulesGroup(TaxRulesGroup $object)
     {
         static $tax_rules_group = null;
-
         if ($tax_rules_group === null) {
             $object->update();
             $tax_rules_group = $object;

--- a/controllers/admin/AdminTaxRulesGroupController.php
+++ b/controllers/admin/AdminTaxRulesGroupController.php
@@ -515,7 +515,7 @@ class AdminTaxRulesGroupControllerCore extends AdminController
         $this->deleteTaxRule([Tools::getValue('id_tax_rule')]);
     }
 
-    public function displayAjaxUpdateTaxRule()
+    protected function displayAjaxUpdateTaxRule()
     {
         if ($this->access('view')) {
             $id_tax_rule = Tools::getValue('id_tax_rule');

--- a/controllers/admin/AdminTaxRulesGroupController.php
+++ b/controllers/admin/AdminTaxRulesGroupController.php
@@ -432,8 +432,8 @@ class AdminTaxRulesGroupControllerCore extends AdminController
             $this->selected_states = [0];
         }
         $tax_rules_group = new TaxRulesGroup((int) $id_tax_rules_group);
+
         foreach ($this->selected_countries as $id_country) {
-            $first = true;
             foreach ($this->selected_states as $id_state) {
                 if ($tax_rules_group->hasUniqueTaxRuleForCountry($id_country, $id_state, $id_rule)) {
                     $this->errors[] = $this->trans('A tax rule already exists for this country/state with tax only behavior.', [], 'Admin.International.Notification');
@@ -441,11 +441,11 @@ class AdminTaxRulesGroupControllerCore extends AdminController
                     continue;
                 }
                 $tr = new TaxRule();
+                // Here we want to update if we selected only one country,
+                // otherwise we create a new one for each country if we selected ALL option
 
-                // update or creation?
-                if ($first) {
+                if (count($this->selected_countries) === 1) {
                     $tr->id = $id_rule;
-                    $first = false;
                 }
 
                 $tr->id_tax = $id_tax;
@@ -515,7 +515,7 @@ class AdminTaxRulesGroupControllerCore extends AdminController
         $this->deleteTaxRule([Tools::getValue('id_tax_rule')]);
     }
 
-    protected function displayAjaxUpdateTaxRule()
+    public function displayAjaxUpdateTaxRule()
     {
         if ($this->access('view')) {
             $id_tax_rule = Tools::getValue('id_tax_rule');
@@ -571,6 +571,7 @@ class AdminTaxRulesGroupControllerCore extends AdminController
     protected function updateTaxRulesGroup(TaxRulesGroup $object)
     {
         static $tax_rules_group = null;
+
         if ($tax_rules_group === null) {
             $object->update();
             $tax_rules_group = $object;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | [See below](#description)
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See the issue [#15689](https://github.com/PrestaShop/PrestaShop/issues/15689)
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/10283934019
| Fixed issue or discussion? | -

### Description

This pull request fixed the issue 15689. In the Tax Rules section when you create a new tax rule you can choose one country or ALL countries. The case is when you select one country and you save everything is ok. However, when you want to update it with the ALL option, only Zimbabwe was selected. It appears because instead of adding new entries with all countries, we doing an update for each country, and Zimbabwe is at the end of the list. That's why we have Zimbabwe. 
