### PR TITLE
Minor order page UX improvements

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -226,7 +226,10 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $this->getLinkedOrders($order),
             $this->addressFormatter->format(new AddressId((int) $order->id_address_delivery)),
             $this->addressFormatter->format(new AddressId((int) $order->id_address_invoice)),
-            (string) $order->note
+            (string) $order->note,
+            (string) $order->payment,
+            (string) $order->module,
+            (int) $order->id_cart
         );
     }
 

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -243,7 +243,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
         $currency = new Currency($order->id_currency);
         $customer = new Customer($order->id_customer);
         $genderName = '';
-        $totalSpentSinceRegistration = null;
+        $totalSpentSinceRegistration = 0;
 
         if (!Validate::isLoadedObject($customer)) {
             $customer = $this->buildFakeCustomerObject($order, $invoiceAddress);
@@ -290,7 +290,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $genderName,
             $customer->email,
             new DateTimeImmutable($customer->date_add ?? 'now'),
-            $totalSpentSinceRegistration !== null ? $this->locale->formatPrice($totalSpentSinceRegistration, $currency->iso_code) : '',
+            $this->locale->formatPrice((float) $totalSpentSinceRegistration, $currency->iso_code),
             $customerStats['nb_orders'],
             $customer->note,
             (bool) $customer->is_guest,

--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -230,7 +230,10 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                     null,
                     '',
                     $packItemType,
-                    (bool) Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($pack_item['id_product']))
+                    (bool) Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($pack_item['id_product'])),
+                    [],
+                    null,
+                    $pack_item['mpn']
                 );
             }
 
@@ -261,7 +264,8 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                 $productType,
                 (bool) Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($product['product_id'])),
                 $packItems,
-                $product['customizations']
+                $product['customizations'],
+                $product['product_mpn']
             );
         }
 

--- a/src/Core/Domain/Order/QueryResult/OrderForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderForViewing.php
@@ -39,6 +39,11 @@ class OrderForViewing
     private $orderId;
 
     /**
+     * @var int
+     */
+    private $cartId;
+
+    /**
      * @var OrderCustomerForViewing
      */
     private $customer;
@@ -198,6 +203,16 @@ class OrderForViewing
     private $note;
 
     /**
+     * @var string
+     */
+    private $paymentName;
+
+    /**
+     * @var string
+     */
+    private $paymentModule;
+
+    /**
      * @param int $orderId
      * @param int $currencyId
      * @param int $carrierId
@@ -231,6 +246,9 @@ class OrderForViewing
      * @param string $shippingAddressFormatted
      * @param string $invoiceAddressFormatted
      * @param string $note
+     * @param string $paymentName
+     * @param string $paymentModule
+     * @param int $cartId
      */
     public function __construct(
         int $orderId,
@@ -265,7 +283,10 @@ class OrderForViewing
         LinkedOrdersForViewing $linkedOrders,
         string $shippingAddressFormatted = '',
         string $invoiceAddressFormatted = '',
-        string $note = ''
+        string $note = '',
+        string $paymentName = '',
+        string $paymentModule = '',
+        int $cartId = 0
     ) {
         $this->reference = $reference;
         $this->customer = $customer;
@@ -300,6 +321,9 @@ class OrderForViewing
         $this->shippingAddressFormatted = $shippingAddressFormatted;
         $this->invoiceAddressFormatted = $invoiceAddressFormatted;
         $this->note = $note;
+        $this->paymentName = $paymentName;
+        $this->paymentModule = $paymentModule;
+        $this->cartId = $cartId;
     }
 
     /**
@@ -308,6 +332,14 @@ class OrderForViewing
     public function getId(): int
     {
         return $this->orderId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCartId(): int
+    {
+        return $this->cartId;
     }
 
     /**
@@ -584,5 +616,21 @@ class OrderForViewing
     public function getNote(): string
     {
         return $this->note;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPaymentName(): string
+    {
+        return $this->paymentName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPaymentModule(): string
+    {
+        return $this->paymentModule;
     }
 }

--- a/src/Core/Domain/Order/QueryResult/OrderProductForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderProductForViewing.php
@@ -160,6 +160,11 @@ class OrderProductForViewing implements JsonSerializable
     private $customizations;
 
     /**
+     * @var string
+     */
+    private $mpn;
+
+    /**
      * @param int $orderDetailId
      * @param int $id
      * @param int $combinationId
@@ -185,6 +190,7 @@ class OrderProductForViewing implements JsonSerializable
      * @param bool $availableOutOfStock
      * @param array $packItems
      * @param OrderProductCustomizationsForViewing|null $customizations
+     * @param string $mpn
      */
     public function __construct(
         ?int $orderDetailId,
@@ -211,7 +217,8 @@ class OrderProductForViewing implements JsonSerializable
         string $type,
         bool $availableOutOfStock,
         array $packItems = [],
-        ?OrderProductCustomizationsForViewing $customizations = null
+        ?OrderProductCustomizationsForViewing $customizations = null,
+        string $mpn = ''
     ) {
         $this->id = $id;
         $this->combinationId = $combinationId;
@@ -238,6 +245,7 @@ class OrderProductForViewing implements JsonSerializable
         $this->availableOutOfStock = $availableOutOfStock;
         $this->packItems = $packItems;
         $this->customizations = $customizations;
+        $this->mpn = $mpn;
     }
 
     /**
@@ -507,6 +515,16 @@ class OrderProductForViewing implements JsonSerializable
     }
 
     /**
+     * Get product MPN
+     *
+     * @return string
+     */
+    public function getMpn(): string
+    {
+        return $this->mpn;
+    }
+
+    /**
      * @return array
      */
     public function jsonSerialize(): array
