### PR TITLE
SEO delete category in URL product scheme during installation

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -118,7 +118,7 @@ class DispatcherCore
         ],
         'product_rule' => [
             'controller' => 'product',
-            'rule' => '{category:/}{id}{-:id_product_attribute}-{rewrite}{-:ean13}.html',
+            'rule' => '{id}{-:id_product_attribute}-{rewrite}{-:ean13}.html',
             'keywords' => [
                 'id' => ['regexp' => '[0-9]+', 'param' => 'id_product'],
                 'id_product_attribute' => ['regexp' => '[0-9]*+', 'param' => 'id_product_attribute'],

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -118,7 +118,7 @@ class DispatcherCore
         ],
         'product_rule' => [
             'controller' => 'product',
-            'rule' => '{id}{-:id_product_attribute}-{rewrite}{-:ean13}.html',
+            'rule' => '{id}{-:id_product_attribute}-{rewrite}.html',
             'keywords' => [
                 'id' => ['regexp' => '[0-9]+', 'param' => 'id_product'],
                 'id_product_attribute' => ['regexp' => '[0-9]*+', 'param' => 'id_product_attribute'],

--- a/tests/UI/campaigns/functional/FO/classic/08_menuAndNavigation/02_sortAndFilter/02_filterProducts.ts
+++ b/tests/UI/campaigns/functional/FO/classic/08_menuAndNavigation/02_sortAndFilter/02_filterProducts.ts
@@ -146,15 +146,6 @@ describe('FO - Menu and navigation : Filter products', async () => {
       expect(productsNumber).to.be.above(1);
     });
 
-    it('should check the products list', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkProductsList', baseContext);
-
-      for (let i = 1; i <= productsNumber; i++) {
-        const productURL = await foClassicCategoryPage.getProductHref(page, i);
-        expect(productURL).to.contain.oneOf(['accessories', 'art', 'stationery']);
-      }
-    });
-
     it('should clear all filters', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'clearAllFilters', baseContext);
 

--- a/tests/UI/campaigns/functional/FO/hummingbird/08_menuAndNavigation/02_sortAndFilter/02_filterProducts.ts
+++ b/tests/UI/campaigns/functional/FO/hummingbird/08_menuAndNavigation/02_sortAndFilter/02_filterProducts.ts
@@ -154,15 +154,6 @@ describe('FO - Menu and navigation : Filter products', async () => {
       expect(productsNumber).to.be.above(1);
     });
 
-    it('should check the products list', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkProductsList', baseContext);
-
-      for (let i = 1; i <= productsNumber; i++) {
-        const productURL = await foHummingbirdCategoryPage.getProductHref(page, i);
-        expect(productURL).to.contain.oneOf(['accessories', 'art', 'stationery']);
-      }
-    });
-
     it('should clear all filters', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'clearAllFilters', baseContext);
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Replace {category:/}{id}{-:id_product_attribute}-{rewrite}{-:ean13}.html by {id}{-:id_product_attribute}-{rewrite}{-:ean13}.html in product url sheme. Removal of category reference in product URLs during PrestaShop installation. This has no effect on PrestaShop updates. It simplifies product URLs, allowing you to simply add the category if you wish without any further action, and avoids the need to redirect old URLs including categories to 301 if the user wishes to remove this data.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| UI Tests | https://github.com/florine2623/testing_pr/actions/runs/12070989574 ✅ 
| How to test?      | This change modifies the structure of product URLs when PrestaShop is installed, and only when it's installed. It doesn't change anything when you upgrade, or at least it shouldn't modify the information when you upgrade.
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/37437
| Sponsor company   | Mediacom87.fr
