### PR TITLE
Deprecate separate search tag methods

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -1042,6 +1042,10 @@ class SearchCore
         $queryArray3 = [];
     }
 
+    /**
+     * @deprecated since 8.2.0 and will be removed in 9.0.0, searching products by tags
+     * is already included in Search::find method. Tags are indexed for each product.
+     */
     public static function searchTag(
         $id_lang,
         $tag,

--- a/controllers/front/listing/SearchController.php
+++ b/controllers/front/listing/SearchController.php
@@ -51,12 +51,17 @@ class SearchControllerCore extends ProductListingFrontController
             $this->search_string = Tools::getValue('search_query');
         }
 
+        // @deprecated since 8.2.0 and will be removed in 9.0.0, searching products by tags
+        // is already included in Search::find method. Tags are indexed for each product.
         $this->search_tag = Tools::getValue('tag');
 
         $this->context->smarty->assign(
             [
                 'search_string' => $this->search_string,
+                // @deprecated since 8.2.0 and will be removed in 9.0.0, searching products by tags
+                // is already included in Search::find method. Tags are indexed for each product.
                 'search_tag' => $this->search_tag,
+                // @deprecated since 8.2.0 and will be removed in 9.0.0, unused
                 'subcategories' => [],
             ]
         );
@@ -99,6 +104,8 @@ class SearchControllerCore extends ProductListingFrontController
             ->setQueryType('search')
             ->setSortOrder(new SortOrder('product', 'position', 'desc'))
             ->setSearchString($this->search_string)
+            // @deprecated since 8.2.0 and will be removed in 9.0.0, searching products by tags
+            // is already included in Search::find method. Tags are indexed for each product.
             ->setSearchTag($this->search_tag);
 
         return $query;

--- a/src/Adapter/Search/SearchProductSearchProvider.php
+++ b/src/Adapter/Search/SearchProductSearchProvider.php
@@ -85,10 +85,12 @@ class SearchProductSearchProvider implements ProductSearchProviderInterface
                 'searched_query' => $queryString,
                 'total' => $count,
 
-                // deprecated since 1.7.x
+                // @deprecated since 1.7.x and will be removed in 9.0.0
                 'expr' => $queryString,
             ]);
         } elseif (($tag = $query->getSearchTag())) {
+            // @deprecated since 8.2.0 and will be removed in 9.0.0, searching products by tags
+            // is already included in Search::find method. Tags are indexed for each product.
             $queryString = urldecode($tag);
 
             $products = Search::searchTag(
@@ -119,7 +121,7 @@ class SearchProductSearchProvider implements ProductSearchProviderInterface
                 'searched_query' => $queryString,
                 'total' => $count,
 
-                // deprecated since 1.7.x
+                // @deprecated since 1.7.x and will be removed in 9.0.0
                 'expr' => $queryString,
             ]);
         }

--- a/src/Core/Product/Search/ProductSearchQuery.php
+++ b/src/Core/Product/Search/ProductSearchQuery.php
@@ -57,6 +57,9 @@ class ProductSearchQuery
     private $searchString;
 
     /**
+     * @deprecated since 8.2.0 and will be removed in 9.0.0, searching products by tags
+     * is already included in Search::find method. Tags are indexed for each product.
+     *
      * @var string
      */
     private $searchTag;
@@ -253,6 +256,9 @@ class ProductSearchQuery
     }
 
     /**
+     * @deprecated since 8.2.0 and will be removed in 9.0.0, searching products by tags
+     * is already included in Search::find method. Tags are indexed for each product.
+     *
      * @param string $searchTag
      *
      * @return $this
@@ -265,6 +271,9 @@ class ProductSearchQuery
     }
 
     /**
+     * @deprecated since 8.2.0 and will be removed in 9.0.0, searching products by tags
+     * is already included in Search::find method. Tags are indexed for each product.
+     *
      * @return string
      */
     public function getSearchTag()


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Searching products by tags is already included in Search::find method, they are normally indexed and searched with other data. This is a code that is unused for a long time and there is no way to use it, unless you change the URL. Will be removed in 9.0.0. Discussed with @kpodemski.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | No need to test, only comments.
| UI Tests          | 
| Fixed issue or discussion?     |
| Related PRs       | 
| Sponsor company   | 
