### PR TITLE
Try and move the SSL certificate generation inside the docker

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -9,12 +9,13 @@ ARG GROUP_ID
 ARG USER_ID
 ARG NODE_VERSION
 ARG INSTALL_XDEBUG
-
+ARG PS_ENABLE_SSL
 
 RUN groupmod -g $GROUP_ID www-data \
   && usermod -u $USER_ID -g $GROUP_ID www-data
 
 COPY .docker/wait-for-it.sh /tmp/
+COPY .docker/install-certificate.sh /tmp/
 
 # Install mailutils to make sendmail work
 RUN apt update && apt install -y mailutils
@@ -29,6 +30,16 @@ RUN if [ "$INSTALL_XDEBUG" = "true" ]; then \
         && echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
         && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
         && echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
+    fi
+
+# Generate certificate
+RUN if [ "$PS_ENABLE_SSL" = "true" ] || [ "$PS_ENABLE_SSL" = "1" ]; then \
+      apt-get update; \
+      apt install -y libnss3-tools; \
+      curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"; \
+      chmod +x mkcert-v*-linux-amd64; \
+      mv mkcert-v*-linux-amd64 /usr/local/bin/mkcert; \
+      mkcert -key-file /tmp/ssl.key -cert-file /tmp/ssl.crt localhost; \
     fi
 
 COPY .docker/docker_run_git.sh /tmp/

--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -1,7 +1,17 @@
 #!/bin/sh
 
-if [ $PS_ENABLE_SSL = 1 ]; then
-  if [ -f ./.docker/ssl.key ]; then
+if [ "$PS_ENABLE_SSL" = "true" ] || [ "$PS_ENABLE_SSL" = "1" ]; then
+  if [ -f /tmp/ssl.crt ] && [ ! -f ./.docker/ssl.crt ]; then
+    echo "\n* Copy certificate file from tmp folder ...";
+    cp /tmp/ssl.crt ./.docker/ssl.crt
+  fi
+
+  if [ -f /tmp/ssl.key ] && [ ! -f ./.docker/ssl.key ]; then
+    echo "\n* Copy certificate key file from tmp folder ...";
+    cp /tmp/ssl.key ./.docker/ssl.key
+  fi
+
+  if [ -f ./.docker/ssl.key ] && [ -f ./.docker/ssl.crt ]; then
     echo "\n* Remove default-ssl.conf file ...";
     rm /etc/apache2/sites-available/default-ssl.conf
 
@@ -28,7 +38,8 @@ if [ $PS_ENABLE_SSL = 1 ]; then
     echo "\n* Stop apache ...";
     service apache2 stop
   else
-    echo "\n* The file .docker/ssl.key has not been found.";
+    echo "\n* The file .docker/ssl.key or .docker/ssl.crt have not been found.";
+    exit 1
   fi
 else
   echo "\n* HTTPS is not enabled.";
@@ -175,8 +186,13 @@ fi
 
 echo "\n***"
 echo "**"
