### PR TITLE
Fix category shop association

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -227,9 +227,9 @@ class CategoryCore extends ObjectModel
                 $this->addPosition($position, $idShop);
             }
         } else {
-            foreach (Shop::getShops(true) as $shop) {
-                $position = (int) Category::getLastPosition((int) $this->id_parent, $shop['id_shop']);
-                $this->addPosition($position, $shop['id_shop']);
+            foreach ($this->getShopIdsList() as $idAssociatedShop) {
+                $position = (int) Category::getLastPosition((int) $this->id_parent, $idAssociatedShop);
+                $this->addPosition($position, $idAssociatedShop);
             }
         }
 
@@ -286,8 +286,8 @@ class CategoryCore extends ObjectModel
                     $this->addPosition($this->position, (int) $idShop);
                 }
             } else {
-                foreach (Shop::getShops(true) as $shop) {
-                    $this->addPosition($this->position, $shop['id_shop']);
+                foreach ($this->getShopIdsList() as $idAssociatedShop) {
+                    $this->addPosition($this->position, $idAssociatedShop);
                 }
             }
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | When creating a category through the Model object, the id_shop_list property is not taken into account during persistence. So even when specifying the list of associated shops, by default the category is associated with all shops.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/36780
| UI Tests          | https://github.com/paulnoelcholot/ga.tests.ui.pr/actions/runs/23536437728
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/36780
| Related PRs       | N/A
| Sponsor company   | Evolutive
