### PR TITLE
Fix: Disabled or expired voucher is not removed from the cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -480,8 +480,10 @@ class CartCore extends ObjectModel
                 WHERE `id_cart` = ' . (int) $this->id . '
                 ' . ($filter == CartRule::FILTER_ACTION_SHIPPING ? 'AND free_shipping = 1' : '') . '
                 ' . ($filter == CartRule::FILTER_ACTION_GIFT ? 'AND gift_product != 0' : '') . '
-                ' . ($filter == CartRule::FILTER_ACTION_REDUCTION ? 'AND (reduction_percent != 0 OR reduction_amount != 0)' : '')
-                . ' ORDER by cr.priority ASC, cr.gift_product DESC'
+                ' . ($filter == CartRule::FILTER_ACTION_REDUCTION ? 'AND (reduction_percent != 0 OR reduction_amount != 0)' : '') . '
+                AND `active` = 1
+                AND NOW() BETWEEN `date_from` AND `date_to`
+                ORDER by cr.priority ASC, cr.gift_product DESC'
             );
             Cache::store($cache_key, $result);
         } else {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -481,9 +481,12 @@ class CartCore extends ObjectModel
                 ' . ($filter == CartRule::FILTER_ACTION_SHIPPING ? 'AND free_shipping = 1' : '') . '
                 ' . ($filter == CartRule::FILTER_ACTION_GIFT ? 'AND gift_product != 0' : '') . '
                 ' . ($filter == CartRule::FILTER_ACTION_REDUCTION ? 'AND (reduction_percent != 0 OR reduction_amount != 0)' : '') . '
-                AND `active` = 1
-                AND NOW() BETWEEN `date_from` AND `date_to`
-                ORDER by cr.priority ASC, cr.gift_product DESC'
+                AND cr.`active` = 1
+                AND cr.`quantity` > 0
+                AND cr.`deleted` = 0
+                AND cr.`date_from` <= "' . date('Y-m-d H:i:s') . '"
+                AND cr.`date_to` >= "' . date('Y-m-d H:i:s') . '"
+                ORDER by cr.`priority` ASC, cr.`gift_product` DESC'
             );
             Cache::store($cache_key, $result);
         } else {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -483,7 +483,6 @@ class CartCore extends ObjectModel
                 ' . ($filter == CartRule::FILTER_ACTION_REDUCTION ? 'AND (reduction_percent != 0 OR reduction_amount != 0)' : '') . '
                 AND cr.`active` = 1
                 AND cr.`quantity` > 0
-                AND cr.`deleted` = 0
                 AND cr.`date_from` <= "' . date('Y-m-d H:i:s') . '"
                 AND cr.`date_to` >= "' . date('Y-m-d H:i:s') . '"
                 ORDER by cr.`priority` ASC, cr.`gift_product` DESC'


### PR DESCRIPTION
Added check on the 'active' field and verified the voucher expiration

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | If a discount is added to the cart and later deactivated or its expiration date is changed, making it expire, the discount remains in the cart. Warning! There must be at least 2 discounts created, because if there is only one discount and it is disabled, it works correctly due to the system performing this check: CartRule::isFeatureActive().
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1 - Create 2 valid discounts. 2 - Add one of the 2 discounts to the cart. 3 - Disable the discount in the admin panel or change the date to make it expire. 4 - View the cart in the front office. 5 - The discount must not be calculated in the cart total.
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | Fixes #36982
| Sponsor company   | @Codencode 
