### PR TITLE
Fix button style issue inside alerts for default theme

### DIFF
--- a/admin-dev/themes/default/scss/partials/_alerts.scss
+++ b/admin-dev/themes/default/scss/partials/_alerts.scss
@@ -1,10 +1,10 @@
 .alert {
-  a,
+  a:not(.btn),
   p {
     color: var(--#{$cdk}primary-800);
   }
 
-  a {
+  a:not(.btn) {
     text-decoration: underline;
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix button style issue inside alerts for default theme
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | @PrestaShopCorp

**Before:**
![image](https://github.com/user-attachments/assets/ce6342e4-8abd-4ae8-9366-bf6c8eada60f)

**After:**
![image](https://github.com/user-attachments/assets/6a4f9ebc-d6f6-4152-8780-5b01dc17a7b8)

