### PR TITLE
Initialise Language context settings in the SF module command

### DIFF
--- a/src/PrestaShopBundle/Command/ModuleCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleCommand.php
@@ -30,6 +30,8 @@ use Employee;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Configuration\ModuleSelfConfigurator;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Context\ContextBuilderPreparer;
 use PrestaShop\PrestaShop\Core\Module\ModuleManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\FormatterHelper;
@@ -52,11 +54,6 @@ class ModuleCommand extends Command
     ];
 
     /**
-     * @var TranslatorInterface
-     */
-    protected $translator;
-
-    /**
      * @var InputInterface
      */
     protected $input;
@@ -66,32 +63,15 @@ class ModuleCommand extends Command
      */
     protected $output;
 
-    /**
-     * @var LegacyContext
-     */
-    private $context;
-
-    /**
-     * @var ModuleSelfConfigurator
-     */
-    private $moduleSelfConfigurator;
-
-    /**
-     * @var ModuleManager
-     */
-    private $moduleManager;
-
     public function __construct(
-        TranslatorInterface $translator,
-        LegacyContext $context,
-        ModuleSelfConfigurator $moduleSelfConfigurator,
-        ModuleManager $moduleManager
+        protected readonly TranslatorInterface $translator,
+        protected readonly LegacyContext $context,
+        protected readonly ModuleSelfConfigurator $moduleSelfConfigurator,
+        protected readonly ModuleManager $moduleManager,
+        protected readonly ContextBuilderPreparer $contextBuilderPreparer,
+        protected readonly ConfigurationInterface $configuration,
     ) {
         parent::__construct();
-        $this->translator = $translator;
-        $this->context = $context;
-        $this->moduleSelfConfigurator = $moduleSelfConfigurator;
-        $this->moduleManager = $moduleManager;
     }
 
     protected function configure()
@@ -114,6 +94,9 @@ class ModuleCommand extends Command
             // Even a non existing employee is fine
             $this->context->getContext()->employee = new Employee(42);
         }
+
+        // We must initialize the language context because ModuleRepository depends on it for its cache key
+        $this->contextBuilderPreparer->prepareLanguageId($this->configuration->get('PS_LANG_DEFAULT'));
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -35,14 +35,21 @@ services:
     autoconfigure: true
     public: false
 
-  prestashop.adapter.module.self_configurator:
-    class: PrestaShop\PrestaShop\Adapter\Module\Configuration\ModuleSelfConfigurator
+  PrestaShop\PrestaShop\Adapter\Module\Configuration\ModuleSelfConfigurator:
     arguments:
       - '@PrestaShop\PrestaShop\Core\Module\ModuleRepository'
       - "@prestashop.adapter.legacy.configuration"
       - "@doctrine.dbal.default_connection"
       - "@filesystem"
     lazy: true
+    public: false
+
+  prestashop.adapter.module.self_configurator:
+    alias: PrestaShop\PrestaShop\Adapter\Module\Configuration\ModuleSelfConfigurator
+    deprecated:
+      package: PrestaShop\PrestaShop
+      version: 9.0
+    public: true
 
   # MODULE TAB MANAGEMENT
   prestashop.adapter.module.tab.register:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/command.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/command.yml
@@ -38,11 +38,7 @@ services:
       - 'console.command'
 
   PrestaShopBundle\Command\ModuleCommand:
-    arguments:
-      - '@translator'
-      - '@prestashop.adapter.legacy.context'
-      - '@prestashop.adapter.module.self_configurator'
-      - '@PrestaShop\PrestaShop\Core\Module\ModuleManager'
+    autowire: true
     tags:
       - 'console.command'
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Initialise Language context settings in the SF module command because of the ModuleRepository dependency Related to https://github.com/PrestaShop/PrestaShop/pull/37215
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | CI green
| UI Tests          | ~
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
