### PR TITLE
Improve speed of getting combination images

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2640,11 +2640,10 @@ class ProductCore extends ObjectModel
         }
 
         $result = Db::getInstance()->executeS(
-            '
-            SELECT pai.`id_image`, pai.`id_product_attribute`, il.`legend`
+            'SELECT pai.`id_image`, pai.`id_product_attribute`, il.`legend`
             FROM `' . _DB_PREFIX_ . 'product_attribute_image` pai
             LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (il.`id_image` = pai.`id_image`)
-            LEFT JOIN `' . _DB_PREFIX_ . 'image` i ON (i.`id_image` = pai.`id_image`)
+            INNER JOIN `' . _DB_PREFIX_ . 'image` i ON (i.`id_image` = pai.`id_image`)
             WHERE i.`id_product` = ' . (int) $this->id . ' AND il.`id_lang` = ' . (int) $id_lang . ' ORDER by i.`position`'
         );
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2626,30 +2626,17 @@ class ProductCore extends ObjectModel
     }
 
     /**
+     * Returns information about product images that are paired to specific combination
+     *
      * @param int $id_lang Language identifier
      *
      * @return array|false
      */
     public function getCombinationImages($id_lang)
     {
+        // If combination feature is disabled, no need to do any queries
         if (!Combination::isFeatureActive()) {
             return false;
-        }
-
-        $product_attributes = Db::getInstance()->executeS(
-            'SELECT `id_product_attribute`
-            FROM `' . _DB_PREFIX_ . 'product_attribute`
-            WHERE `id_product` = ' . (int) $this->id
-        );
-
-        if (!$product_attributes) {
-            return false;
-        }
-
-        $ids = [];
-
-        foreach ($product_attributes as $product_attribute) {
-            $ids[] = (int) $product_attribute['id_product_attribute'];
         }
 
         $result = Db::getInstance()->executeS(
@@ -2658,7 +2645,7 @@ class ProductCore extends ObjectModel
             FROM `' . _DB_PREFIX_ . 'product_attribute_image` pai
             LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il ON (il.`id_image` = pai.`id_image`)
             LEFT JOIN `' . _DB_PREFIX_ . 'image` i ON (i.`id_image` = pai.`id_image`)
-            WHERE pai.`id_product_attribute` IN (' . implode(', ', $ids) . ') AND il.`id_lang` = ' . (int) $id_lang . ' ORDER by i.`position`'
+            WHERE i.`id_product` = ' . (int) $this->id . ' AND il.`id_lang` = ' . (int) $id_lang . ' ORDER by i.`position`'
         );
 
         if (!$result) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Improves speed of getting combination images. On combination heavy sites, it will help with performance. On one of my clients site I got query count from ~510 to ~490 and speed from ~350 ms to ~340 ms. There is no need to specify which combinations to retrieve when getting the images. We are getting all images for all combinations of the current products. So we can just id_product in image table to filter it, instead of doing another query.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Auto test.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 
