### PR TITLE
Do not populated Features Form with custom values

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/FeatureValueListener.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/FeatureValueListener.php
@@ -103,7 +103,7 @@ class FeatureValueListener implements EventSubscriberInterface
             return $hasPresentValue || !empty($customValue);
         }, false);
 
-        $featureValues = $this->featureValuesChoiceProvider->getChoices(['feature_id' => (int) $data['feature_id'], 'custom' => $hasCustomValue]);
+        $featureValues = $this->featureValuesChoiceProvider->getChoices(['feature_id' => (int) $data['feature_id'], 'custom' => false]);
         $options = $this->getOptions($hasCustomValue || empty($featureValues));
         $options['choices'] = $featureValues;
 

--- a/tests/Integration/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/FeatureValueListenerTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/FeatureValueListenerTest.php
@@ -136,7 +136,7 @@ class FeatureValueListenerTest extends FormListenerTestCase
                 'feature_id' => 42,
                 'custom_value' => [
                     1 => '',
-                    2 => false,
+                    2 => null,
                 ],
             ],
             [
@@ -200,7 +200,7 @@ class FeatureValueListenerTest extends FormListenerTestCase
                 'feature_id' => 42,
                 'custom_value' => [
                     1 => 'custom',
-                    2 => false,
+                    2 => null,
                 ],
             ],
             [],

--- a/tests/Integration/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/FeatureValueListenerTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/FeatureValueListenerTest.php
@@ -136,7 +136,7 @@ class FeatureValueListenerTest extends FormListenerTestCase
                 'feature_id' => 42,
                 'custom_value' => [
                     1 => '',
-                    2 => null,
+                    2 => false,
                 ],
             ],
             [
@@ -200,7 +200,7 @@ class FeatureValueListenerTest extends FormListenerTestCase
                 'feature_id' => 42,
                 'custom_value' => [
                     1 => 'custom',
-                    2 => null,
+                    2 => false,
                 ],
             ],
             [],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | In product Page v2, the Pre-defined feature values are populated with custom values associated with other products
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See issue
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/37543
| Sponsor company   | @friends-of-presta
