### PR TITLE
Missing .htaccess in js folder - security (malicious PHP files can be hidden in this folder)

### DIFF
--- a/js/.htaccess
+++ b/js/.htaccess
@@ -1,0 +1,22 @@
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+    <Files ~ "(?i)^.*\.(css|js|gif|png|jpg|svg|html|map|eot|ttf|woff)$">
+        Allow from all
+    </Files>
+    <Files ~ "(?i)^.*(jquery\.noConflict\.php|retro-compat\.js\.php)$">
+        Allow from all
+    </Files>
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+    <Files ~ "(?i)^.*\.(css|js|gif|png|jpg|svg|html|map|eot|ttf|woff)$">
+        Require all granted
+    </Files>
+    <Files ~ "(?i)^.*(jquery\.noConflict\.php|retro-compat\.js\.php)$">
+        Require all granted
+    </Files>
+</IfModule>

--- a/js/.htaccess
+++ b/js/.htaccess
@@ -5,18 +5,12 @@
     <Files ~ "(?i)^.*\.(css|js|gif|png|jpg|svg|html|map|eot|ttf|woff)$">
         Allow from all
     </Files>
-    <Files ~ "(?i)^.*(jquery\.noConflict\.php|retro-compat\.js\.php)$">
-        Allow from all
-    </Files>
 </IfModule>
 
 # Apache 2.4
 <IfModule mod_authz_core.c>
     Require all denied
     <Files ~ "(?i)^.*\.(css|js|gif|png|jpg|svg|html|map|eot|ttf|woff)$">
-        Require all granted
-    </Files>
-    <Files ~ "(?i)^.*(jquery\.noConflict\.php|retro-compat\.js\.php)$">
         Require all granted
     </Files>
 </IfModule>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Check below
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     |
| Related PRs       |
| Sponsor company   | https://www.openservis.cz/

### DESCRIPTION
From develop were removed _.htaccess_ from folder "_js_", I don't know why. Malware infection is often hidden in this folder. There must be .htaccess to prevent running of malicious PHP files. Similar like we have in "img" folder. For example, today I found PS with this infection. _.htaccess_ will partially help with this problem.
_js/jquery/plugins/jqzoom/meepKqZU.php
js/jquery/plugins/jstree/themes/default/Qnwe0Zf.php
js/jquery/plugins/thickbox/WS5DepV.php
js/jquery/plugins/chosen/xRlyM.php
js/jquery/iz8Wll.php
js/tiny_mce/plugins/print/Vtb68.php
js/tiny_mce/plugins/charmap/F04apba.php
js/tiny_mce/plugins/autolink/De1DT.php_

**No PHP files should be in this folder!**