### PR TITLE
Migrate module configuration

### DIFF
--- a/admin-dev/.htaccess
+++ b/admin-dev/.htaccess
@@ -37,10 +37,6 @@ DirectoryIndex index.php
     # Keep legacy entry points
     RewriteRule ^(cron_currency_rates|get-file-admin)\.php - [P]
 
-    # If the URL is a legacy on index.php?controller=..., do not rewrite (let the legacy take it)
-    RewriteCond  %{QUERY_STRING} (^|&)controller=|(^|&)tab=
-    RewriteRule .* - [P]
-
     # Redirect to URI without front controller to prevent duplicate content
     # (with and without `/app.php`). Only do this redirect on the initial
     # rewrite by Apache and not on subsequent cycles. Otherwise we would get an

--- a/admin-dev/themes/default/scss/font.scss
+++ b/admin-dev/themes/default/scss/font.scss
@@ -7,7 +7,7 @@ $local-font: true;
 
 @mixin setFont() {
   @if $local-font {
-    
+
     // IBM Plex Sans
     @include IBM.faces(
       $subsets: all,
@@ -25,6 +25,14 @@ $local-font: true;
     // Material Symbols Outlined
     @font-face {
       font-family: "Material Symbols Outlined";
+      font-style: normal;
+      font-display: swap;
+      src: url("#{$material-symbols-font-path}material-symbols-outlined.woff2") format("woff2");
+    }
+
+    // This is a fallback for old buttons relying on Material Icons
+    @font-face {
+      font-family: "Material Icons";
       font-style: normal;
       font-display: swap;
       src: url("#{$material-symbols-font-path}material-symbols-outlined.woff2") format("woff2");

--- a/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
@@ -45,6 +45,12 @@
     font-weight: 600;
   }
 
+  .page-subtitle {
+    width: 100%;
+    padding: 0;
+    margin-bottom: 0;
+  }
+
   // breadcrumb
   nav {
     @include media-breakpoint-down(sm) {

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -186,8 +186,32 @@ class ToolsCore
      */
     public static function redirectAdmin($url)
     {
-        header('Location: ' . $url);
+        header('Location: ' . self::sanitizeAdminUrl($url));
         exit;
+    }
+
+    /**
+     * Sanitize an url used in the Admin (back office context) to make sure it is correctly written to be
+     * used for redirection. If the provided URL is not absolute the shop url is prepended, if the admin
+     * folder is absent it is also prepended. Absolute urls are left untouched.
+     *
+     * @param string $url
+     *
+     * @return string
+     */
+    public static function sanitizeAdminUrl(string $url): string
+    {
+        $link = Context::getContext()->link;
+        if (!preg_match('@^https?://@i', $url) && $link) {
+            $baseUrl = rtrim($link->getAdminBaseLink(), '/');
+            if (!str_contains($url, basename(_PS_ADMIN_DIR_))) {
+                $baseUrl .= '/' . basename(_PS_ADMIN_DIR_);
+            }
+
+            $url = $baseUrl . '/' . trim($url, '/');
+        }
+
+        return $url;
     }
 
     /**

--- a/classes/lang/KeysReference/FeatureFlagLang.php
+++ b/classes/lang/KeysReference/FeatureFlagLang.php
@@ -90,3 +90,6 @@ trans('Enable / Disable the search configuration page.', 'Admin.Advparameters.He
 
 trans('Merchandise return', 'Admin.Advparameters.Feature');
 trans('Enable / Disable the merchandise return page.', 'Admin.Advparameters.Help');
+
+trans('Module configuration', 'Admin.Advparameters.Feature');
+trans('Enable / Disable the module configuration page.', 'Admin.Advparameters.Help');

--- a/install-dev/data/xml/feature_flag.xml
+++ b/install-dev/data/xml/feature_flag.xml
@@ -26,5 +26,7 @@
     <feature_flag id="store" name="store" type="env,dotenv,db" label_wording="Store" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the store page." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
     <feature_flag id="search_conf" name="search_conf" type="env,dotenv,db" label_wording="Search configuration" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the search configuration page." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
     <feature_flag id="merchandise_return" name="merchandise_return" type="env,dotenv,db" label_wording="Merchandise return" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the merchandise return page." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
+    <feature_flag id="module_configuration" name="module_configuration" type="env,dotenv,db" label_wording="Module configuration" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the module configuration page." description_domain="Admin.Advparameters.Help" state="1" stability="beta" />
+
   </entities>
 </entity_feature_flag>

--- a/js/admin.js
+++ b/js/admin.js
@@ -1089,11 +1089,16 @@ function ajaxStates(id_state_selected)
 }
 
 function dniRequired() {
+  var countryId = $('#id_country').val();
+  if (!countryId) {
+    return;
+  }
+
   $.ajax({
     url: 'index.php',
     dataType: 'json',
     cache: false,
-    data: 'token=' + address_token + '&ajax=1&dni_required=1&controller=AdminAddresses&id_country=' + $('#id_country').val(),
+    data: 'token=' + address_token + '&ajax=1&dni_required=1&controller=AdminAddresses&id_country=' + countryId,
     success: function(resp) {
       if (resp && resp.dni_required) {
         $("#dni_required").fadeIn();

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -216,6 +216,11 @@ parameters:
 			path: src/Core/Context/EmployeeContextBuilder.php
 
 		-
+			message: "#^Namespace Language is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 2
+			path: src/Core/Context/LegacyControllerContext.php
+
+		-
 			message: "#^Namespace Media is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 6
 			path: src/Core/Context/LegacyControllerContext.php

--- a/src/Core/Context/LegacyControllerContext.php
+++ b/src/Core/Context/LegacyControllerContext.php
@@ -31,6 +31,7 @@ namespace PrestaShop\PrestaShop\Core\Context;
 use Language;
 use Media;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Traversable;
 
 /**
@@ -102,6 +103,8 @@ class LegacyControllerContext
      */
     public array|Traversable $page_header_toolbar_btn = [];
 
+    public bool $ajax = false;
+
     protected array $languages = [];
 
     /**
@@ -126,10 +129,15 @@ class LegacyControllerContext
         public readonly string $override_folder,
         public readonly string $currentIndex,
         public readonly string $table,
-        public readonly bool $ajax,
+        protected readonly Request $request,
         protected readonly int $employeeLanguageId,
+        protected readonly string $baseUri,
+        protected readonly string $adminFolderName,
+        protected readonly bool $isLanguageRTL,
+        protected readonly string $psVersion,
     ) {
         $this->php_self = $this->controller_name;
+        $this->ajax = (bool) $this->request->get('ajax');
     }
 
     public function addCSS(array|string $css_uri, string $css_media_type = 'all', ?int $offset = null, bool $check_path = true): void
@@ -242,5 +250,63 @@ class LegacyControllerContext
     public function getContainer(): ContainerInterface
     {
         return $this->container;
+    }
+
+    /**
+     * This is an equivalent of AdminController::setMedia(false)
+     *
+     * @return void
+     */
+    public function loadLegacyMedia(): void
+    {
+        $jsDir = rtrim($this->baseUri, '/') . '/js';
+        $adminDir = rtrim($this->baseUri, '/') . '/' . $this->adminFolderName;
+        if ($this->isLanguageRTL) {
+            $this->addCSS($adminDir . '/themes/default/public/rtl.css?v=' . $this->psVersion, 'all', 0);
+        }
+
+        // Bootstrap
+        $this->addCSS($adminDir . '/themes/default/css/theme.css?v=' . $this->psVersion, 'all', 0);
+        $this->addCSS($adminDir . '/themes/default/css/vendor/titatoggle-min.css', 'all', 0);
+        $this->addCSS($adminDir . '/themes/default/public/theme.css?v=' . $this->psVersion, 'all', 0);
+
+        // add Jquery 3 and its migration script
+        $this->addJs($jsDir . '/jquery/jquery-3.7.1.min.js');
+        $this->addJs($jsDir . '/jquery/bo-migrate-mute.min.js');
+        $this->addJs($jsDir . '/jquery/jquery-migrate-3.4.0.min.js');
+
+        $this->addJqueryPlugin(['scrollTo', 'alerts', 'chosen', 'autosize', 'fancybox']);
+        $this->addJqueryPlugin('growl', null, false);
+        $this->addJqueryUI(['ui.slider', 'ui.datepicker']);
+
+        $this->addJS($adminDir . '/themes/default/js/vendor/bootstrap.min.js');
+        $this->addJS($adminDir . '/themes/default/js/vendor/modernizr.min.js');
+        $this->addJS($adminDir . '/themes/default/js/modernizr-loads.js');
+        $this->addJS($adminDir . '/themes/default/js/vendor/moment-with-langs.min.js');
+        $this->addJS($adminDir . '/themes/default/public/theme.bundle.js?v=' . $this->psVersion);
+
+        $this->addJS($jsDir . '/jquery/plugins/timepicker/jquery-ui-timepicker-addon.js');
+
+        if (!$this->request->get('liteDisplaying')) {
+            $this->addJS($adminDir . '/themes/default/js/help.js?v=' . $this->psVersion);
+        }
+
+        if (!$this->request->get('submitFormAjax')) {
+            $this->addJS($jsDir . '/admin/notifications.js?v=' . $this->psVersion);
+        }
+
+        // Specific Admin Theme
+        $this->addCSS($adminDir . '/themes/default/css/overrides.css', 'all', PHP_INT_MAX);
+
+        $this->addCSS($adminDir . '/themes/new-theme/public/create_product_default_theme.css?v=' . $this->psVersion, 'all', 0);
+        $this->addJS([
+            $jsDir . '/admin.js?v=' . $this->psVersion, // TODO: SEE IF REMOVABLE
+            $adminDir . '/themes/new-theme/public/cldr.bundle.js?v=' . $this->psVersion,
+            $jsDir . '/tools.js?v=' . $this->psVersion,
+            $adminDir . '/public/bundle.js?v=' . $this->psVersion,
+        ]);
+
+        // This is handled as an external common dependency for both themes, but once new-theme is the only one it should be integrated directly into the main.bundle.js file
+        $this->addJS($adminDir . '/themes/new-theme/public/create_product.bundle.js?v=' . $this->psVersion);
     }
 }

--- a/src/Core/Context/LegacyControllerContext.php
+++ b/src/Core/Context/LegacyControllerContext.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Context;
 
+use Language;
 use Media;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Traversable;
@@ -101,6 +102,8 @@ class LegacyControllerContext
      */
     public array|Traversable $page_header_toolbar_btn = [];
 
+    protected array $languages = [];
+
     /**
      * @param ContainerInterface $container Dependency container
      * @param string $controller_name Current controller name without suffix
@@ -123,11 +126,12 @@ class LegacyControllerContext
         public readonly string $override_folder,
         public readonly string $currentIndex,
         public readonly string $table,
+        protected readonly int $employeeLanguageId,
     ) {
         $this->php_self = $this->controller_name;
     }
 
-    public function addCSS($css_uri, $css_media_type = 'all', $offset = null, $check_path = true): void
+    public function addCSS(array|string $css_uri, string $css_media_type = 'all', ?int $offset = null, bool $check_path = true): void
     {
         if (!is_array($css_uri)) {
             $css_uri = [$css_uri];
@@ -160,7 +164,7 @@ class LegacyControllerContext
         }
     }
 
-    public function addJS($js_uri, $check_path = true): void
+    public function addJS(array|string $js_uri, bool $check_path = true): void
     {
         if (!is_array($js_uri)) {
             $js_uri = [$js_uri];
@@ -218,6 +222,20 @@ class LegacyControllerContext
                 $this->addCSS(key($plugin_path['css']), 'all', null, false);
             }
         }
+    }
+
+    public function getLanguages(): array
+    {
+        if (!empty($this->languages)) {
+            return $this->languages;
+        }
+
+        $this->languages = Language::getLanguages(false);
+        foreach ($this->languages as $k => $language) {
+            $this->languages[$k]['is_default'] = (int) ($language['id_lang'] == $this->employeeLanguageId);
+        }
+
+        return $this->languages;
     }
 
     public function getContainer(): ContainerInterface

--- a/src/Core/Context/LegacyControllerContext.php
+++ b/src/Core/Context/LegacyControllerContext.php
@@ -126,6 +126,7 @@ class LegacyControllerContext
         public readonly string $override_folder,
         public readonly string $currentIndex,
         public readonly string $table,
+        public readonly bool $ajax,
         protected readonly int $employeeLanguageId,
     ) {
         $this->php_self = $this->controller_name;

--- a/src/Core/Context/LegacyControllerContextBuilder.php
+++ b/src/Core/Context/LegacyControllerContextBuilder.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Util\Inflector;
 use PrestaShopBundle\Entity\Repository\TabRepository;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Tools;
 
 class LegacyControllerContextBuilder
@@ -47,6 +48,7 @@ class LegacyControllerContextBuilder
         private readonly TabRepository $tabRepository,
         private readonly ContainerInterface $container,
         private readonly ConfigurationInterface $configuration,
+        private readonly RequestStack $requestStack,
     ) {
     }
 
@@ -79,6 +81,7 @@ class LegacyControllerContextBuilder
             $overrideFolder,
             $this->getCurrentIndex(),
             $table,
+            (bool) $this->requestStack->getCurrentRequest()?->get('ajax'),
             $employeeLanguageId,
         );
     }

--- a/src/Core/Context/LegacyControllerContextBuilder.php
+++ b/src/Core/Context/LegacyControllerContextBuilder.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Context;
 
 use Doctrine\ORM\NoResultException;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Util\Inflector;
 use PrestaShopBundle\Entity\Repository\TabRepository;
@@ -45,6 +46,7 @@ class LegacyControllerContextBuilder
         private readonly array $controllersLockedToAllShopContext,
         private readonly TabRepository $tabRepository,
         private readonly ContainerInterface $container,
+        private readonly ConfigurationInterface $configuration,
     ) {
     }
 
@@ -53,8 +55,12 @@ class LegacyControllerContextBuilder
         $multiShopContext = $this->getMultiShopContext($this->getControllerName());
         $id = $this->getTabId($this->getControllerName());
         $employeeId = '';
+        $employeeLanguageId = (int) $this->configuration->get('PS_LANG_DEFAULT');
         if ($this->employeeContext->getEmployee()) {
             $employeeId = $this->employeeContext->getEmployee()->getId();
+            if ($this->configuration->get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG')) {
+                $employeeLanguageId = $this->employeeContext->getEmployee()->getLanguageId();
+            }
         }
         $token = Tools::getAdminToken($this->getControllerName() . $id . $employeeId);
         $overrideFolder = Tools::toUnderscoreCase(substr($this->getControllerName(), 5)) . '/';
@@ -73,6 +79,7 @@ class LegacyControllerContextBuilder
             $overrideFolder,
             $this->getCurrentIndex(),
             $table,
+            $employeeLanguageId,
         );
     }
 

--- a/src/Core/Context/LegacyControllerContextBuilder.php
+++ b/src/Core/Context/LegacyControllerContextBuilder.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Util\Inflector;
 use PrestaShopBundle\Entity\Repository\TabRepository;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Tools;
 
@@ -43,12 +44,16 @@ class LegacyControllerContextBuilder
     private ?string $redirectionUrl = null;
 
     public function __construct(
-        private readonly EmployeeContext $employeeContext,
-        private readonly array $controllersLockedToAllShopContext,
-        private readonly TabRepository $tabRepository,
-        private readonly ContainerInterface $container,
-        private readonly ConfigurationInterface $configuration,
-        private readonly RequestStack $requestStack,
+        protected readonly EmployeeContext $employeeContext,
+        protected readonly array $controllersLockedToAllShopContext,
+        protected readonly TabRepository $tabRepository,
+        protected readonly ContainerInterface $container,
+        protected readonly ConfigurationInterface $configuration,
+        protected readonly RequestStack $requestStack,
+        protected readonly ShopContext $shopContext,
+        protected readonly LanguageContext $languageContext,
+        protected readonly string $adminFolderName,
+        protected string $psVersion,
     ) {
     }
 
@@ -81,8 +86,12 @@ class LegacyControllerContextBuilder
             $overrideFolder,
             $this->getCurrentIndex(),
             $table,
-            (bool) $this->requestStack->getCurrentRequest()?->get('ajax'),
+            $this->requestStack->getCurrentRequest() ?: Request::createFromGlobals(),
             $employeeLanguageId,
+            $this->shopContext->getBaseURI(),
+            $this->adminFolderName,
+            $this->languageContext->isRTL(),
+            $this->psVersion,
         );
     }
 

--- a/src/Core/FeatureFlag/FeatureFlagSettings.php
+++ b/src/Core/FeatureFlag/FeatureFlagSettings.php
@@ -53,4 +53,6 @@ class FeatureFlagSettings
     public const FEATURE_FLAG_ADMIN_API_MULTISTORE = 'admin_api_multistore';
     public const FEATURE_FLAG_ADMIN_API_EXPERIMENTAL_ENDPOINTS = 'admin_api_experimental_endpoints';
     public const FEATURE_FLAG_FRONT_CONTAINER_V2 = 'front_container_v2';
+
+    public const FEATURE_FLAG_MODULE_CONFIGURATION = 'module_configuration';
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -43,6 +43,7 @@ use PrestaShopBundle\Controller\Admin\Improve\Modules\ModuleAbstractController;
 use PrestaShopBundle\Entity\ModuleHistory;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider;
+use PrestaShopBundle\Twig\Layout\MenuLink;
 use Symfony\Component\Form\Util\ServerParams;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -169,6 +170,17 @@ class ModuleController extends ModuleAbstractController
                 'translationLinks' => $this->getTranslationLinks($module, $legacyContext),
                 'layoutTitle' => $this->trans('Configure', [], 'Admin.Modules.Feature'),
                 'layoutSubTitle' => $layoutSubTitle,
+                'breadcrumbLinks' => [
+                    'container' => new MenuLink(
+                        $this->trans('Modules', [], 'Admin.Modules.Feature'),
+                        $this->generateUrl('admin_module_manage'),
+                    ),
+                    'tab' => new MenuLink(
+                        $this->trans('Configure', [], 'Admin.Modules.Feature'),
+                        $this->generateUrl('admin_module_configure_action', ['module_name' => $module_name]),
+                        'build',
+                    ),
+                ],
                 'enableSidebar' => true,
                 'help_link' => $this->generateSidebarLink('AdminModules'),
             ]

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -171,6 +171,8 @@ class ModuleController extends ModuleAbstractController
                 'layoutHeaderToolbarBtn' => $this->getConfigureToolbarButtons($module),
                 'translationLinks' => $this->getTranslationLinks($module, $legacyContext),
                 'layoutTitle' => $this->trans('Configure', [], 'Admin.Modules.Feature'),
+                // Force metaTitle to match the legacy page one (based on the parent)
+                'metaTitle' => $this->trans('Module Manager', [], 'Admin.Navigation.Menu'),
                 'layoutSubTitle' => $layoutSubTitle,
                 'breadcrumbLinks' => [
                     'container' => new MenuLink(

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -30,10 +30,11 @@ use DateTime;
 use Db;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Module as ModuleAdapter;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\Module\ModuleCollection;
-use PrestaShop\PrestaShop\Core\Module\ModuleInterface;
 use PrestaShop\PrestaShop\Core\Module\ModuleManager;
 use PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerNotFoundException;
 use PrestaShop\PrestaShop\Core\Module\SourceHandler\ZipSourceHandler;
@@ -42,12 +43,10 @@ use PrestaShopBundle\Controller\Admin\Improve\Modules\ModuleAbstractController;
 use PrestaShopBundle\Entity\ModuleHistory;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Form\Util\ServerParams;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Twig\Environment;
@@ -122,46 +121,57 @@ class ModuleController extends ModuleAbstractController
     #[AdminSecurity("is_granted('read', 'ADMINMODULESSF_') || is_granted('create', 'ADMINMODULESSF_') || is_granted('update', 'ADMINMODULESSF_') || is_granted('delete', 'ADMINMODULESSF_')")]
     public function configureModuleAction(
         string $module_name,
-        #[Autowire(service: 'prestashop.core.admin.url_generator_legacy')]
-        UrlGeneratorInterface $legacyUrlGenerator,
+        LegacyContext $legacyContext,
     ): Response {
         // Get accessed module object
-        $moduleAccessed = $this->getModuleRepository()->getModule($module_name);
-
-        // Get current employee Id
-        $currentEmployeeId = $this->getEmployeeContext()->getEmployee()->getId();
-        // Get accessed module DB Id
-        $moduleAccessedId = (int) $moduleAccessed->database->get('id');
-
-        // Save history for this module
-        $moduleHistory = $this->entityManager
-            ->getRepository(ModuleHistory::class)
-            ->findOneBy(
-                [
-                    'idEmployee' => $currentEmployeeId,
-                    'idModule' => $moduleAccessedId,
-                ]
-            );
-
-        if (null === $moduleHistory) {
-            $moduleHistory = new ModuleHistory();
+        /** @var ModuleAdapter $module */
+        $module = $this->getModuleRepository()->getModule($module_name);
+        if (!$module->getInstance()) {
+            $this->addFlash('error', $this->trans(
+                'The module "%modulename%" cannot be found',
+                ['%modulename%' => $module_name],
+                'Admin.Modules.Notification'
+            ));
+            $layoutSubTitle = null;
+        } else {
+            $this->saveModuleHistory($module);
+            $layoutSubTitle = $module->getInstance()->displayName;
         }
 
-        $moduleHistory->setIdEmployee($currentEmployeeId);
-        $moduleHistory->setIdModule($moduleAccessedId);
-        $moduleHistory->setDateUpd(new DateTime());
+        if ($this->getFeatureFlagStateChecker()->isDisabled(FeatureFlagSettings::FEATURE_FLAG_MODULE_CONFIGURATION)) {
+            return $this->redirect($legacyContext->getAdminLink('AdminModules', true, ['configure' => $module_name]));
+        }
 
-        $this->entityManager->persist($moduleHistory);
-        $this->entityManager->flush();
+        // This controller is not purely migrated, in the sense that it still relies on the legacy layout because module implementing
+        // getContent need the default theme to be working as expected
+        $smarty = $legacyContext->getSmarty();
+        $smarty->setTemplateDir([
+            _PS_BO_ALL_THEMES_DIR_ . 'default/template/',
+            _PS_OVERRIDE_DIR_ . 'controllers/admin/templates',
+        ]);
+        $this->getLegacyControllerContext()->addJqueryPlugin(['autocomplete', 'fancybox', 'tablefilter']);
 
-        return $this->redirect(
-            $legacyUrlGenerator->generate(
-                'admin_module_configure_action',
-                [
-                    // do not transmit limit & offset: go to the first page when redirecting
-                    'configure' => $module_name,
-                ]
-            )
+        if (method_exists($module->getInstance(), 'getContent')) {
+            $moduleContent = $module->getInstance()->getContent();
+        } else {
+            $moduleContent = null;
+            $this->addFlash('error', $this->trans('Module %s has no getContent() method', [$module->getInstance()->name], 'Admin.Modules.Notification'));
+        }
+
+        return $this->render(
+            '@PrestaShop/Admin/Module/configure.html.twig',
+            [
+                'moduleContent' => $moduleContent,
+                'showContentHeader' => true,
+                // Force legacy layout to load legacy assets like AdminController::setMedia does
+                'loadLegacyMedia' => true,
+                'layoutHeaderToolbarBtn' => $this->getConfigureToolbarButtons($module),
+                'translationLinks' => $this->getTranslationLinks($module, $legacyContext),
+                'layoutTitle' => $this->trans('Configure', [], 'Admin.Modules.Feature'),
+                'layoutSubTitle' => $layoutSubTitle,
+                'enableSidebar' => true,
+                'help_link' => $this->generateSidebarLink('AdminModules'),
+            ]
         );
     }
 
@@ -223,6 +233,7 @@ class ModuleController extends ModuleAbstractController
             }
             if ($action === ModuleAdapter::ACTION_UNINSTALL) {
                 $args[] = (bool) ($request->request->all('actionParams')['deletion'] ?? false);
+                /** @var ModuleAdapter $moduleInstance */
                 $moduleInstance = $this->getModuleRepository()->getModule($moduleName);
                 $response[$moduleName]['refresh_needed'] = $this->moduleNeedsReload($moduleInstance);
                 $response[$moduleName]['has_download_url'] = $moduleInstance->attributes->has('download_url');
@@ -249,6 +260,7 @@ class ModuleController extends ModuleAbstractController
             return new JsonResponse($response);
         }
 
+        /** @var ModuleAdapter $moduleInstance */
         $moduleInstance = $this->getModuleRepository()->getModule($moduleName);
         if ($response[$moduleName]['status'] === true) {
             if (!isset($response[$moduleName]['refresh_needed'])) {
@@ -440,7 +452,36 @@ class ModuleController extends ModuleAbstractController
         return new JsonResponse($installationResponse);
     }
 
-    private function moduleNeedsReload(ModuleInterface $module): bool
+    private function saveModuleHistory(ModuleAdapter $module): void
+    {
+        // Get current employee Id
+        $currentEmployeeId = $this->getEmployeeContext()->getEmployee()->getId();
+        // Get accessed module DB ID
+        $moduleAccessedId = (int) $module->database->get('id');
+
+        // Save history for this module
+        $moduleHistory = $this->entityManager
+            ->getRepository(ModuleHistory::class)
+            ->findOneBy(
+                [
+                    'idEmployee' => $currentEmployeeId,
+                    'idModule' => $moduleAccessedId,
+                ]
+            );
+
+        if (null === $moduleHistory) {
+            $moduleHistory = new ModuleHistory();
+        }
+
+        $moduleHistory->setIdEmployee($currentEmployeeId);
+        $moduleHistory->setIdModule($moduleAccessedId);
+        $moduleHistory->setDateUpd(new DateTime());
+
+        $this->entityManager->persist($moduleHistory);
+        $this->entityManager->flush();
+    }
+
+    private function moduleNeedsReload(ModuleAdapter $module): bool
     {
         $instance = $module->getInstance();
         if (!empty($instance->getTabs())) {
@@ -488,5 +529,67 @@ class ModuleController extends ModuleAbstractController
         }
 
         return $categories;
+    }
+
+    protected function getTranslationLinks(ModuleAdapter $module, LegacyContext $legacyContext): array
+    {
+        $translationLinks = [];
+        $isNewTranslateSystem = $module->getInstance()->isUsingNewTranslationSystem();
+        foreach ($this->getLegacyControllerContext()->getLanguages() as $lang) {
+            if ($isNewTranslateSystem) {
+                $translationLinks[$lang['name']] = $this->generateUrl('admin_international_translation_overview', [
+                    'lang' => $lang['iso_code'],
+                    'type' => 'modules',
+                    'selected' => $module->getInstance()->name,
+                    'locale' => $lang['locale'],
+                ]);
+            } else {
+                $translationLinks[$lang['name']] = $legacyContext->getAdminLink('AdminTranslations', true, [
+                    'type' => 'modules',
+                    'module' => $module->getInstance()->name,
+                    'lang' => $lang['iso_code'],
+                ]);
+            }
+        }
+
+        return $translationLinks;
+    }
+
+    /**
+     * Common method for all module related controller for getting the header buttons.
+     *
+     * @return array
+     */
+    protected function getConfigureToolbarButtons(?ModuleAdapter $module): array
+    {
+        $toolbarButtons = [
+            'module-back' => [
+                'href' => $this->generateUrl('admin_module_manage'),
+                'desc' => $this->trans('Back', [], 'Admin.Global'),
+                'icon' => 'arrow_back',
+                'help' => $this->trans('Module Manager', [], 'Admin.Navigation.Menu'),
+            ],
+        ];
+
+        if ($this->isGranted(Permission::CREATE, self::CONTROLLER_NAME) || $this->isGranted(Permission::DELETE, self::CONTROLLER_NAME)) {
+            $toolbarButtons['module-translate'] = [
+                'href' => '#',
+                'desc' => $this->trans('Translate', [], 'Admin.Modules.Feature'),
+                'icon' => 'flag',
+                'help' => $this->trans('Translate', [], 'Admin.Modules.Feature'),
+                'modal_target' => '#moduleTradLangSelect',
+            ];
+
+            if ($module !== null) {
+                $toolbarButtons['module-hook'] = [
+                    'href' => $this->generateUrl('admin_modules_positions', ['show_modules' => (int) $module->database->get('id')]),
+                    'desc' => $this->trans('Manage hooks', [], 'Admin.Modules.Feature'),
+                    'icon' => 'anchor',
+                    'help' => $this->trans('Manage hooks', [], 'Admin.Modules.Feature'),
+                ];
+            }
+        }
+
+        return $toolbarButtons;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -150,6 +150,10 @@ class ModuleController extends ModuleAbstractController
             _PS_BO_ALL_THEMES_DIR_ . 'default/template/',
             _PS_OVERRIDE_DIR_ . 'controllers/admin/templates',
         ]);
+
+        // Force legacy layout to load legacy assets like AdminController::setMedia does
+        $this->getLegacyControllerContext()->loadLegacyMedia();
+        // Only after can we add additional plugins (to be sure jquery is loaded before the plugins)
         $this->getLegacyControllerContext()->addJqueryPlugin(['autocomplete', 'fancybox', 'tablefilter']);
 
         if (method_exists($module->getInstance(), 'getContent')) {
@@ -164,8 +168,6 @@ class ModuleController extends ModuleAbstractController
             [
                 'moduleContent' => $moduleContent,
                 'showContentHeader' => true,
-                // Force legacy layout to load legacy assets like AdminController::setMedia does
-                'loadLegacyMedia' => true,
                 'layoutHeaderToolbarBtn' => $this->getConfigureToolbarButtons($module),
                 'translationLinks' => $this->getTranslationLinks($module, $legacyContext),
                 'layoutTitle' => $this->trans('Configure', [], 'Admin.Modules.Feature'),

--- a/src/PrestaShopBundle/Controller/Admin/PrestaShopAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/PrestaShopAdminController.php
@@ -38,6 +38,7 @@ use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Context\LegacyControllerContext;
 use PrestaShop\PrestaShop\Core\Context\ShopContext;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\GridDefinitionFactoryInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridInterface;
 use PrestaShop\PrestaShop\Core\Grid\Position\GridPositionUpdaterInterface;
@@ -84,6 +85,7 @@ class PrestaShopAdminController extends AbstractController
             ResponseBuilder::class => ResponseBuilder::class,
             PositionUpdateFactoryInterface::class => PositionUpdateFactoryInterface::class,
             GridPositionUpdaterInterface::class => GridPositionUpdaterInterface::class,
+            FeatureFlagStateCheckerInterface::class => FeatureFlagStateCheckerInterface::class,
         ];
     }
 
@@ -95,6 +97,11 @@ class PrestaShopAdminController extends AbstractController
     protected function getConfiguration(): ConfigurationInterface
     {
         return $this->container->get(ConfigurationInterface::class);
+    }
+
+    protected function getFeatureFlagStateChecker(): FeatureFlagStateCheckerInterface
+    {
+        return $this->container->get(FeatureFlagStateCheckerInterface::class);
     }
 
     protected function getApiClientContext(): ApiClientContext

--- a/src/PrestaShopBundle/EventListener/Admin/LegacyUrlListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/LegacyUrlListener.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\EventListener\Admin;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShopBundle\Routing\Converter\LegacyUrlConverter;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 /**
@@ -64,6 +65,6 @@ class LegacyUrlListener
             return;
         }
 
-        $event->setResponse(new RedirectResponse($convertedUrl));
+        $event->setResponse(new RedirectResponse($convertedUrl, Response::HTTP_PERMANENTLY_REDIRECT));
     }
 }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/modules/_modules.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/modules/_modules.yml
@@ -24,11 +24,10 @@ admin_module_configure_action:
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Improve\ModuleController::configureModuleAction
     _legacy_controller: AdminModules
-# WARNING: This controller is not fully migrated yet, it is an overlay that redirects to the legacy controller,
-# but here is the proper configuration when it will be really migrated
-#    _legacy_link: AdminModules:configure
-#    _legacy_parameters:
-#      configure: module_name
+    _legacy_link: AdminModules:configure
+    _legacy_parameters:
+      configure: module_name
+    _legacy_feature_flag: module_configuration
 
 admin_module_manage_action_bulk:
   path: /manage/bulk/{action}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
@@ -9,7 +9,6 @@ services:
       $controllersLockedToAllShopContext: '%prestashop.controllers_all_shop_context%'
       $defaultLanguageContext: '@prestashop.default.language.context'
       $cookieKey: '%cookie_key%'
-      $adminFolderName: '%prestashop.admin_folder_name%'
 
   Twig\Extension\StringLoaderExtension: ~
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
@@ -9,6 +9,7 @@ services:
       $controllersLockedToAllShopContext: '%prestashop.controllers_all_shop_context%'
       $defaultLanguageContext: '@prestashop.default.language.context'
       $cookieKey: '%cookie_key%'
+      $adminFolderName: '%prestashop.admin_folder_name%'
 
   Twig\Extension\StringLoaderExtension: ~
 

--- a/src/PrestaShopBundle/Resources/config/services/core/context.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/context.yml
@@ -6,6 +6,8 @@ services:
     bind:
       $controllersLockedToAllShopContext: '%prestashop.controllers_all_shop_context%'
       $container: "@service_container"
+      $adminFolderName: '%prestashop.admin_folder_name%'
+      $psVersion: !php/const _PS_VERSION_
   _instanceof:
     PrestaShop\PrestaShop\Core\Context\LegacyContextBuilderInterface:
       tags: [ 'core.legacy_context_builder' ]

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/toolbar.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/toolbar.html.twig
@@ -31,11 +31,15 @@
         <nav aria-label="Breadcrumb">
           <ol class="breadcrumb">
             {% if this.breadcrumbs.container is defined and this.breadcrumbs.container.name != '' %}
-              <li class="breadcrumb-item">{{ this.breadcrumbs.container.name|escape }}</li>
+              <li class="breadcrumb-item">
+                {% if this.breadcrumbs.container.icon is not empty %}<i class="material-icons">{{ this.breadcrumbs.container.icon }}</i>{% endif %}
+                {{ this.breadcrumbs.container.name|escape }}
+              </li>
             {% endif %}
 
             {% if this.breadcrumbs.container is defined and this.breadcrumbs.tab is defined and this.breadcrumbs.tab.name != '' and this.breadcrumbs.container.name != this.breadcrumbs.tab.name and this.breadcrumbs.tab.href != '' %}
               <li class="breadcrumb-item active">
+                {% if this.breadcrumbs.tab.icon is not empty %}<i class="material-icons">{{ this.breadcrumbs.tab.icon }}</i>{% endif %}
                 <a href="{{ this.breadcrumbs.tab.href|escape }}" aria-current="page">{{ this.breadcrumbs.tab.name|escape }}</a>
               </li>
             {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/toolbar.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/toolbar.html.twig
@@ -44,7 +44,7 @@
       {% endif %}
     {% endblock %}
 
-    {% set persistent_help_btn = help_link is defined and help_link is not same as (false) and layoutHeaderToolbarBtn is empty %}
+    {% set persistent_help_btn = help_link is defined and help_link is not same as (false) and this.layoutHeaderToolbarBtn is empty %}
     <div class="title-row {% if persistent_help_btn %}flex-nowrap flex-md-wrap{% endif %}">
       {% block pageTitle %}
           <h1 class="title">
@@ -55,7 +55,7 @@
         <div class="toolbar-icons{% if persistent_help_btn %} toolbar-icons--persistent{% endif %}">
           <div class="wrapper">
             {{ renderhook('displayDashboardToolbarTopMenu') }}
-            {% for k, btn in layoutHeaderToolbarBtn %}
+            {% for k, btn in this.layoutHeaderToolbarBtn %}
               {% if k != 'back' and k != 'modules-list' %}
                 {#TODO: REFACTOR ALL THIS THINGS#}
                 <a
@@ -85,16 +85,16 @@
                 </a>
               {% endif %}
             {% endfor %}
-            {% if layoutHeaderToolbarBtn['modules-list'] is defined %}
+            {% if this.layoutHeaderToolbarBtn['modules-list'] is defined %}
               {#TODO: REFACTOR ALL THIS THINGS#}
               <a
-                class="btn btn-outline-secondary {% if layoutHeaderToolbarBtn['modules-list'].target is defined and layoutHeaderToolbarBtn['modules-list'].target %} _blank{% endif %}"
-                id="page-header-desc-{{ table|default('configuration') }}-{% if layoutHeaderToolbarBtn['modules-list'].imgclass is defined %}{{ layoutHeaderToolbarBtn['modules-list'].imgclass }}{% else %}modules-list{% endif %}"
-                {% if layoutHeaderToolbarBtn['modules-list'].href is defined %}href="{{ layoutHeaderToolbarBtn['modules-list'].href }}"{% endif %}
-                title="{{ layoutHeaderToolbarBtn['modules-list'].desc }}"
-                {% if layoutHeaderToolbarBtn['modules-list'].js is defined and layoutHeaderToolbarBtn['modules-list'].js %}onclick="{{ layoutHeaderToolbarBtn['modules-list'].js }}"{% endif %}
+                class="btn btn-outline-secondary {% if this.layoutHeaderToolbarBtn['modules-list'].target is defined and this.layoutHeaderToolbarBtn['modules-list'].target %} _blank{% endif %}"
+                id="page-header-desc-{{ table|default('configuration') }}-{% if this.layoutHeaderToolbarBtn['modules-list'].imgclass is defined %}{{ this.layoutHeaderToolbarBtn['modules-list'].imgclass }}{% else %}modules-list{% endif %}"
+                {% if this.layoutHeaderToolbarBtn['modules-list'].href is defined %}href="{{ this.layoutHeaderToolbarBtn['modules-list'].href }}"{% endif %}
+                title="{{ this.layoutHeaderToolbarBtn['modules-list'].desc }}"
+                {% if this.layoutHeaderToolbarBtn['modules-list'].js is defined and this.layoutHeaderToolbarBtn['modules-list'].js %}onclick="{{ this.layoutHeaderToolbarBtn['modules-list'].js }}"{% endif %}
               >
-                {{ layoutHeaderToolbarBtn['modules-list'].desc }}
+                {{ this.layoutHeaderToolbarBtn['modules-list'].desc }}
               </a>
             {% endif %}
 
@@ -131,6 +131,13 @@
           </div>
         </div>
       {% endblock %}
+      {% block pageSubTitle %}
+        {% if this.subTitle is not empty %}
+          <h4 class="page-subtitle">
+            {{ this.subTitle }}
+          </h4>
+        {% endif %}
+      {% endblock %}
     </div>
   </div>
 
@@ -163,7 +170,7 @@
     </div>
   {% endif %}
 
-  {% if layoutHeaderToolbarBtn is defined and layoutHeaderToolbarBtn is not empty %}
+  {% if this.layoutHeaderToolbarBtn is defined and this.layoutHeaderToolbarBtn is not empty %}
     <div class="btn-floating">
       <button class="btn btn-primary collapsed" data-toggle="collapse" data-target=".btn-floating-container"
               aria-expanded="false">
@@ -173,7 +180,7 @@
         <div class="btn-floating-menu">
           {{ renderhook('displayDashboardToolbarTopMenu') }}
 
-          {% for k, btn in layoutHeaderToolbarBtn %}
+          {% for k, btn in this.layoutHeaderToolbarBtn %}
             {% if k != 'back' and k != 'modules-list' %}
               <a
                 class="btn btn-floating-item {% if btn.floating_class is defined and btn.floating_class %}{{ btn.floating_class|escape }}{% endif %} {% if btn.target is defined and btn.target %} _blank{% endif %} pointer"{% if btn.href is defined %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/toolbar.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/toolbar.html.twig
@@ -30,6 +30,7 @@
         {# Container #}
         {% if this.breadcrumbs.container is defined and this.breadcrumbs.container.name != '' %}
         <li class="breadcrumb-container">
+          {% if this.breadcrumbs.container.icon is not empty %}<i class="material-icons">{{ this.breadcrumbs.container.icon }}</i>{% endif %}
           {{ this.breadcrumbs.container.name|escape }}
         </li>
         {% endif %}
@@ -37,6 +38,7 @@
         {# Current Tab #}
         {% if this.breadcrumbs.tab is defined and this.breadcrumbs.tab.name != '' %}
         <li class="breadcrumb-current">
+          {% if this.breadcrumbs.tab.icon is not empty %}<i class="material-icons">{{ this.breadcrumbs.tab.icon }}</i>{% endif %}
           {% if this.breadcrumbs.tab.href != '' %}<a href="{{ this.breadcrumbs.tab.href|escape }}">{% endif %}
             {{ this.breadcrumbs.tab.name|escape }}
           {% if this.breadcrumbs.tab.href != '' %}</a>{% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/toolbar.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/toolbar.html.twig
@@ -106,6 +106,13 @@
         </div>
       </div>
       {% endblock %}
+      {% block pageSubTitle %}
+        {% if this.subTitle is not empty %}
+          <h4 class="page-subtitle">
+            {{ this.subTitle }}
+          </h4>
+        {% endif %}
+      {% endblock %}
   </div>
 
     {% if this.currentTabLevel >= 3 %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Layout/default_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Layout/default_layout.html.twig
@@ -140,8 +140,10 @@
 {% if showContentHeader %}
   {% component Toolbar with {
     layoutTitle: layoutTitle|default,
+    layoutSubTitle: layoutSubTitle|default,
     helpLink: help_link|default(''),
-    enableSidebar: enableSidebar|default(false)
+    enableSidebar: enableSidebar|default(false),
+    layoutHeaderToolbarBtn: layoutHeaderToolbarBtn|default([])
   } %}
     {% block pageTitle %}{{ block(outerBlocks.pageTitle) ?: parent() }}{% endblock %}
   {% endcomponent %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Layout/default_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Layout/default_layout.html.twig
@@ -143,7 +143,8 @@
     layoutSubTitle: layoutSubTitle|default,
     helpLink: help_link|default(''),
     enableSidebar: enableSidebar|default(false),
-    layoutHeaderToolbarBtn: layoutHeaderToolbarBtn|default([])
+    layoutHeaderToolbarBtn: layoutHeaderToolbarBtn|default([]),
+    breadcrumbLinks: breadcrumbLinks|default([]),
   } %}
     {% block pageTitle %}{{ block(outerBlocks.pageTitle) ?: parent() }}{% endblock %}
   {% endcomponent %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Layout/legacy_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Layout/legacy_layout.html.twig
@@ -30,7 +30,7 @@
 <html lang="{{ ps.isoUser }}">
 <head>
   {% block header %}
-    {{ component('LegacyHeadTag', {loadLegacyMedia: loadLegacyMedia|default(false)}) }}
+    {{ component('LegacyHeadTag') }}
   {% endblock %}
 </head>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Layout/legacy_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Layout/legacy_layout.html.twig
@@ -30,7 +30,7 @@
 <html lang="{{ ps.isoUser }}">
 <head>
   {% block header %}
-    {{ component('LegacyHeadTag') }}
+    {{ component('LegacyHeadTag', {loadLegacyMedia: loadLegacyMedia|default(false)}) }}
   {% endblock %}
 </head>
 
@@ -122,7 +122,13 @@
     <div id="content" class="bootstrap{% if ps.displayedWithTabs %} with-tabs{% endif %}">
       {# Page header toolbar #}
       {% if showContentHeader %}
-        {{ component('LegacyToolbar') }}
+        {{ component('LegacyToolbar', {
+          layoutTitle: layoutTitle|default,
+          layoutSubTitle: layoutSubTitle|default,
+          helpLink: help_link|default,
+          enableSidebar: enableSidebar|default(false),
+          layoutHeaderToolbarBtn: layoutHeaderToolbarBtn|default([])
+        }) }}
       {% endif %}
 
       {% block content_header %}
@@ -143,7 +149,7 @@
     </div>
   </div>
 
-  {% if modals is not empty %}
+  {% if modals is defined and modals is not empty %}
     <div class="bootstrap">
       {{ modals|raw }}
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Layout/legacy_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Layout/legacy_layout.html.twig
@@ -127,7 +127,8 @@
           layoutSubTitle: layoutSubTitle|default,
           helpLink: help_link|default,
           enableSidebar: enableSidebar|default(false),
-          layoutHeaderToolbarBtn: layoutHeaderToolbarBtn|default([])
+          layoutHeaderToolbarBtn: layoutHeaderToolbarBtn|default([]),
+          breadcrumbLinks: breadcrumbLinks|default([]),
         }) }}
       {% endif %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Layout/legacy_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Layout/legacy_layout.html.twig
@@ -30,7 +30,7 @@
 <html lang="{{ ps.isoUser }}">
 <head>
   {% block header %}
-    {{ component('LegacyHeadTag') }}
+    {{ component('LegacyHeadTag', {metaTitle: metaTitle|default}) }}
   {% endblock %}
 </head>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_translation_language_selector.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_translation_language_selector.html.twig
@@ -1,0 +1,51 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+<div id="moduleTradLangSelect" class="modal  modal-vcenter fade" role="dialog">
+  <div class="modal-dialog">
+    <!-- Modal content-->
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">×</button>
+        <h4 class="modal-title module-modal-title">{{ 'Translate this module'|trans({}, 'Admin.Modules.Feature') }}</h4>
+      </div>
+      <div class="modal-body">
+        <div class="input-group">
+          <button type="button" class="btn btn-default dropdown-toggle" tabindex="-1" data-toggle="dropdown">
+            <i class="icon-flag"></i>
+            {{ 'Manage translations'|trans({}, 'Admin.Modules.Feature') }}
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            {% for language, translationLink in translationLinks %}
+            <li>
+              <a href="{{ translationLink }}">{{ language }}</a>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/configure.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/configure.html.twig
@@ -1,0 +1,34 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+{% extends '@PrestaShop/Admin/Layout/legacy_layout.html.twig' %}
+
+{% block content %}
+  {% if moduleContent is not empty %}
+    {{ moduleContent|raw }}
+  {% endif %}
+
+  {% include '@PrestaShop/Admin/Module/Includes/modal_translation_language_selector.html.twig' with { 'translationLinks' : translationLinks } %}
+{% endblock %}

--- a/src/PrestaShopBundle/Routing/Converter/LegacyUrlConverter.php
+++ b/src/PrestaShopBundle/Routing/Converter/LegacyUrlConverter.php
@@ -141,7 +141,7 @@ final class LegacyUrlConverter
         $legacyAction = $this->getActionFromParameters($parameters);
 
         foreach ($legacyRoute->getRouteParameters() as $legacyParameter => $parameter) {
-            if (isset($parameters[$legacyParameter])) {
+            if (isset($parameters[$legacyParameter]) && !isset($parameters[$parameter])) {
                 $parameters[$parameter] = $parameters[$legacyParameter];
                 unset($parameters[$legacyParameter]);
             }

--- a/src/PrestaShopBundle/Twig/Component/Legacy/LegacyControllerTrait.php
+++ b/src/PrestaShopBundle/Twig/Component/Legacy/LegacyControllerTrait.php
@@ -43,4 +43,9 @@ trait LegacyControllerTrait
     {
         return $this->context->getContext()->controller;
     }
+
+    protected function hasLegacyController(): bool
+    {
+        return $this->context->getContext()->controller instanceof AdminController;
+    }
 }

--- a/src/PrestaShopBundle/Twig/Component/Legacy/LegacyHeadTag.php
+++ b/src/PrestaShopBundle/Twig/Component/Legacy/LegacyHeadTag.php
@@ -39,6 +39,7 @@ use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Twig\Component\HeadTag;
 use PrestaShopBundle\Twig\Layout\MenuBuilder;
 use PrestaShopBundle\Twig\Layout\TemplateVariables;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
@@ -60,6 +61,9 @@ class LegacyHeadTag extends HeadTag
         CurrencyContext $currencyContext,
         LegacyControllerContext $legacyControllerContext,
         protected readonly LegacyContext $context,
+        protected string $adminFolderName,
+        protected string $psVersion,
+        protected RequestStack $requestStack,
     ) {
         parent::__construct(
             $configuration,
@@ -76,34 +80,57 @@ class LegacyHeadTag extends HeadTag
         );
     }
 
-    public function mount(string $metaTitle = ''): void
+    public function mount(string $metaTitle = '', bool $loadLegacyMedia = false): void
     {
-        parent::mount($this->getLegacyMetaTitle());
+        if ($loadLegacyMedia) {
+            $this->loadLegacyMedia();
+        }
+        parent::mount($this->hasLegacyController() ? $this->getLegacyMetaTitle() : $metaTitle);
     }
 
     public function getControllerName(): string
     {
-        return $this->getLegacyController()->controller_name;
+        if ($this->hasLegacyController()) {
+            return $this->getLegacyController()->controller_name;
+        }
+
+        return parent::getControllerName();
     }
 
     public function getLegacyToken(): string
     {
-        return $this->getLegacyController()->token;
+        if ($this->hasLegacyController()) {
+            return $this->getLegacyController()->token;
+        }
+
+        return parent::getLegacyToken();
     }
 
     public function getCurrentIndex(): string
     {
-        return $this->getLegacyController()::$currentIndex;
+        if ($this->hasLegacyController()) {
+            return $this->getLegacyController()::$currentIndex;
+        }
+
+        return parent::getCurrentIndex();
     }
 
     public function getCssFiles(): array
     {
-        return $this->getLegacyController()->css_files;
+        if ($this->hasLegacyController()) {
+            return $this->getLegacyController()->css_files;
+        }
+
+        return parent::getCssFiles();
     }
 
     public function getJsFiles(): array
     {
-        return $this->getLegacyController()->js_files;
+        if ($this->hasLegacyController()) {
+            return $this->getLegacyController()->js_files;
+        }
+
+        return parent::getJsFiles();
     }
 
     /**
@@ -133,5 +160,99 @@ class LegacyHeadTag extends HeadTag
         }
 
         return $legacyMetaTitle;
+    }
+
+    /**
+     * This is an equivalent of AdminController::setMedia(false)
+     *
+     * @return void
+     */
+    protected function loadLegacyMedia(): void
+    {
+        $jsDir = rtrim($this->shopContext->getBaseURI(), '/') . '/js';
+        $adminDir = rtrim($this->shopContext->getBaseURI(), '/') . '/' . $this->adminFolderName;
+        if ($this->languageContext->isRTL()) {
+            $this->addCSS($adminDir . '/themes/default/public/rtl.css?v=' . $this->psVersion, 'all', 0);
+        }
+
+        // Bootstrap
+        $this->addCSS($adminDir . '/themes/default/css/theme.css?v=' . $this->psVersion, 'all', 0);
+        $this->addCSS($adminDir . '/themes/default/css/vendor/titatoggle-min.css', 'all', 0);
+        $this->addCSS($adminDir . '/themes/default/public/theme.css?v=' . $this->psVersion, 'all', 0);
+
+        // add Jquery 3 and its migration script
+        $this->addJs($jsDir . '/jquery/jquery-3.7.1.min.js');
+        $this->addJs($jsDir . '/jquery/bo-migrate-mute.min.js');
+        $this->addJs($jsDir . '/jquery/jquery-migrate-3.4.0.min.js');
+
+        $this->addJqueryPlugin(['scrollTo', 'alerts', 'chosen', 'autosize', 'fancybox']);
+        $this->addJqueryPlugin('growl', null, false);
+        $this->addJqueryUI(['ui.slider', 'ui.datepicker']);
+
+        $this->addJS($adminDir . '/themes/default/js/vendor/bootstrap.min.js');
+        $this->addJS($adminDir . '/themes/default/js/vendor/modernizr.min.js');
+        $this->addJS($adminDir . '/themes/default/js/modernizr-loads.js');
+        $this->addJS($adminDir . '/themes/default/js/vendor/moment-with-langs.min.js');
+        $this->addJS($adminDir . '/themes/default/public/theme.bundle.js?v=' . $this->psVersion);
+
+        $this->addJS($jsDir . '/jquery/plugins/timepicker/jquery-ui-timepicker-addon.js');
+
+        if ((bool) $this->requestStack->getCurrentRequest() || !$this->requestStack->getCurrentRequest()->get('liteDisplaying')) {
+            $this->addJS($adminDir . '/themes/default/js/help.js?v=' . $this->psVersion);
+        }
+
+        if (!$this->requestStack->getCurrentRequest() || !$this->requestStack->getCurrentRequest()->get('submitFormAjax')) {
+            $this->addJS($jsDir . '/admin/notifications.js?v=' . $this->psVersion);
+        }
+
+        // Specific Admin Theme
+        $this->addCSS($adminDir . '/themes/default/css/overrides.css', 'all', PHP_INT_MAX);
+
+        $this->addCSS($adminDir . '/themes/new-theme/public/create_product_default_theme.css?v=' . $this->psVersion, 'all', 0);
+        $this->addJS([
+            $jsDir . '/admin.js?v=' . $this->psVersion, // TODO: SEE IF REMOVABLE
+            $adminDir . '/themes/new-theme/public/cldr.bundle.js?v=' . $this->psVersion,
+            $jsDir . '/tools.js?v=' . $this->psVersion,
+            $adminDir . '/public/bundle.js?v=' . $this->psVersion,
+        ]);
+
+        // This is handled as an external common dependency for both themes, but once new-theme is the only one it should be integrated directly into the main.bundle.js file
+        $this->addJS($adminDir . '/themes/new-theme/public/create_product.bundle.js?v=' . $this->psVersion);
+    }
+
+    protected function addCss(array|string $cssUri, string $cssMediaType = 'all', ?int $offset = null, bool $checkPath = true): void
+    {
+        if ($this->hasLegacyController()) {
+            $this->getLegacyController()->addCSS($cssUri, $cssMediaType, $offset, $checkPath);
+        } else {
+            $this->legacyControllerContext->addCSS($cssUri, $cssMediaType, $offset, $checkPath);
+        }
+    }
+
+    protected function addJs(array|string $jsUri, bool $checkPath = true): void
+    {
+        if ($this->hasLegacyController()) {
+            $this->getLegacyController()->addJS($jsUri, $checkPath);
+        } else {
+            $this->legacyControllerContext->addJS($jsUri, $checkPath);
+        }
+    }
+
+    protected function addJqueryUI(array|string $component, string $theme = 'base', bool $checkDependencies = true): void
+    {
+        if ($this->hasLegacyController()) {
+            $this->getLegacyController()->addJqueryUI($component, $theme, $checkDependencies);
+        } else {
+            $this->legacyControllerContext->addJqueryUI($component, $theme, $checkDependencies);
+        }
+    }
+
+    protected function addJqueryPlugin(array|string $name, ?string $folder = null, bool $css = true): void
+    {
+        if ($this->hasLegacyController()) {
+            $this->getLegacyController()->addJqueryPlugin($name, $folder, $css);
+        } else {
+            $this->legacyControllerContext->addJqueryPlugin($name, $folder, $css);
+        }
     }
 }

--- a/src/PrestaShopBundle/Twig/Component/Legacy/LegacyToolbar.php
+++ b/src/PrestaShopBundle/Twig/Component/Legacy/LegacyToolbar.php
@@ -58,22 +58,31 @@ class LegacyToolbar extends Toolbar
      * @param string $helpLink
      * @param bool $enableSidebar
      */
-    public function mount(string $layoutTitle = '', string $helpLink = '', bool $enableSidebar = false): void
+    public function mount(string $layoutTitle = '', string $helpLink = '', bool $enableSidebar = false, string $layoutSubTitle = '', array $layoutHeaderToolbarBtn = []): void
     {
+        if (empty($helpLink) && $this->hasLegacyController()) {
+            $helpLink = urldecode($this->helpDocumentation->generateLink($this->getLegacyController()->controller_name, $this->languageContext->getIsoCode()));
+        }
+
+        if (empty($layoutHeaderToolbarBtn) && $this->hasLegacyController()) {
+            $layoutHeaderToolbarBtn = $this->getLegacyController()->page_header_toolbar_btn;
+        }
+
         parent::mount(
             $layoutTitle,
-            urldecode($this->helpDocumentation->generateLink($this->getLegacyController()->controller_name, $this->languageContext->getIsoCode())),
-            $enableSidebar
+            $helpLink,
+            $enableSidebar,
+            $layoutSubTitle,
+            $layoutHeaderToolbarBtn,
         );
-    }
-
-    public function getLayoutHeaderToolbarBtn(): array
-    {
-        return $this->getLegacyController()->page_header_toolbar_btn;
     }
 
     public function getTable(): string
     {
-        return $this->getLegacyController()->table;
+        if ($this->hasLegacyController()) {
+            return $this->getLegacyController()->table;
+        }
+
+        return 'configuration';
     }
 }

--- a/src/PrestaShopBundle/Twig/Component/Legacy/LegacyToolbar.php
+++ b/src/PrestaShopBundle/Twig/Component/Legacy/LegacyToolbar.php
@@ -51,14 +51,7 @@ class LegacyToolbar extends Toolbar
         parent::__construct($hookDispatcher, $menuBuilder);
     }
 
