### PR TITLE
Add 'product Sales' to default product sort parameter and in front category page

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1025,7 +1025,7 @@ class CategoryCore extends ObjectModel
 					pl.`available_later`, pl.`link_rewrite`, pl.`meta_description`, pl.`meta_title`, pl.`name`, image_shop.`id_image` id_image,
 					il.`legend` as legend, m.`name` AS manufacturer_name, cl.`name` AS category_default,
 					DATEDIFF(product_shop.`date_add`, DATE_SUB("' . date('Y-m-d') . ' 00:00:00",
-					INTERVAL ' . (int) $nbDaysNewProduct . ' DAY)) > 0 AS new, product_shop.price AS orderprice
+					INTERVAL ' . (int) $nbDaysNewProduct . ' DAY)) > 0 AS new, product_shop.price AS orderprice, psales.`quantity` as sales
 				FROM `' . _DB_PREFIX_ . 'category_product` cp
 				LEFT JOIN `' . _DB_PREFIX_ . 'product` p
 					ON p.`id_product` = cp.`id_product`
@@ -1046,6 +1046,8 @@ class CategoryCore extends ObjectModel
 					AND il.`id_lang` = ' . (int) $idLang . ')
 				LEFT JOIN `' . _DB_PREFIX_ . 'manufacturer` m
 					ON m.`id_manufacturer` = p.`id_manufacturer`
+                LEFT JOIN `' . _DB_PREFIX_ . 'product_sale` psales
+					ON psales.`id_product` = p.`id_product`
 				WHERE product_shop.`id_shop` = ' . (int) $context->shop->id . '
 					AND cp.`id_category` = ' . (int) $this->id
                     . ($active ? ' AND product_shop.`active` = 1' : '')

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2893,7 +2893,7 @@ exit;
     {
         switch ($type) {
             case 'by':
-                $list = [0 => 'name', 1 => 'price', 2 => 'date_add', 3 => 'date_upd', 4 => 'position', 5 => 'manufacturer_name', 6 => 'quantity', 7 => 'reference'];
+                $list = [0 => 'name', 1 => 'price', 2 => 'date_add', 3 => 'date_upd', 4 => 'position', 5 => 'manufacturer_name', 6 => 'quantity', 7 => 'reference', 8 => 'sales'];
                 $value = (null === $value || $value === false || $value === '') ? (int) Configuration::get('PS_PRODUCTS_ORDER_BY') : $value;
                 $value = (isset($list[$value])) ? $list[$value] : ((in_array($value, $list)) ? $value : 'position');
                 $order_by_prefix = '';

--- a/src/Adapter/Category/CategoryProductSearchProvider.php
+++ b/src/Adapter/Category/CategoryProductSearchProvider.php
@@ -132,6 +132,9 @@ class CategoryProductSearchProvider implements ProductSearchProviderInterface
                         (new SortOrder('product', 'position', 'asc'))->setLabel(
                             $this->translator->trans('Relevance', [], 'Shop.Theme.Catalog')
                         ),
+                        (new SortOrder('product', 'sales', 'desc'))->setLabel(
+                            $this->translator->trans('Best sales', [], 'Shop.Theme.Catalog')
+                        ),
                     ],
                     $this->sortOrdersCollection->getDefaults())
             );

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
@@ -70,6 +70,7 @@ class PaginationType extends TranslatorAwareType
                     'Brand' => 5,
                     'Product quantity' => 6,
                     'Product reference' => 7,
+                    'Product sales' => 8,
                 ],
                 'required' => false,
                 'placeholder' => false,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Add 'product Sales' to default product sort parameter and in front category page
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to product settings : choose Sales product
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/12280062961 ✅ 
| Fixed issue or discussion?     | (https://github.com/PrestaShop/PrestaShop/issues/37431)
| Sponsor company   | Creabilis.com