-echo "** Front-office: http://${PS_DOMAIN}/"
-echo "**  Back-office: http://${PS_DOMAIN}/admin-dev"
+if [ "$PS_ENABLE_SSL" = "true" ] || [ "$PS_ENABLE_SSL" = "1" ]; then
+  echo "** Front-office: https://${PS_DOMAIN}/"
+  echo "**  Back-office: https://${PS_DOMAIN}/admin-dev"
+else
+  echo "** Front-office: http://${PS_DOMAIN}/"
+  echo "**  Back-office: http://${PS_DOMAIN}/admin-dev"
+fi
 echo "**   Login with:"
 echo "**     username: ${ADMIN_MAIL}"
 echo "**     password: ${ADMIN_PASSWD}"

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -43,26 +43,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    # Certificate for SSL
-    - name: Generate a Certificate
-      if: inputs.ENABLE_SSL == 'true'
-      shell: bash
-      run: |
-        ## Install MkCert
-          sudo apt-get update
-          sudo apt install libnss3-tools
-          curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"
-          chmod +x mkcert-v*-linux-amd64
-          sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
-          ## Generate certificate
-          mkcert -key-file ${{ inputs.PRESTASHOP_DIR }}/.docker/ssl.key -cert-file ${{ inputs.PRESTASHOP_DIR }}/.docker/ssl.crt localhost
-          ## Link certificate to Chrome Trust Store
-          mkdir -p $HOME/.pki/nssdb
-          certutil -d $HOME/.pki/nssdb -N
-          certutil -d sql:$HOME/.pki/nssdb -n localhost -A -t "TCu,Cu,Tu" -i ${{ inputs.PRESTASHOP_DIR }}/.docker/ssl.crt
-          ## Add self-signed certificate to Chrome Trust Store
-          mkcert -install
-
     # Run composer install outside of docker because inside it regularly has network issues
     - name: Composer Install
       if: inputs.DISABLE_MAKE != 'true'

--- a/docker-compose.mariadb.yml
+++ b/docker-compose.mariadb.yml
@@ -1,5 +1,3 @@
-version: '2.1'
-
 volumes:
   db-data:
 
@@ -47,7 +45,7 @@ services:
       PS_COUNTRY: ${PS_COUNTRY:-fr}
       PS_LANGUAGE: ${PS_LANGUAGE:-en}
       PS_DEV_MODE: ${PS_DEV_MODE:-1}
-      PS_ENABLE_SSL: ${PS_ENABLE_SSL:-0}
+      PS_ENABLE_SSL: ${PS_ENABLE_SSL:-1}
       PS_ERASE_DB: ${PS_ERASE_DB:-0}
       PS_USE_DOCKER_MAILDEV: ${PS_USE_DOCKER_MAILDEV:-1}
       ADMIN_MAIL: ${ADMIN_MAIL:-demo@prestashop.com}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.1'
-
 volumes:
   db-data:
 
@@ -28,6 +26,7 @@ services:
         - GROUP_ID=${GROUP_ID:-1000}
         - NODE_VERSION=${NODE_VERSION:-20.17.0}
         - INSTALL_XDEBUG=${INSTALL_XDEBUG:-false}
+        - PS_ENABLE_SSL=${PS_ENABLE_SSL:-1}
     environment:
       DISABLE_MAKE: ${DISABLE_MAKE:-0}
       PS_INSTALL_AUTO: ${PS_INSTALL_AUTO:-1}
@@ -35,13 +34,13 @@ services:
       DB_NAME: ${DB_NAME:-prestashop}
       DB_SERVER: ${DB_SERVER:-mysql}
       DB_PREFIX: ${DB_PREFIX:-ps_}
-      PS_DOMAIN: ${PS_DOMAIN:-localhost:8001}
+      PS_DOMAIN: ${PS_DOMAIN:-localhost:8002}
       PS_FOLDER_INSTALL: ${PS_FOLDER_INSTALL:-install-dev}
       PS_FOLDER_ADMIN: ${PS_FOLDER_ADMIN:-admin-dev}
       PS_COUNTRY: ${PS_COUNTRY:-fr}
       PS_LANGUAGE: ${PS_LANGUAGE:-en}
       PS_DEV_MODE: ${PS_DEV_MODE:-1}
-      PS_ENABLE_SSL: ${PS_ENABLE_SSL:-0}
+      PS_ENABLE_SSL: ${PS_ENABLE_SSL:-1}
       PS_ERASE_DB: ${PS_ERASE_DB:-0}
       PS_USE_DOCKER_MAILDEV: ${PS_USE_DOCKER_MAILDEV:-1}
       ADMIN_MAIL: ${ADMIN_MAIL:-demo@prestashop.com}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Try and move the SSL certificate generation inside the docker
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green UI tests green, can run `docker compose up` and the site is accessible via https
| UI Tests          | ~
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
