### PR TITLE
Fixing maintenance mode link in BO header

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Layout/default_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Layout/default_layout.html.twig
@@ -39,7 +39,7 @@
     {% endblock %}
   </head>
 
-  <body class="lang-{{ ps.isoUser }}{% if ps.isRtlLanguage %} lang-rtl{% endif %} {{ ps.controllerName|escape|lower }}{% if ps.menuCollapsed %} page-sidebar-closed{% endif %}{% if ps.multiShop|default(false) %} multishop-enabled{% endif %}{% if ps.debugMode|default(false) %} developer-mode{% endif %} ps-bo-rebrand"
+  <body class="lang-{{ ps.isoUser }}{% if ps.isRtlLanguage %} lang-rtl{% endif %} {{ ps.controllerName|escape|lower }}{% if ps.menuCollapsed %} page-sidebar-closed{% endif %}{% if ps.multiShop|default(false) %} multishop-enabled{% endif %}{% if ps.debugMode|default(false) %} developer-mode{% endif %}"
     {% if ps.jsRouterMetadata is defined and ps.jsRouterMetadata.base_url is defined %}data-base-url="{{ ps.jsRouterMetadata.base_url }}"{% endif %}
     {% if ps.jsRouterMetadata is defined and ps.jsRouterMetadata.token is defined %}data-token="{{ ps.jsRouterMetadata.token }}"{% endif %}
   >
@@ -85,7 +85,7 @@
         </div>
       {% endif %}
 
-      {% if ps.maintenanceModeEnabled|default(false) %}
+      {% if ps.isMaintenanceEnabled|default(false) %}
         {% set maintenanceTitle %}
           <p class="text-left text-nowrap">
             <strong>
@@ -113,7 +113,9 @@
              title="{{ maintenanceTitle|e('html') }}"
              href="{{ url('admin_maintenance') }}"
           >
-            <i class="material-icons">build</i>
+            <i class="material-icons"
+               style="{% if ps.frontOfficeAccessibleForAdmins|default(false) %}color: var(--green);{% endif %}"
+            >build</i>
             <span>{{ 'Maintenance mode'|trans({}, 'Admin.Navigation.Header') }}</span>
           </a>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Layout/default_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Layout/default_layout.html.twig
@@ -39,7 +39,7 @@
     {% endblock %}
   </head>
 
-  <body class="lang-{{ ps.isoUser }}{% if ps.isRtlLanguage %} lang-rtl{% endif %} {{ ps.controllerName|escape|lower }}{% if ps.menuCollapsed %} page-sidebar-closed{% endif %}{% if ps.multiShop|default(false) %} multishop-enabled{% endif %}{% if ps.debugMode|default(false) %} developer-mode{% endif %}"
+  <body class="lang-{{ ps.isoUser }}{% if ps.isRtlLanguage %} lang-rtl{% endif %} {{ ps.controllerName|escape|lower }}{% if ps.menuCollapsed %} page-sidebar-closed{% endif %}{% if ps.multiShop|default(false) %} multishop-enabled{% endif %}{% if ps.debugMode|default(false) %} developer-mode{% endif %} ps-bo-rebrand"
     {% if ps.jsRouterMetadata is defined and ps.jsRouterMetadata.base_url is defined %}data-base-url="{{ ps.jsRouterMetadata.base_url }}"{% endif %}
     {% if ps.jsRouterMetadata is defined and ps.jsRouterMetadata.token is defined %}data-token="{{ ps.jsRouterMetadata.token }}"{% endif %}
   >

--- a/src/PrestaShopBundle/Resources/views/Admin/Layout/default_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Layout/default_layout.html.twig
@@ -113,9 +113,7 @@
              title="{{ maintenanceTitle|e('html') }}"
              href="{{ url('admin_maintenance') }}"
           >
-            <i class="material-icons"
-               style="{% if ps.frontOfficeAccessibleForAdmins|default(false) %}color: var(--green);{% endif %}"
-            >build</i>
+            <i class="material-icons">build</i>
             <span>{{ 'Maintenance mode'|trans({}, 'Admin.Navigation.Header') }}</span>
           </a>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Layout/legacy_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Layout/legacy_layout.html.twig
@@ -67,8 +67,7 @@
           </a>
         </div>
       {% endif %}
-
-      {% if ps.maintenanceModeEnabled|default(false) %}
+      {% if ps.isMaintenanceEnabled|default(false) %}
         {% set maintenanceTitle %}
           <p class="text-left">
             <strong>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixing the maintenance mode display on BO.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| UI Tests | https://github.com/florine2623/testing_pr/actions/runs/10578141554
| How to test?      | Follow the steps on this [issue](https://github.com/PrestaShop/PrestaShop/issues/36599)
| Fixed issue or discussion?     | Fixes #[36599](https://github.com/PrestaShop/PrestaShop/issues/36599)