### PR TITLE
Slovakia VAT change from 2025/01 to 5% and 19% and 23%

### DIFF
--- a/localization/sk.xml
+++ b/localization/sk.xml
@@ -7,8 +7,8 @@
     <language iso_code="sk"/>
   </languages>
   <taxes>
-    <tax id="1" name="DPH SK 20%" rate="20" eu-tax-group="virtual"/>
-    <tax id="2" name="DPH SK 10%" rate="10"/>
+    <tax id="1" name="DPH SK 23%" rate="23" eu-tax-group="virtual"/>
+    <tax id="2" name="DPH SK 19%" rate="19"/>
     <tax id="3" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="4" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="5" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -37,7 +37,8 @@
     <tax id="28" name="TVA RO 19%" rate="19" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="30" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
-    <taxRulesGroup name="SK Standard Rate (20%)">
+    <tax id="31" name="DPH SK 5%" rate="5"/>
+    <taxRulesGroup name="SK Standard Rate (23%)">
       <taxRule iso_code_country="be" id_tax="1"/>
       <taxRule iso_code_country="bg" id_tax="1"/>
       <taxRule iso_code_country="cz" id_tax="1"/>
@@ -68,7 +69,7 @@
       <taxRule iso_code_country="se" id_tax="1"/>
       <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
-    <taxRulesGroup name="SK Reduced Rate (10%)">
+    <taxRulesGroup name="SK Reduced Rate 1 (19%)">
       <taxRule iso_code_country="be" id_tax="2"/>
       <taxRule iso_code_country="bg" id_tax="2"/>
       <taxRule iso_code_country="cz" id_tax="2"/>
@@ -99,67 +100,36 @@
       <taxRule iso_code_country="se" id_tax="2"/>
       <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