-    /**
-     * No parameters are passed to this component but we must respect the method signature.
-     *
-     * @param string $layoutTitle
-     * @param string $helpLink
-     * @param bool $enableSidebar
-     */
-    public function mount(string $layoutTitle = '', string $helpLink = '', bool $enableSidebar = false, string $layoutSubTitle = '', array $layoutHeaderToolbarBtn = []): void
+    public function mount(string $layoutTitle = '', string $helpLink = '', bool $enableSidebar = false, string $layoutSubTitle = '', array $layoutHeaderToolbarBtn = [], array $breadcrumbLinks = []): void
     {
         if (empty($helpLink) && $this->hasLegacyController()) {
             $helpLink = urldecode($this->helpDocumentation->generateLink($this->getLegacyController()->controller_name, $this->languageContext->getIsoCode()));
@@ -74,6 +67,7 @@ class LegacyToolbar extends Toolbar
             $enableSidebar,
             $layoutSubTitle,
             $layoutHeaderToolbarBtn,
+            $breadcrumbLinks,
         );
     }
 

--- a/src/PrestaShopBundle/Twig/Component/Toolbar.php
+++ b/src/PrestaShopBundle/Twig/Component/Toolbar.php
@@ -62,27 +62,33 @@ class Toolbar
     ) {
     }
 
