### PR TITLE
Fix: remove required tax rule when freeshipping is enabled

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-manager.ts
@@ -86,9 +86,11 @@ export default class CarrierFormManager {
 
   private refreshFreeShipping(): void {
     const isFreeShipping = $(`${CarrierFormMap.freeShippingInput}:checked`).val() === '1';
+
     CarrierFormMap.shippingControls.forEach((inputId: string) => {
       const $inputGroup = $(inputId).closest('.form-group');
       $inputGroup.toggleClass('d-none', isFreeShipping);
+      $(inputId).prop('required', isFreeShipping);
     });
   }
 

--- a/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-manager.ts
@@ -90,7 +90,7 @@ export default class CarrierFormManager {
     CarrierFormMap.shippingControls.forEach((inputId: string) => {
       const $inputGroup = $(inputId).closest('.form-group');
       $inputGroup.toggleClass('d-none', isFreeShipping);
-      $(inputId).prop('required', isFreeShipping);
+      $(inputId).prop('required', !isFreeShipping);
     });
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In the new carrier page when you try to create a carrier and enable free shipping, we get a javascript error because tax rules are mandatory, and when free shipping is enable you don't need to select a tax rules
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to the new carrier page and create one, select free shipping at true, and try to save it should work.


Without fix:

https://github.com/user-attachments/assets/94b7a842-87fe-4785-8e58-0cc70f86edd4



With fix:



https://github.com/user-attachments/assets/0fc1460d-3d15-48dd-b5f3-284540ced719

