### PR TITLE
Fix obvious notice in Warehouse class

### DIFF
--- a/classes/stock/Warehouse.php
+++ b/classes/stock/Warehouse.php
@@ -308,21 +308,25 @@ class WarehouseCore extends ObjectModel
     {
         // if it's a pack, returns warehouses if and only if some products use the advanced stock management
         $share_stock = false;
+        $shop_group_id = false;
         if ($id_shop === null) {
             if (Shop::getContext() == Shop::CONTEXT_GROUP) {
                 $shop_group = Shop::getContextShopGroup();
+                $shop_group_id = (int) $shop_group->id;
             } else {
                 $shop_group = Context::getContext()->shop->getGroup();
+                $shop_group_id = (int) $shop_group->id;
                 $id_shop = (int) Context::getContext()->shop->id;
             }
             $share_stock = $shop_group->share_stock;
         } else {
-            $shop_group = Shop::getGroupFromShop($id_shop);
+            $shop_group = Shop::getGroupFromShop($id_shop, false);
             $share_stock = $shop_group['share_stock'];
+            $shop_group_id = (int) $shop_group['id'];
         }
 
-        if ($share_stock) {
-            $ids_shop = Shop::getShops(true, (int) $shop_group->id, true);
+        if ($share_stock && $shop_group_id) {
+            $ids_shop = Shop::getShops(true, (int) $shop_group_id, true);
         } else {
             $ids_shop = [(int) $id_shop];
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | We use `Shop::getGroupFromShop` but, by default, it returns an id of the group while a line later we need information from the array, this PR fixes this obvious mistake. AH01071: Got error 'PHP message: PHP Warning:  Trying to access array offset on value of type int in classes/stock/Warehouse.php on line 329PHP message: PHP Warning:  Trying to access array offset on value of type int in. We also need to get shop group id correctly since once it's an object and once it's an array
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Just look at the code + auto tests
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/12081102374 ✅ 
| Fixed issue or discussion?     | n/a
| Related PRs       | n/a
| Sponsor company   | PrestaShop SA
