### PR TITLE
Theme information when theme is switched

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/Partials/theme_card_container.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/Partials/theme_card_container.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-<div class="col-lg-3 col-md-4 col-sm-6 theme-card-container" data-role="{{ themeName }}">
+<div class="col-lg-3 col-md-4 col-sm-6 theme-card-container" data-role="{{ themeName }}" data-theme-framework="{{ themeFramework|default('') }}">
   {% block content %}
   {% endblock %}
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/use_theme_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/use_theme_modal.html.twig
@@ -32,6 +32,12 @@
       </div>
   {% endblock %}
 
+  {% block content %}
+    <div class="alert alert-info m-2">
+      {{ 'When applying a new theme to your store, make sure that the modules you are using are still compatible.'|trans({}, 'Admin.Design.Feature')|raw }}
+    </div>
+  {% endblock %}
+
   {% block footer %}
     <div class="modal-footer">
       <button

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
@@ -85,6 +85,7 @@
             'themeVersion': currentlyUsedTheme.get('version'),
             'themeAuthor': currentlyUsedTheme.get('author.name'),
             'themeAuthorUrl': theme.get('author.url'),
+            'themeFramework': theme.get('meta.compatibility.framework'),
             'isActive': true
           } %}
             {% block image %}
@@ -106,6 +107,7 @@
                 'themeVersion': theme.get('version'),
                 'themeAuthor': theme.get('author.name'),
                 'themeAuthorUrl': theme.get('author.url'),
+                'themeFramework': theme.get('meta.compatibility.framework'),
                 'isActive': false
               }  %}
                 {% block image %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Display information message when a theme is changed from backoffice
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to Design > Themes section, enable hummingbird an information message should be included in the confirmation modal Then enable classic the modal also includes the info
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/11178350343
| Fixed issue or discussion?     | Fixes #36727
| Related PRs       | ~
| Sponsor company   | ~



![Capture d’écran 2024-09-16 à 16 29 38](https://github.com/user-attachments/assets/317a076b-aedb-42da-9180-4fd1b8fd32d3)
