### PR TITLE
Fix : The command defined in "PrestaShopBundle\Command\FeatureFlagCom…

### DIFF
--- a/src/PrestaShopBundle/Command/FeatureFlagCommand.php
+++ b/src/PrestaShopBundle/Command/FeatureFlagCommand.php
@@ -159,4 +159,9 @@ class FeatureFlagCommand extends Command
 
         return self::SUCCESS_RETURN_CODE;
     }
+
+    public static function getDefaultName(): string
+    {
+        return self::$defaultName;
+    }
 }


### PR DESCRIPTION
…mand" cannot have an empty name

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix error The command defined in "PrestaShopBundle\Command\FeatureFlagCommand" cannot hav
  e an empty name while using the command line.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Sponsor company   | @PrestaEdit .
