### PR TITLE
Use LanguageContext in ModuleRepository for better stability

### DIFF
--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -26,6 +26,8 @@
 
 use PrestaShopBundle\Install\Database;
 use PrestaShopBundle\Install\Install;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+use PrestaShop\PrestaShop\Core\Context\ContextBuilderPreparer;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -111,6 +113,11 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
         require_once _PS_ROOT_DIR_ . '/config/smarty.config.inc.php';
 
         Context::getContext()->smarty = $smarty;
+
+        $container = SymfonyContainer::getInstance();
+        /** @var ContextBuilderPreparer $preparer */
+        $preparer = $container->get(ContextBuilderPreparer::class);
+        $preparer->prepareFromLegacyContext(Context::getContext());
     }
 
     public function process()

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -26,6 +26,8 @@
 
 use PrestaShopBundle\Install\Install;
 use PrestaShopBundle\Install\XmlLoader;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+use PrestaShop\PrestaShop\Core\Context\ContextBuilderPreparer;
 
 class InstallControllerHttpProcess extends InstallControllerHttp implements HttpConfigureInterface
 {
@@ -71,6 +73,11 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
         require_once _PS_ROOT_DIR_ . '/config/smarty.config.inc.php';
 
         Context::getContext()->smarty = $smarty;
+
+        $container = SymfonyContainer::getInstance();
+        /** @var ContextBuilderPreparer $preparer */
+        $preparer = $container->get(ContextBuilderPreparer::class);
+        $preparer->prepareFromLegacyContext(Context::getContext());
     }
 
     public function process(): void

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,6 +6,11 @@ parameters:
 			path: src/Core/Addon/Module/ModuleManagerBuilder.php
 
 		-
+			message: "#^Namespace Language is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/Core/Addon/Module/ModuleManagerBuilder.php
+
+		-
 			message: "#^Class AbstractAssetManager is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 4
 			path: src/Core/Addon/Theme/Theme.php
@@ -184,6 +189,16 @@ parameters:
 			message: "#^Namespace Cache is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 7
 			path: src/Core/Category/NameBuilder/CategoryDisplayNameBuilder.php
+
+		-
+			message: "#^Class Context is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/Core/Context/ContextBuilderPreparer.php
+
+		-
+			message: "#^Namespace Context is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/Core/Context/ContextBuilderPreparer.php
 
 		-
 			message: "#^Class Country is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"

--- a/src/Core/Context/ContextBuilderPreparer.php
+++ b/src/Core/Context/ContextBuilderPreparer.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Context;
+
+use Context;
+
+/**
+ * This service is used to help prepare multiple context builders, this is convenient
+ * for install processes or in tests, but it shouldn't be used in other use cases.
+ *
+ * Usually the context builders are initialized via request listeners, this service allows
+ * preparing the builder in advance even if we are not sure if they will be used.
+ *
+ * Since Context services are build lazily by these builders (which are factories) it's safer
+ * to anticipate preparing them in edge cases.
+ *
+ * @internal
+ */
+class ContextBuilderPreparer
+{
+    public function __construct(
+        private readonly LanguageContextBuilder $languageContextBuilder,
+    ) {
+    }
+
+    public function prepareFromLegacyContext(Context $context): void
+    {
+        if ($context->language && $context->language->id) {
+            $this->languageContextBuilder->setLanguageId($context->language->id);
+        }
+    }
+
+    public function prepareLanguageId(int $languageId): void
+    {
+        $this->languageContextBuilder->setLanguageId($languageId);
+    }
+}

--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Adapter\HookManager;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Domain\Module\Exception\ModuleNotFoundException;
 use Symfony\Component\Finder\Finder;
 use Throwable;
@@ -75,25 +76,19 @@ class ModuleRepository implements ModuleRepositoryInterface
     /** @var Module[] */
     private $modulesFromHook;
 
