### PR TITLE
Add addJqueryUI and addJqueryPlugin methods in LegacyControllerContext

### DIFF
--- a/admin-dev/themes/default/scss/partials/_content.scss
+++ b/admin-dev/themes/default/scss/partials/_content.scss
@@ -54,6 +54,12 @@ body {
   }
 }
 
+body.adminmodules {
+  #content.bootstrap {
+    padding-top: var(--#{$cdk}page-head-with-tabs-height);
+  }
+}
+
 .data-focus {
   &.data-focus-primary {
     color: var(--#{$cdk}white);

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -292,6 +292,9 @@ class AdminModulesControllerCore extends AdminController
             'add_permission' => $this->access('add'),
         ]);
 
+        // Since this controller renders the header itself we must prevent le one from the layout to be displayed
+        $this->show_page_header_toolbar = false;
+
         // Display checkbox in toolbar if multishop
         if (Shop::isFeatureActive()) {
             if (Shop::getContext() == Shop::CONTEXT_SHOP) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -217,7 +217,7 @@ parameters:
 
 		-
 			message: "#^Namespace Media is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
-			count: 4
+			count: 6
 			path: src/Core/Context/LegacyControllerContext.php
 
 		-

--- a/src/Core/Context/LegacyControllerContext.php
+++ b/src/Core/Context/LegacyControllerContext.php
@@ -183,6 +183,43 @@ class LegacyControllerContext
         }
     }
 
+    /**
+     * Adds jQuery UI component(s) to queued JS file list.
+     */
+    public function addJqueryUI(string|array $component, string $theme = 'base', bool $checkDependencies = true): void
+    {
+        if (!is_array($component)) {
+            $component = [$component];
+        }
+
+        foreach ($component as $ui) {
+            $ui_path = Media::getJqueryUIPath($ui, $theme, $checkDependencies);
+            $this->addCSS($ui_path['css'], 'all');
+            $this->addJS($ui_path['js'], false);
+        }
+    }
+
+    /**
+     * Adds jQuery plugin(s) to queued JS file list.
+     */
+    public function addJqueryPlugin(string|array $name, ?string $folder = null, bool $css = true): void
+    {
+        if (!is_array($name)) {
+            $name = [$name];
+        }
+
+        foreach ($name as $plugin) {
+            $plugin_path = Media::getJqueryPluginPath($plugin, $folder);
+
+            if (!empty($plugin_path['js'])) {
+                $this->addJS($plugin_path['js'], false);
+            }
+            if ($css && !empty($plugin_path['css'])) {
+                $this->addCSS(key($plugin_path['css']), 'all', null, false);
+            }
+        }
+    }
+
     public function getContainer(): ContainerInterface
     {
         return $this->container;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add addJqueryUI and addJqueryPlugin methods in LegacyControllerContext, plus a small UX bug fixed in module configuration page
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green<br>See how to test section
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/10773040026
| Fixed issue or discussion?     | Fixes #36649
| Related PRs       | ~
| Sponsor company   | ~

### How to test

Edit the `hookActionAdminControllerSetMedia` method in the `modules/blockwishlist/blockwishlist.php` module Add this code:

```php
        $this->context->controller->addJqueryUi('ui.widget');
        $this->context->controller->addJqueryPlugin('tagify');
```

Now go to any migrated page you should have an error referring to not knowing the `addJqueryUi`. With this PR the error no longer exists.