### PR TITLE
change buildGroupedFeatures of product lazy array to public

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -1382,7 +1382,7 @@ class ProductLazyArray extends AbstractLazyArray
      *
      * @return array
      */
-    protected function buildGroupedFeatures(array $productFeatures)
+    public function buildGroupedFeatures(array $productFeatures)
     {
         $valuesByFeatureName = [];
         $groupedFeatures = [];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0
| Description?      | allow buildGroupedFeatures to be called everywhere
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | NA
| Sponsor company   | Creabilis.com
