### PR TITLE
If price is not shown hide add to cart too. Fixes #37532

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -838,6 +838,11 @@ class ProductLazyArray extends AbstractLazyArray
             return false;
         }
 
+        // Do not enable add to cart button if prices are hidden
+        if (!$this->shouldShowPrice($settings, $product)) {
+            return false;
+        }
+
         if (($product['customizable'] == 2 || !empty($product['customization_required']))) {
             $shouldEnable = false;
 

--- a/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
+++ b/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
@@ -342,7 +342,7 @@ class ProductLazyArrayTest extends TestCase
                     'allow_oosp' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
                 ]
             ),
-            self::PRODUCT_DELIVERY_TIME_OOSBOA,
+            null,
         ];
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Hide add to cart if price is hidden
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install theme that shows "add to cart" on the product listings. Mark guest and visitor groups as "show prices: no". Check the prices and add to cart are hidden. Login with user that is in a group that does show prices. Check that prices and add to cart is shown in the product listing.
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/12279464980 ✅ 
| Fixed issue or discussion?     | #37532
| Related PRs       | https://github.com/PrestaShop/hummingbird/pull/662#pullrequestreview-2464836989
| Sponsor company   | 

All thanks go to @Hlavtox for comment in the original PR to hummingbird theme:  https://github.com/PrestaShop/hummingbird/pull/662#pullrequestreview-2464836989