### PR TITLE
Move the array_unshift in Product::setWsPositionInCategory()

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7267,11 +7267,12 @@ class ProductCore extends ObjectModel
             return false;
         }
 
-        // result is indexed by recordset order and not position. positions start at index 1 so we need an empty element
-        array_unshift($result, null);
+        // result is indexed by recordset order and not position.
         foreach ($result as &$value) {
             $value = $value['id_product'];
         }
+        // positions start at index 1 so we need an empty element
+        array_unshift($result, null);
 
         $current_position = $this->getWsPositionInCategory();
 


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Please read below
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Please read below
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/10699389749
| Fixed issue or discussion?     | Should fix the issue mentioned in https://github.com/PrestaShop/PrestaShop/issues/34199
| Related PRs       | 
| Sponsor company   |

## Description

As explained [here](https://github.com/PrestaShop/PrestaShop/issues/34199#issuecomment-2275342003), in some PHP environments, the following lines of code in Product.php do throw a warning:
```
        array_unshift($result, null);
        foreach ($result as &$value) {
            $value = $value['id_product'];
        }
```

The `$result` array initially contains an array which follows this structure:
```
array(2) {
  [0]=>
  array(1) {
    ["id_product"]=>
    int(1)
  }
  [1]=>
  array(1) {
    ["id_product"]=>
    int(2)
  }
}
```

The goal of the above lines of code is to make this structure flat, with a NULL item in 1st position.
```
array(3) {
  [0]=>
  NULL
  [1]=>
  int(1)
  [2]=>
  int(2)
}
```

However on some PHP configurations, the `$value = $value['id_product'];` being run on NULL triggers the warning `Trying to access array offset on value of type null` . Moving the array_unshift after the foreach loop avoids this bad array access.

## How to reproduce

You can attempt to follow the steps submitted [here](https://github.com/PrestaShop/PrestaShop/issues/34199#issuecomment-2275342003) however you may or may not observe any issue depending on your PHP configuration

## How can we validate this Pull Request without a clear "how to reproduce"?

It is possible to run these lines of code isolated as it was suggested [here](https://github.com/PrestaShop/PrestaShop/issues/34199#issue-1931201479) or to ask a developer to verify, using var_dump or a debugger, that these code changes do not alter the logic being run in these lines of code.