### PR TITLE
Fix: Cart.php class method _deleteCustomization not deleting all image files from same customization but only first

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2002,6 +2002,10 @@ class CartCore extends ObjectModel
             WHERE `id_customization` = ' . (int) $id_customization);
 
         if ($customization) {
+            /*
+             * Now we will select all customized files that could be connected to this customization.
+             * One customization can have multiple fields for files, we need to delete all of them.
+             */
             $cust_datas = Db::getInstance()->executeS('SELECT *
                 FROM `' . _DB_PREFIX_ . 'customized_data`
                 WHERE `id_customization` = ' . (int) $id_customization . '

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2002,14 +2002,18 @@ class CartCore extends ObjectModel
             WHERE `id_customization` = ' . (int) $id_customization);
 
         if ($customization) {
-            $cust_data = Db::getInstance()->getRow('SELECT *
+            $cust_datas = Db::getInstance()->executeS('SELECT *
                 FROM `' . _DB_PREFIX_ . 'customized_data`
-                WHERE `id_customization` = ' . (int) $id_customization);
+                WHERE `id_customization` = ' . (int) $id_customization . '
+                AND `type` = ' . (int) Product::CUSTOMIZE_FILE
+            );
 
-            // Delete customization picture if necessary
-            if (isset($cust_data['type']) && $cust_data['type'] == Product::CUSTOMIZE_FILE) {
-                $result &= file_exists(_PS_UPLOAD_DIR_ . $cust_data['value']) ? @unlink(_PS_UPLOAD_DIR_ . $cust_data['value']) : true;
-                $result &= file_exists(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small') ? @unlink(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small') : true;
+            // Delete customization pictures if necessary
+            if ($cust_datas) {
+                foreach ($cust_datas as $cust_data) {
+                    $result &= file_exists(_PS_UPLOAD_DIR_ . $cust_data['value']) ? @unlink(_PS_UPLOAD_DIR_ . $cust_data['value']) : true;
+                    $result &= file_exists(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small') ? @unlink(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small') : true;
+                }
             }
 
             $result &= Db::getInstance()->execute(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | I have a product with multiple customization fields: 11 text fields, and 3 file fields. Saving customization fields to product works well. But when I remove a product from Cart, customization data is deleted from Database correctly, but attached image files stored at /upload/ folder are not fully deleted. It deletes only first image file, and other image files like 2nd and 3rd remains there.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | in admin create a Product with more customization fields e.g. 5 text fields, and 3 file fields. In frontend fill all customization fields (into file fields upload 3 JPG images). Add this product to Cart, and for now all is fine. Now in Cart remove this product from Cart.Check the /upload/ folder and verify that all files for this customization have been deleted
| UI Tests | https://github.com/florine2623/testing_pr/actions/runs/10903699993
| Fixed issue or discussion?     | Fixes #36904
| Sponsor company   | @Codencode 
