### PR TITLE
Fix: Initialize the Country object according the context during the checkout process to avoid issues

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -503,7 +503,7 @@ class FrontControllerCore extends Controller
 
         if (isset($cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')}) && $cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')}) {
             $infos = Address::getCountryAndState((int) $cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
-            $country = new Country((int) $infos['id_country']);
+            $country = new Country((int) $infos['id_country'], (int) $this->context->language->id);
             $this->context->country = $country;
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Initialize the Country object according the context during the checkout process to avoid issues. During the checkout process, this code will return an array with the language names instead of the name depending on the language of the current context
| Type?             | bug fix
| Category?         | FO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | 1 - Go to checkout step in FO. 2 - Try to dump de context country object. 3 - See the country is an string
| Fixed issue or discussion?     | Fixes #36984
| Sponsor company   | @Codencode 
