### PR TITLE
Can't transformToCustomer while password max length is shorter than default 16 length

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1222,12 +1222,11 @@ class CustomerCore extends ObjectModel
         * we set a random one for now.
         */
         if (empty($password)) {
-            $this->passwd = Tools::passwdGen(16, 'RANDOM');
+            $password = Tools::passwdGen(16, 'RANDOM');
         } else {
             if (!Validate::isAcceptablePasswordLength($password) || !Validate::isAcceptablePasswordScore($password)) {
                 return false;
             }
-            $this->passwd = $crypto->hash($password);
         }
 
         /** @var \PrestaShop\PrestaShop\Core\Crypto\Hashing $crypto */

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1222,21 +1222,12 @@ class CustomerCore extends ObjectModel
         * we set a random one for now.
         */
         if (empty($password)) {
-            $pass_length = 16;
-            $min_pass_length = (int) Configuration::get('PS_SECURITY_PASSWORD_POLICY_MINIMUM_LENGTH');
-            if ($min_pass_length > 0 && $pass_length < $min_pass_length) {
-                $pass_length = $min_pass_length;
+            $this->passwd = $crypto->hash(Tools::passwdGen(16, 'RANDOM'));
+        } else {
+            if (!Validate::isAcceptablePasswordLength($password) || !Validate::isAcceptablePasswordScore($password)) {
+                return false;
             }
-
-            $max_pass_length = (int) Configuration::get('PS_SECURITY_PASSWORD_POLICY_MAXIMUM_LENGTH');
-            if ($max_pass_length > 0 && $pass_length > $max_pass_length) {
-                $pass_length = $max_pass_length;
-            }
-            $password = Tools::passwdGen($pass_length, 'RANDOM');
-        }
-
-        if (!Validate::isAcceptablePasswordLength($password) || !Validate::isAcceptablePasswordScore($password)) {
-            return false;
+            $this->passwd = $crypto->hash($password);
         }
 
         /** @var \PrestaShop\PrestaShop\Core\Crypto\Hashing $crypto */

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1220,11 +1220,14 @@ class CustomerCore extends ObjectModel
         /*
         * If this is an anonymous conversion and we want the customer to set his own password,
         * we set a random one for now.
-        * TODO - This should be revised in the future because 16 chars can be outside of bounds of
-        * isAcceptablePasswordLength. It should not be checked.
         */
         if (empty($password)) {
-            $password = Tools::passwdGen(16, 'RANDOM');
+            $pass_length = 16;
+            $max_pass_length = (int)Configuration::get('PS_SECURITY_PASSWORD_POLICY_MAXIMUM_LENGTH');
+            if ($max_pass_length > 0 && $default_pass_length > $max_pass_length) {
+                $pass_length = $max_pass_length;
+            }
+            $password = Tools::passwdGen($pass_length, 'RANDOM');
         }
 
         if (!Validate::isAcceptablePasswordLength($password) || !Validate::isAcceptablePasswordScore($password)) {

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1222,7 +1222,7 @@ class CustomerCore extends ObjectModel
         * we set a random one for now.
         */
         if (empty($password)) {
-            $this->passwd = $crypto->hash(Tools::passwdGen(16, 'RANDOM'));
+            $this->passwd = Tools::passwdGen(16, 'RANDOM');
         } else {
             if (!Validate::isAcceptablePasswordLength($password) || !Validate::isAcceptablePasswordScore($password)) {
                 return false;

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1224,7 +1224,7 @@ class CustomerCore extends ObjectModel
         if (empty($password)) {
             $pass_length = 16;
             $max_pass_length = (int)Configuration::get('PS_SECURITY_PASSWORD_POLICY_MAXIMUM_LENGTH');
-            if ($max_pass_length > 0 && $default_pass_length > $max_pass_length) {
+            if ($max_pass_length > 0 && $pass_length > $max_pass_length) {
                 $pass_length = $max_pass_length;
             }
             $password = Tools::passwdGen($pass_length, 'RANDOM');

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1223,12 +1223,12 @@ class CustomerCore extends ObjectModel
         */
         if (empty($password)) {
             $pass_length = 16;
-            $min_pass_length = (int)Configuration::get('PS_SECURITY_PASSWORD_POLICY_MINIMUM_LENGTH');
+            $min_pass_length = (int) Configuration::get('PS_SECURITY_PASSWORD_POLICY_MINIMUM_LENGTH');
             if ($min_pass_length > 0 && $pass_length < $min_pass_length) {
                 $pass_length = $min_pass_length;
             }
 
-            $max_pass_length = (int)Configuration::get('PS_SECURITY_PASSWORD_POLICY_MAXIMUM_LENGTH');
+            $max_pass_length = (int) Configuration::get('PS_SECURITY_PASSWORD_POLICY_MAXIMUM_LENGTH');
             if ($max_pass_length > 0 && $pass_length > $max_pass_length) {
                 $pass_length = $max_pass_length;
             }

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1223,6 +1223,11 @@ class CustomerCore extends ObjectModel
         */
         if (empty($password)) {
             $pass_length = 16;
+            $min_pass_length = (int)Configuration::get('PS_SECURITY_PASSWORD_POLICY_MINIMUM_LENGTH');
+            if ($min_pass_length > 0 && $pass_length < $min_pass_length) {
+                $pass_length = $min_pass_length;
+            }
+
             $max_pass_length = (int)Configuration::get('PS_SECURITY_PASSWORD_POLICY_MAXIMUM_LENGTH');
             if ($max_pass_length > 0 && $pass_length > $max_pass_length) {
                 $pass_length = $max_pass_length;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | There is known bug, because already there is text "_TODO - This should be revised in the future because 16 chars can be outside of bounds of * isAcceptablePasswordLength. It should not be checked._". I found it accidentally, when eshop owner reported me transform Host to Customer isn't working. I found it. Problem is when we set up maximum password length lower than default 16 characters. In this PR I already took into account opposite story (min pass length) - but this is only theoretical, from land of dreams... :)
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set maximal password length to 15 (for example), before this PR you are not able to transfer Host to Customer. After apply this PR, it will works.
| UI Tests          |  https://github.com/florine2623/testing_pr/actions/runs/10920473355
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
