### PR TITLE
Add attr_stringify_fetches to PDO init config to avoid BC Break

### DIFF
--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -73,7 +73,7 @@ class DbPDOCore extends Db
                 PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
                 PDO::MYSQL_ATTR_MULTI_STATEMENTS => _PS_ALLOW_MULTI_STATEMENTS_QUERIES_,
                 // FIX This option keeps all data as strings and stops automatic casting to integers, floats and other types
-                PDO::ATTR_STRINGIFY_FETCHES => true
+                PDO::ATTR_STRINGIFY_FETCHES => true,
             ]
         );
     }

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -72,6 +72,8 @@ class DbPDOCore extends Db
                 PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
                 PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
                 PDO::MYSQL_ATTR_MULTI_STATEMENTS => _PS_ALLOW_MULTI_STATEMENTS_QUERIES_,
+                // FIX This option keeps all data as strings and stops automatic casting to integers, floats and other types
+                PDO::ATTR_STRINGIFY_FETCHES => true
             ]
         );
     }
@@ -147,7 +149,7 @@ class DbPDOCore extends Db
     {
         try {
             return $this->link->query($sql);
-        } catch (\PDOException $exception) {
+        } catch (PDOException $exception) {
             throw new PrestaShopException($exception->getMessage(), (int) $exception->getCode(), $exception);
         }
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Fix Incompatibility Issue with PDO Returning Integer Values with PHP 8.1
| Type?             | bug fix 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| UI Tests | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/10845473917
| How to test?      | dump a response from database returned by PDO, and check type of values.
| Fixed issue or discussion?     | Fix #36836
| Sponsor company   | PrestaShop