### PR TITLE
Do not reset some cart fields

### DIFF
--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -544,11 +544,8 @@ class CartLazyArray extends AbstractLazyArray
             'ecotax_rate',
             'specific_prices',
             'customizable',
-            'online_only',
             'reduction',
             'reduction_without_tax',
-            'new',
-            'condition',
             'pack',
         ];
         foreach ($resetFields as $field) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | There is no need to remove this information from cart products. This is, for example, making it harder to log if a product was new during order creation.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | TODO
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 