### PR TITLE
Added management of the 'addedByModule' field in the "CustomizationField" object

### DIFF
--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/CustomizationFieldsCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/CustomizationFieldsCommandsBuilder.php
@@ -74,7 +74,7 @@ final class CustomizationFieldsCommandsBuilder implements ProductCommandsBuilder
                 'type' => (int) $customization['type'],
                 'localized_names' => $customization['name'],
                 'is_required' => (bool) $customization['required'],
-                'added_by_module' => false,
+                'added_by_module' => isset($customization['addedByModule']) ? (bool) $customization['addedByModule'] : false,
                 'id' => isset($customization['id']) ? (int) $customization['id'] : null,
             ];
         }

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -616,7 +616,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
                 'name' => $customizationField->getLocalizedNames(),
                 'type' => $customizationField->getType(),
                 'required' => $customizationField->isRequired(),
-                'addedByModule' => $customizationField->isAddedByModule()
+                'addedByModule' => $customizationField->isAddedByModule(),
             ];
         }
 

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -616,6 +616,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
                 'name' => $customizationField->getLocalizedNames(),
                 'type' => $customizationField->getType(),
                 'required' => $customizationField->isRequired(),
+                'addedByModule' => $customizationField->isAddedByModule()
             ];
         }
 

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -1008,12 +1008,14 @@ class ProductFormDataProviderTest extends TestCase
                     'name' => $localizedNames,
                     'type' => 1,
                     'required' => false,
+                    'addedByModule' => false,
                 ],
                 [
                     'id' => 2,
                     'name' => $localizedNames,
                     'type' => 0,
                     'required' => true,
+                    'addedByModule' => false,
                 ],
             ],
         ];
@@ -1024,12 +1026,14 @@ class ProductFormDataProviderTest extends TestCase
                 'name' => $localizedNames,
                 'type' => CustomizationFieldType::TYPE_TEXT,
                 'required' => false,
+                'addedByModule' => false,
             ],
             [
                 'id' => 2,
                 'name' => $localizedNames,
                 'type' => CustomizationFieldType::TYPE_FILE,
                 'required' => true,
+                'addedByModule' => false,
             ],
         ];
 


### PR DESCRIPTION
In the ProductFormDataProvider::extractCustomizationsData() method, I added the 'addedByModule' key to the $fields array. In the CustomizationFieldsCommandsBuilder::buildCustomizationFields() method, I added the 'added_by_module' key to the $customizationFields array.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | If a module uses product customization and sets in the table 'PREFIX_customization_field' is_module=1 , every time the product is saved (after changing name,price etc ) using Prestashops Save and Publish, the product is saved with is_module=0
| Type?             | bug fix
| Category?         |  BO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | 1) Create a product with a customization field. 2) In the `customization_field` table, set `is_module` to 1 for the record corresponding to the field of the created product. This simulates that the field was created by a module. 3) Go to BO and update the product and verify that the `is_module` field in `customization_field` table remains set to 1.
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/36897
| UI Tests | https://github.com/florine2623/testing_pr/actions/runs/10903696477
| Sponsor company   | @Codencode 
