### PR TITLE
Use basename on user given filename in legacy uploadcontroller

### DIFF
--- a/controllers/front/UploadController.php
+++ b/controllers/front/UploadController.php
@@ -75,6 +75,6 @@ class UploadControllerCore extends GetFileController
 
     private function getPath(): string
     {
-        return _PS_UPLOAD_DIR_ . $this->filename;
+        return _PS_UPLOAD_DIR_ . basename($this->filename);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Improve security by using the php `basename` function. (this is a minor security improvement: this could not be exploited without being connected to back office)
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green
| UI Tests          | https://github.com/matthieu-rolland/ga.tests.ui.pr/actions/runs/10923477257
| Fixed issue or discussion?     | none
| Related PRs       | none
| Sponsor company   | PrestaShop SA