### PR TITLE
Do not wipe cart cache for nothing, simplify checking minimal value

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1493,13 +1493,15 @@ class CartCore extends ObjectModel
             die(Tools::displayError(sprintf('Product with ID "%s" could not be loaded.', $id_product)));
         }
 
+        // Wipe all product-related caches, because something will probably change
         if (isset(self::$_nbProducts[$this->id])) {
             unset(self::$_nbProducts[$this->id]);
         }
-
         if (isset(self::$_totalWeight[$this->id])) {
             unset(self::$_totalWeight[$this->id]);
         }
+        $this->_products = null;
+        $this->_products_with_separated_gifts = null;
 
         $data = [
             'cart' => $this,
@@ -1767,13 +1769,15 @@ class CartCore extends ObjectModel
         bool $preserveGiftsRemoval = true,
         bool $useOrderPrices = false
     ) {
+        // Wipe all product-related caches, because something will probably change
         if (isset(self::$_nbProducts[$this->id])) {
             unset(self::$_nbProducts[$this->id]);
         }
-
         if (isset(self::$_totalWeight[$this->id])) {
             unset(self::$_totalWeight[$this->id]);
         }
+        $this->_products = null;
+        $this->_products_with_separated_gifts = null;
 
         // First, if we are deleting a product with customization, we delete it from the database
         if ((int) $id_customization) {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -252,6 +252,18 @@ class CartCore extends ObjectModel
         static::$cacheMultiAddressDelivery = [];
     }
 
+    public function resetProductRelatedStaticCache()
+    {
+        if (isset(self::$_nbProducts[$this->id])) {
+            unset(self::$_nbProducts[$this->id]);
+        }
+        if (isset(self::$_totalWeight[$this->id])) {
+            unset(self::$_totalWeight[$this->id]);
+        }
+        $this->_products = null;
+        $this->_products_with_separated_gifts = null;
+    }
+
     /**
      * Set Tax calculation method.
      */
@@ -302,14 +314,7 @@ class CartCore extends ObjectModel
     public function update($nullValues = false)
     {
         // Wipe all product-related caches, because something may just change
-        if (isset(self::$_nbProducts[$this->id])) {
-            unset(self::$_nbProducts[$this->id]);
-        }
-        if (isset(self::$_totalWeight[$this->id])) {
-            unset(self::$_totalWeight[$this->id]);
-        }
-        $this->_products = null;
-        $this->_products_with_separated_gifts = null;
+        $this->resetProductRelatedStaticCache();
 
         $return = parent::update($nullValues);
         Hook::exec('actionCartSave', ['cart' => $this]);
@@ -1493,15 +1498,7 @@ class CartCore extends ObjectModel
             die(Tools::displayError(sprintf('Product with ID "%s" could not be loaded.', $id_product)));
         }
 
-        // Wipe all product-related caches, because something will probably change
-        if (isset(self::$_nbProducts[$this->id])) {
-            unset(self::$_nbProducts[$this->id]);
-        }
-        if (isset(self::$_totalWeight[$this->id])) {
-            unset(self::$_totalWeight[$this->id]);
-        }
-        $this->_products = null;
-        $this->_products_with_separated_gifts = null;
+        $this->resetProductRelatedStaticCache();
 
         $data = [
             'cart' => $this,
@@ -1769,15 +1766,7 @@ class CartCore extends ObjectModel
         bool $preserveGiftsRemoval = true,
         bool $useOrderPrices = false
     ) {
-        // Wipe all product-related caches, because something will probably change
-        if (isset(self::$_nbProducts[$this->id])) {
-            unset(self::$_nbProducts[$this->id]);
-        }
-        if (isset(self::$_totalWeight[$this->id])) {
-            unset(self::$_totalWeight[$this->id]);
-        }
-        $this->_products = null;
-        $this->_products_with_separated_gifts = null;
+        $this->resetProductRelatedStaticCache();
 
         // First, if we are deleting a product with customization, we delete it from the database
         if ((int) $id_customization) {
@@ -1812,6 +1801,7 @@ class CartCore extends ObjectModel
             // so they remain. We must specifically target the product ID, combination ID and customization ID.
             // If we didn't use these conditions, we would set all cart rows with this product ID to $preservedGifts[$giftKey].
             if (isset($preservedGifts[$giftKey]) && $preservedGifts[$giftKey] > 0) {
+                $this->resetProductRelatedStaticCache();
                 return Db::getInstance()->execute(
                     'UPDATE `' . _DB_PREFIX_ . 'cart_product`
                     SET `quantity` = ' . (int) $preservedGifts[$giftKey] . '
@@ -1824,6 +1814,7 @@ class CartCore extends ObjectModel
         }
 
         /* Product deletion */
+        $this->resetProductRelatedStaticCache();
         $result = Db::getInstance()->execute('
         DELETE FROM `' . _DB_PREFIX_ . 'cart_product`
         WHERE `id_product` = ' . (int) $id_product . '

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -104,6 +104,7 @@ class CartCore extends ObjectModel
     protected static $_isVirtualCart = [];
 
     protected $_products = null;
+    protected $_products_with_separated_gifts = null;
     protected static $_totalWeight = [];
     protected $_taxCalculationMethod = PS_TAX_EXC;
     protected static $_carriers = null;
@@ -191,6 +192,7 @@ class CartCore extends ObjectModel
     public const ONLY_SHIPPING = 5;
     public const ONLY_WRAPPING = 6;
     public const ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING = 8;
+    public const ONLY_PRODUCTS_WITHOUT_GIFTS = 9;
 
     private const DEFAULT_ATTRIBUTES_KEYS = ['attributes' => '', 'attributes_small' => ''];
 
@@ -304,6 +306,7 @@ class CartCore extends ObjectModel
             unset(self::$_totalWeight[$this->id]);
         }
         $this->_products = null;
+        $this->_products_with_separated_gifts = null;
 
         $return = parent::update($nullValues);
         Hook::exec('actionCartSave', ['cart' => $this]);
@@ -625,11 +628,19 @@ class CartCore extends ObjectModel
         if (!$this->id) {
             return [];
         }
+
+        // Get cache key we will use
+        if ($this->shouldSplitGiftProductsQuantity) {
+            $cacheKey = '_products_with_separated_gifts';
+        } else {
+            $cacheKey = '_products';
+        }
+
         // Product cache must be strictly compared to NULL, or else an empty cart will add dozens of queries
-        if ($this->_products !== null && !$refresh) {
+        if ($this->{$cacheKey} !== null && !$refresh) {
             // Return product row with specified ID if it exists
             if (is_int($id_product)) {
-                foreach ($this->_products as $product) {
+                foreach ($this->{$cacheKey} as $product) {
                     if ($product['id_product'] == $id_product) {
                         return [$product];
                     }
@@ -638,7 +649,7 @@ class CartCore extends ObjectModel
                 return [];
             }
 
-            return $this->_products;
+            return $this->{$cacheKey};
         }
 
         // Build query
@@ -767,7 +778,7 @@ class CartCore extends ObjectModel
         Cart::cacheSomeAttributesLists($pa_ids, (int) $this->getAssociatedLanguage()->getId());
 
         if (empty($products)) {
-            $this->_products = [];
+            $this->{$cacheKey} = [];
 
             return [];
         }
@@ -806,7 +817,7 @@ class CartCore extends ObjectModel
                 }
             }
 
-            $this->_products = [];
+            $this->{$cacheKey} = [];
 
             foreach ($products as &$product) {
                 if (!array_key_exists('is_gift', $product)) {
@@ -834,7 +845,7 @@ class CartCore extends ObjectModel
                     $product = $this->applyProductCalculations($product, $cart_shop_context, null, $keepOrderPrices);
                 } else {
                     // Separate products given away from those manually added to cart
-                    $this->_products[] = $this->applyProductCalculations($product, $cart_shop_context, $givenAwayQuantity, $keepOrderPrices);
+                    $this->{$cacheKey}[] = $this->applyProductCalculations($product, $cart_shop_context, $givenAwayQuantity, $keepOrderPrices);
                     unset($product['is_gift']);
                     $product = $this->applyProductCalculations(
                         $product,
@@ -844,13 +855,13 @@ class CartCore extends ObjectModel
                     );
                 }
 
-                $this->_products[] = $product;
+                $this->{$cacheKey}[] = $product;
             }
         } else {
-            $this->_products = $products;
+            $this->{$cacheKey} = $products;
         }
 
-        return $this->_products;
+        return $this->{$cacheKey};
     }
 
     /**
@@ -1922,6 +1933,7 @@ class CartCore extends ObjectModel
      *                  - BOTH_WITHOUT_SHIPPING
      *                  - ONLY_SHIPPING
      *                  - ONLY_WRAPPING
+     *                  - ONLY_PRODUCTS_WITHOUT_GIFTS
      *
      * @return string Formatted amount in Cart
      */
@@ -1966,6 +1978,7 @@ class CartCore extends ObjectModel
      *                  - Cart::ONLY_SHIPPING
      *                  - Cart::ONLY_WRAPPING
      *                  - Cart::ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING
+     *                  - Cart::ONLY_PRODUCTS_WITHOUT_GIFTS
      * @param array $products
      * @param int $id_carrier
      * @param bool $use_cache @deprecated
@@ -1997,6 +2010,7 @@ class CartCore extends ObjectModel
             Cart::ONLY_SHIPPING,
             Cart::ONLY_WRAPPING,
             Cart::ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING,
+            Cart::ONLY_PRODUCTS_WITHOUT_GIFTS,
         ];
         if (!in_array($type, $allowedTypes)) {
             throw new Exception('Invalid calculation type: ' . $type);
@@ -2019,7 +2033,13 @@ class CartCore extends ObjectModel
 
         // filter products
         if (null === $products) {
-            $products = $this->getProducts(false, false, null, true, $keepOrderPrices);
+            if ($type == Cart::ONLY_PRODUCTS_WITHOUT_GIFTS) {
+                $this->splitGiftsProductsQuantity();
+                $products = $this->getProducts(false, false, null, true, $keepOrderPrices);
+                $this->mergeGiftsProductsQuantity();
+            } else {
+                $products = $this->getProducts(false, false, null, true, $keepOrderPrices);
+            }
         }
 
         if ($type == Cart::ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING) {
@@ -2028,10 +2048,9 @@ class CartCore extends ObjectModel
                     unset($products[$key]);
                 }
             }
-            $type = Cart::ONLY_PRODUCTS;
         }
 
-        if ($type == Cart::ONLY_PRODUCTS) {
+        if ($type == Cart::ONLY_PRODUCTS_WITHOUT_GIFTS) {
             foreach ($products as $key => $product) {
                 if (!empty($product['is_gift'])) {
                     unset($products[$key]);
@@ -2075,6 +2094,8 @@ class CartCore extends ObjectModel
                 $calculator->calculateCartRulesWithoutFreeShipping();
                 $amount = $calculator->getTotal(true);
                 break;
+            case Cart::ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING:
+            case Cart::ONLY_PRODUCTS_WITHOUT_GIFTS:
             case Cart::ONLY_PRODUCTS:
                 $calculator->calculateRows();
                 $amount = $calculator->getRowTotal();
@@ -2171,11 +2192,7 @@ class CartCore extends ObjectModel
      */
     public function getDiscountSubtotalWithoutGifts($withTaxes = true)
     {
-        $discountSubtotal = $this->excludeGiftsDiscountFromTotal()
-            ->getOrderTotal($withTaxes, self::ONLY_DISCOUNTS);
-        $this->includeGiftsDiscountInTotal();
-
-        return $discountSubtotal;
+        return $this->getOrderTotal($withTaxes, self::ONLY_DISCOUNTS);
     }
 
     /**
@@ -4607,7 +4624,6 @@ class CartCore extends ObjectModel
     protected function splitGiftsProductsQuantity()
     {
         $this->shouldSplitGiftProductsQuantity = true;
-        $this->_products = null;
 
         return $this;
     }
@@ -4618,23 +4634,6 @@ class CartCore extends ObjectModel
     protected function mergeGiftsProductsQuantity()
     {
         $this->shouldSplitGiftProductsQuantity = false;
-        $this->_products = null;
-
-        return $this;
-    }
-
-    protected function excludeGiftsDiscountFromTotal()
-    {
-        $this->shouldExcludeGiftsDiscount = true;
-        $this->_products = null;
-
-        return $this;
-    }
-
-    protected function includeGiftsDiscountInTotal()
-    {
-        $this->shouldExcludeGiftsDiscount = false;
-        $this->_products = null;
 
         return $this;
     }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4649,7 +4649,7 @@ class CartCore extends ObjectModel
     public function getProductsWithSeparatedGifts()
     {
         $products = $this->splitGiftsProductsQuantity()
-            ->getProducts($refresh = true);
+            ->getProducts();
         $this->mergeGiftsProductsQuantity();
 
         return $products;

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -183,6 +183,9 @@ class CartCore extends ObjectModel
 
     protected $shouldSplitGiftProductsQuantity = false;
 
+    /**
+     * @deprecated since 9.0.0 - it doesn't do anything and will be removed
+     */
     protected $shouldExcludeGiftsDiscount = false;
 
     public const ONLY_PRODUCTS = 1;

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -901,7 +901,7 @@ class CartRuleCore extends ObjectModel
             // Let's get the full cart total first, add shipping price if the rule was configured like this.
             $cartTotal = $cart->getOrderTotal(
                 $this->minimum_amount_tax,
-                Cart::ONLY_PRODUCTS,
+                Cart::ONLY_PRODUCTS_WITHOUT_GIFTS,
                 null,
                 null,
                 false,
@@ -918,31 +918,7 @@ class CartRuleCore extends ObjectModel
                 );
             }
 
-            /*
-             * Now, we will reduce the cart total by all already applied gifts in the cart.
-             *
-             * This is big magic happening here, because it's subtracting the gifts from the cart total one by one, by matching it.
-             *
-             * It would be much better if $cart->getOrderTotal returned the total without the gifts, which it should actually do by the way.
-             * Check inside of that method, if 'is_gift' is not empty, it should skip that product.
-             * But, that would require calling getProducts inside that method with $cart->shouldSplitGiftProductsQuantity enabled.
-             * But, if that started to work, it would mess up all places in the code, where it expects Cart::ONLY_PRODUCTS to include gifts.
-             *
-             * A solution would be to create Cart::ONLY_PRODUCTS_WITHOUT_GIFTS, that we could use here.
-             */
-            $products = $cart->getProducts();
-            $cart_rules = $cart->getCartRules(CartRule::FILTER_ACTION_ALL, false);
-
-            foreach ($cart_rules as $cart_rule) {
-                if ($cart_rule['gift_product']) {
-                    foreach ($products as $key => &$product) {
-                        if (empty($product['is_gift']) && $product['id_product'] == $cart_rule['gift_product'] && $product['id_product_attribute'] == $cart_rule['gift_product_attribute'] && empty($product['id_customization'])) {
-                            $cartTotal = Tools::ps_round($cartTotal - $product[$this->minimum_amount_tax ? 'price_wt' : 'price'], (int) $context->currency->decimals * Context::getContext()->getComputingPrecision());
-                        }
-                    }
-                }
-            }
-
+            // And check if the cart meets our requirements
             if ($cartTotal < $minimum_amount) {
                 return (!$display_error) ? false : $this->trans('The minimum amount to benefit from this promo code is %s.', [Tools::getContextLocale($context)->formatPrice($minimum_amount, $context->currency->iso_code)], 'Shop.Notifications.Error');
             }

--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -107,7 +107,7 @@ class CartLazyArray extends AbstractLazyArray
         if ($this->shouldSeparateGifts) {
             $rawProducts = $this->cart->getProductsWithSeparatedGifts();
         } else {
-            $rawProducts = $this->cart->getProducts(true);
+            $rawProducts = $this->cart->getProducts();
         }
 
         /*

--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -169,7 +169,7 @@ class CartLazyArray extends AbstractLazyArray
     {
         $subtotals = [];
         $totalCartAmount = $this->cart->getOrderTotal($this->cartPresenter->includeTaxes(), Cart::ONLY_PRODUCTS);
-        $total_discount = $this->cart->getDiscountSubtotalWithoutGifts($this->cartPresenter->includeTaxes());
+        $total_discount = $this->cart->getOrderTotal($this->cartPresenter->includeTaxes(), Cart::ONLY_DISCOUNTS);
         $subtotals['products'] = [
             'type' => 'products',
             'label' => $this->translator->trans('Subtotal', [], 'Shop.Theme.Checkout'),


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | See below. There is usuall a huge amount of duplicated queries that are cached, but wiped for no reason. I already optimized this in my previous PR, this is another result of evening boredom. Will speed up rendering the cart.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Automatic test + verification of queries
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Change 1 - caching both types of getProducts calls
- Cart class is caching result of `getProducts` method to a `_products` static variable, so it does not have to load everything again and again.
- But, when doing this with separated gifts via `getProductsWithSeparatedGifts` method, it always resets this cache in `splitGiftsProductsQuantity`, for nothing.
- So you once call it normally, once with separated, once normally, once separated. So maybe if you are lucky, it's getting cached only a few times.
- So, I made a new cache key that will cache both types of response, so once you call it, it's cached. Until the cart is updated, if it is.

### Change 2 - much simplier checking of minimal cart rule value, potentially cached also
- When I was last working with CartRule class and commenting/fixing something, I commented the huge magic that was there.
- It took total products value and subtracted gifts from it one by one, matching it by id product or combination ID. A big place for random errors, rounding issues, not a good code.
- So I checked the whole logic of cart and found out that `ONLY_PRODUCTS`, should actually return the products without gifts, but it never worked.
- So, in order to avoid a BC break, I just left it that way and added a new way called `ONLY_PRODUCTS_WITHOUT_GIFTS`.
- It does what you want it to do. getOrderTotal with `ONLY_PRODUCTS` returns the product total for everything, getOrderTotal with `ONLY_PRODUCTS_WITHOUT_GIFTS` returns it without gifts.
- So I used this value in the CartRule class and I could delete the whole mess that was there.

### Change 3 - tiny call change for total discounts
- In CartLazyArray, there was a call to `getDiscountSubtotalWithoutGifts`, which is just a wrapper for `$cart->getOrderTotal($taxesYesNo, Cart::ONLY_DISCOUNTS),` so I called it directly.
- This allowed me to get rid of the useless cache wiping in `excludeGiftsDiscountFromTotal` and `includeGiftsDiscountInTotal`

### Change 4 - getting rid of forced refresh
- There is no need to call `getProducts` with forced refresh in `CartLazyArray`.
- There is no need to call `getProducts` with forced refresh in `getProductsWithSeparatedGifts`.

### Change 5 - make sure that all escape returns from update methods are covered
- After removing all the unnecessary cache wiping, tests failed in one case, because my changes discovered a bug.
- In `Cart::deleteProduct` method, there is a return near `if (isset($preservedGifts[$giftKey]) && $preservedGifts[$giftKey] > 0) {`, which doesn't update the cache for the remainder of the request, or until someone hard refreshes it. The only reason it worked was because there was a refresh on all the `getProducts` calls the test seen.

### Performance gain
- On our store, testing on cart page, it removed all of those duplicate huge queries.
- From 666 to 658 queries and load time from 275 to 255 ms.