-    public function mount(string $layoutTitle, string $helpLink, bool $enableSidebar, string $layoutSubTitle, array $layoutHeaderToolbarBtn): void
+    public function mount(string $layoutTitle, string $helpLink, bool $enableSidebar, string $layoutSubTitle, array $layoutHeaderToolbarBtn, array $breadcrumbLinks = []): void
     {
         $this->sidebarEnabled = $enableSidebar;
         $this->helpLink = $helpLink;
         $this->layoutHeaderToolbarBtn = $layoutHeaderToolbarBtn;
-        $tab = $this->menuBuilder->getCurrentTab();
-        if (null !== $tab) {
-            $tabs = [];
-            $tabs[] = $tab;
-            $ancestorsTab = $this->menuBuilder->getAncestorsTab($tab->getId());
+        $currentTab = $this->menuBuilder->getCurrentTab();
+        $tabs = [];
+        $ancestorsTab = [];
+        if (null !== $currentTab) {
+            $tabs[] = $currentTab;
+            $ancestorsTab = $this->menuBuilder->getAncestorsTab($currentTab->getId());
             if (!empty($ancestorsTab)) {
                 $tabs[] = $ancestorsTab;
                 $this->currentTabLevel = count($ancestorsTab);
 
                 if ($this->currentTabLevel >= 3) {
-                    $this->navigationTabs = $this->menuBuilder->buildNavigationTabs($tab);
+                    $this->navigationTabs = $this->menuBuilder->buildNavigationTabs($currentTab);
                 }
             }
-
-            $this->setBreadcrumbs($tab, $ancestorsTab, $tabs);
         }
+
+        if (!empty($breadcrumbLinks)) {
+            $this->setBreadcrumbs($breadcrumbLinks, $tabs);
+        } elseif ($currentTab !== null) {
+            $this->setBreadcrumbs($this->menuBuilder->convertTabsToBreadcrumbLinks($currentTab, $ancestorsTab), $tabs);
+        }
+
         $this->setTitle($layoutTitle);
         $this->subTitle = $layoutSubTitle;
     }
@@ -136,9 +142,15 @@ class Toolbar
         }
     }
 
