### PR TITLE
Add excplicit escape parameter to prevent PHP 8.4 deprecation notice

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1094,7 +1094,7 @@ class AdminControllerCore extends Controller
                 }
             }
         }
-        fputcsv($fd, $headers, ';', $text_delimiter);
+        fputcsv($fd, $headers, ';', $text_delimiter, '');
 
         foreach ($this->_list as $i => $row) {
             $content = [];
@@ -1116,7 +1116,7 @@ class AdminControllerCore extends Controller
                 }
                 $content[] = $field_value;
             }
-            fputcsv($fd, $content, ';', $text_delimiter);
+            fputcsv($fd, $content, ';', $text_delimiter, '');
         }
         @fclose($fd);
         die;

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -806,7 +806,7 @@ class AdminImportControllerCore extends AdminController
         $html .= '</tr></thead><tbody>';
 
         AdminImportController::setLocale();
-        for ($current_line = 0; $current_line < 10 && $line = fgetcsv($handle, MAX_LINE_SIZE, $glue); ++$current_line) {
+        for ($current_line = 0; $current_line < 10 && $line = fgetcsv($handle, MAX_LINE_SIZE, $glue, '"', ''); ++$current_line) {
             /* UTF-8 conversion */
             if ($this->convert) {
                 $line = $this->utf8EncodeArray($line);
@@ -909,7 +909,7 @@ class AdminImportControllerCore extends AdminController
             return [];
         }
 
-        $tab = fgetcsv($fd, MAX_LINE_SIZE, $separator);
+        $tab = fgetcsv($fd, MAX_LINE_SIZE, $separator, '"', '');
         fclose($fd);
         if ($uniqid_path !== false && file_exists($uniqid_path)) {
             @unlink($uniqid_path);
@@ -1117,7 +1117,7 @@ class AdminImportControllerCore extends AdminController
         }
 
         $line_count = 0;
-        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator)) && (!$limit || $current_line < $limit); ++$current_line) {
+        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator, '"', '')) && (!$limit || $current_line < $limit); ++$current_line) {
             ++$line_count;
             if ($this->convert) {
                 $line = $this->utf8EncodeArray($line);
@@ -1420,7 +1420,7 @@ class AdminImportControllerCore extends AdminController
         }
 
         $line_count = 0;
-        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator)) && (!$limit || $current_line < $limit); ++$current_line) {
+        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator, '"', '')) && (!$limit || $current_line < $limit); ++$current_line) {
             ++$line_count;
             if ($this->convert) {
                 $line = $this->utf8EncodeArray($line);
@@ -2166,7 +2166,7 @@ class AdminImportControllerCore extends AdminController
         $shop_is_feature_active = Shop::isFeatureActive();
 
         $line_count = 0;
-        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator)) && (!$limit || $current_line < $limit); ++$current_line) {
+        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator, '"', '')) && (!$limit || $current_line < $limit); ++$current_line) {
             ++$line_count;
 
             if ($this->convert) {
@@ -2611,7 +2611,7 @@ class AdminImportControllerCore extends AdminController
         $force_ids = Tools::getValue('forceIDs');
 
         $line_count = 0;
-        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator)) && (!$limit || $current_line < $limit); ++$current_line) {
+        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator, '"', '')) && (!$limit || $current_line < $limit); ++$current_line) {
             ++$line_count;
             if ($this->convert) {
                 $line = $this->utf8EncodeArray($line);
@@ -2873,7 +2873,7 @@ class AdminImportControllerCore extends AdminController
         $force_ids = Tools::getValue('forceIDs');
 
         $line_count = 0;
-        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator)) && (!$limit || $current_line < $limit); ++$current_line) {
+        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator, '"', '')) && (!$limit || $current_line < $limit); ++$current_line) {
             ++$line_count;
             if ($this->convert) {
                 $line = $this->utf8EncodeArray($line);
@@ -3191,7 +3191,7 @@ class AdminImportControllerCore extends AdminController
         $force_ids = Tools::getValue('forceIDs');
 
         $line_count = 0;
-        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator)) && (!$limit || $current_line < $limit); ++$current_line) {
+        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator, '"', '')) && (!$limit || $current_line < $limit); ++$current_line) {
             ++$line_count;
             if ($this->convert) {
                 $line = $this->utf8EncodeArray($line);
@@ -3306,7 +3306,7 @@ class AdminImportControllerCore extends AdminController
         $force_ids = Tools::getValue('forceIDs');
 
         $line_count = 0;
-        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator)) && (!$limit || $current_line < $limit); ++$current_line) {
+        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator, '"', '')) && (!$limit || $current_line < $limit); ++$current_line) {
             ++$line_count;
             if ($this->convert) {
                 $line = $this->utf8EncodeArray($line);
@@ -3414,7 +3414,7 @@ class AdminImportControllerCore extends AdminController
         $force_ids = Tools::getValue('forceIDs');
 
         $line_count = 0;
-        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator)) && (!$limit || $current_line < $limit); ++$current_line) {
+        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator, '"', '')) && (!$limit || $current_line < $limit); ++$current_line) {
             ++$line_count;
             if ($this->convert) {
                 $line = $this->utf8EncodeArray($line);
@@ -3492,7 +3492,7 @@ class AdminImportControllerCore extends AdminController
         $regenerate = Tools::getValue('regenerate');
 
         $line_count = 0;
-        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator)) && (!$limit || $current_line < $limit); ++$current_line) {
+        for ($current_line = 0; ($line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator, '"', '')) && (!$limit || $current_line < $limit); ++$current_line) {
             ++$line_count;
             if ($this->convert) {
                 $line = $this->utf8EncodeArray($line);
@@ -3693,7 +3693,7 @@ class AdminImportControllerCore extends AdminController
         if (!is_resource($handle)) {
             return false;
         }
-        $tmp = fgetcsv($handle, MAX_LINE_SIZE, $glue);
+        $tmp = fgetcsv($handle, MAX_LINE_SIZE, $glue, '"', '');
         AdminImportController::rewindBomAware($handle);
 
         return count($tmp);
@@ -3732,7 +3732,7 @@ class AdminImportControllerCore extends AdminController
             $toSkip += $offset;
         }
         for ($i = 0; $i < $toSkip; ++$i) {
-            $line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator);
+            $line = fgetcsv($handle, MAX_LINE_SIZE, $this->separator, '"', '');
             if ($line === false) {
                 return false; // reached end of file
             }
@@ -4047,7 +4047,7 @@ class AdminImportControllerCore extends AdminController
                     $handle = $this->openCsvFile(0);
                     if ($handle) {
                         $count = 0;
-                        while (fgetcsv($handle, MAX_LINE_SIZE, $this->separator)) {
+                        while (fgetcsv($handle, MAX_LINE_SIZE, $this->separator, '"', '')) {
                             ++$count;
                         }
                         $results['totalCount'] = $count;

--- a/src/Adapter/Import/ImportDataFormatter.php
+++ b/src/Adapter/Import/ImportDataFormatter.php
@@ -130,7 +130,7 @@ final class ImportDataFormatter
             return [];
         }
 
-        $content = fgetcsv($fd, 0, $separator);
+        $content = fgetcsv($fd, 0, $separator, '"', '');
         fclose($fd);
 
         if ($uniqidPath !== false && file_exists($uniqidPath)) {

--- a/src/Core/Export/FileWriter/ExportCsvFileWriter.php
+++ b/src/Core/Export/FileWriter/ExportCsvFileWriter.php
@@ -66,10 +66,10 @@ final class ExportCsvFileWriter implements FileWriterInterface
             );
         }
 
-        $exportFile->fputcsv($data->getTitles(), $separator);
+        $exportFile->fputcsv($data->getTitles(), $separator, '"', '');
 
         foreach ($data->getRows() as $row) {
-            $exportFile->fputcsv($row, $separator);
+            $exportFile->fputcsv($row, $separator, '"', '');
         }
 
         return $exportFile;

--- a/src/PrestaShopBundle/Component/CsvResponse.php
+++ b/src/PrestaShopBundle/Component/CsvResponse.php
@@ -227,11 +227,11 @@ class CsvResponse extends StreamedResponse
         $handle = tmpfile();
 
         if ($this->includeHeaderRow) {
-            fputcsv($handle, $this->headersData, ';');
+            fputcsv($handle, $this->headersData, ';', '"', '');
         }
 
         foreach ($this->data as $line) {
-            fputcsv($handle, $line, ';');
+            fputcsv($handle, $line, ';', '"', '');
         }
 
         $this->dumpFile($handle);
@@ -245,7 +245,7 @@ class CsvResponse extends StreamedResponse
         $handle = tmpfile();
 
         if ($this->includeHeaderRow) {
-            fputcsv($handle, $this->headersData, ';');
+            fputcsv($handle, $this->headersData, ';', '"', '');
         }
 
         do {
@@ -265,7 +265,7 @@ class CsvResponse extends StreamedResponse
                     }
                 }
 
-                fputcsv($handle, $lineData, ';');
+                fputcsv($handle, $lineData, ';', '"', '');
             }
 
             $this->incrementData();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | In PHP 8.4, not passing the $escape parameter emits a deprecation notice. Passing the $escape parameter explicitly avoids the deprecation notice. https://php.watch/versions/8.4 https://php.watch/versions/8.4/csv-functions-escape-parameter
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Auto test
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       |
| Sponsor company   | 
