### PR TITLE
Add path parameter to Htaccess Create action hook - #37534

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2254,10 +2254,10 @@ class ToolsCore
                     $path_components = [];
                     for ($i = 1; $i <= 7; ++$i) {
                         $path_components[] = '$' . ($i + 1); // paths start on 2
-                        $path = implode('/', $path_components);
+                        $path_images = implode('/', $path_components);
                         fwrite($write_fd, $media_domains);
                         fwrite($write_fd, $domain_rewrite_cond);
-                        fwrite($write_fd, 'RewriteRule ^(' . str_repeat('([\d])', $i) . '(?:\-[\w-]*)?)/.+(\.(?:jpe?g|webp|png|avif))$ %{ENV:REWRITEBASE}img/p/' . $path . '/$1$' . ($i + 2) . " [L]\n");
+                        fwrite($write_fd, 'RewriteRule ^(' . str_repeat('([\d])', $i) . '(?:\-[\w-]*)?)/.+(\.(?:jpe?g|webp|png|avif))$ %{ENV:REWRITEBASE}img/p/' . $path_images . '/$1$' . ($i + 2) . " [L]\n");
                     }
 
                     fwrite($write_fd, "# Rewrites for category images\n");
@@ -2372,7 +2372,7 @@ FileETag none
         fclose($write_fd);
 
         if (!defined('PS_INSTALLATION_IN_PROGRESS')) {
-            Hook::exec('actionHtaccessCreate');
+            Hook::exec('actionHtaccessCreate', ['path' => $path]);
         }
 
         return true;


### PR DESCRIPTION
Try to fix issue #37534

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | The function "generateHtaccess" (https://github.com/PrestaShop/PrestaShop/blob/develop/classes/Tools.php#L2097) have a parameter $path that specify .htaccess location. In this function, PrestaShop execute "actionHtaccessCreate" (https://github.com/PrestaShop/PrestaShop/blob/develop/classes/Tools.php#L2369) without any parameter. Modules hooked cannot guess path passed in parameter.
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     |no
| How to test?      | Create a module register to hook "actionHtaccessCreate". $parameters['path'] is set.
| UI Tests          | https://github.com/paulnoelcholot/testing_pr/actions/runs/13786519943
| Fixed issue or discussion?     | Fixes #37534 
| Related PRs       | 
| Sponsor company   |@Pliciweb
