### PR TITLE
Fix Incorrect SpecificPrice Currency Conversion (Issue 36844)

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3893,7 +3893,7 @@ class ProductCore extends ObjectModel
             !(
                 $specific_price['price'] >= 0 &&
                 $specific_price['id_currency'] &&
-                $id_currency == $specific_price['id_currency']
+                (int) $id_currency === (int) $specific_price['id_currency']
             )
         ) {
             $price = Tools::convertPrice($price, $id_currency);

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3893,7 +3893,7 @@ class ProductCore extends ObjectModel
             !(
                 $specific_price['price'] >= 0 &&
                 $specific_price['id_currency'] &&
-                $id_currency === $specific_price['id_currency']
+                $id_currency == $specific_price['id_currency']
             )
         ) {
             $price = Tools::convertPrice($price, $id_currency);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Specific Prices have a currency conversion applied to them even if the currency has been set and no conversion is necessary. See issue for full details. 
| Type?             | bug fix 
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |  For a product set a "Specific Price" that does not use the default shop currency and view the item in the store in the same currency. If an exchange rate is set then the price should still match the one set in the back office and the exchange rate will not be applied.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #36844 , Fixes #36629
| Related PRs       | 
| Sponsor company   | 
