### PR TITLE
Further improve URL structure

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -118,7 +118,7 @@ class DispatcherCore
         ],
         'product_rule' => [
             'controller' => 'product',
-            'rule' => '{id}{-:id_product_attribute}-{rewrite}.html',
+            'rule' => 'product/{id}{-:id_product_attribute}-{rewrite}',
             'keywords' => [
                 'id' => ['regexp' => '[0-9]+', 'param' => 'id_product'],
                 'id_product_attribute' => ['regexp' => '[0-9]*+', 'param' => 'id_product_attribute'],

--- a/tests/Integration/Classes/LinkTest.php
+++ b/tests/Integration/Classes/LinkTest.php
@@ -62,14 +62,14 @@ class LinkTest extends TestCase
     {
         $filename = basename($this->getProductLink(true, 1, 2)['path']);
 
-        $this->assertEquals('1-2-hummingbird-printed-t-shirt.html', $filename);
+        $this->assertEquals('1-2-hummingbird-printed-t-shirt', $filename);
     }
 
     public function testUrlIgnoresVariantIfNotSpecifiedWithUrlRewriting(): void
     {
         $filename = basename($this->getProductLink(true, 1, null)['path']);
 
-        $this->assertEquals('1-hummingbird-printed-t-shirt.html', $filename);
+        $this->assertEquals('1-hummingbird-printed-t-shirt', $filename);
     }
 
     public function testUrlTakesVariantIntoAccountWithoutUrlRewriting(): void


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Extension of https://github.com/PrestaShop/PrestaShop/pull/37467/, see more below.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Test that everything works normally.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

This builds upon https://github.com/PrestaShop/PrestaShop/pull/37467/ where we removed the category and ean from default URL structure. For the sake of consistency, I proposed to alter the URL futher a tiny bit, when we are changing it. But let's do it in another PR here.

So, most other URLs are `/something/XX-rewrite` and only the product is now `/XX-rewrite.html`. The `.html` is there because of conflict with category URLs.

**Example:**
`supplier/{id}-{rewrite}`
`brand/{id}-{rewrite}`
`content/{id}-{rewrite}`

So, this PR changes the structure from:
`www.domain.com/123-perfect-product.html`
to:
`www.domain.com/product/123-perfect-product`

So, we get rid of the `.html` historic remain and make it consistent with other URLs.