### PR TITLE
Remove use of deprecated method in customizations

### DIFF
--- a/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
@@ -125,6 +125,7 @@ final class GetCartForViewingHandler implements GetCartForViewingHandlerInterfac
         $products = $sorter->natural($products, Sorter::ORDER_DESC, 'reference', 'supplier_reference');
 
         foreach ($products as &$product) {
+            // Add proper prices depending on customer group price display style
             if ($tax_calculation_method == PS_TAX_EXC) {
                 $product['product_price'] = $product['price'];
                 $product['product_total'] = $product['total'];
@@ -133,12 +134,14 @@ final class GetCartForViewingHandler implements GetCartForViewingHandlerInterfac
                 $product['product_total'] = $product['total_wt'];
             }
 
+            // Add CURRENT quantity in stock
             $product['qty_in_stock'] = StockAvailable::getQuantityAvailableByProduct(
                 $product['id_product'],
                 isset($product['id_product_attribute']) ? $product['id_product_attribute'] : null,
                 (int) $id_shop
             );
 
+            // Add customizations for the product
             $customized_datas = Product::getAllCustomizedDatas(
                 $context->cart->id,
                 null,
@@ -147,12 +150,6 @@ final class GetCartForViewingHandler implements GetCartForViewingHandlerInterfac
                 (int) $product['id_customization']
             );
             $context->cart->setProductCustomizedDatas($product, $customized_datas);
-
-            $product['id_address_delivery'] = (int) $cart->id_address_delivery;
-
-            if ($customized_datas) {
-                Product::addProductCustomizationPrice($product, $customized_datas);
-            }
         }
         unset($product);
 

--- a/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
+++ b/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
@@ -261,7 +261,6 @@ final class MailPreviewVariablesBuilder
 
         $products = $order->getProducts();
         $customizedDatas = Product::getAllCustomizedDatas($order->id_cart);
-        Product::addCustomizationPrice($products, $customizedDatas);
         foreach ($products as $key => $product) {
             $unitPrice = $product['product_price_wt'];
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | There were some remaining usage of deprecated methods related to customization. See below.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Automatic test + see how I tested it. :-)
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/12373607299 ✅ 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   |

### Description
Customization system was improved some time ago and now all the customization price impacts, that can be added by module, are included in product price. However, there were two places, where it still called the deprecated method `Product::addProductCustomizationPrice`, that don't do anything. On backoffice cart view and in email preview in BO.

So, I removed these calls and tested everything.

_Note - the removed line for delivery address was added by me in https://github.com/PrestaShop/PrestaShop/pull/36653, it was just a quick fix to an issue inside that method, which is no longer called now._

### My test
I made a cart and I added a different customization prices for both items.

![fo](https://github.com/user-attachments/assets/a0971f34-8221-4c87-84f4-06e2ad30b0ef)
![database](https://github.com/user-attachments/assets/cf51b983-5882-40b5-b90a-7d87aeba3deb)

First change - I checked if backoffice display works the same. ✅

![bo](https://github.com/user-attachments/assets/e77e6b85-e2cf-4739-8a0f-cb947de54f3d)

Second change - I checked if email preview works the same. It uses the last order created as a test data. ✅

![email preview](https://github.com/user-attachments/assets/c8315110-de7f-4fb8-8451-f0168ec4abf8)


