### PR TITLE
Apply backoffice optimizations

### DIFF
--- a/admin-dev/themes/default/scss/modules/_variables.scss
+++ b/admin-dev/themes/default/scss/modules/_variables.scss
@@ -275,9 +275,9 @@ $list-group-link-heading-color: map-get($map: $cdk-primary, $key: "primary-800")
 
 // Panels
 $panel-bg: map-get($map: $cdk-common, $key: "white");
-$panel-body-padding: map-get($map: $cdk-size, $key: "size-24");
-$panel-heading-padding: map-get($map: $cdk-size, $key: "size-24");
-$panel-footer-padding: map-get($map: $cdk-size, $key: "size-24");
+$panel-body-padding: map-get($map: $cdk-size, $key: "size-16");
+$panel-heading-padding: map-get($map: $cdk-size, $key: "size-16");
+$panel-footer-padding: map-get($map: $cdk-size, $key: "size-16");
 
 $panel-default-text: map-get($map: $cdk-primary, $key: "primary-800");
 $panel-default-border: map-get($map: $cdk-primary, $key: "primary-400");

--- a/admin-dev/themes/default/scss/partials/_panels.scss
+++ b/admin-dev/themes/default/scss/partials/_panels.scss
@@ -10,18 +10,18 @@ $component: panel;
     gap: map-get($map: $cdk-size, $key: "size-16");
     align-items: center;
     width: 100%;
-    padding: map-get($map: $cdk-size, $key: "size-24");
+    padding: map-get($map: $cdk-size, $key: "size-16");
     margin: map-get($map: $cdk-size, $key: "size-0");
-    font-size: map-get($map: $cdk-size, $key: "size-24");
+    font-size: map-get($map: $cdk-size, $key: "size-18");
     font-weight: 600;
 
     > i {
-      font-size: map-get($map: $cdk-size, $key: "size-24");
+      font-size: map-get($map: $cdk-size, $key: "size-18");
     }
   }
 
   &-title {
-    font-size: map-get($map: $cdk-size, $key: "size-24");
+    font-size: map-get($map: $cdk-size, $key: "size-18");
     font-weight: 600;
   }
 
@@ -70,7 +70,7 @@ $component: panel;
     }
 
     &:not(:has(.#{$component}-heading, .#{$component}-body, .#{$component}-footer)) {
-      padding: map-get($map: $cdk-size, $key: "size-24");
+      padding: map-get($map: $cdk-size, $key: "size-16");
     }
   }
 
@@ -82,7 +82,7 @@ $component: panel;
 
       *:is(.panel) {
         &:not(:has(.#{$component}-footer)) {
-          padding: map-get($map: $cdk-size, $key: "size-24");
+          padding: map-get($map: $cdk-size, $key: "size-16");
         }
       }
     }
@@ -94,7 +94,7 @@ $component: panel;
 
   &:has(.#{$component}-heading, > h3) {
     &:not(:has(.#{$component}-footer, .#{$component}-body)) {
-      padding: map-get($map: $cdk-size, $key: "size-24");
+      padding: map-get($map: $cdk-size, $key: "size-16");
 
       .#{$component}-heading,
       .#{$component} > h3
@@ -104,12 +104,12 @@ $component: panel;
 
       .#{$component}-heading,
       .#{$component} > h3 {
-        padding-bottom: map-get($map: $cdk-size, $key: "size-24");
+        padding-bottom: map-get($map: $cdk-size, $key: "size-16");
       }
     }
   }
 
   &:not(:has(> *)) {
-    padding: map-get($map: $cdk-size, $key: "size-24");
+    padding: map-get($map: $cdk-size, $key: "size-16");
   }
 }

