### PR TITLE
Allow configuring maximum word difference

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -128,7 +128,7 @@ class SearchCore
     public const PS_SEARCH_ORDINATE_MAX = -1;
     public const PS_SEARCH_ABSCISSA_MIN = 0.5;
     public const PS_SEARCH_ABSCISSA_MAX = 2;
-    public const PS_DISTANCE_MAX = 8;
+    public const PS_DISTANCE_MAX = 5;
 
     /**
      * Method that takes a raw string (sentence) and extract all keywords it can find.
@@ -1175,6 +1175,7 @@ class SearchCore
         $distance = []; // cache levenshtein distance
         $searchMinWordLength = (int) Configuration::get('PS_SEARCH_MINWORDLEN');
         $psSearchMaxWordLength = (int) Configuration::get('PS_SEARCH_MAX_WORD_LENGTH');
+        $levenshteinMaxWordDifference = (int) Configuration::get('PS_SEARCH_FUZZY_MAX_DIFFERENCE');
 
         if (!self::$totalWordInSearchWordTable) {
             $sql = 'SELECT count(*) FROM `' . _DB_PREFIX_ . 'search_word`;';
@@ -1263,7 +1264,7 @@ class SearchCore
             ['word' => 'initial', 'weight' => 0, 'levenshtein' => 100]
         );
 
-        return $closestWord['levenshtein'] < static::PS_DISTANCE_MAX ? $closestWord['word'] : '';
+        return $closestWord['levenshtein'] <= $levenshteinMaxWordDifference ? $closestWord['word'] : '';
     }
 
     /**

--- a/controllers/admin/AdminSearchConfController.php
+++ b/controllers/admin/AdminSearchConfController.php
@@ -220,6 +220,21 @@ class AdminSearchConfControllerCore extends AdminController
                         'type' => 'text',
                         'cast' => 'intval',
                     ],
+                    'PS_SEARCH_FUZZY_MAX_DIFFERENCE' => [
+                        'title' => $this->trans(
+                            'Maximum acceptable word difference',
+                            [],
+                            'Admin.Shopparameters.Feature'
+                        ),
+                        'desc' => $this->trans(
+                            'This option defines how much different can the alternative words found by fuzzy search be. Or, how many characters can be different/missing/added. The default value is 5.',
+                            [],
+                            'Admin.Shopparameters.Help'
+                        ),
+                        'validation' => 'isUnsignedInt',
+                        'type' => 'text',
+                        'cast' => 'intval',
+                    ],
                     'PS_SEARCH_MAX_WORD_LENGTH' => [
                         'title' => $this->trans(
                             'Maximum word length (in characters)',

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -155,6 +155,9 @@
   <configuration id="PS_SEARCH_FUZZY_MAX_LOOP" name="PS_SEARCH_FUZZY_MAX_LOOP">
     <value>4</value>
   </configuration>
+  <configuration id="PS_SEARCH_FUZZY_MAX_DIFFERENCE" name="PS_SEARCH_FUZZY_MAX_DIFFERENCE">
+    <value>5</value>
+  </configuration>
   <configuration id="PS_SEARCH_MAX_WORD_LENGTH" name="PS_SEARCH_MAX_WORD_LENGTH">
     <value>15</value>
   </configuration>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?             | 9.0.x
| Description?      | This PR allows to set additional search settings. See more below.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to play with this field and see that it changes the amount of typos you can make in a word for the product to be found.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/11833815220 ✅ 
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/1035
| Sponsor company   | TRENDO s.r.o.

### Context
- In Prestashop, there is fuzzy search enabled by default. This allows to find things even if there is a typo.
- If it doesn't find anything for a keyword, it will try to find list of simmilar words and takes the next closest one, until it finds something.
- It compares the words by a https://www.php.net/manual/en/function.levenshtein.php function, that compares how different two words are, and takes the closest word.

### The problem
- There is a limit to how the word can be different, by default it's 7. Which is unnecessarily high.
- So, imagine you are searching for something and there are cases where it should find nothing, but finds something irrelevant.
- For example, I search for `Blanco` and I can still find it with `Baaaaoaaa`.
- Simmilarily, this just invents completely irrelevant words.

### Solution
- Configure this to more sensible number, like 3 changes maximmum.
- So, I made a configuration field for this in search settings.