### PR TITLE
Improve image setting wording

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageSettingsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageSettingsType.php
@@ -51,7 +51,7 @@ class ImageSettingsType extends TranslatorAwareType
     {
         // Check if AVIF is enabled on the server
         $avifEnabled = $this->avifExtensionChecker->isAvailable();
-        $helpFormats = $this->trans('Choose which image formats you want to be generated. Base image will always have .jpg extension, other formats will have .webp or .avif.', 'Admin.Design.Help');
+        $helpFormats = $this->trans('Choose which image formats you want to be generated. Base image will always have .jpg extension, other formats will have .webp or .avif. Think twice before enabling all of them, because it can easily double the size of your shop.', 'Admin.Design.Help');
 
         if (!$avifEnabled) {
             $helpFormats .= '<br/><strong>' . $this->trans('AVIF is disabled because it\'s not supported on your server, check your configuration if you want to use it.', 'Admin.Design.Help') . '</strong>';
@@ -75,6 +75,7 @@ class ImageSettingsType extends TranslatorAwareType
             ])
             ->add('base-format', ChoiceType::class, [
                 'label' => $this->trans('Base format', 'Admin.Design.Feature'),
+                'help' => $this->trans('JPEG images have a small file size and standard quality. PNG images have a larger file size, a higher quality and support transparency. Note that in all cases, these thumbnails will have .jpg extension.', 'Admin.Design.Feature'),
                 'expanded' => true,
                 'choices' => [
                     $this->trans('Use JPEG', 'Admin.Design.Feature') => 'jpg',

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/form-settings.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/ImageSettings/form-settings.html.twig
@@ -31,9 +31,9 @@
       {{ 'Images generation options'|trans({}, 'Admin.Design.Feature') }}
     </h3>
     <div class="alert alert-info mx-3 mt-3 mb-0">
-      {{ 'JPEG images have a small file size and standard quality. PNG images have a larger file size, a higher quality and support transparency. Note that in all cases the image files will have the .jpg extension.'|trans({}, 'Admin.Design.Help') }}
-      <br /><br/>
-      {{ 'WARNING: This feature may not be compatible with your theme, or with some of your modules. In particular, PNG mode is not compatible with the Watermark module. If you encounter any issues, turn it off by selecting "Use JPEG'|trans({}, 'Admin.Design.Help') }}
+      <p>{{ 'The original images of objects you create are almost never used, optimized thumbnails are used instead. In this section, you can define the formats of thumbnails and their quality.'|trans({}, 'Admin.Design.Help') }}</p>
+      <p class="mb-3">{{ 'Most common setup is to have the base JPG/PNG format and one modern WebP or AVIF format - the browser will choose the format it likes the most.'|trans({}, 'Admin.Design.Help') }}</p>
+      <p>{{ 'Beware that to benefit from modern image formats, they must be supported by your theme.'|trans({}, 'Admin.Design.Help') }}</p>
     </div>
     <div class="card-body">
       <div class="form-wrapper">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Improves the wording of image settings to better inform merchants about the image settings. What usually happens now is that the merchant just clicks all the formats and the size of shop goes from 70 GB to 120 GB. "I did not know what is better so I enabled all of them".
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### How it looks like

![Snímek obrazovky 2024-09-05 113359](https://github.com/user-attachments/assets/e4614521-5ce5-4870-8ac6-b4f2a96cec78)

Ping @ShaiMagal @kpodemski @ibahloul-ps