### PR TITLE
Fix(carrier): handle page redirection on fields that are on error

### DIFF
--- a/admin-dev/themes/new-theme/js/components/navbar-form-error-handler.ts
+++ b/admin-dev/themes/new-theme/js/components/navbar-form-error-handler.ts
@@ -40,50 +40,50 @@ export default class NavbarFormErrorHandler {
 
   private readonly navbarHandler: NavbarHandler;
 
-  private firstInvalidField: HTMLElement | null = null;
-
   constructor(options: NavbarFormErrorHandlerType) {
     this.navbarHandler = options.navbarHandler;
     this.form = options.form;
 
     this.initListener();
-    this.resetInvalidField();
   }
 
-  private findRequiredFieldsFromForm(): NodeListOf<HTMLElement> {
-    return this.form.querySelectorAll('[required]');
+  private findAllFormFields(): NodeListOf<HTMLElement> {
+    return this.form.querySelectorAll('input, select, textarea');
   }
 
   private initListener(): void {
-    this.findRequiredFieldsFromForm().forEach((field) => {
+    let isFirstInvalidField = false;
+
+    this.findAllFormFields().forEach((field) => {
       field.addEventListener('invalid', () => {
-        if (!this.firstInvalidField) {
-          this.firstInvalidField = field;
-
-          const tab = field.closest('[role="tabpanel"]');
-
-          if (!tab || typeof tab === null) {
-            throw new Error('NavbarFormErrorHandler: Cannot find the tab that contains some form fields in error.');
-          }
-
-          if (!('id' in tab)) {
-            throw new Error('NavbarFormErrorHandler: Id missing from the tab.');
-          }
-
-          this.navbarHandler.switchToTarget(`#${tab.id}`);
-
-          field.scrollIntoView({
-            behavior: 'smooth',
-            block: 'end',
-          });
+        if (isFirstInvalidField) {
+          return;
         }
+
+        isFirstInvalidField = true;
+
+        const tab = field.closest('[role="tabpanel"]');
+
+        if (!tab || typeof tab === null) {
+          throw new Error('NavbarFormErrorHandler: Cannot find the tab that contains some form fields in error.');
+        }
+
+        if (!('id' in tab)) {
+          throw new Error('NavbarFormErrorHandler: Id missing from the tab.');
+        }
+
+        this.navbarHandler.switchToTarget(`#${tab.id}`);
+
+        field.scrollIntoView({
+          behavior: 'smooth',
+          block: 'end',
+        });
+
+        // Set a timeout to reset the flag after the current event loop
+        setTimeout(() => {
+          isFirstInvalidField = false;
+        }, 0);
       });
     });
-  }
-
-  private resetInvalidField() {
-    this.form.addEventListener('click', () => {
-      this.firstInvalidField = null;
-    }, true);
   }
 }

--- a/admin-dev/themes/new-theme/js/components/navbar-form-error-handler.ts
+++ b/admin-dev/themes/new-theme/js/components/navbar-form-error-handler.ts
@@ -36,11 +36,11 @@ type NavbarFormErrorHandlerType = {
  * Use this component only if you are using a form with NavbarHandler.
  */
 export default class NavbarFormErrorHandler {
-  form: HTMLElement;
+  private readonly form: HTMLElement;
 
-  navbarHandler: NavbarHandler;
+  private readonly navbarHandler: NavbarHandler;
 
-  firstInvalidField: Element | null = null;
+  private firstInvalidField: HTMLElement | null = null;
 
   constructor(options: NavbarFormErrorHandlerType) {
     this.navbarHandler = options.navbarHandler;
@@ -50,7 +50,7 @@ export default class NavbarFormErrorHandler {
     this.resetInvalidField();
   }
 
-  private findRequiredFieldsFromForm(): NodeListOf<Element> {
+  private findRequiredFieldsFromForm(): NodeListOf<HTMLElement> {
     return this.form.querySelectorAll('[required]');
   }
 
@@ -61,7 +61,16 @@ export default class NavbarFormErrorHandler {
           this.firstInvalidField = field;
 
           const tab = field.closest('[role="tabpanel"]');
-          this.navbarHandler.switchToTarget(`#${tab?.id}`);
+
+          if (!tab || typeof tab === null) {
+            throw new Error('NavbarFormErrorHandler: Cannot find the tab that contains some form fields in error.');
+          }
+
+          if (!('id' in tab)) {
+            throw new Error('NavbarFormErrorHandler: Id missing from the tab.');
+          }
+
+          this.navbarHandler.switchToTarget(`#${tab.id}`);
 
           field.scrollIntoView({
             behavior: 'smooth',

--- a/admin-dev/themes/new-theme/js/components/navbar-form-error-handler.ts
+++ b/admin-dev/themes/new-theme/js/components/navbar-form-error-handler.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+import NavbarHandler from './navbar-handler';
+
+type NavbarFormErrorHandlerType = {
+  form: HTMLElement;
+  navbarHandler: NavbarHandler;
+}
+
+/**
+ * This component is used as a wrapper for the NavbahHandler component. It allows handling
+ * tab redirection to the tab that contains some HTML form errors.
+ * Use this component only if you are using a form with NavbarHandler.
+ */
+export default class NavbarFormErrorHandler {
+  form: HTMLElement;
+
+  navbarHandler: NavbarHandler;
+
+  firstInvalidField: Element | null = null;
+
+  constructor(options: NavbarFormErrorHandlerType) {
+    this.navbarHandler = options.navbarHandler;
+    this.form = options.form;
+
+    this.initListener();
+    this.resetInvalidField();
+  }
+
+  private findRequiredFieldsFromForm(): NodeListOf<Element> {
+    return this.form.querySelectorAll('[required]');
+  }
+
+  private initListener(): void {
+    this.findRequiredFieldsFromForm().forEach((field) => {
+      field.addEventListener('invalid', () => {
+        if (!this.firstInvalidField) {
+          this.firstInvalidField = field;
+
+          const tab = field.closest('[role="tabpanel"]');
+          this.navbarHandler.switchToTarget(`#${tab?.id}`);
+
+          field.scrollIntoView({
+            behavior: 'smooth',
+            block: 'end',
+          });
+        }
+      });
+    });
+  }
+
+  private resetInvalidField() {
+    this.form.addEventListener('click', () => {
+      this.firstInvalidField = null;
+    }, true);
+  }
+}

--- a/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-manager.ts
@@ -28,7 +28,6 @@ import CarrierFormMap from '@pages/carrier/form/carrier-form-map';
 import CarrierFormEventMap from '@pages/carrier/form/carrier-form-event-map';
 import ConfirmModal from '@js/components/modal/confirm-modal';
 import {Range} from '@pages/carrier/form/types';
-import NavbarHandler from '@components/navbar-handler';
 
 const {$} = window;
 
@@ -50,15 +49,12 @@ export default class CarrierFormManager {
 
   $freeShippingInput: JQuery;
 
-  navBarHandler: NavbarHandler;
-
   /**
    * @param {EventEmitter} eventEmitter
    */
   constructor(eventEmitter: EventEmitter) {
     this.eventEmitter = eventEmitter;
     this.currentShippingSymbol = '';
-    this.navBarHandler = new NavbarHandler($(CarrierFormMap.navigationBar));
 
     // Initialize dom elements
     this.$zonesInput = $(CarrierFormMap.zonesInput);
@@ -91,35 +87,6 @@ export default class CarrierFormManager {
     this.$shippingMethodInput.on('change', () => this.refreshCurrentShippingSymbol());
     $(CarrierFormMap.zonesContainer).on('click', CarrierFormMap.deleteZoneButton, (e:Event) => this.onDeleteZone(e));
     this.eventEmitter.on(CarrierFormEventMap.rangesUpdated, (ranges: Range[]) => this.onChangeRanges(ranges));
-
-    this.initErrorListener();
-  }
-
-  private initErrorListener(): void {
-    const carrierForm = document.querySelector(CarrierFormMap.form);
-    const requiredFields = carrierForm?.querySelectorAll('[required]');
-
-    let firstInvalidField: Element | null = null;
-
-    requiredFields?.forEach((field) => {
-      field.addEventListener('invalid', () => {
-        if (!firstInvalidField) {
-          firstInvalidField = field;
-
-          const tab = field.closest('[role="tabpanel"]');
-          this.navBarHandler.switchToTarget(`#${tab?.id}`);
-
-          field.scrollIntoView({
-            behavior: 'smooth',
-            block: 'end',
-          });
-        }
-      });
-    });
-
-    carrierForm?.addEventListener('click', () => {
-      firstInvalidField = null;
-    }, true);
   }
 
   private refreshFreeShipping(): void {

--- a/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-map.ts
@@ -29,7 +29,6 @@ export default {
   freeShippingInput: 'input[name="carrier[shipping_settings][is_free]"]',
   zonesInput: '#carrier_shipping_settings_zones',
   zoneIdOption: (zoneId: number|string): string => `option[value="${zoneId}"]`,
-  navigationBar: '#form-nav',
   rangesInput: '#carrier_shipping_settings_ranges_data',
   rangesSelectionAppId: '#carrier_shipping_settings_ranges-app',
   addRangeButton: '.js-add-carrier-ranges-btn',

--- a/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/carrier-form-map.ts
@@ -24,6 +24,8 @@
  */
 
 export default {
+  form: 'form[name="carrier"]',
+  navigationBar: '#form-nav',
   freeShippingInput: 'input[name="carrier[shipping_settings][is_free]"]',
   zonesInput: '#carrier_shipping_settings_zones',
   zoneIdOption: (zoneId: number|string): string => `option[value="${zoneId}"]`,

--- a/admin-dev/themes/new-theme/js/pages/carrier/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/index.ts
@@ -23,10 +23,12 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import NavbarHandler from '@components/navbar-handler';
+import ChoiceTable from '@js/components/choice-table';
+import NavbarHandler from '@js/components/navbar-handler';
 import CarrierFormManager from '@pages/carrier/form/carrier-form-manager';
 import CarrierRanges from '@pages/carrier/form/carrier-range-modal';
-import CarrierFormMap from './carrier-form-map';
+import CarrierFormMap from '@pages/carrier/form/carrier-form-map';
+import NavbarFormErrorHandler from '@js/components/navbar-form-error-handler';
 
 $(() => {
   // Initialize components
@@ -40,8 +42,17 @@ $(() => {
   // Initialize the ranges selection modal
   new CarrierRanges(window.prestashop.instance.eventEmitter);
 
-  new NavbarHandler($(CarrierFormMap.navigationBar));
+  new ChoiceTable();
 
   // Initialize the carrier form manager
   new CarrierFormManager(window.prestashop.instance.eventEmitter);
+
+  const carrierForm = document.querySelector(CarrierFormMap.form);
+
+  if (carrierForm instanceof HTMLElement) {
+    new NavbarFormErrorHandler({
+      form: carrierForm,
+      navbarHandler: new NavbarHandler($(CarrierFormMap.navigationBar)),
+    });
+  }
 });


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This pull request solve the issue mentioned in the issue #36759 regarding the bug 6. Before the pull request, when submitting the form, if there was an error in a field that was in another tab, nothing happen. The user cannot see any errors and don't know what to do. Now, if there is an error anywhere in the form, Independent from the tab, the user will be redirected to the first field that is in error.
| Type?             |  improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See description in the issue #36759
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/10936613034
| Fixed issue or discussion?     | Fixes #36759
| Related PRs       | none
| Sponsor company   | PrestaShop
