### PR TITLE
Remove redirection on cms exception

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -93,24 +93,7 @@ class CmsPageController extends FrameworkBundleAdminController
     public function indexAction(CmsPageCategoryFilters $categoryFilters, CmsPageFilters $cmsFilters, Request $request)
     {
         $cmsCategoryParentId = (int) $categoryFilters->getFilters()['id_cms_category_parent'];
-        $viewData = [];
-
-        try {
-            $viewData = $this
-                ->get('prestashop.core.cms_page.data_provider.cms_page_view')
-                ->getView($cmsCategoryParentId)
-            ;
-        } catch (Exception $exception) {
-            $this->addFlash(
-                'error',
-                $this->getErrorMessageForException($exception, $this->getErrorMessages())
-            );
-
-            if ($exception instanceof CmsPageCategoryNotFoundException) {
-                return $this->redirectToRoute('admin_cms_pages_index');
-            }
-        }
-
+        $viewData = $this->get('prestashop.core.cms_page.data_provider.cms_page_view')->getView($cmsCategoryParentId);
         $cmsCategoryGridFactory = $this->get('prestashop.core.grid.factory.cms_page_category');
         $cmsCategoryGrid = $cmsCategoryGridFactory->getGrid($categoryFilters);
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.2.x
| Description?      | Small improvement we found with @ShaiMagal. Dominik was finding a cause of an issue of infinite redirect on one of PrestaShop stores migrated from older versions, which was happening only on CMS pages. The cause was a missing lang entry for CMS category. When a CMS category can't be loaded, it redirects to the same page, with the same filters, so it won't be found again, so you never see the error message, that the CMS category is wrong. This just throws the exception.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to `ps_cms_category_lang` and remove all rows. Go to CMS page section in BO and see that you get an infinite redirect loop. With this PR, you get error.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/10905137750
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
