### PR TITLE
Event "OrderCreateProductSearched" not managed in custom modules (related #35970)

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/create/product-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/product-manager.ts
@@ -113,9 +113,10 @@ export default class ProductManager {
    *
    * @private
    */
+
   private onProductSearch(): void {
-    EventEmitter.on(eventMap.productSearched, (response) => {
-      this.products = response.products;
+    document.addEventListener(eventMap.productSearched, (event: any) => {
+      this.products = event.detail.products;
       this.productRenderer.renderSearchResults(this.products);
       this.selectFirstResult();
     });
@@ -267,7 +268,7 @@ export default class ProductManager {
 
     $searchRequest
       .then((response) => {
-        EventEmitter.emit(eventMap.productSearched, response);
+        document.dispatchEvent(new CustomEvent(eventMap.productSearched, {detail: response}));
       })
       .catch((response: JQuery.jqXHR) => {
         if (response.statusText === 'abort') {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      |  Dispatch customEvent "OrderCreateProductSearched" instead eventEmitter instance
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |  see "Steps to reproduce" section of #35970 issue (replace code of `OrderCreateProductSearched.js `in module `testEvent `- see comment below)
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/14469252108
| Fixed issue or discussion?     | Fixes #35970
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
