### PR TITLE
Assemble cart products in bulk

### DIFF
--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -119,7 +119,7 @@ class CartLazyArray extends AbstractLazyArray
          * We could possibly add something like $prioritizeOriginalData to ProductAssembler.
          */
         $assembledProducts = $this->cartPresenter->getProductAssembler()->assembleProducts($rawProducts);
-        foreach($rawProducts as $k => $v) {
+        foreach ($rawProducts as $k => $v) {
             $rawProducts[$k] = array_merge($assembledProducts[$k], $v);
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Increases performance of cart page by loading product data in bulk. See more below.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Auto test. Live shop here - https://eshop-franke.cz/
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Description
- Before presenting products, we load their data by ProductAssembler. This class used to do it one by one, but I also introduced a bulk way of doing it, we now use this in product list.
- Now, I also put this faster way to cart.

### Performance benefit
- It reduces number of queries by number of presented products.
- In my case with 13 products in cart, the queries drop from 1013 to 980. The load time drops by about 10 ms from 385 ms to 375 ms.