### PR TITLE
Distinguish when availability is in stock

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -1094,7 +1094,7 @@ class ProductLazyArray extends AbstractLazyArray
                     'Shop.Theme.Catalog'
                 );
             } else {
-                $this->product['availability'] = 'available';
+                $this->product['availability'] = 'in_stock';
 
                 // We will primarily use label from combination if set, then label on product, then the default label from PS settings
                 if (!empty($combinationData['available_now'])) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allows to distinguish between **available on backorder** and **in stock** availability. It's hard to style green/yellow alert in the theme now, with this PR, it's easy to do.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | If you apply the template change, no visible change should be on default themes.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/11048653205 ✅ 
| Fixed issue or discussion?     | 
| Related PRs       | Theme PRs will follow.
| Sponsor company   | 

## What this is
- We now have following options on `$product.availability` - `last_remaining_items`, `available`, `unavailable`
- I added a new one - `in_stock`

### Specifications
- https://github.com/PrestaShop/prestashop-specs/blob/master/content/1.7/back-office/shop-parameters/product-settings/page.md
- https://www.figma.com/design/aCBf2HlypjT0ZxP2XcsT68/Core-Github-issues?node-id=207-4875&node-type=canvas

### Theme change required
It's needed to alter one line in the default templates:
`{if $product.availability == 'available'}` to `{if $product.availability == 'available' || $product.availability == 'in_stock'}`

Here:
- https://github.com/PrestaShop/hummingbird/blob/813304d6b2f4c65f739d813d0f4282ce8c6d6d99/templates/catalog/_partials/product-add-to-cart.tpl#L11
- https://github.com/PrestaShop/classic-theme/blob/5b47c0470bebe768681f1ab6344000558c219580/templates/catalog/_partials/product-add-to-cart.tpl#L71

### What it enables to do
You can now do

```
{if $product.availability == 'in_stock'}
<div class="alert alert-success">
{elseif $product.availability == 'available'}
<div class="alert alert-warning">
{else}
<div class="alert alert-danger">
{/if}
```