### PR TITLE
E_STRICT error level was removed, constant E_STRICT is now deprecated

### DIFF
--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -42,7 +42,7 @@ if (!defined('_PS_DISPLAY_ONLY_ERRORS_')) {
     define('_PS_DISPLAY_ONLY_ERRORS_', false);
 }
 if (_PS_MODE_DEV_ === true) {
-    $errorReportingLevel = E_ALL | E_STRICT;
+    $errorReportingLevel = E_ALL;
     if (_PS_DISPLAY_COMPATIBILITY_WARNING_ === false) {
         $errorReportingLevel = $errorReportingLevel & ~E_DEPRECATED & ~E_USER_DEPRECATED;
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | E_STRICT removed from PHP 8.4 (source: https://www.php.net/manual/en/migration84.deprecated.php), but in reality E_STRICT hasn't been used for ages so there's no reason to have it in PS9.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/11570390243
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
