### PR TITLE
fix: add attr_stringify_fetches to PDO init config

### DIFF
--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -72,6 +72,8 @@ class DbPDOCore extends Db
                 PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
                 PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
                 PDO::MYSQL_ATTR_MULTI_STATEMENTS => _PS_ALLOW_MULTI_STATEMENTS_QUERIES_,
+                // FIX https://github.com/PrestaShop/PrestaShop/issues/36836
+                PDO::ATTR_STRINGIFY_FETCHES => true
             ]
         );
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix Incompatibility Issue with PDO Returning Integer Values with PHP 8.1
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | dump a response from database returned by PDO, and check type of values.
| Fixed issue or discussion?     | Fix #36836
| Sponsor company   | PrestaShop
