### PR TITLE
Fix amount (tax) when changing the order status on the admin page

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3743,7 +3743,7 @@ exit;
                 $adjustment_factor += $sign * 1 / $unit;
             }
 
-            if (isset($row[$column])) {
+            if (is_array($row)) {
                 $row[$column] += $adjustment_factor;
             } else {
                 $row += $adjustment_factor;

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3743,7 +3743,11 @@ exit;
                 $adjustment_factor += $sign * 1 / $unit;
             }
 
-            $row[$column] += $adjustment_factor;
+            if (isset($row[$column])) {
+                $row[$column] += $adjustment_factor;
+            } else {
+                $row += $adjustment_factor;
+            }
 
             ++$position;
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Error: Cannot use a scalar value as an array (Tools.php) (at get getTaxesAmount, \classes\tax\AverageTaxOfProductsTaxCalculator.php)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | Fulfil an order that has tax. The order must have a tax, but when changing the order status on the admin page, change it to the status that updates the invoice (pdf invoice)
| UI Tests          | ~
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~

![error_tools](https://github.com/user-attachments/assets/85b33521-5e18-4617-b45f-e55e13310cc1)  

The numeric value id_tax comes as a key, but not as a string key id_tax (This is correct):
 ![error_calc_1](https://github.com/user-attachments/assets/45ec2f5f-000e-44f6-9288-c046c4015db6) 

Here we are trying to get by string key "id_tax", but $row returns a number (This error):
 ![error_calc_2](https://github.com/user-attachments/assets/f4d588f7-c50a-4cc9-a8e9-d913ae7e3531)

This is also called from the "setInvoiceDetails" function of the Order class (line 1396, $tax_calculator->getTaxesAmount):
- \classes\order\Order.php (line 1366, 1396, function setInvoiceDetails)