### PR TITLE
Assemble accessories and packs in bulk

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -365,11 +365,12 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
             // Presenting pack items
             $pack_items = Pack::isPack($this->product->id) ? Pack::getItemTable($this->product->id, $this->context->language->id, true) : [];
+            $pack_items = $assembler->assembleProducts($pack_items);
             $presentedPackItems = [];
             foreach ($pack_items as $item) {
                 $presentedPackItems[] = $presenter->present(
                     $this->getProductPresentationSettings(),
-                    $assembler->assembleProduct($item),
+                    $item,
                     $this->context->language
                 );
             }
@@ -385,10 +386,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             // Assign accessories
             $accessories = $this->product->getAccessories($this->context->language->id);
             if (is_array($accessories)) {
+                $accessories = $assembler->assembleProducts($accessories);
                 foreach ($accessories as &$accessory) {
                     $accessory = $presenter->present(
                         $presentationSettings,
-                        $assembler->assembleProduct($accessory),
+                        $accessory,
                         $this->context->language
                     );
                 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Increases performance of product page by loading product data in bulk. See more below.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Auto test. Live shop here - https://eshop-franke.cz/
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Description
- Before presenting products, we load their data by ProductAssembler. This class used to do it one by one, but I also introduced a bulk way of doing it, we now use this in product list.
- Now, I also put this faster way to accessory and pack on product page.

### Performance benefit
- It reduces number of queries by number of presented products.