### PR TITLE
Fix unreliable translation export

### DIFF
--- a/src/Core/Translation/Export/TranslationCatalogueExporter.php
+++ b/src/Core/Translation/Export/TranslationCatalogueExporter.php
@@ -203,6 +203,14 @@ class TranslationCatalogueExporter
         return $messageCatalogue;
     }
 
+    /**
+     * After export, our files are named with their domain only, FullDomainName.xlf for example.
+     * This method will append the locale name to the end of the file, so the result is something like
+     * FullDomainName.ab-AB.xlf
+     *
+     * @param string $locale Locale to append to filenames
+     * @param string $path Folder to work in
+     */
     protected function renameCatalogues(string $locale, string $path): void
     {
         $finder = Finder::create();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Translation export into ZIP file is buggy and complicated for no reason. This fixes it. It also fixes a potential conflict, when two people exporting at the same time could collide.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Test translation export and see that it always works fine.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/11551665367
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### What it did occasionaly (fixed now)
![translation_export_720](https://github.com/user-attachments/assets/b00e67af-e687-4aa2-9b0b-fe6bbc9032b9)

### What was the probable cause
- The logitc works by exporting XLF to a folder, then renaming it by adding the domain.
- But I think that the file is not deleted properly and stays behind.
- And on the next exports, it re-renames it and adds it to the zip.

### What is changed
- Every export run is saved into it's own randomly named folder, this prevents a potential conflict when 2 exports can run at the same time.
- Also, this fixes another random issue when sometimes there were old undeleted files (or who knows how they got there) interfering and it was wrongly renaming the catalogues. As you can see on screenshot above.
