### PR TITLE
Add manual removal fallback in SymfonyCacheClearer

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -42,7 +42,7 @@ jobs:
         run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
 
       - name: Run PHPCSFixer
-        run: ./vendor/bin/php-cs-fixer fix --dry-run --diff --path-mode=intersection
+        run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Run ergebnis/composer-normalize
         run: composer normalize --dry-run --no-check-lock

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -13,9 +13,9 @@ $finder = PhpCsFixer\Finder::create()->in([
     __DIR__.'/app/parameters.php',
     'Unit/Resources/config/params.php',
     'Unit/Resources/config/params_modified.php',
-    'tests/Resources/modules_tests/testtrickyconflict/override/classes/Cart.php',
+    'Resources/modules_tests/testtrickyconflict/override/classes/Cart.php',
+    'Resources/modules_tests/override_for_unit_test/classes/Cart.php',
 ]);
-
 
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)

--- a/admin-api/index.php
+++ b/admin-api/index.php
@@ -23,6 +23,8 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
+use PrestaShop\PrestaShop\Core\Util\CacheClearLocker;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpFoundation\Request;
@@ -59,6 +61,10 @@ $dotEnvFile = dirname(__FILE__, 2) . '/.env';
     ->usePutenv(false)
     ->loadEnv($dotEnvFile)
 ;
+
+// Block the process until the cache clear is in progress, this must be done before the kernel is created so it doesn't
+// try to use the old container
+CacheClearLocker::waitUntilUnlocked(_PS_ENV_, _PS_APP_ID_);
 
 $kernel = new AdminAPIKernel(_PS_ENV_, _PS_MODE_DEV_);
 // When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter

