### PR TITLE
No need to query information about customized products for not custom…

### DIFF
--- a/src/Adapter/Presenter/AbstractLazyArray.php
+++ b/src/Adapter/Presenter/AbstractLazyArray.php
@@ -398,7 +398,7 @@ abstract class AbstractLazyArray implements Iterator, ArrayAccess, Countable, Js
         if ($this->arrayAccessList->offsetExists($offset)) {
             $offsetData = $this->arrayAccessList->offsetGet($offset);
 
-            if (!$force && !$offsetData['isRewritable'] && $offsetData['type'] !== 'variable') {
+            if (!$force && empty($offsetData['isRewritable']) && $offsetData['type'] !== 'variable') {
                 $errorMessage = sprintf(
                     'Trying to set the index %s of the LazyArray %s already defined by a method is not allowed.',
                     print_r($offset, true),

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -85,7 +85,7 @@ class CartPresenter implements PresenterInterface
         return array_map(function ($product) use ($cart) {
             $customizations = [];
 
-            if (!$product->customizable) {
+            if (empty($product['id_customization'])) {
                 return $product;
             }
 

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -85,6 +85,10 @@ class CartPresenter implements PresenterInterface
         return array_map(function ($product) use ($cart) {
             $customizations = [];
 
+            if (!$product->customizable) {
+                return $product;
+            }
+
             $data = Product::getAllCustomizedDatas($cart->id, null, true, null, (int) $product['id_customization']);
 
             if (!$data) {

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -86,6 +86,7 @@ class CartPresenter implements PresenterInterface
             $customizations = [];
 
             if (empty($product['id_customization'])) {
+                $product['customizations'] = [];
                 return $product;
             }
 


### PR DESCRIPTION
…izable products

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Minor performance optimization, with 11 products in cart, 11 fewer queries.  I also fixed tiny thing with `Warning: Undefined array key "isRewritable" in src/Adapter/Presenter/AbstractLazyArray.php on line 401`
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check if you can order customized products and they work ok.
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/11882314013
| Fixed issue or discussion?     | n/a
| Related PRs       | n/a
| Sponsor company   | Krystian Podemski