-    protected function setBreadcrumbs(Tab $tab, array $ancestorsTab, array $tabs): void
+    /**
+     * @param MenuLink[] $breadcrumbs
+     * @param Tab[] $tabs
+     *
+     * @return void
+     */
+    protected function setBreadcrumbs(array $breadcrumbs, array $tabs): void
     {
-        $this->breadcrumbs = $this->menuBuilder->convertTabsToBreadcrumbLinks($tab, $ancestorsTab);
+        $this->breadcrumbs = $breadcrumbs;
         $this->hookDispatcher->dispatchWithParameters('actionAdminBreadcrumbModifier', ['tabs' => $tabs, 'breadcrumb' => &$this->breadcrumbs]);
     }
 }

--- a/src/PrestaShopBundle/Twig/Component/Toolbar.php
+++ b/src/PrestaShopBundle/Twig/Component/Toolbar.php
@@ -38,6 +38,8 @@ use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 class Toolbar
 {
     protected string $title = '';
+
+    protected string $subTitle = '';
     protected string $helpLink = '';
     protected bool $sidebarEnabled = true;
     protected int $currentTabLevel = 0;
@@ -52,16 +54,19 @@ class Toolbar
      */
     protected array $breadcrumbs = [];
 
+    protected array $layoutHeaderToolbarBtn = [];
+
     public function __construct(
         protected readonly HookDispatcherInterface $hookDispatcher,
         protected readonly MenuBuilder $menuBuilder,
     ) {
     }
 
-    public function mount(string $layoutTitle, string $helpLink, bool $enableSidebar): void
+    public function mount(string $layoutTitle, string $helpLink, bool $enableSidebar, string $layoutSubTitle, array $layoutHeaderToolbarBtn): void
     {
         $this->sidebarEnabled = $enableSidebar;
         $this->helpLink = $helpLink;
+        $this->layoutHeaderToolbarBtn = $layoutHeaderToolbarBtn;
         $tab = $this->menuBuilder->getCurrentTab();
         if (null !== $tab) {
             $tabs = [];
@@ -79,11 +84,17 @@ class Toolbar
             $this->setBreadcrumbs($tab, $ancestorsTab, $tabs);
         }
         $this->setTitle($layoutTitle);
+        $this->subTitle = $layoutSubTitle;
     }
 
     public function getTitle(): string
     {
         return $this->title;
+    }
+
+    public function getSubTitle(): string
+    {
+        return $this->subTitle;
     }
 
     public function getCurrentTabLevel(): int
@@ -109,6 +120,11 @@ class Toolbar
     public function getHelpLink(): string
     {
         return $this->helpLink;
+    }
+
+    public function getLayoutHeaderToolbarBtn(): array
+    {
+        return $this->layoutHeaderToolbarBtn;
     }
 
     protected function setTitle(string $layoutTitle): void

--- a/src/PrestaShopBundle/Twig/Layout/MenuBuilder.php
+++ b/src/PrestaShopBundle/Twig/Layout/MenuBuilder.php
@@ -141,7 +141,7 @@ class MenuBuilder
         return new MenuLink(
             name: $this->getBreadcrumbLabel($tab),
             href: $this->getLinkFromTab($tab),
-            icon: 'icon-' . $tab->getClassName(),
+            icon: $tab->getIcon(),
         );
     }
 

