### PR TITLE
Fix absolute urls that were broken by our custom Router

### DIFF
--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -106,7 +106,7 @@ else
   echo "error_log=/var/www/html/var/logs/php.log" >> /usr/local/etc/php/php.ini
 fi
 
-if [ ! -f ./config/settings.inc.php ]; then
+if [ ! -f ./app/config/parameters.php ]; then
     if [ $PS_INSTALL_AUTO = 1 ]; then
 
         echo "\n* Installing PrestaShop, this may take a while ...";

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Then reach your shop on this URL: http://localhost:8001
 Docker will bind your port 8001 to the web server. If you want to use other port, open and modify the file `docker-compose.yml`.
 MySQL credentials can also be found and modified in this file if needed.
 
-**Note:**  Before auto-installing PrestaShop, this container checks the file *config/settings.inc.php* does not exist on startup.
+**Note:**  Before auto-installing PrestaShop, this container checks the file *app/config/parameters.php* does not exist on startup.
 If you expect the container to (re)install your shop, remove this file if it exists. And make sure the container user `www-data`
 has write access to the whole workspace.
 
@@ -73,7 +73,7 @@ git reset --hard origin/develop
 git clean -dfx
 
 # inform build scripts to reinstall shop
-rm config/settings.inc.php
+rm app/config/parameters.php
 
 # clear all docker caches and rebuild everything
 docker compose down -v

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -145,6 +145,4 @@ if ($lastParametersModificationTime) {
         define('_RIJNDAEL_KEY_', $config['parameters']['_rijndael_key']);
         define('_RIJNDAEL_IV_', $config['parameters']['_rijndael_iv']);
     }
-} elseif (file_exists(_PS_ROOT_DIR_.'/config/settings.inc.php')) {
-    require_once _PS_ROOT_DIR_.'/config/settings.inc.php';
 }

--- a/install-dev/controllers/http/welcome.php
+++ b/install-dev/controllers/http/welcome.php
@@ -64,7 +64,7 @@ class InstallControllerHttpWelcome extends InstallControllerHttp implements Http
     public function display(): void
     {
         $this->can_upgrade = false;
-        if (file_exists(_PS_ROOT_DIR_ . '/config/settings.inc.php')) {
+        if (file_exists(_PS_ROOT_DIR_ . '/app/config/parameters.php')) {
             if (version_compare(_PS_VERSION_, _PS_INSTALL_VERSION_, '<')) {
                 $this->can_upgrade = true;
                 $this->ps_version = _PS_VERSION_;

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -73,7 +73,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class Install extends AbstractInstall
 {
-    public const SETTINGS_FILE = 'config/settings.inc.php';
+    public const SETTINGS_FILE = 'app/config/parameters.php';
     public const BOOTSTRAP_FILE = 'config/bootstrap.php';
 
     public const DEFAULT_THEME = 'classic';
@@ -230,15 +230,6 @@ class Install extends AbstractInstall
             $parameters
         );
 
-        $settings_content = "<?php\n";
-        $settings_content .= '//@deprecated 1.7';
-
-        if (!file_put_contents(_PS_ROOT_DIR_ . '/' . $this->settingsFile, $settings_content)) {
-            $this->setError($this->translator->trans('Cannot write settings file', [], 'Install'));
-
-            return false;
-        }
-
         if (!$this->processParameters($parameters)) {
             return false;
         }
@@ -256,8 +247,8 @@ class Install extends AbstractInstall
     public function processParameters($parameters)
     {
         $parametersContent = sprintf('<?php return %s;', var_export($parameters, true));
-        if (!file_put_contents(_PS_ROOT_DIR_ . '/app/config/parameters.php', $parametersContent)) {
-            $this->setError($this->translator->trans('Cannot write app/config/parameters.php file', [], 'Install'));
+        if (!file_put_contents(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . $this->settingsFile, $parametersContent)) {
+            $this->setError($this->translator->trans('%file% file is not writable (check permissions)', ['%file%' => $this->settingsFile], 'Install'));
 
             return false;
         } else {

--- a/src/PrestaShopBundle/Service/Routing/Router.php
+++ b/src/PrestaShopBundle/Service/Routing/Router.php
@@ -77,6 +77,15 @@ class Router extends BaseRouter
             $url .= '#' . strtr(rawurlencode($components['fragment']), ['%2F' => '/', '%3F' => '?']);
         }
 
+        // Keep absolute urls absolute
+        if (!empty($components['scheme']) && !empty($components['host'])) {
+            $baseHost = $components['scheme'] . '://' . $components['host'];
+            if (!empty($components['port'])) {
+                $baseHost .= ':' . $components['port'];
+            }
+            $url = $baseHost . $url;
+        }
+
         return $url;
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fix absolute urls that were broken by our custom Router, also not related but the file deprecated `config/settings.inc.php` file usage was removed from install process
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI green and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/11919609605
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~

## Breaking Change

### Symfony router can generate absolute URLs again

Since PrestaShop 1.7.7.0 the Symfony router was never able to generate absolute URLs because of our internal overriding service that breaks the initial URLs apart but forgot to integrate the domain in it (when possible). So from now on using the absolute URL attribute with the Symfony router will truly return absolute URLs.

This may result in unexpected side effects if for example some code forced adding the base URL after the router generate method was called with absolute URL.

### Remove config/settings.inc.php

A legacy file `config/settings.inc.php` was used to check if the docker had to install the shop, it was also used in `PrestaShopBundle\Install\Install` class and auto-generated with deprecated content even though the real parameters config file has been `app/config/parameters.php` for years now. The legacy file generation and checks have been removed, this file won't be generated anymore and shouldn't be used for any automated process anymore.