### PR TITLE
Update AdminCartsController.php

### DIFF
--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -923,6 +923,7 @@ class AdminCartsControllerCore extends AdminController
         $context->cart = new Cart($id_cart);
         $context->currency = new Currency((int) $context->cart->id_currency);
         $context->customer = new Customer((int) $context->cart->id_customer);
+        $context->shop = new Shop((int) $context->cart->id_shop);
 
         return Cart::getTotalCart($id_cart, true, Cart::BOTH_WITHOUT_SHIPPING);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      |When Multistore is enabled and there are at least two active shops, an error occurs in the back-office when viewing the Shopping Carts list with the "All shops" context selected.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| UI Tests | https://github.com/florine2623/testing_pr/actions/runs/10924041285 ✅ 
| Fixed issue or discussion?     | Fixes #36894
| Sponsor company   | @Codencode 