### PR TITLE
Fix tests `ContextMocker` wrong country config var

### DIFF
--- a/tests/Integration/Utility/ContextMocker.php
+++ b/tests/Integration/Utility/ContextMocker.php
@@ -120,7 +120,7 @@ class ContextMocker
         Shop::setContext(Shop::CONTEXT_SHOP, (int) Context::getContext()->shop->id);
         $context->customer = new Customer();
         $context->cookie = new Cookie('mycookie');
-        $context->country = new Country((int) Configuration::get('PS_LANG_DEFAULT'));
+        $context->country = new Country((int) Configuration::get('PS_COUNTRY_DEFAULT'));
         $context->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
         // Use super admin employee by default
         $context->employee = new Employee(1);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x 
| Description?      | Fix tests `ContextMocker` wrogn country config var.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests green
| UI Tests          | N/A
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | Evolutive