### PR TITLE
Allow full anonymous Symfony controller

### DIFF
--- a/app/config/admin/security.yml
+++ b/app/config/admin/security.yml
@@ -48,4 +48,4 @@ security:
     - { route: 'admin_request_password_reset', roles: PUBLIC_ACCESS }
     - { route: 'admin_reset_password', roles: PUBLIC_ACCESS }
     # Check it the legacy anonymous attribute has been set on the request (set by LegacyRouterChecker)
-    - { path: ^/, roles: IS_AUTHENTICATED, allow_if: 'request.attributes.has("_legacy_controller_anonymous") and request.attributes.get("_legacy_controller_anonymous") == true' }
+    - { path: ^/, roles: IS_AUTHENTICATED, allow_if: 'request.attributes.has("_anonymous_controller") and request.attributes.get("_anonymous_controller") == true' }

--- a/src/PrestaShopBundle/Controller/Admin/LegacyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/LegacyController.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Entity\Repository\TabRepository;
 use PrestaShopBundle\Routing\LegacyControllerConstants;
+use PrestaShopBundle\Security\Admin\RequestAttributes;
 use PrestaShopBundle\Twig\Layout\MenuBuilder;
 use PrestaShopBundle\Twig\Layout\SmartyVariablesFiller;
 use ReflectionException;
