### PR TITLE
Remove the discount (if any) from the total amount of credit split

### DIFF
--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -323,6 +323,11 @@ class OrderSlipCreator
             $orderSlip->order_slip_type = VoucherRefundType::SPECIFIC_AMOUNT_REFUND;
         }
 
+        if ($amount && $orderSlip->order_slip_type == VoucherRefundType::PRODUCT_PRICES_EXCLUDING_VOUCHER_REFUND) {
+            $orderSlip->amount -= $amount;
+            $orderSlip->total_products_tax_incl -= $amount;
+        }
+
         if (!$orderSlip->add()) {
             return false;
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This fix should solve the wrong credit slip total amount calculation, despite the pdf generated is correct, the data stored in database is not. Now the value is correct and displayed correctly in the document tab in the order page. When the merchant choose
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow the issue
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | Fixes #35614 
| Sponsor company   | Myself
