### PR TITLE
Generate all image formats for categories right away after saving

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/adapter/image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/image.yml
@@ -4,9 +4,13 @@ services:
 
   prestashop.adapter.image.uploader.category_cover_image_uploader:
     class: 'PrestaShop\PrestaShop\Adapter\Image\Uploader\CategoryCoverImageUploader'
+    arguments:
+      - '@PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration'
 
   prestashop.adapter.image.uploader.category_thumbnail_image_uploader:
     class: 'PrestaShop\PrestaShop\Adapter\Image\Uploader\CategoryThumbnailImageUploader'
+    arguments:
+      - '@PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration'
 
   PrestaShop\PrestaShop\Adapter\Image\Uploader\CategoryImageUploader:
     autowire: true

--- a/tests/Resources/config/services.yml
+++ b/tests/Resources/config/services.yml
@@ -12,6 +12,8 @@ services:
 
     prestashop.adapter.image.uploader.category_cover_image_uploader:
         class: 'PrestaShop\PrestaShop\Adapter\Image\Uploader\CategoryCoverImageUploader'
+        arguments:
+          - '@PrestaShop\PrestaShop\Core\Image\ImageFormatConfiguration'
 
     prestashop.adapter.shop.url.product_image_folder_provider:
         class: 'Tests\Integration\Adapter\Shop\Url\TestProductImageFolderProvider'

--- a/tests/UI/campaigns/functional/BO/08_design/06_imageSettings/11_imageGenerationOnCreation.ts
+++ b/tests/UI/campaigns/functional/BO/08_design/06_imageSettings/11_imageGenerationOnCreation.ts
@@ -311,11 +311,10 @@ describe('BO - Design - Image Settings - Image Generation on creation', async ()
         );
         expect(fileJpegExists, `File ${idCategory}-${imageTypeName}.jpg doesn't exist!`).to.eq(true);
 
-        // @todo : https://github.com/PrestaShop/PrestaShop/issues/37282
-        //const fileWebpExists = await utilsFile.doesFileExist(
-        //  `${utilsFile.getRootPath()}/img/c/${idCategory}-${imageTypeName}.webp`,
-        //);
-        //expect(fileWebpExists, `File ${idCategory}-${imageTypeName}.webp doesn't exist!`).to.eq(true);
+        const fileWebpExists = await utilsFile.doesFileExist(
+          `${utilsFile.getRootPath()}/img/c/${idCategory}-${imageTypeName}.webp`,
+        );
+        expect(fileWebpExists, `File ${idCategory}-${imageTypeName}.webp doesn't exist!`).to.eq(true);
       }));
     });
   });


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Generates all image formats for categories right away after saving.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable generating webp in image settings. Upload and image and go check /img/c folder, there will be both jpg and webp thumbnails for your category.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/37282
| Related PRs       | 
| Sponsor company   | 
