### PR TITLE
Improve and finalize availability

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -622,10 +622,21 @@ class ProductLazyArray extends AbstractLazyArray
         }
 
         if ($this->shouldShowOutOfStockLabel($this->settings, $this->product)) {
-            $config = $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOD');
+            // For the label, we will follow the same logic as for normal stock label,
+            // we will try combination label, then product label, then the general label.
+            $combinationData = $this->getCombinationSpecificData();
+            if (!empty($combinationData['available_later'])) {
+                $message = $combinationData['available_later'];
+            } elseif (!empty($this->product['available_later'])) {
+                $message = $this->product['available_later'];
+            } else {
+                $config = $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOD');
+                $message = $config[$this->language->getId()] ?? null;
+            }
+
             $flags['out_of_stock'] = [
                 'type' => 'out_of_stock',
-                'label' => $config[$this->language->getId()] ?? null,
+                'label' => $message,
             ];
         }
 

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -1138,17 +1138,23 @@ class ProductLazyArray extends AbstractLazyArray
             $this->product['availability_date'] = $product['available_date'];
             $this->product['availability'] = 'unavailable';
 
+            // We will primarily use label from combination if set, then label on product, then the default label from PS settings
+            if (!empty($combinationData['available_later'])) {
+                $this->product['availability_message'] = $combinationData['available_later'];
+            } elseif (!empty($product['available_later'])) {
+                $this->product['availability_message'] = $product['available_later'];
+            } else {
+                $config = $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOD');
+                $this->product['availability_message'] = $config[$language->id] ?? null;
+            }
+
             // If the product has combinations and other combination is in stock, we show a small hint about it
             if ($product['cache_default_attribute'] && $product['quantity_all_versions'] > 0) {
-                $this->product['availability_message'] = $this->translator->trans(
+                $this->product['availability_submessage'] = $this->translator->trans(
                     'Product available with different options',
                     [],
                     'Shop.Theme.Catalog'
                 );
-            } else {
-                // We use label set in PS configuration - label is not customizable per product
-                $config = $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOD');
-                $this->product['availability_message'] = $config[$language->id] ?? null;
             }
         }
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
@@ -125,6 +125,7 @@ class StockType extends TranslatorAwareType
                     ],
                 ],
                 'required' => false,
+                'help' => $this->trans('This will be the default displayed availability of a product, if there is at least 1 in stock. If you don\'t enter anything, nothing will be displayed. Further customization is possible for each product.', 'Admin.Catalog.Help'),
             ])
             ->add('oos_allowed_backorders', TranslatableType::class, [
                 'label' => $this->trans(
@@ -139,6 +140,7 @@ class StockType extends TranslatorAwareType
                     ],
                 ],
                 'required' => false,
+                'help' => $this->trans('This will be the default displayed availability of a product, if it\'s not in stock and backordering it is enabled. If you don\'t enter anything, nothing will be displayed. Further customization is possible for each product.', 'Admin.Catalog.Help'),
             ])
             ->add('oos_denied_backorders', TranslatableType::class, [
                 'label' => $this->trans(
@@ -153,6 +155,7 @@ class StockType extends TranslatorAwareType
                     ],
                 ],
                 'required' => false,
+                'help' => $this->trans('This will be the default displayed availability of a product, if it\'s not in stock and backordering it is denied. If you don\'t enter anything, nothing will be displayed. Further customization is possible for each product.', 'Admin.Catalog.Help'),
             ])
             ->add('delivery_time', TranslatableType::class, [
                 'label' => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
@@ -86,15 +86,26 @@ class CombinationAvailabilityType extends TranslatorAwareType
                 'label' => $this->trans('Label when in stock', 'Admin.Catalog.Feature'),
                 'required' => false,
                 'modify_all_shops' => true,
+                'help' => $this->trans('This will be the displayed availability of the product, if there is at least 1 in stock. If you don\'t enter anything, value from [1]Shop Parameters > Product Settings[/1] will be used.',
+                    'Admin.Catalog.Help',
+                    [
+                        '[1]' => '<a href="' . $this->router->generate('admin_product_preferences') . '#configuration_fieldset_stock">',
+                        '[/1]' => '</a>',
+                    ]
+                ),
             ])
             ->add('available_later_label', TranslatableType::class, [
                 'type' => TextType::class,
-                'label' => $this->trans(
-                    'Label when out of stock (and backorders allowed)',
-                    'Admin.Catalog.Feature'
-                ),
+                'label' => $this->trans('Label when out of stock', 'Admin.Catalog.Feature'),
                 'required' => false,
                 'modify_all_shops' => true,
+                'help' => $this->trans('This will be the displayed availability of the product, if it\'s not in stock. If you don\'t enter anything, value from [1]Shop Parameters > Product Settings[/1] will be used.',
+                    'Admin.Catalog.Help',
+                    [
+                        '[1]' => '<a href="' . $this->router->generate('admin_product_preferences') . '#configuration_fieldset_stock">',
+                        '[/1]' => '</a>',
+                    ]
+                ),
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
@@ -80,11 +80,12 @@ class CombinationStockType extends TranslatorAwareType
                     ],
                 ],
                 'modify_all_shops' => true,