-    /**
-     * @var int
-     */
-    private $contextLangId;
-
     public function __construct(
         ModuleDataProvider $moduleDataProvider,
         AdminModuleDataProvider $adminModuleDataProvider,
         CacheProvider $cacheProvider,
         HookManager $hookManager,
         string $modulePath,
-        int $contextLangId
+        private LanguageContext $languageContext,
     ) {
         $this->moduleDataProvider = $moduleDataProvider;
         $this->adminModuleDataProvider = $adminModuleDataProvider;
         $this->cacheProvider = $cacheProvider;
         $this->hookManager = $hookManager;
         $this->modulePath = $modulePath;
-        $this->contextLangId = $contextLangId;
     }
 
     public function getList(): ModuleCollection
@@ -246,7 +241,7 @@ class ModuleRepository implements ModuleRepositoryInterface
     {
         $shop = $shopId ? [$shopId] : Shop::getContextListShopID();
 
-        return $moduleName . implode('-', $shop) . $this->contextLangId;
+        return $moduleName . implode('-', $shop) . $this->languageContext->getId();
     }
 
     private function getModuleAttributes(string $moduleName, bool $isValid): array

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -56,8 +56,10 @@ use PrestaShop\PrestaShop\Adapter\Entity\ShopUrl;
 use PrestaShop\PrestaShop\Adapter\Entity\Tools;
 use PrestaShop\PrestaShop\Adapter\Entity\Validate;
 use PrestaShop\PrestaShop\Adapter\Module\Module;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
+use PrestaShop\PrestaShop\Core\Context\ContextBuilderPreparer;
 use PrestaShop\PrestaShop\Core\Module\ConfigReader as ModuleConfigReader;
 use PrestaShop\PrestaShop\Core\Theme\ConfigReader as ThemeConfigReader;
 use PrestaShop\PrestaShop\Core\Version;
@@ -409,6 +411,15 @@ class Install extends AbstractInstall
         require_once _PS_ROOT_DIR_ . '/config/smarty.config.inc.php';
 
         $context->smarty = $smarty;
+
+        $container = SymfonyContainer::getInstance();
+        /** @var ContextBuilderPreparer $preparer */
+        $preparer = $container->get(ContextBuilderPreparer::class);
+        $preparer->prepareFromLegacyContext(Context::getContext());
+        // No persisted language is available in the Context at the beginning of the process,
+        // so we hard-code it because it will become available later when LanguageContext is
+        // actually used
+        $preparer->prepareLanguageId(1);
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/core/context.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/context.yml
@@ -53,3 +53,7 @@ services:
   PrestaShop\PrestaShop\Core\Context\ApiClientContext:
     lazy: true
     factory: [ '@PrestaShop\PrestaShop\Core\Context\ApiClientContextBuilder', 'build' ]
+
+  PrestaShop\PrestaShop\Core\Context\ContextBuilderPreparer:
+    public: true
+    lazy: true

--- a/src/PrestaShopBundle/Resources/config/services/core/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/module.yml
@@ -12,13 +12,13 @@ services:
 
   PrestaShop\PrestaShop\Core\Module\ModuleRepository:
     lazy: true
+    autowire: true
     arguments:
       - '@prestashop.adapter.data_provider.module'
       - '@prestashop.adapter.admin.data_provider.module'
       - '@doctrine.cache.provider'
       - '@PrestaShop\PrestaShop\Adapter\HookManager'
       - "@=service('prestashop.adapter.legacy.configuration').get('_PS_MODULE_DIR_')"
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
 
   prestashop.core.admin.module.repository.eventsubscriber:
     class: PrestaShop\PrestaShop\Core\Module\EventSubscriber

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -88,6 +88,7 @@ use Pack;
 use Page;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\Context\ContextBuilderPreparer;
 use Product;
 use ProductAttribute;
 use ProductDownload;
@@ -175,6 +176,9 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
 
         // Disable legacy object model cache to prevent conflicts between scenarios.
         ObjectModel::disableCache();
