### PR TITLE
Use PHP constants for doctrine config

### DIFF
--- a/app/config/doctrine.yml
+++ b/app/config/doctrine.yml
@@ -16,9 +16,9 @@ doctrine:
           enum: string
         options:
           # PDO::MYSQL_ATTR_INIT_COMMAND
-          1002: "SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))"
+          !php/const PDO::MYSQL_ATTR_INIT_COMMAND: "SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))"
           # PDO::MYSQL_ATTR_MULTI_STATEMENTS
-          1013: '%env(const:runtime:_PS_ALLOW_MULTI_STATEMENTS_QUERIES_)%'
+          !php/const PDO::MYSQL_ATTR_MULTI_STATEMENTS: '%env(const:runtime:_PS_ALLOW_MULTI_STATEMENTS_QUERIES_)%'
 
   orm:
     auto_generate_proxy_classes: "%kernel.debug%"

--- a/src/PrestaShopBundle/DependencyInjection/Config/ConfigYamlLoader.php
+++ b/src/PrestaShopBundle/DependencyInjection/Config/ConfigYamlLoader.php
@@ -44,7 +44,7 @@ class ConfigYamlLoader extends FileLoader
     public function load($resource, $type = null)
     {
         $path = $this->locator->locate($resource);
-        $configValues = Yaml::parse(file_get_contents($path));
+        $configValues = Yaml::parse(file_get_contents($path), Yaml::PARSE_CONSTANT);
 
         $this->parseImports($configValues, $path);
         unset($configValues['imports']);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Use PHP constants for doctrine config as informations collected in https://github.com/PrestaShop/PrestaShop/issues/33524 indicate the value of `PDO::MYSQL_ATTR_MULTI_STATEMENTS` change on different environments . This PR is targeting `8.2.x` instead of `develop` and replaces https://github.com/PrestaShop/PrestaShop/pull/36732
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Please see below
| UI Tests          | I will add the UI tests when I have fixed the CI
| Fixed issue or discussion?     |  Should fix https://github.com/PrestaShop/PrestaShop/issues/33524
| Related PRs       | 
| Sponsor company   | 

### How to test

As this is a config specific item, the behavior of the shop should be unchanged. To verify the item, a developer could do:

1. Take `develop` branch and insert the below 2 lines in a Symfony controller to be able to verify the value of the configuration options passed to Doctrine
2. Take this Pull Request branch and do the same, verify that despite the code changes the configuration options passed to Doctrine remain unchanged

2 lines of code
```
$b = $this->get('doctrine.dbal.default_connection');
dump($b->getParams());
```

The behavior is "nothing has changed" because I believe the fix will only fix the situation for a subset of users, victims of https://github.com/PrestaShop/PrestaShop/issues/33524