--- a/tests/Integration/Adapter/ContextStateManagerTest.php
+++ b/tests/Integration/Adapter/ContextStateManagerTest.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Context\LegacyControllerContext;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Shop;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Tests\TestCase\ContextStateTestCase;
 
 class ContextStateManagerTest extends ContextStateTestCase
@@ -74,8 +75,12 @@ class ContextStateManagerTest extends ContextStateTestCase
             'override_folder/',
             'index.php?controller=AdminProducts',
             'product',
+            $this->createMock(Request::class),
+            1,
+            'http://localhost',
+            'admin-dev',
             false,
-            1
+            '9.0.0',
         );
 
         $this->legacyControllerContext2 = new LegacyControllerContext(
@@ -89,8 +94,12 @@ class ContextStateManagerTest extends ContextStateTestCase
             'override_folder/',
             'index.php?controller=AdminCarts',
             'cart',
-            true,
-            1
+            $this->createMock(Request::class),
+            1,
+            'http://localhost',
+            'admin-dev',
+            false,
+            '9.0.0',
         );
     }
 

--- a/tests/Integration/Adapter/ContextStateManagerTest.php
+++ b/tests/Integration/Adapter/ContextStateManagerTest.php
@@ -74,6 +74,7 @@ class ContextStateManagerTest extends ContextStateTestCase
             'override_folder/',
             'index.php?controller=AdminProducts',
             'product',
