### PR TITLE
Remove useless pack quantity

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5541,10 +5541,6 @@ class ProductCore extends ObjectModel
         $row['packItems'] = $row['pack'] ? Pack::getItemTable($row['id_product'], $id_lang) : [];
         $row['nopackprice'] = $row['pack'] ? Pack::noPackPrice($row['id_product']) : 0;
 
-        if ($row['pack'] && !Pack::isInStock($row['id_product'], $quantityToUseForPriceCalculations, $context->cart)) {
-            $row['quantity'] = 0;
-        }
-
         if (!isset($row['attributes'])) {
             $attributes = Product::getAttributesParams($row['id_product'], $row['id_product_attribute']);
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -315,12 +315,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function initContent(): void
     {
         if (!$this->errors) {
-            if (Pack::isPack((int) $this->product->id)
-                && !Pack::isInStock((int) $this->product->id, $this->product->minimal_quantity, $this->context->cart)
-            ) {
-                $this->product->quantity = 0;
-            }
-
             $this->product->description = $this->transformDescriptionWithImg($this->product->description);
 
             $priceDisplay = Product::getTaxCalculationMethod((int) $this->context->cookie->id_customer);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.0.x
| Description?      | Removes two pieces of code that do absolutely nothing. All quantity calculation is already handled in `Product::getQuantity` (that later calls `Pack::getQuantity` etc.). Extracted from https://github.com/PrestaShop/PrestaShop/pull/36684.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Auto test
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       |
| Sponsor company   | 
