### PR TITLE
Fix employee form bugs

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
@@ -88,6 +88,9 @@ export default class EmployeeForm {
 
     // Reload tabs dropdown when employee profile is changed.
     $(document).on('change', this.employeeProfileSelector, (event) => {
+      const $tabsDropdown = $(this.tabsDropdownSelector);
+      $tabsDropdown.empty();
+      $tabsDropdown.prop('disabled', true);
       $.get(
         getTabsUrl,
         {
@@ -137,6 +140,7 @@ export default class EmployeeForm {
         );
       }
     });
+    $tabsDropdown.prop('disabled', false);
   }
 
   /**

--- a/src/Adapter/Tab/TabDataProvider.php
+++ b/src/Adapter/Tab/TabDataProvider.php
@@ -89,23 +89,38 @@ class TabDataProvider
 
         foreach (Tab::getTabs($languageId, 0) as $tab) {
             if ($this->canAccessTab($profileId, $tab['id_tab'])) {
-                $viewableTabs[$tab['id_tab']] = [
-                    'id_tab' => $tab['id_tab'],
-                    'name' => $tab['name'],
-                    'children' => [],
-                ];
-
-                foreach (Tab::getTabs($languageId, $tab['id_tab']) as $children) {
-                    if ($this->canAccessTab($profileId, $children['id_tab'])) {
-                        foreach (Tab::getTabs($languageId, $children['id_tab']) as $subchild) {
-                            if ($this->canAccessTab($profileId, $subchild['id_tab'])) {
-                                $viewableTabs[$tab['id_tab']]['children'][] = [
-                                    'id_tab' => $subchild['id_tab'],
-                                    'name' => $subchild['name'],
-                                ];
+                $children = Tab::getTabs($languageId, $tab['id_tab']);
+                $viewableChildren = [];
+                foreach ($children as $child) {
+                    if ($this->canAccessTab($profileId, $child['id_tab'])) {
+                        $subChildren = Tab::getTabs($languageId, $child['id_tab']);
+                        // If child has sub children (three level menu) we only add the sub children
+                        if (!empty($subChildren)) {
+                            foreach ($subChildren as $subChild) {
+                                if ($this->canAccessTab($profileId, $subChild['id_tab']) && $subChild['active']) {
+                                    $viewableChildren[] = [
+                                        'id_tab' => $subChild['id_tab'],
+                                        'name' => $subChild['name'],
+                                    ];
+                                }
                             }
+                        } elseif ($child['active']) {
+                            // If child is a direct page without children it can be added in the list
+                            $viewableChildren[] = [
+                                'id_tab' => $child['id_tab'],
+                                'name' => $child['name'],
+                            ];
                         }
                     }
+                }
+
+                // Tab not active are not shown unless they have active children
+                if (!empty($viewableChildren) || $tab['active']) {
+                    $viewableTabs[$tab['id_tab']] = [
+                        'id_tab' => $tab['id_tab'],
+                        'name' => $tab['name'],
+                        'children' => $viewableChildren,
+                    ];
                 }
             }
         }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -241,7 +241,7 @@ class EmployeeController extends PrestaShopAdminController
         #[Autowire(service: 'prestashop.core.form.identifiable_object.handler.employee_form_handler')]
         FormHandlerInterface $formHandler,
     ): Response {
-        $employeeForm = $formBuilder->getForm();
+        $employeeForm = $formBuilder->getForm($request->request->all('employee'));
         $employeeForm->handleRequest($request);
 
         try {

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -234,6 +234,7 @@ final class EmployeeType extends AbstractType
                     'Admin.Advparameters.Help'
                 ),
                 'autocomplete' => true,
+                'autocomplete_minimum_choices' => 5,
                 'choices' => $tabChoices,
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -125,7 +125,7 @@ final class EmployeeType extends AbstractType
         $maxLength = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH);
         $minLength = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH);
 
-        $profileId = $builder->getData()['profile'] ?? $this->superAdminProfileId;
+        $profileId = $builder->getData()['profile'] ?? reset($this->profilesChoices);
         $viewableTabs = $this->tabDataProvider->getViewableTabs($profileId, $this->languageContext->getId());
 
         $tabChoices = $this->formatTabs($viewableTabs);

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -419,7 +419,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#62ad5e0dcc4bbe4d6b2bcec8a81fa190addf2927",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#a1742d5af299e9e326c2d2d4c632f84e9f9f7f4e",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^9.0.3",
@@ -7746,7 +7746,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#62ad5e0dcc4bbe4d6b2bcec8a81fa190addf2927",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#a1742d5af299e9e326c2d2d4c632f84e9f9f7f4e",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^9.0.3",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Miscellaneous bug fixes on Employee form:<br/>- Fix prefilled list of pages in employee creation form, should be based on the default selected profile which is not always Super Admin now that the choices are sorted alphabetically<br>- In front when the profile is changed empty and block the page selector until it is refilled<br>- In form creation pass the submitted data when building the form or the page choice list is not accurate and can result in valid choices
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | UI tests and CI green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/12160645949
| Fixed issue or discussion?     | ~
| Related PRs       | https://github.com/PrestaShop/ui-testing-library/pull/277 https://github.com/PrestaShop/ui-testing-library/pull/276
| Sponsor company   | ~
