### PR TITLE
Fix: add missing import for checkbox selection

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/carrier/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/index.ts
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+import ChoiceTable from '@js/components/choice-table';
 import CarrierFormManager from '@pages/carrier/form/carrier-form-manager';
 import CarrierRanges from '@pages/carrier/form/carrier-range-modal';
 
@@ -36,6 +37,8 @@ $(() => {
 
   // Initialize the ranges selection modal
   new CarrierRanges(window.prestashop.instance.eventEmitter);
+
+  new ChoiceTable();
 
   // Initialize the carrier form manager
   new CarrierFormManager(window.prestashop.instance.eventEmitter);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixing the problem on the new carrier creation page the select/unselect all options for group access
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to the new carrier page and create one, use the select all checkbox, it should select all options.


without fix


https://github.com/user-attachments/assets/4c4456da-d017-4a3a-b532-62e44c5672e8


with fix

https://github.com/user-attachments/assets/831ef985-30c8-4bca-ae8d-9a56478bfe91





