### PR TITLE
Cleanup Product and ProductController and migrate several properties into ProductLazyArray

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5515,16 +5515,10 @@ class ProductCore extends ObjectModel
                 $context->cart,
                 false
             );
-
-            $row['available_date'] = Product::getAvailableDate(
-                (int) $row['id_product'],
-                $id_product_attribute
-            );
         }
 
-        // Pack management
+        // Information about if a product is a pack
         $row['pack'] = (!isset($row['cache_is_pack']) ? Pack::isPack($row['id_product']) : (int) $row['cache_is_pack']);
-        $row['packItems'] = $row['pack'] ? Pack::getItemTable($row['id_product'], $id_lang) : [];
 
         if (!isset($row['attributes'])) {
             $attributes = Product::getAttributesParams($row['id_product'], $row['id_product_attribute']);
@@ -5535,8 +5529,6 @@ class ProductCore extends ObjectModel
         }
 
         $row = Product::getTaxesInformations($row, $context);
-
-        $row['ecotax_rate'] = (float) Tax::getProductEcotaxRate($context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
 
         Hook::exec('actionGetProductPropertiesAfter', [
             'id_lang' => $id_lang,

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -546,16 +546,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $id_customer = (isset($this->context->customer) ? (int) $this->context->customer->id : 0);
         $id_group = (int) Group::getCurrent()->id;
         $id_country = $id_customer ? (int) Customer::getCurrentCountry($id_customer) : (int) Tools::getCountry();
-
-        // Tax
-        $tax = (float) $this->product->getTaxesRate(new Address((int) $this->context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')}));
-        $this->context->smarty->assign('tax_rate', $tax);
-
-        $product_price_with_tax = Product::getPriceStatic($this->product->id, true, null, 6);
-        if (Product::$_taxCalculationMethod == PS_TAX_INC) {
-            $product_price_with_tax = Tools::ps_round($product_price_with_tax, 2);
-        }
-
         $id_currency = (int) $this->context->cookie->id_currency;
         $id_product = (int) $this->product->id;
         $id_product_attribute = $this->getIdProductAttributeByGroupOrRequestOrDefault();
@@ -578,14 +568,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         unset($quantity_discount);
 
         $product_price = $this->product->getPrice(Product::$_taxCalculationMethod == PS_TAX_INC, $id_product_attribute, 6, null, false, false);
+        $tax = (float) $this->product->getTaxesRate(new Address((int) $this->context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')}));
 
         $this->quantity_discounts = $this->formatQuantityDiscounts($quantity_discounts, $product_price, (float) $tax, $this->product->ecotax);
-
-        $this->context->smarty->assign([
-            'no_tax' => !Configuration::get('PS_TAX') || !$tax,
-            'tax_enabled' => Configuration::get('PS_TAX') && !Configuration::get('AEUC_LABEL_TAX_INC_EXC'),
-            'customer_group_without_tax' => Group::getPriceDisplayMethod($this->context->customer->id_default_group),
-        ]);
     }
 
     /**
@@ -1190,29 +1175,13 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product['cart_quantity'] = $this->context->cart->getProductQuantity((int) $this->product->id, $product['id_product_attribute'])['quantity'];
         $product['quantity_wanted'] = $this->getRequiredQuantity($product);
         $product['extraContent'] = $extraContentFinder->addParams(['product' => $this->product])->present();
-        $product['ecotax_tax_inc'] = $this->product->getEcotax(null, true, true);
         $product['ecotax'] = Tools::convertPrice($this->getProductEcotax($product), $this->context->currency, true, $this->context);
 
         $product_full = Product::getProductProperties($this->context->language->id, $product, $this->context);
 
         $product_full = $this->addProductCustomizationData($product_full);
 
-        $product_full['show_quantities'] = (bool) (
-            Configuration::get('PS_DISPLAY_QTIES')
-            && Configuration::get('PS_STOCK_MANAGEMENT')
-            && $this->product->quantity > 0
-            && $this->product->available_for_order
-            && !Configuration::isCatalogMode()
-        );
-        $product_full['quantity_label'] = ($this->product->quantity > 1) ? $this->trans('Items', [], 'Shop.Theme.Catalog') : $this->trans('Item', [], 'Shop.Theme.Catalog');
         $product_full['quantity_discounts'] = $this->quantity_discounts;
-
-        $group_reduction = GroupReduction::getValueForProduct($this->product->id, (int) Group::getCurrent()->id);
-        if ($group_reduction === false) {
-            $group_reduction = Group::getReduction((int) $this->context->cookie->id_customer) / 100;
-        }
-        $product_full['customer_group_discount'] = $group_reduction;
-        $product_full['title'] = $this->getProductPageTitle();
 
         return $this->getProductPresenter()->present(
             $productSettings,

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -52,6 +52,7 @@ use Product;
 use ReflectionException;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Tax;
 use Tools;
 use Validate;
 
@@ -502,11 +503,22 @@ class ProductLazyArray extends AbstractLazyArray
             return [
                 'value' => $this->priceFormatter->format($this->product['ecotax']),
                 'amount' => $this->product['ecotax'],
-                'rate' => $this->product['ecotax_rate'],
+                'rate' => $this->getEcotaxRate(),
             ];
         }
 
         return null;
+    }
+
+    /**
+     * @return float
+     */
+    #[LazyArrayAttribute(arrayAccess: true)]
+    public function getEcotaxRate()
+    {
+        return (float) Tax::getProductEcotaxRate(
+            Context::getContext()->cart->{$this->configuration->get('PS_TAX_ADDRESS_TYPE')}
+        );
     }
 
     /**
@@ -1091,9 +1103,6 @@ class ProductLazyArray extends AbstractLazyArray
             $product['quantity_wanted'] = $this->getQuantityWanted();
         }
 
-        // Validate and format availability date
-        $product['available_date'] = $this->prepareAvailabilityDate($product);
-
         // Default data
         $this->product['availability_message'] = null;
         $this->product['availability_submessage'] = null;
@@ -1118,7 +1127,7 @@ class ProductLazyArray extends AbstractLazyArray
         }
 
         // Quantity available we will display is reduced by amount we want to add to cart
-        $availableQuantity = $product['quantity'] - $product['quantity_wanted'];
+        $availableQuantity = $this->product['quantity'] - $product['quantity_wanted'];
         if (isset($product['stock_quantity'])) {
             $availableQuantity = $product['stock_quantity'] - $product['quantity_wanted'];
         }
@@ -1153,7 +1162,7 @@ class ProductLazyArray extends AbstractLazyArray
 
         // Case 2 - Product not in stock, available for order
         } elseif ($product['allow_oosp']) {
-            $this->product['availability_date'] = $product['available_date'];
+            $this->product['availability_date'] = $this->getAvailableDate();
             $this->product['availability'] = 'available';
 
             // We will primarily use label from combination if set, then label on product, then the default label from PS settings
@@ -1167,8 +1176,8 @@ class ProductLazyArray extends AbstractLazyArray
             }
 
         // Case 3 - OOSP disabled and customer wants to add more items to cart than are in stock
-        } elseif ($product['quantity'] > 0) {
-            $this->product['availability_date'] = $product['available_date'];
+        } elseif ($this->product['quantity'] > 0) {
+            $this->product['availability_date'] = $this->getAvailableDate();
             $this->product['availability'] = 'unavailable';
 
             $this->product['availability_message'] = $this->translator->trans(
@@ -1179,11 +1188,11 @@ class ProductLazyArray extends AbstractLazyArray
 
         // Case 4 - Product not in stock, not available for order
         } else {
-            $this->product['availability_date'] = $product['available_date'];
+            $this->product['availability_date'] = $this->getAvailableDate();
             $this->product['availability'] = 'unavailable';
 
             // If the product has combinations and other combination is in stock, we show a small hint about it
-            if ($product['cache_default_attribute'] && $product['quantity_all_versions'] > 0) {
+            if ($product['cache_default_attribute'] && $this->product['quantity_all_versions'] > 0) {
                 $this->product['availability_message'] = $this->translator->trans(
                     'Product available with different options',
                     [],
@@ -1195,6 +1204,46 @@ class ProductLazyArray extends AbstractLazyArray
                 $this->product['availability_message'] = $config[$language->id] ?? null;
             }
         }
+    }
+
+    /**
+     * Returns information, if a precise quantity should be displayed. Used on product page.
+     *
+     * @return bool
+     */
+    #[LazyArrayAttribute(arrayAccess: true)]
+    public function getShowQuantities()
+    {
+        if (!isset($this->product['show_quantities'])) {
+            $this->product['show_quantities'] = (bool) (
+                $this->configuration->get('PS_DISPLAY_QTIES')
+                && $this->configuration->get('PS_STOCK_MANAGEMENT')
+                && $this->product['quantity'] > 0
+                && (bool) $this->product['available_for_order']
+                && !$this->settings->catalog_mode
+            );
+        }
+
+        return $this->product['show_quantities'];
+    }
+
+    /**
+     * Returns a quantity label to use, that is displayed after precise quantity. Used on product page.
+     *
+     * @return string
+     */
+    #[LazyArrayAttribute(arrayAccess: true)]
+    public function getQuantityLabel()
+    {
+        if (!isset($this->product['quantity_label'])) {
+            $this->product['quantity_label'] = (
+                $this->product['quantity'] > 1 ?
+                $this->translator->trans('Items', [], 'Shop.Theme.Catalog') :
+                $this->translator->trans('Item', [], 'Shop.Theme.Catalog')
+            );
+        }
+
+        return $this->product['quantity_label'];
     }
 
     /**
@@ -1217,28 +1266,38 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * Validates and formats available_date property passed into the lazy array.
+     * Returns product availability date.
      * It will return the date back only if it's a valid date in the future.
-     * Also handles the case when the date was not passed at all.
-     *
-     * @param array $product
      *
      * @return string|null
      */
-    private function prepareAvailabilityDate($product)
+    #[LazyArrayAttribute(arrayAccess: true)]
+    public function getAvailableDate()
     {
+        /*
+         * Basic available date is passed here from the product object. We will get it
+         * manually in two cases. If we need it for specific combination, or if it was
+         * not passed for some reason.
+         */
+        if (!isset($this->product['available_date'])) {
+            $this->product['available_date'] = Product::getAvailableDate((int) $this->product['id_product']);
+        }
+        if (!empty($this->product['id_product_attribute'])) {
+            $this->product['available_date'] = Product::getAvailableDate((int) $this->product['id_product'], (int) $this->product['id_product_attribute']);
+        }
+
         // Check if the date is valid
-        if (empty($product['available_date']) || $product['available_date'] == '0000-00-00' || !Validate::isDate($product['available_date'])) {
+        if (empty($this->product['available_date']) || $this->product['available_date'] == '0000-00-00' || !Validate::isDate($this->product['available_date'])) {
             return null;
         }
 
         // Check if it didn't already pass
-        $date = new DateTime($product['available_date']);
+        $date = new DateTime($this->product['available_date']);
         if ($date < new DateTime()) {
             return null;
         }
 
-        return $product['available_date'];
+        return $this->product['available_date'];
     }
 
     /**
@@ -1288,7 +1347,6 @@ class ProductLazyArray extends AbstractLazyArray
             'category_name',
             'condition',
             'cover',
-            'customer_group_discount',
             'customizable',
             'customization_required',
             'customizations',
@@ -1304,7 +1362,6 @@ class ProductLazyArray extends AbstractLazyArray
             'discount_percentage_absolute',
             'discount_type',
             'ecotax',
-            'ecotax_rate',
             'extraContent',
             'features',
             'flags',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Read below
| Type?             | refacto
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Full FO test.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Description
Now, prices and product data are scattered in many places over Prestashop. If we want to fix something, we must have it on one place at least. Currently, data is assigned in `Product::GetProductProperties`, in `Product` object constructor, in `ProductController::initContent`, `ProductController::getTemplateVarProduct`, `ProductController::assignPriceAndTax` and in `ProductLazyArray`. I already reworked a lot of it in previous PR, now, continuing.

In the current state of the PR, I refactored most of price things out of ProductController into `ProductLazyArray`, quantity discounts and one ecotax property is remaining.

I also refactored a lot of things out of `Product::GetProductProperties` into `ProductLazyArray`.

### Changes
- Manufacturer data assigned in separate method, can be overriden if needed.
- Removed unused variables related to customizations and prices.
- Refactored assignments of pack related things and unnecessary calculations.
- Migrated `rounded_display_price` to lazy array.
- Migrated `ecotax_rate` to lazy array.
- Migrated `customization_required` to lazy array.
- Migrated `show_quantities` to lazy array.
- Migrated `quantity_label` to lazy array.
- Migrated availability date into lazy array.

### Things for next time
- Refactor out quantity discounts out of `ProductController::assignPriceAndTax()` and `ProductController::formatQuantityDiscounts()`, but this will slow down things, because of JS objects accessing every single key in the lazy array.
- Migrate quantity array, but this is also problem, because quantity means some thing different if presenting a cart vs listing product.