-    <taxRulesGroup name="SK Foodstuff Rate (20%)">
-      <taxRule iso_code_country="be" id_tax="1"/>
-      <taxRule iso_code_country="bg" id_tax="1"/>
-      <taxRule iso_code_country="cz" id_tax="1"/>
-      <taxRule iso_code_country="dk" id_tax="1"/>
-      <taxRule iso_code_country="de" id_tax="1"/>
-      <taxRule iso_code_country="ee" id_tax="1"/>
-      <taxRule iso_code_country="gr" id_tax="1"/>
-      <taxRule iso_code_country="hr" id_tax="1"/>
-      <taxRule iso_code_country="es" id_tax="1"/>
-      <taxRule iso_code_country="fr" id_tax="1"/>
-      <taxRule iso_code_country="mc" id_tax="1"/>
-      <taxRule iso_code_country="ie" id_tax="1"/>
-      <taxRule iso_code_country="it" id_tax="1"/>
-      <taxRule iso_code_country="cy" id_tax="1"/>
-      <taxRule iso_code_country="lv" id_tax="1"/>
-      <taxRule iso_code_country="lt" id_tax="1"/>
-      <taxRule iso_code_country="lu" id_tax="1"/>
-      <taxRule iso_code_country="hu" id_tax="1"/>
-      <taxRule iso_code_country="mt" id_tax="1"/>
-      <taxRule iso_code_country="nl" id_tax="1"/>
-      <taxRule iso_code_country="at" id_tax="1"/>
-      <taxRule iso_code_country="pl" id_tax="1"/>
-      <taxRule iso_code_country="pt" id_tax="1"/>
-      <taxRule iso_code_country="ro" id_tax="1"/>
-      <taxRule iso_code_country="si" id_tax="1"/>
-      <taxRule iso_code_country="sk" id_tax="1"/>
-      <taxRule iso_code_country="fi" id_tax="1"/>
-      <taxRule iso_code_country="se" id_tax="1"/>
-      <taxRule iso_code_country="gb" id_tax="1"/>
-    </taxRulesGroup>
-    <taxRulesGroup name="SK Books Rate (10%)">
-      <taxRule iso_code_country="be" id_tax="2"/>
-      <taxRule iso_code_country="bg" id_tax="2"/>
-      <taxRule iso_code_country="cz" id_tax="2"/>
-      <taxRule iso_code_country="dk" id_tax="2"/>
-      <taxRule iso_code_country="de" id_tax="2"/>
-      <taxRule iso_code_country="ee" id_tax="2"/>
-      <taxRule iso_code_country="gr" id_tax="2"/>
-      <taxRule iso_code_country="hr" id_tax="2"/>
-      <taxRule iso_code_country="es" id_tax="2"/>
-      <taxRule iso_code_country="fr" id_tax="2"/>
-      <taxRule iso_code_country="mc" id_tax="2"/>
-      <taxRule iso_code_country="ie" id_tax="2"/>
-      <taxRule iso_code_country="it" id_tax="2"/>
-      <taxRule iso_code_country="cy" id_tax="2"/>
-      <taxRule iso_code_country="lv" id_tax="2"/>
-      <taxRule iso_code_country="lt" id_tax="2"/>
-      <taxRule iso_code_country="lu" id_tax="2"/>
-      <taxRule iso_code_country="hu" id_tax="2"/>
-      <taxRule iso_code_country="mt" id_tax="2"/>
-      <taxRule iso_code_country="nl" id_tax="2"/>
-      <taxRule iso_code_country="at" id_tax="2"/>
-      <taxRule iso_code_country="pl" id_tax="2"/>
-      <taxRule iso_code_country="pt" id_tax="2"/>
-      <taxRule iso_code_country="ro" id_tax="2"/>
-      <taxRule iso_code_country="si" id_tax="2"/>
-      <taxRule iso_code_country="sk" id_tax="2"/>
-      <taxRule iso_code_country="fi" id_tax="2"/>
-      <taxRule iso_code_country="se" id_tax="2"/>
-      <taxRule iso_code_country="gb" id_tax="2"/>
+    <taxRulesGroup name="SK Reduced Rate 2 (5%)">
+      <taxRule iso_code_country="be" id_tax="31"/>
+      <taxRule iso_code_country="bg" id_tax="31"/>
+      <taxRule iso_code_country="cz" id_tax="31"/>
+      <taxRule iso_code_country="dk" id_tax="31"/>
+      <taxRule iso_code_country="de" id_tax="31"/>
+      <taxRule iso_code_country="ee" id_tax="31"/>
+      <taxRule iso_code_country="gr" id_tax="31"/>
+      <taxRule iso_code_country="hr" id_tax="31"/>
+      <taxRule iso_code_country="es" id_tax="31"/>
+      <taxRule iso_code_country="fr" id_tax="31"/>
+      <taxRule iso_code_country="mc" id_tax="31"/>
+      <taxRule iso_code_country="ie" id_tax="31"/>
+      <taxRule iso_code_country="it" id_tax="31"/>
+      <taxRule iso_code_country="cy" id_tax="31"/>
+      <taxRule iso_code_country="lv" id_tax="31"/>
+      <taxRule iso_code_country="lt" id_tax="31"/>
+      <taxRule iso_code_country="lu" id_tax="31"/>
+      <taxRule iso_code_country="hu" id_tax="31"/>
+      <taxRule iso_code_country="mt" id_tax="31"/>
+      <taxRule iso_code_country="nl" id_tax="31"/>
+      <taxRule iso_code_country="at" id_tax="31"/>
+      <taxRule iso_code_country="pl" id_tax="31"/>
+      <taxRule iso_code_country="pt" id_tax="31"/>
+      <taxRule iso_code_country="ro" id_tax="31"/>
+      <taxRule iso_code_country="si" id_tax="31"/>
+      <taxRule iso_code_country="sk" id_tax="31"/>
+      <taxRule iso_code_country="fi" id_tax="31"/>
+      <taxRule iso_code_country="se" id_tax="31"/>
+      <taxRule iso_code_country="gb" id_tax="31"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="sk" id_tax="1"/>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Slovakia VAT change from 2025/01. Old rate: 10+20. New rate: 5+19+23, source for example: https://www.ui42.sk/blog/zmeny-sadzieb-dph-od-roku-2025-a-ich-dopad-na-e-shopy
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install PrestaShop with SK package, you should get new rate 5+19+23
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/LocalizationFiles/pull/51
| Sponsor company   | https://www.openservis.cz/
