### PR TITLE
Improve response for nonexistent images to avoid unnecessary load of server

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2308,6 +2308,10 @@ class ToolsCore
                     fwrite($write_fd, $domain_rewrite_cond);
                 }
                 fwrite($write_fd, 'RewriteRule ^images_ie/?([^/]+)\.(jpe?g|png|gif)$ %{ENV:REWRITEBASE}js/jquery/plugins/fancybox/images/$1.$2 [L]' . PHP_EOL);
+
+                fwrite($write_fd, "# non-existent image to 404\n");
+                fwrite($write_fd, "RewriteCond %{REQUEST_FILENAME} !-f\n");
+                fwrite($write_fd, "RewriteRule \.(?:jpe?g|webp|png|avif)$ - [R=404,L]\n");
             }
             // Redirections to dispatcher
             if ($rewrite_settings) {
@@ -2397,7 +2401,9 @@ FileETag none
         // Do not remove ($domains is already iterated upper)
         reset($domains);
         $domain = current($domains);
-        fwrite($write_fd, 'ErrorDocument 404 ' . $domain[0]['physical'] . "index.php?controller=404\n\n");
+        fwrite($write_fd, "<IfModule !mod_rewrite.c>\n");
+        fwrite($write_fd, 'ErrorDocument 404 ' . $domain[0]['physical'] . "index.php?controller=404\n");
+        fwrite($write_fd, "</IfModule>\n\n");
 
         fwrite($write_fd, '# ~~end~~ Do not remove this comment, Prestashop will keep automatically the code outside this comment when .htaccess will be generated again');
         if ($specific_after) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Check below
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open non existent image, for example https://demo80.psmoduly.cz/9999999999999-thickbox_default/aaa.jpg, before PR you will get 404 with website content. After PR you will get 403.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/

### Description:
If bots are accessing your website, they will get 404 on non existent image, this load whole website, content and modules. If bot is spamming (for example Facebook) - check access log below. This can cause the site to slow down significantly as it loads X pages per second as it only expects images. It is possible to totally crash whole website. But the entire site will be displayed.

Of course, source of this problem is not updated data feed (or any bug in bot) but there may be more similiar issues. Returning a 404 to non-existent images doesn't make much sense. OK for products but not for images.

**Biggest eshops in world provide 404 or 403, but both WITHOUT any content of website.**
PrestaShop is now serving content for non exists images, and it shouldn't. We must to get rid of this behavior and follow the biggest players in the industry.

.htaccess can provide this feature for us, but if you prefer another solution, let me know and I can edit this PR.
We can talk about it and find best solution

Here is demo:
website with PR (403):
https://demo80.psmoduly.cz/9999999999999-thickbox_default/aaa.jpg
website without PR (404):
https://demo17.psmoduly.cz/9999999999999-thickbox_default/aaa.jpg

Example access log (in reality there are hundred thousand of this log files per day:
_demo80.psmoduly.cz XXX.XXX.XXX.XXX- - [30/Sep/2024:22:06:13 +0200] "GET /99999999991-thickbox_default/XXX.jpg HTTP/1.1" 404 179524 "-" "facebookcatalog/1.0"
demo80.psmoduly.cz XXX.XXX.XXX.XXX- - [30/Sep/2024:22:06:13 +0200] "GET /99999999992-thickbox_default/XXX.jpg HTTP/1.1" 404 179524 "-" "facebookcatalog/1.0"
demo80.psmoduly.cz XXX.XXX.XXX.XXX- - [30/Sep/2024:22:06:14 +0200] "GET /99999999993-thickbox_default/XXX.jpg HTTP/1.1" 404 179524 "-" "facebookcatalog/1.0"
demo80.psmoduly.cz XXX.XXX.XXX.XXX- - [30/Sep/2024:22:06:14 +0200] "GET /99999999994-thickbox_default/XXX.jpg HTTP/1.1" 404 179524 "-" "facebookcatalog/1.0"
demo80.psmoduly.cz XXX.XXX.XXX.XXX- - [30/Sep/2024:22:06:14 +0200] "GET /99999999995-thickbox_default/XXX.jpg HTTP/1.1" 404 179524 "-" "facebookcatalog/1.0"
demo80.psmoduly.cz XXX.XXX.XXX.XXX- - [30/Sep/2024:22:06:14 +0200] "GET /99999999996-thickbox_default/XXX.jpg HTTP/1.1" 404 179524 "-" "facebookcatalog/1.0"_


BEFORE:
![before](https://github.com/user-attachments/assets/914c11e0-bf34-4861-85bf-4aa6cf72323a)

AFTER:
![after](https://github.com/user-attachments/assets/7d519779-643a-4b55-b6fd-dc7bee5ab4bb)

