### PR TITLE
Keep default language unprefixed by default

### DIFF
--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -21,7 +21,7 @@
     <value>0</value>
   </configuration>
   <configuration id="PS_DEFAULT_LANGUAGE_URL_PREFIX" name="PS_DEFAULT_LANGUAGE_URL_PREFIX">
-    <value>1</value>
+    <value>0</value>
   </configuration>
   <configuration id="PS_ORDER_OUT_OF_STOCK" name="PS_ORDER_OUT_OF_STOCK">
     <value>0</value>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Following my PR that allows to set if a default language should be prefixed - https://github.com/PrestaShop/PrestaShop/pull/37236/, I set the default value for NEW INSTALLS to OFF. Basically, I can't any single benefit of leaving this behavior by default, even if it was in Prestashop for years. Reasons below.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Does not need testing.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Reasons for this change
- If anyone is starting a shop with multiple languages directly and wants to prefix all languages, he can do so when setting up the shop. ✅
- BUT, if someone will be running a shop for a while and he adds another language, if this option is ON (or previous behavior), it will highly damage his SEO, because all URLs will permanently change. 🔴 This will keep all his URLs intact. 🟢

I want to also improve the upgrade mechanism a bit.
- If there are multiple active langs on the shop (prefixes for all langs) > upgrade to YES.
- If there is only single language on the shop (nonprefixed URLs) > upgrade to NO. So when he adds a language, his URLs will remain the same.