### PR TITLE
Fix product refresh when multiple elements

### DIFF
--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -223,10 +223,8 @@ function updateProduct(event, eventType, updateUrl) {
           );
         }
         $(prestashop.selectors.product.prices)
-          .first()
           .replaceWith(data.product_prices);
         $(prestashop.selectors.product.customization)
-          .first()
           .replaceWith(data.product_customization);
 
         // refill customizationId input value when updating quantity or combination
@@ -240,19 +238,15 @@ function updateProduct(event, eventType, updateUrl) {
         }
 
         $(prestashop.selectors.product.variantsUpdate)
-          .first()
           .replaceWith(data.product_variants);
         $(prestashop.selectors.product.discounts)
-          .first()
           .replaceWith(data.product_discounts);
         $(prestashop.selectors.product.additionalInfos)
-          .first()
           .replaceWith(data.product_additional_info);
         $(prestashop.selectors.product.details).replaceWith(
           data.product_details,
         );
         $(prestashop.selectors.product.flags)
-          .first()
           .replaceWith(data.product_flags);
         replaceAddToCartSections(data);
         const minimalProductQuantity = parseInt(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  Fix product refresh when multiple elements.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See description bellow 
| UI Tests          | N/A
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | Evolutive

## How to test

- Go to :  ```templates/catalog/_partials/product-prices.tpl```
- Duplciate the block :
 ```html 
<div class="product__prices js-product-prices">....</div>
```
- Go to FO in product page (product with combinations and different prices)
- Change products combinations et see the price in the duplicated bloc not refresh
