### PR TITLE
Improve security by randomizing prefix

### DIFF
--- a/install-dev/controllers/http/database.php
+++ b/install-dev/controllers/http/database.php
@@ -152,7 +152,7 @@ class InstallControllerHttpDatabase extends InstallControllerHttp implements Htt
             $this->database_login = $parameters['parameters']['database_user'];
             $this->database_password = $parameters['parameters']['database_password'];
             $this->database_engine = $parameters['parameters']['database_engine'];
-            $this->database_prefix = $parameters['parameters']['database_prefix'];
+            $this->database_prefix = substr(str_shuffle(str_repeat('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', mt_rand(1,10))), 0, 5).'_';
 
             $this->database_clear = true;
             $this->use_smtp = false;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Small improvement to security by generatin a random prefix for the database. This will avoid every shop using ps_.
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install the shop, the database step will show a prefilled box with random letters every time.
| UI Tests          | ~~does not work at the moment.~~ https://github.com/florine2623/testing_pr/actions/runs/11323168446
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | Prestaworks AB
