### PR TITLE
EAN13/GTIN14 - better validation

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -716,7 +716,7 @@ class ValidateCore
      */
     public static function isEan13($ean13)
     {
-        return !$ean13 || preg_match('/^[0-9]{0,13}$/', $ean13);
+        return !$ean13 || preg_match(Ean13::VALID_PATTERN, $ean13);
     }
 
     /**

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CustomerName;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Factory\CustomerNameValidatorFactory;
 use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\NumericIsoCode;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\ApeCode;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Gtin;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
 use PrestaShop\PrestaShop\Core\Email\CyrillicCharactersInEmailValidation;

--- a/src/Core/Domain/Product/ValueObject/Ean13.php
+++ b/src/Core/Domain/Product/ValueObject/Ean13.php
@@ -38,7 +38,7 @@ class Ean13
     /**
      * Valid ean regex pattern
      */
-    public const VALID_PATTERN = '/^[0-9]{0,13}$/';
+    public const VALID_PATTERN = '/^[0-9]{8,13}$/';
 
     /**
      * Maximum allowed symbols

--- a/src/Core/Domain/Product/ValueObject/Ean13.php
+++ b/src/Core/Domain/Product/ValueObject/Ean13.php
@@ -38,7 +38,7 @@ class Ean13
     /**
      * Valid ean regex pattern
      */
-    public const VALID_PATTERN = '/^[0-9]{8,13}$/';
+    public const VALID_PATTERN = '/^(|[0-9]{8,13})$/';
 
     /**
      * Maximum allowed symbols

--- a/src/Core/Domain/Product/ValueObject/Gtin.php
+++ b/src/Core/Domain/Product/ValueObject/Gtin.php
@@ -36,7 +36,7 @@ class Gtin
     /**
      * Valid gtin regex pattern
      */
-    public const VALID_PATTERN = '/^[0-9]{0,14}$/';
+    public const VALID_PATTERN = '/^[0-9]{8,14}$/';
 
     /**
      * Maximum allowed symbols

--- a/src/Core/Domain/Product/ValueObject/Gtin.php
+++ b/src/Core/Domain/Product/ValueObject/Gtin.php
@@ -36,7 +36,7 @@ class Gtin
     /**
      * Valid gtin regex pattern
      */
-    public const VALID_PATTERN = '/^[0-9]{8,14}$/';
+    public const VALID_PATTERN = '/^(|[0-9]{8,14})$/';
 
     /**
      * Maximum allowed symbols

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
@@ -610,7 +610,7 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
                 'details' => [
                     'references' => [
                         'isbn' => '0-8044-2957-X',
-                        'ean_13' => '13',
+                        'ean_13' => '98765432',
                         'upc' => '1345',
                         'mpn' => 'mpn',
                         'reference' => '0123456789',

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
@@ -476,12 +476,12 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
         ];
 
         $command = $this->getSingleShopCommand();
-        $command->setGtin('13');
+        $command->setGtin('98765432');
         yield [
             [
                 'details' => [
                     'references' => [
-                        'ean_13' => '13',
+                        'ean_13' => '98765432',
                     ],
                 ],
             ],
@@ -550,7 +550,7 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
             ->setLocalizedLinkRewrites($localizedLinkRewrites)
             ->setRedirectOption(RedirectType::TYPE_PRODUCT_TEMPORARY, 42)
             ->setIsbn('0-8044-2957-X')
-            ->setGtin('13')
+            ->setGtin('98765432')
             ->setUpc('1345')
             ->setMpn('mpn')
             ->setReference('0123456789')


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Now GTIN/EAN pattern accept string with for example length 5, but this is not valid EAN/GTIN. This PR make preg_match for 8 characters minimum and fix Validate.php, where is duplicate preg_match, but we would use Ean13::VALID_PATTERN to prevent duplicates. Same like for Gtin::VALID_PATTERN. Maybe there can be another validation method to specific number, but actual length 8 is better than 0 validate.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
