### PR TITLE
Cleanup customization logic

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -365,10 +365,6 @@ class ProductCore extends ObjectModel
     public $delivery_out_stock;
 
     /**
-     * @var bool|null
-     */
-    public $customization_required;
-    /**
      * @var int|null
      */
     public $pack_quantity;
@@ -5546,13 +5542,6 @@ class ProductCore extends ObjectModel
 
         if ($row['pack'] && !Pack::isInStock($row['id_product'], $quantityToUseForPriceCalculations, $context->cart)) {
             $row['quantity'] = 0;
-        }
-
-        $row['customization_required'] = false;
-        if (isset($row['customizable']) && $row['customizable'] && Customization::isFeatureActive()) {
-            if (count(Product::getRequiredCustomizableFieldsStatic((int) $row['id_product']))) {
-                $row['customization_required'] = true;
-            }
         }
 
         if (!isset($row['attributes'])) {

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -335,38 +335,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 $productPriceWithoutReduction = $this->product->getPriceWithoutReduct(true, null);
             }
 
-            $pictures = [];
-            $text_fields = [];
-            if ($this->product->customizable) {
-                $files = $this->context->cart->getProductCustomization($this->product->id, Product::CUSTOMIZE_FILE, true);
-                foreach ($files as $file) {
-                    $pictures['pictures_' . $this->product->id . '_' . $file['index']] = $file['value'];
-                }
-
-                $texts = $this->context->cart->getProductCustomization($this->product->id, Product::CUSTOMIZE_TEXTFIELD, true);
-
-                foreach ($texts as $text_field) {
-                    $text_fields['textFields_' . $this->product->id . '_' . $text_field['index']] = str_replace('<br />', "\n", $text_field['value']);
-                }
-            }
-
-            $this->context->smarty->assign([
-                'pictures' => $pictures,
-                'textFields' => $text_fields, ]);
-
-            $this->product->customization_required = false;
-            $customization_fields = $this->product->customizable ? $this->product->getCustomizationFields($this->context->language->id) : false;
-            if (is_array($customization_fields)) {
-                foreach ($customization_fields as &$customization_field) {
-                    if ($customization_field['type'] == Product::CUSTOMIZE_FILE) {
-                        $customization_field['key'] = 'pictures_' . $this->product->id . '_' . $customization_field['id_customization_field'];
-                    } elseif ($customization_field['type'] == Product::CUSTOMIZE_TEXTFIELD) {
-                        $customization_field['key'] = 'textFields_' . $this->product->id . '_' . $customization_field['id_customization_field'];
-                    }
-                }
-                unset($customization_field);
-            }
-
             // Assign template vars related to the category + execute hooks related to the category
             $this->assignCategory();
 
@@ -427,10 +395,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 unset($accessory);
             }
 
-            if ($this->product->customizable) {
-                $customization_datas = $this->context->cart->getProductCustomization($this->product->id, null, true);
-            }
-
             $product_for_template = $this->getTemplateVarProduct();
 
             // Chained hook call - if multiple modules are hooked here, they will receive the result of the previous one as a parameter
@@ -451,8 +415,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             $this->context->smarty->assign([
                 'priceDisplay' => $priceDisplay,
                 'productPriceWithoutReduction' => $productPriceWithoutReduction,
-                'customizationFields' => $customization_fields,
-                'id_customization' => empty($customization_datas) ? null : $customization_datas[0]['id_customization'],
+                'id_customization' => empty($product_for_template['id_customization']) ? null : $product_for_template['id_customization'],
                 'accessories' => $accessories,
                 'product' => $product_for_template,
                 'displayUnitPrice' => !empty($product_for_template['unit_price_tax_excluded']),

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Adapter\Presenter\Product;
 use Category;
 use Combination;
 use Context;
+use Customization;
 use DateTime;
 use Db;
 use Language;
@@ -177,6 +178,30 @@ class ProductLazyArray extends AbstractLazyArray
         }
 
         return [];
+    }
+
+    /**
+     * Returns information, if a customization is required to purchase this product.
+     *
+     * @return bool
+     */
+    #[LazyArrayAttribute(arrayAccess: true)]
+    public function getCustomizationRequired()
+    {
+        if (!isset($this->product['customization_required'])) {
+            $this->product['customization_required'] = false;
+            // If customizable property passed here was true and customization feature is enabled,
+            // we can further check the fields.
+            if (!empty($this->product['customizable']) && Customization::isFeatureActive()) {
+                //  Now, we fetch the required customization fields and if we find some, the product requires customization.
+                if (count(Product::getRequiredCustomizableFieldsStatic((int) $this->product['id_product']))) {
+                    // And we cache it
+                    $this->product['customization_required'] = true;
+                }
+            }
+        }
+
+        return $this->product['customization_required'];
     }
 
     /**
@@ -953,7 +978,7 @@ class ProductLazyArray extends AbstractLazyArray
             return false;
         }
 
-        if ($product['customizable'] == ProductCustomizabilitySettings::REQUIRES_CUSTOMIZATION || !empty($product['customization_required'])) {
+        if ($product['customizable'] == ProductCustomizabilitySettings::REQUIRES_CUSTOMIZATION || $this->getCustomizationRequired()) {
             $shouldEnable = false;
 
             if (isset($product['customizations'])) {

--- a/src/Adapter/Presenter/Product/ProductListingLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductListingLazyArray.php
@@ -42,7 +42,7 @@ class ProductListingLazyArray extends ProductLazyArray
             return null;
         }
 
-        if ($this->product['customizable'] == ProductCustomizabilitySettings::REQUIRES_CUSTOMIZATION || !empty($this->product['customization_required'])) {
+        if ($this->product['customizable'] == ProductCustomizabilitySettings::REQUIRES_CUSTOMIZATION || $this->getCustomizationRequired()) {
             return null;
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | See below
| Type?             | refacto
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Test that customizations work normally on product page, required or not. Automatic tests should reveal any issue however.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Description
This PR is another step forward in modernizing the code related to products in front end. It's part of a bigger PR that I am extracting into smaller parts - https://github.com/PrestaShop/PrestaShop/pull/36684

Technically:
- It moves some logic from getProductProperties to ProductLazyArray.
- Removes some unused logic and smarty assignments in ProductController that are there since 1.6 or before, and should bring also some tiny performance benefit. The customization fields are added to the products itself via this line of code `$product_full = $this->addProductCustomizationData($product_full);`