### PR TITLE
Order::getCustomerOrders - in specific case incorrect sorting by date_add DESC

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -993,7 +993,7 @@ class OrderCore extends ObjectModel
         WHERE o.`id_customer` = ' . (int) $id_customer .
             Shop::addSqlRestriction(Shop::SHARE_ORDER) . '
         GROUP BY o.`id_order`
-        ORDER BY o.`date_add` DESC');
+        ORDER BY o.`date_add` DESC, o.`id_order` ASC');
 
         if (!$res) {
             return [];


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Function Order::getCustomerOrders is returning orders for customer, BUT, there is one specific case. If customer make order and it's splitted, there is **same** date_add, so there is "RANDOM" sort (@Hlavtox  already reported this "feature" in his other PR, it's same here). It's specific to mysql database, not PrestaShop. **So we change date_add DESC to id_order DESC - it is working well.**
| Type?             | bug fix
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | make an order that splits into 2, then both have the same date. Then call the function Order::getCustomerOrders and depending on different mysql settings, randomness and other phenomena, you will get a different order every time. In my case, for example, see the screen below. After applying PR, it will already sort correctly as it should. Check below PHP example for developers.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/

How to test via PHP:
     _$orders = Order::getCustomerOrders($this->context->customer->id);
        foreach ($orders as $order) {
            echo $order['id_order'] . '<br />';
        }
        die;_

How 2 splitted orders looks (same date)
![order_splitted](https://github.com/user-attachments/assets/d0b9e26e-d6a3-4583-9a83-ea243333d1ad)
Here is result of php example before PR apply (here you can see incorrect order for our "two" orders:
![bad_sorting](https://github.com/user-attachments/assets/01dc98af-0cfa-4a8d-bca5-4d40a43411aa)

