### PR TITLE
[feat] Add hook to customize ajax refreshed data on product page

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -502,7 +502,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             'actionProductControllerAjaxRefresh',
             [
                 'ajaxData' => &$ajaxData,
-                'product' => $product
+                'product' => $product,
             ],
             null,
             true
@@ -513,7 +513,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 $ajaxData['modules'][$moduleName] = $data;
             }
         }
-        
+
         ob_end_clean();
         header('Content-Type: application/json');
         $this->ajaxRender(json_encode($ajaxData));

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -461,9 +461,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             $minimalProductQuantity = 1;
         }
 
-        ob_end_clean();
-        header('Content-Type: application/json');
-        $this->ajaxRender(json_encode([
+        $ajaxData = [
             'product_prices' => $this->render('catalog/_partials/product-prices'),
             'product_cover_thumbnails' => $this->render('catalog/_partials/product-cover-thumbnails'),
             'product_customization' => $this->render(
@@ -498,7 +496,27 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             'id_customization' => $product['id_customization'],
             'product_title' => $this->getTemplateVarPage()['meta']['title'],
             'is_quick_view' => $this->isQuickView(),
-        ]));
+        ];
+
+        $modulesAjaxData = Hook::exec(
+            'actionProductControllerAjaxRefresh',
+            [
+                'ajaxData' => &$ajaxData,
+                'product' => $product
+            ],
+            null,
+            true
+        );
+
+        if (is_array($modulesAjaxData)) {
+            foreach ($modulesAjaxData as $moduleName => $data) {
+                $ajaxData['modules'][$moduleName] = $data;
+            }
+        }
+        
+        ob_end_clean();
+        header('Content-Type: application/json');
+        $this->ajaxRender(json_encode($ajaxData));
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Adds a hook to add custom data in ajax refreshed data on the product page
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install the test module, go to a product page with combinations, open console > Network, filter by Fetch/XHR, change an attribute in the product page, locate the ajax request, the response should include evo_actionproductcontrollerajaxrefresh data (lorem > ipsum)
[evo_actionproductcontrollerajaxrefresh.zip](https://github.com/user-attachments/files/18035497/evo_actionproductcontrollerajaxrefresh.zip)
![hook](https://github.com/user-attachments/assets/69466353-2117-4dad-af63-47df791e047b)
| UI Tests          | 
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/discussions/37595
| Related PRs       | 
| Sponsor company   | Evolutive
