### PR TITLE
Update runners to rely on Ubuntu 24.04

### DIFF
--- a/.github/workflows/api-module.yml
+++ b/.github/workflows/api-module.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read   #   to clone the repos and get release assets (shivammathur/setup-php)
     name: API Module tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php: [ '8.1', '8.2', '8.3' ]

--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read   #   to clone the repos and get release assets (shivammathur/setup-php)
     name: Behaviour tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php: [ '8.1', '8.2', '8.3' ]

--- a/.github/workflows/create_diff_for_autoupgrade_pr_label.yml
+++ b/.github/workflows/create_diff_for_autoupgrade_pr_label.yml
@@ -8,7 +8,7 @@ jobs:
 
   check_is_merge:
     name: Check is merge PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check is merge PR
         id: check-is-merge
@@ -26,7 +26,7 @@ jobs:
 
   install_prestashop_and_dump:
     name: Install Prestashop and create database dump
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [ check_is_merge ]
     if: needs.check_is_merge.outputs.isMerge != 'true'
     strategy:
@@ -84,7 +84,7 @@ jobs:
   create_diff:
     name: Create database dumps diff
     needs: [ install_prestashop_and_dump ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/download-artifact@v4
 

--- a/.github/workflows/cron_docker_build.yml
+++ b/.github/workflows/cron_docker_build.yml
@@ -9,7 +9,7 @@ jobs:
   docker-build:
     name: Docker build
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:

--- a/.github/workflows/cron_js_routing.yml
+++ b/.github/workflows/cron_js_routing.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write   #   to create branch (peter-evans/create-pull-request)
       pull-requests: write   #   to create a PR (peter-evans/create-pull-request)
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Update JS Routing
     strategy:
       fail-fast: false

--- a/.github/workflows/cron_nightly_build.yml
+++ b/.github/workflows/cron_nightly_build.yml
@@ -13,7 +13,7 @@ jobs:
   nightly-build:
     name: Nightly Build
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/cron_nightly_tests_reports.yml
+++ b/.github/workflows/cron_nightly_tests_reports.yml
@@ -11,7 +11,7 @@ jobs:
   # Add pushed reports to GCP on nightly
   push-nightly-reports:
     name: Push reports to nightly.prestashop-project.org
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/cron_nightly_tests_reusable.yml
+++ b/.github/workflows/cron_nightly_tests_reusable.yml
@@ -41,7 +41,7 @@ jobs:
   # First job: Run tests in parallel
   test:
     name: Nightly tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -317,7 +317,7 @@ jobs:
     if: ${{ always() }}
     needs:
       - test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/cron_php_update_modules.yml
+++ b/.github/workflows/cron_php_update_modules.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write  # for peter-evans/create-pull-request to create branch
       pull-requests: write  # for peter-evans/create-pull-request to create a PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Update PHP Modules
     strategy:
       fail-fast: false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read   #   to clone the repos and get release assets (shivammathur/setup-php)
     name: Integration tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php: [ '8.1', '8.2', '8.3' ]

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   js-unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Run unit tests
     strategy:
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   stylelint:
     name: SCSS Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -28,7 +28,7 @@ jobs:
 
   eslint:
     name: ESLint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -51,7 +51,7 @@ jobs:
 
   yamllint_sf:
     name: YAML Lint (Symfony Check)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -87,7 +87,7 @@ jobs:
 
   yamllint:
     name: YAML Lint (YamlLint Check)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/setup-python@v5
         with:
@@ -111,7 +111,7 @@ jobs:
 
   legacy_link_lint:
     name: Legacy Link Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -141,7 +141,7 @@ jobs:
 
   security_attribute_lint:
     name: Admin Security Attribute Linter
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read  # for actions/checkout to fetch code
     name: PHP CS Fixer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -50,7 +50,7 @@ jobs:
     permissions:
       contents: read  # for actions/checkout to fetch code
     name: PHP Static Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php: [ '8.1', '8.2', '8.3' ]
@@ -90,7 +90,7 @@ jobs:
     permissions:
       contents: read  # for actions/checkout to fetch code
     name: PHPUnit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php: [ '8.1', '8.2', '8.3' ]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ jobs:
   message-check:
     name: Block Merge Commits
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Check is merge PR

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -16,7 +16,7 @@ jobs:
   sanity:
     permissions:
       contents: read   #   to fetch code (actions/checkout)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Sanity
     strategy:
       matrix:

--- a/.github/workflows/symfony-console.yml
+++ b/.github/workflows/symfony-console.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: read  # for actions/checkout to fetch code
     name: Symfony Console
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/twig.yml
+++ b/.github/workflows/twig.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   twig-cs-check:
     name: Twig CS Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Setup PHP

--- a/.github/workflows/ui_tests_code_checks.yml
+++ b/.github/workflows/ui_tests_code_checks.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
 
   ESLint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: ESLint
 
     steps:
@@ -49,7 +49,7 @@ jobs:
         run: npm run lint
 
   tscheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: TypeScript Check
 
     steps:
@@ -74,7 +74,7 @@ jobs:
         run: npm run check:typescript
 
   Steps-identifiers:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Checking Steps identifiers
 
     steps:
@@ -106,7 +106,7 @@ jobs:
         run: npm run check:step-identifiers
 
   suites:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Checking Suites Count
 
     steps:

--- a/.github/workflows/verify_diff_for_autoupgrade_pr_label.yml
+++ b/.github/workflows/verify_diff_for_autoupgrade_pr_label.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   update_label:
     name: Update Needs autoupgrade PR label
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Download artifact
         uses: actions/github-script@v6

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -10,7 +10,7 @@
       "license": "OSL-3.0",
       "dependencies": {
         "@faker-js/faker": "^9.0.3",
-        "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main",
+        "@prestashop-core/ui-testing": "https://github.com/jolelievre/ui-testing-library#update-playwright",
         "chai": "^4.5.0",
         "chai-string": "^1.5.0",
         "dotenv": "^16.4.5",
@@ -416,12 +416,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.1.tgz",
-      "integrity": "sha512-s9RtWoxkOLmRJdw3oFvhFbs9OJS0BzrLUc8Hf6l2UdCNd1rqeEyD4BhCJkvzeEoD1FsK4mirsWwGerhVmYKtZg==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
+      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.48.1"
+        "playwright": "1.49.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -432,11 +432,11 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#49a1a110e5b399f24225a3e8ccaf59161d2a9c05",
+      "resolved": "git+ssh://git@github.com/jolelievre/ui-testing-library.git#a9d19520c66523267132520b267e1217a02979f1",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^9.0.3",
-        "@playwright/test": "^1.48.1",
+        "@playwright/test": "^1.49.0",
         "@s3pweb/keycloak-admin-client-cjs": "^26.0.0",
         "@xmldom/xmldom": "^0.9.5",
         "csv-writer": "^1.6.0",
@@ -6358,12 +6358,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.1.tgz",
-      "integrity": "sha512-j8CiHW/V6HxmbntOfyB4+T/uk08tBy6ph0MpBXwuoofkSnLmlfdYNNkFTYD6ofzzlSqLA1fwH4vwvVFvJgLN0w==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.48.1"
+        "playwright-core": "1.49.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6376,9 +6376,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.1.tgz",
-      "integrity": "sha512-Yw/t4VAFX/bBr1OzwCuOMZkY1Cnb4z/doAFSwf4huqAGWmf9eMNjmK7NiOljCdLmxeRYcGPPmcDgU0zOlzP0YA==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -8411,19 +8411,19 @@
       }
     },
     "@playwright/test": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.1.tgz",
