### PR TITLE
Fix cart value amount

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1351,9 +1351,9 @@ class CartRuleCore extends ObjectModel
                         if ((in_array($product['id_product'] . '-' . $product['id_product_attribute'], $selected_products)
                                 || in_array($product['id_product'] . '-0', $selected_products))
                             && (($this->reduction_exclude_special && !$product['reduction_applies']) || !$this->reduction_exclude_special)) {
-                            $price = $product['price'];
+                            $price = $product['price_with_reduction_without_tax'];
                             if ($use_tax) {
-                                $price = $product['price_without_reduction'];
+                                $price = $product['price_with_reduction'];
                             }
 
                             $selected_products_reduction += $price * $product['cart_quantity'];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The amount is not computed correctly when you call `getCartRules` from a module. The bug doesn't appear in the checkout because it uses `CartPresenter` and it's computed in another place.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| UI Tests | https://github.com/florine2623/testing_pr/actions/runs/11555964630
| How to test?      | #37148 
| Fixed issue or discussion?     | Fixes #37148
| Sponsor company   | idnovate.com
