### PR TITLE
Add more specific filtering to Brand addresses listing

### DIFF
--- a/src/Core/Grid/Query/ManufacturerAddressQueryBuilder.php
+++ b/src/Core/Grid/Query/ManufacturerAddressQueryBuilder.php
@@ -118,6 +118,7 @@ final class ManufacturerAddressQueryBuilder extends AbstractDoctrineQueryBuilder
             ->andWhere('a.id_supplier = 0')
             ->andWhere('a.id_warehouse = 0')
             ->andWhere('a.deleted = 0')
+            ->andWhere('a.id_manufacturer > 0')
         ;
         $this->applyFilters($qb, $filters);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Brand addresses (in the BO) considers every address with id_customer=0 and id_supplier=0 belonging to brand, regardless of id_manufacturer.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create address where id_customer, id_supplier, id_warehouse, id_manufacturer all equal to 0. This address would list in Brands; after fix, it won't appear there unless id_manufacturer > 0