### PR TITLE
Fix lazy array

### DIFF
--- a/src/Adapter/Presenter/AbstractLazyArray.php
+++ b/src/Adapter/Presenter/AbstractLazyArray.php
@@ -398,7 +398,7 @@ abstract class AbstractLazyArray implements Iterator, ArrayAccess, Countable, Js
         if ($this->arrayAccessList->offsetExists($offset)) {
             $offsetData = $this->arrayAccessList->offsetGet($offset);
 
-            if (!$force && !$offsetData['isRewritable'] && $offsetData['type'] !== 'variable') {
+            if (!$force && $offsetData['type'] !== 'variable' && !$offsetData['isRewritable']) {
                 $errorMessage = sprintf(
                     'Trying to set the index %s of the LazyArray %s already defined by a method is not allowed.',
                     print_r($offset, true),


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fix a condition causing an "undefined key" warning error, if offset type is variable, isRewritable will not be set, only class and methods can have this property. So the order of check had to be fixed. This error was introduced when moving the code from 8.2.x to 9.0.x, which is why the bug only happened on 9.0.x
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | Add a customizable product, you should not see any error
| UI Tests          | https://github.com/matthieu-rolland/ga.tests.ui.pr/actions/runs/12184196469
| Fixed issue or discussion?     | Fixes #36907
| Related PRs       | 
| Sponsor company   | PrestaShop SA