### PR TITLE
Upgrade hooks command improvement

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
@@ -70,8 +70,14 @@ services:
   prestashop.adapter.legacy.logger:
     class: PrestaShop\PrestaShop\Adapter\LegacyLogger
 
+  PrestaShop\PrestaShop\Adapter\Hook\HookInformationProvider:
+    public: false
+
   prestashop.adapter.legacy.hook:
-    class: PrestaShop\PrestaShop\Adapter\Hook\HookInformationProvider
+    alias: PrestaShop\PrestaShop\Adapter\Hook\HookInformationProvider
+    deprecated:
+      package: PrestaShop\PrestaShop
+      version: 9.0
 
   # Legacy Hooks registrator
   prestashop.adapter.legacy.hook.subscriber:

--- a/src/PrestaShopBundle/Resources/config/services/core/hook.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/hook.yml
@@ -11,21 +11,39 @@ services:
   prestashop.core.hook.dispatcher:
     alias: 'PrestaShop\PrestaShop\Core\Hook\HookDispatcher'
 
-  prestashop.core.hook.provider.grid_definition_hook_by_service_ids_provider:
-    class: PrestaShop\PrestaShop\Core\Hook\Provider\GridDefinitionHookByServiceIdsProvider
+  PrestaShop\PrestaShop\Core\Hook\Provider\GridDefinitionHookByServiceIdsProvider:
+    public: false
     arguments:
       - '@service_container'
 
-  prestashop.core.hook.provider.identifiable_object_hook_by_form_type_provider:
-    class: PrestaShop\PrestaShop\Core\Hook\Provider\IdentifiableObjectHookByFormTypeProvider
+  prestashop.core.hook.provider.grid_definition_hook_by_service_ids_provider:
+    alias: PrestaShop\PrestaShop\Core\Hook\Provider\GridDefinitionHookByServiceIdsProvider
+    deprecated:
+      package: PrestaShop\PrestaShop
+      version: 9.0
+
+  PrestaShop\PrestaShop\Core\Hook\Provider\IdentifiableObjectHookByFormTypeProvider:
+    public: false
     arguments:
       - '@form.factory'
 
-  prestashop.core.hook.generator.hook_description_generator:
-    class: 'PrestaShop\PrestaShop\Core\Hook\Generator\HookDescriptionGenerator'
+  prestashop.core.hook.provider.identifiable_object_hook_by_form_type_provider:
+    alias: PrestaShop\PrestaShop\Core\Hook\Provider\IdentifiableObjectHookByFormTypeProvider
+    deprecated:
+      package: PrestaShop\PrestaShop
+      version: 9.0
+
+  PrestaShop\PrestaShop\Core\Hook\Generator\HookDescriptionGenerator:
+    public: false
     autowire: true
     arguments:
       $hookDescriptions: '%hook_descriptions%'
+
+  prestashop.core.hook.generator.hook_description_generator:
+    alias: 'PrestaShop\PrestaShop\Core\Hook\Generator\HookDescriptionGenerator'
+    deprecated:
+      package: PrestaShop\PrestaShop
+      version: 9.0
 
 parameters:
   hook_descriptions:

--- a/src/PrestaShopBundle/Resources/config/services_dev/bundle/command.yml
+++ b/src/PrestaShopBundle/Resources/config/services_dev/bundle/command.yml
@@ -17,16 +17,10 @@ services:
       - 'console.command'
 
   PrestaShopBundle\Command\AppendHooksListForSqlUpgradeFileCommand:
+    autowire: true
     arguments:
-      - '%kernel.environment%'
-      - '@prestashop.adapter.legacy.context'
-      - '@prestashop.core.hook.provider.grid_definition_hook_by_service_ids_provider'
-      - '@prestashop.core.hook.provider.identifiable_object_hook_by_form_type_provider'
-      - '@prestashop.adapter.legacy.hook'
-      - '@prestashop.core.hook.generator.hook_description_generator'
-      - '%prestashop.core.grid.definition.service_ids%'
-      - '%prestashop.hook.option_form_hook_names%'
-      - '%prestashop.core.form.identifiable_object.form_types%'
+      $env: '%kernel.environment%'
+      $projectDir: '%kernel.project_dir%'
     tags:
       - 'console.command'
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Refacto the Symfony command to update hooks on autoupgrade module, find old and new hooks based on the fixtures files and then export the two SQL queries in the upgrade file
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green UI tests green Maybe QA by dev
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/11368580096
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~

### Description

This command was updated to use the XML fixture files as a reference to detect new and obsolete hooks, it can then update the SQL files in the autoupgrade module.

The command was used to generated this PR https://github.com/PrestaShop/autoupgrade/pull/957
The CLI command used to generate it was:
```sh
./bin/console prestashop:update:sql-upgrade-file-hooks-listing 8.2.0 /path/to/module/autoupgrade
```
