### PR TITLE
Explicitly type all nullable values for PHP 8.4

### DIFF
--- a/tools/build/Library/InstallUnpacker/classes/Download.php
+++ b/tools/build/Library/InstallUnpacker/classes/Download.php
@@ -43,7 +43,7 @@ class Download
     /**
      * @param BasicFileCache $cachingSystem optional FileCache
      */
-    public function __construct(BasicFileCache $cachingSystem = null)
+    public function __construct(?BasicFileCache $cachingSystem = null)
     {
         if (null === $cachingSystem) {
             $cachingSystem = new BasicFileCache();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Nullable argument without explicit null type will throw a message in PHP 8.4. I scanned whole codebase, extracted all methods, extracted all typed arguments and checked if all arguments with `= null` have a null type.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Auto test
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 
