### PR TITLE
Database connection - usage of "localhost" is about 3% faster than "127.0.0.1"

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -2,7 +2,7 @@
 # Set parameters here that may be different on each deployment target of the app, e.g. development, staging, production.
 # http://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 parameters:
-    database_host:     127.0.0.1
+    database_host:     localhost
     database_port:     ~
     database_name:     prestashop
     database_user:     root


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Check issue 36909
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Ïnstall PrestaShop. Default "database server address" will be "localhost" (not "127.0.0.1")
| UI Tests          | 
| Fixed issue or discussion?     | #36909 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/