### PR TITLE
Add return types for front controllers methods

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1869,7 +1869,7 @@ class AdminControllerCore extends Controller
         $this->display_header_javascript = false;
         $this->display_footer = false;
 
-        return $this->display();
+        $this->display();
     }
 
     protected function redirect()

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -700,7 +700,7 @@ class FrontControllerCore extends Controller
     /**
      * Compiles and outputs full page content.
      *
-     * @return bool
+     * @return void
      *
      * @throws Exception
      * @throws SmartyException
@@ -716,8 +716,6 @@ class FrontControllerCore extends Controller
         ]);
 
         $this->smartyOutputContent($this->template);
-
-        return true;
     }
 
     protected function smartyOutputContent($content)

--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -44,7 +44,7 @@ class AddressControllerCore extends FrontController
      *
      * @see FrontController::init()
      */
-    public function init()
+    public function init(): void
     {
         parent::init();
         $this->address_form = $this->makeAddressForm();
@@ -56,7 +56,7 @@ class AddressControllerCore extends FrontController
      *
      * @see FrontController::postProcess()
      */
-    public function postProcess()
+    public function postProcess(): void
     {
         $this->context->smarty->assign('editing', false);
         $id_address = (int) Tools::getValue('id_address');
@@ -123,7 +123,7 @@ class AddressControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         if (!$this->ajax && $this->should_redirect) {
             if (($back = Tools::getValue('back')) && Tools::urlBelongsToShop($back)) {
@@ -144,7 +144,7 @@ class AddressControllerCore extends FrontController
         );
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
@@ -168,7 +168,7 @@ class AddressControllerCore extends FrontController
         return $breadcrumb;
     }
 
-    public function displayAjaxAddressForm()
+    public function displayAjaxAddressForm(): void
     {
         $addressForm = $this->makeAddressForm();
 

--- a/controllers/front/AddressesController.php
+++ b/controllers/front/AddressesController.php
@@ -39,7 +39,7 @@ class AddressesControllerCore extends FrontController
      *
      * @see FrontController::init()
      */
-    public function init()
+    public function init(): void
     {
         parent::init();
 
@@ -53,13 +53,13 @@ class AddressesControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         parent::initContent();
         $this->setTemplate('customer/addresses');
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 

--- a/controllers/front/AttachmentController.php
+++ b/controllers/front/AttachmentController.php
@@ -25,7 +25,7 @@
  */
 class AttachmentControllerCore extends FrontController
 {
-    public function postProcess()
+    public function postProcess(): void
     {
         $attachment = new Attachment(Tools::getValue('id_attachment'), $this->context->language->id);
         if (!$attachment->id) {

--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -39,7 +39,7 @@ class AuthControllerCore extends FrontController
      *
      * @return bool
      */
-    public function checkAccess()
+    public function checkAccess(): bool
     {
         if ($this->context->customer->isLogged() && !$this->ajax) {
             $this->redirect_after = $this->authRedirection ? urlencode($this->authRedirection) : 'my-account';
@@ -54,10 +54,10 @@ class AuthControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         if (Tools::isSubmit('create_account')) {
-            return $this->redirectWithNotifications('registration');
+            $this->redirectWithNotifications('registration');
         }
 
         $should_redirect = false;
@@ -85,22 +85,22 @@ class AuthControllerCore extends FrontController
             if (Tools::urlBelongsToShop($back)) {
                 // Checks to see if "back" is a fully qualified
                 // URL that is on OUR domain, with the right protocol
-                return $this->redirectWithNotifications($back);
+                $this->redirectWithNotifications($back);
             }
 
             // Well we're not redirecting to a URL,
             // so...
             if ($this->authRedirection) {
                 // We may need to go there if defined
-                return $this->redirectWithNotifications($this->authRedirection);
+                $this->redirectWithNotifications($this->authRedirection);
             }
 
             // go home
-            return $this->redirectWithNotifications(__PS_BASE_URI__);
+            $this->redirectWithNotifications(__PS_BASE_URI__);
         }
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
@@ -115,7 +115,7 @@ class AuthControllerCore extends FrontController
     /**
      * {@inheritdoc}
      */
-    public function getCanonicalURL()
+    public function getCanonicalURL(): string
     {
         return $this->context->link->getPageLink('authentication');
     }

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -55,7 +55,7 @@ class CartControllerCore extends FrontController
      *
      * @param string $canonicalURL
      */
-    public function canonicalRedirection(string $canonicalURL = '')
+    public function canonicalRedirection(string $canonicalURL = ''): void
     {
     }
 
@@ -64,7 +64,7 @@ class CartControllerCore extends FrontController
      *
      * @see FrontController::init()
      */
-    public function init()
+    public function init(): void
     {
         parent::init();
 
@@ -83,7 +83,7 @@ class CartControllerCore extends FrontController
         if ('show' === Tools::getValue('action')) {
             $isAvailable = $this->areProductsAvailable();
             if (Tools::getIsset('checkout')) {
-                return Tools::redirect($this->context->link->getPageLink('order'));
+                Tools::redirect($this->context->link->getPageLink('order'));
             }
             if (true !== $isAvailable) {
                 $this->errors[] = $isAvailable;
@@ -96,7 +96,7 @@ class CartControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         if (Configuration::isCatalogMode() && Tools::getValue('action') === 'show') {
             Tools::redirect('index.php');
@@ -123,7 +123,7 @@ class CartControllerCore extends FrontController
         parent::initContent();
     }
 
-    public function displayAjaxUpdate()
+    public function displayAjaxUpdate(): void
     {
         if (Configuration::isCatalogMode()) {
             return;
@@ -163,7 +163,7 @@ class CartControllerCore extends FrontController
         }
     }
 
-    public function displayAjaxRefresh()
+    public function displayAjaxRefresh(): void
     {
         if (Configuration::isCatalogMode()) {
             return;
@@ -188,7 +188,7 @@ class CartControllerCore extends FrontController
      * @deprecated 1.7.3.1 the product link is now accessible
      *                     in #quantity_wanted[data-url-update]
      */
-    public function displayAjaxProductRefresh()
+    public function displayAjaxProductRefresh(): void
     {
         if ($this->id_product) {
             $idProductAttribute = 0;
@@ -228,12 +228,12 @@ class CartControllerCore extends FrontController
         ]));
     }
 
-    public function postProcess()
+    public function postProcess(): void
     {
         $this->updateCart();
     }
 
-    protected function updateCart()
+    protected function updateCart(): void
     {
         // Update the cart ONLY if it's not a bot, in order to avoid ghost carts
         if (!Connection::isBot()
@@ -289,7 +289,7 @@ class CartControllerCore extends FrontController
     /**
      * This process delete a product from the cart.
      */
-    protected function processDeleteProductInCart()
+    protected function processDeleteProductInCart(): void
     {
         $customization_product = Db::getInstance()->executeS(
             'SELECT * FROM `' . _DB_PREFIX_ . 'customization`'
@@ -320,7 +320,7 @@ class CartControllerCore extends FrontController
                     'Shop.Notifications.Error'
                 );
 
-                return false;
+                return;
             }
         }
 
@@ -362,7 +362,7 @@ class CartControllerCore extends FrontController
     /**
      * This process add or update a product in the cart.
      */
-    protected function processChangeProductInCart()
+    protected function processChangeProductInCart(): void
     {
         $mode = (Tools::getIsset('update') && $this->id_product) ? 'update' : 'add';
         $ErrorKey = ('update' === $mode) ? 'updateOperationError' : 'errors';
@@ -572,7 +572,7 @@ class CartControllerCore extends FrontController
      *
      * @return array
      */
-    public function getTemplateVarPage()
+    public function getTemplateVarPage(): array
     {
         $page = parent::getTemplateVarPage();
         $presented_cart = $this->cart_presenter->present($this->context->cart, true);
@@ -635,7 +635,7 @@ class CartControllerCore extends FrontController
      *
      * @return bool|string
      */
-    protected function areProductsAvailable()
+    protected function areProductsAvailable(): bool|string
     {
         $products = $this->context->cart->getProducts();
 
@@ -679,7 +679,7 @@ class CartControllerCore extends FrontController
     /**
      * Check that minimal quantity conditions are respected for each product in the cart
      */
-    private function checkCartProductsMinimalQuantities()
+    private function checkCartProductsMinimalQuantities(): void
     {
         $productList = $this->context->cart->getProducts();
 

--- a/controllers/front/ChangeCurrencyController.php
+++ b/controllers/front/ChangeCurrencyController.php
@@ -30,7 +30,7 @@ class ChangeCurrencyControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         $currency = new Currency((int) Tools::getValue('id_currency'));
         if (Validate::isLoadedObject($currency) && !$currency->deleted) {

--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -47,7 +47,7 @@ class CmsControllerCore extends FrontController
     /** @var bool */
     public $ssl = false;
 
-    public function canonicalRedirection(string $canonicalURL = '')
+    public function canonicalRedirection(string $canonicalURL = ''): void
     {
         if (Validate::isLoadedObject($this->cms) && ($canonicalURL = $this->context->link->getCMSLink($this->cms, $this->cms->link_rewrite))) {
             parent::canonicalRedirection($canonicalURL);
@@ -61,7 +61,7 @@ class CmsControllerCore extends FrontController
      *
      * @see FrontController::init()
      */
-    public function init()
+    public function init(): void
     {
         if ($id_cms = (int) Tools::getValue('id_cms')) {
             $this->cms = new CMS($id_cms, $this->context->language->id, $this->context->shop->id);
@@ -105,7 +105,7 @@ class CmsControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         if ($this->assignCase == self::CMS_CASE_PAGE) {
             $cmsVar = $this->objectPresenter->present($this->cms);
@@ -168,12 +168,12 @@ class CmsControllerCore extends FrontController
      * Return an array of IDs of CMS pages, which shouldn't be forwared to their canonical URLs in SSL environment.
      * Required for pages which are shown in iframes.
      */
-    protected function getSSLCMSPageIds()
+    protected function getSSLCMSPageIds(): array
     {
         return [(int) Configuration::get('PS_CONDITIONS_CMS_ID'), (int) Configuration::get('LEGAL_CMS_ID_REVOCATION')];
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
@@ -211,7 +211,7 @@ class CmsControllerCore extends FrontController
      *
      * @return array
      */
-    public function getTemplateVarPage()
+    public function getTemplateVarPage(): array
     {
         $page = parent::getTemplateVarPage();
 
@@ -227,7 +227,7 @@ class CmsControllerCore extends FrontController
         return $page;
     }
 
-    public function getTemplateVarCategoryCms()
+    public function getTemplateVarCategoryCms(): array
     {
         $categoryCms = [];
 
@@ -251,7 +251,7 @@ class CmsControllerCore extends FrontController
     /**
      * @return CMS|null
      */
-    public function getCms()
+    public function getCms(): ?CMS
     {
         return $this->cms;
     }
@@ -259,7 +259,7 @@ class CmsControllerCore extends FrontController
     /**
      * @return CMSCategory|null
      */
-    public function getCmsCategory()
+    public function getCmsCategory(): ?CMSCategory
     {
         return $this->cms_category;
     }
@@ -267,7 +267,7 @@ class CmsControllerCore extends FrontController
     /**
      * {@inheritdoc}
      */
-    public function getCanonicalURL()
+    public function getCanonicalURL(): string
     {
         if (Validate::isLoadedObject($this->cms)) {
             return $this->context->link->getCMSLink($this->cms, $this->cms->link_rewrite);

--- a/controllers/front/ContactController.php
+++ b/controllers/front/ContactController.php
@@ -35,14 +35,14 @@ class ContactControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         parent::initContent();
 
         $this->setTemplate('contact');
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
@@ -57,7 +57,7 @@ class ContactControllerCore extends FrontController
     /**
      * {@inheritdoc}
      */
-    public function getCanonicalURL()
+    public function getCanonicalURL(): string
     {
         return $this->context->link->getPageLink('contact');
     }

--- a/controllers/front/DiscountController.php
+++ b/controllers/front/DiscountController.php
@@ -39,7 +39,7 @@ class DiscountControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         if (Configuration::isCatalogMode()) {
             Tools::redirect('index.php');
@@ -53,7 +53,7 @@ class DiscountControllerCore extends FrontController
         $this->setTemplate('customer/discount');
     }
 
-    public function getTemplateVarCartRules()
+    public function getTemplateVarCartRules(): array
     {
         $cart_rules = [];
         $customerId = $this->context->customer->id;
@@ -85,7 +85,7 @@ class DiscountControllerCore extends FrontController
         return $cart_rules;
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -165,7 +165,7 @@ class GetFileControllerCore extends FrontController
      *
      * @see FrontController::init()
      */
-    public function init()
+    public function init(): void
     {
         if (isset($this->context->employee) && $this->context->employee->isLoggedBack() && Tools::getValue('file')) {
             // Admin can directly access to file

--- a/controllers/front/GuestTrackingController.php
+++ b/controllers/front/GuestTrackingController.php
@@ -41,7 +41,7 @@ class GuestTrackingControllerCore extends FrontController
      *
      * @see FrontController::init()
      */
-    public function init()
+    public function init(): void
     {
         if ($this->context->customer->isLogged()) {
             Tools::redirect('history.php');
@@ -55,7 +55,7 @@ class GuestTrackingControllerCore extends FrontController
      *
      * @see FrontController::postProcess()
      */
-    public function postProcess()
+    public function postProcess(): void
     {
         $order_reference = current(explode('#', Tools::getValue('order_reference')));
         $email = Tools::getValue('email');
@@ -142,12 +142,14 @@ class GuestTrackingControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         parent::initContent();
 
         if (!Validate::isLoadedObject($this->order)) {
-            return $this->setTemplate('customer/guest-login');
+            $this->setTemplate('customer/guest-login');
+
+            return;
         }
 
         if ((int) $this->order->isReturnable()) {
@@ -169,10 +171,10 @@ class GuestTrackingControllerCore extends FrontController
             'HOOK_DISPLAYORDERDETAIL' => Hook::exec('displayOrderDetail', ['order' => $this->order]),
         ]);
 
-        return $this->setTemplate('customer/guest-tracking');
+        $this->setTemplate('customer/guest-tracking');
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumbLinks = parent::getBreadcrumbLinks();
 
@@ -194,7 +196,7 @@ class GuestTrackingControllerCore extends FrontController
     /**
      * {@inheritdoc}
      */
-    public function getCanonicalURL()
+    public function getCanonicalURL(): string
     {
         return $this->context->link->getPageLink('guest-tracking');
     }

--- a/controllers/front/HistoryController.php
+++ b/controllers/front/HistoryController.php
@@ -43,7 +43,7 @@ class HistoryControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         if (Configuration::isCatalogMode()) {
             Tools::redirect('index.php');
@@ -65,7 +65,7 @@ class HistoryControllerCore extends FrontController
         $this->setTemplate('customer/history');
     }
 
-    public function getTemplateVarOrders()
+    public function getTemplateVarOrders(): array
     {
         $orders = [];
         $customer_orders = Order::getCustomerOrders($this->context->customer->id);
@@ -123,7 +123,7 @@ class HistoryControllerCore extends FrontController
         return $url_to_reorder;
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 

--- a/controllers/front/IdentityController.php
+++ b/controllers/front/IdentityController.php
@@ -41,7 +41,7 @@ class IdentityControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         $should_redirect = false;
 
@@ -80,7 +80,7 @@ class IdentityControllerCore extends FrontController
         $this->setTemplate('customer/identity');
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 

--- a/controllers/front/IndexController.php
+++ b/controllers/front/IndexController.php
@@ -33,7 +33,7 @@ class IndexControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         parent::initContent();
         $this->context->smarty->assign([
@@ -45,7 +45,7 @@ class IndexControllerCore extends FrontController
     /**
      * {@inheritdoc}
      */
-    public function getCanonicalURL()
+    public function getCanonicalURL(): string
     {
         return $this->context->link->getPageLink('index');
     }

--- a/controllers/front/MyAccountController.php
+++ b/controllers/front/MyAccountController.php
@@ -39,13 +39,13 @@ class MyAccountControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         parent::initContent();
         $this->setTemplate('customer/my-account');
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -52,7 +52,7 @@ class OrderConfirmationControllerCore extends FrontController
      *
      * @see FrontController::init()
      */
-    public function init()
+    public function init(): void
     {
         // Test below to prevent unnecessary logs from "parent::init()"
         $this->id_cart = (int) Tools::getValue('id_cart', 0);
@@ -123,7 +123,7 @@ class OrderConfirmationControllerCore extends FrontController
      *
      * @see FrontController::postProcess()
      */
-    public function postProcess()
+    public function postProcess(): void
     {
         if (Tools::isSubmit('submitTransformGuestToCustomer')) {
             // Only variable we need is the password
@@ -223,7 +223,7 @@ class OrderConfirmationControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         parent::initContent();
 
@@ -266,7 +266,7 @@ class OrderConfirmationControllerCore extends FrontController
     /**
      * Check if an order is free and create it.
      */
-    protected function checkFreeOrder()
+    protected function checkFreeOrder(): void
     {
         $cart = $this->context->cart;
         if ($cart->id_customer == 0 || $cart->id_address_delivery == 0 || $cart->id_address_invoice == 0) {
@@ -313,7 +313,7 @@ class OrderConfirmationControllerCore extends FrontController
         ));
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
@@ -328,7 +328,7 @@ class OrderConfirmationControllerCore extends FrontController
     /**
      * @return Order
      */
-    public function getOrder()
+    public function getOrder(): Order
     {
         return $this->order;
     }
@@ -336,7 +336,7 @@ class OrderConfirmationControllerCore extends FrontController
     /**
      * @return Customer
      */
-    public function getCustomer()
+    public function getCustomer(): Customer
     {
         return $this->customer;
     }

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -68,13 +68,13 @@ class OrderControllerCore extends FrontController
      *
      * @see FrontController::init()
      */
-    public function init()
+    public function init(): void
     {
         parent::init();
         $this->cartChecksum = new CartChecksum(new AddressChecksum());
     }
 
-    public function postProcess()
+    public function postProcess(): void
     {
         parent::postProcess();
 
@@ -108,7 +108,7 @@ class OrderControllerCore extends FrontController
     /**
      * @return CheckoutProcess
      */
-    public function getCheckoutProcess()
+    public function getCheckoutProcess(): CheckoutProcess
     {
         return $this->checkoutProcess;
     }
@@ -116,7 +116,7 @@ class OrderControllerCore extends FrontController
     /**
      * @return CheckoutSession
      */
-    public function getCheckoutSession()
+    public function getCheckoutSession(): CheckoutSession
     {
         $deliveryOptionsFinder = new DeliveryOptionsFinder(
             $this->context,
@@ -133,7 +133,7 @@ class OrderControllerCore extends FrontController
         return $session;
     }
 
-    protected function bootstrap()
+    protected function bootstrap(): void
     {
         $translator = $this->getTranslator();
         $session = $this->getCheckoutSession();
@@ -205,7 +205,7 @@ class OrderControllerCore extends FrontController
         }
     }
 
-    public function displayAjaxselectDeliveryOption()
+    public function displayAjaxselectDeliveryOption(): void
     {
         $cart = $this->cart_presenter->present(
             $this->context->cart,
@@ -245,7 +245,7 @@ class OrderControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         if (Configuration::isCatalogMode()) {
             Tools::redirect('index.php');
@@ -289,7 +289,7 @@ class OrderControllerCore extends FrontController
 
         if (!$this->checkoutProcess->hasErrors()) {
             if ($_SERVER['REQUEST_METHOD'] !== 'GET' && !$this->ajax) {
-                return $this->redirectWithNotifications(
+                $this->redirectWithNotifications(
                     $this->checkoutProcess->getCheckoutSession()->getCheckoutURL()
                 );
             }
@@ -305,7 +305,7 @@ class OrderControllerCore extends FrontController
         $this->setTemplate('checkout/checkout');
     }
 
-    public function displayAjaxAddressForm()
+    public function displayAjaxAddressForm(): void
     {
         $addressForm = $this->makeAddressForm();
 
@@ -346,7 +346,7 @@ class OrderControllerCore extends FrontController
      *
      * @return string|bool
      */
-    protected function getDefaultTermsAndConditions()
+    protected function getDefaultTermsAndConditions(): string|bool
     {
         $cms = new CMS((int) Configuration::get('PS_CONDITIONS_CMS_ID'), $this->context->language->id);
 

--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -45,7 +45,7 @@ class OrderDetailControllerCore extends FrontController
      *
      * @see FrontController::postProcess()
      */
-    public function postProcess()
+    public function postProcess(): void
     {
         if (Tools::isSubmit('submitMessage')) {
             $idOrder = (int) Tools::getValue('id_order');
@@ -159,7 +159,7 @@ class OrderDetailControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         parent::initContent();
         if (Configuration::isCatalogMode()) {
@@ -222,7 +222,7 @@ class OrderDetailControllerCore extends FrontController
         $this->setTemplate('customer/order-detail');
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 

--- a/controllers/front/OrderFollowController.php
+++ b/controllers/front/OrderFollowController.php
@@ -41,7 +41,7 @@ class OrderFollowControllerCore extends FrontController
      *
      * @see FrontController::postProcess()
      */
-    public function postProcess()
+    public function postProcess(): void
     {
         if (Tools::isSubmit('submitReturnMerchandise')) {
             $order_qte_input = Tools::getValue('order_qte_input');
@@ -138,7 +138,7 @@ class OrderFollowControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         if ((bool) Configuration::get('PS_ORDER_RETURN') === false) {
             $this->redirect_after = '404';
@@ -155,7 +155,7 @@ class OrderFollowControllerCore extends FrontController
         $this->setTemplate('customer/order-follow');
     }
 
-    public function getTemplateVarOrdersReturns()
+    public function getTemplateVarOrdersReturns(): array
     {
         $orders_returns = [];
         $orders_return = OrderReturn::getOrdersReturn($this->context->customer->id);
@@ -172,7 +172,7 @@ class OrderFollowControllerCore extends FrontController
         return $orders_returns;
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 

--- a/controllers/front/OrderReturnController.php
+++ b/controllers/front/OrderReturnController.php
@@ -43,7 +43,7 @@ class OrderReturnControllerCore extends FrontController
      *
      * @see FrontController::init()
      */
-    public function init()
+    public function init(): void
     {
         parent::init();
 
@@ -82,7 +82,7 @@ class OrderReturnControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         if (Configuration::isCatalogMode()) {
             Tools::redirect('index.php');
@@ -169,7 +169,7 @@ class OrderReturnControllerCore extends FrontController
         return $product_customizations;
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 

--- a/controllers/front/OrderSlipController.php
+++ b/controllers/front/OrderSlipController.php
@@ -39,7 +39,7 @@ class OrderSlipControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         if (Configuration::isCatalogMode()) {
             Tools::redirect('index.php');
@@ -53,7 +53,7 @@ class OrderSlipControllerCore extends FrontController
         $this->setTemplate('customer/order-slip');
     }
 
-    public function getTemplateVarCreditSlips()
+    public function getTemplateVarCreditSlips(): array
     {
         $credit_slips = [];
         $orders_slip = OrderSlip::getOrdersSlip((int) $this->context->cookie->id_customer);
@@ -72,7 +72,7 @@ class OrderSlipControllerCore extends FrontController
         return $credit_slips;
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 

--- a/controllers/front/PageNotFoundController.php
+++ b/controllers/front/PageNotFoundController.php
@@ -37,7 +37,7 @@ class PageNotFoundControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         header('HTTP/1.1 404 Not Found');
         header('Status: 404 Not Found');
@@ -46,12 +46,12 @@ class PageNotFoundControllerCore extends FrontController
         $this->setTemplate('errors/404');
     }
 
-    protected function canonicalRedirection(string $canonical_url = '')
+    protected function canonicalRedirection(string $canonical_url = ''): void
     {
         // 404 - no need to redirect to the canonical url
     }
 
-    protected function sslRedirection()
+    protected function sslRedirection(): void
     {
         // 404 - no need to redirect
     }
@@ -62,7 +62,7 @@ class PageNotFoundControllerCore extends FrontController
      *
      * @return array
      */
-    public function getTemplateVarPage()
+    public function getTemplateVarPage(): array
     {
         $page = parent::getTemplateVarPage();
         $page['title'] = $this->trans('The page you are looking for was not found.', [], 'Shop.Theme.Global');
@@ -70,7 +70,7 @@ class PageNotFoundControllerCore extends FrontController
         return $page;
     }
 
-    public function displayAjax()
+    public function displayAjax(): void
     {
         header('Content-Type: application/json');
         echo json_encode($this->trans('The page you are looking for was not found.', [], 'Shop.Theme.Global'));

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -51,7 +51,7 @@ class PasswordControllerCore extends FrontController
      *
      * @see FrontController::postProcess()
      */
-    public function postProcess()
+    public function postProcess(): void
     {
         $this->setTemplate('customer/password-email');
 
@@ -64,7 +64,7 @@ class PasswordControllerCore extends FrontController
         }
     }
 
-    protected function sendRenewPasswordLink()
+    protected function sendRenewPasswordLink(): void
     {
         if (!($email = $this->IDNConverter->emailToUtf8(trim(Tools::getValue('email')))) || !Validate::isEmail($email)) {
             $this->errors[] = $this->trans('Invalid email address.', [], 'Shop.Notifications.Error');
@@ -122,7 +122,7 @@ class PasswordControllerCore extends FrontController
         }
     }
 
-    protected function changePassword()
+    protected function changePassword(): void
     {
         $token = Tools::getValue('token');
         $id_customer = (int) Tools::getValue('id_customer');
@@ -263,9 +263,9 @@ class PasswordControllerCore extends FrontController
     }
 
     /**
-     * @return bool
+     * @return void
      */
-    public function display()
+    public function display(): void
     {
         $this->context->smarty->assign(
             [
@@ -279,14 +279,12 @@ class PasswordControllerCore extends FrontController
         );
 
         $this->smartyOutputContent($this->template);
-
-        return true;
     }
 
     /**
      * @return array
      */
-    protected function getErrors()
+    protected function getErrors(): array
     {
         $notifications = $this->prepareNotifications();
 
@@ -301,7 +299,7 @@ class PasswordControllerCore extends FrontController
     /**
      * @return array
      */
-    protected function getSuccesses()
+    protected function getSuccesses(): array
     {
         $notifications = $this->prepareNotifications();
 
@@ -314,7 +312,7 @@ class PasswordControllerCore extends FrontController
         return $successes;
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
@@ -329,7 +327,7 @@ class PasswordControllerCore extends FrontController
     /**
      * {@inheritdoc}
      */
-    public function getCanonicalURL()
+    public function getCanonicalURL(): string
     {
         return $this->context->link->getPageLink('password');
     }

--- a/controllers/front/PdfInvoiceController.php
+++ b/controllers/front/PdfInvoiceController.php
@@ -39,7 +39,7 @@ class PdfInvoiceControllerCore extends FrontController
     /** @var Order */
     public $order;
 
-    public function postProcess()
+    public function postProcess(): void
     {
         // If the customer is not logged in AND no secure key was passed
         if (!$this->context->customer->isLogged() && !Tools::getValue('secure_key')) {
@@ -84,11 +84,11 @@ class PdfInvoiceControllerCore extends FrontController
     }
 
     /**
-     * @return bool|void
+     * @return void
      *
      * @throws PrestaShopException
      */
-    public function display()
+    public function display(): void
     {
         $order_invoice_list = $this->order->getInvoicesCollection();
         Hook::exec('actionPDFInvoiceRender', ['order_invoice_list' => $order_invoice_list]);

--- a/controllers/front/PdfOrderReturnController.php
+++ b/controllers/front/PdfOrderReturnController.php
@@ -39,7 +39,7 @@ class PdfOrderReturnControllerCore extends FrontController
      */
     public $orderReturn;
 
-    public function postProcess()
+    public function postProcess(): void
     {
         $adminToken = Tools::getValue('adtoken');
         if (!empty($adminToken)) {
@@ -72,11 +72,11 @@ class PdfOrderReturnControllerCore extends FrontController
     }
 
     /**
-     * @return bool|void
+     * @return void
      *
      * @throws PrestaShopException
      */
-    public function display()
+    public function display(): void
     {
         $pdf = new PDF($this->orderReturn, PDF::TEMPLATE_ORDER_RETURN, $this->context->smarty);
         $pdf->render();

--- a/controllers/front/PdfOrderSlipController.php
+++ b/controllers/front/PdfOrderSlipController.php
@@ -34,7 +34,7 @@ class PdfOrderSlipControllerCore extends FrontController
 
     protected $order_slip;
 
-    public function postProcess()
+    public function postProcess(): void
     {
         if (!$this->context->customer->isLogged()) {
             Tools::redirect($this->context->link->getPageLink(
@@ -57,11 +57,11 @@ class PdfOrderSlipControllerCore extends FrontController
     }
 
     /**
-     * @return bool|void
+     * @return void
      *
      * @throws PrestaShopException
      */
-    public function display()
+    public function display(): void
     {
         $pdf = new PDF($this->order_slip, PDF::TEMPLATE_ORDER_SLIP, $this->context->smarty);
         $pdf->render();

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -24,7 +24,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
-use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\Manufacturer\ManufacturerPresenter;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter;
@@ -75,7 +74,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      */
     protected $isPreview = false;
 
-    public function canonicalRedirection(string $canonical_url = '')
+    public function canonicalRedirection(string $canonical_url = ''): void
     {
         // This is there to prevent error, because this function is also called
         // in parent front controller before we have even loaded our data.
@@ -123,7 +122,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      *
      * @see FrontController::init()
      */
-    public function init()
+    public function init(): void
     {
         parent::init();
 
@@ -177,7 +176,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     /**
      * Performs multiple checks and redirects user to error page if needed
      */
-    public function checkPermissionsToViewProduct()
+    public function checkPermissionsToViewProduct(): void
     {
         // If the person accessing the product page is admin with proper token, we only do limited checks
         if ($this->isPreview()) {
@@ -278,7 +277,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      * Loads related category to current visit. First it tries to get a category the user came from - it uses HTTP referer for this.
      * If no category is found (or it's invalid), we use product's default category.
      */
-    public function initializeCategory()
+    public function initializeCategory(): void
     {
         $id_category = false;
         if (isset($_SERVER['HTTP_REFERER']) && $_SERVER['HTTP_REFERER'] == Tools::secureReferrer($_SERVER['HTTP_REFERER']) // Assure us the previous page was one of the shop
@@ -313,7 +312,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         if (!$this->errors) {
             if (Pack::isPack((int) $this->product->id)
@@ -485,7 +484,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      *
      * @see FrontController::postProcess()
      */
-    public function postProcess()
+    public function postProcess(): void
     {
         if (Tools::isSubmit('submitCustomizedData')) {
             // If cart has not been saved, we need to do it so that customization fields can have an id_cart
@@ -501,7 +500,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         }
     }
 
-    public function displayAjaxQuickview()
+    public function displayAjaxQuickview(): void
     {
         $productForTemplate = $this->getTemplateVarProduct();
         ob_end_clean();
@@ -510,17 +509,12 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $this->setQuickViewMode();
 
         $this->ajaxRender(json_encode([
-            'quickview_html' => $this->render(
-                'catalog/_partials/quickview',
-                $productForTemplate instanceof AbstractLazyArray ?
-                $productForTemplate->jsonSerialize() :
-                $productForTemplate
-            ),
+            'quickview_html' => $this->render('catalog/_partials/quickview', $productForTemplate->jsonSerialize()),
             'product' => $productForTemplate,
         ]));
     }
 
-    public function displayAjaxRefresh()
+    public function displayAjaxRefresh(): void
     {
         $product = $this->getTemplateVarProduct();
         $minimalProductQuantity = $this->getProductMinimalQuantity($product);
@@ -573,7 +567,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     /**
      * Displays information, if the customer has this product in cart already.
      */
-    protected function addCartQuantityNotification()
+    protected function addCartQuantityNotification(): void
     {
         if ((bool) Configuration::get('PS_DISPLAY_AMOUNT_IN_CART') !== true) {
             return;
@@ -610,7 +604,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     /**
      * Assign price and tax to the template.
      */
-    protected function assignPriceAndTax()
+    protected function assignPriceAndTax(): void
     {
         $id_customer = (isset($this->context->customer) ? (int) $this->context->customer->id : 0);
         $id_group = (int) Group::getCurrent()->id;
@@ -887,7 +881,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     /**
      * Get and assign attributes combinations informations.
      */
-    protected function assignAttributesCombinations()
+    protected function assignAttributesCombinations(): void
     {
         $attributes_combinations = Product::getAttributesInformationsByProduct($this->product->id);
         if (is_array($attributes_combinations) && count($attributes_combinations)) {
@@ -908,7 +902,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     /**
      * Assign template vars related to category.
      */
-    protected function assignCategory()
+    protected function assignCategory(): void
     {
         // Assign category to the template
         if (
@@ -948,10 +942,10 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         return $desc;
     }
 
-    protected function pictureUpload()
+    protected function pictureUpload(): void
     {
         if (!$field_ids = $this->product->getCustomizationFieldIds()) {
-            return false;
+            return;
         }
         $authorized_file_fields = [];
         foreach ($field_ids as $field_id) {
@@ -971,7 +965,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 $product_picture_height = (int) Configuration::get('PS_PRODUCT_PICTURE_HEIGHT');
                 $tmp_name = tempnam(_PS_TMP_IMG_DIR_, 'PS');
                 if ($error || (!$tmp_name || !move_uploaded_file($file['tmp_name'], $tmp_name))) {
-                    return false;
+                    return;
                 }
                 /* Original file */
                 if (!ImageManager::resize($tmp_name, _PS_UPLOAD_DIR_ . $file_name)) {
@@ -984,14 +978,12 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 unlink($tmp_name);
             }
         }
-
-        return true;
     }
 
-    protected function textRecord()
+    protected function textRecord(): void
     {
         if (!$field_ids = $this->product->getCustomizationFieldIds()) {
-            return false;
+            return;
         }
 
         $authorized_text_fields = [];
@@ -1051,7 +1043,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     /**
      * @return Product
      */
-    public function getProduct()
+    public function getProduct(): Product
     {
         return $this->product;
     }
@@ -1059,7 +1051,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     /**
      * @return Category|null
      */
-    public function getCategory()
+    public function getCategory(): ?Category
     {
         return $this->category;
     }
@@ -1069,7 +1061,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      *
      * @return int
      */
-    protected function getIdProductAttributeByRequest()
+    protected function getIdProductAttributeByRequest(): int
     {
         $requestedIdProductAttribute = (int) Tools::getValue('id_product_attribute');
 
@@ -1084,7 +1076,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      *
      * @throws PrestaShopException
      */
-    private function getIdProductAttributeByGroupOrRequestOrDefault()
+    private function getIdProductAttributeByGroupOrRequestOrDefault(): ?int
     {
         // If the product has no combinations, we return early
         if (!$this->product->hasCombinations()) {
@@ -1193,7 +1185,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      *
      * @throws PrestaShopException
      */
-    private function getIdProductAttributeByGroup()
+    private function getIdProductAttributeByGroup(): ?int
     {
         try {
             $groups = Tools::getValue('group');
@@ -1218,7 +1210,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         return 0;
     }
 
-    public function getTemplateVarProduct()
+    public function getTemplateVarProduct(): ProductLazyArray
     {
         $productSettings = $this->getProductPresentationSettings();
         // Hook displayProductExtraContent
@@ -1500,7 +1492,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      *
      * @return array
      */
-    public function getTemplateVarPage()
+    public function getTemplateVarPage(): array
     {
         $page = parent::getTemplateVarPage();
 

--- a/controllers/front/RegistrationController.php
+++ b/controllers/front/RegistrationController.php
@@ -39,7 +39,7 @@ class RegistrationControllerCore extends FrontController
      *
      * @return bool
      */
-    public function checkAccess()
+    public function checkAccess(): bool
     {
         // If the customer is already logged and he got here by 'accident', we will redirect him away
         if ($this->context->customer->isLogged() && !$this->ajax) {
@@ -55,7 +55,7 @@ class RegistrationControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         $register_form = $this
             ->makeCustomerForm()
@@ -78,16 +78,16 @@ class RegistrationControllerCore extends FrontController
                 // Before that, we need to check if 'back' is legit URL that is on OUR domain, with the right protocol
                 $back = rawurldecode(Tools::getValue('back'));
                 if (Tools::urlBelongsToShop($back)) {
-                    return $this->redirectWithNotifications($back);
+                    $this->redirectWithNotifications($back);
                 }
 
                 // Second option - we will redirect him to authRedirection if set
                 if ($this->authRedirection) {
-                    return $this->redirectWithNotifications($this->authRedirection);
+                    $this->redirectWithNotifications($this->authRedirection);
                 }
 
                 // Third option - we will redirect him to home URL
-                return $this->redirectWithNotifications(__PS_BASE_URI__);
+                $this->redirectWithNotifications(__PS_BASE_URI__);
             }
         }
 
@@ -100,7 +100,7 @@ class RegistrationControllerCore extends FrontController
         parent::initContent();
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
@@ -115,7 +115,7 @@ class RegistrationControllerCore extends FrontController
     /**
      * {@inheritdoc}
      */
-    public function getCanonicalURL()
+    public function getCanonicalURL(): string
     {
         return $this->context->link->getPageLink('registration');
     }

--- a/controllers/front/SitemapController.php
+++ b/controllers/front/SitemapController.php
@@ -33,7 +33,7 @@ class SitemapControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         $sitemapUrls = [
             'our_offers' => [
@@ -88,7 +88,7 @@ class SitemapControllerCore extends FrontController
         $this->setTemplate('cms/sitemap');
     }
 
-    public function getCategoriesLinks()
+    public function getCategoriesLinks(): array
     {
         return [Category::getRootCategory()->recurseLiteCategTree(0, 0, null, null, 'sitemap')];
     }
@@ -96,7 +96,7 @@ class SitemapControllerCore extends FrontController
     /**
      * @return array
      */
-    protected function getPagesLinks()
+    protected function getPagesLinks(): array
     {
         $cms = CMSCategory::getRecurseCategory($this->context->language->id, 1, 1, 1);
         $links = $this->getCmsTree($cms);
@@ -128,7 +128,7 @@ class SitemapControllerCore extends FrontController
     /**
      * @return array
      */
-    protected function getCmsTree($cms)
+    protected function getCmsTree($cms): array
     {
         $links = [];
 
@@ -157,7 +157,7 @@ class SitemapControllerCore extends FrontController
     /**
      * @return array
      */
-    protected function getUserAccountLinks()
+    protected function getUserAccountLinks(): array
     {
         $links = [];
 
@@ -179,7 +179,7 @@ class SitemapControllerCore extends FrontController
     /**
      * @return array
      */
-    protected function getOffersLinks()
+    protected function getOffersLinks(): array
     {
         $links = [
             [
@@ -228,7 +228,7 @@ class SitemapControllerCore extends FrontController
         return $links;
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
@@ -243,7 +243,7 @@ class SitemapControllerCore extends FrontController
     /**
      * {@inheritdoc}
      */
-    public function getCanonicalURL()
+    public function getCanonicalURL(): string
     {
         return $this->context->link->getPageLink('sitemap');
     }

--- a/controllers/front/StatisticsController.php
+++ b/controllers/front/StatisticsController.php
@@ -32,7 +32,7 @@ class StatisticsControllerCore extends FrontController
 
     protected $param_token;
 
-    public function postProcess()
+    public function postProcess(): void
     {
         $this->param_token = Tools::getValue('token');
         if (!$this->param_token) {
@@ -51,7 +51,7 @@ class StatisticsControllerCore extends FrontController
     /**
      * Log statistics on navigation (resolution, plugins, etc.).
      */
-    protected function processNavigationStats()
+    protected function processNavigationStats(): void
     {
         $id_guest = (int) Tools::getValue('id_guest');
         if (sha1($id_guest . _COOKIE_KEY_) != $this->param_token) {
@@ -75,7 +75,7 @@ class StatisticsControllerCore extends FrontController
     /**
      * Log statistics on time spend on pages.
      */
-    protected function processPageTime()
+    protected function processPageTime(): void
     {
         $id_connection = (int) Tools::getValue('id_connections');
         $time = (int) Tools::getValue('time');

--- a/controllers/front/StoresController.php
+++ b/controllers/front/StoresController.php
@@ -38,7 +38,7 @@ class StoresControllerCore extends FrontController
      *
      * @see FrontController::init()
      */
-    public function init()
+    public function init(): void
     {
         // Initialize presenter, we will use it for all cases
         $this->storePresenter = new StorePresenter(
@@ -54,7 +54,7 @@ class StoresControllerCore extends FrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         $distance_unit = Configuration::get('PS_DISTANCE_UNIT');
         if (!in_array($distance_unit, ['km', 'mi'])) {
@@ -80,7 +80,7 @@ class StoresControllerCore extends FrontController
         }
     }
 
-    public function getTemplateVarStores()
+    public function getTemplateVarStores(): array
     {
         $stores = Store::getStores($this->context->language->id);
 
@@ -94,7 +94,7 @@ class StoresControllerCore extends FrontController
         return $stores;
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
@@ -109,7 +109,7 @@ class StoresControllerCore extends FrontController
     /**
      * {@inheritdoc}
      */
-    public function getCanonicalURL()
+    public function getCanonicalURL(): string
     {
         return $this->context->link->getPageLink('stores');
     }

--- a/controllers/front/UploadController.php
+++ b/controllers/front/UploadController.php
@@ -35,7 +35,7 @@ class UploadControllerCore extends GetFileController
      *
      * @see FrontController::init()
      */
-    public function init()
+    public function init(): void
     {
         FrontController::init();
         if (Tools::getValue('file') !== null) {
@@ -73,7 +73,7 @@ class UploadControllerCore extends GetFileController
         return (bool) $isCustomization;
     }
 
-    public function postProcess()
+    public function postProcess(): void
     {
         $this->sendFile($this->getPath(), $this->filename, false);
     }

--- a/controllers/front/listing/BestSalesController.php
+++ b/controllers/front/listing/BestSalesController.php
@@ -49,7 +49,7 @@ class BestSalesControllerCore extends ProductListingFrontController
      *
      * @throws PrestaShopException
      */
-    public function init()
+    public function init(): void
     {
         if (Configuration::get('PS_DISPLAY_BEST_SELLERS')) {
             parent::init();
@@ -63,7 +63,7 @@ class BestSalesControllerCore extends ProductListingFrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         parent::initContent();
 
@@ -76,7 +76,7 @@ class BestSalesControllerCore extends ProductListingFrontController
      *
      * @return ProductSearchQuery
      */
-    protected function getProductSearchQuery()
+    protected function getProductSearchQuery(): ProductSearchQuery
     {
         $query = new ProductSearchQuery();
         $query
@@ -91,19 +91,19 @@ class BestSalesControllerCore extends ProductListingFrontController
      *
      * @return BestSalesProductSearchProvider
      */
-    protected function getDefaultProductSearchProvider()
+    protected function getDefaultProductSearchProvider(): BestSalesProductSearchProvider
     {
         return new BestSalesProductSearchProvider(
             $this->getTranslator()
         );
     }
 
-    public function getListingLabel()
+    public function getListingLabel(): string
     {
         return $this->getTranslator()->trans('Best sellers', [], 'Shop.Theme.Catalog');
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -25,6 +25,7 @@
  */
 use PrestaShop\PrestaShop\Adapter\Category\CategoryProductSearchProvider;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+use PrestaShop\PrestaShop\Adapter\Presenter\Category\CategoryLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\Category\CategoryPresenter;
 use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\RedirectType;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
@@ -49,7 +50,7 @@ class CategoryControllerCore extends ProductListingFrontController
     /** @var CategoryPresenter */
     protected $categoryPresenter;
 
-    public function canonicalRedirection(string $canonicalURL = '')
+    public function canonicalRedirection(string $canonicalURL = ''): void
     {
         if (Validate::isLoadedObject($this->category)) {
             parent::canonicalRedirection($this->context->link->getCategoryLink($this->category));
@@ -77,7 +78,7 @@ class CategoryControllerCore extends ProductListingFrontController
      *
      * @throws PrestaShopException
      */
-    public function init()
+    public function init(): void
     {
         $id_category = (int) Tools::getValue('id_category');
         $this->category = new Category(
@@ -147,7 +148,7 @@ class CategoryControllerCore extends ProductListingFrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         parent::initContent();
 
@@ -172,7 +173,7 @@ class CategoryControllerCore extends ProductListingFrontController
      *
      * @return bool|string
      */
-    public function getLayout()
+    public function getLayout(): bool|string
     {
         if (!$this->category->checkAccess($this->context->customer->id) || $this->notFound) {
             return $this->context->shop->theme->getLayoutRelativePathForPage('error');
@@ -181,7 +182,7 @@ class CategoryControllerCore extends ProductListingFrontController
         return parent::getLayout();
     }
 
-    protected function getAjaxProductSearchVariables()
+    protected function getAjaxProductSearchVariables(): array
     {
         // Basic data with rendered products, facets, active filters etc.
         $data = parent::getAjaxProductSearchVariables();
@@ -203,7 +204,7 @@ class CategoryControllerCore extends ProductListingFrontController
      *
      * @throws PrestaShop\PrestaShop\Core\Product\Search\Exception\InvalidSortOrderDirectionException
      */
-    protected function getProductSearchQuery()
+    protected function getProductSearchQuery(): ProductSearchQuery
     {
         $query = new ProductSearchQuery();
         $query
@@ -219,7 +220,7 @@ class CategoryControllerCore extends ProductListingFrontController
      *
      * @return CategoryProductSearchProvider
      */
-    protected function getDefaultProductSearchProvider()
+    protected function getDefaultProductSearchProvider(): CategoryProductSearchProvider
     {
         return new CategoryProductSearchProvider(
             $this->getTranslator(),
@@ -227,7 +228,7 @@ class CategoryControllerCore extends ProductListingFrontController
         );
     }
 
-    protected function getTemplateVarCategory()
+    protected function getTemplateVarCategory(): CategoryLazyArray
     {
         $categoryVar = $this->categoryPresenter->present(
             $this->category,
@@ -251,7 +252,7 @@ class CategoryControllerCore extends ProductListingFrontController
         return $categoryVar;
     }
 
-    protected function getTemplateVarSubCategories()
+    protected function getTemplateVarSubCategories(): array
     {
         $subcategories = $this->category->getSubCategories($this->context->language->id);
 
@@ -277,7 +278,7 @@ class CategoryControllerCore extends ProductListingFrontController
         return $retriever->getImage($object, $id_image);
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
@@ -304,7 +305,7 @@ class CategoryControllerCore extends ProductListingFrontController
     /**
      * @return Category
      */
-    public function getCategory()
+    public function getCategory(): Category
     {
         return $this->category;
     }
@@ -315,7 +316,7 @@ class CategoryControllerCore extends ProductListingFrontController
      *
      * @return array
      */
-    public function getTemplateVarPage()
+    public function getTemplateVarPage(): array
     {
         $page = parent::getTemplateVarPage();
 
@@ -333,7 +334,7 @@ class CategoryControllerCore extends ProductListingFrontController
         return $page;
     }
 
-    public function getListingLabel()
+    public function getListingLabel(): string
     {
         if (!Validate::isLoadedObject($this->category)) {
             $this->category = new Category(

--- a/controllers/front/listing/ManufacturerController.php
+++ b/controllers/front/listing/ManufacturerController.php
@@ -40,7 +40,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
     /** @var ManufacturerPresenter */
     protected $manufacturerPresenter;
 
-    public function canonicalRedirection(string $canonicalURL = '')
+    public function canonicalRedirection(string $canonicalURL = ''): void
     {
         if (Validate::isLoadedObject($this->manufacturer)) {
             parent::canonicalRedirection($this->context->link->getManufacturerLink($this->manufacturer));
@@ -68,7 +68,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
      *
      * @see FrontController::init()
      */
-    public function init()
+    public function init(): void
     {
         if ($id_manufacturer = Tools::getValue('id_manufacturer')) {
             $this->manufacturer = new Manufacturer((int) $id_manufacturer, $this->context->language->id);
@@ -92,7 +92,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         if (Configuration::get('PS_DISPLAY_MANUFACTURERS')) {
             parent::initContent();
@@ -133,7 +133,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
      *
      * @throws PrestaShop\PrestaShop\Core\Product\Search\Exception\InvalidSortOrderDirectionException
      */
-    protected function getProductSearchQuery()
+    protected function getProductSearchQuery(): ProductSearchQuery
     {
         $query = new ProductSearchQuery();
         $query
@@ -149,7 +149,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
      *
      * @return ManufacturerProductSearchProvider
      */
-    protected function getDefaultProductSearchProvider()
+    protected function getDefaultProductSearchProvider(): ManufacturerProductSearchProvider
     {
         return new ManufacturerProductSearchProvider(
             $this->getTranslator(),
@@ -160,7 +160,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
     /**
      * Assign template vars if displaying one manufacturer.
      */
-    protected function assignManufacturer()
+    protected function assignManufacturer(): void
     {
         $manufacturerVar = $this->manufacturerPresenter->present(
             $this->manufacturer,
@@ -190,7 +190,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
     /**
      * Assign template vars if displaying the manufacturer list.
      */
-    protected function assignAll()
+    protected function assignAll(): void
     {
         $manufacturersVar = $this->getTemplateVarManufacturers();
 
@@ -218,7 +218,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
         ]);
     }
 
-    public function getTemplateVarManufacturers()
+    public function getTemplateVarManufacturers(): array
     {
         $manufacturers = Manufacturer::getManufacturers(true, $this->context->language->id);
 
@@ -232,12 +232,12 @@ class ManufacturerControllerCore extends ProductListingFrontController
         return $manufacturers;
     }
 
-    public function getListingLabel()
+    public function getListingLabel(): string
     {
         return $this->label;
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
         $breadcrumb['links'][] = [
@@ -261,7 +261,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
      *
      * @return array
      */
-    public function getTemplateVarPage()
+    public function getTemplateVarPage(): array
     {
         $page = parent::getTemplateVarPage();
 
@@ -276,7 +276,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
     /**
      * @return Manufacturer
      */
-    public function getManufacturer()
+    public function getManufacturer(): Manufacturer
     {
         return $this->manufacturer;
     }

--- a/controllers/front/listing/NewProductsController.php
+++ b/controllers/front/listing/NewProductsController.php
@@ -47,7 +47,7 @@ class NewProductsControllerCore extends ProductListingFrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         parent::initContent();
 
@@ -60,7 +60,7 @@ class NewProductsControllerCore extends ProductListingFrontController
      *
      * @return ProductSearchQuery
      */
-    protected function getProductSearchQuery()
+    protected function getProductSearchQuery(): ProductSearchQuery
     {
         $query = new ProductSearchQuery();
         $query
@@ -75,14 +75,14 @@ class NewProductsControllerCore extends ProductListingFrontController
      *
      * @return NewProductsProductSearchProvider
      */
-    protected function getDefaultProductSearchProvider()
+    protected function getDefaultProductSearchProvider(): NewProductsProductSearchProvider
     {
         return new NewProductsProductSearchProvider(
             $this->getTranslator()
         );
     }
 
-    public function getListingLabel()
+    public function getListingLabel(): string
     {
         return $this->trans(
             'New products',
@@ -91,7 +91,7 @@ class NewProductsControllerCore extends ProductListingFrontController
         );
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 

--- a/controllers/front/listing/PricesDropController.php
+++ b/controllers/front/listing/PricesDropController.php
@@ -47,7 +47,7 @@ class PricesDropControllerCore extends ProductListingFrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         parent::initContent();
 
@@ -60,7 +60,7 @@ class PricesDropControllerCore extends ProductListingFrontController
      *
      * @return ProductSearchQuery
      */
-    protected function getProductSearchQuery()
+    protected function getProductSearchQuery(): ProductSearchQuery
     {
         $query = new ProductSearchQuery();
         $query
@@ -75,14 +75,14 @@ class PricesDropControllerCore extends ProductListingFrontController
      *
      * @return PricesDropProductSearchProvider
      */
-    protected function getDefaultProductSearchProvider()
+    protected function getDefaultProductSearchProvider(): PricesDropProductSearchProvider
     {
         return new PricesDropProductSearchProvider(
             $this->getTranslator()
         );
     }
 
-    public function getListingLabel()
+    public function getListingLabel(): string
     {
         return $this->trans(
             'Prices drop',
@@ -91,7 +91,7 @@ class PricesDropControllerCore extends ProductListingFrontController
         );
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 

--- a/controllers/front/listing/SearchController.php
+++ b/controllers/front/listing/SearchController.php
@@ -42,7 +42,7 @@ class SearchControllerCore extends ProductListingFrontController
      *
      * @see FrontController::init()
      */
-    public function init()
+    public function init(): void
     {
         parent::init();
 
@@ -78,7 +78,7 @@ class SearchControllerCore extends ProductListingFrontController
      *
      * @return array
      */
-    public function getTemplateVarPage()
+    public function getTemplateVarPage(): array
     {
         $page = parent::getTemplateVarPage();
 
@@ -93,7 +93,7 @@ class SearchControllerCore extends ProductListingFrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         parent::initContent();
 
@@ -106,7 +106,7 @@ class SearchControllerCore extends ProductListingFrontController
      *
      * @return ProductSearchQuery
      */
-    protected function getProductSearchQuery()
+    protected function getProductSearchQuery(): ProductSearchQuery
     {
         $query = new ProductSearchQuery();
         $query
@@ -123,19 +123,19 @@ class SearchControllerCore extends ProductListingFrontController
      *
      * @return SearchProductSearchProvider
      */
-    protected function getDefaultProductSearchProvider()
+    protected function getDefaultProductSearchProvider(): SearchProductSearchProvider
     {
         return new SearchProductSearchProvider(
             $this->getTranslator()
         );
     }
 
-    public function getListingLabel()
+    public function getListingLabel(): string
     {
         return $this->getTranslator()->trans('Search results', [], 'Shop.Theme.Catalog');
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
         $breadcrumb['links'][] = [

--- a/controllers/front/listing/SupplierController.php
+++ b/controllers/front/listing/SupplierController.php
@@ -40,7 +40,7 @@ class SupplierControllerCore extends ProductListingFrontController
     /** @var SupplierPresenter */
     protected $supplierPresenter;
 
-    public function canonicalRedirection(string $canonicalURL = '')
+    public function canonicalRedirection(string $canonicalURL = ''): void
     {
         if (Validate::isLoadedObject($this->supplier)) {
             parent::canonicalRedirection($this->context->link->getSupplierLink($this->supplier));
@@ -68,7 +68,7 @@ class SupplierControllerCore extends ProductListingFrontController
      *
      * @see FrontController::init()
      */
-    public function init()
+    public function init(): void
     {
         if ($id_supplier = (int) Tools::getValue('id_supplier')) {
             $this->supplier = new Supplier($id_supplier, $this->context->language->id);
@@ -92,7 +92,7 @@ class SupplierControllerCore extends ProductListingFrontController
      *
      * @see FrontController::initContent()
      */
-    public function initContent()
+    public function initContent(): void
     {
         if (Configuration::get('PS_DISPLAY_SUPPLIERS')) {
             parent::initContent();
@@ -131,7 +131,7 @@ class SupplierControllerCore extends ProductListingFrontController
      *
      * @return ProductSearchQuery
      */
-    protected function getProductSearchQuery()
+    protected function getProductSearchQuery(): ProductSearchQuery
     {
         $query = new ProductSearchQuery();
         $query
@@ -147,7 +147,7 @@ class SupplierControllerCore extends ProductListingFrontController
      *
      * @return SupplierProductSearchProvider
      */
-    protected function getDefaultProductSearchProvider()
+    protected function getDefaultProductSearchProvider(): SupplierProductSearchProvider
     {
         return new SupplierProductSearchProvider(
             $this->getTranslator(),
@@ -158,7 +158,7 @@ class SupplierControllerCore extends ProductListingFrontController
     /**
      * Assign template vars if displaying one supplier.
      */
-    protected function assignSupplier()
+    protected function assignSupplier(): void
     {
         $supplierVar = $this->supplierPresenter->present(
             $this->supplier,
@@ -188,7 +188,7 @@ class SupplierControllerCore extends ProductListingFrontController
     /**
      * Assign template vars if displaying the supplier list.
      */
-    protected function assignAll()
+    protected function assignAll(): void
     {
         $suppliersVar = $this->getTemplateVarSuppliers();
 
@@ -216,7 +216,7 @@ class SupplierControllerCore extends ProductListingFrontController
         ]);
     }
 
-    public function getTemplateVarSuppliers()
+    public function getTemplateVarSuppliers(): array
     {
         $suppliers = Supplier::getSuppliers(true, $this->context->language->id, true);
 
@@ -230,12 +230,12 @@ class SupplierControllerCore extends ProductListingFrontController
         return $suppliers;
     }
 
-    public function getListingLabel()
+    public function getListingLabel(): string
     {
         return $this->label;
     }
 
-    public function getBreadcrumbLinks()
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
         $breadcrumb['links'][] = [
@@ -259,7 +259,7 @@ class SupplierControllerCore extends ProductListingFrontController
      *
      * @return array
      */
-    public function getTemplateVarPage()
+    public function getTemplateVarPage(): array
     {
         $page = parent::getTemplateVarPage();
 
@@ -274,7 +274,7 @@ class SupplierControllerCore extends ProductListingFrontController
     /**
      * @return Supplier
      */
-    public function getSupplier()
+    public function getSupplier(): Supplier
     {
         return $this->supplier;
     }

--- a/src/Adapter/Presenter/Category/CategoryPresenter.php
+++ b/src/Adapter/Presenter/Category/CategoryPresenter.php
@@ -58,7 +58,7 @@ class CategoryPresenter
      *
      * @return CategoryLazyArray
      */
-    public function present(array|Category $category, Language $language)
+    public function present(array|Category $category, Language $language): CategoryLazyArray
     {
         // Convert to array if a Category object was passed
         if (is_object($category)) {

--- a/tests/Resources/modules/cronjobs/controllers/front/callback.php
+++ b/tests/Resources/modules/cronjobs/controllers/front/callback.php
@@ -25,7 +25,7 @@
  */
 class CronjobsCallbackModuleFrontController extends ModuleFrontController
 {
-    public function postProcess()
+    public function postProcess(): void
     {
         $this->module->sendCallback();
         die;

--- a/tests/Resources/modules/translationtest/controllers/front/bar.php
+++ b/tests/Resources/modules/translationtest/controllers/front/bar.php
@@ -30,7 +30,7 @@
  */
 class TranslationtestBarModuleFrontController extends ModuleFrontController
 {
-    public function initContent()
+    public function initContent(): void
     {
         parent::initContent();
 

--- a/tests/Resources/modules/xlftranslatedmodule/controllers/front/bar.php
+++ b/tests/Resources/modules/xlftranslatedmodule/controllers/front/bar.php
@@ -29,7 +29,7 @@
  */
 class XlftranslatedmoduleBarModuleFrontController extends ModuleFrontController
 {
-    public function initContent()
+    public function initContent(): void
     {
         parent::initContent();
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Adds return types to front controllers. Removes some unnecessary returns that were found.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no - I intentionally left FrontController and AdminController alone, so module controllers do not fail on `method X not compatible with FrontController::Y`
| Deprecations?     | no
| How to test?      | Run auto tests.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/11570400336 ✅ 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   |