### PR TITLE
Fix adding customer threads messages

### DIFF
--- a/classes/CustomerThread.php
+++ b/classes/CustomerThread.php
@@ -190,6 +190,19 @@ class CustomerThreadCore extends ObjectModel
         );
     }
 
+    public static function getIdCustomerThreadByEmailAndIdOrderAndIdProduct($email, $id_order, $id_product)
+    {
+        return Db::getInstance()->getValue(
+            '
+			SELECT cm.id_customer_thread
+			FROM ' . _DB_PREFIX_ . 'customer_thread cm
+			WHERE cm.email = \'' . pSQL($email) . '\'
+				AND cm.id_shop = ' . (int) Context::getContext()->shop->id . '
+				AND cm.id_order = ' . (int) $id_order . '
+				AND cm.id_product = ' . (int) $id_product
+        );
+    }
+
     public static function getContacts()
     {
         return Db::getInstance()->executeS('

--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -60,9 +60,9 @@ class OrderDetailControllerCore extends FrontController
             if (!count($this->errors)) {
                 $order = new Order($idOrder);
                 if (Validate::isLoadedObject($order) && $order->id_customer == $this->context->customer->id) {
-                    // check if a thread already exist
-                    $id_customer_thread = CustomerThread::getIdCustomerThreadByEmailAndIdOrder($this->context->customer->email, $order->id);
+                    // check if a thread already exist (for the same product and the same order)
                     $id_product = (int) Tools::getValue('id_product');
+                    $id_customer_thread = CustomerThread::getIdCustomerThreadByEmailAndIdOrderAndIdProduct($this->context->customer->email, $order->id, $id_product);
                     $cm = new CustomerMessage();
                     if (!$id_customer_thread) {
                         $ct = new CustomerThread();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | We have two choice to fix this issue (#15711):<br>1) Adding new customer threads by order and products (and not only order like before).<br>2) Move `id_product` from `customer_threads` table to `customer_message`.<br><br>**This PR aim to fix with the first solution describe before.**
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #15711 
| UI Tests          | ~
| Fixed issue or discussion?     | Fix #15711 
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