--- a/admin-dev/index.php
+++ b/admin-dev/index.php
@@ -23,11 +23,11 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
+use PrestaShop\PrestaShop\Core\Util\CacheClearLocker;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 if (!defined('_PS_ADMIN_DIR_')) {
@@ -69,6 +69,10 @@ $dotEnvFile = dirname(__FILE__, 2) . '/.env';
     ->usePutenv(false)
     ->loadEnv($dotEnvFile)
 ;
+
+// Block the process until the cache clear is in progress, this must be done before the kernel is created so it doesn't
+// try to use the old container
+CacheClearLocker::waitUntilUnlocked(_PS_ENV_, _PS_APP_ID_);
 
 $kernel = new AdminKernel(_PS_ENV_, _PS_MODE_DEV_);
 // When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -27,6 +27,7 @@
 use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Core\Util\CacheClearLocker;
 use PrestaShop\PrestaShop\Core\Version;
 use PrestaShop\TranslationToolsBundle\TranslationToolsBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -41,14 +42,6 @@ abstract class AppKernel extends Kernel
     public const MAJOR_VERSION = Version::MAJOR_VERSION;
     public const MINOR_VERSION = Version::MINOR_VERSION;
     public const RELEASE_VERSION = Version::RELEASE_VERSION;
-
-    /**
-     * Lock stream is saved as static field, this way if multiple AppKernel are instanciated (this can happen in
-     * test environment, they will be able to detect that a lock has already been made by the current process).
-     *
-     * @var resource|null
-     */
-    protected static $lockStream = null;
 
     /**
      * @var ModuleRepository
@@ -101,50 +94,9 @@ abstract class AppKernel extends Kernel
      */
     public function boot()
     {
-        $this->waitUntilCacheClearIsOver();
+        CacheClearLocker::waitUntilUnlocked($this->environment, $this->getAppId());
         parent::boot();
         $this->cleanKernelReferences();
-    }
-
-    /**
-     * Perform a lock on a file before cache clear is performed, this lock will be unlocked once the cache has been cleared.
-     * Until then any other process will have to wait until the file is unlocked.
-     *
-     * @return bool returns boolean indicating if the lock file was successfully locked
-     */
-    public function locksCacheClear(): bool
-    {
-        $clearCacheLockPath = $this->getContainerClearCacheLockPath();
-        $lockStream = fopen($clearCacheLockPath, 'w');
-        if (false === $lockStream) {
-            // Could not open writable lock for some reason
-            return false;
-        }
-
-        // Non-blocking flock, if false is returned it means the file is already locked (meaning the cache is being cleared by another process)
-        $clearCacheLocked = flock($lockStream, LOCK_EX | LOCK_NB);
-        if (false === $clearCacheLocked) {
-            // Clear cache is already locked by another process, so we simply return
-            fclose($lockStream);
-
-            return false;
-        }
-
-        // Save the locked stream so that we can close it later and most importantly, the process doesn't block it self
-        // during the cache clear operation which reboots the app
-        self::$lockStream = $lockStream;
-
-        return true;
-    }
-
-    public function unlocksCacheClear(): void
-    {
-        if (null === self::$lockStream) {
-            return;
-        }
-
-        $this->unlockCacheStream(self::$lockStream);
-        self::$lockStream = null;
     }
 
     /**
@@ -353,64 +305,6 @@ abstract class AppKernel extends Kernel
         }
 
         return $this->moduleRepository;
-    }
-
-    protected function getContainerClearCacheLockPath(): string
-    {
-        $class = $this->getContainerClass();
-        $cacheDir = $this->getCacheDir();
-
-        return sprintf('%s/%s.php.cache_clear.lock', $cacheDir, $class);
-    }
-
-    protected function waitUntilCacheClearIsOver(): void
-    {
-        // CLI environment shouldn't be blocked, this allows for example clearing the cache even when the kernel is blocked for HTTP requests
-        // which is exactly what the SymfonyCacheClearer does.
-        if (Tools::isPHPCLI()) {
-            return;
-        }
-
-        if (null !== self::$lockStream) {
-            // If lockStream is not null it means we are actually in the process that locked it, we don't wait for anything
-            // or the cache clear will never happen
-            return;
-        }
-
-        $clearCacheLockPath = $this->getContainerClearCacheLockPath();
-        // No lock file no need to wait for its unlock
-        if (!file_exists($clearCacheLockPath)) {
-            return;
-        }
-
-        $lockStream = fopen($clearCacheLockPath, 'w');
-        if (false === $lockStream) {
-            // Could not open writable lock for some reason
-            return;
-        }
-
-        // Check if the lock file is currently locked (see locksCacheClear responsible for locking this file), this
-        // function call is blocking until the lock has been released.
-        flock($lockStream, LOCK_SH);
-
-        // Now that the file is unlocked it means the cache has been cleared we can safely continue the process as the container
-        // has been rebuilt and is good to go.
-        $this->unlockCacheStream($lockStream);
-    }
-
-    /**
-     * @param resource $lockStream
-     */
-    protected function unlockCacheStream($lockStream): void
-    {
-        flock($lockStream, LOCK_UN);
-        fclose($lockStream);
-
-        // Also remove the lock file so that the lock check is ignored right away
-        $clearCacheLockPath = $this->getContainerClearCacheLockPath();
-        if (file_exists($clearCacheLockPath)) {
-            unlink($clearCacheLockPath);
-        }
     }
 
     /**

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -27,7 +27,6 @@
 use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
-use PrestaShop\PrestaShop\Core\Util\CacheClearLocker;
 use PrestaShop\PrestaShop\Core\Version;
 use PrestaShop\TranslationToolsBundle\TranslationToolsBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -94,7 +93,6 @@ abstract class AppKernel extends Kernel
      */
     public function boot()
     {
-        CacheClearLocker::waitUntilUnlocked($this->environment, $this->getAppId());
         parent::boot();
         $this->cleanKernelReferences();
     }

--- a/composer.json
+++ b/composer.json
@@ -287,8 +287,8 @@
             "@php -d date.timezone=UTC -d memory_limit=-1 ./vendor/phpunit/phpunit/phpunit -c tests/Integration/phpunit.xml",
             "@php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests/Integration/phpunit-isolated.xml"
         ],
