### PR TITLE
Prevent carrier negative range

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/carrier/form/components/CarrierRangesModal.vue
+++ b/admin-dev/themes/new-theme/js/pages/carrier/form/components/CarrierRangesModal.vue
@@ -48,6 +48,13 @@
         >
           {{ $t('modal.overlappingAlert') }}
         </div>
+        <div
+          class="alert alert-danger"
+          v-if="negativeRangeAlert"
+          role="alert"
+        >
+          {{ $t('modal.negativeRangeAlert') }}
+        </div>
         <div class="table-container">
           <table class="table table-carrier-ranges-modal">
             <thead>
@@ -82,7 +89,7 @@
                         type="number"
                         class="form-control form-from"
                         inputmode="decimal"
-                        v-model="r.from"
+                        v-model.number="r.from"
                       >
                     </div>
                   </td>
@@ -95,7 +102,7 @@
                         type="number"
                         class="form-control form-to"
                         inputmode="decimal"
-                        v-model="r.to"
+                        v-model.number="r.to"
                       >
                     </div>
                   </td>
@@ -154,6 +161,7 @@
         refreshKey: 0,
         errors: false,
         overlappingAlert: false,
+        negativeRangeAlert: false,
         symbol: '',
       };
     },
@@ -190,6 +198,7 @@
         // We reset the errors
         this.errors = false;
         this.overlappingAlert = false;
+        this.negativeRangeAlert = false;
       },
       closeModal() {
         // We remove the class to allow scrolling
@@ -224,6 +233,7 @@
         // Reset errors
         this.errors = false;
         this.overlappingAlert = false;
+        this.negativeRangeAlert = false;
         // We remove the error class from all inputs already in error
         table.querySelectorAll('input.is-invalid').forEach((input) => {
           input.classList.remove('is-invalid');
@@ -235,20 +245,22 @@
         // We check ranges
         let saveMax: null | number = null;
         this.ranges.forEach((range, index) => {
-          // Check if all fields are filled
-          if (range.from === null) {
+          // Check if all fields are filled and are not negative
+          if (range.from === null || typeof range.from === 'string' || range.from < 0) {
             table.querySelectorAll(`tr[data-row="${index}"] input.form-from`)
               .forEach((input) => {
                 input.classList.add('is-invalid');
               });
             this.errors = true;
+            this.negativeRangeAlert = true;
           }
-          if (range.to === null) {
+          if (range.to === null || typeof range.to === 'string' || range.to < 0) {
             table.querySelectorAll(`tr[data-row="${index}"] input.form-to`)
               .forEach((input) => {
                 input.classList.add('is-invalid');
               });
             this.errors = true;
+            this.negativeRangeAlert = true;
           }
           // Check overlapping
           if (saveMax !== null && range.from !== null && range.from < saveMax) {

--- a/src/Core/Domain/Carrier/Exception/CarrierConstraintException.php
+++ b/src/Core/Domain/Carrier/Exception/CarrierConstraintException.php
@@ -142,4 +142,9 @@ class CarrierConstraintException extends CarrierException
      * Thrown when carrier is save without at least one zone
      */
     public const INVALID_ZONE_MISSING = 210;
+
+    /**
+     * Thrown when carrier range is a negative value
+     */
+    public const INVALID_RANGE_NEGATIVE = 220;
 }

--- a/src/Core/Domain/Carrier/ValueObject/CarrierRangeZone.php
+++ b/src/Core/Domain/Carrier/ValueObject/CarrierRangeZone.php
@@ -109,6 +109,12 @@ class CarrierRangeZone
 
         // Then, we can check if ranges are overlapping or not
         foreach ($ranges as $range) {
+            if ($range['range_from'] < 0 || $range['range_to'] < 0) {
+                throw new CarrierConstraintException(
+                    'Carrier range cannot be less than zero.',
+                    CarrierConstraintException::INVALID_RANGE_NEGATIVE
+                );
+            }
             if ($min > $range['range_from']) {
                 throw new CarrierConstraintException(
                     'Carrier ranges are overlapping',

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CarrierRangesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CarrierRangesType.php
@@ -66,6 +66,7 @@ class CarrierRangesType extends TranslatorAwareType
                         'modal.col.to' => $this->trans('Maximum', 'Admin.Shipping.Feature'),
                         'modal.col.action' => $this->trans('Action', 'Admin.Shipping.Feature'),
                         'modal.overlappingAlert' => $this->trans('Make sure there are no overlapping ranges. Remember, the minimum is part of the range, but the maximum isn\'t. So, the upper limit of a range is the lower limit of the next range.', 'Admin.Shipping.Feature'),
+                        'modal.negativeRangeAlert' => $this->trans('You can not add a negative range', 'Admin.Shipping.Feature'),
                     ]),
                 ],
             ])

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeType.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Improve\Shipping\Carrier\Type;
 
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\PositiveOrZero;
 use PrestaShopBundle\Form\Admin\Type\MoneyWithSuffixType;
 use PrestaShopBundle\Form\Admin\Type\TextPreviewType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
@@ -46,13 +47,24 @@ class CostsRangeType extends TranslatorAwareType
             ->add('range', TextPreviewType::class, [
                 'label' => $this->trans('Range', 'Admin.Shipping.Feature'),
             ])
-            ->add('from', HiddenType::class)
-            ->add('to', HiddenType::class)
+            ->add('from', HiddenType::class, [
+                'constraints' => [
+                    new PositiveOrZero([
+                        'message' => 'The value must be a positive number.',
+                    ]),
+                ],
+            ])
+            ->add('to', HiddenType::class, [
+                'constraints' => [
+                    new PositiveOrZero([
+                        'message' => 'The value must be a positive number.',
+                    ]),
+                ],
+            ])
             ->add('price', MoneyWithSuffixType::class, [
                 'label' => $this->trans('Price (VAT excl.)', 'Admin.Shipping.Feature'),
                 'empty_data' => '0.0', // string instead number needed for DecimalNumber.php validation
-            ])
-        ;
+            ]);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Carrier/Ranges/carrier_ranges.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Carrier/Ranges/carrier_ranges.feature
@@ -154,3 +154,21 @@ Feature: Carrier ranges
       | shippingMethod   | weight                             |
       | zones            |                                    |
     Then carrier should throw an error with error code "INVALID_ZONE_MISSING"
+
+  Scenario: Adding negative ranges in carrier
+    When I create carrier "carrier1" with specified properties:
+      | name             | Carrier 1                          |
+      | shippingMethod   | weight                             |
+      | zones            | zone1, zone2                       |
+    Then I set ranges for carrier "carrier1" with specified properties for all shops:
+      | id_zone | range_from | range_to | range_price |
+      | zone1   | -5         | 100      | 10          |
+    Then carrier should throw an error with error code "INVALID_RANGE_NEGATIVE"
+    When I create carrier "carrier2" with specified properties:
+      | name             | Carrier 2                          |
+      | shippingMethod   | weight                             |
+      | zones            | zone1, zone2                       |
+    Then I set ranges for carrier "carrier2" with specified properties for all shops:
+      | id_zone | range_from | range_to | range_price |
+      | zone1   | 0         | -100      | 10          |
+    Then carrier should throw an error with error code "INVALID_RANGE_NEGATIVE"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Prevent the user to add a range with a negative number or an empty field.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Describe in the associated issue
| UI Tests          | https://github.com/tleon/ga.tests.ui.pr/actions/runs/11840524867
| Fixed issue or discussion?     | #37154
| Sponsor company   | PrestaShop SA