+                'help' => $this->trans('This will be the displayed availability of the combination, if there is at least 1 in stock. If you don\'t enter anything, the base value set on the product will be used.', 'Admin.Catalog.Help'),
             ])
             ->add('available_later_label', TranslatableType::class, [
                 'type' => TextType::class,
                 'label' => $this->trans(
-                    'Label when out of stock (and backorders allowed)',
+                    'Label when out of stock',
                     'Admin.Catalog.Feature'
                 ),
                 'required' => false,
@@ -102,6 +103,7 @@ class CombinationStockType extends TranslatorAwareType
                     ],
                 ],
                 'modify_all_shops' => true,
+                'help' => $this->trans('This will be the displayed availability of the combination, if it\'s not in stock. If you don\'t enter anything, the base value set on the product will be used.', 'Admin.Catalog.Help'),
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
@@ -106,11 +106,18 @@ class AvailabilityType extends TranslatorAwareType
                         ]),
                     ],
                 ],
+                'help' => $this->trans('This will be the displayed availability of the product, if there is at least 1 in stock. If you don\'t enter anything, value from [1]Shop Parameters > Product Settings[/1] will be used.',
+                    'Admin.Catalog.Help',
+                    [
+                        '[1]' => '<a href="' . $this->router->generate('admin_product_preferences') . '#configuration_fieldset_stock">',
+                        '[/1]' => '</a>',
+                    ]
+                ),
             ])
             ->add('available_later_label', TranslatableType::class, [
                 'type' => TextType::class,
                 'label' => $this->trans(
-                    'Label when out of stock (and backorders allowed)',
+                    'Label when out of stock',
                     'Admin.Catalog.Feature'
                 ),
                 'required' => false,
@@ -128,6 +135,13 @@ class AvailabilityType extends TranslatorAwareType
                         ]),
                     ],
                 ],
