### PR TITLE
Refacto CustomerService with PrestaShopAdminController

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
@@ -31,10 +31,14 @@ use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnConstrain
 use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnOrderStateConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\UpdateOrderReturnException;
-use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface as OptionFormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\MerchandiseReturnFilters;
-use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -42,7 +46,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Class MerchandiseReturnController responsible for "Sell > Customer Service > Merchandise Returns" page
  */
-class MerchandiseReturnController extends FrameworkBundleAdminController
+class MerchandiseReturnController extends PrestaShopAdminController
 {
     /**
      * Render merchandise returns grid and options.
@@ -53,23 +57,26 @@ class MerchandiseReturnController extends FrameworkBundleAdminController
      * @return Response|RedirectResponse
      */
     #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute: 'admin_merchandise_returns_index')]
-    public function indexAction(Request $request, MerchandiseReturnFilters $filters): Response
-    {
-        $gridFactory = $this->get('prestashop.core.grid.factory.merchandise_return');
-
-        $optionsFormHandler = $this->getOptionsFormHandler();
-        $optionsForm = $optionsFormHandler->getForm();
+    public function indexAction(
+        Request $request,
+        #[Autowire(service: 'prestashop.core.grid.factory.merchandise_return')]
+        GridFactoryInterface $gridFactory,
+        MerchandiseReturnFilters $filters,
+        #[Autowire(service: 'prestashop.admin.merchandise_return_options.form_handler')]
+        OptionFormHandlerInterface $optionFormHandler
+    ): Response {
+        $optionsForm = $optionFormHandler->getForm();
         $optionsForm->handleRequest($request);
 
         if ($optionsForm->isSubmitted() && $optionsForm->isValid()) {
-            $errors = $optionsFormHandler->save($optionsForm->getData());
+            $errors = $optionFormHandler->save($optionsForm->getData());
 
             if (empty($errors)) {
-                $this->addFlash('success', $this->trans('Update successful', 'Admin.Notifications.Success'));
+                $this->addFlash('success', $this->trans('Update successful', [], 'Admin.Notifications.Success'));
 
                 return $this->redirectToRoute('admin_merchandise_returns_index');
             } else {
-                $this->flashErrors($errors);
+                $this->addFlashErrors($errors);
             }
         }
 
@@ -90,11 +97,14 @@ class MerchandiseReturnController extends FrameworkBundleAdminController
      * @return Response
      */
     #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_merchandise_returns_index')]
-    public function editAction(int $orderReturnId, Request $request): Response
-    {
-        $formBuilder = $this->get('prestashop.core.form.identifiable_object.builder.order_return_form_builder');
-        $formHandler = $this->get('prestashop.core.form.identifiable_object.handler.order_return_form_handler');
-
+    public function editAction(
+        int $orderReturnId,
+        Request $request,
+        #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.order_return_form_builder')]
+        FormBuilderInterface $formBuilder,
+        #[Autowire(service: 'prestashop.core.form.identifiable_object.handler.order_return_form_handler')]
+        FormHandlerInterface $formHandler
+    ): Response {
         try {
             $form = $formBuilder->getFormFor($orderReturnId);
             $form->handleRequest($request);
@@ -102,7 +112,7 @@ class MerchandiseReturnController extends FrameworkBundleAdminController
             $result = $formHandler->handleFor($orderReturnId, $form);
 
             if ($result->isSubmitted() && $result->isValid()) {
-                $this->addFlash('success', $this->trans('Update successful', 'Admin.Notifications.Success'));
+                $this->addFlash('success', $this->trans('Update successful', [], 'Admin.Notifications.Success'));
 
                 return $this->redirectToRoute('admin_merchandise_returns_index');
             }
@@ -116,7 +126,7 @@ class MerchandiseReturnController extends FrameworkBundleAdminController
             'orderReturnForm' => $form->createView(),
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'enableSidebar' => true,
-            'layoutTitle' => $this->trans('Return merchandise authorization (RMA)', 'Admin.Navigation.Menu'),
+            'layoutTitle' => $this->trans('Return merchandise authorization (RMA)', [], 'Admin.Navigation.Menu'),
         ]);
     }
 
@@ -131,31 +141,27 @@ class MerchandiseReturnController extends FrameworkBundleAdminController
             OrderReturnConstraintException::class => [
                 OrderReturnConstraintException::INVALID_ID => $this->trans(
                     'The object cannot be loaded (the identifier is missing or invalid)',
+                    [],
                     'Admin.Notifications.Error'
                 ),
             ],
             OrderReturnNotFoundException::class => $this->trans(
                 'Merchandise return not found.',
+                [],
                 'Admin.Orderscustomers.Notification'
             ),
             OrderReturnOrderStateConstraintException::class => [
                 OrderReturnOrderStateConstraintException::INVALID_ID => $this->trans(
                     'The object cannot be loaded (the identifier is missing or invalid)',
+                    [],
                     'Admin.Notifications.Error'
                 ),
             ],
             UpdateOrderReturnException::class => $this->trans(
                 'An error occurred while trying to update merchandise return.',
+                [],
                 'Admin.Orderscustomers.Notification'
             ),
         ];
-    }
-
-    /**
-     * @return FormHandlerInterface
-     */
-    private function getOptionsFormHandler(): FormHandlerInterface
-    {
-        return $this->get('prestashop.admin.merchandise_return_options.form_handler');
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/index.html.twig
@@ -25,6 +25,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/customer_threads' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Refacto CustomerService with `PrestaShopAdminController` instead of `FrameworkBundleAdminController` that is deprecated.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable new `Customer service` and `Merchandise Returns` pages<br/>2. Navigate in all sub-pages in `Sell -> Customer Service` in BO.
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/10704545149
| Fixed issue or discussion?     | Fixes #36811 
| Related PRs       | 
| Sponsor company   | PrestaShop SA