+            false,
             1
         );
 
@@ -88,6 +89,7 @@ class ContextStateManagerTest extends ContextStateTestCase
             'override_folder/',
             'index.php?controller=AdminCarts',
             'cart',
+            true,
             1
         );
     }
@@ -104,17 +106,20 @@ class ContextStateManagerTest extends ContextStateTestCase
     {
         $this->legacyContext->getContext()->controller = $this->legacyControllerContext1;
         $this->assertEquals($this->legacyControllerContext1->controller_name, $this->legacyContext->getContext()->controller->controller_name);
+        $this->assertEquals($this->legacyControllerContext1->ajax, $this->legacyContext->getContext()->controller->ajax);
 
         $contextStateManager = new ContextStateManager($this->legacyContext);
         $this->assertNull($contextStateManager->getContextFieldsStack());
 
         $contextStateManager->setController($this->legacyControllerContext2);
         $this->assertEquals($this->legacyControllerContext2->controller_name, $this->legacyContext->getContext()->controller->controller_name);
+        $this->assertEquals($this->legacyControllerContext2->ajax, $this->legacyContext->getContext()->controller->ajax);
         $this->assertIsArray($contextStateManager->getContextFieldsStack());
         $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
         $contextStateManager->restorePreviousContext();
         $this->assertEquals($this->legacyControllerContext1->controller_name, $this->legacyContext->getContext()->controller->controller_name);
+        $this->assertEquals($this->legacyControllerContext1->ajax, $this->legacyContext->getContext()->controller->ajax);
         $this->assertNull($contextStateManager->getContextFieldsStack());
     }
 