-      "integrity": "sha512-s9RtWoxkOLmRJdw3oFvhFbs9OJS0BzrLUc8Hf6l2UdCNd1rqeEyD4BhCJkvzeEoD1FsK4mirsWwGerhVmYKtZg==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
+      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
       "requires": {
-        "playwright": "1.48.1"
+        "playwright": "1.49.0"
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#49a1a110e5b399f24225a3e8ccaf59161d2a9c05",
-      "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
+      "version": "git+ssh://git@github.com/jolelievre/ui-testing-library.git#a9d19520c66523267132520b267e1217a02979f1",
+      "from": "@prestashop-core/ui-testing@https://github.com/jolelievre/ui-testing-library#update-playwright",
       "requires": {
         "@faker-js/faker": "^9.0.3",
-        "@playwright/test": "^1.48.1",
+        "@playwright/test": "^1.49.0",
         "@s3pweb/keycloak-admin-client-cjs": "^26.0.0",
         "@xmldom/xmldom": "^0.9.5",
         "csv-writer": "^1.6.0",
@@ -12714,18 +12714,18 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "playwright": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.1.tgz",
-      "integrity": "sha512-j8CiHW/V6HxmbntOfyB4+T/uk08tBy6ph0MpBXwuoofkSnLmlfdYNNkFTYD6ofzzlSqLA1fwH4vwvVFvJgLN0w==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.48.1"
+        "playwright-core": "1.49.0"
       }
     },
     "playwright-core": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.1.tgz",
-      "integrity": "sha512-Yw/t4VAFX/bBr1OzwCuOMZkY1Cnb4z/doAFSwf4huqAGWmf9eMNjmK7NiOljCdLmxeRYcGPPmcDgU0zOlzP0YA=="
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA=="
     },
     "possible-typed-array-names": {
       "version": "1.0.0",

--- a/tests/UI/package.json
+++ b/tests/UI/package.json
@@ -111,7 +111,7 @@
   "homepage": "https://github.com/PrestaShop/PrestaShop/tree/develop/tests/UI#readme",
   "dependencies": {
     "@faker-js/faker": "^9.0.3",
-    "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main",
+    "@prestashop-core/ui-testing": "https://github.com/jolelievre/ui-testing-library#update-playwright",
     "chai": "^4.5.0",
     "chai-string": "^1.5.0",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Update runners to rely on Ubuntu 24.04 to see if webkit sanity tests are more stable
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green without reboots, especially sanity
| UI Tests          | ~
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
