### PR TITLE
Improved performance of Cart with no gifts inside

### DIFF
--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -152,7 +152,9 @@ class CartLazyArray extends AbstractLazyArray
     {
         $subtotals = [];
         $totalCartAmount = $this->cart->getOrderTotal($this->cartPresenter->includeTaxes(), Cart::ONLY_PRODUCTS);
-        $total_discount = $this->cart->getDiscountSubtotalWithoutGifts($this->cartPresenter->includeTaxes());
+        $total_discount = $this->cart->gift ?
+            $this->cart->getDiscountSubtotalWithoutGifts($this->cartPresenter->includeTaxes())
+            : $this->cart->getOrderTotal($this->cartPresenter->includeTaxes(), Cart::ONLY_DISCOUNTS);
         $subtotals['products'] = [
             'type' => 'products',
             'label' => $this->translator->trans('Subtotal', [], 'Shop.Theme.Checkout'),


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | If there is no gift in the cart, there is no need to refresh $products to exclude them from cart totals, producing extra queries.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check if gifts work as expected
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | n/a
| Related PRs       | n/a
| Sponsor company   | Krystian Podemski
