### PR TITLE
fix: display the filesize of uploaded logo on carrier

### DIFF
--- a/admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/carrier_wizard/helpers/form/form.tpl
@@ -55,7 +55,7 @@
 			</div>
 			<p class="help-block">
 					{l s='Format:' d='Admin.Shipping.Help'} JPG, GIF, PNG, WEBP. {l s='Filesize:' d='Admin.Shipping.Help'} {$max_image_size|string_format:"%.2f"} {l s='MB max.' d='Admin.Shipping.Help'}
-					{l s='Current size:' d='Admin.Shipping.Help'} <span id="carrier_logo_size">{l s='undefined' d='Admin.Shipping.Help'}</span>.
+					{l s='Current size:' d='Admin.Shipping.Help'} <span id="carrier_logo_size">{$carrier_logo_filesize}</span>.
 			</p>
 		</div>
 	{/if}

--- a/admin-dev/themes/default/template/controllers/carrier_wizard/logo.tpl
+++ b/admin-dev/themes/default/template/controllers/carrier_wizard/logo.tpl
@@ -57,11 +57,14 @@
 			success: function (data, status) {
 				data = data.getElementsByTagName('return')[0];
 				var message = data.getAttribute("message");
+        var size = data.getAttribute("data-size");
+
 				if (data.getAttribute("result") == "success")
 				{
 					$('#carrier_logo_img').attr('src', message);
 					$('#logo').val(message);
 					$('#carrier_logo_remove').show();
+          $('#carrier_logo_size').text(size);
 				}
 				else
 					alert(message);

--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -24,7 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
- use PrestaShop\PrestaShop\Core\Util\File\FileSizeConverter;
+use PrestaShop\PrestaShop\Core\Util\File\FileSizeConverter;
+
 /**
  * @property Carrier $object
  */
@@ -784,7 +785,7 @@ class AdminCarrierWizardControllerCore extends AdminController
 
             $fileSize = (new FileSizeConverter())->convert(filesize($file));
             @unlink($file);
-            die('<return result="success" message="' . Tools::safeOutput(_PS_TMP_IMG_ . $tmp_name) . '" data-size="'. $fileSize .'" />');
+            die('<return result="success" message="' . Tools::safeOutput(_PS_TMP_IMG_ . $tmp_name) . '" data-size="' . $fileSize . '" />');
         }
 
         die('<return result="error" message="Cannot upload file" />');

--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -24,6 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+ use PrestaShop\PrestaShop\Core\Util\File\FileSizeConverter;
 /**
  * @property Carrier $object
  */
@@ -247,7 +248,13 @@ class AdminCarrierWizardControllerCore extends AdminController
             ],
         ];
 
-        $tpl_vars = ['max_image_size' => (int) Configuration::get('PS_PRODUCT_PICTURE_MAX_SIZE') / 1024 / 1024];
+        $carrierLogoSize = file_exists(_PS_SHIP_IMG_DIR_ . $carrier->id . '.jpg') ? filesize(_PS_SHIP_IMG_DIR_ . $carrier->id . '.jpg') : 0;
+
+        $tpl_vars = [
+            'max_image_size' => (int) Configuration::get('PS_PRODUCT_PICTURE_MAX_SIZE') / 1024 / 1024,
+            'carrier_logo_filesize' => (new FileSizeConverter())->convert($carrierLogoSize),
+        ];
+
         $fields_value = $this->getStepOneFieldsValues($carrier);
 
         return $this->renderGenericForm(['form' => $this->fields_form], $fields_value, $tpl_vars);
@@ -774,8 +781,10 @@ class AdminCarrierWizardControllerCore extends AdminController
             if (!ImageManager::resize($file, _PS_TMP_IMG_DIR_ . $tmp_name)) {
                 die('<return result="error" message="Impossible to resize the image into ' . Tools::safeOutput(_PS_TMP_IMG_DIR_) . '" />');
             }
+
+            $fileSize = (new FileSizeConverter())->convert(filesize($file));
             @unlink($file);
-            die('<return result="success" message="' . Tools::safeOutput(_PS_TMP_IMG_ . $tmp_name) . '" />');
+            die('<return result="success" message="' . Tools::safeOutput(_PS_TMP_IMG_ . $tmp_name) . '" data-size="'. $fileSize .'" />');
         }
 
         die('<return result="error" message="Cannot upload file" />');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop or 8.1.x maybe?
| Description?      | Fixing problem on carrier page, when you upload a logo at the first step, we always undefined for filesize under the input for upload file. For getting more detail see this [issue].(https://github.com/PrestaShop/PrestaShop/issues/36395)
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow the steps on [issue](https://github.com/PrestaShop/PrestaShop/issues/36395)
| Fixed issue or discussion?     | Fixes [#36395](https://github.com/PrestaShop/PrestaShop/issues/36395)
