### PR TITLE
Add missing actionPDFInvoiceRender hook to install

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -251,6 +251,11 @@
       <title>PDF Invoice - Legal Free Text</title>
       <description>This hook allows you to modify the legal free text on PDF invoices</description>
     </hook>
+    <hook id="actionPDFInvoiceRender">
+      <name>actionPDFInvoiceRender</name>
+      <title>PDF Invoice - Render</title>
+      <description>This hook is called when a PDF invoice is rendered from the Front Office and the Back Office</description>
+    </hook>
     <hook id="displayAdminCustomers">
       <name>displayAdminCustomers</name>
       <title>Display new elements in the Back Office, tab AdminCustomers</title>


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The hook 'actionPDFInvoiceRender' is referenced in the core, but fresh installs don't include it in the ps_hook table. This adds it back into the installation files.
| Type?             | bug fix
| Category?         | FO and BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install prestashop and look for 'actionPDFInvoiceRender' in the ps_hook table
| Fixed issue or discussion?     | Fixes #36741
| Sponsor company   | Adipso
