### PR TITLE
Do not reload product cache immediately

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -296,15 +296,15 @@ class CartCore extends ObjectModel
      */
     public function update($nullValues = false)
     {
+        // Wipe all product-related caches, because something may just change
         if (isset(self::$_nbProducts[$this->id])) {
             unset(self::$_nbProducts[$this->id]);
         }
-
         if (isset(self::$_totalWeight[$this->id])) {
             unset(self::$_totalWeight[$this->id]);
         }
-
         $this->_products = null;
+
         $return = parent::update($nullValues);
         Hook::exec('actionCartSave', ['cart' => $this]);
 
@@ -1608,9 +1608,9 @@ class CartCore extends ObjectModel
             }
         }
 
-        // refresh cache of self::_products
-        $this->_products = $this->getProducts(true);
+        // Update the cart, it will automatically wipe all caches needed
         $this->update();
+
         $context = Context::getContext()->cloneContext();
         /* @phpstan-ignore-next-line */
         $context->cart = $this;
@@ -1814,9 +1814,9 @@ class CartCore extends ObjectModel
         AND `id_cart` = ' . (int) $this->id);
 
         if ($result) {
+            // Update the cart, it will automatically wipe all caches needed
             $return = $this->update();
-            // refresh cache of self::_products
-            $this->_products = $this->getProducts(true);
+
             if (!isset($preservedGifts[$giftKey]) || $preservedGifts[$giftKey] <= 0) {
                 CartRule::autoRemoveFromCart(null, $useOrderPrices);
                 CartRule::autoAddToCart(null, $useOrderPrices);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Reloading `$this->getProducts` immediately after these two actions is not required for two reasons. **Reason 1** - It's wiped right a way by **$this->update()** anyway. **Reason 2** - it may not be needed and we would just slow down the action. If it's needed, `$this->getProducts` will load it.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Since it concerns adding and removing products to cart, it should be covered by automatic tests.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Description
- `$cart->_products` is a cache for product list. A protected property never accessed from the outside.
- I found two places in `Cart` class, where it does some action in cart and immediately calls `$this->getProducts`.
- **This is not needed for two reasons.**
  - In one places, `$cart->update` is called immediately that will just wipe it to `null` again. Wasting that `getProducts` call.
  - And in both places, we don't have to load it if we don't know it's gonna be needed. Maybe it's the only thing this request does, maybe somebody is doing something in bulk.

### Possible performance benefits
- Speeding up cart bulk actions, like order reoder.
- Speeding up regular cart add/remove. Maybe the controller will load getProducts after that anyway, but still.