### PR TITLE
fix Dispatcher.php for module frontcontroller call in wrong case name

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -385,7 +385,7 @@ class DispatcherCore
                 $controller_class = 'PageNotFoundController';
                 if (Validate::isLoadedObject($module) && $module->active) {
                     $controllers = Dispatcher::getControllers(_PS_MODULE_DIR_ . "$module_name/controllers/front/");
-                    if (isset($controllers[$this->controller])) {
+                    if (array_search($this->controller, $controllers)) {
                         include_once _PS_MODULE_DIR_ . "$module_name/controllers/front/{$this->controller}.php";
                         if (file_exists(
                             _PS_OVERRIDE_DIR_ . "modules/$module_name/controllers/front/{$this->controller}.php"

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -384,16 +384,14 @@ class DispatcherCore
                 $module = Module::getInstanceByName($module_name);
                 $controller_class = 'PageNotFoundController';
                 if (Validate::isLoadedObject($module) && $module->active) {
-                    $controllers = Dispatcher::getControllers(_PS_MODULE_DIR_ . "$module_name/controllers/front/");
-                    if (array_search($this->controller, $controllers)) {
-                        include_once _PS_MODULE_DIR_ . "$module_name/controllers/front/{$this->controller}.php";
-                        if (file_exists(
-                            _PS_OVERRIDE_DIR_ . "modules/$module_name/controllers/front/{$this->controller}.php"
-                        )) {
-                            include_once _PS_OVERRIDE_DIR_ . "modules/$module_name/controllers/front/{$this->controller}.php";
-                            $controller_class = $module_name . $this->controller . 'ModuleFrontControllerOverride';
-                        } else {
-                            $controller_class = $module_name . $this->controller . 'ModuleFrontController';
+                    $controllers = Dispatcher::getControllers(_PS_MODULE_DIR_ . $module_name . '/controllers/front/');
+                    if ($controller_name = $controllers[strtolower($this->controller)] ?? null) {
+                        $controller_file = $module_name . '/controllers/front/' . $controller_name . '.php';
+                        include_once(_PS_MODULE_DIR_ . $controller_file);
+                        $controller_class = $module_name . $controller_name . 'ModuleFrontController';
+                        if (file_exists(_PS_OVERRIDE_DIR_ . 'modules/' . $controller_file)) {
+                            include_once(_PS_OVERRIDE_DIR_ . 'modules/' . $controller_file);
+                            $controller_class = $module_name . $controller_name . 'ModuleFrontControllerOverride';
                         }
                     }
                 }

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -385,7 +385,7 @@ class DispatcherCore
                 $controller_class = 'PageNotFoundController';
                 if (Validate::isLoadedObject($module) && $module->active) {
                     $controllers = Dispatcher::getControllers(_PS_MODULE_DIR_ . "$module_name/controllers/front/");
-                    if (isset($controllers[strtolower($this->controller)])) {
+                    if (isset($controllers[$this->controller])) {
                         include_once _PS_MODULE_DIR_ . "$module_name/controllers/front/{$this->controller}.php";
                         if (file_exists(
                             _PS_OVERRIDE_DIR_ . "modules/$module_name/controllers/front/{$this->controller}.php"


### PR DESCRIPTION
Fix 500 error output when call module controller in leading Capital. real 'controller.php' call 'Controller'

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.2.x
| Description?      | if you have /modules/mymodule/controllers/front/somecontroller.php but try to call /module/mymodule/Somecontroller (with leading Cap) you got http 500 in front
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | no 
| Deprecations?     |  no
| How to test?      | Call any frontcontroller for example /module/cronjobs/Callback instead /module/cronjobs/callback
| UI Tests          | ---
| Fixed issue or discussion?     | ---
| Related PRs       | ---
| Sponsor company   | ---
