### PR TITLE
Fix creating guest accounts from back office

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -886,7 +886,7 @@ class CustomerController extends AbstractAdminController
             return;
         }
 
-        $customerData = $request->request->get('customer');
+        $customerData = $request->request->all('customer');
         $customerData['group_ids'] = [];
 
         $request->request->set('customer', $customerData);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | It was impossible to create a guest account from the back office
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to create a guest account from the back office before and after this change
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/11455516404
| Fixed issue or discussion?     | n/a
| Related PRs       | n/a
| Sponsor company | impSolutions
