### PR TITLE
Refactor rounding and fix compatibility with PHP 8.4

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1619,10 +1619,7 @@ class ToolsCore
      */
     public static function math_round($value, $places, $mode = PS_ROUND_HALF_UP)
     {
-        // PHP rounding mode is Prestashop rounding mode - 1, see config/defines.inc.php
-        $phpRoundingMode = $mode - 1;
-
-        return round($value, $places, $phpRoundingMode);
+        return Tools::ps_round($value, $places, $mode);
     }
 
     /**

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1566,9 +1566,9 @@ class ToolsCore
     }
 
     /**
-     * returns the rounded value of $value to specified precision, according to your configuration;.
+     * Returns the rounded value of $value to specified precision, according to your configuration.
      *
-     * @note : PHP 5.3.0 introduce a 3rd parameter mode in round function
+     * Warning - this method accepts our own PS rounding constants with different integer values.
      *
      * @param float $value
      * @param int $precision
@@ -1593,14 +1593,24 @@ class ToolsCore
             case PS_ROUND_HALF_DOWN:
             case PS_ROUND_HALF_EVEN:
             case PS_ROUND_HALF_ODD:
-                return Tools::math_round($value, $precision, $round_mode);
             case PS_ROUND_HALF_UP:
             default:
-                return Tools::math_round($value, $precision, PS_ROUND_HALF_UP);
+            // PHP rounding mode is Prestashop rounding mode - 1, see config/defines.inc.php
+            $phpRoundingMode = $round_mode - 1;
+
+            return round($value, $precision, $phpRoundingMode);
         }
     }
 
     /**
+     * This method is a wrapper for PHP round method. It doesn't do much now, but it
+     * was needed in the past, because PHP did not support rounding modes like it does
+     * not. There was a huge logic here.
+     *
+     * Warning - this method accepts our own PS rounding methods with different integer values.
+     *
+     * @deprecated since 9.0.0 and will be removed in 10.0.0. Use ps_round or round directly.
+     *
      * @param int|float $value
      * @param int|float $places
      * @param int<2,5> $mode (PS_ROUND_HALF_UP|PS_ROUND_HALF_DOWN|PS_ROUND_HALF_EVEN|PS_ROUND_HALF_ODD)
@@ -1609,60 +1619,10 @@ class ToolsCore
      */
     public static function math_round($value, $places, $mode = PS_ROUND_HALF_UP)
     {
-        // If PHP_ROUND_HALF_UP exist (PHP 5.3) use it and pass correct mode value (PrestaShop define - 1)
-        if (defined('PHP_ROUND_HALF_UP')) {
-            return round($value, $places, $mode - 1);
-        }
+        // PHP rounding mode is Prestashop rounding mode - 1, see config/defines.inc.php
+        $phpRoundingMode = $mode - 1;
 
-        $precision_places = 14 - floor(log10(abs($value)));
-        $f1 = 10.0 ** (float) abs($places);
-
-        /* If the decimal precision guaranteed by FP arithmetic is higher than
-        * the requested places BUT is small enough to make sure a non-zero value
-        * is returned, pre-round the result to the precision */
-        if ($precision_places > $places && $precision_places - $places < 15) {
-            $f2 = 10.0 ** (float) abs($precision_places);
-
-            if ($precision_places >= 0) {
-                $tmp_value = $value * $f2;
-            } else {
-                $tmp_value = $value / $f2;
-            }
-
-            /* preround the result (tmp_value will always be something * 1e14,
-            * thus never larger than 1e15 here) */
-            $tmp_value = Tools::round_helper($tmp_value, $mode);
-            /* now correctly move the decimal point */
-            $f2 = 10.0 ** (float) abs($places - $precision_places);
-            /* because places < precision_places */
-            $tmp_value = $tmp_value / $f2;
-        } else {
-            /* adjust the value */
-            if ($places >= 0) {
-                $tmp_value = $value * $f1;
-            } else {
-                $tmp_value = $value / $f1;
-            }
-
-            /* This value is beyond our precision, so rounding it is pointless */
-            if (abs($tmp_value) >= 1e15) {
-                return $value;
-            }
-        }
-
-        /* round the temp value */
-        $tmp_value = Tools::round_helper($tmp_value, $mode);
-
-        /* see if it makes sense to use simple division to round the value */
-        if (abs($places) < 23) {
-            if ($places > 0) {
-                $tmp_value /= $f1;
-            } else {
-                $tmp_value *= $f1;
-            }
-        }
-
-        return $tmp_value;
+        return round($value, $places, $phpRoundingMode);
     }
 
     /**

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1572,6 +1572,7 @@ class ToolsCore
      *
      * @param float $value
      * @param int $precision
+     * @param int<0,5>|null $round_mode
      *
      * @return float
      */
@@ -1595,10 +1596,9 @@ class ToolsCore
             case PS_ROUND_HALF_ODD:
             case PS_ROUND_HALF_UP:
             default:
-            // PHP rounding mode is Prestashop rounding mode - 1, see config/defines.inc.php
-            $phpRoundingMode = $round_mode - 1;
-
-            return round($value, $precision, $phpRoundingMode);
+                // PHP rounding mode is Prestashop rounding mode - 1, see config/defines.inc.php
+                /* @phpstan-ignore-next-line */
+                return round($value, $precision, $round_mode - 1);
         }
     }
 

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -184,12 +184,18 @@ define('_PS_TRANS_PATTERN_', '(.*[^\\\\])');
 define('PS_TAX_EXC', 1);
 define('PS_TAX_INC', 0);
 
