### PR TITLE
Handle form choice duplicates

### DIFF
--- a/src/Adapter/Form/ChoiceProvider/CountryStateByIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/CountryStateByIdChoiceProvider.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
 use Country;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
 use PrestaShopException;
 use State;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -56,11 +57,11 @@ final class CountryStateByIdChoiceProvider implements ConfigurableFormChoiceProv
                 return [];
             }
 
-            $states = State::getStatesByIdCountry($countryId, $resolvedOptions['only_active'], 'name', 'asc');
-
-            foreach ($states as $state) {
-                $choices[$state['name']] = $state['id_state'];
-            }
+            $choices = FormChoiceFormatter::formatFormChoices(
+                State::getStatesByIdCountry($countryId, $resolvedOptions['only_active'], 'name', 'asc'),
+                'id_state',
+                'name'
+            );
         } catch (PrestaShopException $e) {
             throw new CoreException(sprintf('An error occurred when getting states for country id "%s"', $countryId));
         }

--- a/src/Adapter/Form/ChoiceProvider/FeatureValuesChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/FeatureValuesChoiceProvider.php
@@ -31,6 +31,7 @@ namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
 use PrestaShop\PrestaShop\Adapter\Feature\Repository\FeatureValueRepository;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
 
 class FeatureValuesChoiceProvider implements ConfigurableFormChoiceProviderInterface
 {
@@ -74,15 +75,16 @@ class FeatureValuesChoiceProvider implements ConfigurableFormChoiceProviderInter
         if (isset($options['custom'])) {
             $filters['custom'] = $options['custom'];
         }
-        $cacheKey = md5(serialize($filters));
-        if (!empty($this->cacheFeatureValueChoices[$cacheKey])) {
-            return $this->cacheFeatureValueChoices[$cacheKey];
-        }
 
-        $featureValues = $this->featureValueRepository->getFeatureValuesByLang($this->contextLanguageId, $filters);
-        $this->cacheFeatureValueChoices[$cacheKey] = [];
-        foreach ($featureValues as $feature) {
-            $this->cacheFeatureValueChoices[$cacheKey][$feature['value']] = (int) $feature['id_feature_value'];
+        // Get cache key and if this is the first time we are accessing it,
+        // we build the options
+        $cacheKey = md5(serialize($filters));
+        if (empty($this->cacheFeatureValueChoices[$cacheKey])) {
+            $this->cacheFeatureValueChoices[$cacheKey] = FormChoiceFormatter::formatFormChoices(
+                $this->featureValueRepository->getFeatureValuesByLang($this->contextLanguageId, $filters),
+                'id_feature_value',
+                'value'
+            );
         }
 
         return $this->cacheFeatureValueChoices[$cacheKey];

--- a/src/Adapter/Form/ChoiceProvider/ManufacturerNameByIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/ManufacturerNameByIdChoiceProvider.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
 
+use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 
 /**
@@ -50,12 +51,10 @@ final class ManufacturerNameByIdChoiceProvider implements FormChoiceProviderInte
      */
     public function getChoices()
     {
-        $choices = [];
-
-        foreach ($this->manufacturers as $manufacturer) {
-            $choices[$manufacturer['name']] = (int) $manufacturer['id_manufacturer'];
-        }
-
-        return $choices;
+        return FormChoiceFormatter::formatFormChoices(
+            $this->manufacturers,
+            'id_manufacturer',
+            'name'
+        );
     }
 }

--- a/src/Adapter/Form/ChoiceProvider/OrderCountriesChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/OrderCountriesChoiceProvider.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
 use Context;
 use Country;
 use Db;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use Shop;
 
@@ -46,7 +47,7 @@ final class OrderCountriesChoiceProvider implements FormChoiceProviderInterface
             return [];
         }
 
-        $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
+        $countries = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 			SELECT DISTINCT c.id_country, cl.`name`
 			FROM `' . _DB_PREFIX_ . 'orders` o
 			' . Shop::addSqlAssociation('orders', 'o') . '
@@ -60,12 +61,10 @@ final class OrderCountriesChoiceProvider implements FormChoiceProviderInterface
 			ORDER BY cl.name ASC'
         );
 
-        $choices = [];
-
-        foreach ($result as $row) {
-            $choices[$row['name']] = $row['id_country'];
-        }
-
-        return $choices;
+        return FormChoiceFormatter::formatFormChoices(
+            $countries,
+            'id_country',
+            'name'
+        );
     }
 }

--- a/src/Adapter/Form/ChoiceProvider/ProfileByIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/ProfileByIdChoiceProvider.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
 
