### PR TITLE
#36901 Fix inconsistency of related products in search BO product page

### DIFF
--- a/admin-dev/themes/new-theme/js/product-page/product-search-autocomplete.js
+++ b/admin-dev/themes/new-theme/js/product-page/product-search-autocomplete.js
@@ -90,7 +90,7 @@ export default function () {
     }, {
       display: autocompleteObject.attr('data-mappingname'),
       source: document[`${autocompleteFormId}_source`],
-      limit: 30,
+      limit: 128,
       templates: {
         suggestion(item) {
           return `<div><img src="${item.image}" style="width:50px" /> ${item.name}</div>`;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | When searching for related products in the product page the select give not all informations of products
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | try to search products to add to product related on shop with lot of products with the same beginning of name, some products wont come out in the select, change the limit and products will come out in the select
| UI Tests          | no
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/issues/36901
| Related PRs       | no
| Sponsor company   | Adrien THIERRY