### PR TITLE
Remove outdated E_STRICT

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -729,7 +729,6 @@ class WebserviceRequestCore
             E_USER_ERROR => 'Error',
             E_USER_WARNING => 'User warning',
             E_USER_NOTICE => 'User notice',
-            E_STRICT => 'Runtime Notice',
             E_RECOVERABLE_ERROR => 'Recoverable error',
         ];
         $type = $errortype[$errno] ?? 'Unknown error';


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This error level is long outdated and removed in PHP 8.4 - The [E_STRICT](https://www.php.net/manual/en/errorfunc.constants.php#constant.e-strict) error level has been removed, as it was no longer in use within the PHP engine. The [E_STRICT](https://www.php.net/manual/en/errorfunc.constants.php#constant.e-strict) constant has been deprecated. It was already removed by @ShaiMagal here - https://github.com/PrestaShop/PrestaShop/pull/37257
| Type?             | refacto
| Category?         | WS
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | No need to test
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 
