### PR TITLE
Fix: Product customization text appears as raw HTML in order confirmation email (order_conf)

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -478,7 +478,7 @@ abstract class PaymentModuleCore extends Module
                         $customization_text = '';
                         if (isset($customization['datas'][Product::CUSTOMIZE_TEXTFIELD])) {
                             foreach ($customization['datas'][Product::CUSTOMIZE_TEXTFIELD] as $text) {
-                                $customization_text .= '<strong>' . $text['name'] . '</strong>: ' . $text['value'] . '<br />';
+                                $customization_text .= '<strong>' . $text['name'] . '</strong>: ' . htmlspecialchars($text['value'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '<br />';
                             }
                         }
 

--- a/mails/_partials/order_conf_product_list.tpl
+++ b/mails/_partials/order_conf_product_list.tpl
@@ -47,7 +47,7 @@
 						{if count($product['customization']) == 1}
 							<br>
 							{foreach $product['customization'] as $customization}
-								{$customization['customization_text']}
+								{$customization['customization_text'] nofilter}
 							{/foreach}
 						{/if}
 
@@ -107,7 +107,7 @@
   					<td width="5">&nbsp;</td>
   					<td>
   						<font size="2" face="Open-sans, sans-serif" color="#555454">
-  							{$customization['customization_text']}
+  							{$customization['customization_text'] nofilter}
   						</font>
   					</td>
   					<td width="5">&nbsp;</td>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | When a customer places an order for a customized product in Prestashop, the order confirmation email (order_conf) displays the product customization text as raw HTML rather than showing the text formatted correctly.
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to a product that can be customized (e.g.: Customizable mug ID 19)<br/> 2. Make a customization (e.g.: My text)<br/> 3. Save the customization<br/> 4. Add the customized product to the cart<br/> 5. Complete the order<br/> 6. In the order confirmation email, instead of displaying raw HTML for the customization, show something like: **Type your text:** text entered in the customization
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/19328315772
| Fixed issue or discussion?     | Fixes #36795
| Sponsor company   | Codencode snc
