### PR TITLE
Fixed documentation URL for PrestaShop 9.0.x

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -8,7 +8,7 @@ body:
          ### ❗️ Read this before submitting your bug report:
          - **Write in English.** Reports in all other languages will be closed.
          - **Provide as much detail as possible** - error logs, screenshots, your exact configuration. If the issue cannot be reproduced, it cannot be fixed.
-         - **Follow the [bug report guidelines](https://devdocs.prestashop-project.org/8/contribute/contribute-reporting-issues/#best-practices-for-writing-an-issue).** This will help issue managers qualify your report faster.
+         - **Follow the [bug report guidelines](https://devdocs.prestashop-project.org/9/contribute/contribute-reporting-issues/#best-practices-for-writing-an-issue).** This will help issue managers qualify your report faster.
          - **Avoid reporting "error 500" or "white page" errors** - this is a universal error message that does not provide enough information to qualify the issue. Enable debug mode in the Performance section of PrestaShop or manually in `/config/defines.inc.php` and try again. You should get a proper error message.
          - If reporting a problem with the upgrade process, open `/admin/autoupgrade/tmp` and attach the last part of `log.txt` to the issue. It may contain information about the upgrade errors helpful in resolving the issue. Do not upload the entire `log.txt` as it contains sensitive data.
   - type: checkboxes

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -48,7 +48,7 @@
 
 To install PrestaShop 9, you need a web server running PHP 8.1+ and any flavor of MySQL 5.6+ (MySQL, MariaDB, Percona Server, etc.).
 
-You can find more information on our System requirements (https://devdocs.prestashop-project.org/8/basics/installation/system-requirements/) page and on the System Administrator Guide (https://docs.prestashop-project.org/1-6-documentation/english-documentation/system-administrator-guide).
+You can find more information on our System requirements (https://devdocs.prestashop-project.org/9/basics/installation/system-requirements/) page and on the System Administrator Guide (https://docs.prestashop-project.org/1-6-documentation/english-documentation/system-administrator-guide).
 
 === Installing PrestaShop
 

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -64,7 +64,7 @@ class WebserviceRequestCore
      *
      * @var string
      */
-    protected $_docUrl = 'https://devdocs.prestashop-project.org/8/webservice';
+    protected $_docUrl = 'https://devdocs.prestashop-project.org/9/webservice';
 
     /**
      * Set if the authentication key was checked.

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/index.html.twig
@@ -45,7 +45,7 @@
   {% endblock %}
 
   {% block webservice_api_status %}
-    {% set devdocUrl = 'https://devdocs.prestashop-project.org/8/webservice/' %}
+    {% set devdocUrl = 'https://devdocs.prestashop-project.org/9/webservice/' %}
 
     {% if webserviceStatus.isEnabled == true %}
       <div class="card">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/exchange_rates.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/exchange_rates.html.twig
@@ -38,7 +38,7 @@
           </label>
           <div class="col-sm">
             <small class="form-text">
-              {{ 'Check the [a]developer documentation[/a] for setup instructions.'|trans({'[a]': '<a href="https://devdocs.prestashop-project.org/8/faq/pricing/#refresh-exchange-rates" target="_blank">', '[/a]': '</a>'}, 'Admin.International.Notification')|raw }}
+              {{ 'Check the [a]developer documentation[/a] for setup instructions.'|trans({'[a]': '<a href="https://devdocs.prestashop-project.org/9/faq/pricing/#refresh-exchange-rates" target="_blank">', '[/a]': '</a>'}, 'Admin.International.Notification')|raw }}
             </small>
           </div>
         </div>

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,7 +28,7 @@ We use [Mocha](https://mochajs.org/), [Playwright](https://github.com/microsoft/
 
 ## How to write e2e tests
 
-Please refer to our [documentation](https://devdocs.prestashop-project.org/8/testing/ui-tests/how-to-contribute-and-create-ui-tests/).
+Please refer to our [documentation](https://devdocs.prestashop-project.org/9/testing/ui-tests/how-to-contribute-and-create-ui-tests/).
 
 # Unit tests
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x 
| Description?      | Fixed documentation URL for PrestaShop 9.0.x
| Type?             | bug fix 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | N/A
| UI Tests          | N/A
| Fixed issue or discussion?     | Fixes #37119
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA 
