### PR TITLE
Make Twig accessible for modules inside hooks

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3461,6 +3461,12 @@ abstract class ModuleCore implements ModuleInterface
      */
     public function get($serviceName)
     {
+        if ($serviceName === 'twig' && method_exists($this->context->controller, 'getTwig')) {
+            trigger_deprecation('prestashop/prestashop', '9.0', 'Load Twig using $this->context->controller->getTwig().', 'getTwig');
+
+            return $this->context->controller->getTwig();
+        }
+
         try {
             $container = $this->getContainer();
         } catch (ContainerNotFoundException $e) {

--- a/src/Core/Context/LegacyControllerContext.php
+++ b/src/Core/Context/LegacyControllerContext.php
@@ -33,6 +33,7 @@ use Media;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Traversable;
+use Twig\Environment;
 
 /**
  * This class ensures compatibility with the context controller in pages migrated to Symfony.
@@ -107,6 +108,8 @@ class LegacyControllerContext
 
     protected array $languages = [];
 
+    public bool $multishop_context_group = true;
+
     /**
      * @param ContainerInterface $container Dependency container
      * @param string $controller_name Current controller name without suffix
@@ -135,9 +138,15 @@ class LegacyControllerContext
         protected readonly string $adminFolderName,
         protected readonly bool $isLanguageRTL,
         protected readonly string $psVersion,
+        protected readonly Environment $twig,
     ) {
         $this->php_self = $this->controller_name;
         $this->ajax = (bool) $this->request->get('ajax');
+    }
+
+    public function getTwig(): Environment
+    {
+        return $this->twig;
     }
 
     public function addCSS(array|string $css_uri, string $css_media_type = 'all', ?int $offset = null, bool $check_path = true): void

--- a/src/Core/Context/LegacyControllerContextBuilder.php
+++ b/src/Core/Context/LegacyControllerContextBuilder.php
@@ -37,6 +37,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Tools;
+use Twig\Environment;
 
 class LegacyControllerContextBuilder
 {
@@ -54,6 +55,7 @@ class LegacyControllerContextBuilder
         protected readonly LanguageContext $languageContext,
         protected readonly string $adminFolderName,
         protected string $psVersion,
+        protected readonly Environment $twig,
     ) {
     }
 
@@ -92,6 +94,7 @@ class LegacyControllerContextBuilder
             $this->adminFolderName,
             $this->languageContext->isRTL(),
             $this->psVersion,
+            $this->twig,
         );
     }
 

--- a/tests/Integration/Adapter/ContextStateManagerTest.php
+++ b/tests/Integration/Adapter/ContextStateManagerTest.php
@@ -34,6 +34,7 @@ use Shop;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\TestCase\ContextStateTestCase;
+use Twig\Environment;
 
 class ContextStateManagerTest extends ContextStateTestCase
 {
@@ -81,6 +82,7 @@ class ContextStateManagerTest extends ContextStateTestCase
             'admin-dev',
             false,
             '9.0.0',
+            $this->createMock(Environment::class),
         );
 
         $this->legacyControllerContext2 = new LegacyControllerContext(
@@ -100,6 +102,7 @@ class ContextStateManagerTest extends ContextStateTestCase
             'admin-dev',
             false,
             '9.0.0',
+            $this->createMock(Environment::class),
         );
     }
 

--- a/tests/TestCase/ContextStateTestCase.php
+++ b/tests/TestCase/ContextStateTestCase.php
@@ -42,6 +42,7 @@ use Shop;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\Integration\Utility\ContextMockerTrait;
+use Twig\Environment;
 
 abstract class ContextStateTestCase extends TestCase
 {
@@ -131,6 +132,7 @@ abstract class ContextStateTestCase extends TestCase
                 'admin-dev',
                 false,
                 '9.0.0',
+                $this->createMock(Environment::class),
             ])
         ;
 

--- a/tests/Unit/Core/Context/LegacyControllerContextBuilderTest.php
+++ b/tests/Unit/Core/Context/LegacyControllerContextBuilderTest.php
@@ -42,6 +42,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Tests\Unit\Core\Configuration\MockConfigurationTrait;
+use Twig\Environment;
 
 class LegacyControllerContextBuilderTest extends TestCase
 {
@@ -70,6 +71,7 @@ class LegacyControllerContextBuilderTest extends TestCase
             $this->createMock(LanguageContext::class),
             'admin-dev',
             '9.0.0',
+            $this->createMock(Environment::class),
         );
 
         $builder->setControllerName($controllerName);
@@ -210,6 +212,7 @@ class LegacyControllerContextBuilderTest extends TestCase
             $this->createMock(LanguageContext::class),
             'admin-dev',
             '9.0.0',
+            $this->createMock(Environment::class),
         );
 
         // We don't call setControllerName so the builder falls back on AdminNotFound

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextListenerTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextListenerTest.php
@@ -38,6 +38,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Tests\Unit\PrestaShopBundle\EventListener\ContextEventListenerTestCase;
+use Twig\Environment;
 
 class LegacyControllerContextListenerTest extends ContextEventListenerTestCase
 {
@@ -100,6 +101,7 @@ class LegacyControllerContextListenerTest extends ContextEventListenerTestCase
             $this->createMock(LanguageContext::class),
             'admin-dev',
             '9.0.0',
+            $this->createMock(Environment::class)
         );
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | It is not possible to access Twig inside back office display hooks using `$this->get('twig')`, this change aims to make Twig accessible explicitly without making it a public service - please note that it is a BC Break anyway, and I'm not sure if this is a better approach than making it global in general. I also added the missing `multishop_context_group` property, when missing, it breaks modules configuration page in multi-store context.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | yes
| How to test?      | To be tested by a dev, try to `$this->context->controller->getTwig()` in any back office display hook. I also added a fallback when using $this->get('twig') You can use the example module from this PR https://github.com/PrestaShop/example-modules/pull/194 (or from the main branch if it has been merged already), when the module is installed some additional blocks should be visible on the Order view page without exception triggered
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/12175474744
| Fixed issue or discussion?     | n/a
| Related PRs       | n/a
| Sponsor company   | PrestaShop SA

### Breaking Change

`ModuleCore::get` is now strictly typed `object|null` it doesn't return `false` anymore