### PR TITLE
Update UI testing library to work on Mac OS

### DIFF
--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -431,7 +431,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#ce0a17c346e0f07d74cd3b07dbd5560706944a3d",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#5e536f964c2ef962906c1b6ebaad4b46bfb2e1cf",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^8.3.1",
@@ -8444,7 +8444,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#ce0a17c346e0f07d74cd3b07dbd5560706944a3d",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#5e536f964c2ef962906c1b6ebaad4b46bfb2e1cf",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^8.3.1",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Update UI testing library to work on Mac OS (the UI tests couldn't be installed anymore on Mac OS)
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/10262575703
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
