### PR TITLE
Adjust error handling

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -333,14 +333,7 @@ class CustomerCore extends ObjectModel
             }
         }
 
-        try {
-            return parent::update(true);
-        } catch (PrestaShopException $exception) {
-            $message = $exception->getMessage();
-            error_log($message);
-
-            return false;
-        }
+        return parent::update(true);
     }
 
     /**

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -944,6 +944,7 @@ class LinkCore
             if (strpos($idImage, '-')) {
                 $idImage = explode('-', $idImage)[1];
                 if (_PS_MODE_DEV_) {
+                    // @deprecated
                     trigger_error(
                         'Passing image identifier in the old format is deprecated, use only image ID. This fallback will be removed in next major.',
                         E_USER_DEPRECATED

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1077,7 +1077,6 @@ class ToolsCore
      * Prints object information into error log.
      *
      * @see error_log()
-     *
      * @deprecated since 9.0.0 and will be removed in 10.0.0. Use error_log directly.
      *             If you have an object or array, you can stringify it for example by print_r($object, true).
      *

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1078,6 +1078,9 @@ class ToolsCore
      *
      * @see error_log()
      *
+     * @deprecated since 9.0.0 and will be removed in 10.0.0. Use error_log directly.
+     *             If you have an object or array, you can stringify it for example by print_r($object, true).
+     *
      * @param mixed $object
      * @param int|null $message_type
      * @param string|null $destination

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -732,7 +732,7 @@ class WebserviceRequestCore
             E_RECOVERABLE_ERROR => 'Recoverable error',
         ];
         $type = $errortype[$errno] ?? 'Unknown error';
-        Tools::error_log('[PHP ' . $type . ' #' . $errno . '] ' . $errstr . ' (' . $errfile . ', line ' . $errline . ')');
+        error_log('[PHP ' . $type . ' #' . $errno . '] ' . $errstr . ' (' . $errfile . ', line ' . $errline . ')');
 
         switch ($errno) {
             case E_ERROR:

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -426,11 +426,6 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
      */
     private function buildShopConstraintFromContext(): ShopConstraint
     {
-        @trigger_error(
-            'Not specifying the optional ShopConstraint parameter is deprecated since version 1.7.8.0',
-            E_USER_DEPRECATED
-        );
-
         if (Shop::getContext() === Shop::CONTEXT_SHOP) {
             return ShopConstraint::shop(Shop::getContextShopID());
         } elseif (Shop::getContext() === Shop::CONTEXT_GROUP) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Minor tweaks for error handling. More below.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | Auto test.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Changes
- Custom logging of customer update exception removed, let the exception happen.
- `@deprecated` notice on a custom notice I added, so I can find it when searching the code for this tag.
- Single use of `Tools::error_log` changed to a direct call.
- Deprecated `Tools::error_log`, which is just a wrapper for PHP method.
- Removed notice in `buildShopConstraintFromContext` which is just flooding the logs all the time. Configuration is called without a shop context in most places right now.