### PR TITLE
Fixes free product cart rule not being added

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1149,7 +1149,7 @@ abstract class PaymentModuleCore extends Module
             ];
 
             // If the reduction is not applicable to this order, then continue with the next one
-            if (!$values['tax_excl']) {
+            if (!$values['tax_excl'] && empty($cartRule->gift_product)) {
                 continue;
             }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Customers were able to reuse a cart rule intended for a one-time free gift because the entry in ps_order_cart_rule wasn't recorded when the cart total had a zero price. This PR introduces a check to ensure that cart rules of the “gift product” type are correctly accounted for, regardless of the cart total.
| Type?             | bug fix 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check #15751 steps to reproduce before / after this patch
| UI Tests          |  N/A
| Fixed issue or discussion?     | Fixes #15751 
| Related PRs       |
| Sponsor company   |
