### PR TITLE
Fix: Multistore - Can't disable a group shop

### DIFF
--- a/controllers/admin/AdminShopGroupController.php
+++ b/controllers/admin/AdminShopGroupController.php
@@ -308,7 +308,7 @@ class AdminShopGroupControllerCore extends AdminController
         ];
 
         $this->fields_value = [
-            'active' => true,
+            'active' => $obj->id ? (bool) $obj->active : true,
         ];
 
         return parent::renderForm();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | When I disable a group shop, it is not taken into account. The group shop is still enabled.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #37028
| Related PRs       | 
| Sponsor company   | @Codencode 
