### PR TITLE
fix: prevent user saving form with empty value or negative number

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/carrier/form/components/CarrierRangesModal.vue
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/components/CarrierRangesModal.vue
@@ -30,7 +30,6 @@
       :confirm-label="$t('modal.apply')"
       :cancel-label="$t('modal.cancel')"
       :confirmation="true"
-      :close-on-click-outside="false"
       @close="cancelChanges"
       @confirm="applyChanges"
       @mouseleave="mouseLeave"
@@ -82,7 +81,7 @@
                         type="number"
                         class="form-control form-from"
                         inputmode="decimal"
-                        v-model="r.from"
+                        v-model.number="r.from"
                       >
                     </div>
                   </td>
@@ -95,7 +94,7 @@
                         type="number"
                         class="form-control form-to"
                         inputmode="decimal"
-                        v-model="r.to"
+                        v-model.number="r.to"
                       >
                     </div>
                   </td>
@@ -236,14 +235,14 @@
         let saveMax: null | number = null;
         this.ranges.forEach((range, index) => {
           // Check if all fields are filled
-          if (range.from === null) {
+          if (range.from === null || typeof range.from === 'string' || range.from < 0) {
             table.querySelectorAll(`tr[data-row="${index}"] input.form-from`)
               .forEach((input) => {
                 input.classList.add('is-invalid');
               });
             this.errors = true;
           }
-          if (range.to === null) {
+          if (range.to === null || typeof range.to === 'string' || range.to < 0) {
             table.querySelectorAll(`tr[data-row="${index}"] input.form-to`)
               .forEach((input) => {
                 input.classList.add('is-invalid');

--- a/admin-dev/themes/new-theme/js/pages/carrier/form/components/CarrierRangesModal.vue
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/components/CarrierRangesModal.vue
@@ -30,6 +30,7 @@
       :confirm-label="$t('modal.apply')"
       :cancel-label="$t('modal.cancel')"
       :confirmation="true"
+      :close-on-click-outside="false"
       @close="cancelChanges"
       @confirm="applyChanges"
       @mouseleave="mouseLeave"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Prevent the user to add a range with a negative number or an empty field.
| Type?             | bug fix / improvement / new feature / refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Describe in the associated issue
| UI Tests          | https://github.com/Nakahiru/ga.tests.ui.pr/actions/runs/11386110594
| Fixed issue or discussion?     | #37154
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
