### PR TITLE
Clean behat context constructors

### DIFF
--- a/tests/Integration/Behaviour/Features/Context/AbstractPrestaShopFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/AbstractPrestaShopFeatureContext.php
@@ -27,6 +27,7 @@
 namespace Tests\Integration\Behaviour\Features\Context;
 
 use Behat\Behat\Context\Context as BehatContext;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use RuntimeException;
 
 /**
@@ -56,5 +57,26 @@ abstract class AbstractPrestaShopFeatureContext implements BehatContext
                 $firstFixtureNamesStr
             ));
         }
+    }
+
+    /**
+     * @return int
+     */
+    protected function getDefaultLangId(): int
+    {
+        return (int) $this->getConfiguration()->get('PS_LANG_DEFAULT');
+    }
+
+    /**
+     * @return int
+     */
+    protected function getDefaultShopId(): int
+    {
+        return (int) $this->getConfiguration()->get('PS_SHOP_DEFAULT');
+    }
+
+    protected function getConfiguration(): ConfigurationInterface
+    {
+        return CommonFeatureContext::getContainer()->get(ConfigurationInterface::class);
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -28,20 +28,18 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\TableNode;
-use Configuration;
 use Currency;
 use Language;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Tests\Integration\Behaviour\Features\Context\AbstractPrestaShopFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\LastExceptionTrait;
-use Tests\Integration\Behaviour\Features\Context\SharedStorageTrait;
 use Tests\Resources\MailDevClient;
 
-abstract class AbstractDomainFeatureContext implements Context
+abstract class AbstractDomainFeatureContext extends AbstractPrestaShopFeatureContext implements Context
 {
-    use SharedStorageTrait;
     use LastExceptionTrait;
 
     protected const JPG_IMAGE_TYPE = '.jpg';
@@ -163,14 +161,6 @@ abstract class AbstractDomainFeatureContext implements Context
         return $localizedValues;
     }
 
-    /**
-     * @return int
-     */
-    protected function getDefaultLangId(): int
-    {
-        return (int) Configuration::get('PS_LANG_DEFAULT');
-    }
-
     protected function getDefaultCurrencyId(): int
     {
         return Currency::getDefaultCurrencyId();
@@ -179,14 +169,6 @@ abstract class AbstractDomainFeatureContext implements Context
     protected function getDefaultCurrencyIsoCode(): string
     {
         return Currency::getIsoCodeById($this->getDefaultCurrencyId());
-    }
-
-    /**
-     * @return int
-     */
-    protected function getDefaultShopId(): int
-    {
-        return (int) Configuration::get('PS_SHOP_DEFAULT');
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -67,25 +67,10 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
         'down' => 1,
     ];
 
-    /** @var int */
-    private $defaultLanguageId;
-
-    /** @var string */
-    private $psCatImgDir;
-
     private const PROPERTY_TYPE_BASIC = 0;
     private const PROPERTY_TYPE_REFERENCE = 1;
     private const PROPERTY_TYPE_REFERENCE_ARRAY = 2;
     private const PROPERTY_TYPE_BOOL = 3;
-
-    /**
-     * CategoryFeatureContext constructor.
-     */
-    public function __construct()
-    {
-        $this->defaultLanguageId = (int) Configuration::get('PS_LANG_DEFAULT');
-        $this->psCatImgDir = _PS_CAT_IMG_DIR_;
-    }
 
     /**
      * @Then I should see following root categories in ":langIso" language:
@@ -575,7 +560,7 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
      */
     public function assertCategoryExistsByName(string $categoryReference, string $categoryName)
     {
-        $foundCategory = Category::searchByName($this->defaultLanguageId, $categoryName, true);
+        $foundCategory = Category::searchByName($this->getDefaultLangId(), $categoryName, true);
 
         if (!isset($foundCategory['name']) || $foundCategory['name'] !== $categoryName) {
             throw new RuntimeException(sprintf(
@@ -764,7 +749,7 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
         return $this->uploadImage(
             $imageReference,
             $fileName,
-            $this->psCatImgDir . $categoryId . self::JPG_IMAGE_TYPE
+            _PS_CAT_IMG_DIR_ . $categoryId . self::JPG_IMAGE_TYPE
         );
     }
 
@@ -780,7 +765,7 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
         return $this->uploadImage(
             $imageReference,
             $fileName,
-            $this->psCatImgDir . $categoryId . '_thumb' . self::JPG_IMAGE_TYPE
+            _PS_CAT_IMG_DIR_ . $categoryId . '_thumb' . self::JPG_IMAGE_TYPE
         );
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/CmsPageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CmsPageFeatureContext.php
@@ -43,7 +43,6 @@ use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryN
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Query\GetCmsPageCategoryForEditing;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\ValueObject\CmsPageCategoryId;
 use RuntimeException;
-use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\NoExceptionAlthoughExpectedException;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
@@ -51,29 +50,12 @@ use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 class CmsPageFeatureContext extends AbstractDomainFeatureContext
 {
     /**
-     * @var int
-     */
-    private $defaultLangId;
-
-    /**
-     * @var int
-     */
-    private $defaultShopId;
-
-    /**
      * "When" steps perform actions, and some of them store the latest exception
      * in this variable so that "Then" action can check it
      *
      * @var mixed
      */
     private $latestException;
-
-    public function __construct()
-    {
-        $configuration = CommonFeatureContext::getContainer()->get('prestashop.adapter.legacy.configuration');
-        $this->defaultLangId = $configuration->get('PS_LANG_DEFAULT');
-        $this->defaultShopId = $configuration->get('PS_SHOP_DEFAULT');
-    }
 
     /**
      * @When I add new CMS page :cmsPageReference with following properties:
@@ -109,19 +91,19 @@ class CmsPageFeatureContext extends AbstractDomainFeatureContext
         $data = $node->getRowsHash();
 
         if (isset($data['meta_title'])) {
-            $command->setLocalizedTitle([$this->defaultLangId => $data['meta_title']]);
+            $command->setLocalizedTitle([$this->getDefaultLangId() => $data['meta_title']]);
         }
         if (isset($data['head_seo_title'])) {
-            $command->setLocalizedMetaTitle([$this->defaultLangId => $data['head_seo_title']]);
+            $command->setLocalizedMetaTitle([$this->getDefaultLangId() => $data['head_seo_title']]);
         }
         if (isset($data['meta_description'])) {
-            $command->setLocalizedMetaDescription([$this->defaultLangId => $data['meta_description']]);
+            $command->setLocalizedMetaDescription([$this->getDefaultLangId() => $data['meta_description']]);
         }
         if (isset($data['link_rewrite'])) {
-            $command->setLocalizedFriendlyUrl([$this->defaultLangId => $data['link_rewrite']]);
+            $command->setLocalizedFriendlyUrl([$this->getDefaultLangId() => $data['link_rewrite']]);
         }
         if (isset($data['content'])) {
-            $command->setLocalizedContent([$this->defaultLangId => $data['content']]);
+            $command->setLocalizedContent([$this->getDefaultLangId() => $data['content']]);
         }
         if (isset($data['indexation'])) {
             $command->setIsIndexedForSearch(PrimitiveUtils::castStringBooleanIntoBoolean($data['indexation']));
@@ -283,8 +265,8 @@ class CmsPageFeatureContext extends AbstractDomainFeatureContext
     {
         /** @var CMS $cmsPage */
         $cmsPage = SharedStorage::getStorage()->get($cmsPageReference);
-        if ($cmsPage->$field[$this->defaultLangId] !== $value) {
-            throw new RuntimeException(sprintf('Cms page "%s" has "%s" %s, but "%s" was expected.', $cmsPageReference, $cmsPage->$field[$this->defaultLangId], $field, $value));
+        if ($cmsPage->$field[$this->getDefaultLangId()] !== $value) {
+            throw new RuntimeException(sprintf('Cms page "%s" has "%s" %s, but "%s" was expected.', $cmsPageReference, $cmsPage->$field[$this->getDefaultLangId()], $field, $value));
         }
     }
 
@@ -295,8 +277,8 @@ class CmsPageFeatureContext extends AbstractDomainFeatureContext
     {
         /** @var CMS $cmsPage */
         $cmsPage = SharedStorage::getStorage()->get($cmsPageReference);
-        if ($cmsPage->$field[$this->defaultLangId] !== '') {
-            throw new RuntimeException(sprintf('Cms page "%s" has "%s" %s, but it was expected to be empty', $cmsPageReference, $cmsPage->$field[$this->defaultLangId], $field));
+        if ($cmsPage->$field[$this->getDefaultLangId()] !== '') {
+            throw new RuntimeException(sprintf('Cms page "%s" has "%s" %s, but it was expected to be empty', $cmsPageReference, $cmsPage->$field[$this->getDefaultLangId()], $field));
         }
     }
 
@@ -338,14 +320,14 @@ class CmsPageFeatureContext extends AbstractDomainFeatureContext
     {
         $command = new AddCmsPageCommand(
             (int) $data['id_cms_category'],
-            [$this->defaultLangId => $data['meta_title']],
-            [$this->defaultLangId => $data['head_seo_title']],
-            [$this->defaultLangId => $data['meta_description']],
-            [$this->defaultLangId => $data['link_rewrite']],
-            [$this->defaultLangId => $data['content']],
+            [$this->getDefaultLangId() => $data['meta_title']],
+            [$this->getDefaultLangId() => $data['head_seo_title']],
+            [$this->getDefaultLangId() => $data['meta_description']],
+            [$this->getDefaultLangId() => $data['link_rewrite']],
+            [$this->getDefaultLangId() => $data['content']],
             PrimitiveUtils::castStringBooleanIntoBoolean($data['indexation']),
             PrimitiveUtils::castStringBooleanIntoBoolean($data['active']),
-            [$this->defaultShopId]
+            [$this->getDefaultShopId()]
         );
 
         /** @var CmsPageId $cmsPageId */

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
@@ -38,24 +38,12 @@ use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerThreadFor
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerThreadView;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\ValueObject\CustomerThreadStatus;
 use RuntimeException;
-use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\NoExceptionAlthoughExpectedException;
 use Tools;
 
 class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
 {
-    /**
-     * @var int default shop id from configs
-     */
-    private $defaultShopId;
-
-    public function __construct()
-    {
-        $configuration = CommonFeatureContext::getContainer()->get('prestashop.adapter.legacy.configuration');
-        $this->defaultShopId = $configuration->get('PS_SHOP_DEFAULT');
-    }
-
     /**
      * @When I add new customer thread :threadReference with following properties:
      *
@@ -70,7 +58,7 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
         $customerThread = new CustomerThread();
         $customerThread->id_contact = 2;
         $customerThread->id_customer = 1;
-        $customerThread->id_shop = $this->defaultShopId;
+        $customerThread->id_shop = $this->getDefaultShopId();
         $customerThread->id_order = 0;
         $customerThread->id_lang = 1;
         $customerThread->email = 'test@gmail.com';

--- a/tests/Integration/Behaviour/Features/Context/Domain/ManufacturerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ManufacturerFeatureContext.php
@@ -47,30 +47,12 @@ use PrestaShop\PrestaShop\Core\Domain\Manufacturer\QueryResult\ViewableManufactu
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
 use RuntimeException;
 use stdClass;
-use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\NoExceptionAlthoughExpectedException;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 class ManufacturerFeatureContext extends AbstractDomainFeatureContext
 {
-    /**
-     * @var int default language id from configs
-     */
-    private $defaultLangId;
-
-    /**
-     * @var int default shop id from configs
-     */
-    private $defaultShopId;
-
-    public function __construct()
-    {
-        $configuration = CommonFeatureContext::getContainer()->get('prestashop.adapter.legacy.configuration');
-        $this->defaultLangId = $configuration->get('PS_LANG_DEFAULT');
-        $this->defaultShopId = $configuration->get('PS_SHOP_DEFAULT');
-    }
-
     /**
      * Needed for getting Viewable objects from handlers, for example ViewableManufacturer
      *
@@ -115,16 +97,16 @@ class ManufacturerFeatureContext extends AbstractDomainFeatureContext
             $command->setEnabled(PrimitiveUtils::castStringBooleanIntoBoolean($data['enabled']));
         }
         if (isset($data['short_description'])) {
-            [$this->defaultLangId => $command->setLocalizedShortDescriptions($data['short_description'])];
+            [$this->getDefaultLangId() => $command->setLocalizedShortDescriptions($data['short_description'])];
         }
         if (isset($data['description'])) {
-            [$this->defaultLangId => $command->setLocalizedDescriptions($data['description'])];
+            [$this->getDefaultLangId() => $command->setLocalizedDescriptions($data['description'])];
         }
         if (isset($data['meta_title'])) {
-            [$this->defaultLangId => $command->setLocalizedMetaTitles($data['meta_title'])];
+            [$this->getDefaultLangId() => $command->setLocalizedMetaTitles($data['meta_title'])];
         }
         if (isset($data['meta_description'])) {
-            [$this->defaultLangId => $command->setLocalizedMetaDescriptions($data['meta_description'])];
+            [$this->getDefaultLangId() => $command->setLocalizedMetaDescriptions($data['meta_description'])];
         }
         if (isset($data['logo image'])) {
             $this->pretendImageUploaded(_PS_MANU_IMG_DIR_, $data['logo image'], $manufacturerId);
@@ -189,8 +171,8 @@ class ManufacturerFeatureContext extends AbstractDomainFeatureContext
         /** @var Manufacturer $manufacturer */
         $manufacturer = SharedStorage::getStorage()->get($reference);
 
-        if ($manufacturer->$field[$this->defaultLangId] !== $value) {
-            throw new RuntimeException(sprintf('Manufacturer "%s" has "%s" %s, but "%s" was expected.', $reference, $manufacturer->$field[$this->defaultLangId], $field, $value));
+        if ($manufacturer->$field[$this->getDefaultLangId()] !== $value) {
+            throw new RuntimeException(sprintf('Manufacturer "%s" has "%s" %s, but "%s" was expected.', $reference, $manufacturer->$field[$this->getDefaultLangId()], $field, $value));
         }
     }
 
@@ -201,8 +183,8 @@ class ManufacturerFeatureContext extends AbstractDomainFeatureContext
     {
         $manufacturer = SharedStorage::getStorage()->get($reference);
 
-        if ($manufacturer->$field[$this->defaultLangId] !== '') {
-            throw new RuntimeException(sprintf('Manufacturer "%s" has "%s" %s, but it was expected to be empty', $reference, $manufacturer->$field[$this->defaultLangId], $field));
+        if ($manufacturer->$field[$this->getDefaultLangId()] !== '') {
+            throw new RuntimeException(sprintf('Manufacturer "%s" has "%s" %s, but it was expected to be empty', $reference, $manufacturer->$field[$this->getDefaultLangId()], $field));
         }
     }
 
@@ -363,11 +345,11 @@ class ManufacturerFeatureContext extends AbstractDomainFeatureContext
         $command = new AddManufacturerCommand(
             $data['name'],
             PrimitiveUtils::castStringBooleanIntoBoolean($data['enabled']),
-            [$this->defaultLangId => $data['short_description']],
-            [$this->defaultLangId => $data['description']],
-            [$this->defaultLangId => $data['meta_title']],
-            [$this->defaultLangId => $data['meta_description']],
-            [$this->defaultShopId]
+            [$this->getDefaultLangId() => $data['short_description']],
+            [$this->getDefaultLangId() => $data['description']],
+            [$this->getDefaultLangId() => $data['meta_title']],
+            [$this->getDefaultLangId() => $data['meta_description']],
+            [$this->getDefaultShopId()]
         );
 
         /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderReturnStateFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderReturnStateFeatureContext.php
@@ -41,22 +41,10 @@ use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStat
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Query\GetOrderReturnStateForEditing;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\QueryResult\EditableOrderReturnState;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\ValueObject\OrderReturnStateId;
-use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 
 class OrderReturnStateFeatureContext extends AbstractDomainFeatureContext
 {
-    /**
-     * @var int default language id from configs
-     */
-    private $defaultLangId;
-
-    public function __construct()
-    {
-        $configuration = CommonFeatureContext::getContainer()->get('prestashop.adapter.legacy.configuration');
-        $this->defaultLangId = $configuration->get('PS_LANG_DEFAULT');
-    }
-
     /**
      * @Given I add a new order return state :orderReturnStateReference with the following details:
      *
@@ -71,7 +59,7 @@ class OrderReturnStateFeatureContext extends AbstractDomainFeatureContext
             /** @var OrderReturnStateId $orderReturnStateId */
             $orderReturnStateId = $this->getCommandBus()->handle(new AddOrderReturnStateCommand(
                 [
-                    $this->defaultLangId => $data['name'],
+                    $this->getDefaultLangId() => $data['name'],
                 ],
                 $data['color']
             ));
@@ -97,7 +85,7 @@ class OrderReturnStateFeatureContext extends AbstractDomainFeatureContext
         $data = $table->getRowsHash();
         if (isset($data['name'])) {
             $editableOrderReturnState->setName([
-                $this->defaultLangId => $data['name'],
+                $this->getDefaultLangId() => $data['name'],
             ]);
         }
         if (isset($data['color'])) {
@@ -163,8 +151,8 @@ class OrderReturnStateFeatureContext extends AbstractDomainFeatureContext
 
         $localizedNames = $editableOrderReturnState->getLocalizedNames();
         Assert::assertIsArray($localizedNames);
-        Assert::assertArrayHasKey($this->defaultLangId, $localizedNames);
-        Assert::assertEquals($data['name'], $localizedNames[$this->defaultLangId]);
+        Assert::assertArrayHasKey($this->getDefaultLangId(), $localizedNames);
+        Assert::assertEquals($data['name'], $localizedNames[$this->getDefaultLangId()]);
         Assert::assertEquals($data['color'], $editableOrderReturnState->getColor());
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderStateFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderStateFeatureContext.php
@@ -41,22 +41,10 @@ use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateNotFoundExc
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Query\GetOrderStateForEditing;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\QueryResult\EditableOrderState;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\ValueObject\OrderStateId;
-use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 
 class OrderStateFeatureContext extends AbstractDomainFeatureContext
 {
-    /**
-     * @var int default language id from configs
-     */
-    private $defaultLangId;
-
-    public function __construct()
-    {
-        $configuration = CommonFeatureContext::getContainer()->get('prestashop.adapter.legacy.configuration');
-        $this->defaultLangId = $configuration->get('PS_LANG_DEFAULT');
-    }
-
     /**
      * @Given I add a new order state :orderStateReference with the following details:
      *
@@ -71,7 +59,7 @@ class OrderStateFeatureContext extends AbstractDomainFeatureContext
             /** @var OrderStateId $orderStateId */
             $orderStateId = $this->getCommandBus()->handle(new AddOrderStateCommand(
                 [
-                    $this->defaultLangId => $data['name'],
+                    $this->getDefaultLangId() => $data['name'],
                 ],
                 $data['color'],
                 (bool) $data['isLoggable'],
@@ -107,7 +95,7 @@ class OrderStateFeatureContext extends AbstractDomainFeatureContext
         $data = $table->getRowsHash();
         if (isset($data['name'])) {
             $editableOrderState->setName([
-                $this->defaultLangId => $data['name'],
+                $this->getDefaultLangId() => $data['name'],
             ]);
         }
         if (isset($data['color'])) {
@@ -139,7 +127,7 @@ class OrderStateFeatureContext extends AbstractDomainFeatureContext
         }
         if (isset($data['template'])) {
             $editableOrderState->setTemplate([
-                $this->defaultLangId => $data['template'],
+                $this->getDefaultLangId() => $data['template'],
             ]);
         }
 
@@ -203,13 +191,13 @@ class OrderStateFeatureContext extends AbstractDomainFeatureContext
         $localizedNames = $editableOrderState->getLocalizedNames();
         $localizedTemplates = $editableOrderState->getLocalizedTemplates();
         Assert::assertIsArray($localizedNames);
-        Assert::assertArrayHasKey($this->defaultLangId, $localizedNames);
-        Assert::assertEquals($data['name'], $localizedNames[$this->defaultLangId]);
+        Assert::assertArrayHasKey($this->getDefaultLangId(), $localizedNames);
+        Assert::assertEquals($data['name'], $localizedNames[$this->getDefaultLangId()]);
         Assert::assertEquals($data['color'], $editableOrderState->getColor());
         Assert::assertEquals((bool) $data['hasSendMail'], $editableOrderState->isSendEmailEnabled());
         Assert::assertIsArray($localizedTemplates);
-        Assert::assertArrayHasKey($this->defaultLangId, $localizedTemplates);
-        Assert::assertEquals($data['template'], $localizedTemplates[$this->defaultLangId]);
+        Assert::assertArrayHasKey($this->getDefaultLangId(), $localizedTemplates);
+        Assert::assertEquals($data['template'], $localizedTemplates[$this->getDefaultLangId()]);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/PermissionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/PermissionFeatureContext.php
@@ -54,7 +54,7 @@ class PermissionFeatureContext extends AbstractDomainFeatureContext
      */
     public function assertTabsPermissionForProfile(string $profileReference, TableNode $table): void
     {
-        $configuration = $this->getConfiguration();
+        $configuration = $this->getConfigurablePermissions();
         $tabsPermissionsForAllProfiles = $configuration->getProfilePermissionsForTabs();
         $profileId = $this->getSharedStorage()->get($profileReference);
 
@@ -107,7 +107,7 @@ class PermissionFeatureContext extends AbstractDomainFeatureContext
      */
     public function assertModulesPermissionForProfile(string $profileReference, TableNode $table): void
     {
-        $configuration = $this->getConfiguration();
+        $configuration = $this->getConfigurablePermissions();
         $modulesPermissionsForAllProfiles = $configuration->getProfilePermissionsForModules();
         $profileId = $this->getSharedStorage()->get($profileReference);
 
@@ -227,7 +227,7 @@ class PermissionFeatureContext extends AbstractDomainFeatureContext
      *
      * @return ConfigurablePermissions
      */
-    private function getConfiguration(): ConfigurablePermissions
+    private function getConfigurablePermissions(): ConfigurablePermissions
     {
         return $this->getQueryBus()->handle(new GetPermissionsForConfiguration(self::SUPER_ADMIN_ID));
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
@@ -57,19 +57,9 @@ use Tests\Resources\DummyFileUploader;
 class ProductImageFeatureContext extends AbstractProductFeatureContext
 {
     /**
-     * @var ProductImageRepository
-     */
-    private $productImageRepository;
-
-    /**
      * @var ShopProductImagesCollection
      */
     private $shopProductImagesCollection;
-
-    public function __construct()
-    {
-        $this->productImageRepository = $this->getContainer()->get(ProductImageRepository::class);
-    }
 
     /**
      * @Given following image types should be applicable to products:
@@ -77,7 +67,9 @@ class ProductImageFeatureContext extends AbstractProductFeatureContext
     public function assertProductsImageTypesExists(TableNode $tableNode): void
     {
         $dataRows = $tableNode->getColumnsHash();
-        $imageTypes = $this->productImageRepository->getProductImageTypes();
+        /** @var ProductImageRepository $productImageRepository */
+        $productImageRepository = $this->getContainer()->get(ProductImageRepository::class);
+        $imageTypes = $productImageRepository->getProductImageTypes();
 
         Assert::assertEquals(
             count($dataRows),

--- a/tests/Integration/Behaviour/Features/Context/Domain/StateFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/StateFeatureContext.php
@@ -47,7 +47,6 @@ use PrestaShop\PrestaShop\Core\Domain\State\QueryResult\EditableState;
 use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\StateId;
 use RuntimeException;
 use State;
-use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\NoExceptionAlthoughExpectedException;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
@@ -55,17 +54,6 @@ use Zone;
 
 class StateFeatureContext extends AbstractDomainFeatureContext
 {
-    /**
-     * @var int default shop id from configs
-     */
-    private $defaultLangId;
-
-    public function __construct()
-    {
-        $configuration = CommonFeatureContext::getContainer()->get('prestashop.adapter.legacy.configuration');
-        $this->defaultLangId = $configuration->get('PS_LANG_DEFAULT');
-    }
-
     /**
      * @When I add new state :stateReference with following properties:
      *
@@ -79,7 +67,7 @@ class StateFeatureContext extends AbstractDomainFeatureContext
         try {
             /** @var StateId $stateId */
             $stateId = $this->getCommandBus()->handle(new AddStateCommand(
-                (int) Country::getIdByName($this->defaultLangId, $data['country']),
+                (int) Country::getIdByName($this->getDefaultLangId(), $data['country']),
                 Zone::getIdByName($data['zone']),
                 $data['name'],
                 $data['iso_code'],
@@ -115,7 +103,7 @@ class StateFeatureContext extends AbstractDomainFeatureContext
             $command->setActive(PrimitiveUtils::castStringBooleanIntoBoolean($data['enabled']));
         }
         if (isset($data['country'])) {
-            $command->setCountryId((int) Country::getIdByName($this->defaultLangId, $data['country']));
+            $command->setCountryId((int) Country::getIdByName($this->getDefaultLangId(), $data['country']));
         }
         if (isset($data['zone'])) {
             $command->setZoneId((int) Zone::getIdByName($data['zone']));
@@ -224,7 +212,7 @@ class StateFeatureContext extends AbstractDomainFeatureContext
         $state = new State((int) SharedStorage::getStorage()->get($stateReference));
         $country = new Country($state->id_country);
 
-        if ($country->name[$this->defaultLangId] !== $name) {
+        if ($country->name[$this->getDefaultLangId()] !== $name) {
             throw new RuntimeException(sprintf(
                 'Country "%s" has "%s" name, but "%s" was expected.',
                 $stateReference,

--- a/tests/Integration/Behaviour/Features/Context/Domain/TaxFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/TaxFeatureContext.php
@@ -43,7 +43,6 @@ use Tax;
 use TaxCalculator;
 use TaxRule;
 use TaxRulesGroup;
-use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\NoExceptionAlthoughExpectedException;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
@@ -51,18 +50,6 @@ use Tests\Resources\Resetter\TaxesResetter;
 
 class TaxFeatureContext extends AbstractDomainFeatureContext
 {
-    /**
-     * @var int default language id from configuration
-     */
-    private $defaultLangId;
-
-    public function __construct()
-    {
-        $this->defaultLangId = CommonFeatureContext::getContainer()
-            ->get('prestashop.adapter.legacy.configuration')
-            ->get('PS_LANG_DEFAULT');
-    }
-
     /**
      * @BeforeFeature @restore-taxes-before-feature
      */
@@ -99,7 +86,7 @@ class TaxFeatureContext extends AbstractDomainFeatureContext
         $taxId = (int) $tax->id;
         $command = new EditTaxCommand($taxId);
         if (isset($data['name'])) {
-            $command->setLocalizedNames([$this->defaultLangId => $data['name']]);
+            $command->setLocalizedNames([$this->getDefaultLangId() => $data['name']]);
         }
         if (isset($data['rate'])) {
             $command->setRate($data['rate']);
@@ -211,7 +198,7 @@ class TaxFeatureContext extends AbstractDomainFeatureContext
         /** @var Tax $tax */
         $tax = SharedStorage::getStorage()->get($taxReference);
 
-        if ($tax->name[$this->defaultLangId] !== $name) {
+        if ($tax->name[$this->getDefaultLangId()] !== $name) {
             throw new RuntimeException(sprintf('Tax "%s" has "%s" name, but "%s" was expected.', $taxReference, $tax->name, $name));
         }
     }
@@ -265,7 +252,7 @@ class TaxFeatureContext extends AbstractDomainFeatureContext
     private function createTaxUsingCommand(string $taxReference, array $data): void
     {
         $command = new AddTaxCommand(
-            [$this->defaultLangId => $data['name']],
+            [$this->getDefaultLangId() => $data['name']],
             $data['rate'],
             PrimitiveUtils::castStringBooleanIntoBoolean($data['is_enabled'])
         );

--- a/tests/Integration/Behaviour/Features/Context/Domain/ZoneFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ZoneFeatureContext.php
@@ -37,7 +37,6 @@ use PrestaShop\PrestaShop\Core\Domain\Zone\Exception\ZoneException;
 use PrestaShop\PrestaShop\Core\Domain\Zone\Exception\ZoneNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Zone\Query\GetZoneForEditing;
 use RuntimeException;
-use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\NoExceptionAlthoughExpectedException;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
@@ -45,17 +44,6 @@ use Zone;
 
 class ZoneFeatureContext extends AbstractDomainFeatureContext
 {
-    /**
-     * @var int default shop id from configs
-     */
-    private $defaultShopId;
-
-    public function __construct()
-    {
-        $configuration = CommonFeatureContext::getContainer()->get('prestashop.adapter.legacy.configuration');
-        $this->defaultShopId = $configuration->get('PS_SHOP_DEFAULT');
-    }
-
     /**
      * @When I add new zone :zoneReference with following properties:
      *
@@ -70,7 +58,7 @@ class ZoneFeatureContext extends AbstractDomainFeatureContext
             $zoneId = $this->getCommandBus()->handle(new AddZoneCommand(
                 $data['name'],
                 PrimitiveUtils::castStringBooleanIntoBoolean($data['enabled']),
-                [$this->defaultShopId]
+                [$this->getDefaultShopId()]
             ));
             $this->getSharedStorage()->set($zoneReference, new Zone($zoneId->getValue()));
         } catch (ZoneException $e) {

--- a/tests/Integration/Behaviour/Features/Context/StoreFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/StoreFeatureContext.php
@@ -34,17 +34,6 @@ use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 class StoreFeatureContext extends AbstractPrestaShopFeatureContext
 {
     /**
-     * @var int default lang id from configs
-     */
-    private $defaultLangId;
-
-    public function __construct()
-    {
-        $configuration = CommonFeatureContext::getContainer()->get('prestashop.adapter.legacy.configuration');
-        $this->defaultLangId = (int) $configuration->get('PS_LANG_DEFAULT');
-    }
-
-    /**
      * @When I add new store :storeReference with following properties:
      *
      * @param string $storeReference
@@ -55,13 +44,13 @@ class StoreFeatureContext extends AbstractPrestaShopFeatureContext
         $data = $table->getRowsHash();
 
         $store = new Store();
-        $store->name = [$this->defaultLangId => (string) $data['name']];
+        $store->name = [$this->getDefaultLangId() => (string) $data['name']];
         $store->active = PrimitiveUtils::castStringBooleanIntoBoolean($data['enabled']);
-        $store->address1 = [$this->defaultLangId => (string) $data['address1']];
+        $store->address1 = [$this->getDefaultLangId() => (string) $data['address1']];
         $store->city = $data['city'];
         $store->latitude = (float) $data['latitude'];
         $store->longitude = (float) $data['longitude'];
-        $store->id_country = (int) Country::getIdByName($this->defaultLangId, $data['country']);
+        $store->id_country = (int) Country::getIdByName($this->getDefaultLangId(), $data['country']);
         $store->add();
 
         SharedStorage::getStorage()->set($storeReference, new Store($store->id));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Remove all constructor in context, especially the ones accessing the container as it may occur befor it was initialized
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green
| UI Tests          | ~
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
