### PR TITLE
Fix translating modules using the old system

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -780,7 +780,7 @@ class AdminTranslationsControllerCore extends AdminController
      *
      * @throws PrestaShopException
      */
-    protected function findAndWriteTranslationsIntoFile(string $file_name, array $files, string $theme_name, string $module_name, string|bool $dir = false)
+    protected function findAndWriteTranslationsIntoFile(string $file_name, array $files, ?string $theme_name, string $module_name, string|bool $dir = false)
     {
         // These static vars allow to use file to write just one time.
         static $cache_file = [];
@@ -892,7 +892,7 @@ class AdminTranslationsControllerCore extends AdminController
      * @param string $module_name
      * @param string|bool $dir
      */
-    protected function findAndFillTranslations(array $files, string $theme_name, string $module_name, string|bool $dir = false)
+    protected function findAndFillTranslations(array $files, ?string $theme_name, string $module_name, string|bool $dir = false)
     {
         $name_var = (empty($this->translations_informations[$this->type_selected]['var']) ? false : $this->translations_informations[$this->type_selected]['var']);
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This fixes module translations that were broken because of types. $theme_name in these methods must be allowed to be null, because there is no theme used.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Translate a module that is using the old system. Ping @ShaiMagal 
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/11570395481 ✅ 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/37144
| Related PRs       | 
| Sponsor company   | 