### PR TITLE
API localized values can be indexed by locale

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "prestashop/hummingbird": "^1.0.0",
         "prestashop/pagesnotfound": "^2",
         "prestashop/productcomments": "^7.0",
-        "prestashop/ps_apiresources": "dev-dev",
+        "prestashop/ps_apiresources": "dev-localized-values",
         "prestashop/ps_banner": "^2",
         "prestashop/ps_bestsellers": "^1.0",
         "prestashop/ps_brandlist": "^1.0",
@@ -212,7 +212,7 @@
         },
         "ps_apiresources": {
             "type": "vcs",
-            "url": "https://github.com/PrestaShop/ps_apiresources.git"
+            "url": "https://github.com/jolelievre/ps_apiresources.git"
         }
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2665f8f54a56c2e57c743d33a485c655",
+    "content-hash": "bb4cd98f4dd02775fc3dd857d4a724d9",
     "packages": [
         {
             "name": "api-platform/core",
@@ -5202,16 +5202,16 @@
         },
         {
             "name": "prestashop/ps_apiresources",
-            "version": "dev-dev",
+            "version": "dev-localized-values",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PrestaShop/ps_apiresources.git",
-                "reference": "d75f2b0f485cc844052a453c65e71e3eae793155"
+                "url": "https://github.com/jolelievre/ps_apiresources.git",
+                "reference": "9808ef6ad7bfe78e41c94ff67b91dd178b317ec8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_apiresources/zipball/d75f2b0f485cc844052a453c65e71e3eae793155",
-                "reference": "d75f2b0f485cc844052a453c65e71e3eae793155",
+                "url": "https://api.github.com/repos/jolelievre/ps_apiresources/zipball/9808ef6ad7bfe78e41c94ff67b91dd178b317ec8",
+                "reference": "9808ef6ad7bfe78e41c94ff67b91dd178b317ec8",
                 "shasum": ""
             },
             "require": {
@@ -5223,7 +5223,6 @@
                 "phpunit/phpunit": "^10",
                 "prestashop/php-dev-tools": "^4.3"
             },
-            "default-branch": true,
             "type": "prestashop-module",
             "autoload": {
                 "psr-4": {
@@ -5265,9 +5264,9 @@
             "description": "PrestaShop - API Resources",
             "homepage": "https://github.com/PrestaShop/ps_apiresources",
             "support": {
-                "source": "https://github.com/PrestaShop/ps_apiresources/tree/dev"
+                "source": "https://github.com/jolelievre/ps_apiresources/tree/localized-values"
             },
-            "time": "2024-11-25T14:30:45+00:00"
+            "time": "2024-12-16T11:32:20+00:00"
         },
         {
             "name": "prestashop/ps_banner",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -971,6 +971,11 @@ parameters:
 			path: src/PrestaShopBundle/ApiPlatform/Normalizer/CQRSApiNormalizer.php
 
 		-
+			message: "#^Method Symfony\\\\Component\\\\Serializer\\\\Normalizer\\\\DenormalizerInterface\\:\\:supportsDenormalization\\(\\) invoked with 4 parameters, 2\\-3 required\\.$#"
+			count: 1
+			path: src/PrestaShopBundle/ApiPlatform/Normalizer/CQRSApiNormalizer.php
+
+		-
 			message: "#^Class Employee is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 1
 			path: src/PrestaShopBundle/Command/AppendConfigurationFileHooksListCommand.php

--- a/src/PrestaShopBundle/ApiPlatform/Exception/LocaleNotFoundException.php
+++ b/src/PrestaShopBundle/ApiPlatform/Exception/LocaleNotFoundException.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\ApiPlatform\Exception;
+
+use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
+
+class LocaleNotFoundException extends InvalidArgumentException
+{
+}

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/LocalizedValue.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/LocalizedValue.php
@@ -29,6 +29,13 @@ namespace PrestaShopBundle\ApiPlatform\Metadata;
 use Attribute;
 use Symfony\Component\Serializer\Attribute\Context;
 
+/**
+ * This attribute can be added on a property in an API resource class, when set the localized values
+ * are no longer index by Language IDs but by Language's locale instead. It impacts both inputs and outputs
+ * where JSON localized value must be indexed by locale:
+ *
+ *   {names: {"2": "english name", "4": "nom français"}} => {"names": {"en-US": "english name", "fr-FR": "nom français"}}
+ */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class LocalizedValue extends Context
 {

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/LocalizedValue.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/LocalizedValue.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\ApiPlatform\Metadata;
+
+use Attribute;
+use Symfony\Component\Serializer\Attribute\Context;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class LocalizedValue extends Context
+{
+    public const IS_LOCALIZED_VALUE = 'is_localized_value';
+
+    public function __construct(array $context = [], array $normalizationContext = [], array $denormalizationContext = [], array|string $groups = [])
+    {
+        parent::__construct([self::IS_LOCALIZED_VALUE => true] + $context, $normalizationContext, $denormalizationContext, $groups);
+    }
+}

--- a/src/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizer.php
+++ b/src/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizer.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\ApiPlatform\Normalizer;
+
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
+use ReflectionNamedType;
+use ReflectionParameter;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+#[AutoconfigureTag('prestashop.api.normalizers')]
+class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    public const VALUE_OBJECT_RETURNED_AS_SCALAR = 'value_object_returned_as_scalar';
+
+    protected Inflector $inflector;
+
+    /**
+     * @var array<string, string[]>
+     */
+    protected array $allowedNamesByType = [];
+
+    /**
+     * @var array<string, ?ReflectionParameter>
+     */
+    protected array $constructorParameter = [];
+
+    public function __construct(
+        protected readonly ClassMetadataFactoryInterface $classMetadataFactory
+    ) {
+        $this->inflector = InflectorFactory::create()->build();
+    }
+
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = [])
+    {
+        if (!$this->supportsDenormalization($data, $type)) {
+            throw new InvalidArgumentException('Cannot denormalize to ' . $type);
+        }
+
+        if ($this->matchesConstructorParameter($data, $type)) {
+            $parameterValue = $data;
+        } else {
+            $constructorParameter = $this->getConstructorParameter($type);
+            $parameterValue = $constructorParameter->isDefaultValueAvailable() ? $constructorParameter->getDefaultValue() : null;
+            foreach ($this->getAllowedValueNames($type) as $argumentName) {
+                if (isset($data[$argumentName])) {
+                    $parameterValue = $data[$argumentName];
+                    break;
+                }
+
+                if (isset($data['value'][$argumentName])) {
+                    $parameterValue = $data[$argumentName];
+                    break;
+                }
+            }
+        }
+
+        if (!empty($context[self::VALUE_OBJECT_RETURNED_AS_SCALAR])) {
+            return $parameterValue;
+        }
+
+        return new $type($parameterValue);
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null)
+    {
+        if (!$this->isValueObjectType($type)) {
+            return false;
+        }
+
+        if ($this->matchesConstructorParameter($data, $type)) {
+            return true;
+        }
+
+        if (!is_array($data)) {
+            return false;
+        }
+
+        $allowedNames = $this->getAllowedValueNames($type);
+        foreach ($allowedNames as $allowedName) {
+            if (isset($data[$allowedName])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function normalize(mixed $object, ?string $format = null, array $context = [])
+    {
+        if (!$this->isValueObject($object)) {
+            throw new InvalidArgumentException('Expected object to be a ValueObject');
+        }
+
+        if (!empty($context[self::VALUE_OBJECT_RETURNED_AS_SCALAR])) {
+            return $object->getValue();
+        }
+
+        $metadata = $this->classMetadataFactory->getMetadataFor($object);
+
+        return [
+            lcfirst($metadata->getReflectionClass()->getShortName()) => $object->getValue(),
+        ];
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null)
+    {
+        return $this->isValueObject($data);
+    }
+
+    protected function isValueObject(mixed $data): bool
+    {
+        return is_object($data)
+            && !is_iterable($data)
+            && method_exists($data, 'getValue')
+            // Check that ValueObject is part of the namespace
+            && str_contains(get_class($data), 'ValueObject')
+            && $this->getConstructorParameter($data);
+    }
+
+    protected function isValueObjectType(string $type): bool
+    {
+        return class_exists($type)
+            && method_exists($type, 'getValue')
+            // Check that ValueObject is part of the namespace
+            && str_contains($type, 'ValueObject')
+            && $this->getConstructorParameter($type);
+    }
+
+    protected function matchesConstructorParameter(mixed $value, string $type): bool
+    {
+        $constructorParameter = $this->getConstructorParameter($type);
+
+        // If the type is not strict we assume it MAY match
+        if (!$constructorParameter || !$constructorParameter->hasType()) {
+            return true;
+        }
+
+        $type = $constructorParameter->getType();
+        if ($type instanceof ReflectionNamedType && $type->isBuiltin()) {
+            $checkMethod = 'is_' . $type->getName();
+
+            return $checkMethod($value);
+        }
+
+        return false;
+    }
+
+    protected function getAllowedValueNames(string $type): array
+    {
+        if (!isset($this->allowedNamesByType[$type])) {
+            $className = substr($type, strrpos($type, '\\') + 1);
+
+            $this->allowedNamesByType[$type] = [
+                $this->inflector->camelize($className),
+                $this->inflector->tableize($className),
+            ];
+
+            $constructorParameter = $this->getConstructorParameter($type);
+            if ($constructorParameter && !in_array($constructorParameter->getName(), $this->allowedNamesByType[$type])) {
+                $this->allowedNamesByType[$type][] = $constructorParameter->getName();
+            }
+            if (!in_array('value', $this->allowedNamesByType[$type])) {
+                $this->allowedNamesByType[$type][] = 'value';
+            }
+        }
+
+        return $this->allowedNamesByType[$type];
+    }
+
+    protected function getConstructorParameter(object|string $type): ?ReflectionParameter
+    {
+        $objectType = is_object($type) ? get_class($type) : $type;
+        if (!array_key_exists($objectType, $this->constructorParameter)) {
+            $metadata = $this->classMetadataFactory->getMetadataFor($type);
+            if (!$metadata->getReflectionClass()->getConstructor()) {
+                $this->constructorParameter[$objectType] = null;
+            } elseif ($metadata->getReflectionClass()->getConstructor()->getNumberOfRequiredParameters() !== 1) {
+                // ValueObject are supposed to have only one required parameter (if the convention evolves, this normalizer should evolve too)
+                $this->constructorParameter[$objectType] = null;
+            } else {
+                $parameter = $metadata->getReflectionClass()->getConstructor()->getParameters()[0];
+                if (!$parameter->hasType()) {
+                    $this->constructorParameter[$objectType] = $parameter;
+                } elseif (!($parameter->getType() instanceof ReflectionNamedType) || !$parameter->getType()->isBuiltin()) {
+                    $this->constructorParameter[$objectType] = null;
+                } else {
+                    $this->constructorParameter[$objectType] = $parameter;
+                }
+            }
+        }
+
+        return $this->constructorParameter[$objectType] ?? null;
+    }
+}

--- a/src/PrestaShopBundle/ApiPlatform/Provider/QueryListProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/QueryListProvider.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Search\Builder\FiltersBuilderInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters;
 use PrestaShopBundle\ApiPlatform\ContextParametersTrait;
 use PrestaShopBundle\ApiPlatform\Exception\GridDataFactoryNotFoundException;
+use PrestaShopBundle\ApiPlatform\Normalizer\CQRSApiNormalizer;
 use PrestaShopBundle\ApiPlatform\Pagination\PaginationElements;
 use PrestaShopBundle\ApiPlatform\QueryResultSerializerTrait;
 use PrestaShopBundle\ApiPlatform\Serializer\DomainSerializer;
@@ -113,7 +114,11 @@ class QueryListProvider implements ProviderInterface
                 $result,
                 $operation->getClass(),
                 null,
-                [DomainSerializer::NORMALIZATION_MAPPING => $this->getApiResourceMapping($operation)]
+                [
+                    DomainSerializer::NORMALIZATION_MAPPING => $this->getApiResourceMapping($operation),
+                    // Query list builders return boolean value as tiny int, so we must cast them
+                    CQRSApiNormalizer::CAST_BOOL => true,
+                ]
             );
         }
 

--- a/src/PrestaShopBundle/Entity/Repository/LangRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/LangRepository.php
@@ -95,6 +95,22 @@ class LangRepository extends EntityRepository implements LanguageRepositoryInter
         return $language;
     }
 
+    public function getMapping(): array
+    {
+        $qb = $this->createQueryBuilder('l');
+        $qb->select('l.id, l.locale');
+        $result = $qb->getQuery()->getArrayResult();
+
+        $mapping = [];
+        foreach ($result as $row) {
+            $mapping[$row['id']] = [
+                'locale' => $row['locale'],
+            ];
+        }
+
+        return $mapping;
+    }
+
     /**
      * @param string $key
      * @param string $value

--- a/src/PrestaShopBundle/Entity/Repository/LangRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/LangRepository.php
@@ -95,6 +95,12 @@ class LangRepository extends EntityRepository implements LanguageRepositoryInter
         return $language;
     }
 
+    /**
+     * Returns all the mapping for all installed languages, the returned array is indexed by Language ID,
+     * it contains an array with Language info, only locale is relevant for now but it may evolve in the future.
+     *
+     * @return array<int, array{'locale': string}>
+     */
     public function getMapping(): array
     {
         $qb = $this->createQueryBuilder('l');

--- a/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
@@ -6,6 +6,7 @@ services:
   # Configuration to automatically inject normalizers into DomainSerializer
   PrestaShopBundle\ApiPlatform\Normalizer\:
     resource: "../../../../ApiPlatform/Normalizer/*"
+    autowire: true
     tags: [ 'prestashop.api.normalizers' ]
 
   # This is a custom serializer used by our custom providers/processors for ApiPlatform

--- a/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
@@ -26,12 +26,17 @@ services:
     arguments:
       - PrestaShopBundle\Entity\Translation
 
-  prestashop.core.admin.lang.repository:
-    class: PrestaShopBundle\Entity\Repository\LangRepository
+  PrestaShopBundle\Entity\Repository\LangRepository:
     factory: [ '@doctrine.orm.default_entity_manager', getRepository ]
     arguments:
       - PrestaShopBundle\Entity\Lang
     lazy: true
+
+  prestashop.core.admin.lang.repository:
+    alias: PrestaShopBundle\Entity\Repository\LangRepository
+    deprecated:
+      package: PrestaShop\PrestaShop
+      version: 9.0
 
   PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface: '@prestashop.core.admin.lang.repository'
 

--- a/tests/Integration/ApiPlatform/EndPoint/ApiTestCase.php
+++ b/tests/Integration/ApiPlatform/EndPoint/ApiTestCase.php
@@ -34,15 +34,17 @@ use ApiPlatform\Symfony\Bundle\Test\Client;
 use Configuration;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\AddApiClientCommand;
 use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
-use PrestaShop\PrestaShop\Core\Domain\Language\Command\AddLanguageCommand;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use RuntimeException;
 use Shop;
 use ShopGroup;
+use Tests\Integration\Utility\LanguageTrait;
 use Tests\Resources\Resetter\ApiClientResetter;
 
 abstract class ApiTestCase extends ApiPlatformTestCase
 {
+    use LanguageTrait;
+
     protected const CLIENT_ID = 'test_client_id';
     protected const CLIENT_NAME = 'test_client_name';
 
@@ -178,40 +180,6 @@ abstract class ApiTestCase extends ApiPlatformTestCase
         $createdApiClient = $commandBus->handle($command);
 
         self::$clientSecret = $createdApiClient->getSecret();
-    }
-
-    protected static function addLanguageByLocale(string $locale): int
-    {
-        $isoCode = substr($locale, 0, strpos($locale, '-'));
-
-        // Copy resource assets into tmp folder to mimic an upload file path
-        $flagImage = __DIR__ . '/../../../Resources/assets/lang/' . $isoCode . '.jpg';
-        if (!file_exists($flagImage)) {
-            $flagImage = __DIR__ . '/../../../Resources/assets/lang/en.jpg';
-        }
-
-        $tmpFlagImage = sys_get_temp_dir() . '/' . $isoCode . '.jpg';
-        $tmpNoPictureImage = sys_get_temp_dir() . '/' . $isoCode . '-no-picture.jpg';
-        copy($flagImage, $tmpFlagImage);
-        copy($flagImage, $tmpNoPictureImage);
-
-        $command = new AddLanguageCommand(
-            $locale,
-            $isoCode,
-            $locale,
-            'd/m/Y',
-            'd/m/Y H:i:s',
-            $tmpFlagImage,
-            $tmpNoPictureImage,
-            false,
-            true,
-            [1]
-        );
-
-        $container = static::createClient()->getContainer();
-        $commandBus = $container->get('prestashop.core.command_bus');
-
-        return $commandBus->handle($command)->getValue();
     }
 
     protected static function addShopGroup(string $groupName, ?string $color = null): int

--- a/tests/Integration/ApiPlatform/Serializer/DomainSerializerTest.php
+++ b/tests/Integration/ApiPlatform/Serializer/DomainSerializerTest.php
@@ -94,7 +94,7 @@ class DomainSerializerTest extends KernelTestCase
 
     public function getExpectedDenormalizedData()
     {
-        yield [
+        yield 'command with various property types all in constructor' => [
             [
                 'localizedNames' => [
                     1 => 'test1',
@@ -131,7 +131,7 @@ class DomainSerializerTest extends KernelTestCase
         $editCartRuleCommand->setTotalQuantity(100);
         $editCartRuleCommand->setQuantityPerUser(1);
         $editCartRuleCommand->setCartRuleAction(new CartRuleAction(true));
-        yield [
+        yield 'object with complex setter methods based on multiple properties or sub types' => [
             [
                 'cartRuleId' => 1,
                 'description' => 'test description',
@@ -162,7 +162,7 @@ class DomainSerializerTest extends KernelTestCase
         ];
 
         $customerGroupQuery = new GetCustomerGroupForEditing(51);
-        yield 'value object with wrong parameter converted via mapping' => [
+        yield 'value object with wrong parameter name converted via mapping' => [
             [
                 'groupId' => 51,
             ],
@@ -250,21 +250,10 @@ class DomainSerializerTest extends KernelTestCase
         $hook->name = 'testHook';
         $hook->title = 'testHookTitle';
         $hook->description = '';
-        yield [
+        yield 'denormalize an APIPlatform DTO with specified mapping' => [
             [
                 'id_hook' => 1,
-                'active' => 1,
-                'name' => 'testHook',
-                'title' => 'testHookTitle',
-                'description' => '',
-            ],
-            $hook,
-            ['[id_hook]' => '[id]'],
-        ];
-        yield [
-            [
-                'id_hook' => 1,
-                'active' => '1',
+                'active' => true,
                 'name' => 'testHook',
                 'title' => 'testHookTitle',
                 'description' => '',
@@ -331,7 +320,7 @@ class DomainSerializerTest extends KernelTestCase
         ];
 
         $createdApiClient = new CreatedApiClient(42, 'my_secret');
-        yield 'normalize command result that contains a ValueObject' => [
+        yield 'normalize command result that contains a ValueObject, returned as an integer not an array' => [
             $createdApiClient,
             [
                 'apiClientId' => 42,
@@ -340,7 +329,7 @@ class DomainSerializerTest extends KernelTestCase
         ];
 
         $groupId = new GroupId(42);
-        yield 'normalize GroupId value object' => [
+        yield 'normalize GroupId value object returned as array' => [
             $groupId,
             [
                 'groupId' => 42,
@@ -348,7 +337,7 @@ class DomainSerializerTest extends KernelTestCase
         ];
 
         $productId = new ProductId(42);
-        yield 'normalize ProductId value object' => [
+        yield 'normalize ProductId value object returned as array' => [
             $productId,
             [
                 'productId' => 42,

--- a/tests/Integration/ApiPlatform/Serializer/DomainSerializerTest.php
+++ b/tests/Integration/ApiPlatform/Serializer/DomainSerializerTest.php
@@ -103,22 +103,31 @@ class DomainSerializerTest extends KernelTestCase
 
     public function getExpectedDenormalizedData()
     {
-        $productResource = new Product();
-        $productResource->productId = 42;
-        $productResource->names = [
-            'en-US' => 'english name',
-            'fr-FR' => 'nom français',
+        $localizedResource = new LocalizedResource([
+            'en-US' => 'english link',
+            'fr-FR' => 'lien français',
+        ]);
+
+        // This property has no context attributes, so it remains indexed by IDs
+        $localizedResource->names = [
+            self::EN_LANG_ID => 'english name',
+            self::getFrenchId() => 'nom français',
         ];
-        $productResource->descriptions = [
+        $localizedResource->descriptions = [
             'en-US' => 'english description',
             'fr-FR' => 'description française',
         ];
-        $productResource->active = true;
-        $productResource->type = ProductType::TYPE_STANDARD;
+        $localizedResource->titles = [
+            'en-US' => 'english title',
+            'fr-FR' => 'titre français',
+        ];
 
         yield 'api resource with localized properties should have indexes based on locale values instead of integers' => [
             [
-                'productId' => 42,
+                'localizedLinks' => [
+                    self::EN_LANG_ID => 'english link',
+                    self::getFrenchId() => 'lien français',
+                ],
                 'names' => [
                     self::EN_LANG_ID => 'english name',
                     self::getFrenchId() => 'nom français',
@@ -127,10 +136,12 @@ class DomainSerializerTest extends KernelTestCase
                     self::EN_LANG_ID => 'english description',
                     self::getFrenchId() => 'description française',
                 ],
-                'active' => true,
-                'type' => ProductType::TYPE_STANDARD,
+                'titles' => [
+                    self::EN_LANG_ID => 'english title',
+                    self::getFrenchId() => 'titre français',
+                ],
             ],
-            $productResource,
+            $localizedResource,
         ];
 
         yield 'command with various property types all in constructor' => [

--- a/tests/Integration/Utility/LanguageTrait.php
+++ b/tests/Integration/Utility/LanguageTrait.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Integration\Utility;
+
+use PrestaShop\PrestaShop\Core\Domain\Language\Command\AddLanguageCommand;
+
+trait LanguageTrait
+{
+    protected static function addLanguageByLocale(string $locale): int
+    {
+        $isoCode = substr($locale, 0, strpos($locale, '-'));
+
+        // Copy resource assets into tmp folder to mimic an upload file path
+        $flagImage = __DIR__ . '/../../Resources/assets/lang/' . $isoCode . '.jpg';
+        if (!file_exists($flagImage)) {
+            $flagImage = __DIR__ . '/../../Resources/assets/lang/en.jpg';
+        }
+
+        $tmpFlagImage = sys_get_temp_dir() . '/' . $isoCode . '.jpg';
+        $tmpNoPictureImage = sys_get_temp_dir() . '/' . $isoCode . '-no-picture.jpg';
+        copy($flagImage, $tmpFlagImage);
+        copy($flagImage, $tmpNoPictureImage);
+
+        $command = new AddLanguageCommand(
+            $locale,
+            $isoCode,
+            $locale,
+            'd/m/Y',
+            'd/m/Y H:i:s',
+            $tmpFlagImage,
+            $tmpNoPictureImage,
+            false,
+            true,
+            [1]
+        );
+
+        $container = static::getContainer();
+        $commandBus = $container->get('prestashop.core.command_bus');
+
+        return $commandBus->handle($command)->getValue();
+    }
+}

--- a/tests/Resources/ApiPlatform/Resources/LocalizedResource.php
+++ b/tests/Resources/ApiPlatform/Resources/LocalizedResource.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Resources\ApiPlatform\Resources;
+
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\Serializer\Attribute\Context;
+
+/**
+ * This a test class showing how localized values can be handled in the API Platform resource classes:
+ *   - you can manually specify the is_localized_value context option
+ *   - you can use the customer helper LocalizedValue attribute
+ *   - you can set it on class fields and/or getter methods
+ *   - if you don't specify it the fields will be indexed by integer
+ */
+class LocalizedResource
+{
+    public function __construct(
+        private readonly array $localizedLinks,
+    ) {
+    }
+
+    public array $names;
+
+    #[LocalizedValue]
+    public array $descriptions;
+
+    #[Context([LocalizedValue::IS_LOCALIZED_VALUE => true])]
+    public array $titles;
+
+    #[LocalizedValue]
+    public function getLocalizedLinks(): array
+    {
+        return $this->localizedLinks;
+    }
+}

--- a/tests/UI/campaigns/functional/API/02_endpoints/04_customerGroup/03_getCustomerGroupsId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/04_customerGroup/03_getCustomerGroupsId.ts
@@ -244,8 +244,8 @@ describe('API : GET /customers/group/{customerGroupId}', async () => {
 
       expect(jsonResponse).to.have.property('localizedNames');
       expect(jsonResponse.localizedNames).to.be.a('object');
-      expect(jsonResponse.localizedNames[dataLanguages.english.id]).to.be.equal(nameEn);
-      expect(jsonResponse.localizedNames[dataLanguages.french.id]).to.be.equal(nameFr);
+      expect(jsonResponse.localizedNames[dataLanguages.english.locale]).to.be.equal(nameEn);
+      expect(jsonResponse.localizedNames[dataLanguages.french.locale]).to.be.equal(nameFr);
     });
 
     it('should check the JSON Response : `reductionPercent`', async function () {

--- a/tests/UI/campaigns/functional/API/02_endpoints/04_customerGroup/04_putCustomerGroupsId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/04_customerGroup/04_putCustomerGroupsId.ts
@@ -225,8 +225,8 @@ describe('API : PUT /customers/group/{customerGroupId}', async () => {
         data: {
           customerGroupId: idCustomerGroup,
           localizedNames: {
-            [dataLanguages.french.id]: updateGroupData.frName,
-            [dataLanguages.english.id]: updateGroupData.name,
+            [dataLanguages.french.locale]: updateGroupData.frName,
+            [dataLanguages.english.locale]: updateGroupData.name,
           },
           reductionPercent: updateGroupData.discount,
           displayPriceTaxExcluded: updateGroupData.priceDisplayMethod === 'Tax excluded',
@@ -257,7 +257,10 @@ describe('API : PUT /customers/group/{customerGroupId}', async () => {
       await testContext.addContextItem(this, 'testIdentifier', 'checkResponseJSON', baseContext);
 
       expect(jsonResponse.customerGroupId).to.equal(idCustomerGroup);
-      expect(jsonResponse.localizedNames).to.deep.equal({1: updateGroupData.name, 2: updateGroupData.frName});
+      expect(jsonResponse.localizedNames).to.deep.equal({
+        [dataLanguages.english.locale]: updateGroupData.name,
+        [dataLanguages.french.locale]: updateGroupData.frName,
+      });
       expect(jsonResponse.reductionPercent).to.equal(updateGroupData.discount);
       expect(jsonResponse.displayPriceTaxExcluded).to.equal(updateGroupData.priceDisplayMethod === 'Tax excluded');
       expect(jsonResponse.showPrice).to.equal(updateGroupData.shownPrices);
@@ -292,14 +295,14 @@ describe('API : PUT /customers/group/{customerGroupId}', async () => {
       await testContext.addContextItem(this, 'testIdentifier', 'checkResponseLocalizedNamesEN', baseContext);
 
       const value = await boCustomerGroupsCreatePage.getValue(page, 'localizedNames', dataLanguages.english.id);
-      expect(jsonResponse.localizedNames[dataLanguages.english.id]).to.be.equal(value);
+      expect(jsonResponse.localizedNames[dataLanguages.english.locale]).to.be.equal(value);
     });
 
     it('should check the JSON Response : `localizedNames` (FR)', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkResponseLocalizedNamesFR', baseContext);
 
       const value = await boCustomerGroupsCreatePage.getValue(page, 'localizedNames', dataLanguages.french.id);
-      expect(jsonResponse.localizedNames[dataLanguages.french.id]).to.be.equal(value);
+      expect(jsonResponse.localizedNames[dataLanguages.french.locale]).to.be.equal(value);
     });
 
     it('should check the JSON Response : `reductionPercent`', async function () {

--- a/tests/UI/campaigns/functional/API/02_endpoints/10_product/01_postProduct.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/10_product/01_postProduct.ts
@@ -150,12 +150,12 @@ describe('API : POST /product', async () => {
           type: createProduct.type,
           active: createProduct.status,
           names: {
-            [dataLanguages.english.id]: createProduct.name,
-            [dataLanguages.french.id]: createProduct.nameFR,
+            [dataLanguages.english.locale]: createProduct.name,
+            [dataLanguages.french.locale]: createProduct.nameFR,
           },
           descriptions: {
-            [dataLanguages.english.id]: createProduct.description,
-            [dataLanguages.french.id]: createProduct.descriptionFR,
+            [dataLanguages.english.locale]: createProduct.description,
+            [dataLanguages.french.locale]: createProduct.descriptionFR,
           },
         },
       });
@@ -183,8 +183,8 @@ describe('API : POST /product', async () => {
 
       expect(jsonResponse.productId).to.be.gt(0);
       expect(jsonResponse.type).to.equal(createProduct.type);
-      expect(jsonResponse.names[dataLanguages.english.id]).to.equal(createProduct.name);
-      expect(jsonResponse.names[dataLanguages.french.id]).to.equal(createProduct.nameFR);
+      expect(jsonResponse.names[dataLanguages.english.locale]).to.equal(createProduct.name);
+      expect(jsonResponse.names[dataLanguages.french.locale]).to.equal(createProduct.nameFR);
       // @todo : https://github.com/PrestaShop/PrestaShop/issues/35619
       //expect(jsonResponse.descriptions[dataLanguages.english.id]).to.equal(createProduct.description);
       //expect(jsonResponse.descriptions[dataLanguages.french.id]).to.equal(createProduct.descriptionFR);
@@ -246,28 +246,28 @@ describe('API : POST /product', async () => {
       await testContext.addContextItem(this, 'testIdentifier', 'checkResponseNamesEN', baseContext);
 
       const value = await createProductsPage.getProductName(page, dataLanguages.english.isoCode);
-      expect(value).to.equal(jsonResponse.names[dataLanguages.english.id]);
+      expect(value).to.equal(jsonResponse.names[dataLanguages.english.locale]);
     });
 
     it('should check the JSON Response : `names` (FR)', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkResponseNamesFR', baseContext);
 
       const value = await createProductsPage.getProductName(page, dataLanguages.french.isoCode);
-      expect(value).to.equal(jsonResponse.names[dataLanguages.french.id]);
+      expect(value).to.equal(jsonResponse.names[dataLanguages.french.locale]);
     });
 
     it('should check the JSON Response : `description` (EN)', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkResponseDescriptionsEN', baseContext);
 
       const value = await boProductsCreateTabDescriptionPage.getValue(page, 'description', dataLanguages.english.id.toString());
-      expect(value).to.equal(jsonResponse.descriptions[dataLanguages.english.id]);
+      expect(value).to.equal(jsonResponse.descriptions[dataLanguages.english.locale]);
     });
 
     it('should check the JSON Response : `description` (FR)', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkResponseDescriptionsFR', baseContext);
 
       const value = await boProductsCreateTabDescriptionPage.getValue(page, 'description', dataLanguages.french.id.toString());
-      expect(value).to.equal(jsonResponse.descriptions[dataLanguages.french.id]);
+      expect(value).to.equal(jsonResponse.descriptions[dataLanguages.french.locale]);
     });
   });
 

--- a/tests/UI/campaigns/functional/API/02_endpoints/10_product/03_getProductId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/10_product/03_getProductId.ts
@@ -266,8 +266,8 @@ describe('API : GET /product/{productId}', async () => {
 
       expect(jsonResponse).to.have.property('names');
       expect(jsonResponse.names).to.be.a('object');
-      expect(jsonResponse.names[dataLanguages.english.id]).to.be.equal(productNameEn);
-      expect(jsonResponse.names[dataLanguages.french.id]).to.be.equal(productNameFr);
+      expect(jsonResponse.names[dataLanguages.english.locale]).to.be.equal(productNameEn);
+      expect(jsonResponse.names[dataLanguages.french.locale]).to.be.equal(productNameFr);
     });
 
     it('should check the JSON Response : `descriptions`', async function () {
@@ -275,8 +275,8 @@ describe('API : GET /product/{productId}', async () => {
 
       expect(jsonResponse).to.have.property('descriptions');
       expect(jsonResponse.descriptions).to.be.a('object');
-      expect(jsonResponse.descriptions[dataLanguages.english.id]).to.be.equal(productDescriptionEn);
-      expect(jsonResponse.descriptions[dataLanguages.french.id]).to.be.equal(productDescriptionFr);
+      expect(jsonResponse.descriptions[dataLanguages.english.locale]).to.be.equal(productDescriptionEn);
+      expect(jsonResponse.descriptions[dataLanguages.french.locale]).to.be.equal(productDescriptionFr);
     });
   });
 

--- a/tests/UI/campaigns/functional/API/02_endpoints/10_product/04_patchProductId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/10_product/04_patchProductId.ts
@@ -199,15 +199,15 @@ describe('API : PATCH /product/{productId}', async () => {
       {
         propertyName: 'names',
         propertyValue: {
-          [dataLanguages.english.id]: patchProduct.name,
-          [dataLanguages.french.id]: patchProduct.nameFR,
+          [dataLanguages.english.locale]: patchProduct.name,
+          [dataLanguages.french.locale]: patchProduct.nameFR,
         },
       },
       {
         propertyName: 'descriptions',
         propertyValue: {
-          [dataLanguages.english.id]: patchProduct.description,
-          [dataLanguages.french.id]: patchProduct.descriptionFR,
+          [dataLanguages.english.locale]: patchProduct.description,
+          [dataLanguages.french.locale]: patchProduct.descriptionFR,
         },
       },
     ].forEach((data: { propertyName: string, propertyValue: boolean|string|object}) => {
@@ -248,8 +248,8 @@ describe('API : PATCH /product/{productId}', async () => {
             const valuePropertyEN = await createProductsPage.getProductName(page, dataLanguages.english.isoCode);
             const valuePropertyFR = await createProductsPage.getProductName(page, dataLanguages.french.isoCode);
             expect({
-              [dataLanguages.english.id]: valuePropertyEN,
-              [dataLanguages.french.id]: valuePropertyFR,
+              [dataLanguages.english.locale]: valuePropertyEN,
+              [dataLanguages.french.locale]: valuePropertyFR,
             }).to.deep.equal(data.propertyValue);
           } else if (data.propertyName === 'descriptions') {
             const valuePropertyEN = await boProductsCreateTabDescriptionPage.getValue(
@@ -263,8 +263,8 @@ describe('API : PATCH /product/{productId}', async () => {
               dataLanguages.french.id.toString(),
             );
             expect({
-              [dataLanguages.english.id]: valuePropertyEN,
-              [dataLanguages.french.id]: valuePropertyFR,
+              [dataLanguages.english.locale]: valuePropertyEN,
+              [dataLanguages.french.locale]: valuePropertyFR,
             }).to.deep.equal(data.propertyValue);
           }
         });

--- a/tests/UI/campaigns/functional/API/02_endpoints/10_product/05_postProductIdImage.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/10_product/05_postProductIdImage.ts
@@ -225,10 +225,10 @@ describe('API : POST /product/{productId}/image', async () => {
 
         expect(jsonResponse.thumbnailUrl).to.be.a('string');
 
-        expect(jsonResponse.legends[dataLanguages.english.id]).to.be.a('string');
-        expect(jsonResponse.legends[dataLanguages.english.id]).to.equals('');
-        expect(jsonResponse.legends[dataLanguages.french.id]).to.be.a('string');
-        expect(jsonResponse.legends[dataLanguages.french.id]).to.equals('');
+        expect(jsonResponse.legends[dataLanguages.english.locale]).to.be.a('string');
+        expect(jsonResponse.legends[dataLanguages.english.locale]).to.equals('');
+        expect(jsonResponse.legends[dataLanguages.french.locale]).to.be.a('string');
+        expect(jsonResponse.legends[dataLanguages.french.locale]).to.equals('');
 
         expect(jsonResponse.cover).to.be.a('boolean');
         expect(jsonResponse.cover).to.be.equals(true);
@@ -262,8 +262,8 @@ describe('API : POST /product/{productId}/image', async () => {
       it('should check the JSON Response : `legends`', async function () {
         await testContext.addContextItem(this, 'testIdentifier', 'checkResponseLegends', baseContext);
 
-        expect(productImageInformation.caption.en).to.equal(jsonResponse.legends[dataLanguages.english.id]);
-        expect(productImageInformation.caption.fr).to.equal(jsonResponse.legends[dataLanguages.french.id]);
+        expect(productImageInformation.caption.en).to.equal(jsonResponse.legends[dataLanguages.english.locale]);
+        expect(productImageInformation.caption.fr).to.equal(jsonResponse.legends[dataLanguages.french.locale]);
       });
 
       it('should check the JSON Response : `cover`', async function () {

--- a/tests/UI/campaigns/functional/API/02_endpoints/10_product/06_getProductIdImages.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/10_product/06_getProductIdImages.ts
@@ -173,8 +173,8 @@ describe('API : GET /product/{productId}/images', async () => {
           expect(jsonResponse[i].imageId).to.be.gt(0);
           expect(jsonResponse[i].imageUrl).to.be.a('string');
           expect(jsonResponse[i].thumbnailUrl).to.be.a('string');
-          expect(jsonResponse[i].legends[dataLanguages.english.id]).to.be.a('string');
-          expect(jsonResponse[i].legends[dataLanguages.french.id]).to.be.a('string');
+          expect(jsonResponse[i].legends[dataLanguages.english.locale]).to.be.a('string');
+          expect(jsonResponse[i].legends[dataLanguages.french.locale]).to.be.a('string');
           expect(jsonResponse[i].cover).to.be.a('boolean');
           expect(jsonResponse[i].position).to.be.a('number');
           expect(jsonResponse[i].shopIds).to.be.a('array');
@@ -226,8 +226,8 @@ describe('API : GET /product/{productId}/images', async () => {
 
           expect(productImageInformation.id).to.equal(jsonResponse[idxItem].imageId);
 
-          expect(productImageInformation.caption.en).to.equal(jsonResponse[idxItem].legends[dataLanguages.english.id]);
-          expect(productImageInformation.caption.fr).to.equal(jsonResponse[idxItem].legends[dataLanguages.french.id]);
+          expect(productImageInformation.caption.en).to.equal(jsonResponse[idxItem].legends[dataLanguages.english.locale]);
+          expect(productImageInformation.caption.fr).to.equal(jsonResponse[idxItem].legends[dataLanguages.french.locale]);
 
           expect(productImageInformation.isCover).to.equal(jsonResponse[idxItem].cover);
 

--- a/tests/UI/campaigns/functional/API/02_endpoints/10_product/07_getProductImageId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/10_product/07_getProductImageId.ts
@@ -170,8 +170,8 @@ describe('API : GET /product/image/{imageId}', async () => {
       expect(jsonResponse.imageId).to.be.gt(0);
       expect(jsonResponse.imageUrl).to.be.a('string');
       expect(jsonResponse.thumbnailUrl).to.be.a('string');
-      expect(jsonResponse.legends[dataLanguages.english.id]).to.be.a('string');
-      expect(jsonResponse.legends[dataLanguages.french.id]).to.be.a('string');
+      expect(jsonResponse.legends[dataLanguages.english.locale]).to.be.a('string');
+      expect(jsonResponse.legends[dataLanguages.french.locale]).to.be.a('string');
       expect(jsonResponse.cover).to.be.a('boolean');
       expect(jsonResponse.position).to.be.a('number');
       expect(jsonResponse.shopIds).to.be.a('array');
@@ -218,8 +218,8 @@ describe('API : GET /product/image/{imageId}', async () => {
 
       expect(productImageInformation.id).to.equal(jsonResponse.imageId);
 
-      expect(productImageInformation.caption.en).to.equal(jsonResponse.legends[dataLanguages.english.id]);
-      expect(productImageInformation.caption.fr).to.equal(jsonResponse.legends[dataLanguages.french.id]);
+      expect(productImageInformation.caption.en).to.equal(jsonResponse.legends[dataLanguages.english.locale]);
+      expect(productImageInformation.caption.fr).to.equal(jsonResponse.legends[dataLanguages.french.locale]);
 
       expect(productImageInformation.isCover).to.equal(jsonResponse.cover);
 

--- a/tests/UI/campaigns/functional/API/02_endpoints/10_product/08_postProductImageId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/10_product/08_postProductImageId.ts
@@ -233,8 +233,8 @@ describe('API : POST /product/image/{imageId}', async () => {
         await testContext.addContextItem(this, 'testIdentifier', 'requestEndpoint', baseContext);
 
         const dataMultipart: any = {};
-        dataMultipart[`legends[${dataLanguages.english.id}]`] = productCaptionUpdatedEN;
-        dataMultipart[`legends[${dataLanguages.french.id}]`] = productCaptionUpdatedFR;
+        dataMultipart[`legends[${dataLanguages.english.locale}]`] = productCaptionUpdatedEN;
+        dataMultipart[`legends[${dataLanguages.french.locale}]`] = productCaptionUpdatedFR;
 
         const apiResponse = await apiContext.post(`product/image/${productImageInformation.id}`, {
           headers: {
@@ -281,10 +281,10 @@ describe('API : POST /product/image/{imageId}', async () => {
 
         expect(jsonResponse.thumbnailUrl).to.be.a('string');
 
-        expect(jsonResponse.legends[dataLanguages.english.id]).to.be.a('string');
-        expect(jsonResponse.legends[dataLanguages.english.id]).to.equals(productCaptionUpdatedEN);
-        expect(jsonResponse.legends[dataLanguages.french.id]).to.be.a('string');
-        expect(jsonResponse.legends[dataLanguages.french.id]).to.equals(productCaptionUpdatedFR);
+        expect(jsonResponse.legends[dataLanguages.english.locale]).to.be.a('string');
+        expect(jsonResponse.legends[dataLanguages.english.locale]).to.equals(productCaptionUpdatedEN);
+        expect(jsonResponse.legends[dataLanguages.french.locale]).to.be.a('string');
+        expect(jsonResponse.legends[dataLanguages.french.locale]).to.equals(productCaptionUpdatedFR);
 
         expect(jsonResponse.cover).to.be.a('boolean');
         expect(jsonResponse.cover).to.be.equals(true);
@@ -314,10 +314,10 @@ describe('API : POST /product/image/{imageId}', async () => {
       it('should check the JSON Response : `legends`', async function () {
         await testContext.addContextItem(this, 'testIdentifier', 'checkResponseLegends', baseContext);
 
-        expect(productImageInformation.caption.en).to.equal(jsonResponse.legends[dataLanguages.english.id]);
+        expect(productImageInformation.caption.en).to.equal(jsonResponse.legends[dataLanguages.english.locale]);
         expect(productImageInformation.caption.en).to.equal(productCaptionUpdatedEN);
 
-        expect(productImageInformation.caption.fr).to.equal(jsonResponse.legends[dataLanguages.french.id]);
+        expect(productImageInformation.caption.fr).to.equal(jsonResponse.legends[dataLanguages.french.locale]);
         expect(productImageInformation.caption.fr).to.equal(productCaptionUpdatedFR);
       });
 

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -419,7 +419,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#fa01aff3e3836fa1225ab374ace54a9b647e7cb0",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#42e566c8da4a822934b06dd245924ca5e47d006e",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^9.0.3",
@@ -7746,7 +7746,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#fa01aff3e3836fa1225ab374ace54a9b647e7cb0",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#42e566c8da4a822934b06dd245924ca5e47d006e",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^9.0.3",

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizerTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizerTest.php
@@ -118,7 +118,8 @@ class ValueObjectNormalizerTest extends TestCase
      * @dataProvider getSupportsDenormalizeValues
      *
      * @param mixed $data
-     * @param bool $expectedSupport
+     * @param string $type
+     * @param mixed $expectedDenormalize
      * @param array $context
      *
      * @return void

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizerTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizerTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\ApiPlatform\Normalizer;
+
+use DbMySQLi;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\CartRule\Command\EditCartRuleCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+
+class ValueObjectNormalizerTest extends TestCase
+{
+    /**
+     * @dataProvider getSupportsNormalizationValues
+     *
+     * @param mixed $data
+     * @param bool $expectedSupport
+     *
+     * @return void
+     */
+    public function testSupportsNormalization(mixed $data, bool $expectedSupport): void
+    {
+        $normalizer = new ValueObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
+        $this->assertEquals($expectedSupport, $normalizer->supportsNormalization($data));
+    }
+
+    public static function getSupportsNormalizationValues(): iterable
+    {
+        yield 'real value object based on integer' => [new ProductId(1), true];
+        yield 'real value object based on string' => [new ProductType(ProductType::TYPE_STANDARD), true];
+        yield 'object with getValue but not ValueObject namespace' => [new DbMySQLi('localhost', 'root', 'root', 'prestashop', false), false];
+        yield 'object without getValue method' => [new ContactTypeChoiceProvider(1), false];
+    }
+
+    /**
+     * @dataProvider getNormalizationValues
+     *
+     * @param mixed $data
+     * @param mixed $expectedNormalization
+     * @param array $context
+     *
+     * @return void
+     */
+    public function testNormalize(mixed $data, mixed $expectedNormalization, array $context = []): void
+    {
+        $normalizer = new ValueObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
+        $this->assertEquals($expectedNormalization, $normalizer->normalize($data, null, $context));
+    }
+
+    public static function getNormalizationValues(): iterable
+    {
+        yield 'VO integer' => [new ProductId(1), ['productId' => 1]];
+        yield 'VO string' => [new ProductType(ProductType::TYPE_STANDARD), ['productType' => ProductType::TYPE_STANDARD]];
+
+        yield 'VO integer as scalar' => [new ProductId(1), 1, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+        yield 'VO string as scalar' => [new ProductType(ProductType::TYPE_STANDARD), ProductType::TYPE_STANDARD, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+    }
+
+    /**
+     * @dataProvider getSupportsDenormalizationValues
+     *
+     * @param mixed $data
+     * @param bool $expectedSupport
+     *
+     * @return void
+     */
+    public function testSupportsDenormalization(mixed $data, string $type, bool $expectedSupport): void
+    {
+        $normalizer = new ValueObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
+        $this->assertEquals($expectedSupport, $normalizer->supportsDenormalization($data, $type));
+    }
+
+    public function getSupportsDenormalizationValues(): iterable
+    {
+        yield 'class with single parameter but not a ValueObject' => [1, EditCartRuleCommand::class, false];
+
+        yield 'product ID' => [['productId' => 42], ProductId::class, true];
+        yield 'product ID snake case' => [['product_id' => 42], ProductId::class, true];
+        yield 'product ID value' => [['value' => 42], ProductId::class, true];
+        yield 'product ID integer' => [42, ProductId::class, true];
+        yield 'product ID string' => ['42', ProductId::class, false];
+
+        yield 'product type' => [['productType' => ProductType::TYPE_COMBINATIONS], ProductType::class, true];
+        yield 'product type snake case' => [['product_type' => ProductType::TYPE_COMBINATIONS], ProductType::class, true];
+        yield 'product type value' => [['value' => ProductType::TYPE_COMBINATIONS], ProductType::class, true];
+        yield 'product type string' => [ProductType::TYPE_COMBINATIONS, ProductType::class, true];
+        yield 'product type integer' => [42, ProductType::class, false];
+    }
+
+    /**
+     * @dataProvider getSupportsDenormalizeValues
+     *
+     * @param mixed $data
+     * @param bool $expectedSupport
+     * @param array $context
+     *
+     * @return void
+     */
+    public function testDenormalize(mixed $data, string $type, mixed $expectedDenormalize, array $context = []): void
+    {
+        $normalizer = new ValueObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
+        $this->assertEquals($expectedDenormalize, $normalizer->denormalize($data, $type, null, $context));
+    }
+
+    public function getSupportsDenormalizeValues(): iterable
+    {
+        yield 'product ID' => [['productId' => 42], ProductId::class, new ProductId(42)];
+        yield 'product ID snake case' => [['product_id' => 42], ProductId::class, new ProductId(42)];
+        yield 'product ID value' => [['value' => 42], ProductId::class, new ProductId(42)];
+        yield 'product ID integer' => [42, ProductId::class, new ProductId(42)];
+
+        yield 'product type' => [['productType' => ProductType::TYPE_COMBINATIONS], ProductType::class, new ProductType(ProductType::TYPE_COMBINATIONS)];
+        yield 'product type snake case' => [['product_type' => ProductType::TYPE_COMBINATIONS], ProductType::class, new ProductType(ProductType::TYPE_COMBINATIONS)];
+        yield 'product type value' => [['value' => ProductType::TYPE_COMBINATIONS], ProductType::class, new ProductType(ProductType::TYPE_COMBINATIONS)];
+        yield 'product type string' => [ProductType::TYPE_COMBINATIONS, ProductType::class, new ProductType(ProductType::TYPE_COMBINATIONS)];
+
+        yield 'product ID as scalar' => [['productId' => 42], ProductId::class, 42, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+        yield 'product ID snake case as scalar' => [['product_id' => 42], ProductId::class, 42, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+        yield 'product ID value as scalar' => [['value' => 42], ProductId::class, 42, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+        yield 'product ID integer as scalar' => [42, ProductId::class, 42, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+
+        yield 'product type as scalar' => [['productType' => ProductType::TYPE_COMBINATIONS], ProductType::class, ProductType::TYPE_COMBINATIONS, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+        yield 'product type snake case as scalar' => [['product_type' => ProductType::TYPE_COMBINATIONS], ProductType::class, ProductType::TYPE_COMBINATIONS, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+        yield 'product type value as scalar' => [['value' => ProductType::TYPE_COMBINATIONS], ProductType::class, ProductType::TYPE_COMBINATIONS, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+        yield 'product type string as scalar' => [ProductType::TYPE_COMBINATIONS, ProductType::class, ProductType::TYPE_COMBINATIONS, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+    }
+}

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/StateProvider/QueryProviderTest.php
@@ -51,6 +51,7 @@ use PrestaShopBundle\ApiPlatform\Normalizer\CQRSApiNormalizer;
 use PrestaShopBundle\ApiPlatform\Normalizer\DecimalNumberNormalizer;
 use PrestaShopBundle\ApiPlatform\Provider\QueryProvider;
 use PrestaShopBundle\ApiPlatform\Serializer\DomainSerializer;
+use PrestaShopBundle\Entity\Repository\LangRepository;
 use RuntimeException;
 
 class QueryProviderTest extends TestCase
@@ -78,7 +79,7 @@ class QueryProviderTest extends TestCase
      */
     public function setUp(): void
     {
-        $denormalizers = new ArrayIterator([new DecimalNumberNormalizer(), new CQRSApiNormalizer()]);
+        $denormalizers = new ArrayIterator([new DecimalNumberNormalizer(), new CQRSApiNormalizer($this->createMock(LangRepository::class))]);
         $this->serializer = new DomainSerializer($denormalizers);
         $this->queryBus = $this->createMock(CommandBusInterface::class);
         $this->queryBus


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | DomainSerializer, and more specifically CQRSApiNormalizer is able to normalize localized value indexes from locale to language IDs
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/12357084268
| Fixed issue or discussion?     | Fixes #37461
| Related PRs       | https://github.com/PrestaShop/ps_apiresources/pull/42
| Sponsor company   | ~