-        "php-cs-fixer": "@php ./vendor/bin/php-cs-fixer fix --path-mode=intersection",
-        "php-cs-fixer:dry": "@php ./vendor/bin/php-cs-fixer fix --dry-run --diff --path-mode=intersection",
+        "php-cs-fixer": "@php ./vendor/bin/php-cs-fixer fix",
+        "php-cs-fixer:dry": "@php ./vendor/bin/php-cs-fixer fix --dry-run --diff",
         "phpstan": "@php -d memory_limit=-1 ./vendor/bin/phpstan analyze -c phpstan.neon.dist",
         "phpstan:generate-baseline": "@php -d memory_limit=-1 ./vendor/bin/phpstan analyze -c phpstan.neon.dist --generate-baseline",
         "restore-test-db": [

--- a/index.php
+++ b/index.php
@@ -24,6 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+use PrestaShop\PrestaShop\Core\Util\CacheClearLocker;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpFoundation\Request;
@@ -49,6 +50,10 @@ if (isset($_ENV['PS_FF_FRONT_CONTAINER_V2']) && filter_var($_ENV['PS_FF_FRONT_CO
     if (_PS_MODE_DEV_) {
         Debug::enable();
     }
+
+    // Block the process until the cache clear is in progress, this must be done before the kernel is created so it doesn't
+    // try to use the old container
+    CacheClearLocker::waitUntilUnlocked(_PS_ENV_, _PS_APP_ID_);
 
     // Starting Kernel
     $kernel = new FrontKernel(_PS_ENV_, _PS_MODE_DEV_);

--- a/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
@@ -33,6 +33,7 @@ use FrontKernel;
 use Hook;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Filesystem\Filesystem;
 use Throwable;
 
 /**
@@ -46,6 +47,7 @@ final class SymfonyCacheClearer implements CacheClearerInterface
 
     public function __construct(
         private readonly LoggerInterface $logger,
+        private readonly Filesystem $filesystem,
     ) {
     }
 
@@ -101,6 +103,9 @@ final class SymfonyCacheClearer implements CacheClearerInterface
 
                             if ($result !== 0) {
                                 $this->logger->error('SymfonyCacheClearer: Could not clear cache for ' . $applicationKernel->getAppId() . ' env ' . $environment . 'output: ' . var_export($output, true));
+                                $this->logger->info('SymfonyCacheClearer: Trying manual removal of cache folder ' . $cacheDir);
+                                $this->filesystem->remove($cacheDir);
+                                continue;
                             } else {
                                 $this->logger->info('SymfonyCacheClearer: Successfully cleared cache for ' . $applicationKernel->getAppId() . ' env ' . $environment);
                             }

--- a/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
@@ -32,6 +32,7 @@ use AppKernel;
 use FrontKernel;
 use Hook;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
+use PrestaShop\PrestaShop\Core\Util\CacheClearLocker;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Throwable;
@@ -67,7 +68,7 @@ final class SymfonyCacheClearer implements CacheClearerInterface
         }
         $this->clearCacheRequested = true;
 
-        $cacheClearLocked = $kernel->locksCacheClear();
+        $cacheClearLocked = CacheClearLocker::lock($kernel->getEnvironment(), $kernel->getAppId());
         if (false === $cacheClearLocked) {
             // The lock was not possible for some reason we should exit
             return;
@@ -141,7 +142,7 @@ final class SymfonyCacheClearer implements CacheClearerInterface
                 $this->logger->error('SymfonyCacheClearer: Something went wrong while clearing cache: ' . $e->getMessage());
             } finally {
                 Hook::exec('actionClearSf2Cache');
-                $kernel->unlocksCacheClear();
+                CacheClearLocker::unlock($kernel->getEnvironment(), $kernel->getAppId());
             }
         });
     }

--- a/src/Core/Util/CacheClearLocker.php
+++ b/src/Core/Util/CacheClearLocker.php
@@ -153,7 +153,7 @@ class CacheClearLocker
 
         // Also remove the lock file so that the lock check is ignored right away
         if (file_exists($lockPath)) {
-            unlink($lockPath);
+            @unlink($lockPath);
         }
     }
 

--- a/src/Core/Util/CacheClearLocker.php
+++ b/src/Core/Util/CacheClearLocker.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Util;
+
+/**
+ * This class handles a lock file that is used between processes to warn them that the Symfony cache is being cleared and other
+ * processes should wait until it is done to continue their action. It allows being sure the container is up-to-date after some actions
+ * that modify it are done (feature flag switching, module actions, ...). We use the flock function inner blocking system to temporarily
+ * stop the processes. While the file is locked all other process wait until the lock is freed.
+ *
+ * When the initial process is done and releases the lock file all the locked processes will resume their job.
+ */
+class CacheClearLocker
+{
+    /**
+     * Lock stream is saved as static field, this way if multiple services try to lock the same file (this can happen in
+     * test environment), they will be able to detect that a lock has already been made by the current process.
+     *
+     * @var array<string, resource>
+     */
+    protected static array $lockStream = [];
+
+    /**
+     * Perform a lock on a file, this lock will be unlocked once the unlockFile method is called.
+     * Until then any other process will have to wait until the file is unlocked.
+     *
+     * @param string $environment Kernel environment (prod, dev, test)
+     * @param string $appId Kernel application ID (admin, admin-api, front)
+     *
+     * @return bool returns boolean indicating if the lock file was successfully locked
+     */
+    public static function lock(string $environment, string $appId): bool
+    {
+        $lockPath = self::getClearCacheLockPath($environment, $appId);
+        $lockStream = fopen($lockPath, 'w');
+        if (false === $lockStream) {
+            // Could not open writable lock for some reason
+            return false;
+        }
+
+        // Non-blocking flock, if false is returned it means the file is already locked (meaning the cache is being cleared by another process)
+        $fileLocked = flock($lockStream, LOCK_EX | LOCK_NB);
+        if (false === $fileLocked) {
+            // Clear cache is already locked by another process, so we simply return
+            fclose($lockStream);
+
+            return false;
+        }
+
+        // Save the locked stream so that we can close it later and most importantly, the process doesn't block it self
+        // during the cache clear operation which reboots the app
+        self::$lockStream[$lockPath] = $lockStream;
+
+        return true;
+    }
+
+    /**
+     * Release the lock on the file, this will unblock processes that were waiting for it.
+     *
+     * @param string $environment Kernel environment (prod, dev, test)
+     * @param string $appId Kernel application ID (admin, admin-api, front)
+     *
+     * @return void
+     */
+    public static function unlock(string $environment, string $appId): void
+    {
+        $lockPath = self::getClearCacheLockPath($environment, $appId);
+        if (!isset(self::$lockStream[$lockPath])) {
+            return;
+        }
+
+        self::unlockCacheStream(self::$lockStream[$lockPath], $lockPath);
+        unset(self::$lockStream[$lockPath]);
+    }
+
+    /**
+     * This method is blocking, it means no further code will be executed after this method is called
+     * until the locked file has been released by another process. If no process locked the file it
+     * executes instantaneously.
+     *
+     * @param string $environment Kernel environment (prod, dev, test)
+     * @param string $appId Kernel application ID (admin, admin-api, front)
+     *
+     * @return void
+     */
+    public static function waitUntilUnlocked(string $environment, string $appId): void
+    {
+        $lockPath = self::getClearCacheLockPath($environment, $appId);
+
+        // CLI environment shouldn't be blocked, this allows for example clearing the cache even when the kernel is blocked for HTTP requests
+        // which is exactly what the SymfonyCacheClearer does.
+        if (PHPCli::isPHPCli()) {
+            return;
+        }
+
+        if (isset(self::$lockStream[$lockPath])) {
+            // If lockStream is not null it means we are actually in the process that locked it, we don't wait for anything
+            // or the cache clear will never happen
+            return;
+        }
+
+        // No lock file no need to wait for its unlock
+        if (!file_exists($lockPath)) {
+            return;
+        }
+
+        $lockStream = fopen($lockPath, 'w');
+        if (false === $lockStream) {
+            // Could not open writable lock for some reason
+            return;
+        }
+
+        // Check if the lock file is currently locked (see locksCacheClear responsible for locking this file), this
+        // function call is blocking until the lock has been released.
+        flock($lockStream, LOCK_SH);
+
+        // Now that the file is unlocked it means the cache has been cleared we can safely continue the process as the container
+        // has been rebuilt and is good to go.
+        self::unlockCacheStream($lockStream, $lockPath);
+    }
+
+    /**
+     * @param resource $lockStream
+     */
+    protected static function unlockCacheStream($lockStream, string $lockPath): void
+    {
+        flock($lockStream, LOCK_UN);
+        fclose($lockStream);
+
+        // Also remove the lock file so that the lock check is ignored right away
+        if (file_exists($lockPath)) {
+            unlink($lockPath);
+        }
+    }
+
+    /**
+     * The lock file path must reflect the kernel it is linked to, but it's important that it's not in the kernel
+     * cache folder itself because the whole folder could be removed during cache clearing, and we don't want the lock
+     * to be removed when that happens, or the lock file to prevent the removal either.
+     *
+     * @param string $environment Kernel environment (prod, dev, test)
+     * @param string $appId Kernel application ID (admin, admin-api, front)
+     *
+     * @return string
+     */
+    protected static function getClearCacheLockPath(string $environment, string $appId): string
+    {
+        $cacheDir = self::getCacheDir();
+
+        return sprintf('%s/%s_%s_cache_clear.lock', $cacheDir, $appId, $environment);
+    }
+
+    protected static function getCacheDir(): string
+    {
+        return static::getProjectDir() . '/var/cache';
+    }
+
+    protected static function getProjectDir(): string
+    {
+        return realpath(__DIR__ . '/../../..');
+    }
+}

--- a/src/Core/Util/PHPCli.php
+++ b/src/Core/Util/PHPCli.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Util;
+
+class PHPCli
+{
+    public static function isPHPCli(): bool
+    {
+        return defined('STDIN') || (strtolower(PHP_SAPI) == 'cli' && empty($_SERVER['REMOTE_ADDR']));
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add fallback in SymfonyCacheClearer to manually remove the cache folder when the command did not work
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green, test enable/disable feature flags Test actions on modules (install, uninstall, enable, disable)
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/11161008811
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