@@ -240,7 +241,7 @@ class LegacyController extends PrestaShopAdminController
     private function checkIsRequestAllowed(Request $request, AdminController $adminController): void
     {
         // If LegacyRouterChecker has already set the request as anonymous no need for further check
-        if ($request->attributes->get(LegacyControllerConstants::ANONYMOUS_ATTRIBUTE) === true) {
+        if ($request->attributes->get(RequestAttributes::ANONYMOUS_CONTROLLER_ATTRIBUTE) === true) {
             return;
         }
 

--- a/src/PrestaShopBundle/EventListener/Admin/TokenizedUrlsListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/TokenizedUrlsListener.php
@@ -44,13 +44,6 @@ use Symfony\Component\Security\Http\AccessMapInterface;
  */
 class TokenizedUrlsListener
 {
-    public const PUBLIC_ROUTES = [
-        'admin_login',
-        'admin_homepage',
-        'admin_request_password_reset',
-        'admin_reset_password',
-    ];
-
     public function __construct(
         private readonly RouterInterface $router,
         private readonly UserTokenManager $userTokenManager,

--- a/src/PrestaShopBundle/EventListener/Admin/TokenizedUrlsListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/TokenizedUrlsListener.php
@@ -28,7 +28,7 @@ namespace PrestaShopBundle\EventListener\Admin;
 
 use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 use PrestaShop\PrestaShop\Core\Util\Url\UrlCleaner;
-use PrestaShopBundle\Routing\LegacyControllerConstants;
+use PrestaShopBundle\Security\Admin\RequestAttributes;
 use PrestaShopBundle\Security\Admin\UserTokenManager;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -87,7 +87,7 @@ class TokenizedUrlsListener
 
     private function isRequestAnonymous(Request $request): bool
     {
-        $publicLegacyRoute = $request->attributes->get(LegacyControllerConstants::ANONYMOUS_ATTRIBUTE);
+        $publicLegacyRoute = $request->attributes->get(RequestAttributes::ANONYMOUS_CONTROLLER_ATTRIBUTE);
         if ($publicLegacyRoute === true) {
             return true;
         }

--- a/src/PrestaShopBundle/Routing/LegacyRouterChecker.php
+++ b/src/PrestaShopBundle/Routing/LegacyRouterChecker.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Entity\Repository\TabRepository;
 use PrestaShopBundle\Routing\Converter\LegacyParametersConverter;
+use PrestaShopBundle\Security\Admin\RequestAttributes;
 use Symfony\Bundle\FrameworkBundle\Routing\Attribute\AsRoutingConditionService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -118,7 +119,7 @@ class LegacyRouterChecker
         $adminController->init();
 
         $request->attributes->set(LegacyControllerConstants::INSTANCE_ATTRIBUTE, $adminController);
-        $request->attributes->set(LegacyControllerConstants::ANONYMOUS_ATTRIBUTE, $adminController->isAnonymousAllowed());
+        $request->attributes->set(RequestAttributes::ANONYMOUS_CONTROLLER_ATTRIBUTE, $adminController->isAnonymousAllowed());
         $request->attributes->set(LegacyControllerConstants::IS_ALL_SHOP_CONTEXT_ATTRIBUTE, $adminController->multishop_context === ShopConstraint::ALL_SHOPS);
         $request->attributes->set(LegacyControllerConstants::CONTROLLER_CLASS_ATTRIBUTE, $controllerClass);
         $request->attributes->set(LegacyControllerConstants::IS_MODULE_ATTRIBUTE, $isModule);

--- a/src/PrestaShopBundle/Security/Admin/RequestAttributes.php
+++ b/src/PrestaShopBundle/Security/Admin/RequestAttributes.php
@@ -24,16 +24,29 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-declare(strict_types=1);
+namespace PrestaShopBundle\Security\Admin;
 
-namespace PrestaShopBundle\Routing;
-
-class LegacyControllerConstants
+/**
+ * This class contains constants for specific attributes used on the request to add some features.
+ */
+class RequestAttributes
 {
-    public const CONTROLLER_CLASS_ATTRIBUTE = '_legacy_controller_class';
-    public const CONTROLLER_NAME_ATTRIBUTE = '_legacy_controller_name';
-    public const CONTROLLER_ACTION_ATTRIBUTE = '_legacy_controller_action';
-    public const INSTANCE_ATTRIBUTE = '_legacy_controller_instance';
-    public const IS_MODULE_ATTRIBUTE = '_legacy_controller_is_module';
-    public const IS_ALL_SHOP_CONTEXT_ATTRIBUTE = '_legacy_controller_is_all_shop_context';
+    /**
+     * Setting this attribute to true on a request makes it "anonymous" or "public access", meaning
+     * it can be accessed even without being authenticated and no CSRF token will be added in the
+     * URL.
+     *
+     * It is equivalent to settings an access_control in the framework config except this attribute can
+     * be set on a particular route settings which is very convenient for modules that can't modify the
+     * access controls.
+     *
+     * Route example:
+     *
+     *  public_anonymous_route:
+     *      path: /public_anonymous_route
+     *      defaults:
+     *          _controller: PrestaShop\Module\PublicRoute\AnonymousController::anonymousAction
+     *          _anonymous_controller: true
+     */
+    public const ANONYMOUS_CONTROLLER_ATTRIBUTE = '_anonymous_controller';
 }

--- a/tests/Integration/PrestaShopBundle/EventListener/Admin/AccessDeniedListenerTest.php
+++ b/tests/Integration/PrestaShopBundle/EventListener/Admin/AccessDeniedListenerTest.php
@@ -77,4 +77,19 @@ class AccessDeniedListenerTest extends WebTestCase
         $this->assertStringStartsWith('/tests/something-complex?_token=', $response->headers->get('location'));
         $this->assertStringContainsString('Redirecting to /tests/something-complex', $response->getContent());
     }
+
+    public function testAnonymous(): void
+    {
+        $this->client->request('GET', $this->router->generate('test_anonymous'));
+
+        $response = $this->client->getResponse();
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertEquals('AnonymousController', $response->getContent());
+
+        $this->client->request('GET', $this->router->generate('test_hard_coded_anonymous'));
+
+        $response = $this->client->getResponse();
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertEquals('AnonymousController', $response->getContent());
+    }
 }

--- a/tests/Resources/Controller/TestController.php
+++ b/tests/Resources/Controller/TestController.php
@@ -26,6 +26,7 @@
 
 namespace Tests\Resources\Controller;
 
+use PrestaShopBundle\Security\Admin\RequestAttributes;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\ExpressionLanguage\Expression;
@@ -63,5 +64,17 @@ class TestController extends AbstractController
     public function doRedirectIfForbidden(): Response
     {
         return new Response();
+    }
+
+    #[Route('/anonymous-controller', name: 'test_anonymous', defaults: [RequestAttributes::ANONYMOUS_CONTROLLER_ATTRIBUTE => true])]
+    public function anonymousController()
+    {
+        return new Response('AnonymousController');
+    }
+
+    #[Route('/anonymous-hard-coded-controller', name: 'test_hard_coded_anonymous', defaults: ['_anonymous_controller' => true])]
+    public function hardCodedAnonymousController()
+    {
+        return new Response('AnonymousController');
     }
 }

--- a/tests/UI/pages/BO/catalog/products/add/descriptionTab.ts
+++ b/tests/UI/pages/BO/catalog/products/add/descriptionTab.ts
@@ -20,6 +20,8 @@ class DescriptionTab extends BOBasePage {
 
   private readonly imagePreviewBlock: string;
 
+  private readonly imageDefaultBlock: string;
+
   private readonly imagePreviewCover: string;
 
   private readonly productImage: string;
@@ -113,6 +115,7 @@ class DescriptionTab extends BOBasePage {
     // Image selectors
     this.productImageDropZoneDiv = '#product-images-dropzone';
     this.imagePreviewBlock = `${this.productImageDropZoneDiv} div.dz-preview.openfilemanager`;
+    this.imageDefaultBlock = `${this.productImageDropZoneDiv} div.dz-default.openfilemanager`;
     this.imagePreviewCover = `${this.productImageDropZoneDiv} div.dz-preview.is-cover`;
     this.productImage = `${this.productImageDropZoneDiv} div.dz-preview.dz-image-preview.dz-complete`;
     this.productImageContainer = '#product-images-container';
@@ -189,10 +192,10 @@ class DescriptionTab extends BOBasePage {
     const filteredImagePaths = imagesPaths.filter((el) => el !== null);
 
     if (filteredImagePaths !== null && filteredImagePaths.length !== 0) {
-      const numberOfImages = await this.getNumberOfImages(page);
+      const imagePreviewBlock = await page.locator(this.imagePreviewBlock).isVisible({timeout: 5000});
       await this.uploadOnFileChooser(
         page,
-        numberOfImages === 0 ? this.productImageDropZoneDiv : this.imagePreviewBlock,
+        imagePreviewBlock ? this.imagePreviewBlock : this.imageDefaultBlock,
         filteredImagePaths,
       );
     }
@@ -209,10 +212,10 @@ class DescriptionTab extends BOBasePage {
 
     if (filteredImagePaths !== null && filteredImagePaths.length !== 0) {
       const numberOfImages = await this.getNumberOfImages(page);
-      await this.waitForVisibleSelector(page, numberOfImages === 0 ? this.productImageDropZoneDiv : this.imagePreviewBlock);
+      const imagePreviewBlock = await page.locator(this.imagePreviewBlock).isVisible({timeout: 5000});
       await this.uploadOnFileChooser(
         page,
-        numberOfImages === 0 ? this.productImageDropZoneDiv : this.imagePreviewBlock,
+        imagePreviewBlock ? this.imagePreviewBlock : this.imageDefaultBlock,
         filteredImagePaths,
       );
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Handle anonymous controllers more generically, we still rely on an attribute set on the request but it is now more generic, this way it can be used direct in module's routing if they need to create an anonymous Symfony controller they just need to add `_anonymous_controller: true` in the route configuration
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green UI tests green (see below for test details)
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/10421903915
| Fixed issue or discussion?     | 
| Related PRs       | ~
| Sponsor company   | ~

### How to test

You can use this module for tests:
[public_route.zip](https://github.com/user-attachments/files/16612885/public_route.zip)

It is a very simple module that adds an anonymous route on the URL `/admin-dev/modules/public_anonymous_route` without this PR the URL cannot be accessed unless you are connected to the back office, with this PR the URL is accessible and the router doesn't add the CSRF token in its URL when it is generated.

**How to test**
1. Install the module
2. Go to module manager search for the module and click on Configure
3. In the module configuration you should see a link to the anonymous URL `/admin-dev/modules/public_anonymous_route`  The URL must NOT contain an `_token` parameter
4. Click on the link a simple string is returned `Anonymous content`
5. Logout from the BO and refresh the page with the anonymous content, it is still accessible

### Anonymous route

Here's an example of an anonymous route:
```yaml
public_anonymous_route:
  path: /public_anonymous_route
  defaults:
    _controller: PrestaShop\Module\PublicRoute\AnonymousController::anonymousAction
    _anonymous_controller: true
```