### PR TITLE
Update circuit breaker and Distribution API client, remove Guzzle completely

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
         "prestashop/ps_customersignin": "^2",
         "prestashop/ps_customtext": "^4",
         "prestashop/ps_dataprivacy": "^2.0",
-        "prestashop/ps_distributionapiclient": "^1.0",
+        "prestashop/ps_distributionapiclient": "^2",
         "prestashop/ps_emailalerts": "^3",
         "prestashop/ps_emailsubscription": "^2.7",
         "prestashop/ps_facetedsearch": "^3",

--- a/composer.lock
+++ b/composer.lock
@@ -2311,331 +2311,6 @@
             "time": "2022-02-01T09:26:56+00:00"
         },
         {
-            "name": "guzzlehttp/guzzle",
-            "version": "7.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "fb7566caccf22d74d1ab270de3551f72a58399f5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/fb7566caccf22d74d1ab270de3551f72a58399f5",
-                "reference": "fb7566caccf22d74d1ab270de3551f72a58399f5",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "guzzlehttp/promises": "^1.5.3 || ^2.0",
-                "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
-                "php": "^7.2.5 || ^8.0",
-                "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
-            },
-            "provide": {
-                "psr/http-client-implementation": "1.0"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
-                "ext-curl": "*",
-                "php-http/client-integration-tests": "dev-master#2c025848417c1135031fdf9c728ee53d0a7ceaee as 3.0.999",
-                "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23",
-                "psr/log": "^1.1 || ^2.0 || ^3.0"
-            },
-            "suggest": {
-                "ext-curl": "Required for CURL handler support",
-                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
-                "psr/log": "Required for using the Log middleware"
-            },
-            "type": "library",
-            "extra": {
-                "bamarni-bin": {
-                    "bin-links": true,
-                    "forward-command": false
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                },
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Jeremy Lindblom",
-                    "email": "jeremeamia@gmail.com",
-                    "homepage": "https://github.com/jeremeamia"
-                },
-                {
-                    "name": "George Mponos",
-                    "email": "gmponos@gmail.com",
-                    "homepage": "https://github.com/gmponos"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
-                },
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com",
-                    "homepage": "https://github.com/sagikazarmark"
-                },
-                {
-                    "name": "Tobias Schultze",
-                    "email": "webmaster@tubo-world.de",
-                    "homepage": "https://github.com/Tobion"
-                }
-            ],
-            "description": "Guzzle is a PHP HTTP client library",
-            "keywords": [
-                "client",
-                "curl",
-                "framework",
-                "http",
-                "http client",
-                "psr-18",
-                "psr-7",
-                "rest",
-                "web service"
-            ],
-            "support": {
-                "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.7.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/Nyholm",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-05-21T14:04:53+00:00"
-        },
-        {
-            "name": "guzzlehttp/promises",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/promises.git",
-                "reference": "3a494dc7dc1d7d12e511890177ae2d0e6c107da6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/3a494dc7dc1d7d12e511890177ae2d0e6c107da6",
-                "reference": "3a494dc7dc1d7d12e511890177ae2d0e6c107da6",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5 || ^8.0"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
-            },
-            "type": "library",
-            "extra": {
-                "bamarni-bin": {
-                    "bin-links": true,
-                    "forward-command": false
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Promise\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                },
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
-                },
-                {
-                    "name": "Tobias Schultze",
-                    "email": "webmaster@tubo-world.de",
-                    "homepage": "https://github.com/Tobion"
-                }
-            ],
-            "description": "Guzzle promises library",
-            "keywords": [
-                "promise"
-            ],
-            "support": {
-                "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/Nyholm",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-05-21T13:50:22+00:00"
-        },
-        {
-            "name": "guzzlehttp/psr7",
-            "version": "2.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/psr7.git",
-                "reference": "b635f279edd83fc275f822a1188157ffea568ff6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/b635f279edd83fc275f822a1188157ffea568ff6",
-                "reference": "b635f279edd83fc275f822a1188157ffea568ff6",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5 || ^8.0",
-                "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
-            },
-            "provide": {
-                "psr/http-factory-implementation": "1.0",
-                "psr/http-message-implementation": "1.0"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
-                "http-interop/http-factory-tests": "^0.9",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
-            },
-            "suggest": {
-                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
-            },
-            "type": "library",
-            "extra": {
-                "bamarni-bin": {
-                    "bin-links": true,
-                    "forward-command": false
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Psr7\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                },
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "George Mponos",
-                    "email": "gmponos@gmail.com",
-                    "homepage": "https://github.com/gmponos"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
-                },
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com",
-                    "homepage": "https://github.com/sagikazarmark"
-                },
-                {
-                    "name": "Tobias Schultze",
-                    "email": "webmaster@tubo-world.de",
-                    "homepage": "https://github.com/Tobion"
-                },
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com",
-                    "homepage": "https://sagikazarmark.hu"
-                }
-            ],
-            "description": "PSR-7 message implementation that also provides common utility methods",
-            "keywords": [
-                "http",
-                "message",
-                "psr-7",
-                "request",
-                "response",
-                "stream",
-                "uri",
-                "url"
-            ],
-            "support": {
-                "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.5.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/Nyholm",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-04-17T16:11:26+00:00"
-        },
-        {
             "name": "incenteev/composer-parameter-handler",
             "version": "v2.1.5",
             "source": {
@@ -5003,23 +4678,25 @@
         },
         {
             "name": "prestashop/circuit-breaker",
-            "version": "v4.0.1",
+            "version": "v4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/circuit-breaker.git",
-                "reference": "8dff14c1411448d4d64b740d12100637ad64f5c7"
+                "reference": "25fcd9babceb47b491f1759a20cdc274c633b58f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/circuit-breaker/zipball/8dff14c1411448d4d64b740d12100637ad64f5c7",
-                "reference": "8dff14c1411448d4d64b740d12100637ad64f5c7",
+                "url": "https://api.github.com/repos/PrestaShop/circuit-breaker/zipball/25fcd9babceb47b491f1759a20cdc274c633b58f",
+                "reference": "25fcd9babceb47b491f1759a20cdc274c633b58f",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "^7.3"
+                "php": ">=7.2.34",
+                "symfony/http-client": "^5.4 || ^6"
             },
             "require-dev": {
                 "doctrine/cache": "^1.10.2",
+                "guzzlehttp/guzzle": "^7.3",
                 "phpunit/phpunit": "^8",
                 "prestashop/php-dev-tools": "^4.1",
                 "psr/simple-cache": "^1.0",
@@ -5029,6 +4706,7 @@
             "suggest": {
                 "doctrine/cache": "Allows use of Doctrine Cache adapters to store transactions",
                 "ext-apcu": "Allows use of APCu adapter (performant) to store transactions",
+                "guzzlehttp/guzzle": "Allows use of Guzzle to perform HTTP requests instead of Symfony HttpClient",
                 "symfony/cache": "Allows use of Symfony Cache adapters to store transactions"
             },
             "type": "library",
@@ -5053,10 +4731,9 @@
             ],
             "description": "A circuit breaker implementation for PHP",
             "support": {
-                "issues": "https://github.com/PrestaShop/circuit-breaker/issues",
-                "source": "https://github.com/PrestaShop/circuit-breaker/tree/v4.0.1"
+                "source": "https://github.com/PrestaShop/circuit-breaker/tree/v4.0.3"
             },
-            "time": "2021-10-12T15:22:50+00:00"
+            "time": "2024-11-21T10:24:47+00:00"
         },
         {
             "name": "prestashop/classic",
@@ -8485,50 +8162,6 @@
                 "source": "https://github.com/php-fig/simple-cache/tree/master"
             },
             "time": "2017-10-23T01:57:42+00:00"