@@ -517,6 +535,7 @@ class OrderProductForViewing implements JsonSerializable
             'name' => $this->getName(),
             'reference' => $this->getReference(),
             'supplierReference' => $this->getSupplierReference(),
+            'mpn' => $this->getMpn(),
             'location' => $this->getLocation(),
             'imagePath' => $this->getImagePath(),
             'quantity' => $this->getQuantity(),

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/view_product_pack_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/view_product_pack_modal.html.twig
@@ -63,6 +63,9 @@
                 <p class="mb-0 product-reference">
                   {{ 'Reference number:'|trans({}, 'Admin.Orderscustomers.Feature') }}
                 </p>
+                <p class="mb-0 product-mpn">
+                  {{ 'MPN:'|trans({}, 'Admin.Orderscustomers.Feature') }}
+                </p>
                 <p class="mb-0 product-supplier-reference">
                   {{ 'Supplier reference:'|trans({}, 'Admin.Orderscustomers.Feature') }}
                 </p>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/basic_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/basic_information.html.twig
@@ -1,0 +1,62 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+<div class="card">
+  <div class="card-header">
+    <h3 class="card-header-title">
+      {{ 'Basic information'|trans({}, 'Admin.Global') }}
+    </h3>
+  </div>
+  <div class="card-body">
+    <div class="row mb-1">
+      <div class="col-xxl-4 text-xxl-right font-weight-bold">{{ 'ID'|trans({}, 'Admin.Global') }}</div>
+      <div class="col-xxl-8">{{ orderForViewing.id }}</div>
+    </div>
+    <div class="row mb-1">
+      <div class="col-xxl-4 text-xxl-right font-weight-bold">{{ 'Order reference'|trans({}, 'Admin.Global') }}</div>
+      <div class="col-xxl-8">{{ orderForViewing.reference }}</div>
+    </div>
+    <div class="row mb-1">
+      <div class="col-xxl-4 text-xxl-right font-weight-bold">{{ 'Created from cart'|trans({}, 'Admin.Global') }}</div>
+      <div class="col-xxl-8"><a href="{{ path('admin_carts_view', {'cartId': orderForViewing.cartId}) }}">#{{ orderForViewing.cartId }}</a>
+    </div></div>
+    <div class="row mb-1">
+      <div class="col-xxl-4 text-xxl-right font-weight-bold">{{ 'Total price'|trans({}, 'Admin.Global') }}</div>
+      <div class="col-xxl-8">{{ orderForViewing.prices.totalAmountFormatted }}</div>
+    </div>
+    <div class="row mb-1">
+      <div class="col-xxl-4 text-xxl-right font-weight-bold">{{ 'Created on'|trans({}, 'Admin.Global') }}</div>
+      <div class="col-xxl-8">{{ orderForViewing.createdAt|date_format_full }}</div>
+    </div>
+    <div class="row mb-1">
+      <div class="col-xxl-4 text-xxl-right font-weight-bold">{{ 'Payment'|trans({}, 'Admin.Global') }}</div>
+      <div class="col-xxl-8">{{ orderForViewing.paymentName }}</div>
+    </div>
+    <div class="row mb-1">
+      <div class="col-xxl-4 text-xxl-right font-weight-bold">{{ 'Delivery'|trans({}, 'Admin.Global') }}</div>
+      <div class="col-xxl-8">{{ orderForViewing.carrierName }}</div>
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/basic_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/basic_information.html.twig
@@ -1,4 +1,4 @@
-{#**
+{# **
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,7 +21,7 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ * #}
 
 <div class="card">
   <div class="card-header">
@@ -40,7 +40,7 @@
     </div>
     <div class="row mb-1">
       <div class="col-xxl-4 text-xxl-right font-weight-bold">{{ 'Created from cart'|trans({}, 'Admin.Global') }}</div>
-      <div class="col-xxl-8"><a href="{{ path('admin_carts_view', {'cartId': orderForViewing.cartId}) }}">#{{ orderForViewing.cartId }}</a>
+      <div class="col-xxl-8"><a href="{{ path('admin_carts_view', {cartId: orderForViewing.cartId}) }}">#{{ orderForViewing.cartId }}</a>
     </div></div>
     <div class="row mb-1">
       <div class="col-xxl-4 text-xxl-right font-weight-bold">{{ 'Total price'|trans({}, 'Admin.Global') }}</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -203,7 +203,7 @@
 
           <div class="col-md-6">
             <h3 class="mb-0{{ not isPrivateNoteOpen ? ' d-print-none' : '' }}">
-              {{ 'Private note'|trans({}, 'Admin.Orderscustomers.Feature') }}
+              {{ 'Customer private note'|trans({}, 'Admin.Orderscustomers.Feature') }}
             </h3>
           </div>
           <div class="col-md-6 text-right d-print-none">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -67,14 +67,14 @@
       <div class="info-block mt-2">
         <p class="mb-0"><strong>{{ 'ID:'|trans({}, 'Admin.Global') }}</strong> {{ orderForViewing.customer.id }}</p>
         <p class="mb-0"><strong>{{ 'Email:'|trans({}, 'Admin.Global') }}</strong> <a href="mailto:{{ orderForViewing.customer.email }}">{{ orderForViewing.customer.email }}</a></p>
-        <p class="mb-0"><strong>{{ 'Customer type:'|trans({}, 'Admin.Global') }}</strong> 
-          {%  if orderForViewing.customer.isGuest is same as(false) %}
+        <p class="mb-0"><strong>{{ 'Customer type:'|trans({}, 'Admin.Global') }}</strong>
+          {% if orderForViewing.customer.isGuest is same as(false) %}
             {{ 'Registered customer'|trans({}, 'Admin.Global') }}
           {% else %}
             {{ 'Guest customer'|trans({}, 'Admin.Global') }}
           {% endif %}
         </p>
-        {%  if orderForViewing.customer.isGuest is same as(false) %}
+        {% if orderForViewing.customer.isGuest is same as(false) %}
           <p class="mb-0"><strong>{{ 'Account registered:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong> {{ orderForViewing.customer.accountRegistrationDate|date_format_full }}</p>
           <p class="mb-0"><strong>{{ 'Total spent since registration:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong> {{ orderForViewing.customer.totalSpentSinceRegistration }}</p>
           <p class="mb-0"><strong>{{ 'Validated orders placed:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong> {{ orderForViewing.customer.validOrdersPlaced }}</p>
@@ -85,7 +85,7 @@
         {% if orderForViewing.customer.ape is not empty %}
         <p class="mb-0"><strong>{{ 'APE'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong> {{ orderForViewing.customer.ape }}</p>
         {% endif %}
-      </div>  
+      </div>
     {% endif %}
     <div class="info-block mt-2">
       <div class="row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -43,8 +43,8 @@
             </h2>
           </div>
           <div id="viewFullDetails" class="col-xxl-5 text-xxl-right">
-            <a class="d-print-none" href="{{ path('admin_customers_view', {customerId: orderForViewing.customer.id}) }}">
-              {{ 'View full details'|trans({}, 'Admin.Actions') }}
+            <a class="d-print-none btn btn-primary btn-sm" href="{{ path('admin_customers_view', {customerId: orderForViewing.customer.id}) }}">
+              {{ 'View details'|trans({}, 'Admin.Actions') }}
             </a>
           </div>
         {% else %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -37,14 +37,10 @@
           <div class="col-xxl-7">
             <h2 class="mb-0">
               <i class="material-icons">account_box</i>
-
               {{ orderForViewing.customer.gender }}
               {{ orderForViewing.customer.firstName }}
               {{ orderForViewing.customer.lastName }}
-
-              <strong class="text-muted ml-2">#{{ orderForViewing.customer.id }}</strong>
             </h2>
-
           </div>
           <div id="viewFullDetails" class="col-xxl-5 text-xxl-right">
             <a class="d-print-none" href="{{ path('admin_customers_view', {customerId: orderForViewing.customer.id}) }}">
@@ -68,63 +64,28 @@
 
     </div>
     {% if orderForViewing.customer is not null and orderForViewing.customer.id != 0 %}
-      <div class="row mt-3">
-        <div id="customerEmail" class="col-xxl-6">
-          <p class="mb-1">
-            <strong>{{ 'Email:'|trans({}, 'Admin.Global') }}</strong>
-          </p>
-          <p>
-            <a href="mailto:{{ orderForViewing.customer.email }}">
-              {{ orderForViewing.customer.email }}
-            </a>
-          </p>
-
-          {% if orderForViewing.customer.isGuest is same as(false) %}
-            <p class="mb-1">
-              <strong>{{ 'Account registered:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-            </p>
-            <p>{{ orderForViewing.customer.accountRegistrationDate|date_format_full }}</p>
+      <div class="info-block mt-2">
+        <p class="mb-0"><strong>{{ 'ID:'|trans({}, 'Admin.Global') }}</strong> {{ orderForViewing.customer.id }}</p>
+        <p class="mb-0"><strong>{{ 'Email:'|trans({}, 'Admin.Global') }}</strong> <a href="mailto:{{ orderForViewing.customer.email }}">{{ orderForViewing.customer.email }}</a></p>
+        <p class="mb-0"><strong>{{ 'Customer type:'|trans({}, 'Admin.Global') }}</strong> 
+          {%  if orderForViewing.customer.isGuest is same as(false) %}
+            {{ 'Registered customer'|trans({}, 'Admin.Global') }}
+          {% else %}
+            {{ 'Guest customer'|trans({}, 'Admin.Global') }}
           {% endif %}
-
-          {% if orderForViewing.customer.siret is not empty %}
-            <p class="mb-1">
-              <strong>{{ 'SIRET'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-            </p>
-            <p>{{ orderForViewing.customer.siret }}</p>
-          {% endif %}
-
-          {% if orderForViewing.customer.ape is not empty %}
-            <p class="mb-1 d-block d-md-none">
-              <strong>{{ 'APE'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-            </p>
-            <p class="d-block d-md-none">{{ orderForViewing.customer.ape }}</p>
-          {% endif %}
-        </div>
-        <div id="validatedOrders" class="col-xxl-6">
-          <p class="mb-1">
-            <strong>{{ 'Validated orders placed:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-          </p>
-          <p>
-            <span class="badge rounded badge-dark">{{ orderForViewing.customer.validOrdersPlaced }}</span>
-          </p>
-
-          {% if orderForViewing.customer.isGuest is same as(false) %}
-            <p class="mb-1">
-              <strong>{{ 'Total spent since registration:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-            </p>
-            <p>
-              <span class="badge rounded badge-dark">{{ orderForViewing.customer.totalSpentSinceRegistration }}</span>
-            </p>
-          {% endif %}
-
-          {% if orderForViewing.customer.ape is not empty %}
-            <p class="mb-1 d-none d-md-block">
-              <strong>{{ 'APE'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-            </p>
-            <p class="d-none d-md-block">{{ orderForViewing.customer.ape }}</p>
-          {% endif %}
-        </div>
-      </div>
+        </p>
+        {%  if orderForViewing.customer.isGuest is same as(false) %}
+          <p class="mb-0"><strong>{{ 'Account registered:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong> {{ orderForViewing.customer.accountRegistrationDate|date_format_full }}</p>
+          <p class="mb-0"><strong>{{ 'Total spent since registration:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong> {{ orderForViewing.customer.totalSpentSinceRegistration }}</p>
+          <p class="mb-0"><strong>{{ 'Validated orders placed:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong> {{ orderForViewing.customer.validOrdersPlaced }}</p>
+        {% endif %}
+        {% if orderForViewing.customer.siret is not empty %}
+        <p class="mb-0"><strong>{{ 'SIRET'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong> {{ orderForViewing.customer.siret }}</p>
+        {% endif %}
+        {% if orderForViewing.customer.ape is not empty %}
+        <p class="mb-0"><strong>{{ 'APE'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong> {{ orderForViewing.customer.ape }}</p>
+        {% endif %}
+      </div>  
     {% endif %}
     <div class="info-block mt-2">
       <div class="row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/header.html.twig
@@ -25,7 +25,7 @@
 
 <div class="title-content">
   <h1 class="d-inline">
-    {{ 'Order'|trans({}, 'Admin.Global') }} 
+    {{ 'Order'|trans({}, 'Admin.Global') }}
     <strong class="text-muted" data-role="order-id">#{{ orderForViewing.id }}</strong>
     <strong data-role="order-reference">{{ orderForViewing.reference }}</strong>
   </h1>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/header.html.twig
@@ -25,37 +25,8 @@
 
 <div class="title-content">
   <h1 class="d-inline">
+    {{ 'Order'|trans({}, 'Admin.Global') }} 
     <strong class="text-muted" data-role="order-id">#{{ orderForViewing.id }}</strong>
     <strong data-role="order-reference">{{ orderForViewing.reference }}</strong>
   </h1>
-
-  <p class="lead d-inline">
-    {{ 'from'|trans({}, 'Admin.Global') }}
-
-    {% if orderForViewing.customer is not null and orderForViewing.customer.id != 0 %}
-      {{ orderForViewing.customer.firstName }}
-      {{ orderForViewing.customer.lastName }}
-    {% else %}
-      {{ 'Deleted customer'|trans({}, 'Admin.Global') }}
-    {% endif %}
-  </p>
-
-  <span class="badge rounded badge-dark ml-2 mr-2 font-size-100">
-    {{ orderForViewing.prices.totalAmountFormatted }}
-  </span>
-
-  <p class="lead d-inline">
-    {{ orderForViewing.createdAt|date_format_lite }}
-    <span class="text-muted">
-      {{ 'at'|trans({}, 'Admin.Global') }}
-
-      {{ orderForViewing.createdAt|date('H:i:s') }}
-    </span>
-  </p>
-
-    {% if orderForViewing.shipping.giftWrapping %}
-      <p class="lead d-inline">
-        <span class="badge rounded badge-success ml-2 mr-2 font-size-100 ">{{ 'Gift wrapping'|trans({}, 'Admin.Orderscustomers.Feature') }}</span>
-      </p>
-    {% endif %}
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/history.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/history.html.twig
@@ -49,7 +49,7 @@
         {% if status.withEmail %}
           <form method="post"
                 action="{{ path('admin_orders_resend_email', {orderId: orderForViewing.id, orderHistoryId: status.orderHistoryId, orderStatusId: status.orderStatusId}) }}">
-            <button class="btn btn-link pt-0 pb-0">
+            <button class="btn btn-primary btn-sm">
               {{ 'Resend email'|trans({}, 'Admin.Orderscustomers.Feature') }}
             </button>
           </form>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/internal_note.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/internal_note.html.twig
@@ -28,7 +28,7 @@
 
     <div class="col-md-6">
       <h3 class="mb-0{{ not isNoteOpen ? ' d-print-none' : '' }}">
-        {{ 'Order note'|trans({}, 'Admin.Orderscustomers.Feature') }}
+        {{ 'Order private note'|trans({}, 'Admin.Orderscustomers.Feature') }}
       </h3>
     </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -39,6 +39,12 @@
           {{ product.reference }}
         </p>
       {% endif %}
+      {% if product.mpn is not empty %}
+        <p class="mb-0 productSupplierReference">
+          {{ 'MPN:'|trans({}, 'Admin.Orderscustomers.Feature') }}
+          {{ product.mpn }}
+        </p>
+      {% endif %}
       {% if product.supplierReference is not empty %}
         <p class="mb-0 productSupplierReference">
           {{ 'Supplier reference:'|trans({}, 'Admin.Orderscustomers.Feature') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
@@ -57,6 +57,7 @@
 
     <div class="product-row row">
       <div class="col-md-4 left-column">
+        {{ include('@PrestaShop/Admin/Sell/Order/Order/Blocks/View/basic_information.html.twig') }}
         {{ include('@PrestaShop/Admin/Sell/Order/Order/Blocks/View/customer.html.twig') }}
         {{ renderhook('displayAdminOrderSide', {id_order: orderForViewing.id}) }}
         {{ include('@PrestaShop/Admin/Sell/Order/Order/Blocks/View/messages.html.twig') }}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This slightly improves the UX of the order detail page and adds more data.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check order detail page in BO.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/12177912859
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Changes
1. Removed the UX disaster in the header.
2. Added a basic information block with ID, reference, link to cart this order was created from, date, price, payment and delivery. Uses the same design as basic information block on customer detail page.
3. Improved the block with customer details - more data, same space, better responsivity.
4. Changed the link to customer details - more visible, same space.
5. Added MPN to product list.
6. Change button to resend status email - more visible, same space.
7. Specified what is customer and what is order private note, my clients were confused.

_In another PR, I will add tax excl and tax incl totals also._

![changes](https://github.com/user-attachments/assets/561ee6a4-ec17-4caf-aa99-e41458e792e7)



