### PR TITLE
Fix: check if legacy context force multishop mode

### DIFF
--- a/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextListener.php
@@ -111,6 +111,7 @@ class ShopContextListener implements EventSubscriberInterface
         $redirectResponse = $this->redirectShopContext($event);
         if ($redirectResponse) {
             $event->setResponse($redirectResponse);
+
             return;
         }
 

--- a/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextListener.php
@@ -115,7 +115,9 @@ class ShopContextListener implements EventSubscriberInterface
             return;
         }
 
-        if (!$this->multistoreFeature->isUsed()) {
+        $legacyControllerIsMultishopContext = $event->getRequest()->attributes->get(LegacyControllerConstants::IS_ALL_SHOP_CONTEXT_ATTRIBUTE, false);
+
+        if (!$this->multistoreFeature->isUsed() && !$legacyControllerIsMultishopContext) {
             $shopConstraint = ShopConstraint::shop($this->getConfiguredDefaultShopId());
         } else {
             $shopConstraint = $this->getMultiShopConstraint($event->getRequest());

--- a/src/PrestaShopBundle/Routing/LegacyControllerConstants.php
+++ b/src/PrestaShopBundle/Routing/LegacyControllerConstants.php
@@ -35,5 +35,5 @@ class LegacyControllerConstants
     public const CONTROLLER_ACTION_ATTRIBUTE = '_legacy_controller_action';
     public const INSTANCE_ATTRIBUTE = '_legacy_controller_instance';
     public const IS_MODULE_ATTRIBUTE = '_legacy_controller_is_module';
-    public const IS_ALL_SHOP_CONTEXT_ATTRIBUTE = '_legacy_controller_is_all_shop_context';
+    public const MULTISHOP_CONTEXT_ATTRIBUTE = '_legacy_controller_is_all_shop_context';
 }

--- a/src/PrestaShopBundle/Routing/LegacyRouterChecker.php
+++ b/src/PrestaShopBundle/Routing/LegacyRouterChecker.php
@@ -120,7 +120,7 @@ class LegacyRouterChecker
 
         $request->attributes->set(LegacyControllerConstants::INSTANCE_ATTRIBUTE, $adminController);
         $request->attributes->set(RequestAttributes::ANONYMOUS_CONTROLLER_ATTRIBUTE, $adminController->isAnonymousAllowed());
-        $request->attributes->set(LegacyControllerConstants::IS_ALL_SHOP_CONTEXT_ATTRIBUTE, $adminController->multishop_context === ShopConstraint::ALL_SHOPS);
+        $request->attributes->set(LegacyControllerConstants::MULTISHOP_CONTEXT_ATTRIBUTE, $adminController->multishop_context);
         $request->attributes->set(LegacyControllerConstants::CONTROLLER_CLASS_ATTRIBUTE, $controllerClass);
         $request->attributes->set(LegacyControllerConstants::IS_MODULE_ATTRIBUTE, $isModule);
 

--- a/src/PrestaShopBundle/Routing/LegacyRouterChecker.php
+++ b/src/PrestaShopBundle/Routing/LegacyRouterChecker.php
@@ -29,7 +29,6 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Routing;
 
 use Dispatcher;
-use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Entity\Repository\TabRepository;

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextListenerTest.php
@@ -34,7 +34,9 @@ use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
 use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShopBundle\EventListener\Admin\Context\ShopContextListener;
+use PrestaShopBundle\Routing\LegacyControllerConstants;
 use PrestaShopBundle\Security\Admin\TokenAttributes;
+use Shop;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -43,8 +45,6 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Tests\Unit\PrestaShopBundle\EventListener\ContextEventListenerTestCase;
-use PrestaShopBundle\Routing\LegacyControllerConstants;
-use Shop;
 
 class ShopContextListenerTest extends ContextEventListenerTestCase
 {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Since the new builder ShopContextBuilder.php was implemented to handle context, there were some issues regarding the legacy controller that forced the context to Shop::CONTEXT_ALL. For example, the controller AdminCarrierWizardController.php is set to Shop::CONTEXT_ALL and all stuff regarding carrier does not handle multishop. So all writing to the database regarding carrier is saved with id_shop and id_shop_group to NULL (like multishop). Since ShopContextBuilder.php, It was no longer the case, and the context was overridden by ShopContextBuilder.php to a single shop instead. Carrier were saved with id_shop.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See in the linked issue #36896
| UI Tests          | https://github.com/Nakahiru/ga.tests.ui.pr/actions/runs/11212999910
| Fixed issue or discussion?     | Fixes #36896
| Related PRs       | none
| Sponsor company   | PrestaShop