-        },
-        {
-            "name": "ralouphie/getallheaders",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ralouphie/getallheaders.git",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "php-coveralls/php-coveralls": "^2.1",
-                "phpunit/phpunit": "^5 || ^6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/getallheaders.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ralph Khattar",
-                    "email": "ralph.khattar@gmail.com"
-                }
-            ],
-            "description": "A polyfill for getallheaders.",
-            "support": {
-                "issues": "https://github.com/ralouphie/getallheaders/issues",
-                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
-            },
-            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a96b8bd769fe82394378d0fadb42502",
+    "content-hash": "84c736aeb649ad63cd1703efa11da9ee",
     "packages": [
         {
             "name": "api-platform/core",
@@ -6001,26 +6001,27 @@
         },
         {
             "name": "prestashop/ps_distributionapiclient",
-            "version": "v1.1.1",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_distributionapiclient.git",
-                "reference": "4db438b616fb26b9281607db436e60f382fb2391"
+                "reference": "dc1d457fdc28f9a39ab54f1c5eda8d6e078ac885"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_distributionapiclient/zipball/4db438b616fb26b9281607db436e60f382fb2391",
-                "reference": "4db438b616fb26b9281607db436e60f382fb2391",
+                "url": "https://api.github.com/repos/PrestaShop/ps_distributionapiclient/zipball/dc1d457fdc28f9a39ab54f1c5eda8d6e078ac885",
+                "reference": "dc1d457fdc28f9a39ab54f1c5eda8d6e078ac885",
                 "shasum": ""
             },
             "require": {
                 "doctrine/cache": "^2.1",
-                "php": ">=7.2.5",
-                "prestashop/circuit-breaker": "^4.0"
+                "php": ">=8.1",
+                "prestashop/circuit-breaker": "^4.0",
+                "symfony/http-client": "6.4.*"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.4",
-                "phpunit/phpunit": "^8.5",
+                "phpunit/phpunit": "^10",
                 "prestashop/php-dev-tools": "^4.2"
             },
             "type": "prestashop-module",
@@ -6046,9 +6047,9 @@
             "homepage": "https://github.com/PrestaShop/ps_distributionapiclient",
             "support": {
                 "issues": "https://github.com/PrestaShop/ps_distributionapiclient/issues",
-                "source": "https://github.com/PrestaShop/ps_distributionapiclient/tree/v1.1.1"
+                "source": "https://github.com/PrestaShop/ps_distributionapiclient/tree/v2.0.0"
             },
-            "time": "2024-01-19T16:20:17+00:00"
+            "time": "2024-11-28T20:20:42+00:00"
         },
         {
             "name": "prestashop/ps_emailalerts",

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -432,7 +432,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#49a1a110e5b399f24225a3e8ccaf59161d2a9c05",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#5b3dc2d73c731162762b1dc1c227084254e786e7",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^9.0.3",
@@ -8419,7 +8419,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#49a1a110e5b399f24225a3e8ccaf59161d2a9c05",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#5b3dc2d73c731162762b1dc1c227084254e786e7",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^9.0.3",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Update circuit breaker library to latest version, which completely cleans guzzle from our dependencies (This reapplies this PR https://github.com/PrestaShop/PrestaShop/pull/37507 after it was reverted here because the initial one was merged a bit too soon https://github.com/PrestaShop/PrestaShop/pull/37508)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI green and UI tests green
| UI Tests          | See below, final: https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/12083006372
| Fixed issue or discussion?     | Fixes #32855
| Related PRs       | https://github.com/PrestaShop/ps_distributionapiclient/pull/36<br/>https://github.com/PrestaShop/keycloak_connector_demo/pull/89
| Sponsor company   | ~

### Description

We finally removed Guzzle completely from our dependencies (some sub-dependencies were still including it in the composer.lock and we falsely thought it was a done deal). We still have one module that was based on Guzzle though `ps_distributionapiclient` so the first step of this PR is to clean Guzzle, run the UI tests and notify the module doesn't work anymore:

https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/12066207268

Then we test this PR with the current PR on the module https://github.com/PrestaShop/ps_distributionapiclient/pull/36 which will validate the changes made on the module:

https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/12073041885

Finally, we can release the module new 2.0.0 version and update it in the composer.lock in this PR:

https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/12083006372