### PR TITLE
Regenerate images after new theme is enabled

### DIFF
--- a/src/Adapter/ImageThumbnailsRegenerator.php
+++ b/src/Adapter/ImageThumbnailsRegenerator.php
@@ -280,10 +280,11 @@ class ImageThumbnailsRegenerator
                     $file = _PS_PRODUCT_IMG_DIR_ . $defaultLang->getIsoCode() . '.jpg';
                 }
                 foreach ($configuredImageFormats as $imageFormat) {
-                    if (!file_exists($dir . $language->getIsoCode() . '-default-' . stripslashes($image_type->getName()) . '.' . $imageFormat)) {
+                    $defaultImagePath = $dir . $language->getIsoCode() . '-default-' . stripslashes($image_type->getName()) . '.' . $imageFormat;
+                    if (!file_exists($defaultImagePath)) {
                         if (!LegacyImageManager::resize(
                             $file,
-                            $dir . $language->getIsoCode() . '-default-' . stripslashes($image_type->getName()) . '.' . $imageFormat,
+                            $defaultImagePath,
                             (int) $image_type->getWidth(),
                             (int) $image_type->getHeight(),
                             $imageFormat

--- a/src/Core/Domain/ImageSettings/Command/RegenerateDefaultProductThumbnailsCommand.php
+++ b/src/Core/Domain/ImageSettings/Command/RegenerateDefaultProductThumbnailsCommand.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command;
+
+class RegenerateDefaultProductThumbnailsCommand
+{
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/RegenerateDefaultProductThumbnailsHandler.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/RegenerateDefaultProductThumbnailsHandler.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\ImageThumbnailsRegenerator;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\RegenerateDefaultProductThumbnailsCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\RegenerateThumbnailsTimeoutException;
+use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
+use PrestaShopBundle\Entity\Repository\ImageTypeRepository;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+#[AsCommandHandler]
+class RegenerateDefaultProductThumbnailsHandler implements RegenerateDefaultProductThumbnailsHandlerInterface
+{
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+        private readonly ImageTypeRepository $imageTypeRepository,
+        private readonly LanguageRepositoryInterface $langRepository,
+        private readonly ImageThumbnailsRegenerator $imageThumbnailsRegenerator,
+    ) {
+    }
+
+    public function handle(RegenerateDefaultProductThumbnailsCommand $command): void
+    {
+        // Get all languages
+        $languages = $this->langRepository->findAll();
+        $formats = $this->imageTypeRepository->findBy(['products' => 1]);
+        if ($this->imageThumbnailsRegenerator->regenerateNoPictureImages(_PS_PRODUCT_IMG_DIR_, $formats, $languages)) {
+            throw new RegenerateThumbnailsTimeoutException($this->translator->trans(
+                'Cannot write images for this type: %1$s. Please check the %2$s folder\'s writing permissions.',
+                ['products', _PS_PRODUCT_IMG_DIR_],
+                'Admin.Design.Notification'
+            ));
+        }
+    }
+}

--- a/src/Core/Domain/ImageSettings/CommandHandler/RegenerateDefaultProductThumbnailsHandlerInterface.php
+++ b/src/Core/Domain/ImageSettings/CommandHandler/RegenerateDefaultProductThumbnailsHandlerInterface.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\RegenerateDefaultProductThumbnailsCommand;
+
+interface RegenerateDefaultProductThumbnailsHandlerInterface
+{
+    public function handle(RegenerateDefaultProductThumbnailsCommand $command): void;
+}

--- a/src/PrestaShopBundle/Resources/config/services/core/domain/image_settings.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/domain/image_settings.yml
@@ -11,6 +11,7 @@ services:
   PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\DeleteImagesFromTypeHandler: ~
   PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\EditImageSettingsHandler: ~
   PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\RegenerateThumbnailsHandler: ~
+  PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\RegenerateDefaultProductThumbnailsHandler: ~
 
   PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryHandler\GetImageTypeForEditingHandler: ~
   PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryHandler\GetImageSettingsForEditingHandler: ~


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Regenerate images after new theme is enabled, especially to make sure default images are generated for products without timages
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install develop branch, create a product with no images Enable hummingbird theme, in the product list the product without image will have the default image
| UI Tests          | ~
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/hummingbird/issues/617
| Related PRs       | https://github.com/PrestaShop/hummingbird/pull/648
| Sponsor company   | ~
