### PR TITLE
Fix apache error.log filler on active sites

### DIFF
--- a/img/.htaccess
+++ b/img/.htaccess
@@ -1,16 +1,6 @@
-# Apache 2.2
-<IfModule !mod_authz_core.c>
-    Order deny,allow
-    Deny from all
-    <Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp|avif)$">
-        Allow from all
-    </Files>
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteCond %{REQUEST_URI} !((?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp|avif)$) [NC]
+    RewriteRule .* /index.php  [L,R=404]
 </IfModule>
 
-# Apache 2.4
-<IfModule mod_authz_core.c>
-    Require all denied
-    <Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp|avif)$">
-        Require all granted
-    </Files>
-</IfModule>

--- a/img/.htaccess
+++ b/img/.htaccess
@@ -1,6 +1,6 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
     RewriteCond %{REQUEST_URI} !((?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp|avif)$) [NC]
-    RewriteRule .* /index.php  [L,R=404]
+    RewriteRule .* [R=404]
 </IfModule>
-
+ErrorDocument 404 /img/404.gif

--- a/img/.htaccess
+++ b/img/.htaccess
@@ -3,4 +3,4 @@
     RewriteCond %{REQUEST_URI} !((?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp|avif)$) [NC]
     RewriteRule .* [R=404]
 </IfModule>
-ErrorDocument 404 /img/404.gif
+ErrorDocument 404 "Not Found"


### PR DESCRIPTION
When a search engine requests a non-existent image, it should receive a 404 response instead of 403. If the site is not dead and there are constant changes, the search engine gets 403 too often. Many servers have programs installed, such as fail2ban, and for too frequent 403, they issue a ban on the IP. This is normal, because if there is a 403, then there is no need to go there. This is my last attempt to fix this stupidity in /img/.htaccess

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.x / 1.7.x
| Description?      | When a search engine requests a non-existent image, it should receive a 404 response instead of 403. If the site is not dead and there are constant changes, the search engine gets 403 too often. Many servers have programs installed, such as fail2ban, and for too frequent 403, they issue a ban on the IP. This is normal, because if there is a 403, then there is no need to go there.
| Type?             | bug fix 
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | look a logs on active sites.
| UI Tests          | apache22/24 mod_rewrite
| Fixed issue or discussion?     | 
| Related PRs       |
| Sponsor company   | 