+use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use Profile;
 
@@ -52,13 +53,11 @@ final class ProfileByIdChoiceProvider implements FormChoiceProviderInterface
      */
     public function getChoices()
     {
-        $profiles = Profile::getProfiles($this->contextLangId);
-        $choices = [];
-
-        foreach ($profiles as $profile) {
-            $choices[$profile['name']] = $profile['id_profile'];
-        }
-
-        return $choices;
+        return FormChoiceFormatter::formatFormChoices(
+            Profile::getProfiles($this->contextLangId),
+            'id_profile',
+            'name',
+            false
+        );
     }
 }

--- a/src/Adapter/Form/ChoiceProvider/SupplierNameByIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/SupplierNameByIdChoiceProvider.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
 
+use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use Supplier;
 
@@ -41,33 +42,10 @@ final class SupplierNameByIdChoiceProvider implements FormChoiceProviderInterfac
      */
     public function getChoices()
     {
-        $choices = [];
-        $suppliers = Supplier::getSuppliers(false, 0, false);
-        $hasDuplicated = $this->hasDuplicateSuppliers($suppliers);
-
-        foreach ($suppliers as $supplier) {
-            // Integrate the ID in the name so that suppliers with identical names don't override themselves (only when duplicate are detected)
-            $supplierName = $supplier['name'];
-            if ($hasDuplicated) {
-                $supplierName = sprintf('%d - %s', $supplier['id_supplier'], $supplierName);
-            }
-            $choices[$supplierName] = (int) $supplier['id_supplier'];
-        }
-
-        return $choices;
-    }
-
-    private function hasDuplicateSuppliers(array $suppliers): bool
-    {
-        $names = [];
-        foreach ($suppliers as $supplier) {
-            if (in_array($supplier['name'], $names)) {
-                return true;
-            }
-
-            $names[] = $supplier['name'];
-        }
-
-        return false;
+        return FormChoiceFormatter::formatFormChoices(
+            Supplier::getSuppliers(false, 0, false),
+            'id_supplier',
+            'name'
+        );
     }
 }

--- a/src/Adapter/Form/ChoiceProvider/ZoneByIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/ZoneByIdChoiceProvider.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
 
 use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Zone;
 
@@ -44,14 +45,11 @@ class ZoneByIdChoiceProvider implements ConfigurableFormChoiceProviderInterface
     {
         $options = $this->resolveOptions($options);
 
-        $zones = Zone::getZones($options['active'], $options['active_first']);
-        $choices = [];
-
-        foreach ($zones as $zone) {
-            $choices[$zone['name']] = (int) $zone['id_zone'];
-        }
-
-        return $choices;
+        return FormChoiceFormatter::formatFormChoices(
+            Zone::getZones($options['active'], $options['active_first']),
+            'id_zone',
+            'name'
+        );
     }
 
     private function resolveOptions(array $options): array

--- a/src/Core/Form/ChoiceProvider/CountryByIdChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/CountryByIdChoiceProvider.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
 use PrestaShop\PrestaShop\Adapter\Country\CountryDataProvider;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceAttributeProviderInterface;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 
 /**
@@ -79,14 +80,11 @@ final class CountryByIdChoiceProvider implements FormChoiceProviderInterface, Fo
      */
     public function getChoices()
     {
-        $countries = $this->getCountries();
-        $choices = [];
-
-        foreach ($countries as $country) {
-            $choices[$country['name']] = $country['id_country'];
-        }
-
-        return $choices;
+        return FormChoiceFormatter::formatFormChoices(
+            $this->getCountries(),
+            'id_country',
+            'name'
+        );
     }
 
     /**

--- a/src/Core/Form/ChoiceProvider/CountryByIsoCodeChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/CountryByIsoCodeChoiceProvider.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
 use PrestaShop\PrestaShop\Adapter\Country\CountryDataProvider;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 
 /**
@@ -63,13 +64,10 @@ final class CountryByIsoCodeChoiceProvider implements FormChoiceProviderInterfac
      */
     public function getChoices()
     {
-        $choices = [];
-        $countries = $this->countryDataProvider->getCountries($this->langId);
-
-        foreach ($countries as $country) {
-            $choices[$country['name']] = $country['iso_code'];
-        }
-
-        return $choices;
+        return FormChoiceFormatter::formatFormChoices(
+            $this->countryDataProvider->getCountries($this->langId),
+            'iso_code',
+            'name'
+        );
     }
 }

