### PR TITLE
Do not index filtered pages

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2562,9 +2562,11 @@ FileETag none
             }
         }
 
+        // We prevent indexing some standardized parameters from the URL
+        // For example, "q" is a filter query, "order" is sorting etc.
         $tab['GB'] = [
-            '?order=', '?tag=', '?id_currency=', '?search_query=', '?back=', '?n=',
-            '&order=', '&tag=', '&id_currency=', '&search_query=', '&back=', '&n=',
+            '?order=', '?tag=', '?id_currency=', '?search_query=', '?back=', '?n=', '?q=',
+            '&order=', '&tag=', '&id_currency=', '&search_query=', '&back=', '&n=', '&q=',
         ];
 
         foreach ($disallow_controllers as $controller) {

--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -565,6 +565,23 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
     }
 
     /**
+     * Do not index filtered pages or when sorting was used.
+     * This should correlate with robots.txt content. Make sure to update it also,
+     * if you change anything here.
+     */
+    public function getTemplateVarPage()
+    {
+        $page = parent::getTemplateVarPage();
+
+        // If some search parameters are submitted, or user selected some custom sorting,
+        if (Tools::isSubmit('q') || Tools::isSubmit('order')) {
+            $page['meta']['robots'] = 'noindex';
+        }
+
+        return $page;
+    }
+
+    /**
      * Similar to "getProductSearchVariables" but used in AJAX queries.
      *
      * It returns an array with the HTML for the products and facets,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | We were resolving some crawling issues of our clients with @Hlavtox and we found out that for some reason, some bots started crawling and thousands and thousands of filtered pages. See below for more information.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Click some filter in FO, refresh page and see source code. There will be meta robots no index.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/11252709504
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/

### Description
- Some bots started crawling and thousands and thousands of filtered pages. This must be prevented.
- It was already done on robots.txt level for pages with custom sorting `order`, but not for filtering using `q`.
- Some templates like classic-rocket have it hardcoded in the theme - https://github.com/prestarocket-agence/classic-rocket/blob/6e6d0a2af2b8874a2bfbf079adb5c25a19e9159c/templates/_partials/head.tpl#L42, so @Hlavtox did not even know about the issue.
- So, we went to resolve it.

### Changes
- There is a possibility for a controller to return a custom robots meta tag, and the template outputs it, but only search controller uses it currently. So, we did it in the controller that all listing controllers inherit from. If there is a sorting or filtering query, do not index this page.
- We extended robots.txt by the `q` param. It already had the `order` param.