### PR TITLE
Unify error handling in FO and get rid of Tools::displayError calls

### DIFF
--- a/admin-dev/filemanager/config/config.php
+++ b/admin-dev/filemanager/config/config.php
@@ -41,7 +41,7 @@ $products_accesses = Profile::getProfileAccess(Context::getContext()->employee->
 $cms_accesses = Profile::getProfileAccess(Context::getContext()->employee->id_profile, Tab::getIdFromClassName('AdminCmsContent'));
 
 if (!$products_accesses['edit'] && !$cms_accesses['edit']) {
-    die(Tools::displayError('Access forbidden.'));
+    throw new PrestaShopException('Access forbidden.');
 }
 //------------------------------------------------------------------------------
 // DON'T COPY THIS VARIABLES IN FOLDERS config.php FILES

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -241,7 +241,7 @@ class CMSCategoryCore extends ObjectModel
     protected function recursiveDelete(array &$to_delete, $id_cms_category)
     {
         if (!$id_cms_category) {
-            die(Tools::displayError('Parameter "id_cms_category" is invalid.'));
+            throw new PrestaShopException('Parameter "id_cms_category" is invalid.');
         }
 
         $result = Db::getInstance()->executeS('

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -1245,7 +1245,7 @@ class CarrierCore extends ObjectModel
     public function setTaxRulesGroup($id_tax_rules_group, $all_shops = false)
     {
         if (!Validate::isUnsignedId($id_tax_rules_group)) {
-            die(Tools::displayError('Parameter "id_tax_rules_group" is invalid.'));
+            throw new PrestaShopException('Parameter "id_tax_rules_group" is invalid.');
         }
 
         if (!$all_shops) {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1476,7 +1476,7 @@ class CartCore extends ObjectModel
         }
 
         if (!Validate::isLoadedObject($product)) {
-            die(Tools::displayError(sprintf('Product with ID "%s" could not be loaded.', $id_product)));
+            throw new PrestaShopException(sprintf('Product with ID "%s" could not be loaded.', $id_product));
         }
 
         if (isset(self::$_nbProducts[$this->id])) {
@@ -1929,7 +1929,7 @@ class CartCore extends ObjectModel
     {
         $cart = new Cart($id_cart);
         if (!Validate::isLoadedObject($cart)) {
-            die(Tools::displayError(sprintf('Cart with ID "%s" could not be loaded.', $id_cart)));
+            throw new PrestaShopException(sprintf('Cart with ID "%s" could not be loaded.', $id_cart));
         }
 
         $with_taxes = $use_tax_display ? $cart->_taxCalculationMethod != PS_TAX_EXC : true;

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -362,7 +362,7 @@ class CategoryCore extends ObjectModel
     protected function recursiveDelete(array &$toDelete, $idCategory)
     {
         if (!$idCategory) {
-            die(Tools::displayError('Parameter "idCategory" is invalid.'));
+            throw new PrestaShopException('Parameter "idCategory" is invalid.');
         }
 
         $sql = new DbQuery();
@@ -692,7 +692,7 @@ class CategoryCore extends ObjectModel
         $limit = ''
     ) {
         if (isset($idRootCategory) && !Validate::isInt($idRootCategory)) {
-            die(Tools::displayError('Parameter "idRootCategory" was provided, but it\'s not a valid integer.'));
+            throw new PrestaShopException('Parameter "idRootCategory" was provided, but it\'s not a valid integer.');
         }
 
         if (isset($groups) && Group::isFeatureActive() && !is_array($groups)) {
@@ -763,7 +763,7 @@ class CategoryCore extends ObjectModel
         $limit = ''
     ) {
         if (isset($idRootCategory) && !Validate::isInt($idRootCategory)) {
-            die(Tools::displayError('Parameter "idRootCategory" was provided, but it\'s not a valid integer.'));
+            throw new PrestaShopException('Parameter "idRootCategory" was provided, but it\'s not a valid integer.');
         }
 
         if (isset($groups) && Group::isFeatureActive() && !is_array($groups)) {

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -378,7 +378,7 @@ class ConfigurationCore extends ObjectModel
     public static function set($key, $values, $idShopGroup = null, $idShop = null)
     {
         if (!Validate::isConfigName($key)) {
-            die(Tools::displayError(Context::getContext()->getTranslator()->trans('[%s] is not a valid configuration key', [Tools::htmlentitiesUTF8($key)], 'Admin.Notifications.Error')));
+            throw new PrestaShopException(Context::getContext()->getTranslator()->trans('[%s] is not a valid configuration key', [Tools::htmlentitiesUTF8($key)], 'Admin.Notifications.Error'));
         }
 
         if ($idShop === null) {
@@ -439,7 +439,7 @@ class ConfigurationCore extends ObjectModel
     public static function updateValue($key, $values, $html = false, $idShopGroup = null, $idShop = null)
     {
         if (!Validate::isConfigName($key)) {
-            die(Tools::displayError(Context::getContext()->getTranslator()->trans('[%s] is not a valid configuration key', [Tools::htmlentitiesUTF8($key)], 'Admin.Notifications.Error')));
+            throw new PrestaShopException(Context::getContext()->getTranslator()->trans('[%s] is not a valid configuration key', [Tools::htmlentitiesUTF8($key)], 'Admin.Notifications.Error'));
         }
 
         if ($idShop === null || !Shop::isFeatureActive()) {

--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -228,10 +228,10 @@ class CookieCore
     public function __set($key, $value)
     {
         if (is_array($value)) {
-            die(Tools::displayError('Cookie value can\'t be an array.'));
+            throw new PrestaShopException('Cookie value can\'t be an array.');
         }
         if (preg_match('/¤|\|/', $key . $value)) {
-            throw new Exception('Forbidden chars in cookie');
+            throw new PrestaShopException('Forbidden chars in cookie');
         }
         if (!$this->_modified && (!array_key_exists($key, $this->_content) || $this->_content[$key] != $value)) {
             $this->_modified = true;

--- a/classes/Country.php
+++ b/classes/Country.php
@@ -184,7 +184,7 @@ class CountryCore extends ObjectModel
     public static function getByIso($isoCode, $active = false)
     {
         if (!Validate::isLanguageIsoCode($isoCode)) {
-            die(Tools::displayError('Given iso code (' . $isoCode . ') is not valid.'));
+            throw new PrestaShopException('Given iso code (' . $isoCode . ') is not valid.');
         }
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow(
             '
@@ -211,7 +211,7 @@ class CountryCore extends ObjectModel
     public static function getIdZone($idCountry)
     {
         if (!Validate::isUnsignedId($idCountry)) {
-            die(Tools::displayError('Country ID is invalid.'));
+            throw new PrestaShopException('Country ID is invalid.');
         }
 
         if (isset(self::$_idZones[$idCountry])) {
@@ -363,10 +363,10 @@ class CountryCore extends ObjectModel
     public static function getCountriesByZoneId($idZone, $idLang)
     {
         if (empty($idZone)) {
-            die(Tools::displayError('Zone ID is invalid.'));
+            throw new PrestaShopException('Zone ID is invalid.');
         }
         if (empty($idLang)) {
-            die(Tools::displayError('Lang ID is invalid.'));
+            throw new PrestaShopException('Lang ID is invalid.');
         }
 
         $sql = ' SELECT DISTINCT c.*, cl.*

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -829,7 +829,7 @@ class CustomerCore extends ObjectModel
     public static function checkPassword($idCustomer, $passwordHash)
     {
         if (!Validate::isUnsignedId($idCustomer)) {
-            die(Tools::displayError('Customer ID is invalid.'));
+            throw new PrestaShopException('Customer ID is invalid.');
         }
 
         // Check that customers password hasn't changed since last login

--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -305,7 +305,7 @@ class EmployeeCore extends ObjectModel
     public function getByEmail($email, $plaintextPassword = null, $activeOnly = true)
     {
         if (!Validate::isEmail($email)) {
-            die(Tools::displayError('Email address is invalid.'));
+            throw new PrestaShopException('Email address is invalid.');
         }
 
         $sql = new DbQuery();
@@ -358,7 +358,7 @@ class EmployeeCore extends ObjectModel
     public static function employeeExists($email)
     {
         if (!Validate::isEmail($email)) {
-            die(Tools::displayError('Email address is invalid.'));
+            throw new PrestaShopException('Email address is invalid.');
         }
 
         return (bool) Db::getInstance()->getValue('
@@ -378,7 +378,7 @@ class EmployeeCore extends ObjectModel
     public static function checkPassword($idEmployee, $passwordHash)
     {
         if (!Validate::isUnsignedId($idEmployee)) {
-            die(Tools::displayError('Employee ID is invalid.'));
+            throw new PrestaShopException('Employee ID is invalid.');
         }
 
         $sql = new DbQuery();

--- a/classes/Feature.php
+++ b/classes/Feature.php
@@ -155,7 +155,7 @@ class FeatureCore extends ObjectModel
         foreach ($fields as $field) {
             foreach (array_keys($field) as $key) {
                 if (!Validate::isTableOrIdentifier($key)) {
-                    die(Tools::displayError('Invalid column name in feature_lang table.'));
+                    throw new PrestaShopException('Invalid column name in feature_lang table.');
                 }
             }
 

--- a/classes/Image.php
+++ b/classes/Image.php
@@ -362,7 +362,7 @@ class ImageCore extends ObjectModel
     public static function deleteCover($idProduct)
     {
         if (!Validate::isUnsignedId($idProduct)) {
-            die(Tools::displayError('Product ID is invalid.'));
+            throw new PrestaShopException('Product ID is invalid.');
         }
 
         if (file_exists(_PS_TMP_IMG_DIR_ . 'product_' . $idProduct . '.jpg')) {

--- a/classes/ImageType.php
+++ b/classes/ImageType.php
@@ -136,7 +136,7 @@ class ImageTypeCore extends ObjectModel
     public static function typeAlreadyExists($typeName)
     {
         if (!Validate::isImageTypeName($typeName)) {
-            die(Tools::displayError(sprintf('"%s" is not valid image type name.', $typeName)));
+            throw new PrestaShopException(sprintf('"%s" is not valid image type name.', $typeName));
         }
 
         Db::getInstance()->executeS('

--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -398,7 +398,7 @@ class ManufacturerCore extends ObjectModel
         }
 
         if (!Validate::isOrderBy($orderBy) || !Validate::isOrderWay($orderWay)) {
-            die(Tools::displayError('Invalid sorting parameters provided.'));
+            throw new PrestaShopException('Invalid sorting parameters provided.');
         }
 
         $groups = FrontController::getCurrentCustomerGroups();

--- a/classes/Message.php
+++ b/classes/Message.php
@@ -175,10 +175,10 @@ class MessageCore extends ObjectModel
     public static function markAsReaded($idMessage, $idEmployee)
     {
         if (!Validate::isUnsignedId($idMessage)) {
-            die(Tools::displayError('Message ID is invalid.'));
+            throw new PrestaShopException('Message ID is invalid.');
         }
         if (!Validate::isUnsignedId($idEmployee)) {
-            die(Tools::displayError('Employee ID is invalid.'));
+            throw new PrestaShopException('Employee ID is invalid.');
         }
 
         $result = Db::getInstance()->execute('

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -68,14 +68,14 @@ class MetaCore extends ObjectModel
     {
         $selectedPages = [];
         if (!$files = Tools::scandir(_PS_CORE_DIR_ . DIRECTORY_SEPARATOR . 'controllers' . DIRECTORY_SEPARATOR . 'front' . DIRECTORY_SEPARATOR, 'php', '', true)) {
-            die(Tools::displayError(Context::getContext()->getTranslator()->trans('Cannot scan root directory', [], 'Admin.Notifications.Error')));
+            throw new PrestaShopException(Context::getContext()->getTranslator()->trans('Cannot scan root directory', [], 'Admin.Notifications.Error'));
         }
 
         $overrideDir = _PS_CORE_DIR_ . DIRECTORY_SEPARATOR . 'override' . DIRECTORY_SEPARATOR . 'controllers' . DIRECTORY_SEPARATOR . 'front' . DIRECTORY_SEPARATOR;
         if (!is_dir($overrideDir)) {
             $overrideFiles = [];
         } elseif (!$overrideFiles = Tools::scandir($overrideDir, 'php', '', true)) {
-            die(Tools::displayError(Context::getContext()->getTranslator()->trans('Cannot scan "override" directory', [], 'Admin.Notifications.Error')));
+            throw new PrestaShopException(Context::getContext()->getTranslator()->trans('Cannot scan "override" directory', [], 'Admin.Notifications.Error'));
         }
 
         $files = array_values(array_unique(array_merge($files, $overrideFiles)));

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -252,7 +252,7 @@ abstract class PaymentModuleCore extends Module
 
         if (!$this->active) {
             PrestaShopLogger::addLog('PaymentModule::validateOrder - Module is not active', 3, null, 'Cart', (int) $id_cart, true);
-            die(Tools::displayError('Error processing order. Payment module is not active.'));
+            throw new PrestaShopException('Error processing order. Payment module is not active.');
         }
 
         // Make sure cart is loaded and not related to an existing order
@@ -260,12 +260,12 @@ abstract class PaymentModuleCore extends Module
         if (!$cart_is_loaded || $this->context->cart->OrderExists()) {
             $error = $this->trans('Cart cannot be loaded or an order has already been placed using this cart', [], 'Admin.Payment.Notification');
             PrestaShopLogger::addLog($error, 4, 1, 'Cart', (int) $this->context->cart->id);
-            die(Tools::displayError($error));
+            throw new PrestaShopException($error);
         }
 
         if ($secure_key !== false && $secure_key != $this->context->cart->secure_key) {
             PrestaShopLogger::addLog('PaymentModule::validateOrder - Secure key does not match', 3, null, 'Cart', (int) $id_cart, true);
-            die(Tools::displayError('Error processing order. Secure key does not match.'));
+            throw new PrestaShopException('Error processing order. Secure key does not match.');
         }
 
         // For each package, generate an order
@@ -417,7 +417,7 @@ abstract class PaymentModuleCore extends Module
             if (!isset($order->id)) {
                 $error = $this->trans('Order creation failed', [], 'Admin.Payment.Notification');
                 PrestaShopLogger::addLog($error, 4, 2, 'Cart', (int) $order->id_cart);
-                die(Tools::displayError($error));
+                throw new PrestaShopException($error);
             }
             if (!$secure_key) {
                 $message .= '<br />' . $this->trans('Warning: the secure key is empty, check your payment account before validation', [], 'Admin.Payment.Notification');

--- a/classes/PrestaShopBackup.php
+++ b/classes/PrestaShopBackup.php
@@ -121,7 +121,7 @@ class PrestaShopBackupCore
         $backupdir = realpath(_PS_ADMIN_DIR_ . self::$backupDir);
 
         if ($backupdir === false) {
-            die(Tools::displayError(Context::getContext()->getTranslator()->trans('"Backup" directory does not exist.', [], 'Admin.Advparameters.Notification')));
+            throw new PrestaShopException(Context::getContext()->getTranslator()->trans('"Backup" directory does not exist.', [], 'Admin.Advparameters.Notification'));
         }
 
         // Check the realpath so we can validate the backup file is under the backup directory
@@ -132,7 +132,7 @@ class PrestaShopBackupCore
         }
 
         if ($backupfile === false || strncmp($backupdir, $backupfile, strlen($backupdir)) != 0) {
-            die(Tools::displayError('Invalid backup file.'));
+            throw new PrestaShopException('Invalid backup file.');
         }
 
         return $backupfile;
@@ -150,7 +150,7 @@ class PrestaShopBackupCore
         $backupdir = realpath(_PS_ADMIN_DIR_ . self::$backupDir);
 
         if ($backupdir === false) {
-            die(Tools::displayError(Context::getContext()->getTranslator()->trans('"Backup" directory does not exist.', [], 'Admin.Advparameters.Notification')));
+            throw new PrestaShopException(Context::getContext()->getTranslator()->trans('"Backup" directory does not exist.', [], 'Admin.Advparameters.Notification'));
         }
 
         return @filemtime($backupdir . DIRECTORY_SEPARATOR . $filename);

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -884,7 +884,7 @@ class ProductCore extends ObjectModel
         if ((int) $id_customer > 0) {
             $customer = new Customer((int) $id_customer);
             if (!Validate::isLoadedObject($customer)) {
-                die(Tools::displayError(sprintf('Customer with ID "%s" could not be loaded.', $id_customer)));
+                throw new PrestaShopException(sprintf('Customer with ID "%s" could not be loaded.', $id_customer));
             }
             self::$_taxCalculationMethod = Group::getPriceDisplayMethod((int) $customer->id_default_group);
             $cur_cart = Context::getContext()->cart;
@@ -1589,7 +1589,7 @@ class ProductCore extends ObjectModel
         }
 
         if (!Validate::isOrderBy($order_by) || !Validate::isOrderWay($order_way)) {
-            die(Tools::displayError('Invalid sorting parameters provided.'));
+            throw new PrestaShopException('Invalid sorting parameters provided.');
         }
         if ($order_by == 'id_product' || $order_by == 'price' || $order_by == 'date_add' || $order_by == 'date_upd') {
             $order_by_prefix = 'p';
@@ -2764,7 +2764,7 @@ class ProductCore extends ObjectModel
             $order_by_prefix = 'pl';
         }
         if (!Validate::isOrderBy($order_by) || !Validate::isOrderWay($order_way)) {
-            die(Tools::displayError('Invalid sorting parameters provided.'));
+            throw new PrestaShopException('Invalid sorting parameters provided.');
         }
 
         $sql_groups = '';
@@ -3036,7 +3036,7 @@ class ProductCore extends ObjectModel
             $order_by_prefix = 'pl';
         }
         if (!Validate::isOrderBy($order_by) || !Validate::isOrderWay($order_way)) {
-            die(Tools::displayError('Invalid sorting parameters provided.'));
+            throw new PrestaShopException('Invalid sorting parameters provided.');
         }
         $current_date = date('Y-m-d H:i:00');
         $ids_product = Product::_getProductIdByDate(!$beginning ? $current_date : $beginning, !$ending ? $current_date : $ending, $context);
@@ -3371,7 +3371,7 @@ class ProductCore extends ObjectModel
         }
 
         if (!Validate::isUnsignedId($id_product)) {
-            die(Tools::displayError('Product ID is invalid.'));
+            throw new PrestaShopException('Product ID is invalid.');
         }
 
         // Initializations
@@ -3391,7 +3391,7 @@ class ProductCore extends ObjectModel
             * When called from the back office, cart ID can be inexistant
             */
             if (!$id_cart && !isset($context->employee)) {
-                die(Tools::displayError('If no employee is assigned in the context, cart ID must be provided to this method.'));
+                throw new PrestaShopException('If no employee is assigned in the context, cart ID must be provided to this method.');
             }
             $cur_cart = new Cart($id_cart);
             // Store cart in context to avoid multiple instantiations in BO

--- a/classes/State.php
+++ b/classes/State.php
@@ -210,7 +210,7 @@ class StateCore extends ObjectModel
     public static function getStatesByIdCountry($idCountry, $active = false, $orderBy = null, $sort = 'ASC')
     {
         if (empty($idCountry)) {
-            die(Tools::displayError('Country ID is invalid.'));
+            throw new PrestaShopException('Country ID is invalid.');
         }
 
         $available_sort = ['DESC', 'ASC', 'asc', 'desc'];
@@ -241,7 +241,7 @@ class StateCore extends ObjectModel
     public static function getIdZone($idState)
     {
         if (!Validate::isUnsignedId($idState)) {
-            die(Tools::displayError('State ID is invalid.'));
+            throw new PrestaShopException('State ID is invalid.');
         }
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(

--- a/classes/Supplier.php
+++ b/classes/Supplier.php
@@ -299,7 +299,7 @@ class SupplierCore extends ObjectModel
         }
 
         if (!Validate::isOrderBy($orderBy) || !Validate::isOrderWay($orderWay)) {
-            die(Tools::displayError('Invalid sorting parameters provided.'));
+            throw new PrestaShopException('Invalid sorting parameters provided.');
         }
 
         $sqlGroups = '';

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1001,6 +1001,9 @@ class ToolsCore
      * @return string
      *
      * @throws PrestaShopException If _PS_MODE_DEV_ is enabled
+     *
+     * @deprecated since 9.0.0 - Please throw an exception directly. It will be handled better and logged
+     * in all enviroments, to both PHP and our logs. This method will be eventually removed
      */
     public static function displayError($errorMessage = null, $htmlentities = null, ?Context $context = null)
     {

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1626,7 +1626,7 @@ class AdminControllerCore extends Controller
                     $back = self::$currentIndex . '&token=' . $this->token;
                 }
                 if (!Validate::isCleanHtml($back)) {
-                    die(Tools::displayError('Provided "back" parameter is invalid.'));
+                    throw new PrestaShopException('Provided "back" parameter is invalid.');
                 }
                 if (!$this->lite_display) {
                     $this->page_header_toolbar_btn['back'] = [
@@ -1699,7 +1699,7 @@ class AdminControllerCore extends Controller
                     $back = self::$currentIndex . '&token=' . $this->token;
                 }
                 if (!Validate::isCleanHtml($back)) {
-                    die(Tools::displayError('Provided "back" parameter is invalid.'));
+                    throw new PrestaShopException('Provided "back" parameter is invalid.');
                 }
                 if (!$this->lite_display) {
                     $this->toolbar_btn['cancel'] = [
@@ -1716,7 +1716,7 @@ class AdminControllerCore extends Controller
                     $back = self::$currentIndex . '&token=' . $this->token;
                 }
                 if (!Validate::isCleanHtml($back)) {
-                    die(Tools::displayError('Provided "back" parameter is invalid.'));
+                    throw new PrestaShopException('Provided "back" parameter is invalid.');
                 }
                 if (!$this->lite_display) {
                     $this->toolbar_btn['back'] = [
@@ -2515,7 +2515,7 @@ class AdminControllerCore extends Controller
                 $back = self::$currentIndex . '&token=' . $this->token;
             }
             if (!Validate::isCleanHtml($back)) {
-                die(Tools::displayError('Provided "back" parameter is invalid.'));
+                throw new PrestaShopException('Provided "back" parameter is invalid.');
             }
 
             $helper->back_url = $back;

--- a/classes/db/DbMySQLi.php
+++ b/classes/db/DbMySQLi.php
@@ -71,12 +71,23 @@ class DbMySQLiCore extends Db
 
         // Do not use object way for error because this work bad before PHP 5.2.9
         if (mysqli_connect_error()) {
-            throw new PrestaShopDatabaseException(sprintf(Tools::displayError('Link to database cannot be established: %s'), mysqli_connect_error()));
+            throw new PrestaShopDatabaseException(sprintf(
+                Context::getContext()->getTranslator()->trans(
+                    'Link to database cannot be established: %s',
+                    [],
+                    'Admin.Notifications.Error'
+                ),
+                mysqli_connect_error()
+            ));
         }
 
         // UTF-8 support
         if (!$this->link->query('SET NAMES utf8mb4')) {
-            throw new PrestaShopDatabaseException(Tools::displayError('PrestaShop Fatal error: no utf-8 support. Please check your server configuration.'));
+            throw new PrestaShopDatabaseException(Context::getContext()->getTranslator()->trans(
+                'PrestaShop Fatal error: no utf-8 support. Please check your server configuration.',
+                [],
+                'Admin.Notifications.Error'
+            ));
         }
 
         $this->link->query('SET SESSION sql_mode = \'\'');

--- a/classes/log/FileLogger.php
+++ b/classes/log/FileLogger.php
@@ -72,7 +72,7 @@ class FileLoggerCore extends AbstractLogger
     public function getFilename()
     {
         if (empty($this->filename)) {
-            die(Tools::displayError('Filename is empty.'));
+            throw new PrestaShopException('Filename is empty.');
         }
 
         return $this->filename;

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1226,11 +1226,11 @@ abstract class ModuleCore implements ModuleInterface
                 return false;
             }
 
-            die(Tools::displayError(Context::getContext()->getTranslator()->trans(
+            throw new PrestaShopException(Context::getContext()->getTranslator()->trans(
                 '%1$s is not a valid module name.',
                 [Tools::safeOutput($module_name)],
                 'Admin.Modules.Notification'
-            )));
+            ));
         }
 
         if (!isset(static::$_INSTANCE[$module_name])) {

--- a/classes/module/ModuleGraph.php
+++ b/classes/module/ModuleGraph.php
@@ -261,10 +261,10 @@ abstract class ModuleGraphCore extends Module
     public function create($render, $type, $width, $height, $layers)
     {
         if (!Validate::isModuleName($render)) {
-            die(Tools::displayError('Invalid graph module name.'));
+            throw new PrestaShopException('Invalid graph module name.');
         }
         if (!Tools::file_exists_cache($file = _PS_ROOT_DIR_ . '/modules/' . $render . '/' . $render . '.php')) {
-            die(Tools::displayError('Main graph module file does not exist.'));
+            throw new PrestaShopException('Main graph module file does not exist.');
         }
         require_once $file;
         $this->_render = new $render($type);
@@ -295,7 +295,7 @@ abstract class ModuleGraphCore extends Module
             return Context::getContext()->getTranslator()->trans('No graph engine selected', [], 'Admin.Modules.Notification');
         }
         if (!Validate::isModuleName($render)) {
-            die(Tools::displayError('Invalid graph module name.'));
+            throw new PrestaShopException('Invalid graph module name.');
         }
         if (!file_exists(_PS_ROOT_DIR_ . '/modules/' . $render . '/' . $render . '.php')) {
             return Context::getContext()->getTranslator()->trans('Graph engine selected is unavailable.', [], 'Admin.Modules.Notification');

--- a/classes/module/ModuleGrid.php
+++ b/classes/module/ModuleGrid.php
@@ -72,10 +72,10 @@ abstract class ModuleGridCore extends Module
     public function create($render, $type, $width, $height, $start, $limit, $sort, $dir)
     {
         if (!Validate::isModuleName($render)) {
-            die(Tools::displayError('Invalid grid module name.'));
+            throw new PrestaShopException('Invalid grid module name.');
         }
         if (!Tools::file_exists_cache($file = _PS_ROOT_DIR_ . '/modules/' . $render . '/' . $render . '.php')) {
-            die(Tools::displayError('Main grid module file does not exist.'));
+            throw new PrestaShopException('Main grid module file does not exist.');
         }
         require_once $file;
         $this->_render = new $render($type);
@@ -105,7 +105,7 @@ abstract class ModuleGridCore extends Module
             return Context::getContext()->getTranslator()->trans('No grid engine selected', [], 'Admin.Modules.Notification');
         }
         if (!Validate::isModuleName($render)) {
-            die(Tools::displayError('Invalid grid module name.'));
+            throw new PrestaShopException('Invalid grid module name.');
         }
         if (!file_exists(_PS_ROOT_DIR_ . '/modules/' . $render . '/' . $render . '.php')) {
             return Context::getContext()->getTranslator()->trans('Grid engine selected is unavailable.', [], 'Admin.Modules.Notification');

--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -95,7 +95,7 @@ class OrderReturnCore extends ObjectModel
     {
         $order = new Order((int) $this->id_order);
         if (!Validate::isLoadedObject($order)) {
-            die(Tools::displayError(sprintf('Order with ID "%s" could not be loaded.', $this->id_order)));
+            throw new PrestaShopException(sprintf('Order with ID "%s" could not be loaded.', $this->id_order));
         }
         $products = $order->getProducts();
         /* Products already returned */
@@ -200,7 +200,7 @@ class OrderReturnCore extends ObjectModel
         $returns = Customization::getReturnedCustomizations($id_order);
         $order = new Order((int) $id_order);
         if (!Validate::isLoadedObject($order)) {
-            die(Tools::displayError(sprintf('Order with ID "%s" could not be loaded.', $id_order)));
+            throw new PrestaShopException(sprintf('Order with ID "%s" could not be loaded.', $id_order));
         }
         $products = $order->getProducts();
 

--- a/classes/tax/TaxRule.php
+++ b/classes/tax/TaxRule.php
@@ -63,7 +63,7 @@ class TaxRuleCore extends ObjectModel
     public static function deleteByGroupId($id_group)
     {
         if (empty($id_group)) {
-            die(Tools::displayError('Parameter "id_group" (id_tax_rules_group you want to delete) is invalid.'));
+            throw new PrestaShopException('Parameter "id_group" (id_tax_rules_group you want to delete) is invalid.');
         }
 
         return Db::getInstance()->execute(

--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -555,11 +555,11 @@ class AdminCustomerThreadsControllerCore extends AdminController
         }
 
         if (!$extension) {
-            die(Tools::displayError('Invalid file extension.'));
+            throw new PrestaShopException('Invalid file extension.');
         }
 
         if (!Validate::isFileName($filename)) {
-            die(Tools::displayError('Invalid filename.'));
+            throw new PrestaShopException('Invalid filename.');
         }
 
         if (ob_get_level() && ob_get_length() > 0) {

--- a/controllers/admin/AdminReturnController.php
+++ b/controllers/admin/AdminReturnController.php
@@ -232,7 +232,7 @@ class AdminReturnControllerCore extends AdminController
                     if (($id_order_return = (int) Tools::getValue('id_order_return')) && Validate::isUnsignedId($id_order_return)) {
                         $orderReturn = new OrderReturn($id_order_return);
                         if (!Validate::isLoadedObject($orderReturn)) {
-                            die(Tools::displayError(sprintf('Order return with ID "%s" could not be loaded.', $id_order_return)));
+                            throw new PrestaShopException(sprintf('Order return with ID "%s" could not be loaded.', $id_order_return));
                         }
                         if ((int) $orderReturn->countProduct() > 1) {
                             if (OrderReturn::deleteOrderReturnDetail($id_order_return, $id_order_detail, (int) Tools::getValue('id_customization', 0))) {

--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -1000,7 +1000,11 @@ class AdminStatsControllerCore extends AdminStatsTabController
         /** @var ModuleGraph|false $graph */
         $graph = Module::getInstanceByName($module);
         if (false === $graph) {
-            $this->ajaxRender(Tools::displayError('Graph module could not be loaded.'));
+            $this->ajaxRender($this->trans(
+                'Graph module could not be loaded.',
+                [],
+                'Admin.Notifications.Error'
+            ));
 
             return;
         }
@@ -1040,7 +1044,11 @@ class AdminStatsControllerCore extends AdminStatsTabController
         /** @var ModuleGrid|false $grid */
         $grid = Module::getInstanceByName($module);
         if (false === $grid) {
-            $this->ajaxRender(Tools::displayError('Grid module could not be loaded.'));
+            $this->ajaxRender($this->trans(
+                'Grid module could not be loaded.',
+                [],
+                'Admin.Notifications.Error'
+            ));
 
             return;
         }

--- a/controllers/front/AddressesController.php
+++ b/controllers/front/AddressesController.php
@@ -44,7 +44,7 @@ class AddressesControllerCore extends FrontController
         parent::init();
 
         if (!Validate::isLoadedObject($this->context->customer)) {
-            die(Tools::displayError($this->trans('The customer could not be found.', [], 'Shop.Notifications.Error')));
+            throw new PrestaShopException($this->trans('The customer could not be found.', [], 'Shop.Notifications.Error'));
         }
     }
 

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -171,7 +171,7 @@ class GetFileControllerCore extends FrontController
             // Admin can directly access to file
             $filename = Tools::getValue('file');
             if (!Validate::isSha1($filename)) {
-                die(Tools::displayError('Filename is not a valid SHA1 checksum.'));
+                throw new PrestaShopException('Filename is not a valid SHA1 checksum.');
             }
             $file = _PS_DOWNLOAD_DIR_ . (string) preg_replace('/\.{2,}/', '.', $filename);
             $filename = ProductDownload::getFilenameFromFilename(Tools::getValue('file'));

--- a/tests/Integration/Utility/CartOld.php
+++ b/tests/Integration/Utility/CartOld.php
@@ -32,6 +32,7 @@ use Configuration;
 use Context;
 use Order;
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;
+use PrestaShopException;
 use Shop;
 use Tools;
 
@@ -94,7 +95,7 @@ class CartOld extends Cart
         $virtual_context->cart = $this;
 
         if (!in_array($type, $array_type)) {
-            die(Tools::displayError());
+            throw new PrestaShopException();
         }
 
         $with_shipping = in_array($type, [Cart::BOTH, Cart::ONLY_SHIPPING]);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | See below
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | Automatic test.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Description
- Current error handling is a goulash of `Tools::displayError`, prestashop log in database, prestashop symfony log in `var`, legacy exception handling and symfony exception handling. With different ways to handle it in PROD and DEV environments.
- `Tools::displayError` works by:
  - Just doing an `echo` and `die` in `prod` environment.
  - Throwing PrestaShopException in `dev` environment.
- So, the problem is that if `Tools::displayError` happens, we don't know anything about it, unless
- I previously improved this by at least provididing a specific error messages to all `Tools::displayError` calls. This is another step.

### What I changed
- I changed all `Tools::displayError` calls to throw exception directly, so they are handled by the "handler" in PrestashopException class.
- This results in:
  - `Oops, something went wrong.` in prod environment.
  - Full display with stack trace in dev enviroment.
  - But, in both cases, the error is logged to `/var/logs` AND to PHP logs.
- **So, now, every error is a logged thrown exception the merchant can know about and fix.**

### Note
There is still lot to improve. For example another type of exceptions don't have this handling and are just logged, not sure why, for example `PrestaShopDatabaseException`, but that should be resolved by migrating FO to symfony, that will handle all types of exceptions.