### PR TITLE
Clean productcontroller initcontent

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5525,7 +5525,6 @@ class ProductCore extends ObjectModel
         // Pack management
         $row['pack'] = (!isset($row['cache_is_pack']) ? Pack::isPack($row['id_product']) : (int) $row['cache_is_pack']);
         $row['packItems'] = $row['pack'] ? Pack::getItemTable($row['id_product'], $id_lang) : [];
-        $row['nopackprice'] = $row['pack'] ? Pack::noPackPrice($row['id_product']) : 0;
 
         if (!isset($row['attributes'])) {
             $attributes = Product::getAttributesParams($row['id_product'], $row['id_product_attribute']);

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -315,7 +315,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function initContent(): void
     {
         if (!$this->errors) {
-            $this->product->description = $this->transformDescriptionWithImg($this->product->description);
 
             $priceDisplay = Product::getTaxCalculationMethod((int) $this->context->cookie->id_customer);
             $productPrice = 0;
@@ -1191,6 +1190,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $extraContentFinder = new ProductExtraContentFinder();
 
         $product = $this->objectPresenter->present($this->product);
+        $product['description'] = $this->transformDescriptionWithImg($this->product->description);
         $product['out_of_stock'] = (int) $this->product->out_of_stock;
         $product['id_product_attribute'] = $this->getIdProductAttributeByGroupOrRequestOrDefault();
         $product['minimal_quantity'] = $this->getProductMinimalQuantity($product);

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -315,19 +315,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function initContent(): void
     {
         if (!$this->errors) {
-
-            $priceDisplay = Product::getTaxCalculationMethod((int) $this->context->cookie->id_customer);
-            $productPrice = 0;
-            $productPriceWithoutReduction = 0;
-
-            if (!$priceDisplay || $priceDisplay == 2) {
-                $productPrice = $this->product->getPrice(true, null, 6);
-                $productPriceWithoutReduction = $this->product->getPriceWithoutReduct(false, null);
-            } elseif ($priceDisplay == 1) {
-                $productPrice = $this->product->getPrice(false, null, 6);
-                $productPriceWithoutReduction = $this->product->getPriceWithoutReduct(true, null);
-            }
-
             // Assign template vars related to the category + execute hooks related to the category
             $this->assignCategory();
 
@@ -343,53 +330,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             // Add notification about this product being in cart
             $this->addCartQuantityNotification();
 
-            // Prepare product presenter for related items like packs and accessories
-            $assembler = new ProductAssembler($this->context);
-            $presenter = new ProductListingPresenter(
-                new ImageRetriever(
-                    $this->context->link
-                ),
-                $this->context->link,
-                new PriceFormatter(),
-                new ProductColorsRetriever(),
-                $this->getTranslator()
-            );
-            $presentationSettings = $this->getProductPresentationSettings();
-
-            // Presenting pack items
-            $pack_items = Pack::isPack($this->product->id) ? Pack::getItemTable($this->product->id, $this->context->language->id, true) : [];
-            $pack_items = $assembler->assembleProducts($pack_items);
-            $presentedPackItems = [];
-            foreach ($pack_items as $item) {
-                $presentedPackItems[] = $presenter->present(
-                    $this->getProductPresentationSettings(),
-                    $item,
-                    $this->context->language
-                );
-            }
-
-            $this->context->smarty->assign('packItems', $presentedPackItems);
-            $this->context->smarty->assign('noPackPrice', $this->product->getNoPackPrice());
-            $this->context->smarty->assign('displayPackPrice', $pack_items && $productPrice < Pack::noPackPrice((int) $this->product->id));
-            $this->context->smarty->assign('priceDisplay', $priceDisplay);
-
-            // Variable containing information about a pack that this product belongs to
-            $this->context->smarty->assign('packs', Pack::getPacksTable($this->product->id, $this->context->language->id, true, 1));
-
-            // Assign accessories
-            $accessories = $this->product->getAccessories($this->context->language->id);
-            if (is_array($accessories)) {
-                $accessories = $assembler->assembleProducts($accessories);
-                foreach ($accessories as &$accessory) {
-                    $accessory = $presenter->present(
-                        $presentationSettings,
-                        $accessory,
-                        $this->context->language
-                    );
-                }
-                unset($accessory);
-            }
-
+            // Get our product itself
+            // At this phase, it's already a presented lazy array, ready to go
             $product_for_template = $this->getTemplateVarProduct();
 
             // Chained hook call - if multiple modules are hooked here, they will receive the result of the previous one as a parameter
@@ -407,13 +349,64 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 $product_for_template = $filteredProduct['object'];
             }
 
+            // Prepare product presenter for related items like packs and accessories
+            $assembler = new ProductAssembler($this->context);
+            $presenter = new ProductListingPresenter(
+                new ImageRetriever(
+                    $this->context->link
+                ),
+                $this->context->link,
+                new PriceFormatter(),
+                new ProductColorsRetriever(),
+                $this->getTranslator()
+            );
+            $presentationSettings = $this->getProductPresentationSettings();
+
+            // Presenting pack items
+            $pack_items = $product_for_template['pack'] ? $product_for_template['packItems'] : [];
+            $pack_items = $assembler->assembleProducts($pack_items);
+            $presentedPackItems = [];
+            foreach ($pack_items as $item) {
+                $presentedPackItems[] = $presenter->present(
+                    $presentationSettings,
+                    $item,
+                    $this->context->language
+                );
+            }
+
+            // Assign accessories
+            $accessories = $this->product->getAccessories($this->context->language->id);
+            if (is_array($accessories)) {
+                $accessories = $assembler->assembleProducts($accessories);
+                foreach ($accessories as &$accessory) {
+                    $accessory = $presenter->present(
+                        $presentationSettings,
+                        $accessory,
+                        $this->context->language
+                    );
+                }
+                unset($accessory);
+            }
+
+            // Assign everything to the template
             $this->context->smarty->assign([
-                'priceDisplay' => $priceDisplay,
-                'productPriceWithoutReduction' => $productPriceWithoutReduction,
-                'id_customization' => empty($product_for_template['id_customization']) ? null : $product_for_template['id_customization'],
-                'accessories' => $accessories,
                 'product' => $product_for_template,
+                // How to display prices, tax or no tax?
+                'priceDisplay' => Product::getTaxCalculationMethod((int) $this->context->cookie->id_customer),
+                // If product is customized but not added to cart, ID of the customization
+                'id_customization' => empty($product_for_template['id_customization']) ? null : $product_for_template['id_customization'],
+                // Related products
+                'accessories' => $accessories,
+                // Should price per unit be displayed?
                 'displayUnitPrice' => !empty($product_for_template['unit_price_tax_excluded']),
+                // If product is a pack, pack contents
+                'packItems' => $presentedPackItems,
+                // Price of the product if it wasn't in the pack (should be migrated to lazy array)
+                'noPackPrice' => $product_for_template['nopackprice_to_display'],
+                // Should display the price of product if it wasn't in the pack?
+                'displayPackPrice' => !empty($product_for_template['pack']) && $product_for_template['price_amount'] < $product_for_template['nopackprice'],
+                // Variable containing information about a pack that this product belongs to
+                'packs' => Pack::getPacksTable($this->product->id, $this->context->language->id, true, 1),
             ]);
 
             // Assign attribute groups to the template
@@ -1221,15 +1214,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product_full['customer_group_discount'] = $group_reduction;
         $product_full['title'] = $this->getProductPageTitle();
 
-        // round display price (without formatting, we don't want the currency symbol here, just the raw rounded value
-        $product_full['rounded_display_price'] = Tools::ps_round(
-            $product_full['price'],
-            Context::getContext()->currency->precision
-        );
-
-        $presenter = $this->getProductPresenter();
-
-        return $presenter->present(
+        return $this->getProductPresenter()->present(
             $productSettings,
             $product_full,
             $this->context->language

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -35,6 +35,7 @@ use Db;
 use Language;
 use Link;
 use Manufacturer;
+use Pack;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\Decimal\Operation\Rounding;
 use PrestaShop\PrestaShop\Adapter\Configuration;
@@ -949,6 +950,28 @@ class ProductLazyArray extends AbstractLazyArray
             $this->product['unit_price'] = '';
             $this->product['unit_price_full'] = '';
         }
+
+        // Assign no-pack prices in case of products that are packs
+        if ($this->product['pack']) {
+            $rawNoPackPrice = Pack::noPackPrice((int) $this->product['id_product']);
+            $this->product['nopackprice'] = $rawNoPackPrice;
+            $this->product['nopackprice_to_display'] = $this->priceFormatter->format($rawNoPackPrice);
+        } else {
+            $this->product['nopackprice'] = null;
+            $this->product['nopackprice_to_display'] = null;
+        }
+    }
+
+    /**
+     * @return float
+     */
+    #[LazyArrayAttribute(arrayAccess: true)]
+    public function getRoundedDisplayPrice()
+    {
+        return Tools::ps_round(
+            $this->product['price_amount'],
+            Context::getContext()->currency->precision
+        );
     }
 
     /**

--- a/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
+++ b/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
@@ -83,6 +83,7 @@ class ProductLazyArrayTest extends TestCase
      * @var array
      */
     private $baseProduct = [
+        'id_product' => 0,
         'id_product_attribute' => 0,
         'price_tax_exc' => 0,
         'specific_prices' => 0,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | See below. This is another part of https://github.com/PrestaShop/PrestaShop/pull/36684 extracted out. It completely cleans `ProductController::initContent` out of any price calculations, towards cleaner future.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | yes - but only one unused variable.
| Deprecations?     | no
| How to test?      | Auto test, see if packs work normally.
| UI Tests          | 🟢 https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/11990807342
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Changes
- `$this->transformDescriptionWithImg` moved to `getTemplateVarProduct`, so it's now called also for ajax calls. It belongs there better and maybe could fix an issue nobody noticed.
- `Pack::isPack($this->product->id) ? Pack::getItemTable($this->product->id, $this->context->language->id, true) : [];` is now not needed, we can fetch the pack products from our presented product, no need to call it again. That's why I moved the product code part few blocks to the top.
- `'noPackPrice' => $product_for_template['nopackprice_to_display'],` is now assigned in the lazy array.
- `'displayPackPrice' => !empty($product_for_template['pack']) && $product_for_template['price_amount'] < $product_for_template['nopackprice'],` is now using data we already have from lazy array, no need to call anything again.
- `$product_full['rounded_display_price']` moved to lazy array.

### Performance
- It can bring some performance benefit, because I saved
  - One `getPrice` call,
  - One `getPriceWithoutReduct` call
  - One `Pack::isPack` call
  - One `Pack::getItemTable` call
  - One `Pack::noPackPrice` call.
- It doesn't bring any performance regression for `nopackprice`, even if somebody dumps the whole lazy array, because we assigned it in `Product::getProductProperties` all the time anyway.

### BC breaks
- Removed unused template variable `productPriceWithoutReduction`