### PR TITLE
Add more options to pagination

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -174,7 +174,7 @@ class CommonController extends FrameworkBundleAdminController
                 $limitParam => $limit,
             ]
         ));
-        $limitChoices = $request->attributes->get('limit_choices', [10, 20, 50, 100]);
+        $limitChoices = $request->attributes->get('limit_choices', [10, 20, 50, 100, 300, 1000]);
 
         // Template vars injection
         $vars = [

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/catalog_price_rules.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/catalog_price_rules.html.twig
@@ -55,7 +55,7 @@
       <div class="row justify-content-center" id="catalog-price-rules-pagination">
         {{ include('@PrestaShop/Admin/Common/javascript_pagination.html.twig', {
           'limit': 10,
-          'limitChoices': [10, 20, 50, 100],
+          'limitChoices': [10, 20, 50, 100, 300, 1000],
         }) }}
       </div>
       <script type="text/html" id="catalog-price-rule-tr-template">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/Blocks/list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/Blocks/list.html.twig
@@ -53,7 +53,7 @@
   <div class="row justify-content-center" id="specific-prices-pagination">
     {{ include('@PrestaShop/Admin/Common/javascript_pagination.html.twig', {
       'limit': 10,
-      'limitChoices': [10, 20, 50, 100],
+      'limitChoices': [10, 20, 50, 100, 300, 1000],
     }) }}
   </div>
   <script type="text/html" id="specific-price-tr-template">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Adds more options to grid pagination. 100 is not enough for common tasks, for example when you are deleting a lot of products or customers.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/37113
| Related PRs       | 
| Sponsor company   | 