### PR TITLE
Delete getTabByIdProfile method

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -636,34 +636,6 @@ class TabCore extends ObjectModel
     }
 
     /**
-     * Get Tab by Profile ID.
-     *
-     * @param int $idParent
-     * @param int $idProfile
-     *
-     * @return array|false|mysqli_result|PDOStatement|resource|null
-     */
-    public static function getTabByIdProfile($idParent, $idProfile)
-    {
-        return Db::getInstance()->executeS('
-			SELECT t.`id_tab`, t.`id_parent`, tl.`name`, a.`id_profile`
-			FROM `' . _DB_PREFIX_ . 'tab` t
-			LEFT JOIN `' . _DB_PREFIX_ . 'access` a
-				ON (a.`id_tab` = t.`id_tab`)
-			LEFT JOIN `' . _DB_PREFIX_ . 'tab_lang` tl
-				ON (t.`id_tab` = tl.`id_tab` AND tl.`id_lang` = ' . (int) Context::getContext()->language->id . ')
-			WHERE a.`id_profile` = ' . (int) $idProfile . '
-			AND t.`id_parent` = ' . (int) $idParent . '
-			AND a.`view` = 1
-			AND a.`edit` = 1
-			AND a.`delete` = 1
-			AND a.`add` = 1
-			AND t.`id_parent` != 0 AND t.`id_parent` != -1
-			ORDER BY t.`id_parent` ASC
-		');
-    }
-
-    /**
      * @since 1.5.0
      */
     public static function getClassNameById($idTab)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This method is not used and could not be used. Introduced in the 1.5.5 version, this method was never changed when the structure of tables evolved. Call this method and you only facing issue witht malformed SQL.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the ability to retrieve tabs by parent and profile with specific access rights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->