--- a/tests/Integration/Adapter/ContextStateManagerTest.php
+++ b/tests/Integration/Adapter/ContextStateManagerTest.php
@@ -73,7 +73,8 @@ class ContextStateManagerTest extends ContextStateTestCase
             'token',
             'override_folder/',
             'index.php?controller=AdminProducts',
-            'product'
+            'product',
+            1
         );
 
         $this->legacyControllerContext2 = new LegacyControllerContext(
@@ -86,7 +87,8 @@ class ContextStateManagerTest extends ContextStateTestCase
             'token',
             'override_folder/',
             'index.php?controller=AdminCarts',
-            'cart'
+            'cart',
+            1
         );
     }
 

--- a/tests/Integration/Classes/ToolsTest.php
+++ b/tests/Integration/Classes/ToolsTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Integration\Classes;
+
+use PHPUnit\Framework\TestCase;
+use Tests\Integration\Utility\ContextMockerTrait;
+use Tools;
+
+class ToolsTest extends TestCase
+{
+    use ContextMockerTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+    }
+
+    /**
+     * @dataProvider getUrlsToSanitize
+     *
+     * @param string $url
+     * @param string $expected
+     *
+     * @return void
+     */
+    public function testSanitizeAdminUrl(string $url, string $expected): void
+    {
+        $this->assertEquals($expected, Tools::sanitizeAdminUrl($url));
+    }
+
+    public function getUrlsToSanitize(): iterable
+    {
+        yield 'url starting with index.php' => [
+            'index.php?controller=AdminModules',
+            'http://localhost/admin-dev/index.php?controller=AdminModules',
+        ];
+
+        yield 'url starting with /admin-dev/index.php' => [
+            '/admin-dev/index.php?controller=AdminModules',
+            'http://localhost/admin-dev/index.php?controller=AdminModules',
+        ];
+
+        yield 'url symfony style with admin-dev' => [
+            '/admin-dev/modules/link-widget/list',
+            'http://localhost/admin-dev/modules/link-widget/list',
+        ];
+
+        yield 'url symfony style without admin-dev' => [
+            '/modules/link-widget/list',
+            'http://localhost/admin-dev/modules/link-widget/list',
+        ];
+
+        yield 'url symfony style without starting /' => [
+            'modules/link-widget/list',
+            'http://localhost/admin-dev/modules/link-widget/list',
+        ];
+
+        yield 'absolute legacy url' => [
+            'http://localhost/admin-dev/index.php?controller=AdminModules',
+            'http://localhost/admin-dev/index.php?controller=AdminModules',
+        ];
+
+        yield 'absolute symfony url' => [
+            'http://localhost/admin-dev/modules/link-widget/list',
+            'http://localhost/admin-dev/modules/link-widget/list',
+        ];
+
+        yield 'external url' => [
+            'http://www.prestahop-project.org',
+            'http://www.prestahop-project.org',
+        ];
+    }
+}

--- a/tests/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
+++ b/tests/Integration/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
@@ -59,6 +59,9 @@ class LegacyUrlConverterTest extends SymfonyIntegrationTestCase
     public static function getMigratedControllers(): array
     {
         return [
+            'admin_module_configure_action' => ['/improve/modules/manage/action/configure/ps_linklist', 'AdminModules', 'configure', ['module_name' => 'ps_linklist']],
+            'admin_module_configure_action_legacy' => ['/improve/modules/manage/action/configure/ps_linklist', 'AdminModules', 'configure', ['configure' => 'ps_linklist']],
+
             'admin_administration' => ['/configure/advanced/administration/', 'AdminAdminPreferences'],
             'admin_administration_general_save' => ['/configure/advanced/administration/general', 'AdminAdminPreferences', 'update'],
 
@@ -178,9 +181,6 @@ class LegacyUrlConverterTest extends SymfonyIntegrationTestCase
             // 'admin_permissions_update_tab_permissions' => ['/configure/advanced/permissions/update/permissions/tab', 'AdminAccess', 'updateAccess'],
             // 'admin_permissions_update_module_permissions' => ['/configure/advanced/permissions/update/permissions/module', 'AdminAccess', 'updateModuleAccess'],
 
-            // 'admin_module_configure_action' => ['/improve/modules/manage/action/configure/ps_linklist', 'AdminModules', 'configure', ['module_name' => 'ps_linklist']],
-            // 'admin_module_configure_action_legacy' => ['/improve/modules/manage/action/configure/ps_linklist', 'AdminModules', 'configure', ['configure' => 'ps_linklist']],
-
             'admin_sql_request' => ['/configure/advanced/sql-requests/', 'AdminRequestSql'],
             'admin_sql_request_search' => ['/configure/advanced/sql-requests/', 'AdminRequestSql', 'search'],
             'admin_sql_request_process' => ['/configure/advanced/sql-requests/process-settings', 'AdminRequestSql', 'update'],
@@ -262,7 +262,6 @@ class LegacyUrlConverterTest extends SymfonyIntegrationTestCase
             ['/admin-dev/index.php?controller=AdminDashboard', 'AdminDashboard'],
             ['/admin-dev/index.php?controller=AdminModulesPositions&addToHook=', 'AdminModulesPositions', ['addToHook' => '']],
             ['/admin-dev/index.php?controller=AdminModules', 'AdminModules'],
-            ['/admin-dev/index.php?controller=AdminModules&configure=ps_linklist', 'AdminModules', ['configure' => 'ps_linklist']],
         ];
     }
 
@@ -386,7 +385,7 @@ class LegacyUrlConverterTest extends SymfonyIntegrationTestCase
         ?array $params = null
     ): void {
         $parameters = null !== $params ? $params : [];
-        if (null != $action) {
+        if (null != $action && !isset($parameters[$action])) {
             $parameters[$action] = '';
         }
         $linkUrl = $this->link->getAdminLink($controller, true, [], $parameters);

--- a/tests/TestCase/ContextStateTestCase.php
+++ b/tests/TestCase/ContextStateTestCase.php
@@ -130,6 +130,7 @@ abstract class ContextStateTestCase extends TestCase
                 '',
                 'index.php?controller=' . $controllerName,
                 'configuration',
+                false,
                 1,
             ])
         ;