--- a/src/Core/Form/FormChoiceFormatter.php
+++ b/src/Core/Form/FormChoiceFormatter.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form;
+
+/**
+ * Class that formats choices for Symfony forms.
+ */
+class FormChoiceFormatter
+{
+    /**
+     * Returns a choice list in a format required for Symfony form.
+     * Symfony form choice fields accept array with options, where the item name
+     * is the key and item ID is the value.
+     *
+     * So, when there are two items with the same name, they get lost.
+     * This will automatically mark duplicate options with their ID.
+     *
+     * @param array $rawChoices Raw array with data to build the options from
+     * @param string $idKey Key name of the item IDs, id_carrier for example
+     * @param string $nameKey Key name of the item NAMEs, carrier_name for example
+     * @param bool $sortByName Should the list be automatically sorted by name
+     *
+     * @return array Formatted choices
+     */
+    public static function formatFormChoices(array $rawChoices, string $idKey, string $nameKey, bool $sortByName = true): array
+    {
+        // Final array with choices
+        $finalChoices = [];
+
+        // A slim array with just they keys we processed, so we know what are duplicates
+        $alreadyProcessedKeys = [];
+
+        foreach ($rawChoices as $rawChoiceKey => $rawChoice) {
+            // If we already came across this exact value name before, we will
+            // append the option ID before the name.
+            if (in_array($rawChoice[$nameKey], $alreadyProcessedKeys)) {
+                // We store it with ID prepended before the name.
+                $finalChoices[sprintf('%s (%d)', $rawChoice[$nameKey], $rawChoice[$idKey])] = $rawChoice[$idKey];
+
+                // And if it's the first duplicate (second occurence), we also modify the previous normal one.
+                if (isset($finalChoices[$rawChoice[$nameKey]])) {
+                    $previousId = $finalChoices[$rawChoice[$nameKey]];
+                    $finalChoices = self::replaceArrayKey(
+                        $finalChoices,
+                        $rawChoice[$nameKey],
+                        sprintf('%s (%d)', $rawChoice[$nameKey], $previousId)
+                    );
+                }
+            } else {
+                // We store it in the final array normally
+                $finalChoices[$rawChoice[$nameKey]] = $rawChoice[$idKey];
+            }
+
+            // For next time, we mark that we processed this option
+            $alreadyProcessedKeys[] = $rawChoice[$nameKey];
+
+            // And save some memory, we don't need it anymore
+            unset($rawChoices[$rawChoiceKey]);
+        }
+
+        // Order data by displayed value, if desired
+        if ($sortByName) {
+            ksort($finalChoices);
+        }
+
+        return $finalChoices;
+    }
+
+    /*
+     * Renames a given array key without modifying it's position in the array.
+     *
+     * @param array $array Array to work on
+     * @param string $oldKey Old array key
+     * @param string $newKey New array key
+     *
+     * @return array Array with changed key
+     */
+    public static function replaceArrayKey($array, $oldKey, $newKey) {
+        $keys = array_keys($array);
+        $keys[array_search($oldKey, $keys)] = $newKey;
+
+        return array_combine($keys, $array);	
+    }
+}

--- a/src/Core/Form/FormChoiceFormatter.php
+++ b/src/Core/Form/FormChoiceFormatter.php
@@ -101,10 +101,11 @@ class FormChoiceFormatter
      *
      * @return array Array with changed key
      */
