### PR TITLE
Add hook for assigning general purpose variables before the core does it

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -541,31 +541,40 @@ class FrontControllerCore extends Controller
             $cart = new Cart();
         }
 
-        $templateVars = [
-            'cart' => $this->cart_presenter->present($cart),
-            'currency' => $this->getTemplateVarCurrency(),
-            'customer' => $this->getTemplateVarCustomer(),
-            'country' => $this->objectPresenter->present($this->context->country),
-            'language' => $this->objectPresenter->present($this->context->language),
-            'page' => $this->getTemplateVarPage(),
-            'shop' => $this->getTemplateVarShop(),
-            'core_js_public_path' => $this->getCoreJsPublicPath(),
-            'urls' => $this->getTemplateVarUrls(),
-            'configuration' => $this->getTemplateVarConfiguration(),
-            'field_required' => $this->context->customer->validateFieldsRequiredDatabase(),
-            'breadcrumb' => $this->getBreadcrumb(),
-            'link' => $this->context->link,
-            'time' => time(),
-            'static_token' => Tools::getToken(false),
-            'token' => Tools::getToken(),
-            'debug' => _PS_MODE_DEV_,
-        ];
+        $templateVars = [];
+
+        Hook::exec(
+            'actionFrontControllerSetVariablesBefore',
+            [
+                'templateVars' => &$templateVars,
+                'cart' => $cart,
+            ],
+        );
+
+        $templateVars['cart'] = $templateVars['cart'] ?? $this->cart_presenter->present($cart);
+        $templateVars['currency'] = $templateVars['currency'] ?? $this->getTemplateVarCurrency();
+        $templateVars['customer'] = $templateVars['customer'] ?? $this->getTemplateVarCustomer();
+        $templateVars['country'] = $templateVars['country'] ?? $this->objectPresenter->present($this->context->country);
+        $templateVars['language'] = $templateVars['language'] ?? $this->objectPresenter->present($this->context->language);
+        $templateVars['page'] = $templateVars['page'] ?? $this->getTemplateVarPage();
+        $templateVars['shop'] = $templateVars['shop'] ?? $this->getTemplateVarShop();
+        $templateVars['core_js_public_path'] = $templateVars['core_js_public_path'] ?? $this->getCoreJsPublicPath();
+        $templateVars['urls'] = $templateVars['urls'] ?? $this->getTemplateVarUrls();
+        $templateVars['configuration'] = $templateVars['configuration'] ?? $this->getTemplateVarConfiguration();
+        $templateVars['field_required'] = $templateVars['field_required'] ?? $this->context->customer->validateFieldsRequiredDatabase();
+        $templateVars['breadcrumb'] = $templateVars['breadcrumb'] ?? $this->getBreadcrumb();
+        $templateVars['link'] = $templateVars['link'] ?? $this->context->link;
+        $templateVars['time'] = $templateVars['time'] ?? time();
+        $templateVars['static_token'] = $templateVars['static_token'] ?? Tools::getToken(false);
+        $templateVars['token'] = $templateVars['token'] ?? Tools::getToken();
+        $templateVars['debug'] = $templateVars['debug'] ?? _PS_MODE_DEV_;
 
         // An array [module_name => module_output] will be returned
         $modulesVariables = Hook::exec(
             'actionFrontControllerSetVariables',
             [
                 'templateVars' => &$templateVars,
+                'cart' => $cart,
             ],
             null,
             true

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -541,6 +541,9 @@ class FrontControllerCore extends Controller
             $cart = new Cart();
         }
 
+        /**
+         * @var array<string, mixed> $templateVars
+         */
         $templateVars = [];
 
         Hook::exec(
@@ -548,7 +551,7 @@ class FrontControllerCore extends Controller
             [
                 'templateVars' => &$templateVars,
                 'cart' => $cart,
-            ],
+            ]
         );
 
         $templateVars['cart'] = $templateVars['cart'] ?? $this->cart_presenter->present($cart);

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -574,7 +574,6 @@ class FrontControllerCore extends Controller
             'actionFrontControllerSetVariables',
             [
                 'templateVars' => &$templateVars,
-                'cart' => $cart,
             ],
             null,
             true

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -2879,6 +2879,11 @@
       <title>Runs an action after ProductSearchProviderInterface::RunQuery()</title>
       <description>Required to return a previous state of an SQL query or/and to change a result of the SQL query after executing it</description>
     </hook>
+    <hook id="actionFrontControllerSetVariablesBefore">
+      <name>actionFrontControllerSetVariablesBefore</name>
+      <title>Add general purpose variables in JavaScript object and Smarty templates before assignation.</title>
+      <description>Allows defining variables for the JavaScript object before the core does it.</description>
+    </hook>
     <hook id="actionFrontControllerSetVariables">
       <name>actionFrontControllerSetVariables</name>
       <title>Add variables in JavaScript object and Smarty templates</title>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | This PR adds a hook to set general purpose variables on the global JavaScript object, but before assignations made from the core. The code is also slightly modified so that variables already defined are not defined again by the core. It allows customizing the content of a variable without assigning it twice, which unlock performance gains for heavy computation variables.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green
| UI Tests          | 
| Fixed issue or discussion?     | none
| Related PRs       | none
| Sponsor company   | PrestaShop SA