--- a/tests/TestCase/ContextStateTestCase.php
+++ b/tests/TestCase/ContextStateTestCase.php
@@ -130,6 +130,7 @@ abstract class ContextStateTestCase extends TestCase
                 '',
                 'index.php',
                 'configuration',
+                1,
             ])
         ;
 

--- a/tests/TestCase/ContextStateTestCase.php
+++ b/tests/TestCase/ContextStateTestCase.php
@@ -128,7 +128,7 @@ abstract class ContextStateTestCase extends TestCase
                 42,
                 'token',
                 '',
-                'index.php',
+                'index.php?controller=' . $controllerName,
                 'configuration',
                 1,
             ])

--- a/tests/TestCase/ContextStateTestCase.php
+++ b/tests/TestCase/ContextStateTestCase.php
@@ -40,6 +40,7 @@ use PrestaShop\PrestaShop\Core\Context\LegacyControllerContext;
 use PrestaShopBundle\Translation\TranslatorComponent as Translator;
 use Shop;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Tests\Integration\Utility\ContextMockerTrait;
 
 abstract class ContextStateTestCase extends TestCase
@@ -130,8 +131,12 @@ abstract class ContextStateTestCase extends TestCase
                 '',
                 'index.php?controller=' . $controllerName,
                 'configuration',
-                false,
+                $this->createMock(Request::class),
                 1,
+                'http://localhost',
+                'admin-dev',
+                false,
+                '9.0.0',
             ])
         ;
 

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -433,7 +433,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#2a69af194313b644bf83e2c857a30590a5c7fac0",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#1502ec7b5f4a9edfe2362e5d7a3d14e7f4dfeb0e",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^8.3.1",
@@ -8422,7 +8422,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#2a69af194313b644bf83e2c857a30590a5c7fac0",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#1502ec7b5f4a9edfe2362e5d7a3d14e7f4dfeb0e",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^8.3.1",

--- a/tests/UI/pages/BO/modules/moduleConfiguration/index.ts
+++ b/tests/UI/pages/BO/modules/moduleConfiguration/index.ts
@@ -31,9 +31,9 @@ class ModuleConfiguration extends BOBasePage {
     // Header selectors
     this.pageHeadSubtitle = '.page-subtitle';
 
-    this.pageHeadButtonBack = '#desc-module-back';
-    this.pageHeadButtonTranslate = '#desc-module-translate';
-    this.pageHeadButtonManageHooks = '#desc-module-hook';
+    this.pageHeadButtonBack = '#page-header-desc-configuration-module-back';
+    this.pageHeadButtonTranslate = '#page-header-desc-configuration-module-translate';
+    this.pageHeadButtonManageHooks = '#page-header-desc-configuration-module-hook';
 
     this.modalTranslate = '#moduleTradLangSelect';
     this.modalTranslateCloseButton = `${this.modalTranslate} div.modal-header button[data-dismiss="modal"]`;

--- a/tests/Unit/Adapter/ContextStateManagerTest.php
+++ b/tests/Unit/Adapter/ContextStateManagerTest.php
@@ -26,6 +26,7 @@
 
 namespace Tests\Unit\Adapter;
 
+use AdminController;
 use Cart;
 use Country;
 use Currency;
@@ -79,22 +80,30 @@ class ContextStateManagerTest extends ContextStateTestCase
             'controller' => $this->createLegacyControllerContextMock('AdminProductsController'),
         ]);
         $this->assertEquals('AdminProductsController', $context->controller->controller_name);
+        $this->assertEquals('index.php?controller=AdminProductsController', $context->controller->currentIndex);
+        $this->assertEquals(null, AdminController::$currentIndex);
 
         $contextStateManager = new ContextStateManager($this->legacyContext);
         $this->assertNull($contextStateManager->getContextFieldsStack());
 
         $contextStateManager->setController($this->createLegacyControllerContextMock('AdminOrdersController'));
         $this->assertEquals('AdminOrdersController', $context->controller->controller_name);
+        $this->assertEquals('index.php?controller=AdminOrdersController', $context->controller->currentIndex);
+        $this->assertEquals('index.php?controller=AdminOrdersController', AdminController::$currentIndex);
         $this->assertIsArray($contextStateManager->getContextFieldsStack());
         $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
         $contextStateManager->setController($this->createLegacyControllerContextMock('AdminCartsController'));
         $this->assertEquals('AdminCartsController', $context->controller->controller_name);
+        $this->assertEquals('index.php?controller=AdminCartsController', $context->controller->currentIndex);
+        $this->assertEquals('index.php?controller=AdminCartsController', AdminController::$currentIndex);
         $this->assertIsArray($contextStateManager->getContextFieldsStack());
         $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
         $contextStateManager->restorePreviousContext();
         $this->assertEquals('AdminProductsController', $context->controller->controller_name);
+        $this->assertEquals('index.php?controller=AdminProductsController', $context->controller->currentIndex);
+        $this->assertEquals(null, AdminController::$currentIndex);
         $this->assertNull($contextStateManager->getContextFieldsStack());
     }
 

--- a/tests/Unit/Core/Context/LegacyControllerContextBuilderTest.php
+++ b/tests/Unit/Core/Context/LegacyControllerContextBuilderTest.php
@@ -60,6 +60,7 @@ class LegacyControllerContextBuilderTest extends TestCase
             ['AdminCarts'],
             $this->mockTabRepository(),
             $this->createMock(ContainerInterface::class),
+            $this->mockConfiguration()
         );
 
         $builder->setControllerName($controllerName);
@@ -193,6 +194,7 @@ class LegacyControllerContextBuilderTest extends TestCase
             ['AdminCarts'],
             $tabRepository,
             $this->createMock(ContainerInterface::class),
+            $this->mockConfiguration(),
         );
 
         // We don't call setControllerName so the builder falls back on AdminNotFound

--- a/tests/Unit/Core/Context/LegacyControllerContextBuilderTest.php
+++ b/tests/Unit/Core/Context/LegacyControllerContextBuilderTest.php
@@ -33,7 +33,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Context\Employee;
 use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Context\LegacyControllerContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShopBundle\Entity\Repository\TabRepository;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -64,6 +66,10 @@ class LegacyControllerContextBuilderTest extends TestCase
             $this->createMock(ContainerInterface::class),
             $this->mockConfiguration(),
             $this->mockRequestStack(true),
+            $this->createMock(ShopContext::class),
+            $this->createMock(LanguageContext::class),
+            'admin-dev',
+            '9.0.0',
         );
 
         $builder->setControllerName($controllerName);
@@ -200,6 +206,10 @@ class LegacyControllerContextBuilderTest extends TestCase
             $this->createMock(ContainerInterface::class),
             $this->mockConfiguration(),
             $this->mockRequestStack(false),
+            $this->createMock(ShopContext::class),
+            $this->createMock(LanguageContext::class),
+            'admin-dev',
+            '9.0.0',
         );
 
         // We don't call setControllerName so the builder falls back on AdminNotFound

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextListenerTest.php
@@ -90,7 +90,8 @@ class LegacyControllerContextListenerTest extends ContextEventListenerTestCase
             $this->createMock(EmployeeContext::class),
             ['AdminCarts'],
             $this->createMock(TabRepository::class),
-            $this->createMock(ContainerInterface::class)
+            $this->createMock(ContainerInterface::class),
+            $this->mockConfiguration(),
         );
     }
 }

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextListenerTest.php
@@ -34,6 +34,7 @@ use PrestaShopBundle\Entity\Repository\TabRepository;
 use PrestaShopBundle\EventListener\Admin\Context\LegacyControllerContextListener;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Tests\Unit\PrestaShopBundle\EventListener\ContextEventListenerTestCase;
 
 class LegacyControllerContextListenerTest extends ContextEventListenerTestCase
@@ -92,6 +93,7 @@ class LegacyControllerContextListenerTest extends ContextEventListenerTestCase
             $this->createMock(TabRepository::class),
             $this->createMock(ContainerInterface::class),
             $this->mockConfiguration(),
+            $this->createMock(RequestStack::class),
         );
     }
 }

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextListenerTest.php
@@ -29,7 +29,9 @@ declare(strict_types=1);
 namespace Tests\Unit\PrestaShopBundle\EventListener\Admin\Context;
 
 use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Context\LegacyControllerContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShopBundle\Entity\Repository\TabRepository;
 use PrestaShopBundle\EventListener\Admin\Context\LegacyControllerContextListener;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -94,6 +96,10 @@ class LegacyControllerContextListenerTest extends ContextEventListenerTestCase
             $this->createMock(ContainerInterface::class),
             $this->mockConfiguration(),
             $this->createMock(RequestStack::class),
+            $this->createMock(ShopContext::class),
+            $this->createMock(LanguageContext::class),
+            'admin-dev',
+            '9.0.0',
         );
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Migrate the "module configuration" backoffice page, used by modules through the "Configure" button
| Type?             | new feature
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | In the back office and in the Module manager section, check that the `Configure` action still works as expected for all modules The only acceptable bug is related to some images URLs that are no longer accessible, this will require some updates in the module that relied on relative URLs instead of absolute ones
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/11164063674
| Fixed issue or discussion?     | ~
| Related PRs       | https://github.com/PrestaShop/ui-testing-library/pull/137
| Sponsor company   | ~

### Breaking changes

The module configuration page has been migrated, the main change is that its URL is now `/admin-dev/improve/modules/manage/action/configure/{module_name}` so any asset or URL that was previously relative won't work anymore

Besides that we emphasize on keeping as much retro-compatibility as possible:
- the `getContent` method is still called and execute (both for rendering and handling posted data)
- the layout around the page is still based on the `default` admin theme, so all legacy components are still displayed as expected
- the redirections made by `getContent` to legacy URLs are correctly handled even if they were not absolute URLs
- the `.htaccess` for the BO has been improved so that all URLs now pass through the BO index.php file and there is no more unexpected fallback to the FO index.php file, as such an URL like `/admin-dev/improve/modules/manage/action/configure/{module_name}/index.php` no longer results in page not found in FO
- the legacy URL listener that handles redirection has been improved, it is now based on a 308 redirection that keeps request method and body, this means POST request to legacy URLs are redirecting to migrated page but they keep the posted data while redirecting

With all these improvements the behaviour of your module's configuration page should remain intact.
