### PR TITLE
Add replyToName parameter to Hook actionEmailSendBefore

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -179,6 +179,7 @@ class MailCore extends ObjectModel
                 'idShop' => &$idShop,
                 'bcc' => &$bcc,
                 'replyTo' => &$replyTo,
+                'replyToName' => &$replyToName,
             ],
             null,
             true


### PR DESCRIPTION
# Add `replyToName` parameter to `actionEmailSendBefore` hook

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR adds the missing `replyToName` parameter to the `actionEmailSendBefore` hook. This parameter is already present in the `Mail::send()` method but was not being passed to the hook, limiting the ability of modules to modify the reply-to name of outgoing emails.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Check out this branch
|                   | 2. Create a module that hooks into `actionEmailSendBefore`
|                   | 3. Add code to access and potentially modify the `replyToName` parameter
|                   | 4. Trigger an email send (e.g., order confirmation)
|                   | 5. Verify that the `replyToName` parameter is available and can be modified within the hook
| UI Tests          | https://github.com/tleon/ga.tests.ui.pr/actions/runs/11073331304 https://github.com/florine2623/testing_pr/actions/runs/11363633342 ✅ 
| Fixed issue       | Fixes https://github.com/PrestaShop/PrestaShop/issues/37008
| Related PRs       | N/A
| Sponsor company   | [Your company name, if applicable]

## Description

This pull request adds the `replyToName` parameter to the `actionEmailSendBefore` hook in the `Mail` class. The change is minimal and straightforward:

```php
Hook::exec(
    'actionEmailSendBefore',
    [
        // ... existing parameters ...
        'replyTo' => &$replyTo,
        'replyToName' => &$replyToName, // Added this line
    ],
    null,
    true
);
```

This change allows modules to access and modify the `replyToName` parameter, bringing it in line with other email-related parameters already available in the hook.

## Benefits

- Modules can now access and modify the `replyToName` parameter within the `actionEmailSendBefore` hook.
- Consistency with other email-related parameters in the hook.
- Improved flexibility for customizing email behavior.

## Possible impacts

This change should not have any negative impacts as it only adds a new parameter to an existing hook. Existing modules using this hook will continue to function as before.