### PR TITLE
Fix incorrect @see reference in ModuleCore documentation

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -216,7 +216,7 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * @var array array of arrays representing tabs added by this module
      *
-     * @see PrestaShop\PrestaShop\Adapter\Module\Tab\RegisterTabs($module)
+     * @see PrestaShop\PrestaShop\Adapter\Module\Tab\ModuleTabRegister->registerTabs($module)
      */
     protected $tabs = [];
 


### PR DESCRIPTION

- The @see annotation in the ModuleCore class has been updated to reflect the correct path for the registerTabs method.

- Changed the reference from PrestaShop\Adapter\Module\Tab\RegisterTabs to PrestaShop\Adapter\Module\Tab\ModuleTabRegister->registerTabs.

- This ensures better clarity and accuracy in the documentation of the codebase.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Updated the `@see` annotation in the `ModuleCore` class to correct the path for `registerTabs`. Ensures clarity in code documentation and aligns it with the current code structure.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Verify that the updated `@see` annotation points to the correct class and method for `registerTabs` functionality.
| UI Tests          | N/A
| Fixed issue or discussion? | N/A
| Related PRs       | N/A
| Sponsor company   | N/A