--- a/admin-dev/themes/new-theme/scss/components/_cards.scss
+++ b/admin-dev/themes/new-theme/scss/components/_cards.scss
@@ -5,7 +5,7 @@
 .card {
   position: relative;
   display: block;
-  margin-bottom: 1rem;
+  margin-bottom: var(--#{$cdk}size-16);
   background-color: $card-bg;
   border: $card-border-width solid $card-border-color;
   @include border-radius($card-border-radius);
@@ -28,14 +28,6 @@
   margin-bottom: 0;
 }
 
-// .card-actions {
-//   padding: $card-spacer-y $card-spacer-x;
-
-//   .card-link + .card-link {
-//     margin-left: $card-spacer-x;
-//   }
-// }
-
 .card-link {
   @include hover () {
     text-decoration: none;
@@ -47,7 +39,7 @@
 }
 
 .card-body {
-  padding: 1rem;
+  padding: var(--#{$cdk}size-16);
 }
 
 //
@@ -55,7 +47,7 @@
 //
 
 .card-header {
-  padding: 1rem;
+  padding: var(--#{$cdk}size-16);
   font-size: var(--#{$cdk}size-18);
   font-weight: 600;
   line-height: 1.5rem;
@@ -96,7 +88,7 @@
 }
 
 .card-footer {
-  padding: 1rem;
+  padding: var(--#{$cdk}size-16);
   background-color: $card-cap-bg;
   border-top: $card-border-width solid $card-border-color;
 
@@ -104,7 +96,6 @@
     @include border-radius(0 0 $card-border-radius-inner $card-border-radius-inner);
   }
 }
-
 
 //
 // Background variations
@@ -197,7 +188,6 @@
 .card-img-bottom {
   @include border-radius(0 0 $card-border-radius-inner $card-border-radius-inner);
 }
-
 
 //
 // Card set

--- a/admin-dev/themes/new-theme/scss/components/_cards.scss
+++ b/admin-dev/themes/new-theme/scss/components/_cards.scss
@@ -56,19 +56,19 @@
 
 .card-header {
   padding: 1rem;
+  font-size: var(--#{$cdk}size-18);
   font-weight: 600;
   line-height: 1.5rem;
   background-color: $card-cap-bg;
-  font-size: var(--#{$cdk}size-18);
 
   .badge {
     vertical-align: middle;
   }
 
   .card-header-title {
+    font-size: var(--#{$cdk}size-18);
     font-weight: 600;
     line-height: 1.5rem;
-    font-size: var(--#{$cdk}size-18);
   }
 
   &:not(:has(.dropdown-item)) {

--- a/admin-dev/themes/new-theme/scss/components/_cards.scss
+++ b/admin-dev/themes/new-theme/scss/components/_cards.scss
@@ -5,7 +5,7 @@
 .card {
   position: relative;
   display: block;
-  margin-bottom: $card-spacer-y;
+  margin-bottom: 1rem;
   background-color: $card-bg;
   border: $card-border-width solid $card-border-color;
   @include border-radius($card-border-radius);
@@ -46,15 +46,20 @@
   }
 }
 
+.card-body {
+  padding: 1rem;
+}
+
 //
 // Optional textual caps
 //
 
 .card-header {
-  padding: $card-spacer-y $card-spacer-x;
+  padding: 1rem;
   font-weight: 600;
   line-height: 1.5rem;
   background-color: $card-cap-bg;
+  font-size: var(--#{$cdk}size-18);
 
   .badge {
     vertical-align: middle;
@@ -63,6 +68,7 @@
   .card-header-title {
     font-weight: 600;
     line-height: 1.5rem;
+    font-size: var(--#{$cdk}size-18);
   }
 
   &:not(:has(.dropdown-item)) {
@@ -90,7 +96,7 @@
 }
 
 .card-footer {
-  padding: $card-spacer-y $card-spacer-x * 1.5;
+  padding: 1rem;
   background-color: $card-cap-bg;
   border-top: $card-border-width solid $card-border-color;
 

--- a/admin-dev/themes/new-theme/scss/components/_grid.scss
+++ b/admin-dev/themes/new-theme/scss/components/_grid.scss
@@ -365,7 +365,8 @@ table {
         }
       }
 
-      td, th {
+      td,
+      th {
         padding: var(--#{$cdk}size-4);
       }
 

--- a/admin-dev/themes/new-theme/scss/components/_grid.scss
+++ b/admin-dev/themes/new-theme/scss/components/_grid.scss
@@ -136,8 +136,7 @@ table .column-filters {
 
 .table thead .column-filters td,
 .table thead .column-filters th {
-  padding-top: var(--cdk-size-8);
-  padding-bottom: var(--cdk-size-8);
+  padding-block: var(--#{$cdk}size-8);
 }
 
 .grid {
@@ -367,7 +366,7 @@ table {
       }
 
       td, th {
-        padding: .2rem;
+        padding: var(--#{$cdk}size-4);
       }
 
       td {

--- a/admin-dev/themes/new-theme/scss/components/_grid.scss
+++ b/admin-dev/themes/new-theme/scss/components/_grid.scss
@@ -134,6 +134,12 @@ table .column-filters {
   }
 }
 
+.table thead .column-filters td,
+.table thead .column-filters th {
+  padding-top: var(--cdk-size-8);
+  padding-bottom: var(--cdk-size-8);
+}
+
 .grid {
   table.grid-table {
     thead {
@@ -291,7 +297,7 @@ table .column-filters {
 
           &.image-type {
             img {
-              max-width: 3rem;
+              max-width: 2rem;
               height: auto;
             }
           }
@@ -358,6 +364,10 @@ table {
         input {
           max-width: 6rem;
         }
+      }
+
+      td, th {
+        padding: .2rem;
       }
 
       td {

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
@@ -105,7 +105,7 @@
 }
 
 .info-block {
-  padding: 1rem;
+  padding: var(--#{$cdk}size-16);
   background-color: $info-block-background;
 
   & &-col {

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
@@ -105,10 +105,7 @@
 }
 
 .info-block {
-  padding-top: 18px;
-  padding-right: 18px;
-  padding-bottom: 16px;
-  padding-left: 18px;
+  padding: 1rem;
   background-color: $info-block-background;
 
   & &-col {

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -73,12 +73,6 @@
     }
   }
 
-  .customer,
-  #orderProductsPanel,
-  .product-row .tab-content {
-    margin-bottom: 1.875rem;
-  }
-
   .product-row {
     .nav-tabs {
       position: relative;

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/layouts_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/layouts_configuration.html.twig
@@ -24,7 +24,7 @@
  * #}
 
 {% block layouts_configuration %}
-  <div class="col-12 layout-configuration">
+  <div class="layout-configuration">
     <div class="inner-content">
       <div class="float-left">
         <div class="d-inline-block layout-logo">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/personal_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/personal_information.html.twig
@@ -25,14 +25,7 @@
 
 <div class="card customer-personal-informations-card">
   <h3 class="card-header">
-    <i class="material-icons">person</i>
-    {{ customerInformation.personalInformation.firstName }}
-    {{ customerInformation.personalInformation.lastName }}
-    {{ '[%06d]'|format(customerInformation.customerId.value) }}
-    -
-    <a href="mailto:{{ customerInformation.personalInformation.email }}">
-      {{ customerInformation.personalInformation.email }}
-    </a>
+    <i class="material-icons">person</i> {{ 'Basic information'|trans({}, 'Admin.Global') }}
 
     <a href="{{ getAdminLink('AdminCustomers', true, {id_customer: customerInformation.customerId.value, updatecustomer: 1, back: app.request.uri}) }}"
        class="tooltip-link float-right edit-link"
@@ -45,6 +38,36 @@
     </a>
   </h3>
   <div class="card-body">
+
+    <div class="row mb-1">
+      <div class="col-sm-4 text-sm-right font-weight-bold">
+        {{ 'ID'|trans({}, 'Admin.Global') }}
+      </div>
+      <div class="customer-id col-sm-8">
+        {{ customerInformation.customerId.value }}
+      </div>
+    </div>
+
+    <div class="row mb-1">
+      <div class="col-sm-4 text-sm-right font-weight-bold">
+        {{ 'Name'|trans({}, 'Admin.Global') }}
+      </div>
+      <div class="customer-name col-sm-8">
+        {{ customerInformation.personalInformation.firstName }} {{ customerInformation.personalInformation.lastName }}
+      </div>
+    </div>
+
+    <div class="row mb-1">
+      <div class="col-sm-4 text-sm-right font-weight-bold">
+        {{ 'Email'|trans({}, 'Admin.Global') }}
+      </div>
+      <div class="customer-email col-sm-8">
+        <a href="mailto:{{ customerInformation.personalInformation.email }}">
+          {{ customerInformation.personalInformation.email }}
+        </a>
+      </div>
+    </div>
+
     <div class="row mb-1">
       <div class="col-sm-4 text-sm-right font-weight-bold">
         {{ 'Social Title'|trans({}, 'Admin.Global') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/basic_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/basic_information.html.twig
@@ -26,7 +26,7 @@
 <div class="card" id="orderBasicInfo">
   <div class="card-header">
     <h3 class="card-header-title">
-      {{ 'Basic information'|trans({}, 'Admin.Global') }}
+      <i class="material-icons">info</i> {{ 'Basic information'|trans({}, 'Admin.Global') }}
     </h3>
   </div>
   <div class="card-body">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -26,12 +26,12 @@
 <div id="customerCard" class="customer card">
   <div class="card-header">
     <h3 class="card-header-title">
-      {{ 'Customer'|trans({}, 'Admin.Global') }}
+      <i class="material-icons">person</i> {{ 'Customer'|trans({}, 'Admin.Global') }}
     </h3>
   </div>
 
   <div class="card-body">
-    <div id="customerInfo" class="info-block">
+    <div id="customerInfo" class="info-block mb-2">
       <div class="row">
         {% if orderForViewing.customer is not null and orderForViewing.customer.id != 0 %}
           <div class="col-xxl-7">
@@ -64,7 +64,7 @@
 
     </div>
     {% if orderForViewing.customer is not null and orderForViewing.customer.id != 0 %}
-      <div class="info-block mt-2">
+      <div class="info-block mb-2">
         <p class="mb-0" id="customerId"><strong>{{ 'ID:'|trans({}, 'Admin.Global') }}</strong> {{ orderForViewing.customer.id }}</p>
         <p class="mb-0" id="customerEmail"><strong>{{ 'Email:'|trans({}, 'Admin.Global') }}</strong> <a href="mailto:{{ orderForViewing.customer.email }}">{{ orderForViewing.customer.email }}</a></p>
         <p class="mb-0"><strong>{{ 'Customer type:'|trans({}, 'Admin.Global') }}</strong>
@@ -87,7 +87,7 @@
         {% endif %}
       </div>
     {% endif %}
-    <div class="info-block mt-2">
+    <div class="info-block mb-2">
       <div class="row">
         {% if orderForViewing.virtual is same as(false) %}
           <div id="addressShipping" class="info-block-col col-xl-6">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
@@ -39,7 +39,7 @@
   {{ 'Merchandise returns'|trans({}, 'Admin.Orderscustomers.Feature') }} (<span data-role="count">{{ orderForViewing.returns.orderReturns|length }}</span>)
 {% endset %}
 
-<div class="mt-2">
+<div class="mb-3">
   <ul class="nav nav nav-tabs d-print-none" role="tablist">
     <li class="nav-item">
       <a class="nav-link active show" id="historyTab" data-toggle="tab" href="#historyTabContent" role="tab" aria-controls="historyTabContent" aria-expanded="true" aria-selected="false">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details_card.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details_card.html.twig
@@ -22,7 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * #}
-<div class="card card-details">
+<div class="card card-details mb-0">
   <div class="card-header d-none d-print-block">
     {% block header %}
     {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/header.html.twig
@@ -28,5 +28,13 @@
     {{ 'Order'|trans({}, 'Admin.Global') }}
     <strong class="text-muted" data-role="order-id">#{{ orderForViewing.id }}</strong>
     <strong data-role="order-reference">{{ orderForViewing.reference }}</strong>
+    <strong>{{ 'from'|trans({}, 'Admin.Global') }}
+    {% if orderForViewing.customer is not null and orderForViewing.customer.id != 0 %}
+      {{ orderForViewing.customer.firstName }}
+      {{ orderForViewing.customer.lastName }}
+    {% else %}
+      {{ 'Deleted customer'|trans({}, 'Admin.Global') }}
+    {% endif %}
+    </strong>
   </h1>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/messages.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/messages.html.twig
@@ -32,7 +32,7 @@
     <div class="row">
       <div class="col-md-6">
         <h3 class="card-header-title">
-          {{ 'Messages'|trans({}, 'Admin.Global') }} ({{ orderForViewing.messages.total }})
+          <i class="material-icons">message</i> {{ 'Messages'|trans({}, 'Admin.Global') }} ({{ orderForViewing.messages.total }})
         </h3>
       </div>
       {% if orderForViewing.messages.total > messagesToShow %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/payments.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/payments.html.twig
@@ -23,10 +23,10 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * #}
 
-<div class="card mt-2" id="view_order_payments_block">
+<div class="card" id="view_order_payments_block">
   <div class="card-header">
     <h3 class="card-header-title">
-      {{ 'Payment'|trans({}, 'Admin.Global') }} ({{ orderForViewing.payments.payments|length }})
+      <i class="material-icons">payments</i> {{ 'Payment'|trans({}, 'Admin.Global') }} ({{ orderForViewing.payments.payments|length }})
     </h3>
   </div>
 
@@ -36,7 +36,7 @@
         linkedOrders: orderForViewing.linkedOrders
     }) }}
 
-    <table class="table" data-role="payments-grid-table">
+    <table class="table mb-0" data-role="payments-grid-table">
       <thead>
         <tr>
           <th class="table-head-date">{{ 'Date'|trans({}, 'Admin.Global') }}</th>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -37,7 +37,7 @@
 <div class="card" id="orderProductsPanel">
   <div class="card-header">
     <h3 class="card-header-title">
-      {{ 'Products'|trans({}, 'Admin.Global') }} (<span id="orderProductsPanelCount">{{ orderForViewing.products.products|length }}</span>)
+      <i class="material-icons">shopping_basket</i> {{ 'Products'|trans({}, 'Admin.Global') }} (<span id="orderProductsPanelCount">{{ orderForViewing.products.products|length }}</span>)
     </h3>
   </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
@@ -24,7 +24,7 @@
  * #}
 
 {% if not orderForViewing.virtual %}
-    <table class="table" id="shipping-grid-table">
+    <table class="table mb-0" id="shipping-grid-table">
     <thead>
       <tr>
         <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/sources.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/sources.html.twig
@@ -24,42 +24,34 @@
  * #}
 
   {% if orderForViewing.sources.sources is not empty %}
-    <div class="card mt-2 d-print-none">
+    <div class="card d-print-none">
       <div class="card-header">
-        <div class="row">
-          <div class="col-md-6">
-            <i class="material-icons">public</i>
-            {{ 'Sources'|trans({}, 'Admin.Orderscustomers.Feature') }}
-            <span class="badge badge-primary rounded">{{ orderForViewing.sources.sources|length }}</span>
-          </div>
-        </div>
+        <i class="material-icons">public</i>
+        {{ 'Sources'|trans({}, 'Admin.Orderscustomers.Feature') }}
+        <span class="badge badge-primary rounded">{{ orderForViewing.sources.sources|length }}</span>
       </div>
 
       <div class="card-body">
-        <ul id="order-sources-list">
-          {% for source in orderForViewing.sources.sources %}
-            <li>
-              {{ source.addedAt|date_format_full }}
-              <br/>
-              <b>{{ 'From'|trans({}, 'Admin.Orderscustomers.Feature') }}</b>
-              {% if source.httpReferer != '' %}
-                <a href="{{ source.httpReferer }}">{{ source.httpReferer }}</a>
-              {% else %}
-                -
-              {% endif %}
-              <br/>
-              <b>{{ 'To'|trans({}, 'Admin.Orderscustomers.Feature') }}</b>
-              <a href="http://{{ source.requestUri }}">{{ source.requestUri|slice(0, 100) }}</a>
-              <br/>
-              {% if source.keywords != '' %}
-                <b>{{ 'Keywords'|trans({}, 'Admin.Global') }}</b>
-                <br/>
-                {{ source.keywords }}
-              {% endif %}
-              <br/>
-            </li>
-          {% endfor %}
-        </ul>
+        <table class="table" id="order-sources-list">
+          <thead>
+            <tr>
+              <th scope="col">{{ 'Date'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
+              <th scope="col">{{ 'From'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
+              <th scope="col">{{ 'To'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
+              <th scope="col">{{ 'Keywords'|trans({}, 'Admin.Global') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for source in orderForViewing.sources.sources %}
+              <tr>
+                <td>{{ source.addedAt|date_format_full }}</td>
+                <td>{% if source.httpReferer != '' %}<a href="{{ source.httpReferer }}">{{ source.httpReferer }}</a>{% else %}{{ 'Unknown'|trans({}, 'Admin.Orderscustomers.Feature') }}{% endif %}</td>
+                <td><a href="http://{{ source.requestUri }}">{{ source.requestUri|slice(0, 100) }}</a></td>
+                <td>{% if source.keywords != '' %}{{ source.keywords }}{% endif %}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | These are some minor styling changes after discussion with @kpodemski, mostly only optimizes spacing. Read below.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See if nothing is out of ordinary in backoffice.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/19495922552 https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/20622156108
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.


### Changes
- Optimized spacing of cards, card headers, card footers.
- Fixed wrong classes here and there, margin tops, margin bottoms, some extra margins of last elements in a card.
- Optimized spacing of grid rows.
- Refactored the terrible source list on order page into a table.
- Added icons to order page cards to be consistent with customer detail.
- On customer page, modified the basic info block slightly to be more consistent.
- Brought back the customer name in order header, but in the same font, after discussion with Krystian.

### How does it look - open it side by side and compare. Basically, nothing much changed, but it looks clean, you can fit more things on the page.

Customer page Before
![before_customer](https://github.com/user-attachments/assets/8117892c-cabb-452b-8cc0-5b6410a64d39)

Customer page  After
![after_customer](https://github.com/user-attachments/assets/dcdab428-34ab-455c-a186-77a5ff59f590)

Order page Before
![before_order_1](https://github.com/user-attachments/assets/93faa12a-c7a9-470d-8115-d816099837b6)

Order page After
![after_order_1](https://github.com/user-attachments/assets/6108f504-f9a2-4f23-810e-115045e42e02)

Order pageBefore
![before_order_2](https://github.com/user-attachments/assets/67374994-fe69-45cb-b8cb-a6433352fbaa)

Order pageAfter
![after_order_2](https://github.com/user-attachments/assets/cfb94802-b635-4dee-9212-1c13d747b6bb)

Product listBefore
![before_product](https://github.com/user-attachments/assets/180b8ad6-cee9-4ac4-a5fe-ba829b635a20)

Product listAfter
![after_product](https://github.com/user-attachments/assets/5f0becd6-af74-48e6-9f50-977d852ddd97)