+        /** @var ContextBuilderPreparer $preparer */
+        $preparer = static::getContainer()->get(ContextBuilderPreparer::class);
+        $preparer->prepareFromLegacyContext(Context::getContext());
     }
 
     /**

--- a/tests/Integration/Core/Module/ModuleRepositoryTest.php
+++ b/tests/Integration/Core/Module/ModuleRepositoryTest.php
@@ -34,6 +34,8 @@ use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\HookManager;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
+use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Translation\Translator;
@@ -99,7 +101,17 @@ class ModuleRepositoryTest extends TestCase
             $cacheProvider,
             $hookManager,
             dirname(__DIR__, 3) . '/Resources/modules/',
-            1
+            new LanguageContext(
+                1,
+                'English',
+                'en',
+                'en-US',
+                'en-us',
+                false,
+                'm/d/Y',
+                'm/d/Y H:i:s',
+                $this->createMock(LocaleInterface::class),
+            ),
         );
     }
 

--- a/tests/Integration/PrestaShopBundle/Controller/Api/Improve/Design/PositionsControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Api/Improve/Design/PositionsControllerTest.php
@@ -35,6 +35,7 @@ use Employee;
 use Hook;
 use Module;
 use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Core\Context\ContextBuilderPreparer;
 use PrestaShop\PrestaShop\Core\Module\ModuleManager;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -103,6 +104,11 @@ class PositionsControllerTest extends TestCase
         ]));
 
         self::$kernel->getContainer()->set('prestashop.adapter.legacy.configuration', $configurationMock);
+
+        // Language context must be initialized because ModuleRepository depends on it
+        /** @var ContextBuilderPreparer $preparer */
+        $preparer = self::$kernel->getContainer()->get(ContextBuilderPreparer::class);
+        $preparer->prepareLanguageId(1);
 
         /** @var ModuleManager */
         $moduleManager = self::$kernel->getContainer()->get(ModuleManager::class);

--- a/tests/Integration/PrestaShopBundle/Routing/Converter/RoutingCacheKeyGeneratorTest.php
+++ b/tests/Integration/PrestaShopBundle/Routing/Converter/RoutingCacheKeyGeneratorTest.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace Tests\Integration\PrestaShopBundle\Routing\Converter;
 
 use PrestaShop\PrestaShop\Adapter\Module\Module;
+use PrestaShop\PrestaShop\Core\Context\ContextBuilderPreparer;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Routing\Route;
@@ -57,6 +58,11 @@ class RoutingCacheKeyGeneratorTest extends KernelTestCase
         if (is_dir($dirResources . '/Resources/modules_tests/demo')) {
             Tools::recurseCopy($dirResources . '/Resources/modules_tests/demo', _PS_MODULE_DIR_ . '/demo');
         }
+
+        // Language context must be initialized because ModuleRepository depends on it
+        /** @var ContextBuilderPreparer $preparer */
+        $preparer = self::$kernel->getContainer()->get(ContextBuilderPreparer::class);
+        $preparer->prepareLanguageId(1);
 
         $this->module = self::$kernel->getContainer()->get(ModuleRepository::class)->getModule('demo');
         $this->module->onInstall();

--- a/tests/Unit/Core/Module/ModuleRepositoryTest.php
+++ b/tests/Unit/Core/Module/ModuleRepositoryTest.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Adapter\HookManager;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
 
 class ModuleRepositoryTest extends TestCase
@@ -75,7 +76,7 @@ class ModuleRepositoryTest extends TestCase
                 $this->createMock(CacheProvider::class),
                 $this->createMock(HookManager::class),
                 dirname(__DIR__, 3) . '/Resources/modules',
-                1,
+                $this->createMock(LanguageContext::class),
             ])
             ->onlyMethods(['getModule'])
             ->getMock()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Use LanguageContext in ModuleRepository for better stability, we had many issues while developing the module CQRS commands this should improve the service stability<br/>Addin `LanguageContext` as a dependency of `ModuleRepository` highlighted the fact that new Context services are initialized during installation and tests because they were only initialized by Symfony request event listeners So this PR also introduces a `ContextBuilderInitializer` **internal** service dedicated for these specific use cases
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/11631197364
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
