### PR TITLE
Order modules on translation page alphabetically

### DIFF
--- a/src/Core/Form/ChoiceProvider/ModuleByNameChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/ModuleByNameChoiceProvider.php
@@ -60,6 +60,9 @@ final class ModuleByNameChoiceProvider implements FormChoiceProviderInterface
             $moduleChoices[$module->get('displayName')] = $module->get('name');
         }
 
+        // Order modules alphabetically
+        ksort($moduleChoices);
+
         return $moduleChoices;
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Modules on translation page (translation on the top and export section on the bottom), are ordered randomly, in the export section, with no search. This orders them alphabetically.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/10628550883 ✅ 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Before
![before](https://github.com/user-attachments/assets/f7d71811-70ca-4fba-a247-cb4472dad1ed)

### After
![after](https://github.com/user-attachments/assets/8fac64c4-c306-4fc5-8d6b-d013e6f1bb82)