### PR TITLE
Remove configuration of AEUC_LABEL_TAX_INC_EXC from module ps_legalco…

### DIFF
--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -74,7 +74,7 @@ class DeliveryOptionsFinderCore
     {
         $delivery_option_list = $this->context->cart->getDeliveryOptionList();
         $include_taxes = !Product::getTaxCalculationMethod((int) $this->context->cart->id_customer) && (int) Configuration::get('PS_TAX');
-        $display_taxes_label = (Configuration::get('PS_TAX') && $this->context->country->display_tax_label && !Configuration::get('AEUC_LABEL_TAX_INC_EXC'));
+        $display_taxes_label = (Configuration::get('PS_TAX') && $this->context->country->display_tax_label);
 
         $carriers_available = [];
 

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1588,7 +1588,7 @@ class FrontControllerCore extends Controller
 
     protected function getDisplayTaxesLabel()
     {
-        return (Module::isEnabled('ps_legalcompliance') && (bool) Configuration::get('AEUC_LABEL_TAX_INC_EXC')) || $this->context->country->display_tax_label;
+        return $this->context->country->display_tax_label;
     }
 
     /**

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -406,7 +406,7 @@ class OrderControllerCore extends FrontController
                     !Product::getTaxCalculationMethod((int) $this->context->cart->id_customer)
                     && (int) Configuration::get('PS_TAX')
                 )
-                ->setDisplayTaxesLabel(Configuration::get('PS_TAX') && !Configuration::get('AEUC_LABEL_TAX_INC_EXC'))
+                ->setDisplayTaxesLabel(Configuration::get('PS_TAX'))
                 ->setGiftCost(
                     $this->context->cart->getGiftWrappingPrice(
                         $checkoutDeliveryStep->getIncludeTaxes()

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -583,7 +583,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
         $this->context->smarty->assign([
             'no_tax' => !Configuration::get('PS_TAX') || !$tax,
-            'tax_enabled' => Configuration::get('PS_TAX') && !Configuration::get('AEUC_LABEL_TAX_INC_EXC'),
+            'tax_enabled' => Configuration::get('PS_TAX'),
             'customer_group_without_tax' => Group::getPriceDisplayMethod($this->context->customer->id_default_group),
         ]);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x 
| Description?      | In some places there is still access to the configuration AEUC_LABEL_TAX_INC_EXC of the ps_legalcompliance module. This module is archived and this configuration can be deleted from the code.
| Type?             | improvement
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Indicate how to verify that this change works as expected.
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/14532081193
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/37569
| Related PRs       | 
| Sponsor company   | 