-/* Rounding */
+// Rounding
+// Note - since PHP 8.4, there is also a new rounding modes in round()
+// PHP_ROUND_CEILING, PHP_ROUND_FLOOR, PHP_ROUND_TOWARD_ZERO, PHP_ROUND_AWAY_FROM_ZERO
 define('PS_ROUND_UP', 0);
 define('PS_ROUND_DOWN', 1);
+// PHP value PHP_ROUND_HALF_UP is 1
 define('PS_ROUND_HALF_UP', 2);
+// PHP value PHP_ROUND_HALF_DOWN is 2
 define('PS_ROUND_HALF_DOWN', 3);
+// PHP value PHP_ROUND_HALF_EVEN is 3
 define('PS_ROUND_HALF_EVEN', 4);
+// PHP value PHP_ROUND_HALF_ODD is 4
 define('PS_ROUND_HALF_ODD', 5);
 
 /* SQL Replication management */

--- a/src/Adapter/Tools.php
+++ b/src/Adapter/Tools.php
@@ -113,9 +113,9 @@ class Tools
     }
 
     /**
-     * returns the rounded value of $value to specified precision, according to your configuration;.
+     * Returns the rounded value of $value to specified precision, according to your configuration.
      *
-     * @note : PHP 5.3.0 introduce a 3rd parameter mode in round function
+     * Warning - this method accepts our own PS rounding constants with different integer values.
      *
      * @param float $value
      * @param int $precision

--- a/tests/Unit/Classes/ToolsTest.php
+++ b/tests/Unit/Classes/ToolsTest.php
@@ -479,6 +479,9 @@ class ToolsTest extends TestCase
     public function testPsRound(float $expectedResult, float $value, int $precision, int $mode): void
     {
         $this->assertSame($expectedResult, Tools::ps_round($value, $precision, $mode));
+
+        // This method is deprecated and will be removed in 10.0.0, we just keep the tests to avoid regressions
+        $this->assertSame($expectedResult, Tools::math_round($value, $precision, $mode));
     }
 
     public function providerFloorF(): array

--- a/tests/Unit/Classes/ToolsTest.php
+++ b/tests/Unit/Classes/ToolsTest.php
@@ -441,11 +441,13 @@ class ToolsTest extends TestCase
         $this->assertSame($expectedResult, Tools::round_helper($value, $mode));
     }
 
-    public function providerMathRound(): array
+    public function providerPsRound(): array
     {
         return [
             // 0 precision
-            [25, 25.32, 0, self::PS_ROUND_UP],
+            [25, 25.32, 0, self::PS_ROUND_DOWN],
+            [25, 25.52, 0, self::PS_ROUND_DOWN],
+            [26, 25.32, 0, self::PS_ROUND_UP],
             [26, 25.52, 0, self::PS_ROUND_UP],
             [25, 25.32, 0, self::PS_ROUND_HALF_DOWN],
             [25, 25.50, 0, self::PS_ROUND_HALF_DOWN],
@@ -456,7 +458,9 @@ class ToolsTest extends TestCase
             [26, 25.51, 0, self::PS_ROUND_HALF_ODD],
             [25, 25.49, 0, self::PS_ROUND_HALF_ODD],
             // 2 precision
-            [25.32, 25.321, 2, self::PS_ROUND_UP],
+            [25.32, 25.321, 2, self::PS_ROUND_DOWN],
+            [25.52, 25.525, 2, self::PS_ROUND_DOWN],
+            [25.33, 25.321, 2, self::PS_ROUND_UP],
             [25.53, 25.525, 2, self::PS_ROUND_UP],
             [25.32, 25.325, 2, self::PS_ROUND_HALF_DOWN],
             [25.5, 25.505, 2, self::PS_ROUND_HALF_DOWN],
@@ -470,11 +474,11 @@ class ToolsTest extends TestCase
     }
 
     /**
-     * @dataProvider providerMathRound
+     * @dataProvider providerPsRound
      */
-    public function testMathRound(float $expectedResult, float $value, int $precision, int $mode): void
+    public function testPsRound(float $expectedResult, float $value, int $precision, int $mode): void
     {
-        $this->assertSame($expectedResult, Tools::math_round($value, $precision, $mode));
+        $this->assertSame($expectedResult, Tools::ps_round($value, $precision, $mode));
     }
 
     public function providerFloorF(): array


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | See below
| Type?             | refacto
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     | yes
| How to test?      | Auto test
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/11991260303
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Description
- When testing with PHP 8.4, I discovered two issues regarding rounding.
  - `[25, 25.32, 0, self::PS_ROUND_UP]`, is not 25, but 26.
  - `PS_ROUND_UP` and `PS_ROUND_DOWN` sent to `math_round` is not supported for two reasons.
    -  We are using different integers as the constant and it resulted in a nonsense sent there.
    - Up to 8.3, php round cannot ceil or floor.
  - There is a huge pile of PHP 5 related code that was never executed.

### Changes
- Change the test to actually test the ps_round function.
- Added some more test cases, fixed the ones present.
- Deprecated (now) useless math_round and used PHP round instead.