### PR TITLE
Upgrade attachment names length

### DIFF
--- a/classes/Attachment.php
+++ b/classes/Attachment.php
@@ -51,11 +51,11 @@ class AttachmentCore extends ObjectModel
         'fields' => [
             'file' => ['type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true, 'size' => 40],
             'mime' => ['type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'required' => true, 'size' => 128],
-            'file_name' => ['type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'size' => 128],
+            'file_name' => ['type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'size' => 255],
             'file_size' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
 
             /* Lang fields */
-            'name' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => true, 'size' => 32],
+            'name' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => true, 'size' => 255],
             'description' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isCleanHtml', 'size' => FormattedTextareaType::LIMIT_MEDIUMTEXT_UTF8_MB4],
         ],
         'associations' => [

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -58,7 +58,7 @@ CREATE TABLE `PREFIX_alias` (
 CREATE TABLE `PREFIX_attachment` (
   `id_attachment` int(10) unsigned NOT NULL auto_increment,
   `file` varchar(40) NOT NULL,
-  `file_name` varchar(128) NOT NULL,
+  `file_name` varchar(255) NOT NULL,
   `file_size` bigint(10) unsigned NOT NULL DEFAULT '0',
   `mime` varchar(128) NOT NULL,
   PRIMARY KEY (`id_attachment`)
@@ -68,7 +68,7 @@ CREATE TABLE `PREFIX_attachment` (
 CREATE TABLE `PREFIX_attachment_lang` (
   `id_attachment` int(10) unsigned NOT NULL auto_increment,
   `id_lang` int(10) unsigned NOT NULL,
-  `name` varchar(32) DEFAULT NULL,
+  `name` varchar(255) DEFAULT NULL,
   `description` MEDIUMTEXT,
   PRIMARY KEY (`id_attachment`, `id_lang`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;

--- a/src/Core/Domain/Attachment/Configuration/AttachmentConstraint.php
+++ b/src/Core/Domain/Attachment/Configuration/AttachmentConstraint.php
@@ -34,7 +34,7 @@ final class AttachmentConstraint
     /**
      * Maximum length for name (value is constrained by database)
      */
-    public const MAX_NAME_LENGTH = 32;
+    public const MAX_NAME_LENGTH = 255;
 
     /**
      * Prevents class to be instantiated


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | The number of characters available for naming files when they are added in the back office is too short for displaying them on the front, for example, to name a technical manual.
| Type?             |  improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to Catalog > Files and add a new file with a filename greater than 32 characters, and a filename greater than 128 characters.
| UI Tests          | 
| Related PRs    | https://github.com/PrestaShop/autoupgrade/pull/1070
| Sponsor company   | creabilis.com
