### PR TITLE
Delete old thumbnail for variant images when deleting product

### DIFF
--- a/classes/Image.php
+++ b/classes/Image.php
@@ -665,6 +665,15 @@ class ImageCore extends ObjectModel
             }
         }
 
+        // We need to delete old thumbnails (if exists) from variant images as well
+        $old_thumbnails = glob(_PS_TMP_IMG_DIR_ . 'product_mini_*.' . $this->image_format);
+        if (!empty($old_thumbnails)) {
+            foreach ($old_thumbnails as $file) {
+                // we don't care, if it exists, because glob will handle this
+                @unlink($file);
+            }
+        }
+
         // Can we delete the image folder?
         if (is_dir($this->image_dir . $this->getImgFolder())) {
             $deleteFolder = true;

--- a/classes/Image.php
+++ b/classes/Image.php
@@ -666,7 +666,7 @@ class ImageCore extends ObjectModel
         }
 
         // We need to delete old thumbnails (if exists) from variant images as well
-        $old_thumbnails = glob(_PS_TMP_IMG_DIR_ . 'product_mini_*.' . $this->image_format);
+        $old_thumbnails = glob(_PS_TMP_IMG_DIR_ . 'product_mini_' . $this->id_product . '_*.' . $this->image_format);
         if (!empty($old_thumbnails)) {
             foreach ($old_thumbnails as $file) {
                 // we don't care, if it exists, because glob will handle this


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | If you delete product, in folder /img/tmp/ will persist thumbnail image(s) from variant image. For example something like that: product_mini_16_99.jpg, actual solution can't handle this.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check below
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/10938418962
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/


**How to test:**
A) Create product with combinations (any)
B) Upload 2 images to product
C) Open combinations and asign one of images to combinations and save
D) Now order product (make real order for combination product with assigned image)
E) Go to the "Orders" section and open your order (this will create image in /img/tmp/)
F) Now go to Catalog and delete whole product
G) Combination image will persist in /img/tmp/ (it will be like product_mini_XX_YY.jpg), after apply this PR, when you try again, image will be deleted.


Main image format:
product_mini_XX.jpg
Combination image format:
product_mini_XX_YY.jpg