-    public static function replaceArrayKey($array, $oldKey, $newKey) {
+    public static function replaceArrayKey($array, $oldKey, $newKey): array
+    {
         $keys = array_keys($array);
         $keys[array_search($oldKey, $keys)] = $newKey;
 
-        return array_combine($keys, $array);	
+        return array_combine($keys, $array);
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_provider.yml
@@ -34,7 +34,8 @@ services:
 
   prestashop.adapter.data_provider.carrier:
     class: PrestaShop\PrestaShop\Adapter\Carrier\CarrierDataProvider
-    arguments: [ '@prestashop.adapter.legacy.configuration' ]
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'
 
   prestashop.adapter.data_provider.order_invoice:
     class: PrestaShop\PrestaShop\Adapter\Invoice\OrderInvoiceDataProvider

--- a/tests/UI/campaigns/functional/BO/10_payment/02_preferences/03_countryRestrictions.ts
+++ b/tests/UI/campaigns/functional/BO/10_payment/02_preferences/03_countryRestrictions.ts
@@ -27,7 +27,7 @@ describe('BO - Payment - Preferences : Configure country restrictions', async ()
   let browserContext: BrowserContext;
   let page: Page;
 
-  const countryID: number = 74;
+  const countryID: number = 73;
 
   // before and after functions
   before(async function () {

--- a/tests/Unit/Core/Form/FormChoiceFormatterTest.php
+++ b/tests/Unit/Core/Form/FormChoiceFormatterTest.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
+
+class FormChoiceFormatterTest extends TestCase
+{
+    /**
+     * @dataProvider getFormOptionsToFormat
+     *
+     * @param array $rawOptions
+     * @param string $idKey
+     * @param string $nameKey
+     * @param bool $sortByName
+     * @param array $expectedFormattedChoices
+     */
+    public function testFormatFormChoices(array $rawOptions, string $idKey, string $nameKey, bool $sortByName, array $expectedFormattedChoices): void
+    {
+        $returnedFormattedChoices = FormChoiceFormatter::formatFormChoices($rawOptions, $idKey, $nameKey, $sortByName);
+        $this->assertEquals($expectedFormattedChoices, $returnedFormattedChoices);
+    }
+
+    public function getFormOptionsToFormat(): iterable
+    {
+        yield 'manufacturer list with duplicates' => [
+            [
+                [
+                    'id_manufacturer' => 1,
+                    'name' => 'Krystian and son development',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 2,
+                    'name' => 'Preston Manufacturing',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 3,
+                    'name' => 'Trendo',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 4,
+                    'name' => 'Hiba Manufacturing',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 5,
+                    'name' => 'Krystian and son development',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 6,
+                    'name' => 'Daniel Manufacturing',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 7,
+                    'name' => 'Krystian and son development',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 8,
+                    'name' => 'Hiba Manufacturing',
+                    'someproperty' => 'somevalue',
+                ],
+            ],
+            'id_manufacturer',
+            'name',
+            true,
+            [
+                'Daniel Manufacturing' => 6,
+                'Hiba Manufacturing (4)' => 4,
+                'Hiba Manufacturing (8)' => 8,
+                'Krystian and son development (1)' => 1,
+                'Krystian and son development (5)' => 5,
+                'Krystian and son development (7)' => 7,
+                'Preston Manufacturing' => 2,
+                'Trendo' => 3,
+            ],
+        ];
+
+        yield 'manufacturer list without duplicates' => [
+            [
+                [
+                    'id_manufacturer' => 1,
+                    'name' => 'Krystian and son development',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 2,
+                    'name' => 'Preston Manufacturing',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 3,
+                    'name' => 'Trendo',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 4,
+                    'name' => 'Hiba Manufacturing',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 6,
+                    'name' => 'Daniel Manufacturing',
+                    'someproperty' => 'somevalue',
+                ],
+            ],
+            'id_manufacturer',
+            'name',
+            true,
+            [
+                'Daniel Manufacturing' => 6,
+                'Hiba Manufacturing' => 4,
+                'Krystian and son development' => 1,
+                'Preston Manufacturing' => 2,
+                'Trendo' => 3,
+            ],
+        ];
+
+        yield 'manufacturer list with duplicates and disabled sorting' => [
+            [
+                [
+                    'id_manufacturer' => 1,
+                    'name' => 'Krystian and son development',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 2,
+                    'name' => 'Preston Manufacturing',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 3,
+                    'name' => 'Trendo',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 4,
+                    'name' => 'Hiba Manufacturing',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 5,
+                    'name' => 'Krystian and son development',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 6,
+                    'name' => 'Daniel Manufacturing',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 7,
+                    'name' => 'Krystian and son development',
+                    'someproperty' => 'somevalue',
+                ],
+                [
+                    'id_manufacturer' => 8,
+                    'name' => 'Hiba Manufacturing',
+                    'someproperty' => 'somevalue',
+                ],
+            ],
+            'id_manufacturer',
+            'name',
+            false,
+            [
+                'Krystian and son development (1)' => 1,
+                'Preston Manufacturing' => 2,
+                'Trendo' => 3,
+                'Hiba Manufacturing (4)' => 4,
+                'Krystian and son development (5)' => 5,
+                'Daniel Manufacturing' => 6,
+                'Krystian and son development (7)' => 7,
+                'Hiba Manufacturing (8)' => 8,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Introduces a class that formats choices for symfony forms and automatically marks duplicate options with an ID, so we avoid having choices that just disappear. Initally implemented on Manufacturer, Supplier, Feature value and Carrier choices, but easy to do on the rest.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Create two manufacturers with the same name, go to product form, see that you can see both.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/11288952311 ✅ 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/36586
| Related PRs       | 
| Sponsor company   | 