+                'help' => $this->trans('This will be the displayed availability of the product, if it\'s not in stock. If you don\'t enter anything, value from [1]Shop Parameters > Product Settings[/1] will be used.',
+                    'Admin.Catalog.Help',
+                    [
+                        '[1]' => '<a href="' . $this->router->generate('admin_product_preferences') . '#configuration_fieldset_stock">',
+                        '[/1]' => '</a>',
+                    ]
+                ),
             ])
             ->add('available_date', DatePickerType::class, [
                 'label' => $this->trans('Availability date', 'Admin.Catalog.Feature'),

--- a/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
+++ b/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
@@ -434,8 +434,7 @@ class ProductLazyArrayTest extends TestCase
 
         // Product out stock, backorders disabled
         // Product labels filled
-        // Should return not available label from PS configuration
-        // (this label is not configurable per product or per combination)
+        // Should return available later label from product
         yield [
             array_merge(
                 $product,
@@ -448,6 +447,27 @@ class ProductLazyArrayTest extends TestCase
                     'available_date' => false,
                     'available_now' => self::PRODUCT_AVAILABLE_NOW,
                     'available_later' => self::PRODUCT_AVAILABLE_LATER,
+                    'allow_oosp' => OutOfStockType::OUT_OF_STOCK_NOT_AVAILABLE,
+                ]
+            ),
+            self::PRODUCT_AVAILABLE_LATER,
+        ];
+
+        // Product out stock, backorders disabled
+        // Product labels NOT filled
+        // Should return available later label from PS configuration
+        yield [
+            array_merge(
+                $product,
+                [
+                    'cache_default_attribute' => 0,
+                    'quantity_wanted' => 1,
+                    'stock_quantity' => 0,
+                    'quantity' => 0,
+                    'show_availability' => 1,
+                    'available_date' => false,
+                    'available_now' => [],
+                    'available_later' => [],
                     'allow_oosp' => OutOfStockType::OUT_OF_STOCK_NOT_AVAILABLE,
                 ]
             ),

--- a/tests/UI/campaigns/functional/BO/03_catalog/01_products/11_combinationTab.ts
+++ b/tests/UI/campaigns/functional/BO/03_catalog/01_products/11_combinationTab.ts
@@ -343,7 +343,7 @@ describe('BO - Catalog - Products : Combination tab', async () => {
       await testContext.addContextItem(this, 'testIdentifier', 'selectCombination4', baseContext);
 
       const availabilityLabel = await foClassicProductPage.getProductAvailabilityLabel(page);
-      expect(availabilityLabel).to.contains('Product available');
+      expect(availabilityLabel).to.contains('Out-of-Stock');
     });
 
     it('should close the page', async function () {

--- a/tests/UI/campaigns/functional/BO/03_catalog/01_products/15_stocksTab.ts
+++ b/tests/UI/campaigns/functional/BO/03_catalog/01_products/15_stocksTab.ts
@@ -280,7 +280,7 @@ describe('BO - Catalog - Products : Stocks tab', async () => {
       expect(isAddToCartButtonEnabled).to.be.equal(false);
 
       const productAvailability = await foClassicProductPage.getProductAvailabilityLabel(page);
-      expect(productAvailability).to.be.contains('Out-of-Stock');
+      expect(productAvailability).to.be.contains('OUT OF STOCK');
     });
 
     it('should go back to BO', async function () {

--- a/tests/UI/campaigns/functional/FO/hummingbird/09_productPage/02_productPage/10_outOfStockBehaviour.ts
+++ b/tests/UI/campaigns/functional/FO/hummingbird/09_productPage/02_productPage/10_outOfStockBehaviour.ts
@@ -256,7 +256,7 @@ describe('FO - Product page - Product page : Out of stock behaviour', async () =
       expect(isAddToCartButtonEnabled).to.equal(false);
 
       const productAvailability = await foHummingbirdProductPage.getProductAvailabilityLabel(page);
-      expect(productAvailability).to.contains('Out-of-Stock');
+      expect(productAvailability).to.contains('Out of stock');
     });
 
     it('should go back to BO', async function () {

--- a/tests/UI/pages/BO/catalog/products/add/combinationsTab.ts
+++ b/tests/UI/pages/BO/catalog/products/add/combinationsTab.ts
@@ -335,7 +335,7 @@ class CombinationsTab extends BOBasePage {
     this.denyOrderRadioButton = '#product_combinations_availability_out_of_stock_type_0 +i';
     this.allowOrderRadioButton = '#product_combinations_availability_out_of_stock_type_1 +i';
     this.useDefaultBehaviourRadioButton = '#product_combinations_availability_out_of_stock_type_2 +i';
-    this.editDefaultBehaviourLink = '#product_combinations_availability a[href*=configuration_fieldset_stock]';
+    this.editDefaultBehaviourLink = '#product_combinations_availability a.btn-link[href*=configuration_fieldset_stock]';
     this.labelWhenInStock = '#product_combinations_availability_available_now_label_1';
     this.labelWhenOutOfStock = '#product_combinations_availability_available_later_label_1';
   }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | I finished the remaining things regarding availability. See below.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | See below
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/hummingbird/pull/658, https://github.com/PrestaShop/classic-theme/pull/159
| Sponsor company   | 

## What is changed
### 1. Label when out of stock behavior
Product `Label when out of stock` that is configurable for each product, was only used when backorders were enabled for the product. If they were disabled, it only looked on the value in `Shop settings > Product settings`. This is insufficient, because we can't specify the availability for these products.

Example - `We are expecting the delivery in 10/2024.` or `There are problems on manufacturer side, availability on request.` and many other variants.

So, I slightly tweaked it and now this field is used for both cases. If it's empty, it will look to the prestashop settings value.

Before, I was thinking into adding another field to a product, but that's not needed. One field is sufficient. :-)

### 2. Helper labels in admin
Both `Label when in stock` and `Label when out of stock` now have helper labels under them with a link to shop settings, explaining what they do and when they are displayed. Both in combination and product forms.

#### Combination
- `Label when in stock` - `This will be the displayed availability of the combination, if there is at least 1 in stock. If you don\'t enter anything, the base value set on the product will be used.` 
- `Label when out of stock` - `This will be the displayed availability of the combination, if it\'s not in stock. If you don\'t enter anything, the base value set on the product will be used.`

#### Product
- `Label when in stock` - `This will be the displayed availability of the product, if there is at least 1 in stock. If you don\'t enter anything, value from [1]Shop Parameters > Product Settings[/1] will be used.`
- `Label when out of stock` - `This will be the displayed availability of the product, if it\'s not in stock. If you don\'t enter anything, value from [1]Shop Parameters > Product Settings[/1] will be used.`

#### Shop Parameters > Product settings
- `Label of in-stock products` - `This will be the default displayed availability of a product, if there is at least 1 in stock. If you don\'t enter anything, nothing will be displayed. Further customization is possible for each product.`
- `Label of out-of-stock products with allowed backorders` - `This will be the default displayed availability of a product, if it\'s not in stock and backordering it is enabled. If you don\'t enter anything, nothing will be displayed. Further customization is possible for each product.`
- `Label of out-of-stock products with denied backorders` - `This will be the default displayed availability of a product, if it\'s not in stock and backordering it is denied. If you don\'t enter anything, nothing will be displayed. Further customization is possible for each product.`

### 3. availability_submessage
I moved `Product available with different options` into a submessage key, as we originally designed it for hummingbird. This will be a new smaller text under the availability.

See specs - https://github.com/PrestaShop/prestashop-specs/blob/master/content/1.7/back-office/shop-parameters/product-settings/page.md - 

> if at least one other combination than the default one (on the product listings) or the selected one (on product page) can be ordered, the "Other product variations available" message will be displayed under the "Label of out-of-stock products with denied backorders" message.

### 4. How to test
- Go to `Shop settings > Product settings` and set some default texts to both `Label of out-of-stock products with allowed backorders` and `Label of out-of-stock products with denied backorders`.
- Create product with quantity 0, set some text to `Label when out of stock` field on the product.
- Enable backorders, go to frontoffice and see that you see the `Label when out of stock` of the product.
- Disable backorders, go to frontoffice and see that you see the `Label when out of stock` of the product.
- Remove text from `Label when out of stock` on the product.
- Enable backorders, go to frontoffice and see that you see the default text from Shop settings > Product settings.
- Disable backorders, go to frontoffice and see that you see the default text from Shop settings > Product settings.