### PR TITLE
Patch tinymce fullscreen

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_tinymce.scss
+++ b/admin-dev/themes/new-theme/scss/components/_tinymce.scss
@@ -130,8 +130,9 @@
   border: 0;
 
   .mce-edit-area {
-    /* stylelint-enable declaration-no-important */
+    /* stylelint-disable declaration-no-important */
     max-height: inherit !important;
+    /* stylelint-enable declaration-no-important */
   }
 }
 

--- a/admin-dev/themes/new-theme/scss/components/_tinymce.scss
+++ b/admin-dev/themes/new-theme/scss/components/_tinymce.scss
@@ -121,13 +121,16 @@
 }
 
 .mce-fullscreen {
-  z-index: 100;
+  z-index: 1100;
   height: 100%;
   padding: 0;
   margin: 0;
   overflow: hidden;
   background: $white;
   border: 0;
+  .mce-edit-area{
+    max-height: inherit !important;
+  }
 }
 
 div.mce-fullscreen {

--- a/admin-dev/themes/new-theme/scss/components/_tinymce.scss
+++ b/admin-dev/themes/new-theme/scss/components/_tinymce.scss
@@ -128,7 +128,9 @@
   overflow: hidden;
   background: $white;
   border: 0;
+
   .mce-edit-area {
+    /* stylelint-enable declaration-no-important */
     max-height: inherit !important;
   }
 }

--- a/admin-dev/themes/new-theme/scss/components/_tinymce.scss
+++ b/admin-dev/themes/new-theme/scss/components/_tinymce.scss
@@ -128,7 +128,7 @@
   overflow: hidden;
   background: $white;
   border: 0;
-  .mce-edit-area{
+  .mce-edit-area {
     max-height: inherit !important;
   }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fix tinymce fullscreen plugin. Increase z-index and disable max-height to display the editor above the header and nav-bar.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable the tinymce fullscreen plugin. The tinymce editor is now displayed above the header and the nav-bar. cf #37588 
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #37588
| Related PRs       | 
| Sponsor company   | @friends-of-presta
