### PR TITLE
Fix/carrier page bug when deleting range specific zone

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsZoneType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsZoneType.php
@@ -64,6 +64,7 @@ class CostsZoneType extends TranslatorAwareType
                 'label' => false,
                 'required' => false,
                 'allow_add' => true,
+                'allow_delete' => true,
                 'block_prefix' => 'carrier_ranges_costs_zone_ranges_collection',
             ])
         ;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x 
| Description?      | solution push range in ranges array only if for each  range `from` or `to` attribute  is not null
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see https://github.com/PrestaShop/PrestaShop/issues/37151 (error only when deleting range)
| UI Tests          | https://github.com/nicosomb/ga.tests.ui.pr/actions/runs/11610360017
| Fixed issue or discussion?     | Fixes #37151
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | PrestaShop SA