### PR TITLE
Raise payment reference to unify with orders table

### DIFF
--- a/classes/order/OrderPayment.php
+++ b/classes/order/OrderPayment.php
@@ -52,7 +52,7 @@ class OrderPaymentCore extends ObjectModel
         'table' => 'order_payment',
         'primary' => 'id_order_payment',
         'fields' => [
-            'order_reference' => ['type' => self::TYPE_STRING, 'size' => 9],
+            'order_reference' => ['type' => self::TYPE_STRING, 'size' => 255],
             'id_currency' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true],
             'amount' => ['type' => self::TYPE_FLOAT, 'validate' => 'isPrice', 'required' => true],
             'payment_method' => ['type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'size' => 255],

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1563,7 +1563,7 @@ CREATE TABLE `PREFIX_page_viewed` (
 /* Payment info (see payment_invoice) */
 CREATE TABLE `PREFIX_order_payment` (
   `id_order_payment` INT NOT NULL auto_increment,
-  `order_reference` VARCHAR(9),
+  `order_reference` VARCHAR(255),
   `id_currency` INT UNSIGNED NOT NULL,
   `amount` DECIMAL(20, 6) NOT NULL,
   `payment_method` varchar(255) NOT NULL,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Small follow-up PR on https://github.com/PrestaShop/PrestaShop/pull/35882, where I raised limit for order reference. We also need to raise it in order_payment table.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Auto tests are sufficient.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/11101663510 ✅ 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/35877#issuecomment-2376537813
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/919
| Sponsor company   | 
