### PR TITLE
Redirect into closest parent

### DIFF
--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -351,11 +351,11 @@ class CategoryControllerCore extends ProductListingFrontController
 
     /**
      * Returns a category that we will redirect into, in case we need 301/302 redirect.
-     * We will try to get the closest parent of the current category.
+     * We will try to get the closest active parent of the current category.
      *
      * @return int category ID
      */
-    private function getCategoryToRedirectTo()
+    private function getCategoryToRedirectTo(): int
     {
         $categoryToRedirectTo = null;
         foreach ($this->category->getParentsCategories() as $category) {

--- a/src/PrestaShopBundle/Form/Admin/Sell/Category/SEO/RedirectOptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Category/SEO/RedirectOptionType.php
@@ -91,7 +91,7 @@ class RedirectOptionType extends TranslatorAwareType
                     'label' => false,
                     'remote_url' => $this->router->generate('admin_categories_get_ajax_categories', ['query' => '__QUERY__']),
                     'placeholder' => $this->trans('To which category should the page redirect?', 'Admin.Catalog.Help'),
-                    'help' => $this->trans('By default, the root category will be used if no category is selected.', 'Admin.Catalog.Help'),
+                    'help' => $this->trans('By default, the closest active parent category will be used if no category is selected.', 'Admin.Catalog.Help'),
                     'filtered_identities' => [$options['id_category'], $this->homeCategoryId],
                 ]);
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Improves the behavior of the new category redirection function. Now it will redirect into the closest active parent of the current category, showing the customer much more relevant data.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Make a category `Home/Clothes/Men/Shirts/Small`, disable `Shirts` and `Small`, visit `Small`, see that you get redirected into `Men`. Watch out, redirection responses are cached in browsers, try different category if it behaves weird.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/10684056246
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.
