### PR TITLE
Ensure consistent default combination ID

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4264,7 +4264,7 @@ class ProductCore extends ObjectModel
             WHERE pa.`id_product` IN (' . implode(',', array_map('intval', $products)) . ') AND ag.`is_color_group` = 1
             GROUP BY pa.`id_product`, a.`id_attribute`, `group_by`
             ' . ($check_stock ? 'HAVING qty > 0' : '') . '
-            ORDER BY a.`position` ASC;'
+            ORDER BY a.`position` ASC, pa.`id_product_attribute` ASC;'
         )) {
             return false;
         }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1080,7 +1080,8 @@ class ProductCore extends ObjectModel
         $sql = 'SELECT product_attribute_shop.id_product_attribute
                 FROM ' . _DB_PREFIX_ . 'product_attribute pa
                 ' . Shop::addSqlAssociation('product_attribute', 'pa') . '
-                WHERE pa.id_product = ' . (int) $id_product;
+                WHERE pa.id_product = ' . (int) $id_product . '
+                ORDER BY product_attribute_shop.id_product_attribute ASC';
 
         // If none are found, we exit right away
         $result_no_filter = (int) Db::getInstance()->getValue($sql);
@@ -1107,7 +1108,8 @@ class ProductCore extends ObjectModel
                     ' . Shop::addSqlAssociation('product_attribute', 'pa') . '
                     ' . ($minimum_quantity > 0 ? Product::sqlStock('pa', 'pa') : '') .
                     ' WHERE pa.id_product = ' . (int) $id_product
-                    . ($minimum_quantity > 0 ? ' AND IFNULL(stock.quantity, 0) >= ' . (int) $minimum_quantity : '');
+                    . ($minimum_quantity > 0 ? ' AND IFNULL(stock.quantity, 0) >= ' . (int) $minimum_quantity : '') . '
+                    ORDER BY product_attribute_shop.id_product_attribute ASC';
 
             $result = (int) Db::getInstance()->getValue($sql);
         }
@@ -5372,24 +5374,36 @@ class ProductCore extends ObjectModel
             );
         }
 
-        $id_product_attribute = $row['id_product_attribute'] = (!empty($row['id_product_attribute']) ? (int) $row['id_product_attribute'] : null);
-
-        // Product::getDefaultAttribute is only called if id_product_attribute is missing from the SQL query at the origin of it:
-        // consider adding it in order to avoid unnecessary queries
+        // Resolve if product is in stock
         $row['allow_oosp'] = Product::isAvailableWhenOutOfStock($row['out_of_stock']);
