### PR TITLE
Simplify javascript on backoffice pages

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/address/form.ts
+++ b/admin-dev/themes/new-theme/js/pages/address/form.ts
@@ -24,8 +24,6 @@
  */
 
 import AutocompleteWithEmail from '@components/form/autocomplete-with-email';
-import CountryStateSelectionToggler from '@components/country-state-selection-toggler';
-import CountryDniRequiredToggler from '@components/country-dni-required-toggler';
 import CountryPostcodeRequiredToggler from '@components/country-postcode-required-toggler';
 import addressFormMap from './address-form-map';
 
@@ -37,12 +35,12 @@ $(() => {
     lastName: addressFormMap.addressLastnameInput,
     company: addressFormMap.addressCompanyInput,
   });
-  new CountryStateSelectionToggler(
+  new window.prestashop.component.CountryStateSelectionToggler(
     addressFormMap.addressCountrySelect,
     addressFormMap.addressStateSelect,
     addressFormMap.addressStateBlock,
   );
-  new CountryDniRequiredToggler(
+  new window.prestashop.component.CountryDniRequiredToggler(
     addressFormMap.addressCountrySelect,
     addressFormMap.addressDniInput,
     addressFormMap.addressDniInputLabel,

--- a/admin-dev/themes/new-theme/js/pages/address/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/address/index.ts
@@ -23,10 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import ChoiceTable from '@components/choice-table';
-
-const {$} = window;
-
 $(() => {
   const addressGrid = new window.prestashop.component.Grid('address');
 
@@ -39,6 +35,9 @@ $(() => {
   addressGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   addressGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 
-  // needed for address required fields form
-  new ChoiceTable();
+  window.prestashop.component.initComponents(
+    [
+      'ChoiceTable',
+    ],
+  );
 });

--- a/admin-dev/themes/new-theme/js/pages/address/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/address/index.ts
@@ -35,7 +35,7 @@ $(() => {
   addressGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   addressGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   addressGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  addressGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  addressGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   addressGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   addressGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 

--- a/admin-dev/themes/new-theme/js/pages/address/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/address/index.ts
@@ -23,30 +23,21 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import ReloadListExtension from '@components/grid/extension/reload-list-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 import ChoiceTable from '@components/choice-table';
 
 const {$} = window;
 
 $(() => {
-  const addressGrid = new Grid('address');
+  const addressGrid = new window.prestashop.component.Grid('address');
 
-  addressGrid.addExtension(new FiltersResetExtension());
-  addressGrid.addExtension(new SortingExtension());
-  addressGrid.addExtension(new ExportToSqlManagerExtension());
-  addressGrid.addExtension(new ReloadListExtension());
-  addressGrid.addExtension(new BulkActionCheckboxExtension());
-  addressGrid.addExtension(new SubmitBulkExtension());
-  addressGrid.addExtension(new SubmitRowActionExtension());
-  addressGrid.addExtension(new LinkRowActionExtension());
+  addressGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  addressGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  addressGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  addressGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
+  addressGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  addressGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  addressGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  addressGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 
   // needed for address required fields form
   new ChoiceTable();

--- a/admin-dev/themes/new-theme/js/pages/api-client/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/api-client/index.ts
@@ -23,25 +23,17 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
-import AsyncToggleColumnExtension from '@components/grid/extension/column/common/async-toggle-column-extension';
 
 const {$} = window;
 
 $(() => {
-  const grid = new Grid('api_client');
+  const grid = new window.prestashop.component.Grid('api_client');
 
-  grid.addExtension(new ExportToSqlManagerExtension());
-  grid.addExtension(new ReloadListActionExtension());
-  grid.addExtension(new SortingExtension());
-  grid.addExtension(new FiltersResetExtension());
-  grid.addExtension(new SubmitRowActionExtension());
-  grid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  grid.addExtension(new AsyncToggleColumnExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.AsyncToggleColumnExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/api-client/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/api-client/index.ts
@@ -30,7 +30,7 @@ $(() => {
   const grid = new window.prestashop.component.Grid('api_client');
 
   grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());

--- a/admin-dev/themes/new-theme/js/pages/api-client/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/api-client/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const grid = new window.prestashop.component.Grid('api_client');
 

--- a/admin-dev/themes/new-theme/js/pages/attachment/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/attachment/index.ts
@@ -23,10 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import TranslatableInput from '@components/translatable-input';
-
-const {$} = window;
-
 $(() => {
   const attachmentGrid = new window.prestashop.component.Grid('attachment');
 
@@ -39,5 +35,9 @@ $(() => {
   attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 
-  new TranslatableInput();
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+    ],
+  );
 });

--- a/admin-dev/themes/new-theme/js/pages/attachment/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/attachment/index.ts
@@ -35,7 +35,7 @@ $(() => {
   attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 

--- a/admin-dev/themes/new-theme/js/pages/attachment/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/attachment/index.ts
@@ -23,30 +23,21 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import ReloadListExtension from '@components/grid/extension/reload-list-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 import TranslatableInput from '@components/translatable-input';
 
 const {$} = window;
 
 $(() => {
-  const attachmentGrid = new Grid('attachment');
+  const attachmentGrid = new window.prestashop.component.Grid('attachment');
 
-  attachmentGrid.addExtension(new FiltersResetExtension());
-  attachmentGrid.addExtension(new SortingExtension());
-  attachmentGrid.addExtension(new ExportToSqlManagerExtension());
-  attachmentGrid.addExtension(new ReloadListExtension());
-  attachmentGrid.addExtension(new BulkActionCheckboxExtension());
-  attachmentGrid.addExtension(new SubmitBulkExtension());
-  attachmentGrid.addExtension(new SubmitRowActionExtension());
-  attachmentGrid.addExtension(new LinkRowActionExtension());
+  attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
+  attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  attachmentGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 
   new TranslatableInput();
 });

--- a/admin-dev/themes/new-theme/js/pages/attribute-group/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/attribute-group/index.ts
@@ -23,35 +23,24 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
 import ShowcaseCard from '@components/showcase-card/showcase-card';
 import ShowcaseCardCloseExtension from '@components/showcase-card/extension/showcase-card-close-extension';
-import PositionExtension from '@components/grid/extension/position-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 
 const {$} = window;
 
 $(() => {
-  const grid = new Grid('attribute_group');
+  const grid = new window.prestashop.component.Grid('attribute_group');
 
-  grid.addExtension(new ExportToSqlManagerExtension());
-  grid.addExtension(new ReloadListActionExtension());
-  grid.addExtension(new SortingExtension());
-  grid.addExtension(new FiltersResetExtension());
-  grid.addExtension(new SubmitRowActionExtension());
-  grid.addExtension(new SubmitBulkExtension());
-  grid.addExtension(new BulkActionCheckboxExtension());
-  grid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  grid.addExtension(new PositionExtension(grid));
-  grid.addExtension(new LinkRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.PositionExtension(grid));
+  grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 
   const showcaseCard = new ShowcaseCard('attributesShowcaseCard');
   showcaseCard.addExtension(new ShowcaseCardCloseExtension());

--- a/admin-dev/themes/new-theme/js/pages/attribute-group/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/attribute-group/index.ts
@@ -32,11 +32,11 @@ $(() => {
   const grid = new window.prestashop.component.Grid('attribute_group');
 
   grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.PositionExtension(grid));

--- a/admin-dev/themes/new-theme/js/pages/attribute/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/attribute/index.ts
@@ -23,31 +23,20 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
-import PositionExtension from '@components/grid/extension/position-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 
 const {$} = window;
 
 $(() => {
-  const grid = new Grid('attribute');
+  const grid = new window.prestashop.component.Grid('attribute');
 
-  grid.addExtension(new ExportToSqlManagerExtension());
-  grid.addExtension(new ReloadListActionExtension());
-  grid.addExtension(new SortingExtension());
-  grid.addExtension(new FiltersResetExtension());
-  grid.addExtension(new SubmitRowActionExtension());
-  grid.addExtension(new SubmitBulkExtension());
-  grid.addExtension(new BulkActionCheckboxExtension());
-  grid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  grid.addExtension(new PositionExtension(grid));
-  grid.addExtension(new LinkRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.PositionExtension(grid));
+  grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/attribute/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/attribute/index.ts
@@ -30,11 +30,11 @@ $(() => {
   const grid = new window.prestashop.component.Grid('attribute');
 
   grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.PositionExtension(grid));

--- a/admin-dev/themes/new-theme/js/pages/attribute/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/attribute/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const grid = new window.prestashop.component.Grid('attribute');
 

--- a/admin-dev/themes/new-theme/js/pages/backup/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/backup/index.ts
@@ -23,22 +23,15 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
 
 const {$} = window;
 
 $(() => {
-  const backupGrid = new Grid('backup');
+  const backupGrid = new window.prestashop.component.Grid('backup');
 
-  backupGrid.addExtension(new BulkActionCheckboxExtension());
-  backupGrid.addExtension(new SubmitBulkExtension());
-  backupGrid.addExtension(new LinkRowActionExtension());
-  backupGrid.addExtension(new SubmitRowActionExtension());
-  backupGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  backupGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  backupGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  backupGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  backupGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  backupGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/backup/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/backup/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const backupGrid = new window.prestashop.component.Grid('backup');
 

--- a/admin-dev/themes/new-theme/js/pages/backup/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/backup/index.ts
@@ -30,7 +30,7 @@ $(() => {
   const backupGrid = new window.prestashop.component.Grid('backup');
 
   backupGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  backupGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  backupGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   backupGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   backupGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   backupGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());

--- a/admin-dev/themes/new-theme/js/pages/carrier/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/index.ts
@@ -24,7 +24,6 @@
  */
 
 import NavbarHandler from '@components/navbar-handler';
-import ChoiceTable from '@js/components/choice-table';
 import CarrierFormManager from '@pages/carrier/form/carrier-form-manager';
 import CarrierRanges from '@pages/carrier/form/carrier-range-modal';
 import CarrierFormMap from './carrier-form-map';
@@ -35,12 +34,11 @@ $(() => {
     'TranslatableInput',
     'EventEmitter',
     'MultipleZoneChoice',
+    'ChoiceTable',
   ]);
 
   // Initialize the ranges selection modal
   new CarrierRanges(window.prestashop.instance.eventEmitter);
-
-  new ChoiceTable();
 
   new NavbarHandler($(CarrierFormMap.navigationBar));
 

--- a/admin-dev/themes/new-theme/js/pages/carrier/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/carrier/index.ts
@@ -25,35 +25,23 @@
 
 import ShowcaseCard from '@components/showcase-card/showcase-card';
 import ShowcaseCardCloseExtension from '@components/showcase-card/extension/showcase-card-close-extension';
-import Grid from '@components/grid/grid';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import PositionExtension from '@components/grid/extension/position-extension';
 
 const {$} = window;
 
 $(() => {
-  const carrierGrid = new Grid('carrier');
+  const carrierGrid = new window.prestashop.component.Grid('carrier');
 
-  carrierGrid.addExtension(new SortingExtension());
-  carrierGrid.addExtension(new ReloadListActionExtension());
-  carrierGrid.addExtension(new PositionExtension(carrierGrid));
-  carrierGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  carrierGrid.addExtension(new FiltersResetExtension());
-  carrierGrid.addExtension(new ExportToSqlManagerExtension());
-  carrierGrid.addExtension(new ColumnTogglingExtension());
-  carrierGrid.addExtension(new LinkRowActionExtension());
-  carrierGrid.addExtension(new SubmitRowActionExtension());
-  carrierGrid.addExtension(new SubmitBulkExtension());
-  carrierGrid.addExtension(new BulkActionCheckboxExtension());
+  carrierGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  carrierGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  carrierGrid.addExtension(new window.prestashop.component.GridExtensions.PositionExtension(carrierGrid));
+  carrierGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  carrierGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  carrierGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  carrierGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  carrierGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  carrierGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  carrierGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  carrierGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
 
   const showcaseCard = new ShowcaseCard('carriersShowcaseCard');
   showcaseCard.addExtension(new ShowcaseCardCloseExtension());

--- a/admin-dev/themes/new-theme/js/pages/carrier/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/carrier/index.ts
@@ -32,7 +32,7 @@ $(() => {
   const carrierGrid = new window.prestashop.component.Grid('carrier');
 
   carrierGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
-  carrierGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  carrierGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   carrierGrid.addExtension(new window.prestashop.component.GridExtensions.PositionExtension(carrierGrid));
   carrierGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
   carrierGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
@@ -40,7 +40,7 @@ $(() => {
   carrierGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
   carrierGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   carrierGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
-  carrierGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  carrierGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   carrierGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
 
   const showcaseCard = new ShowcaseCard('carriersShowcaseCard');

--- a/admin-dev/themes/new-theme/js/pages/cart-rule/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/cart-rule/form/index.ts
@@ -23,7 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import GeneratableInput from '@components/generatable-input';
 import CartRuleMap from '@pages/cart-rule/cart-rule-map';
 import FormFieldToggler from '@components/form/form-field-toggler';
 import CartRuleEventMap from '@pages/cart-rule/cart-rule-event-map';
@@ -44,9 +43,10 @@ $(() => {
 
   window.prestashop.component.initComponents([
     'DisablingSwitch',
+    'GeneratableInput',
   ]);
 
-  new GeneratableInput().attachOn(CartRuleMap.codeGeneratorBtn);
+  window.prestashop.instance.generatableInput.attachOn(CartRuleMap.codeGeneratorBtn);
   new FormFieldToggler({
     disablingInputSelector: CartRuleMap.codeInput,
     targetSelector: CartRuleMap.highlightSwitchContainer,

--- a/admin-dev/themes/new-theme/js/pages/cart-rule/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/cart-rule/index.ts
@@ -23,30 +23,19 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
 
 const {$} = window;
 
 $(() => {
-  const cartRuleGrid = new Grid('cart_rule');
+  const cartRuleGrid = new window.prestashop.component.Grid('cart_rule');
 
-  cartRuleGrid.addExtension(new ExportToSqlManagerExtension());
-  cartRuleGrid.addExtension(new ReloadListActionExtension());
-  cartRuleGrid.addExtension(new SortingExtension());
-  cartRuleGrid.addExtension(new FiltersResetExtension());
-  cartRuleGrid.addExtension(new ColumnTogglingExtension());
-  cartRuleGrid.addExtension(new SubmitRowActionExtension());
-  cartRuleGrid.addExtension(new SubmitBulkExtension());
-  cartRuleGrid.addExtension(new BulkActionCheckboxExtension());
-  cartRuleGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/cart-rule/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/cart-rule/index.ts
@@ -30,12 +30,12 @@ $(() => {
   const cartRuleGrid = new window.prestashop.component.Grid('cart_rule');
 
   cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
-  cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
   cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
-  cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   cartRuleGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/cart-rule/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/cart-rule/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const cartRuleGrid = new window.prestashop.component.Grid('cart_rule');
 

--- a/admin-dev/themes/new-theme/js/pages/cart/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/cart/index.ts
@@ -24,9 +24,6 @@
  *
  */
 
-
-const {$} = window;
-
 $(() => {
   const grid = new window.prestashop.component.Grid('cart');
   grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());

--- a/admin-dev/themes/new-theme/js/pages/cart/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/cart/index.ts
@@ -30,11 +30,11 @@ const {$} = window;
 $(() => {
   const grid = new window.prestashop.component.Grid('cart');
   grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());

--- a/admin-dev/themes/new-theme/js/pages/cart/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/cart/index.ts
@@ -24,28 +24,18 @@
  *
  */
 
-import Grid from '@components/grid/grid';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
 
 const {$} = window;
 
 $(() => {
-  const grid = new Grid('cart');
-  grid.addExtension(new ExportToSqlManagerExtension());
-  grid.addExtension(new ReloadListActionExtension());
-  grid.addExtension(new FiltersResetExtension());
-  grid.addExtension(new SortingExtension());
-  grid.addExtension(new BulkActionCheckboxExtension());
-  grid.addExtension(new SubmitBulkExtension());
-  grid.addExtension(new SubmitRowActionExtension());
-  grid.addExtension(new LinkRowActionExtension());
-  grid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  const grid = new window.prestashop.component.Grid('cart');
+  grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/catalog-price-rule/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/catalog-price-rule/index.ts
@@ -30,11 +30,11 @@ $(() => {
   const priceRuleGrid = new window.prestashop.component.Grid('catalog_price_rule');
 
   priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
-  priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
-  priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/catalog-price-rule/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/catalog-price-rule/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const priceRuleGrid = new window.prestashop.component.Grid('catalog_price_rule');
 

--- a/admin-dev/themes/new-theme/js/pages/catalog-price-rule/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/catalog-price-rule/index.ts
@@ -23,27 +23,18 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
 
 const {$} = window;
 
 $(() => {
-  const priceRuleGrid = new Grid('catalog_price_rule');
+  const priceRuleGrid = new window.prestashop.component.Grid('catalog_price_rule');
 
-  priceRuleGrid.addExtension(new ExportToSqlManagerExtension());
-  priceRuleGrid.addExtension(new ReloadListActionExtension());
-  priceRuleGrid.addExtension(new SortingExtension());
-  priceRuleGrid.addExtension(new FiltersResetExtension());
-  priceRuleGrid.addExtension(new SubmitRowActionExtension());
-  priceRuleGrid.addExtension(new SubmitBulkExtension());
-  priceRuleGrid.addExtension(new BulkActionCheckboxExtension());
-  priceRuleGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  priceRuleGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/category/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/category/index.ts
@@ -23,17 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import ReloadListExtension from '@components/grid/extension/reload-list-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 import CategoryPositionExtension from '@components/grid/extension/column/catalog/category-position-extension';
-import AsyncToggleColumnExtension from '@components/grid/extension/column/common/async-toggle-column-extension';
 /* eslint-disable */
 import DeleteCategoryRowActionExtension from '@components/grid/extension/action/row/category/delete-category-row-action-extension';
 import DeleteCategoriesBulkActionExtension from '@components/grid/extension/action/bulk/category/delete-categories-bulk-action-extension';
@@ -41,7 +31,6 @@ import DeleteCategoriesBulkActionExtension from '@components/grid/extension/acti
 import ChoiceTable from '@components/choice-table';
 import textToLinkRewriteCopier from '@components/text-to-link-rewrite-copier';
 import FormSubmitButton from '@components/form-submit-button';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
 import ShowcaseCard from '@components/showcase-card/showcase-card';
 import ShowcaseCardCloseExtension from '@components/showcase-card/extension/showcase-card-close-extension';
 import Serp from '@app/utils/serp/index';
@@ -49,21 +38,21 @@ import Serp from '@app/utils/serp/index';
 const {$} = window;
 
 $(() => {
-  const categoriesGrid = new Grid('category');
+  const categoriesGrid = new window.prestashop.component.Grid('category');
 
-  categoriesGrid.addExtension(new FiltersResetExtension());
-  categoriesGrid.addExtension(new SortingExtension());
+  categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   categoriesGrid.addExtension(new CategoryPositionExtension(categoriesGrid));
-  categoriesGrid.addExtension(new ExportToSqlManagerExtension());
-  categoriesGrid.addExtension(new ReloadListExtension());
-  categoriesGrid.addExtension(new BulkActionCheckboxExtension());
-  categoriesGrid.addExtension(new SubmitBulkExtension());
-  categoriesGrid.addExtension(new SubmitRowActionExtension());
-  categoriesGrid.addExtension(new LinkRowActionExtension());
-  categoriesGrid.addExtension(new AsyncToggleColumnExtension());
+  categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
+  categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.AsyncToggleColumnExtension());
   categoriesGrid.addExtension(new DeleteCategoryRowActionExtension());
   categoriesGrid.addExtension(new DeleteCategoriesBulkActionExtension());
-  categoriesGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
   const showcaseCard = new ShowcaseCard('categoriesShowcaseCard');
   showcaseCard.addExtension(new ShowcaseCardCloseExtension());

--- a/admin-dev/themes/new-theme/js/pages/category/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/category/index.ts
@@ -28,7 +28,6 @@ import CategoryPositionExtension from '@components/grid/extension/column/catalog
 import DeleteCategoryRowActionExtension from '@components/grid/extension/action/row/category/delete-category-row-action-extension';
 import DeleteCategoriesBulkActionExtension from '@components/grid/extension/action/bulk/category/delete-categories-bulk-action-extension';
 /* eslint-enable */
-import ChoiceTable from '@components/choice-table';
 import textToLinkRewriteCopier from '@components/text-to-link-rewrite-copier';
 import FormSubmitButton from '@components/form-submit-button';
 import ShowcaseCard from '@components/showcase-card/showcase-card';
@@ -63,11 +62,11 @@ $(() => {
       'TinyMCEEditor',
       'TranslatableInput',
       'TextWithRecommendedLengthCounter',
+      'ChoiceTable',
     ],
   );
 
   const translatorInput = window.prestashop.instance.translatableInput;
-  new ChoiceTable();
 
   textToLinkRewriteCopier({
     sourceElementSelector: 'input[name^="category[name]"]',

--- a/admin-dev/themes/new-theme/js/pages/category/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/category/index.ts
@@ -46,7 +46,7 @@ $(() => {
   categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   categoriesGrid.addExtension(new window.prestashop.component.GridExtensions.AsyncToggleColumnExtension());

--- a/admin-dev/themes/new-theme/js/pages/cms-page/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/cms-page/form/index.ts
@@ -23,7 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import ChoiceTree from '@components/form/choice-tree';
 import textToLinkRewriteCopier from '@components/text-to-link-rewrite-copier';
 import Serp from '@app/utils/serp/index';
 import TextWithRecommendedLengthCounter from '@components/form/text-with-recommended-length-counter';
@@ -31,7 +30,7 @@ import TextWithRecommendedLengthCounter from '@components/form/text-with-recomme
 const {$} = window;
 
 $(() => {
-  new ChoiceTree('#cms_page_page_category_id');
+  new window.prestashop.component.ChoiceTree('#cms_page_page_category_id');
 
   window.prestashop.component.initComponents(
     [
@@ -72,7 +71,7 @@ $(() => {
     destinationElementSelector: `${translatorInput.localeInputSelector}:not(.d-none) input.js-copier-destination-friendly-url`,
   });
 
-  new ChoiceTree('#cms_page_shop_association').enableAutoCheckChildren();
+  new window.prestashop.component.ChoiceTree('#cms_page_shop_association').enableAutoCheckChildren();
 
   new TextWithRecommendedLengthCounter();
 });

--- a/admin-dev/themes/new-theme/js/pages/cms-page/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/cms-page/form/index.ts
@@ -25,7 +25,6 @@
 
 import textToLinkRewriteCopier from '@components/text-to-link-rewrite-copier';
 import Serp from '@app/utils/serp/index';
-import TextWithRecommendedLengthCounter from '@components/form/text-with-recommended-length-counter';
 
 const {$} = window;
 
@@ -37,6 +36,7 @@ $(() => {
       'TranslatableInput',
       'TranslatableField',
       'TinyMCEEditor',
+      'TextWithRecommendedLengthCounter',
     ],
   );
 
@@ -72,6 +72,4 @@ $(() => {
   });
 
   new window.prestashop.component.ChoiceTree('#cms_page_shop_association').enableAutoCheckChildren();
-
-  new TextWithRecommendedLengthCounter();
 });

--- a/admin-dev/themes/new-theme/js/pages/cms-page/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/cms-page/index.ts
@@ -23,10 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import ChoiceTree from '@components/form/choice-tree';
-import TranslatableInput from '@components/translatable-input';
 import textToLinkRewriteCopier from '@components/text-to-link-rewrite-copier';
-import TaggableField from '@components/taggable-field';
 import ShowcaseCard from '@components/showcase-card/showcase-card';
 import ShowcaseCardCloseExtension from '@components/showcase-card/extension/showcase-card-close-extension';
 
@@ -47,7 +44,13 @@ $(() => {
   cmsCategory.addExtension(new window.prestashop.component.GridExtensions.PositionExtension(cmsCategory));
   cmsCategory.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
-  const translatorInput = new TranslatableInput();
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+    ],
+  );
+
+  const translatorInput = window.prestashop.instance.translatableInput;
 
   textToLinkRewriteCopier({
     sourceElementSelector: 'input[name^="cms_page_category[name]"]',
@@ -55,12 +58,12 @@ $(() => {
     destinationElementSelector: `${translatorInput.localeInputSelector}:not(.d-none) input[name^="cms_page_category[friendly_url]"]`,
   });
 
-  new ChoiceTree('#cms_page_category_parent_category');
+  new window.prestashop.component.ChoiceTree('#cms_page_category_parent_category');
 
-  const shopChoiceTree = new ChoiceTree('#cms_page_category_shop_association');
+  const shopChoiceTree = new window.prestashop.component.ChoiceTree('#cms_page_category_shop_association');
   shopChoiceTree.enableAutoCheckChildren();
 
-  new TaggableField({
+  new window.prestashop.component.TaggableField({
     tokenFieldSelector: 'input[name^="cms_page_category[meta_keywords]"]',
     options: {
       createTokensOnBlur: true,

--- a/admin-dev/themes/new-theme/js/pages/cms-page/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/cms-page/index.ts
@@ -23,21 +23,9 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
-import PositionExtension from '@components/grid/extension/position-extension';
 import ChoiceTree from '@components/form/choice-tree';
 import TranslatableInput from '@components/translatable-input';
 import textToLinkRewriteCopier from '@components/text-to-link-rewrite-copier';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
 import TaggableField from '@components/taggable-field';
 import ShowcaseCard from '@components/showcase-card/showcase-card';
 import ShowcaseCardCloseExtension from '@components/showcase-card/extension/showcase-card-close-extension';
@@ -45,19 +33,19 @@ import ShowcaseCardCloseExtension from '@components/showcase-card/extension/show
 const {$} = window;
 
 $(() => {
-  const cmsCategory = new Grid('cms_page_category');
+  const cmsCategory = new window.prestashop.component.Grid('cms_page_category');
 
-  cmsCategory.addExtension(new ReloadListActionExtension());
-  cmsCategory.addExtension(new ExportToSqlManagerExtension());
-  cmsCategory.addExtension(new FiltersResetExtension());
-  cmsCategory.addExtension(new SortingExtension());
-  cmsCategory.addExtension(new LinkRowActionExtension());
-  cmsCategory.addExtension(new SubmitBulkExtension());
-  cmsCategory.addExtension(new BulkActionCheckboxExtension());
-  cmsCategory.addExtension(new SubmitRowActionExtension());
-  cmsCategory.addExtension(new ColumnTogglingExtension());
-  cmsCategory.addExtension(new PositionExtension(cmsCategory));
-  cmsCategory.addExtension(new FiltersSubmitButtonEnablerExtension());
+  cmsCategory.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  cmsCategory.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  cmsCategory.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  cmsCategory.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  cmsCategory.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  cmsCategory.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  cmsCategory.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  cmsCategory.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  cmsCategory.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  cmsCategory.addExtension(new window.prestashop.component.GridExtensions.PositionExtension(cmsCategory));
+  cmsCategory.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
   const translatorInput = new TranslatableInput();
 
@@ -79,18 +67,18 @@ $(() => {
     },
   });
 
-  const cmsGrid = new Grid('cms_page');
-  cmsGrid.addExtension(new ReloadListActionExtension());
-  cmsGrid.addExtension(new ExportToSqlManagerExtension());
-  cmsGrid.addExtension(new FiltersResetExtension());
-  cmsGrid.addExtension(new SortingExtension());
-  cmsGrid.addExtension(new ColumnTogglingExtension());
-  cmsGrid.addExtension(new BulkActionCheckboxExtension());
-  cmsGrid.addExtension(new SubmitBulkExtension());
-  cmsGrid.addExtension(new SubmitRowActionExtension());
-  cmsGrid.addExtension(new PositionExtension(cmsGrid));
-  cmsGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  cmsGrid.addExtension(new LinkRowActionExtension());
+  const cmsGrid = new window.prestashop.component.Grid('cms_page');
+  cmsGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  cmsGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  cmsGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  cmsGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  cmsGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  cmsGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  cmsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  cmsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  cmsGrid.addExtension(new window.prestashop.component.GridExtensions.PositionExtension(cmsGrid));
+  cmsGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  cmsGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 
   const helperBlock = new ShowcaseCard('cms-pages-showcase-card');
   helperBlock.addExtension(new ShowcaseCardCloseExtension());

--- a/admin-dev/themes/new-theme/js/pages/cms-page/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/cms-page/index.ts
@@ -35,12 +35,12 @@ const {$} = window;
 $(() => {
   const cmsCategory = new window.prestashop.component.Grid('cms_page_category');
 
-  cmsCategory.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  cmsCategory.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   cmsCategory.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   cmsCategory.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   cmsCategory.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   cmsCategory.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
-  cmsCategory.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  cmsCategory.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   cmsCategory.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   cmsCategory.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   cmsCategory.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
@@ -68,13 +68,13 @@ $(() => {
   });
 
   const cmsGrid = new window.prestashop.component.Grid('cms_page');
-  cmsGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  cmsGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   cmsGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   cmsGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   cmsGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   cmsGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
   cmsGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  cmsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  cmsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   cmsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   cmsGrid.addExtension(new window.prestashop.component.GridExtensions.PositionExtension(cmsGrid));
   cmsGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());

--- a/admin-dev/themes/new-theme/js/pages/contacts/ContactsPage.ts
+++ b/admin-dev/themes/new-theme/js/pages/contacts/ContactsPage.ts
@@ -23,16 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
 import TranslatableInput from '@components/translatable-input';
 import ChoiceTree from '@components/form/choice-tree';
 
@@ -41,17 +31,17 @@ import ChoiceTree from '@components/form/choice-tree';
  */
 export default class ContactsPage {
   constructor() {
-    const contactGrid = new Grid('contact');
+    const contactGrid = new window.prestashop.component.Grid('contact');
 
-    contactGrid.addExtension(new ReloadListActionExtension());
-    contactGrid.addExtension(new ExportToSqlManagerExtension());
-    contactGrid.addExtension(new FiltersResetExtension());
-    contactGrid.addExtension(new SortingExtension());
-    contactGrid.addExtension(new LinkRowActionExtension());
-    contactGrid.addExtension(new SubmitGridExtension());
-    contactGrid.addExtension(new SubmitBulkExtension());
-    contactGrid.addExtension(new BulkActionCheckboxExtension());
-    contactGrid.addExtension(new SubmitRowActionExtension());
+    contactGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+    contactGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+    contactGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+    contactGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+    contactGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+    contactGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+    contactGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+    contactGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+    contactGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
 
     new TranslatableInput();
 

--- a/admin-dev/themes/new-theme/js/pages/contacts/ContactsPage.ts
+++ b/admin-dev/themes/new-theme/js/pages/contacts/ContactsPage.ts
@@ -33,13 +33,13 @@ export default class ContactsPage {
   constructor() {
     const contactGrid = new window.prestashop.component.Grid('contact');
 
-    contactGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+    contactGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
     contactGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
     contactGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
     contactGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
     contactGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
-    contactGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
-    contactGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+    contactGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
+    contactGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
     contactGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
     contactGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
 

--- a/admin-dev/themes/new-theme/js/pages/contacts/ContactsPage.ts
+++ b/admin-dev/themes/new-theme/js/pages/contacts/ContactsPage.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import TranslatableInput from '@components/translatable-input';
-import ChoiceTree from '@components/form/choice-tree';
-
 /**
  * Responsible for actions in Contacts listing page.
  */
@@ -43,8 +40,12 @@ export default class ContactsPage {
     contactGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
     contactGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
 
-    new TranslatableInput();
+    window.prestashop.component.initComponents(
+      [
+        'TranslatableInput',
+      ],
+    );
 
-    new ChoiceTree('#contact_shop_association').enableAutoCheckChildren();
+    new window.prestashop.component.ChoiceTree('#contact_shop_association').enableAutoCheckChildren();
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/country/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/country/form/index.ts
@@ -25,12 +25,16 @@
 
 import ZipCodeManager from '@pages/country/components/zip-code-manager';
 import FormSubmitButton from '@components/form-submit-button';
-import TranslatableInput from '@components/translatable-input';
 
 const {$} = window;
 
 $(() => {
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+    ],
+  );
+
   new FormSubmitButton();
-  new TranslatableInput();
   new ZipCodeManager();
 });

--- a/admin-dev/themes/new-theme/js/pages/country/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/country/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const countryGrid = new window.prestashop.component.Grid('country');
 

--- a/admin-dev/themes/new-theme/js/pages/country/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/country/index.ts
@@ -34,7 +34,7 @@ $(() => {
   countryGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   countryGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   countryGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  countryGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  countryGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   countryGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   countryGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   countryGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());

--- a/admin-dev/themes/new-theme/js/pages/country/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/country/index.ts
@@ -23,31 +23,20 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import ReloadListExtension from '@components/grid/extension/reload-list-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
 
 const {$} = window;
 
 $(() => {
-  const countryGrid = new Grid('country');
+  const countryGrid = new window.prestashop.component.Grid('country');
 
-  countryGrid.addExtension(new FiltersResetExtension());
-  countryGrid.addExtension(new SortingExtension());
-  countryGrid.addExtension(new ExportToSqlManagerExtension());
-  countryGrid.addExtension(new ReloadListExtension());
-  countryGrid.addExtension(new BulkActionCheckboxExtension());
-  countryGrid.addExtension(new SubmitBulkExtension());
-  countryGrid.addExtension(new SubmitRowActionExtension());
-  countryGrid.addExtension(new LinkRowActionExtension());
-  countryGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  countryGrid.addExtension(new ColumnTogglingExtension());
+  countryGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  countryGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  countryGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  countryGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
+  countryGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  countryGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  countryGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  countryGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  countryGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  countryGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/credit-slip/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/credit-slip/index.ts
@@ -23,10 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import TranslatableInput from '../../components/translatable-input';
-
-const {$} = window;
-
 $(() => {
   const creditSlipGrid = new window.prestashop.component.Grid('credit_slip');
 
@@ -36,5 +32,9 @@ $(() => {
   creditSlipGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   creditSlipGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
-  new TranslatableInput();
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+    ],
+  );
 });

--- a/admin-dev/themes/new-theme/js/pages/credit-slip/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/credit-slip/index.ts
@@ -31,7 +31,7 @@ $(() => {
   const creditSlipGrid = new window.prestashop.component.Grid('credit_slip');
 
   creditSlipGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
-  creditSlipGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  creditSlipGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   creditSlipGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   creditSlipGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   creditSlipGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());

--- a/admin-dev/themes/new-theme/js/pages/credit-slip/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/credit-slip/index.ts
@@ -23,24 +23,18 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '../../components/grid/grid';
-import SortingExtension from '../../components/grid/extension/sorting-extension';
-import FiltersResetExtension from '../../components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '../../components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '../../components/grid/extension/export-to-sql-manager-extension';
 import TranslatableInput from '../../components/translatable-input';
-import FiltersSubmitButtonEnablerExtension from '../../components/grid/extension/filters-submit-button-enabler-extension';
 
 const {$} = window;
 
 $(() => {
-  const creditSlipGrid = new Grid('credit_slip');
+  const creditSlipGrid = new window.prestashop.component.Grid('credit_slip');
 
-  creditSlipGrid.addExtension(new ExportToSqlManagerExtension());
-  creditSlipGrid.addExtension(new ReloadListActionExtension());
-  creditSlipGrid.addExtension(new SortingExtension());
-  creditSlipGrid.addExtension(new FiltersResetExtension());
-  creditSlipGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  creditSlipGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  creditSlipGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  creditSlipGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  creditSlipGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  creditSlipGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
   new TranslatableInput();
 });

--- a/admin-dev/themes/new-theme/js/pages/currency/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/currency/index.ts
@@ -31,11 +31,11 @@ $(() => {
   const currency = new window.prestashop.component.Grid('currency');
 
   currency.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  currency.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  currency.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   currency.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   currency.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   currency.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
-  currency.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  currency.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   currency.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
   currency.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   currency.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());

--- a/admin-dev/themes/new-theme/js/pages/currency/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/currency/index.ts
@@ -23,34 +23,23 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
 import ExchangeRatesUpdateScheduler from '@pages/currency/ExchangeRatesUpdateScheduler';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 
 const {$} = window;
 
 $(() => {
-  const currency = new Grid('currency');
+  const currency = new window.prestashop.component.Grid('currency');
 
-  currency.addExtension(new BulkActionCheckboxExtension());
-  currency.addExtension(new SubmitBulkExtension());
-  currency.addExtension(new ExportToSqlManagerExtension());
-  currency.addExtension(new SortingExtension());
-  currency.addExtension(new FiltersResetExtension());
-  currency.addExtension(new ReloadListActionExtension());
-  currency.addExtension(new ColumnTogglingExtension());
-  currency.addExtension(new SubmitRowActionExtension());
-  currency.addExtension(new FiltersSubmitButtonEnablerExtension());
-  currency.addExtension(new LinkRowActionExtension());
+  currency.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  currency.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  currency.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  currency.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  currency.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  currency.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  currency.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  currency.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  currency.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  currency.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 
   new ExchangeRatesUpdateScheduler();
 });

--- a/admin-dev/themes/new-theme/js/pages/customer-groups/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer-groups/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const customerGroups = new window.prestashop.component.Grid('customer_groups');
 

--- a/admin-dev/themes/new-theme/js/pages/customer-groups/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer-groups/index.ts
@@ -30,11 +30,11 @@ $(() => {
   const customerGroups = new window.prestashop.component.Grid('customer_groups');
 
   customerGroups.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  customerGroups.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  customerGroups.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   customerGroups.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   customerGroups.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   customerGroups.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
-  customerGroups.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  customerGroups.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   customerGroups.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
   customerGroups.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   customerGroups.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());

--- a/admin-dev/themes/new-theme/js/pages/customer-groups/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer-groups/index.ts
@@ -23,31 +23,20 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 
 const {$} = window;
 
 $(() => {
-  const customerGroups = new Grid('customer_groups');
+  const customerGroups = new window.prestashop.component.Grid('customer_groups');
 
-  customerGroups.addExtension(new BulkActionCheckboxExtension());
-  customerGroups.addExtension(new SubmitBulkExtension());
-  customerGroups.addExtension(new ExportToSqlManagerExtension());
-  customerGroups.addExtension(new SortingExtension());
-  customerGroups.addExtension(new FiltersResetExtension());
-  customerGroups.addExtension(new ReloadListActionExtension());
-  customerGroups.addExtension(new ColumnTogglingExtension());
-  customerGroups.addExtension(new SubmitRowActionExtension());
-  customerGroups.addExtension(new FiltersSubmitButtonEnablerExtension());
-  customerGroups.addExtension(new LinkRowActionExtension());
+  customerGroups.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  customerGroups.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  customerGroups.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  customerGroups.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  customerGroups.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  customerGroups.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  customerGroups.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  customerGroups.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  customerGroups.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  customerGroups.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/customer-thread/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer-thread/index.ts
@@ -23,37 +23,23 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
-import ChoiceExtension from '@components/grid/extension/choice-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
-import PositionExtension from '@components/grid/extension/position-extension';
 
 const {$} = window;
 
 $(() => {
-  const grid = new Grid('customer_thread');
+  const grid = new window.prestashop.component.Grid('customer_thread');
 
-  grid.addExtension(new FiltersResetExtension());
-  grid.addExtension(new ReloadListActionExtension());
-  grid.addExtension(new ExportToSqlManagerExtension());
-  grid.addExtension(new SortingExtension());
-  grid.addExtension(new LinkRowActionExtension());
-  grid.addExtension(new SubmitGridExtension());
-  grid.addExtension(new SubmitBulkExtension());
-  grid.addExtension(new BulkActionCheckboxExtension());
-  grid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  grid.addExtension(new ColumnTogglingExtension());
-  grid.addExtension(new SubmitRowActionExtension());
-  grid.addExtension(new ChoiceExtension());
-  grid.addExtension(new PositionExtension(grid));
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ChoiceExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.PositionExtension(grid));
 });

--- a/admin-dev/themes/new-theme/js/pages/customer-thread/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer-thread/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const grid = new window.prestashop.component.Grid('customer_thread');
 

--- a/admin-dev/themes/new-theme/js/pages/customer-thread/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer-thread/index.ts
@@ -30,12 +30,12 @@ $(() => {
   const grid = new window.prestashop.component.Grid('customer_thread');
 
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());

--- a/admin-dev/themes/new-theme/js/pages/customer/form.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/form.ts
@@ -23,12 +23,14 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import ChoiceTable from '@components/choice-table';
 import CustomerForm from './CustomerForm';
 
 $(() => {
   new CustomerForm();
 
-  // needed for "Group access" input in Add/Edit customer forms
-  new ChoiceTable();
+  window.prestashop.component.initComponents(
+    [
+      'ChoiceTable',
+    ],
+  );
 });

--- a/admin-dev/themes/new-theme/js/pages/customer/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/index.ts
@@ -23,71 +23,58 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
 import FormSubmitButton from '@components/form-submit-button';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 import LinkableItem from '@components/linkable-item';
 import DeleteCustomersBulkActionExtension
   from '@components/grid/extension/action/bulk/customer/delete-customers-bulk-action-extension';
 import DeleteCustomerRowActionExtension
   from '@components/grid/extension/action/row/customer/delete-customer-row-action-extension';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
 import ShowcaseCard from '@components/showcase-card/showcase-card';
 import ShowcaseCardCloseExtension from '@components/showcase-card/extension/showcase-card-close-extension';
-import AsyncToggleColumnExtension from '@components/grid/extension/column/common/async-toggle-column-extension';
 import CustomerFormMap from '@pages/customer/customer-form-map';
 
 const {$} = window;
 
 $(() => {
-  const customerGrid = new Grid('customer');
+  const customerGrid = new window.prestashop.component.Grid('customer');
 
-  customerGrid.addExtension(new ReloadListActionExtension());
-  customerGrid.addExtension(new ExportToSqlManagerExtension());
-  customerGrid.addExtension(new FiltersResetExtension());
-  customerGrid.addExtension(new SortingExtension());
-  customerGrid.addExtension(new BulkActionCheckboxExtension());
-  customerGrid.addExtension(new SubmitBulkExtension());
-  customerGrid.addExtension(new SubmitGridExtension());
-  customerGrid.addExtension(new LinkRowActionExtension());
+  customerGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  customerGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  customerGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  customerGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  customerGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  customerGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  customerGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  customerGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   customerGrid.addExtension(new DeleteCustomersBulkActionExtension());
   customerGrid.addExtension(new DeleteCustomerRowActionExtension());
-  customerGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  customerGrid.addExtension(new AsyncToggleColumnExtension());
+  customerGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  customerGrid.addExtension(new window.prestashop.component.GridExtensions.AsyncToggleColumnExtension());
 
-  const customerDiscountsGrid = new Grid('customer_discount');
-  customerDiscountsGrid.addExtension(new SubmitRowActionExtension());
-  customerDiscountsGrid.addExtension(new LinkRowActionExtension());
+  const customerDiscountsGrid = new window.prestashop.component.Grid('customer_discount');
+  customerDiscountsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  customerDiscountsGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 
-  const customerAddressesGrid = new Grid('customer_address');
-  customerAddressesGrid.addExtension(new SubmitRowActionExtension());
-  customerAddressesGrid.addExtension(new SortingExtension());
-  customerAddressesGrid.addExtension(new LinkRowActionExtension());
+  const customerAddressesGrid = new window.prestashop.component.Grid('customer_address');
+  customerAddressesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  customerAddressesGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  customerAddressesGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 
-  const customerOrdersGrid = new Grid('customer_order');
-  customerOrdersGrid.addExtension(new SortingExtension());
-  customerOrdersGrid.addExtension(new SubmitRowActionExtension());
-  customerOrdersGrid.addExtension(new LinkRowActionExtension());
+  const customerOrdersGrid = new window.prestashop.component.Grid('customer_order');
+  customerOrdersGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  customerOrdersGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  customerOrdersGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 
-  const customerCartsGrid = new Grid('customer_cart');
-  customerCartsGrid.addExtension(new SortingExtension());
-  customerCartsGrid.addExtension(new SubmitRowActionExtension());
-  customerCartsGrid.addExtension(new LinkRowActionExtension());
+  const customerCartsGrid = new window.prestashop.component.Grid('customer_cart');
+  customerCartsGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  customerCartsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  customerCartsGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 
-  const customerBoughtProductsGrid = new Grid('customer_bought_product');
-  customerBoughtProductsGrid.addExtension(new SortingExtension());
+  const customerBoughtProductsGrid = new window.prestashop.component.Grid('customer_bought_product');
+  customerBoughtProductsGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
 
-  const customerViewedProductsGrid = new Grid('customer_viewed_product');
-  customerViewedProductsGrid.addExtension(new SortingExtension());
+  const customerViewedProductsGrid = new window.prestashop.component.Grid('customer_viewed_product');
+  customerViewedProductsGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
 
   const showcaseCard = new ShowcaseCard('customersShowcaseCard');
   showcaseCard.addExtension(new ShowcaseCardCloseExtension());

--- a/admin-dev/themes/new-theme/js/pages/customer/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/index.ts
@@ -38,13 +38,13 @@ const {$} = window;
 $(() => {
   const customerGrid = new window.prestashop.component.Grid('customer');
 
-  customerGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  customerGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   customerGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   customerGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   customerGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   customerGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  customerGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
-  customerGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  customerGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
+  customerGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
   customerGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   customerGrid.addExtension(new DeleteCustomersBulkActionExtension());
   customerGrid.addExtension(new DeleteCustomerRowActionExtension());

--- a/admin-dev/themes/new-theme/js/pages/email/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/email/index.ts
@@ -32,14 +32,14 @@ const {$} = window;
 $(() => {
   const emailLogsGrid = new window.prestashop.component.Grid('email_logs');
 
-  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
-  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
   emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 

--- a/admin-dev/themes/new-theme/js/pages/email/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/email/index.ts
@@ -26,34 +26,22 @@
 import EmailSendingTest from '@pages/email/email-sending-test';
 import SmtpConfigurationToggler from '@pages/email/smtp-configuration-toggler';
 import DkimConfigurationToggler from '@pages/email/dkim-configuration-toggler';
-import Grid from '@components/grid/grid';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
 
 const {$} = window;
 
 $(() => {
-  const emailLogsGrid = new Grid('email_logs');
+  const emailLogsGrid = new window.prestashop.component.Grid('email_logs');
 
-  emailLogsGrid.addExtension(new ReloadListActionExtension());
-  emailLogsGrid.addExtension(new ExportToSqlManagerExtension());
-  emailLogsGrid.addExtension(new FiltersResetExtension());
-  emailLogsGrid.addExtension(new SortingExtension());
-  emailLogsGrid.addExtension(new BulkActionCheckboxExtension());
-  emailLogsGrid.addExtension(new SubmitBulkExtension());
-  emailLogsGrid.addExtension(new SubmitRowActionExtension());
-  emailLogsGrid.addExtension(new SubmitGridExtension());
-  emailLogsGrid.addExtension(new LinkRowActionExtension());
-  emailLogsGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  emailLogsGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
   new EmailSendingTest();
   new SmtpConfigurationToggler();

--- a/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
@@ -43,7 +43,7 @@ export default class EmployeeForm {
 
   constructor() {
     this.shopChoiceTreeSelector = employeeFormMap.shopChoiceTree;
-    this.shopChoiceTree = new ChoiceTree(this.shopChoiceTreeSelector);
+    this.shopChoiceTree = new window.prestashop.component.ChoiceTree(this.shopChoiceTreeSelector);
     this.employeeProfileSelector = employeeFormMap.profileSelect;
     this.tabsDropdownSelector = employeeFormMap.defaultPageSelect;
 

--- a/admin-dev/themes/new-theme/js/pages/employee/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/employee/index.ts
@@ -31,7 +31,7 @@ const {$} = window;
 $(() => {
   const employeeGrid = new window.prestashop.component.Grid('employee');
 
-  employeeGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  employeeGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   employeeGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   employeeGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   employeeGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());

--- a/admin-dev/themes/new-theme/js/pages/employee/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/employee/index.ts
@@ -23,36 +23,24 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
-import Grid from '@components/grid/grid';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkActionExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
 import ShowcaseCard from '@components/showcase-card/showcase-card';
 import ShowcaseCardCloseExtension from '@components/showcase-card/extension/showcase-card-close-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 
 const {$} = window;
 
 $(() => {
-  const employeeGrid = new Grid('employee');
+  const employeeGrid = new window.prestashop.component.Grid('employee');
 
-  employeeGrid.addExtension(new ReloadListActionExtension());
-  employeeGrid.addExtension(new ExportToSqlManagerExtension());
-  employeeGrid.addExtension(new FiltersResetExtension());
-  employeeGrid.addExtension(new SortingExtension());
-  employeeGrid.addExtension(new BulkActionCheckboxExtension());
-  employeeGrid.addExtension(new SubmitBulkActionExtension());
-  employeeGrid.addExtension(new SubmitRowActionExtension());
-  employeeGrid.addExtension(new ColumnTogglingExtension());
-  employeeGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  employeeGrid.addExtension(new LinkRowActionExtension());
+  employeeGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  employeeGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  employeeGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  employeeGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  employeeGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  employeeGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
+  employeeGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  employeeGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  employeeGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  employeeGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 
   const showcaseCard = new ShowcaseCard('employeesShowcaseCard');
   showcaseCard.addExtension(new ShowcaseCardCloseExtension());

--- a/admin-dev/themes/new-theme/js/pages/feature/feature-value/form.ts
+++ b/admin-dev/themes/new-theme/js/pages/feature/feature-value/form.ts
@@ -23,8 +23,10 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import TranslatableInput from '@components/translatable-input';
-
 $(() => {
-  new TranslatableInput();
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+    ],
+  );
 });

--- a/admin-dev/themes/new-theme/js/pages/feature/feature-value/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/feature/feature-value/index.ts
@@ -23,29 +23,19 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
-import Grid from '@components/grid/grid';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
 
 const {$} = window;
 
 $(() => {
-  const grid = new Grid('feature_value');
+  const grid = new window.prestashop.component.Grid('feature_value');
 
-  grid.addExtension(new ExportToSqlManagerExtension());
-  grid.addExtension(new FiltersResetExtension());
-  grid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  grid.addExtension(new ReloadListActionExtension());
-  grid.addExtension(new SortingExtension());
-  grid.addExtension(new SubmitRowActionExtension());
-  grid.addExtension(new SubmitBulkExtension());
-  grid.addExtension(new LinkRowActionExtension());
-  grid.addExtension(new BulkActionCheckboxExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/feature/feature-value/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/feature/feature-value/index.ts
@@ -32,10 +32,10 @@ $(() => {
   grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/feature/feature-value/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/feature/feature-value/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const grid = new window.prestashop.component.Grid('feature_value');
 

--- a/admin-dev/themes/new-theme/js/pages/feature/form.ts
+++ b/admin-dev/themes/new-theme/js/pages/feature/form.ts
@@ -23,10 +23,11 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import TranslatableInput from '../../components/translatable-input';
-import ChoiceTree from '../../components/form/choice-tree';
-
 $(() => {
-  new TranslatableInput();
-  new ChoiceTree('#feature_shop_association').enableAutoCheckChildren();
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+    ],
+  );
+  new window.prestashop.component.ChoiceTree('#feature_shop_association').enableAutoCheckChildren();
 });

--- a/admin-dev/themes/new-theme/js/pages/feature/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/feature/index.ts
@@ -32,11 +32,11 @@ $(() => {
   const grid = new window.prestashop.component.Grid('feature');
 
   grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());

--- a/admin-dev/themes/new-theme/js/pages/feature/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/feature/index.ts
@@ -23,36 +23,24 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 import ShowcaseCardCloseExtension from '@components/showcase-card/extension/showcase-card-close-extension';
 import ShowcaseCard from '@components/showcase-card/showcase-card';
-import PositionExtension from '@components/grid/extension/position-extension';
 
 const {$} = window;
 
 $(() => {
-  const grid = new Grid('feature');
+  const grid = new window.prestashop.component.Grid('feature');
 
-  grid.addExtension(new ExportToSqlManagerExtension());
-  grid.addExtension(new ReloadListActionExtension());
-  grid.addExtension(new SortingExtension());
-  grid.addExtension(new FiltersResetExtension());
-  grid.addExtension(new SubmitRowActionExtension());
-  grid.addExtension(new SubmitBulkExtension());
-  grid.addExtension(new BulkActionCheckboxExtension());
-  grid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  grid.addExtension(new LinkRowActionExtension());
-  grid.addExtension(new PositionExtension(grid));
+  grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.PositionExtension(grid));
 
   const showcaseCard = new ShowcaseCard('featuresShowcaseCard');
   showcaseCard.addExtension(new ShowcaseCardCloseExtension());

--- a/admin-dev/themes/new-theme/js/pages/image-settings/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/image-settings/index.ts
@@ -23,18 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
-import ChoiceExtension from '@components/grid/extension/choice-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
 import DeleteImageTypeRowActionExtension
   from '@components/grid/extension/action/row/image_type/delete-image-type-row-action-extension';
 import ConfirmModal from '@components/modal/confirm-modal';
@@ -43,18 +31,18 @@ const {$} = window;
 
 $(() => {
   // Init image type grid
-  const grid = new Grid('image_type');
-  grid.addExtension(new FiltersResetExtension());
-  grid.addExtension(new ReloadListActionExtension());
-  grid.addExtension(new ExportToSqlManagerExtension());
-  grid.addExtension(new SortingExtension());
-  grid.addExtension(new LinkRowActionExtension());
-  grid.addExtension(new SubmitBulkExtension());
-  grid.addExtension(new BulkActionCheckboxExtension());
-  grid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  grid.addExtension(new ChoiceExtension());
-  grid.addExtension(new ColumnTogglingExtension());
-  grid.addExtension(new SubmitRowActionExtension());
+  const grid = new window.prestashop.component.Grid('image_type');
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ChoiceExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   grid.addExtension(new DeleteImageTypeRowActionExtension());
 
   // Regenerate thumbnails system

--- a/admin-dev/themes/new-theme/js/pages/image-settings/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/image-settings/index.ts
@@ -33,11 +33,11 @@ $(() => {
   // Init image type grid
   const grid = new window.prestashop.component.Grid('image_type');
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.ChoiceExtension());

--- a/admin-dev/themes/new-theme/js/pages/invoices/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/invoices/index.ts
@@ -24,17 +24,16 @@
  */
 
 import initDatePickers from '@app/utils/datepicker';
-import TranslatableInput from '@components/translatable-input';
 
 const {$} = window;
 
 $(() => {
   initDatePickers();
-  new TranslatableInput();
 
   window.prestashop.component.initComponents(
     [
       'MultistoreConfigField',
+      'TranslatableInput',
     ],
   );
 });

--- a/admin-dev/themes/new-theme/js/pages/language/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/language/index.ts
@@ -23,10 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import ChoiceTree from '@components/form/choice-tree';
-
-const {$} = window;
-
 $(() => {
   const grid = new window.prestashop.component.Grid('language');
 
@@ -42,5 +38,5 @@ $(() => {
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
   // needed for shop association input in form
-  new ChoiceTree('#language_shop_association').enableAutoCheckChildren();
+  new window.prestashop.component.ChoiceTree('#language_shop_association').enableAutoCheckChildren();
 });

--- a/admin-dev/themes/new-theme/js/pages/language/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/language/index.ts
@@ -23,35 +23,23 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
 import ChoiceTree from '@components/form/choice-tree';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
 
 const {$} = window;
 
 $(() => {
-  const grid = new Grid('language');
+  const grid = new window.prestashop.component.Grid('language');
 
-  grid.addExtension(new ReloadListActionExtension());
-  grid.addExtension(new ExportToSqlManagerExtension());
-  grid.addExtension(new FiltersResetExtension());
-  grid.addExtension(new SortingExtension());
-  grid.addExtension(new LinkRowActionExtension());
-  grid.addExtension(new SubmitBulkExtension());
-  grid.addExtension(new SubmitRowActionExtension());
-  grid.addExtension(new BulkActionCheckboxExtension());
-  grid.addExtension(new ColumnTogglingExtension());
-  grid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
   // needed for shop association input in form
   new ChoiceTree('#language_shop_association').enableAutoCheckChildren();

--- a/admin-dev/themes/new-theme/js/pages/language/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/language/index.ts
@@ -30,12 +30,12 @@ const {$} = window;
 $(() => {
   const grid = new window.prestashop.component.Grid('language');
 
-  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());

--- a/admin-dev/themes/new-theme/js/pages/logs/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/logs/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const grid = new window.prestashop.component.Grid('logs');
 

--- a/admin-dev/themes/new-theme/js/pages/logs/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/logs/index.ts
@@ -29,7 +29,7 @@ const {$} = window;
 $(() => {
   const grid = new window.prestashop.component.Grid('logs');
 
-  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());

--- a/admin-dev/themes/new-theme/js/pages/logs/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/logs/index.ts
@@ -23,24 +23,16 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import SubmitGridActionExtension from '@components/grid/extension/submit-grid-action-extension';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
 
 const {$} = window;
 
 $(() => {
-  const grid = new Grid('logs');
+  const grid = new window.prestashop.component.Grid('logs');
 
-  grid.addExtension(new ReloadListActionExtension());
-  grid.addExtension(new ExportToSqlManagerExtension());
-  grid.addExtension(new FiltersResetExtension());
-  grid.addExtension(new SortingExtension());
-  grid.addExtension(new SubmitGridActionExtension());
-  grid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/manufacturer/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/manufacturer/index.ts
@@ -31,12 +31,12 @@ $(() => {
   ['manufacturer', 'manufacturer_address'].forEach((gridName) => {
     const grid = new Grid(gridName);
     grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
-    grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
-    grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());

--- a/admin-dev/themes/new-theme/js/pages/manufacturer/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/manufacturer/index.ts
@@ -29,7 +29,7 @@ const {$} = window;
 
 $(() => {
   ['manufacturer', 'manufacturer_address'].forEach((gridName) => {
-    const grid = new Grid(gridName);
+    const grid = new window.prestashop.component.Grid(gridName);
     grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());

--- a/admin-dev/themes/new-theme/js/pages/manufacturer/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/manufacturer/index.ts
@@ -24,34 +24,22 @@
  */
 
 import FormSubmitButton from '@components/form-submit-button';
-import Grid from '@components/grid/grid';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 
 const {$} = window;
 
 $(() => {
   ['manufacturer', 'manufacturer_address'].forEach((gridName) => {
     const grid = new Grid(gridName);
-    grid.addExtension(new ExportToSqlManagerExtension());
-    grid.addExtension(new ReloadListActionExtension());
-    grid.addExtension(new SortingExtension());
-    grid.addExtension(new FiltersResetExtension());
-    grid.addExtension(new ColumnTogglingExtension());
-    grid.addExtension(new SubmitRowActionExtension());
-    grid.addExtension(new SubmitBulkExtension());
-    grid.addExtension(new BulkActionCheckboxExtension());
-    grid.addExtension(new FiltersSubmitButtonEnablerExtension());
-    grid.addExtension(new LinkRowActionExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   });
 
   window.prestashop.component.initComponents(

--- a/admin-dev/themes/new-theme/js/pages/manufacturer/manufacturer_address_form.ts
+++ b/admin-dev/themes/new-theme/js/pages/manufacturer/manufacturer_address_form.ts
@@ -23,19 +23,17 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import CountryStateSelectionToggler from '@components/country-state-selection-toggler';
 import ManufacturerAddressMap from '@pages/manufacturer/manufacturer-address-map';
-import CountryDniRequiredToggler from '@components/country-dni-required-toggler';
 
 const {$} = window;
 
 $(() => {
-  new CountryStateSelectionToggler(
+  new window.prestashop.component.CountryStateSelectionToggler(
     ManufacturerAddressMap.manufacturerAddressCountrySelect,
     ManufacturerAddressMap.manufacturerAddressStateSelect,
     ManufacturerAddressMap.manufacturerAddressStateBlock,
   );
-  new CountryDniRequiredToggler(
+  new window.prestashop.component.CountryDniRequiredToggler(
     ManufacturerAddressMap.manufacturerAddressCountrySelect,
     ManufacturerAddressMap.manufacturerAddressDniInput,
     ManufacturerAddressMap.manufacturerAddressDniInputLabel,

--- a/admin-dev/themes/new-theme/js/pages/merchandise-return/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/merchandise-return/index.ts
@@ -23,10 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '../../components/grid/grid';
-import SortingExtension from '../../components/grid/extension/sorting-extension';
-import FiltersResetExtension from '../../components/grid/extension/filters-reset-extension';
-import FiltersSubmitButtonEnablerExtension from '../../components/grid/extension/filters-submit-button-enabler-extension';
 import TranslatableInput from '../../components/translatable-input';
 
 const {$} = window;
@@ -38,10 +34,10 @@ $(() => {
     ],
   );
 
-  const grid = new Grid('merchandise_return');
-  grid.addExtension(new SortingExtension());
-  grid.addExtension(new FiltersResetExtension());
-  grid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  const grid = new window.prestashop.component.Grid('merchandise_return');
+  grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
   new TranslatableInput();
 });

--- a/admin-dev/themes/new-theme/js/pages/merchandise-return/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/merchandise-return/index.ts
@@ -23,14 +23,11 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import TranslatableInput from '../../components/translatable-input';
-
-const {$} = window;
-
 $(() => {
   window.prestashop.component.initComponents(
     [
       'MultistoreConfigField',
+      'TranslatableInput',
     ],
   );
 
@@ -38,6 +35,4 @@ $(() => {
   grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
-
-  new TranslatableInput();
 });

--- a/admin-dev/themes/new-theme/js/pages/meta/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/meta/index.ts
@@ -34,13 +34,13 @@ const {$} = window;
 
 $(() => {
   const meta = new window.prestashop.component.Grid('meta');
-  meta.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  meta.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   meta.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   meta.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   meta.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   meta.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
-  meta.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
-  meta.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  meta.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
+  meta.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   meta.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   meta.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   meta.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());

--- a/admin-dev/themes/new-theme/js/pages/meta/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/meta/index.ts
@@ -26,7 +26,6 @@
 import ShowcaseCard from '@components/showcase-card/showcase-card';
 import ShowcaseCardCloseExtension from '@components/showcase-card/extension/showcase-card-close-extension';
 import MetaPageNameOptionHandler from '@pages/meta/meta-page-name-option-handler';
-import TextWithRecommendedLengthCounter from '@components/form/text-with-recommended-length-counter';
 
 const {$} = window;
 
@@ -59,8 +58,7 @@ $(() => {
     [
       'MultistoreConfigField',
       'TranslatableInput',
+      'TextWithRecommendedLengthCounter',
     ],
   );
-
-  new TextWithRecommendedLengthCounter();
 });

--- a/admin-dev/themes/new-theme/js/pages/meta/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/meta/index.ts
@@ -23,38 +23,27 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
 import ShowcaseCard from '@components/showcase-card/showcase-card';
 import ShowcaseCardCloseExtension from '@components/showcase-card/extension/showcase-card-close-extension';
 import TaggableField from '@components/taggable-field';
 import TranslatableInput from '@components/translatable-input';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
 import MetaPageNameOptionHandler from '@pages/meta/meta-page-name-option-handler';
 import TextWithRecommendedLengthCounter from '@components/form/text-with-recommended-length-counter';
 
 const {$} = window;
 
 $(() => {
-  const meta = new Grid('meta');
-  meta.addExtension(new ReloadListActionExtension());
-  meta.addExtension(new ExportToSqlManagerExtension());
-  meta.addExtension(new FiltersResetExtension());
-  meta.addExtension(new SortingExtension());
-  meta.addExtension(new LinkRowActionExtension());
-  meta.addExtension(new SubmitGridExtension());
-  meta.addExtension(new SubmitBulkExtension());
-  meta.addExtension(new SubmitRowActionExtension());
-  meta.addExtension(new BulkActionCheckboxExtension());
-  meta.addExtension(new FiltersSubmitButtonEnablerExtension());
+  const meta = new window.prestashop.component.Grid('meta');
+  meta.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  meta.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  meta.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  meta.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  meta.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  meta.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  meta.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  meta.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  meta.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  meta.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
   const helperBlock = new ShowcaseCard('seo-urls-showcase-card');
   helperBlock.addExtension(new ShowcaseCardCloseExtension());

--- a/admin-dev/themes/new-theme/js/pages/meta/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/meta/index.ts
@@ -25,8 +25,6 @@
 
 import ShowcaseCard from '@components/showcase-card/showcase-card';
 import ShowcaseCardCloseExtension from '@components/showcase-card/extension/showcase-card-close-extension';
-import TaggableField from '@components/taggable-field';
-import TranslatableInput from '@components/translatable-input';
 import MetaPageNameOptionHandler from '@pages/meta/meta-page-name-option-handler';
 import TextWithRecommendedLengthCounter from '@components/form/text-with-recommended-length-counter';
 
@@ -48,19 +46,19 @@ $(() => {
   const helperBlock = new ShowcaseCard('seo-urls-showcase-card');
   helperBlock.addExtension(new ShowcaseCardCloseExtension());
 
-  new TaggableField({
+  new window.prestashop.component.TaggableField({
     tokenFieldSelector: 'input.js-taggable-field',
     options: {
       createTokensOnBlur: true,
     },
   });
 
-  new TranslatableInput();
   new MetaPageNameOptionHandler();
 
   window.prestashop.component.initComponents(
     [
       'MultistoreConfigField',
+      'TranslatableInput',
     ],
   );
 

--- a/admin-dev/themes/new-theme/js/pages/monitoring/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/monitoring/index.ts
@@ -23,39 +23,24 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitRowActionExtension
-  from '@components/grid/extension/action/row/submit-row-action-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 import DeleteCategoryRowActionExtension
   from '@components/grid/extension/action/row/category/delete-category-row-action-extension';
-import AsyncToggleColumnExtension
-  from '@components/grid/extension/column/common/async-toggle-column-extension';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension
-  from '@components/grid/extension/export-to-sql-manager-extension';
 import ShowcaseCard from '@components/showcase-card/showcase-card';
 import ShowcaseCardCloseExtension from '@components/showcase-card/extension/showcase-card-close-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
 
 const {$} = window;
 
 $(() => {
-  const emptyCategoriesGrid = new Grid('empty_category');
+  const emptyCategoriesGrid = new window.prestashop.component.Grid('empty_category');
 
-  emptyCategoriesGrid.addExtension(new FiltersResetExtension());
-  emptyCategoriesGrid.addExtension(new SortingExtension());
-  emptyCategoriesGrid.addExtension(new ReloadListActionExtension());
-  emptyCategoriesGrid.addExtension(new SubmitRowActionExtension());
-  emptyCategoriesGrid.addExtension(new LinkRowActionExtension());
-  emptyCategoriesGrid.addExtension(new AsyncToggleColumnExtension());
+  emptyCategoriesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  emptyCategoriesGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  emptyCategoriesGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  emptyCategoriesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  emptyCategoriesGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  emptyCategoriesGrid.addExtension(new window.prestashop.component.GridExtensions.AsyncToggleColumnExtension());
   emptyCategoriesGrid.addExtension(new DeleteCategoryRowActionExtension());
-  emptyCategoriesGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  emptyCategoriesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
   [
     'no_qty_product_with_combination',
@@ -67,16 +52,16 @@ $(() => {
   ].forEach((gridName) => {
     const grid = new Grid(gridName);
 
-    grid.addExtension(new SortingExtension());
-    grid.addExtension(new ExportToSqlManagerExtension());
-    grid.addExtension(new ReloadListActionExtension());
-    grid.addExtension(new FiltersResetExtension());
-    grid.addExtension(new AsyncToggleColumnExtension());
-    grid.addExtension(new SubmitRowActionExtension());
-    grid.addExtension(new BulkActionCheckboxExtension());
-    grid.addExtension(new SubmitBulkExtension());
-    grid.addExtension(new LinkRowActionExtension());
-    grid.addExtension(new FiltersSubmitButtonEnablerExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.AsyncToggleColumnExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
   });
 
   const showcaseCard = new ShowcaseCard('monitoringShowcaseCard');

--- a/admin-dev/themes/new-theme/js/pages/monitoring/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/monitoring/index.ts
@@ -35,7 +35,7 @@ $(() => {
 
   emptyCategoriesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   emptyCategoriesGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
-  emptyCategoriesGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  emptyCategoriesGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   emptyCategoriesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   emptyCategoriesGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   emptyCategoriesGrid.addExtension(new window.prestashop.component.GridExtensions.AsyncToggleColumnExtension());
@@ -54,12 +54,12 @@ $(() => {
 
     grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
-    grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.AsyncToggleColumnExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-    grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+    grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
   });

--- a/admin-dev/themes/new-theme/js/pages/monitoring/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/monitoring/index.ts
@@ -50,7 +50,7 @@ $(() => {
     'product_without_description',
     'product_without_price',
   ].forEach((gridName) => {
-    const grid = new Grid(gridName);
+    const grid = new window.prestashop.component.Grid(gridName);
 
     grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
     grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());

--- a/admin-dev/themes/new-theme/js/pages/order-return-states/form.ts
+++ b/admin-dev/themes/new-theme/js/pages/order-return-states/form.ts
@@ -24,11 +24,14 @@
  */
 
 import initColorPickers from '@app/utils/colorpicker';
-import TranslatableInput from '@components/translatable-input';
 
 const {$} = window;
 
 $(() => {
   initColorPickers();
-  new TranslatableInput();
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+    ],
+  );
 });

--- a/admin-dev/themes/new-theme/js/pages/order-states/form.ts
+++ b/admin-dev/themes/new-theme/js/pages/order-states/form.ts
@@ -25,14 +25,17 @@
 
 import initColorPickers from '@app/utils/colorpicker';
 import TranslatableChoice from '@components/form/translatable-choice';
-import TranslatableInput from '@components/translatable-input';
 import FormMap from '@pages/order-states/form-map';
 
 const {$} = window;
 
 $(() => {
   initColorPickers();
-  new TranslatableInput();
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+    ],
+  );
   new TranslatableChoice();
 
   let templatePreviewWindow: null | Record<string, any> = null;

--- a/admin-dev/themes/new-theme/js/pages/order-states/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/order-states/index.ts
@@ -33,9 +33,9 @@ $(() => {
   orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
   orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
-  orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
   orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
@@ -46,9 +46,9 @@ $(() => {
   orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
   orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
-  orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
   orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/order-states/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/order-states/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const orderStatesGrid = new window.prestashop.component.Grid('order_states');
 

--- a/admin-dev/themes/new-theme/js/pages/order-states/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/order-states/index.ts
@@ -23,43 +23,32 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
-import SubmitBulkActionExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
 
 const {$} = window;
 
 $(() => {
-  const orderStatesGrid = new Grid('order_states');
+  const orderStatesGrid = new window.prestashop.component.Grid('order_states');
 
-  orderStatesGrid.addExtension(new FiltersResetExtension());
-  orderStatesGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  orderStatesGrid.addExtension(new SortingExtension());
-  orderStatesGrid.addExtension(new ExportToSqlManagerExtension());
-  orderStatesGrid.addExtension(new ReloadListActionExtension());
-  orderStatesGrid.addExtension(new BulkActionCheckboxExtension());
-  orderStatesGrid.addExtension(new SubmitGridExtension());
-  orderStatesGrid.addExtension(new SubmitBulkActionExtension());
-  orderStatesGrid.addExtension(new SubmitRowActionExtension());
-  orderStatesGrid.addExtension(new ColumnTogglingExtension());
+  orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
+  orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  orderStatesGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
 
-  const orderReturnStatusesGrid = new Grid('order_return_states');
+  const orderReturnStatusesGrid = new window.prestashop.component.Grid('order_return_states');
 
-  orderReturnStatusesGrid.addExtension(new FiltersResetExtension());
-  orderReturnStatusesGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  orderReturnStatusesGrid.addExtension(new SortingExtension());
-  orderReturnStatusesGrid.addExtension(new ExportToSqlManagerExtension());
-  orderReturnStatusesGrid.addExtension(new ReloadListActionExtension());
-  orderReturnStatusesGrid.addExtension(new BulkActionCheckboxExtension());
-  orderReturnStatusesGrid.addExtension(new SubmitGridExtension());
-  orderReturnStatusesGrid.addExtension(new SubmitBulkActionExtension());
-  orderReturnStatusesGrid.addExtension(new SubmitRowActionExtension());
+  orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
+  orderReturnStatusesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/order/delivery/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/delivery/index.ts
@@ -23,10 +23,10 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import TranslatableInput from '@components/translatable-input';
-
-const {$} = window;
-
 $(() => {
-  new TranslatableInput();
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+    ],
+  );
 });

--- a/admin-dev/themes/new-theme/js/pages/order/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/index.ts
@@ -23,37 +23,23 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
-import ChoiceExtension from '@components/grid/extension/choice-extension';
-import ModalFormSubmitExtension from '@components/grid/extension/modal-form-submit-extension';
-import PreviewExtension from '@components/grid/extension/preview-extension';
 import previewProductsToggler from '@pages/order/preview-products-toggler';
-import BulkOpenTabsExtension from '@components/grid/extension/bulk-open-tabs-extension';
 
 const {$} = window;
 
 $(() => {
-  const orderGrid = new Grid('order');
-  orderGrid.addExtension(new ReloadListActionExtension());
-  orderGrid.addExtension(new ExportToSqlManagerExtension());
-  orderGrid.addExtension(new FiltersResetExtension());
-  orderGrid.addExtension(new SortingExtension());
-  orderGrid.addExtension(new LinkRowActionExtension());
-  orderGrid.addExtension(new SubmitGridExtension());
-  orderGrid.addExtension(new SubmitBulkExtension());
-  orderGrid.addExtension(new BulkActionCheckboxExtension());
-  orderGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  orderGrid.addExtension(new ModalFormSubmitExtension());
-  orderGrid.addExtension(new ChoiceExtension());
-  orderGrid.addExtension(new PreviewExtension(previewProductsToggler, orderGrid));
-  orderGrid.addExtension(new BulkOpenTabsExtension());
+  const orderGrid = new window.prestashop.component.Grid('order');
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.ModalFormSubmitExtension());
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.ChoiceExtension());
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.PreviewExtension(previewProductsToggler, orderGrid));
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.BulkOpenTabsExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/order/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/index.ts
@@ -29,13 +29,13 @@ const {$} = window;
 
 $(() => {
   const orderGrid = new window.prestashop.component.Grid('order');
-  orderGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   orderGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   orderGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   orderGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   orderGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
-  orderGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
-  orderGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
+  orderGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   orderGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   orderGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
   orderGrid.addExtension(new window.prestashop.component.GridExtensions.ModalFormSubmitExtension());

--- a/admin-dev/themes/new-theme/js/pages/order/view.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/view.ts
@@ -29,7 +29,6 @@ import InvoiceNoteManager from '@pages/order/invoice-note-manager';
 import OrderViewPage from '@pages/order/view/order-view-page';
 import OrderProductAutocomplete from '@pages/order/view/order-product-add-autocomplete';
 import OrderProductAdd from '@pages/order/view/order-product-add';
-import TextWithLengthCounter from '@components/form/text-with-length-counter';
 import OrderViewPageMessagesHandler from './message/order-view-page-messages-handler';
 
 const {$} = window;
@@ -40,7 +39,9 @@ $(() => {
   const DISCOUNT_TYPE_FREE_SHIPPING = 'free_shipping';
 
   new OrderShippingManager();
-  new TextWithLengthCounter();
+  window.prestashop.component.initComponents([
+    'TextWithLengthCounter',
+  ]);
   const orderViewPage = new OrderViewPage();
   const orderAddAutocomplete = new OrderProductAutocomplete($(OrderViewPageMap.productSearchInput));
   const orderAdd = new OrderProductAdd();

--- a/admin-dev/themes/new-theme/js/pages/order_message/form.ts
+++ b/admin-dev/themes/new-theme/js/pages/order_message/form.ts
@@ -22,10 +22,11 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-import TranslatableInput from '@components/translatable-input';
-
-const {$} = window;
 
 $(() => {
-  new TranslatableInput();
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+    ],
+  );
 });

--- a/admin-dev/themes/new-theme/js/pages/order_message/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/order_message/index.ts
@@ -29,7 +29,7 @@ const {$} = window;
 $(() => {
   const orderMessageGrid = new window.prestashop.component.Grid('order_message');
 
-  orderMessageGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  orderMessageGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   orderMessageGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   orderMessageGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   orderMessageGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());

--- a/admin-dev/themes/new-theme/js/pages/order_message/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/order_message/index.ts
@@ -23,30 +23,19 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
-import SubmitBulkActionExtension from '@components/grid/extension/submit-bulk-action-extension';
 
 const {$} = window;
 
 $(() => {
-  const orderMessageGrid = new Grid('order_message');
+  const orderMessageGrid = new window.prestashop.component.Grid('order_message');
 
-  orderMessageGrid.addExtension(new ReloadListActionExtension());
-  orderMessageGrid.addExtension(new ExportToSqlManagerExtension());
-  orderMessageGrid.addExtension(new FiltersResetExtension());
-  orderMessageGrid.addExtension(new SortingExtension());
-  orderMessageGrid.addExtension(new LinkRowActionExtension());
-  orderMessageGrid.addExtension(new SubmitBulkActionExtension());
-  orderMessageGrid.addExtension(new BulkActionCheckboxExtension());
-  orderMessageGrid.addExtension(new SubmitRowActionExtension());
-  orderMessageGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  orderMessageGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  orderMessageGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  orderMessageGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  orderMessageGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  orderMessageGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  orderMessageGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
+  orderMessageGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  orderMessageGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  orderMessageGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/order_message/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/order_message/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const orderMessageGrid = new window.prestashop.component.Grid('order_message');
 

--- a/admin-dev/themes/new-theme/js/pages/outstanding/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/outstanding/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const outstandingGrid = new window.prestashop.component.Grid('outstanding');
   outstandingGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());

--- a/admin-dev/themes/new-theme/js/pages/outstanding/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/outstanding/index.ts
@@ -23,21 +23,14 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
 
 const {$} = window;
 
 $(() => {
-  const outstandingGrid = new Grid('outstanding');
-  outstandingGrid.addExtension(new FiltersResetExtension());
-  outstandingGrid.addExtension(new ReloadListActionExtension());
-  outstandingGrid.addExtension(new SortingExtension());
-  outstandingGrid.addExtension(new LinkRowActionExtension());
-  outstandingGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  const outstandingGrid = new window.prestashop.component.Grid('outstanding');
+  outstandingGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  outstandingGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  outstandingGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  outstandingGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  outstandingGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/outstanding/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/outstanding/index.ts
@@ -29,7 +29,7 @@ const {$} = window;
 $(() => {
   const outstandingGrid = new window.prestashop.component.Grid('outstanding');
   outstandingGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
-  outstandingGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  outstandingGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   outstandingGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   outstandingGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   outstandingGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());

--- a/admin-dev/themes/new-theme/js/pages/payment-preferences/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/payment-preferences/index.ts
@@ -23,10 +23,10 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import MultipleChoiceTable from '@components/multiple-choice-table';
-
-const {$} = window;
-
 $(() => {
-  new MultipleChoiceTable();
+  window.prestashop.component.initComponents(
+    [
+      'MultipleChoiceTable',
+    ],
+  );
 });

--- a/admin-dev/themes/new-theme/js/pages/performance-preferences/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/performance-preferences/index.ts
@@ -25,7 +25,6 @@
 
 import ConfirmModal from '@components/modal/confirm-modal';
 import PerformancePreferencesPageMap from '@pages/performance-preferences/PerformancePreferencesPageMap';
-import GeneratableInput from '@components/generatable-input';
 
 const {$} = window;
 
@@ -50,6 +49,8 @@ $(() => {
   });
 
   // Initialize cookie name and value generatable inputs
-  const generatableInput = new GeneratableInput();
-  generatableInput.attachOn('.js-generator-btn');
+  window.prestashop.component.initComponents([
+    'GeneratableInput',
+  ]);
+  window.prestashop.instance.generatableInput.attachOn('.js-generator-btn');
 });

--- a/admin-dev/themes/new-theme/js/pages/product-preferences/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product-preferences/index.ts
@@ -23,7 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import TranslatableInput from '@components/translatable-input';
 import StockManagementOptionHandler from '@pages/product-preferences/stock-management-option-handler';
 import CatalogModeOptionHandler from '@pages/product-preferences/catalog-mode-option-handler';
 import * as pageMap from '@pages/product-preferences/product-preferences-page-map';
@@ -31,7 +30,11 @@ import * as pageMap from '@pages/product-preferences/product-preferences-page-ma
 const {$} = window;
 
 $(() => {
-  new TranslatableInput();
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+    ],
+  );
   new StockManagementOptionHandler();
   new CatalogModeOptionHandler(pageMap);
 });

--- a/admin-dev/themes/new-theme/js/pages/product/edit/manager/product-seo-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/manager/product-seo-manager.ts
@@ -26,7 +26,6 @@ import Serp from '@app/utils/serp';
 import {EventEmitter} from 'events';
 import RedirectOptionManager from '@pages/product/edit/manager/redirect-option-manager';
 import ProductMap from '@pages/product/product-map';
-import TaggableField from '@components/taggable-field';
 import TranslatableInput from '@components/translatable-input';
 
 const {$} = window;
@@ -80,7 +79,7 @@ export default class ProductSEOManager {
       previewUrl,
     );
 
-    new TaggableField({
+    new window.prestashop.component.TaggableField({
       tokenFieldSelector: ProductMap.seo.tagFields,
       options: {
         createTokensOnBlur: true,

--- a/admin-dev/themes/new-theme/js/pages/profiles/ProfilesPage.ts
+++ b/admin-dev/themes/new-theme/js/pages/profiles/ProfilesPage.ts
@@ -32,13 +32,13 @@ export default class ProfilesPage {
   constructor() {
     const profilesGrid = new window.prestashop.component.Grid('profile');
 
-    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
     profilesGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
     profilesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
     profilesGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
     profilesGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
-    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
-    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
+    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
     profilesGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
     profilesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
     profilesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());

--- a/admin-dev/themes/new-theme/js/pages/profiles/ProfilesPage.ts
+++ b/admin-dev/themes/new-theme/js/pages/profiles/ProfilesPage.ts
@@ -23,37 +23,25 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
 import TranslatableInput from '@components/translatable-input';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
 
 /**
  * Responsible for actions in Profiles listing page.
  */
 export default class ProfilesPage {
   constructor() {
-    const profilesGrid = new Grid('profile');
+    const profilesGrid = new window.prestashop.component.Grid('profile');
 
-    profilesGrid.addExtension(new ReloadListActionExtension());
-    profilesGrid.addExtension(new ExportToSqlManagerExtension());
-    profilesGrid.addExtension(new FiltersResetExtension());
-    profilesGrid.addExtension(new SortingExtension());
-    profilesGrid.addExtension(new LinkRowActionExtension());
-    profilesGrid.addExtension(new SubmitGridExtension());
-    profilesGrid.addExtension(new SubmitBulkExtension());
-    profilesGrid.addExtension(new BulkActionCheckboxExtension());
-    profilesGrid.addExtension(new SubmitRowActionExtension());
-    profilesGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+    profilesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
     new TranslatableInput();
   }

--- a/admin-dev/themes/new-theme/js/pages/profiles/ProfilesPage.ts
+++ b/admin-dev/themes/new-theme/js/pages/profiles/ProfilesPage.ts
@@ -23,8 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import TranslatableInput from '@components/translatable-input';
-
 /**
  * Responsible for actions in Profiles listing page.
  */
@@ -43,6 +41,10 @@ export default class ProfilesPage {
     profilesGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
     profilesGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
-    new TranslatableInput();
+    window.prestashop.component.initComponents(
+      [
+        'TranslatableInput',
+      ],
+    );
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/search-engine/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/search-engine/index.ts
@@ -23,8 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-const {$} = window;
-
 $(() => {
   const searchEngineGrid = new window.prestashop.component.Grid('search_engine');
 

--- a/admin-dev/themes/new-theme/js/pages/search-engine/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/search-engine/index.ts
@@ -22,29 +22,19 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-import Grid from '@components/grid/grid';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import ReloadListExtension from '@components/grid/extension/reload-list-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import SubmitBulkActionExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 
 const {$} = window;
 
 $(() => {
-  const searchEngineGrid = new Grid('search_engine');
+  const searchEngineGrid = new window.prestashop.component.Grid('search_engine');
 
-  searchEngineGrid.addExtension(new ExportToSqlManagerExtension());
-  searchEngineGrid.addExtension(new ReloadListExtension());
-  searchEngineGrid.addExtension(new SortingExtension());
-  searchEngineGrid.addExtension(new FiltersResetExtension());
-  searchEngineGrid.addExtension(new SubmitRowActionExtension());
-  searchEngineGrid.addExtension(new SubmitBulkActionExtension());
-  searchEngineGrid.addExtension(new BulkActionCheckboxExtension());
-  searchEngineGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  searchEngineGrid.addExtension(new LinkRowActionExtension());
+  searchEngineGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  searchEngineGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
+  searchEngineGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  searchEngineGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  searchEngineGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  searchEngineGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
+  searchEngineGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  searchEngineGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  searchEngineGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/search/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/search/index.ts
@@ -23,17 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
 import TranslatableInput from '@components/translatable-input';
 
 const {$} = window;
@@ -42,18 +31,18 @@ const {$} = window;
  * Responsible for actions in admin search listing page to list aliases.
  */
 $(() => {
-  const aliasGrid = new Grid('alias');
+  const aliasGrid = new window.prestashop.component.Grid('alias');
 
-  aliasGrid.addExtension(new ReloadListActionExtension());
-  aliasGrid.addExtension(new ExportToSqlManagerExtension());
-  aliasGrid.addExtension(new FiltersResetExtension());
-  aliasGrid.addExtension(new SortingExtension());
-  aliasGrid.addExtension(new LinkRowActionExtension());
-  aliasGrid.addExtension(new SubmitGridExtension());
-  aliasGrid.addExtension(new SubmitBulkExtension());
-  aliasGrid.addExtension(new BulkActionCheckboxExtension());
-  aliasGrid.addExtension(new SubmitRowActionExtension());
-  aliasGrid.addExtension(new ColumnTogglingExtension());
+  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
 
   new TranslatableInput();
 });

--- a/admin-dev/themes/new-theme/js/pages/search/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/search/index.ts
@@ -23,10 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import TranslatableInput from '@components/translatable-input';
-
-const {$} = window;
-
 /**
  * Responsible for actions in admin search listing page to list aliases.
  */
@@ -44,5 +40,9 @@ $(() => {
   aliasGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   aliasGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
 
-  new TranslatableInput();
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+    ],
+  );
 });

--- a/admin-dev/themes/new-theme/js/pages/search/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/search/index.ts
@@ -33,13 +33,13 @@ const {$} = window;
 $(() => {
   const aliasGrid = new window.prestashop.component.Grid('alias');
 
-  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   aliasGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   aliasGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   aliasGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   aliasGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
-  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
-  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
+  aliasGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   aliasGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   aliasGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   aliasGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());

--- a/admin-dev/themes/new-theme/js/pages/security/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/security/index.ts
@@ -30,13 +30,13 @@ const {$} = window;
 $(() => {
   const employeeSessionGrid = new window.prestashop.component.Grid('security_session_employee');
 
-  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
-  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
+  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
   employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
@@ -44,13 +44,13 @@ $(() => {
 
   const customerSessionsGrid = new window.prestashop.component.Grid('security_session_customer');
 
-  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
-  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
+  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
   customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());

--- a/admin-dev/themes/new-theme/js/pages/security/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/security/index.ts
@@ -23,51 +23,38 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
 import FormSubmitButton from '@components/form-submit-button';
-import Grid from '@components/grid/grid';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
 
 const {$} = window;
 
 $(() => {
-  const employeeSessionGrid = new Grid('security_session_employee');
+  const employeeSessionGrid = new window.prestashop.component.Grid('security_session_employee');
 
-  employeeSessionGrid.addExtension(new ReloadListActionExtension());
-  employeeSessionGrid.addExtension(new ExportToSqlManagerExtension());
-  employeeSessionGrid.addExtension(new FiltersResetExtension());
-  employeeSessionGrid.addExtension(new SortingExtension());
-  employeeSessionGrid.addExtension(new BulkActionCheckboxExtension());
-  employeeSessionGrid.addExtension(new SubmitBulkExtension());
-  employeeSessionGrid.addExtension(new SubmitGridExtension());
-  employeeSessionGrid.addExtension(new SubmitRowActionExtension());
-  employeeSessionGrid.addExtension(new LinkRowActionExtension());
-  employeeSessionGrid.addExtension(new ColumnTogglingExtension());
-  employeeSessionGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  employeeSessionGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
-  const customerSessionsGrid = new Grid('security_session_customer');
+  const customerSessionsGrid = new window.prestashop.component.Grid('security_session_customer');
 
-  customerSessionsGrid.addExtension(new ReloadListActionExtension());
-  customerSessionsGrid.addExtension(new ExportToSqlManagerExtension());
-  customerSessionsGrid.addExtension(new FiltersResetExtension());
-  customerSessionsGrid.addExtension(new SortingExtension());
-  customerSessionsGrid.addExtension(new BulkActionCheckboxExtension());
-  customerSessionsGrid.addExtension(new SubmitBulkExtension());
-  customerSessionsGrid.addExtension(new SubmitGridExtension());
-  customerSessionsGrid.addExtension(new SubmitRowActionExtension());
-  customerSessionsGrid.addExtension(new LinkRowActionExtension());
-  customerSessionsGrid.addExtension(new ColumnTogglingExtension());
-  customerSessionsGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  customerSessionsGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
   new FormSubmitButton();
 });

--- a/admin-dev/themes/new-theme/js/pages/sql-manager/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/sql-manager/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 class SqlManagerPage {
   constructor() {
     const requestSqlGrid = new window.prestashop.component.Grid('sql_request');

--- a/admin-dev/themes/new-theme/js/pages/sql-manager/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/sql-manager/index.ts
@@ -23,33 +23,22 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
 
 const {$} = window;
 
 class SqlManagerPage {
   constructor() {
-    const requestSqlGrid = new Grid('sql_request');
-    requestSqlGrid.addExtension(new ReloadListActionExtension());
-    requestSqlGrid.addExtension(new ExportToSqlManagerExtension());
-    requestSqlGrid.addExtension(new FiltersResetExtension());
-    requestSqlGrid.addExtension(new SortingExtension());
-    requestSqlGrid.addExtension(new LinkRowActionExtension());
-    requestSqlGrid.addExtension(new SubmitGridExtension());
-    requestSqlGrid.addExtension(new SubmitBulkExtension());
-    requestSqlGrid.addExtension(new SubmitRowActionExtension());
-    requestSqlGrid.addExtension(new BulkActionCheckboxExtension());
-    requestSqlGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+    const requestSqlGrid = new window.prestashop.component.Grid('sql_request');
+    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
     $(document).on('change', '.js-db-tables-select', () => this.reloadDbTableColumns(),
     );

--- a/admin-dev/themes/new-theme/js/pages/sql-manager/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/sql-manager/index.ts
@@ -29,13 +29,13 @@ const {$} = window;
 class SqlManagerPage {
   constructor() {
     const requestSqlGrid = new window.prestashop.component.Grid('sql_request');
-    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
     requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
     requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
     requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
     requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
-    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
-    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
+    requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
     requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
     requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
     requestSqlGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());

--- a/admin-dev/themes/new-theme/js/pages/state/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/state/index.ts
@@ -23,35 +23,23 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
-import AsyncToggleColumnExtension from '@components/grid/extension/column/common/async-toggle-column-extension';
 
 const {$} = window;
 
 class StatePage {
   constructor() {
-    const stateGrid = new Grid('state');
-    stateGrid.addExtension(new FiltersResetExtension());
-    stateGrid.addExtension(new SortingExtension());
-    stateGrid.addExtension(new ExportToSqlManagerExtension());
-    stateGrid.addExtension(new ReloadListActionExtension());
-    stateGrid.addExtension(new BulkActionCheckboxExtension());
-    stateGrid.addExtension(new SubmitBulkExtension());
-    stateGrid.addExtension(new SubmitRowActionExtension());
-    stateGrid.addExtension(new LinkRowActionExtension());
-    stateGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
-    stateGrid.addExtension(new SubmitGridExtension());
-    stateGrid.addExtension(new AsyncToggleColumnExtension());
+    const stateGrid = new window.prestashop.component.Grid('state');
+    stateGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+    stateGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+    stateGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+    stateGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+    stateGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+    stateGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+    stateGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+    stateGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+    stateGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+    stateGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+    stateGrid.addExtension(new window.prestashop.component.GridExtensions.AsyncToggleColumnExtension());
   }
 }
 

--- a/admin-dev/themes/new-theme/js/pages/state/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/state/index.ts
@@ -32,13 +32,13 @@ class StatePage {
     stateGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
     stateGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
     stateGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
-    stateGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+    stateGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
     stateGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-    stateGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+    stateGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
     stateGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
     stateGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
     stateGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
-    stateGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+    stateGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
     stateGrid.addExtension(new window.prestashop.component.GridExtensions.AsyncToggleColumnExtension());
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/state/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/state/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 class StatePage {
   constructor() {
     const stateGrid = new window.prestashop.component.Grid('state');

--- a/admin-dev/themes/new-theme/js/pages/store/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/store/index.ts
@@ -23,30 +23,19 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
 
 const {$} = window;
 
 $(() => {
-  const grid = new Grid('store');
+  const grid = new window.prestashop.component.Grid('store');
 
-  grid.addExtension(new ExportToSqlManagerExtension());
-  grid.addExtension(new ReloadListActionExtension());
-  grid.addExtension(new SortingExtension());
-  grid.addExtension(new FiltersResetExtension());
-  grid.addExtension(new ColumnTogglingExtension());
-  grid.addExtension(new SubmitRowActionExtension());
-  grid.addExtension(new SubmitBulkExtension());
-  grid.addExtension(new BulkActionCheckboxExtension());
-  grid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/store/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/store/index.ts
@@ -30,12 +30,12 @@ $(() => {
   const grid = new window.prestashop.component.Grid('store');
 
   grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/store/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/store/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const grid = new window.prestashop.component.Grid('store');
 

--- a/admin-dev/themes/new-theme/js/pages/supplier/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/supplier/index.ts
@@ -23,33 +23,20 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SubmitGridActionExtension from '@components/grid/extension/submit-grid-action-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkActionExtension from '@components/grid/extension/submit-bulk-action-extension';
-import ReloadListExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 
 const {$} = window;
 
 $(() => {
-  const supplierGrid = new Grid('supplier');
-  supplierGrid.addExtension(new SortingExtension());
-  supplierGrid.addExtension(new SubmitGridActionExtension());
-  supplierGrid.addExtension(new FiltersResetExtension());
-  supplierGrid.addExtension(new ColumnTogglingExtension());
-  supplierGrid.addExtension(new SubmitRowActionExtension());
-  supplierGrid.addExtension(new BulkActionCheckboxExtension());
-  supplierGrid.addExtension(new SubmitBulkActionExtension());
-  supplierGrid.addExtension(new ReloadListExtension());
-  supplierGrid.addExtension(new ExportToSqlManagerExtension());
-  supplierGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  supplierGrid.addExtension(new LinkRowActionExtension());
+  const supplierGrid = new window.prestashop.component.Grid('supplier');
+  supplierGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  supplierGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
+  supplierGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  supplierGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  supplierGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  supplierGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  supplierGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
+  supplierGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
+  supplierGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  supplierGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  supplierGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/supplier/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/supplier/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const supplierGrid = new window.prestashop.component.Grid('supplier');
   supplierGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());

--- a/admin-dev/themes/new-theme/js/pages/tax-rules-group/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/tax-rules-group/index.ts
@@ -23,34 +23,23 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import ReloadListExtension from '@components/grid/extension/reload-list-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 import FormSubmitButton from '@components/form-submit-button';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
 
 const {$} = window;
 
 $(() => {
-  const taxRulesGroupGrid = new Grid('tax_rules_group');
+  const taxRulesGroupGrid = new window.prestashop.component.Grid('tax_rules_group');
 
-  taxRulesGroupGrid.addExtension(new FiltersResetExtension());
-  taxRulesGroupGrid.addExtension(new SortingExtension());
-  taxRulesGroupGrid.addExtension(new ExportToSqlManagerExtension());
-  taxRulesGroupGrid.addExtension(new ReloadListExtension());
-  taxRulesGroupGrid.addExtension(new BulkActionCheckboxExtension());
-  taxRulesGroupGrid.addExtension(new SubmitBulkExtension());
-  taxRulesGroupGrid.addExtension(new SubmitRowActionExtension());
-  taxRulesGroupGrid.addExtension(new LinkRowActionExtension());
-  taxRulesGroupGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  taxRulesGroupGrid.addExtension(new ColumnTogglingExtension());
+  taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
+  taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
 
   new FormSubmitButton();
 });

--- a/admin-dev/themes/new-theme/js/pages/tax-rules-group/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/tax-rules-group/index.ts
@@ -35,7 +35,7 @@ $(() => {
   taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   taxRulesGroupGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());

--- a/admin-dev/themes/new-theme/js/pages/tax-rules/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/tax-rules/index.ts
@@ -23,24 +23,18 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import ReloadListExtension from '@components/grid/extension/reload-list-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
 import FormSubmitButton from '@components/form-submit-button';
 
 const {$} = window;
 
 $(() => {
-  const taxRuleGrid = new Grid('tax_rule');
+  const taxRuleGrid = new window.prestashop.component.Grid('tax_rule');
 
-  taxRuleGrid.addExtension(new ExportToSqlManagerExtension());
-  taxRuleGrid.addExtension(new ReloadListExtension());
-  taxRuleGrid.addExtension(new BulkActionCheckboxExtension());
-  taxRuleGrid.addExtension(new SubmitBulkExtension());
-  taxRuleGrid.addExtension(new SubmitRowActionExtension());
+  taxRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  taxRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
+  taxRuleGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  taxRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  taxRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
 
   new FormSubmitButton();
 });

--- a/admin-dev/themes/new-theme/js/pages/tax-rules/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/tax-rules/index.ts
@@ -33,7 +33,7 @@ $(() => {
   taxRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   taxRuleGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   taxRuleGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  taxRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  taxRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   taxRuleGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
 
   new FormSubmitButton();

--- a/admin-dev/themes/new-theme/js/pages/tax/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/tax/index.ts
@@ -24,7 +24,6 @@
  */
 
 import TaxMap from '@pages/tax/tax-map';
-import TranslatableInput from '@components/translatable-input';
 import DisplayInCartOptionHandler from '@pages/tax/display-in-cart-option-handler';
 
 const {$} = window;
@@ -44,11 +43,11 @@ $(() => {
   taxGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 
   new DisplayInCartOptionHandler();
-  new TranslatableInput();
 
   window.prestashop.component.initComponents(
     [
       'MultistoreConfigField',
+      'TranslatableInput',
     ],
   );
 

--- a/admin-dev/themes/new-theme/js/pages/tax/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/tax/index.ts
@@ -33,12 +33,12 @@ $(() => {
   const taxGrid = new window.prestashop.component.Grid('tax');
 
   taxGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
-  taxGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  taxGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   taxGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   taxGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   taxGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
   taxGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
-  taxGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  taxGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   taxGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   taxGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
   taxGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());

--- a/admin-dev/themes/new-theme/js/pages/tax/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/tax/index.ts
@@ -24,36 +24,24 @@
  */
 
 import TaxMap from '@pages/tax/tax-map';
-import Grid from '@components/grid/grid';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
 import TranslatableInput from '@components/translatable-input';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 import DisplayInCartOptionHandler from '@pages/tax/display-in-cart-option-handler';
 
 const {$} = window;
 
 $(() => {
-  const taxGrid = new Grid('tax');
+  const taxGrid = new window.prestashop.component.Grid('tax');
 
-  taxGrid.addExtension(new ExportToSqlManagerExtension());
-  taxGrid.addExtension(new ReloadListActionExtension());
-  taxGrid.addExtension(new SortingExtension());
-  taxGrid.addExtension(new FiltersResetExtension());
-  taxGrid.addExtension(new ColumnTogglingExtension());
-  taxGrid.addExtension(new SubmitRowActionExtension());
-  taxGrid.addExtension(new SubmitBulkExtension());
-  taxGrid.addExtension(new BulkActionCheckboxExtension());
-  taxGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  taxGrid.addExtension(new LinkRowActionExtension());
+  taxGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  taxGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  taxGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  taxGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  taxGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  taxGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  taxGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  taxGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  taxGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  taxGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 
   new DisplayInCartOptionHandler();
   new TranslatableInput();

--- a/admin-dev/themes/new-theme/js/pages/title/form.ts
+++ b/admin-dev/themes/new-theme/js/pages/title/form.ts
@@ -23,8 +23,10 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import TranslatableInput from '@components/translatable-input';
-
 $(() => {
-  new TranslatableInput();
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+    ],
+  );
 });

--- a/admin-dev/themes/new-theme/js/pages/title/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/title/index.ts
@@ -30,11 +30,11 @@ $(() => {
   const title = new window.prestashop.component.Grid('title');
 
   title.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
-  title.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  title.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   title.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   title.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   title.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
-  title.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  title.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   title.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
   title.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   title.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());

--- a/admin-dev/themes/new-theme/js/pages/title/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/title/index.ts
@@ -23,31 +23,20 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 
 const {$} = window;
 
 $(() => {
-  const title = new Grid('title');
+  const title = new window.prestashop.component.Grid('title');
 
-  title.addExtension(new BulkActionCheckboxExtension());
-  title.addExtension(new SubmitBulkExtension());
-  title.addExtension(new ExportToSqlManagerExtension());
-  title.addExtension(new SortingExtension());
-  title.addExtension(new FiltersResetExtension());
-  title.addExtension(new ReloadListActionExtension());
-  title.addExtension(new ColumnTogglingExtension());
-  title.addExtension(new SubmitRowActionExtension());
-  title.addExtension(new FiltersSubmitButtonEnablerExtension());
-  title.addExtension(new LinkRowActionExtension());
+  title.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  title.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  title.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  title.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  title.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  title.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  title.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  title.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  title.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  title.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 });

--- a/admin-dev/themes/new-theme/js/pages/title/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/title/index.ts
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-
-const {$} = window;
-
 $(() => {
   const title = new window.prestashop.component.Grid('title');
 

--- a/admin-dev/themes/new-theme/js/pages/webservice/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/webservice/index.ts
@@ -30,7 +30,7 @@ const {$} = window;
 $(() => {
   const webserviceGrid = new window.prestashop.component.Grid('webservice_key');
 
-  webserviceGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  webserviceGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   webserviceGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   webserviceGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
   webserviceGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());

--- a/admin-dev/themes/new-theme/js/pages/webservice/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/webservice/index.ts
@@ -23,32 +23,22 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '../../components/grid/grid';
-import FiltersResetExtension from '../../components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '../../components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '../../components/grid/extension/export-to-sql-manager-extension';
-import BulkActionCheckboxExtension from '../../components/grid/extension/bulk-action-checkbox-extension';
-import SubmitBulkActionExtension from '../../components/grid/extension/submit-bulk-action-extension';
-import SortingExtension from '../../components/grid/extension/sorting-extension';
-import SubmitRowActionExtension from '../../components/grid/extension/action/row/submit-row-action-extension';
-import ColumnTogglingExtension from '../../components/grid/extension/column-toggling-extension';
 import PermissionsRowSelector from './permissions-row-selector';
-import LinkRowActionExtension from '../../components/grid/extension/link-row-action-extension';
 
 const {$} = window;
 
 $(() => {
-  const webserviceGrid = new Grid('webservice_key');
+  const webserviceGrid = new window.prestashop.component.Grid('webservice_key');
 
-  webserviceGrid.addExtension(new ReloadListActionExtension());
-  webserviceGrid.addExtension(new ExportToSqlManagerExtension());
-  webserviceGrid.addExtension(new FiltersResetExtension());
-  webserviceGrid.addExtension(new ColumnTogglingExtension());
-  webserviceGrid.addExtension(new SortingExtension());
-  webserviceGrid.addExtension(new SubmitBulkActionExtension());
-  webserviceGrid.addExtension(new SubmitRowActionExtension());
-  webserviceGrid.addExtension(new BulkActionCheckboxExtension());
-  webserviceGrid.addExtension(new LinkRowActionExtension());
+  webserviceGrid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  webserviceGrid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  webserviceGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  webserviceGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  webserviceGrid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  webserviceGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
+  webserviceGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
+  webserviceGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  webserviceGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
 
   // needed for shop association input in form
   new window.prestashop.component.ChoiceTree('#webservice_key_shop_association').enableAutoCheckChildren();

--- a/admin-dev/themes/new-theme/js/pages/zone/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/zone/index.ts
@@ -23,10 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import ChoiceTree from '@components/form/choice-tree';
-
-const {$} = window;
-
 $(() => {
   const grid = new window.prestashop.component.Grid('zone');
 
@@ -43,5 +39,5 @@ $(() => {
   grid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
 
-  new ChoiceTree('#zone_shop_association').enableAutoCheckChildren();
+  new window.prestashop.component.ChoiceTree('#zone_shop_association').enableAutoCheckChildren();
 });

--- a/admin-dev/themes/new-theme/js/pages/zone/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/zone/index.ts
@@ -23,39 +23,25 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import Grid from '@components/grid/grid';
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
-import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
-import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
-import SortingExtension from '@components/grid/extension/sorting-extension';
-import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
-import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
-import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
-import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
-import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
-import FiltersSubmitButtonEnablerExtension
-  from '@components/grid/extension/filters-submit-button-enabler-extension';
-import ChoiceExtension from '@components/grid/extension/choice-extension';
-import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
 import ChoiceTree from '@components/form/choice-tree';
 
 const {$} = window;
 
 $(() => {
-  const grid = new Grid('zone');
+  const grid = new window.prestashop.component.Grid('zone');
 
-  grid.addExtension(new FiltersResetExtension());
-  grid.addExtension(new ReloadListActionExtension());
-  grid.addExtension(new ExportToSqlManagerExtension());
-  grid.addExtension(new SortingExtension());
-  grid.addExtension(new LinkRowActionExtension());
-  grid.addExtension(new SubmitGridExtension());
-  grid.addExtension(new SubmitBulkExtension());
-  grid.addExtension(new BulkActionCheckboxExtension());
-  grid.addExtension(new FiltersSubmitButtonEnablerExtension());
-  grid.addExtension(new ChoiceExtension());
-  grid.addExtension(new ColumnTogglingExtension());
-  grid.addExtension(new SubmitRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ChoiceExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
 
   new ChoiceTree('#zone_shop_association').enableAutoCheckChildren();
 });

--- a/admin-dev/themes/new-theme/js/pages/zone/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/zone/index.ts
@@ -31,12 +31,12 @@ $(() => {
   const grid = new window.prestashop.component.Grid('zone');
 
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersResetExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.ReloadListExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.ExportToSqlManagerExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.SortingExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridExtension());
-  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitGridActionExtension());
+  grid.addExtension(new window.prestashop.component.GridExtensions.SubmitBulkActionExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.ChoiceExtension());


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Almost all components are globally initialized, we can just use them instead of bundling them again and again.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Green tests should reveal an issue. Even a green asset build is a good indicator that everything is OK.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/10862142706
| Fixed issue or discussion?     |
| Related PRs       | 
| Sponsor company   | 

### Changes
- Changed all `grid.addExtension(new ExtensionName());` to `grid.addExtension(new window.prestashop.component.GridExtensions.ExtensionName());` and removed `import ExtensionName from '@components/grid/extension/path...';`
- Extensions `SubmitBulkExtension`, `SubmitGridExtension`, `ReloadListActionExtension` were changed to use the standard name.
- Use `ChoiceTable`, `TranslatableInput`, `ChoiceTree`, `CountryStateSelectionToggler`, `CountryDniRequiredToggler`, `GeneratableInput`, `TextWithRecommendedLengthCounter`, `MultipleChoiceTable` from `window.prestashop.component`