### PR TITLE
Add idShop cache value for getLinkRewrite Category and Category CMS

### DIFF
--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -498,23 +498,38 @@ class CMSCategoryCore extends ObjectModel
         }
     }
 
-    public static function getLinkRewrite($id_cms_category, $id_lang)
+    /**
+     * Get the rewrite link of the given CMS Category.
+     *
+     * @param int $idCMSCategory CMS Category ID
+     * @param int $idLang Language ID
+     * @param int $idShop Shop ID
+     *
+     * @return bool|mixed
+     */
+    public static function getLinkRewrite($idCMSCategory, $idLang, $idShop = null)
     {
-        if (!Validate::isUnsignedId($id_cms_category) || !Validate::isUnsignedId($id_lang)) {
+        if (!Validate::isUnsignedId($idCMSCategory) || !Validate::isUnsignedId($idLang)) {
             return false;
         }
 
-        if (isset(self::$_links[$id_cms_category . '-' . $id_lang])) {
-            return self::$_links[$id_cms_category . '-' . $id_lang];
+        if(empty($idShop) || !Validate::isUnsignedInt($idShop)) {
+            $idShop = Context::getContext()->shop->id ? 
+                Context::getContext()->shop->id : 
+                Configuration::get('PS_SHOP_DEFAULT');
+        }
+
+        if (isset(self::$_links[$idCMSCategory . '-' . $idLang . '-' . $idShop])) {
+            return self::$_links[$idCMSCategory . '-' . $idLang . '-' . $idShop];
         }
 
         $result = Db::getInstance()->getRow('
-		SELECT cl.`link_rewrite`
-		FROM `' . _DB_PREFIX_ . 'cms_category` c
-		LEFT JOIN `' . _DB_PREFIX_ . 'cms_category_lang` cl ON c.`id_cms_category` = cl.`id_cms_category`
-		WHERE `id_lang` = ' . (int) $id_lang . '
-		AND c.`id_cms_category` = ' . (int) $id_cms_category);
-        self::$_links[$id_cms_category . '-' . $id_lang] = $result['link_rewrite'];
+		SELECT `link_rewrite`
+		FROM `' . _DB_PREFIX_ . 'cms_category_lang`
+		WHERE `id_lang` = ' . (int) $idLang . '
+		' . Shop::addSqlRestrictionOnLang(null, (int) $idShop) . '
+		AND `id_cms_category` = ' . (int) $idCMSCategory);
+        self::$_links[$idCMSCategory . '-' . $idLang  . '-' . $idShop] = $result['link_rewrite'];
 
         return $result['link_rewrite'];
     }

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -519,19 +519,16 @@ class CMSCategoryCore extends ObjectModel
                 Configuration::get('PS_SHOP_DEFAULT');
         }
 
-        if (isset(self::$_links[$idCMSCategory . '-' . $idLang . '-' . $idShop])) {
-            return self::$_links[$idCMSCategory . '-' . $idLang . '-' . $idShop];
+        if (!isset(self::$_links[$idCategory . '-' . $idLang . '-' . $idShop])) {
+            self::$_links[$idCMSCategory . '-' . $idLang . '-' . $idShop] = Db::getInstance()->getValue('
+    		SELECT `link_rewrite`
+    		FROM `' . _DB_PREFIX_ . 'cms_category_lang`
+    		WHERE `id_lang` = ' . (int) $idLang . '
+    		' . Shop::addSqlRestrictionOnLang(null, (int) $idShop) . '
+    		AND `id_cms_category` = ' . (int) $idCMSCategory);
         }
 
-        $result = Db::getInstance()->getRow('
-		SELECT `link_rewrite`
-		FROM `' . _DB_PREFIX_ . 'cms_category_lang`
-		WHERE `id_lang` = ' . (int) $idLang . '
-		' . Shop::addSqlRestrictionOnLang(null, (int) $idShop) . '
-		AND `id_cms_category` = ' . (int) $idCMSCategory);
-        self::$_links[$idCMSCategory . '-' . $idLang . '-' . $idShop] = $result['link_rewrite'];
-
-        return $result['link_rewrite'];
+        return self::$_links[$idCMSCategory . '-' . $idLang . '-' . $idShop];
     }
 
     public function getLink(?Link $link = null)

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -519,7 +519,7 @@ class CMSCategoryCore extends ObjectModel
                 Configuration::get('PS_SHOP_DEFAULT');
         }
 
-        if (!isset(self::$_links[$idCategory . '-' . $idLang . '-' . $idShop])) {
+        if (!isset(self::$_links[$idCMSCategory . '-' . $idLang . '-' . $idShop])) {
             self::$_links[$idCMSCategory . '-' . $idLang . '-' . $idShop] = Db::getInstance()->getValue('
     		SELECT `link_rewrite`
     		FROM `' . _DB_PREFIX_ . 'cms_category_lang`

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -513,7 +513,7 @@ class CMSCategoryCore extends ObjectModel
             return false;
         }
 
-        if(empty($idShop) || !Validate::isUnsignedInt($idShop)) {
+        if (empty($idShop) || !Validate::isUnsignedInt($idShop)) {
             $idShop = Context::getContext()->shop->id ? 
                 Context::getContext()->shop->id : 
                 Configuration::get('PS_SHOP_DEFAULT');
@@ -529,7 +529,7 @@ class CMSCategoryCore extends ObjectModel
 		WHERE `id_lang` = ' . (int) $idLang . '
 		' . Shop::addSqlRestrictionOnLang(null, (int) $idShop) . '
 		AND `id_cms_category` = ' . (int) $idCMSCategory);
-        self::$_links[$idCMSCategory . '-' . $idLang  . '-' . $idShop] = $result['link_rewrite'];
+        self::$_links[$idCMSCategory . '-' . $idLang . '-' . $idShop] = $result['link_rewrite'];
 
         return $result['link_rewrite'];
     }

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -514,8 +514,8 @@ class CMSCategoryCore extends ObjectModel
         }
 
         if (empty($idShop) || !Validate::isUnsignedInt($idShop)) {
-            $idShop = Context::getContext()->shop->id ? 
-                Context::getContext()->shop->id : 
+            $idShop = Context::getContext()->shop->id ?
+                Context::getContext()->shop->id :
                 Configuration::get('PS_SHOP_DEFAULT');
         }
 

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -503,7 +503,7 @@ class CMSCategoryCore extends ObjectModel
      *
      * @param int $idCMSCategory CMS Category ID
      * @param int $idLang Language ID
-     * @param int $idShop Shop ID
+     * @param int|null $idShop Shop ID
      *
      * @return bool|string
      */

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -505,7 +505,7 @@ class CMSCategoryCore extends ObjectModel
      * @param int $idLang Language ID
      * @param int $idShop Shop ID
      *
-     * @return bool|mixed
+     * @return bool|string
      */
     public static function getLinkRewrite($idCMSCategory, $idLang, $idShop = null)
     {

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1353,7 +1353,7 @@ class CategoryCore extends ObjectModel
      * @param int $idLang Language ID
      * @param int $idShop Shop ID
      *
-     * @return bool|false
+     * @return bool|string
      */
     public static function getLinkRewrite($idCategory, $idLang, $idShop = null)
     {

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1362,8 +1362,8 @@ class CategoryCore extends ObjectModel
         }
 
         if (empty($idShop) || !Validate::isUnsignedInt($idShop)) {
-            $idShop = Context::getContext()->shop->id ? 
-                Context::getContext()->shop->id : 
+            $idShop = Context::getContext()->shop->id ?
+                Context::getContext()->shop->id :
                 Configuration::get('PS_SHOP_DEFAULT');
         }
 

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1361,7 +1361,7 @@ class CategoryCore extends ObjectModel
             return false;
         }
 
-        if(empty($idShop) || !Validate::isUnsignedInt($idShop)) {
+        if (empty($idShop) || !Validate::isUnsignedInt($idShop)) {
             $idShop = Context::getContext()->shop->id ? 
                 Context::getContext()->shop->id : 
                 Configuration::get('PS_SHOP_DEFAULT');

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1373,7 +1373,7 @@ class CategoryCore extends ObjectModel
 			FROM `' . _DB_PREFIX_ . 'category_lang`
 			WHERE `id_lang` = ' . (int) $idLang . '
 			' . Shop::addSqlRestrictionOnLang(null, (int) $idShop) . '
-			AND cl.`id_category` = ' . (int) $idCategory);
+			AND `id_category` = ' . (int) $idCategory);
         }
 
         return self::$_links[$idCategory . '-' . $idLang . '-' . $idShop];

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1351,7 +1351,7 @@ class CategoryCore extends ObjectModel
      *
      * @param int $idCategory Category ID
      * @param int $idLang Language ID
-     * @param int $idShop Shop ID
+     * @param int|null $idShop Shop ID
      *
      * @return bool|string
      */

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1351,25 +1351,32 @@ class CategoryCore extends ObjectModel
      *
      * @param int $idCategory Category ID
      * @param int $idLang Language ID
+     * @param int $idShop Shop ID
      *
      * @return bool|mixed
      */
-    public static function getLinkRewrite($idCategory, $idLang)
+    public static function getLinkRewrite($idCategory, $idLang, $idShop = null)
     {
         if (!Validate::isUnsignedId($idCategory) || !Validate::isUnsignedId($idLang)) {
             return false;
         }
 
-        if (!isset(self::$_links[$idCategory . '-' . $idLang])) {
-            self::$_links[$idCategory . '-' . $idLang] = Db::getInstance()->getValue('
-			SELECT cl.`link_rewrite`
-			FROM `' . _DB_PREFIX_ . 'category_lang` cl
+        if(empty($idShop) || !Validate::isUnsignedInt($idShop)) {
+            $idShop = Context::getContext()->shop->id ? 
+                Context::getContext()->shop->id : 
+                Configuration::get('PS_SHOP_DEFAULT');
+        }
+
+        if (!isset(self::$_links[$idCategory . '-' . $idLang . '-' . $idShop])) {
+            self::$_links[$idCategory . '-' . $idLang . '-' . $idShop] = Db::getInstance()->getValue('
+			SELECT `link_rewrite`
+			FROM `' . _DB_PREFIX_ . 'category_lang`
 			WHERE `id_lang` = ' . (int) $idLang . '
-			' . Shop::addSqlRestrictionOnLang('cl') . '
+			' . Shop::addSqlRestrictionOnLang(null, (int) $idShop) . '
 			AND cl.`id_category` = ' . (int) $idCategory);
         }
 
-        return self::$_links[$idCategory . '-' . $idLang];
+        return self::$_links[$idCategory . '-' . $idLang . '-' . $idShop];
     }
 
     /**

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1353,7 +1353,7 @@ class CategoryCore extends ObjectModel
      * @param int $idLang Language ID
      * @param int $idShop Shop ID
      *
-     * @return bool|mixed
+     * @return bool|false
      */
     public static function getLinkRewrite($idCategory, $idLang, $idShop = null)
     {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Category link cache doesn't take shopId as a parameter
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See issue
| UI Tests | https://github.com/florine2623/testing_pr/actions/runs/12117377994 ✅ 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/36794
| Sponsor company   | @friends-of-presta
