### PR TITLE
Refactor isReturnable method

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1577,6 +1577,7 @@ class FrontControllerCore extends Controller
             ],
             'voucher_enabled' => (int) CartRule::isFeatureActive(),
             'return_enabled' => (int) Configuration::get('PS_ORDER_RETURN'),
+            'return_condition' => (int) Configuration::get('PS_ORDER_RETURN_CONDITION'),
             'number_of_days_for_return' => (int) Configuration::get('PS_ORDER_RETURN_NB_DAYS'),
             'password_policy' => [
                 'minimum_length' => (int) Configuration::get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH),

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1207,7 +1207,12 @@ class OrderCore extends ObjectModel
      */
     public function isReturnable()
     {
-        if (Configuration::get('PS_ORDER_RETURN', null, null, $this->id_shop) && $this->isPaidAndShipped()) {
+        // Check if order has been paid or shipped
+        $isPaidOrShipped = $this->hasBeenPaid() || $this->hasBeenShipped();
+
+        // Check if order returns are enabled in configuration
+        // Returnable if both conditions are met
+        if (Configuration::get('PS_ORDER_RETURN', null, null, $this->id_shop) && $isPaidOrShipped) {
             return $this->getNumberOfDays();
         }
 

--- a/classes/pdf/HTMLTemplateOrderReturn.php
+++ b/classes/pdf/HTMLTemplateOrderReturn.php
@@ -78,6 +78,7 @@ class HTMLTemplateOrderReturnCore extends HTMLTemplate
         $this->smarty->assign([
             'order_return' => $this->order_return,
             'return_nb_days' => (int) Configuration::get('PS_ORDER_RETURN_NB_DAYS'),
+            'return_condition' => Configuration::get('PS_ORDER_RETURN_CONDITION'),
             'products' => OrderReturn::getOrdersReturnProducts((int) $this->order_return->id, $this->order),
             'delivery_address' => $formatted_delivery_address,
             'invoice_address' => $formatted_invoice_address,

--- a/controllers/admin/AdminReturnController.php
+++ b/controllers/admin/AdminReturnController.php
@@ -60,6 +60,17 @@ class AdminReturnControllerCore extends AdminController
                         'title' => $this->trans('Enable returns', [], 'Admin.Orderscustomers.Feature'),
                         'desc' => $this->trans('Would you like to allow merchandise returns in your shop?', [], 'Admin.Orderscustomers.Help'),
                         'cast' => 'intval', 'type' => 'bool', ],
+                    'PS_ORDER_RETURN_CONDITION' => [
+                        'title' => $this->trans('Return conditions', [], 'Admin.Orderscustomers.Feature'),
+                        'desc' => $this->trans('Choose the type of return conditions.', [], 'Admin.Orderscustomers.Help'),
+                        'type' => 'select',
+                        'list' => [
+                            ['id' => 1, 'name' => $this->trans('If the order is delivered and paid for.', [], 'Admin.Orderscustomers.Feature')],
+                            ['id' => 2, 'name' => $this->trans('If the order is delivered.', [], 'Admin.Orderscustomers.Feature')],
+                            ['id' => 3, 'name' => $this->trans('If the order is paid', [], 'Admin.Orderscustomers.Feature')],
+                        ],
+                        'identifier' => 'id',
+                    ],
                     'PS_ORDER_RETURN_NB_DAYS' => [
                         'title' => $this->trans('Time limit of validity', [], 'Admin.Orderscustomers.Feature'),
                         'desc' => $this->trans('How many days after the delivery date does the customer have to return a product?', [], 'Admin.Orderscustomers.Help'),

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -101,6 +101,9 @@
   <configuration id="PS_ORDER_RETURN" name="PS_ORDER_RETURN">
     <value>0</value>
   </configuration>
+  <configuration id="PS_ORDER_RETURN_NB_DAYS" name="PS_ORDER_RETURN_CONDITION">
+    <value>1</value>
+  </configuration>
   <configuration id="PS_ORDER_RETURN_NB_DAYS" name="PS_ORDER_RETURN_NB_DAYS">
     <value>14</value>
   </configuration>

--- a/src/Core/MerchandiseReturn/Configuration/MerchandiseReturnOptionsConfiguration.php
+++ b/src/Core/MerchandiseReturn/Configuration/MerchandiseReturnOptionsConfiguration.php
@@ -36,6 +36,7 @@ class MerchandiseReturnOptionsConfiguration extends AbstractMultistoreConfigurat
 {
     private const CONFIGURATION_FIELDS = [
         'enable_order_return',
+        'order_return_condition',
         'order_return_period_in_days',
         'order_return_prefix',
     ];
@@ -49,6 +50,7 @@ class MerchandiseReturnOptionsConfiguration extends AbstractMultistoreConfigurat
 
         return [
             'enable_order_return' => (bool) $this->configuration->get('PS_ORDER_RETURN', null, $shopConstraint),
+            'order_return_condition' => (int) $this->configuration->get('PS_ORDER_RETURN_CONDITION', null, $shopConstraint),
             'order_return_period_in_days' => (int) $this->configuration->get('PS_ORDER_RETURN_NB_DAYS', null, $shopConstraint),
             'order_return_prefix' => $this->configuration->get('PS_RETURN_PREFIX', null, $shopConstraint),
         ];
@@ -76,6 +78,12 @@ class MerchandiseReturnOptionsConfiguration extends AbstractMultistoreConfigurat
             $shopConstraint
         );
         $this->updateConfigurationValue(
+            'PS_ORDER_RETURN_CONDITION',
+            'order_return_condition',
+            $configuration,
+            $shopConstraint
+        );
+        $this->updateConfigurationValue(
             'PS_ORDER_RETURN_NB_DAYS',
             'order_return_period_in_days',
             $configuration,
@@ -99,6 +107,7 @@ class MerchandiseReturnOptionsConfiguration extends AbstractMultistoreConfigurat
         return (new OptionsResolver())
             ->setDefined(self::CONFIGURATION_FIELDS)
             ->setAllowedTypes('enable_order_return', 'bool')
+            ->setAllowedTypes('order_return_condition', 'int')
             ->setAllowedTypes('order_return_period_in_days', 'int')
             ->setAllowedTypes('order_return_prefix', 'array');
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/MerchandiseReturn/MerchandiseReturnOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/MerchandiseReturn/MerchandiseReturnOptionsType.php
@@ -31,6 +31,7 @@ use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use PrestaShopBundle\Form\Extension\MultistoreConfigurationTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
@@ -41,6 +42,7 @@ use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 class MerchandiseReturnOptionsType extends TranslatorAwareType
 {
     public const FIELD_ENABLE_ORDER_RETURN = 'enable_order_return';
+    public const FIELD_ORDER_RETURN_CONDITION = 'order_return_condition';
     public const FIELD_ORDER_RETURN_PERIOD_IN_DAYS = 'order_return_period_in_days';
     public const FIELD_ORDER_RETURN_PREFIX = 'order_return_prefix';
 
@@ -57,6 +59,18 @@ class MerchandiseReturnOptionsType extends TranslatorAwareType
                 ),
                 'required' => false,
                 'multistore_configuration_key' => 'PS_ORDER_RETURN',
+            ])
+            ->add(static::FIELD_ORDER_RETURN_CONDITION, ChoiceType::class, [
+                'label' => $this->trans(
+                    'Return conditions',
+                    'Admin.Orderscustomers.Feature'
+                ),
+                'choices' => [
+                    $this->trans('If the order is delivered and paid for.', 'Admin.Orderscustomers.Feature') => 1,
+                    $this->trans('If the order is delivered.', 'Admin.Orderscustomers.Feature') => 2,
+                    $this->trans('If the order is paid', 'Admin.Orderscustomers.Feature') => 3,
+                ],
+                'multistore_configuration_key' => 'PS_ORDER_RETURN_CONDITION',
             ])
             ->add(static::FIELD_ORDER_RETURN_PERIOD_IN_DAYS, IntegerType::class, [
                 'label' => $this->trans(

--- a/tests/Unit/Core/MerchandiseReturn/Configuration/MerchandiseReturnOptionsConfigurationTest.php
+++ b/tests/Unit/Core/MerchandiseReturn/Configuration/MerchandiseReturnOptionsConfigurationTest.php
@@ -41,6 +41,7 @@ class MerchandiseReturnOptionsConfigurationTest extends AbstractConfigurationTes
 
     private const VALID_CONFIGURATION = [
         MerchandiseReturnOptionsType::FIELD_ENABLE_ORDER_RETURN => true,
+        MerchandiseReturnOptionsType::FIELD_ORDER_RETURN_CONDITION => 1,
         MerchandiseReturnOptionsType::FIELD_ORDER_RETURN_PERIOD_IN_DAYS => 123,
         MerchandiseReturnOptionsType::FIELD_ORDER_RETURN_PREFIX => ['#RE'],
     ];
@@ -71,6 +72,12 @@ class MerchandiseReturnOptionsConfigurationTest extends AbstractConfigurationTes
                         null,
                         $shopConstraint,
                         self::VALID_CONFIGURATION[MerchandiseReturnOptionsType::FIELD_ENABLE_ORDER_RETURN],
+                    ],
+                    [
+                        'PS_ORDER_RETURN_CONDITION',
+                        null,
+                        $shopConstraint,
+                        self::VALID_CONFIGURATION[MerchandiseReturnOptionsType::FIELD_ORDER_RETURN_CONDITION],
                     ],
                     [
                         'PS_ORDER_RETURN_NB_DAYS',


### PR DESCRIPTION
Order is now returnable if paid or shipped and if product return is active.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Order is now returnable if paid or shipped and if product return is active.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Make a product return as a customer or an employee.
| UI Tests          | First commit : https://github.com/laradev43/ga.tests.ui.pr/actions/runs/12157871152 Second commit : https://github.com/laradev43/ga.tests.ui.pr/actions/runs/12254137402
| Fixed issue or discussion?     | Nothing
| Related PRs       | Nothing
| Sponsor company   | Laradev
