### PR TITLE
Disable autocapitalize for SMTP settings (mobile)

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php
@@ -48,17 +48,26 @@ class SmtpConfigurationType extends TranslatorAwareType
                 'empty_data' => '',
                 'label' => $this->trans('Email domain name', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('Fully qualified domain name (keep this field empty if you don\'t know).', 'Admin.Advparameters.Help'),
+                'attr' => [
+                    'autocapitalize' => 'off',
+                ],
             ])
             ->add('server', TextType::class, [
                 'required' => false,
                 'label' => $this->trans('SMTP server', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('IP address or server name (e.g. smtp.mydomain.com).', 'Admin.Advparameters.Help'),
+                'attr' => [
+                    'autocapitalize' => 'off',
+                ],
             ])
             ->add('username', TextType::class, [
                 'required' => false,
                 'empty_data' => '',
                 'label' => $this->trans('SMTP username', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('Leave blank if not applicable.', 'Admin.Advparameters.Help'),
+                'attr' => [
+                    'autocapitalize' => 'off',
+                ],
             ])
             ->add('password', PasswordType::class, [
                 'required' => false,
@@ -67,7 +76,8 @@ class SmtpConfigurationType extends TranslatorAwareType
                 'help' => $this->trans('Leave blank if not applicable.', 'Admin.Advparameters.Help'),
                 /* Some browsers (for example Google Chrome) are totally ignoring "off" value, so we use "new-password" - which is working well for this purpose */
                 'attr' => [
-                    'autocomplete' => 'new-password',
+                    'autocomplete' => 'new-password',,
+                    'autocapitalize' => 'off',
                 ],
             ])
             ->add('encryption', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php
@@ -76,7 +76,7 @@ class SmtpConfigurationType extends TranslatorAwareType
                 'help' => $this->trans('Leave blank if not applicable.', 'Admin.Advparameters.Help'),
                 /* Some browsers (for example Google Chrome) are totally ignoring "off" value, so we use "new-password" - which is working well for this purpose */
                 'attr' => [
-                    'autocomplete' => 'new-password',,
+                    'autocomplete' => 'new-password',
                     'autocapitalize' => 'off',
                 ],
             ])


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Mobile device autocapitalize first character, we really don't want it for SMTP settings. We want lowercase default for SMTP settings.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Visit SMTP settings via mobile device, first character will be uppercase. After apply this PR this will be lowercase default.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
