### PR TITLE
Guest.php - OS/Browser unnecessary logging to PHP error log in specific conditions

### DIFF
--- a/classes/Guest.php
+++ b/classes/Guest.php
@@ -142,7 +142,7 @@ class GuestCore extends ObjectModel
 				FROM `' . _DB_PREFIX_ . 'web_browser` wb
 				WHERE wb.`name` = \'' . pSQL($k) . '\'');
 
-                return $result['id_web_browser'];
+                return $result['id_web_browser'] ?? null;
             }
         }
 
@@ -175,7 +175,7 @@ class GuestCore extends ObjectModel
 				FROM `' . _DB_PREFIX_ . 'operating_system` os
 				WHERE os.`name` = \'' . pSQL($k) . '\'');
 
-                return $result['id_operating_system'];
+                return $result['id_operating_system'] ?? null;
             }
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | In some conditions there will not be sucessfull query result, so we need to validate result of query first before we return it. We must do this to get rid of unnecessary logging in the php error log. Similar logic is already defined in this file - look for line "return $result['id_guest'] ?? false;".
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/11551673272
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/

Log real examples:
[24-Sep-2024 16:11:49 Europe/Prague] PHP Warning:  Trying to access array offset on false in XXX/classes/Guest.php on line 178
[24-Sep-2024 16:11:49 Europe/Prague] PHP Warning:  Trying to access array offset on false in XXX/classes/Guest.php on line 145