-        if (
-            Combination::isFeatureActive()
-            && $id_product_attribute === null
-            && (
-                (isset($row['cache_default_attribute']) && ($ipa_default = $row['cache_default_attribute']) !== null)
-                || ($ipa_default = Product::getDefaultAttribute($row['id_product'], (int) !$row['allow_oosp']))
-            )
-        ) {
-            $id_product_attribute = $row['id_product_attribute'] = $ipa_default;
+
+        /* 
+         * Resolve default product combination, if combinations are enabled on the shop.
+         */
+        $id_product_attribute = 0;
+        if (Combination::isFeatureActive()) {
+            /*
+             * If we have some specific combination ID passed, we will use it and don't ask other questions
+             * It doesn't have to be the default combination. For example, a filtering module can directly pass
+             * an id_product_attribute it wants to use and display to the user.
+             */
+            if (!empty($row['id_product_attribute'])) {
+                $id_product_attribute = (int) $row['id_product_attribute'];
+            /* 
+             * If nothing was passed, we will look for cache_default_attribute, this is a cached default combination
+             * ID on the product ID. Passing this or id_product_attribute above directly will save performance.
+             */
+            } elseif (!empty($row['cache_default_attribute'])) {
+                $id_product_attribute = (int) $row['cache_default_attribute'];
+            /* 
+             * If nothing was passed, we will get the combination to use manually.
+             * Product::getDefaultAttribute finds the best combination to use.
+             */
+            } else {
+                $id_product_attribute = (int) Product::getDefaultAttribute($row['id_product'], (int) !$row['allow_oosp']);
+            }
         }
-        if (!Combination::isFeatureActive() || !isset($row['id_product_attribute'])) {
-            $id_product_attribute = $row['id_product_attribute'] = 0;
-        }
+        $row['id_product_attribute'] = $id_product_attribute;
 
         // Tax
         $usetax = Configuration::get('PS_TAX');

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5377,7 +5377,7 @@ class ProductCore extends ObjectModel
         // Resolve if product is in stock
         $row['allow_oosp'] = Product::isAvailableWhenOutOfStock($row['out_of_stock']);
 
-        /* 
+        /*
          * Resolve default product combination, if combinations are enabled on the shop.
          */
         $id_product_attribute = 0;
@@ -5389,13 +5389,13 @@ class ProductCore extends ObjectModel
              */
             if (!empty($row['id_product_attribute'])) {
                 $id_product_attribute = (int) $row['id_product_attribute'];
-            /* 
+            /*
              * If nothing was passed, we will look for cache_default_attribute, this is a cached default combination
              * ID on the product ID. Passing this or id_product_attribute above directly will save performance.
              */
             } elseif (!empty($row['cache_default_attribute'])) {
                 $id_product_attribute = (int) $row['cache_default_attribute'];
-            /* 
+            /*
              * If nothing was passed, we will get the combination to use manually.
              * Product::getDefaultAttribute finds the best combination to use.
              */

--- a/tests/UI/campaigns/functional/FO/classic/06_homePage/05_selectColor.ts
+++ b/tests/UI/campaigns/functional/FO/classic/06_homePage/05_selectColor.ts
@@ -58,11 +58,6 @@ describe('FO - Home Page : Select color on hover on product list', async () => {
   it('should check that the displayed product is white', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'checkDisplayedProduct', baseContext);
 
-    // @todo : https://github.com/PrestaShop/PrestaShop/issues/36356
-    if (global.INSTALL.DB_SERVER === 'mariadb') {
-      this.skip();
-    }
-
     const pageURL = await foClassicProductPage.getCurrentURL(page);
     expect(pageURL).to.contains('color-white')
       .and.to.contains('size-m');

--- a/tests/UI/campaigns/functional/FO/classic/06_homePage/05_selectColor.ts
+++ b/tests/UI/campaigns/functional/FO/classic/06_homePage/05_selectColor.ts
@@ -60,7 +60,7 @@ describe('FO - Home Page : Select color on hover on product list', async () => {
 
     const pageURL = await foClassicProductPage.getCurrentURL(page);
     expect(pageURL).to.contains('color-white')
-      .and.to.contains('size-m');
+      .and.to.contains('size-s');
   });
 
   it('should go to Home page', async function () {

--- a/tests/UI/campaigns/functional/FO/hummingbird/06_homePage/05_selectColor.ts
+++ b/tests/UI/campaigns/functional/FO/hummingbird/06_homePage/05_selectColor.ts
@@ -57,7 +57,7 @@ describe('FO - Home Page : Select color', async () => {
 
       const pageURL = await foHummingbirdProductPage.getCurrentURL(page);
       expect(pageURL).to.contains('color-white')
-      .and.to.contains('size-s');
+        .and.to.contains('size-s');
     });
 
     it('should go to Home page', async function () {
@@ -83,7 +83,7 @@ describe('FO - Home Page : Select color', async () => {
 
       const pageURL = await foHummingbirdProductPage.getCurrentURL(page);
       expect(pageURL).to.contains('color-black')
-      .and.to.contains('size-s');
+        .and.to.contains('size-s');
     });
   });
 

--- a/tests/UI/campaigns/functional/FO/hummingbird/06_homePage/05_selectColor.ts
+++ b/tests/UI/campaigns/functional/FO/hummingbird/06_homePage/05_selectColor.ts
@@ -56,9 +56,8 @@ describe('FO - Home Page : Select color', async () => {
       await testContext.addContextItem(this, 'testIdentifier', 'checkDisplayedProduct', baseContext);
 
       const pageURL = await foHummingbirdProductPage.getCurrentURL(page);
-      expect(pageURL).to.contains('color-white');
-      // @todo : https://github.com/PrestaShop/PrestaShop/issues/35481
-      // .and.to.contains('size-m');
+      expect(pageURL).to.contains('color-white')
+      .and.to.contains('size-s');
     });
 
     it('should go to Home page', async function () {
@@ -83,9 +82,8 @@ describe('FO - Home Page : Select color', async () => {
       await testContext.addContextItem(this, 'testIdentifier', 'checkDisplayedProduct2', baseContext);
 
       const pageURL = await foHummingbirdProductPage.getCurrentURL(page);
-      expect(pageURL).to.contains('color-black');
-      // @todo : https://github.com/PrestaShop/PrestaShop/issues/35481
-      // .and.to.contains('size-m');
+      expect(pageURL).to.contains('color-black')
+      .and.to.contains('size-s');
     });
   });
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Ensures that default combination ID on product list is always consistent by adding an ORDER BY clause to the query that selects the default combination. Should fix the related issue. Also, makes the code to fetch the default combination a bit more readable, the historic thing that is there now is not very readable. I can then just copy paste it to a better place.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | This feature is used so much, that tests would reveal any issue. @Progi1984 can check if it fixed his issue.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/36356
| Related PRs       | 
| Sponsor company   | 
