### PR TITLE
Display output on error of intermediate commands during release creation

### DIFF
--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -482,6 +482,8 @@ class ReleaseCreator
         }
 
         if (!file_put_contents($this->tempProjectPath . '/LICENSES', $content)) {
+            $this->consoleWriter->displayText(" FAILED{$this->lineSeparator}", ConsoleWriter::COLOR_RED);
+
             throw new BuildException('Unable to create LICENSES file.');
         }
         $this->consoleWriter->displayText(" DONE{$this->lineSeparator}", ConsoleWriter::COLOR_GREEN);
@@ -515,6 +517,8 @@ class ReleaseCreator
         foreach ($fileLocations as $fileLocation) {
             $filePath = $this->tempProjectPath . $fileLocation . 'CACHEDIR.TAG';
             if (!file_put_contents($filePath, $fileContent)) {
+                $this->consoleWriter->displayText(" FAILED{$this->lineSeparator}", ConsoleWriter::COLOR_RED);
+
                 throw new BuildException('Unable to create ' . $filePath);
             }
         }
@@ -541,6 +545,8 @@ class ReleaseCreator
         exec($command, $output, $returnCode);
 
         if ($returnCode !== 0) {
+            $this->consoleWriter->displayText(" FAILED{$this->lineSeparator}", ConsoleWriter::COLOR_RED);
+            $this->consoleWriter->displayText(implode($this->lineSeparator, $output));
             throw new BuildException('Unable to run composer install.');
         }
 
@@ -563,6 +569,8 @@ class ReleaseCreator
         exec($command, $output, $returnCode);
 
         if ($returnCode !== 0) {
+            $this->consoleWriter->displayText(" FAILED{$this->lineSeparator}", ConsoleWriter::COLOR_RED);
+            $this->consoleWriter->displayText(implode($this->lineSeparator, $output));
             throw new BuildException('Unable to build assets.');
         }
 
@@ -862,6 +870,7 @@ class ReleaseCreator
             . "</checksum_list>{$this->lineSeparator}";
 
         if (!file_put_contents($xmlPath, $content)) {
+            $this->consoleWriter->displayText(" FAILED{$this->lineSeparator}", ConsoleWriter::COLOR_RED);
             throw new BuildException('Unable to generate XML checksum.');
         }
         $this->consoleWriter->displayText(" DONE{$this->lineSeparator}", ConsoleWriter::COLOR_GREEN);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | When an error occurs while building the release, I have no idea what happened. It makes the debugging impossible. This PR displays the output of the command when something wrong happens, in case on success, the contents remains lite.
| Type?             | improvement
| Category?         | PM
| BC breaks?        | Nope
| Deprecations?     | Nope
| How to test?      | Running the creation of release with Node 20 seems to make the build of release fail. Upgrade your environnment with this version and see the result.
| UI Tests          | /
| Fixed issue or discussion?     | /
| Related PRs       | /
| Sponsor company   | @PrestaShopCorp


### Behavior introduced with this PR

![Capture d’écran du 2024-09-25 11-41-09](https://github.com/user-attachments/assets/054a9059-40c2-4e7d-abdc-8548bbb3d2b3)
...
![Capture d’écran du 2024-09-25 11-42-04](https://github.com/user-attachments/assets/d0e09887-e5b6-4812-9aad-005df040f51c)


### Prior behavior on `8.2.x` and `develop`

![Capture d’écran du 2024-09-25 11-29-50](https://github.com/user-attachments/assets/d3e50496-b6eb-46a2-b878-0bac5f7e62f7)
