### PR TITLE
Add sales to manufacturer sort

### DIFF
--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -439,6 +439,8 @@ class ManufacturerCore extends ObjectModel
             $alias = 'm.';
         } elseif ($orderBy == 'quantity') {
             $alias = 'stock.';
+        } elseif ($orderBy == 'sales') {
+            $alias = '';
         } else {
             $alias = 'p.';
         }
@@ -453,7 +455,7 @@ class ManufacturerCore extends ObjectModel
 						"' . date('Y-m-d') . ' 00:00:00",
 						INTERVAL ' . (Validate::isUnsignedInt(Configuration::get('PS_NB_DAYS_NEW_PRODUCT')) ? Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20) . ' DAY
 					)
-				) > 0 AS new'
+				) > 0 AS new, psales.`quantity` as sales'
             . ' FROM `' . _DB_PREFIX_ . 'product` p
 			' . Shop::addSqlAssociation('product', 'p') .
             (Combination::isFeatureActive() ? 'LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_shop` product_attribute_shop
@@ -464,6 +466,8 @@ class ManufacturerCore extends ObjectModel
 					ON (image_shop.`id_product` = p.`id_product` AND image_shop.cover=1 AND image_shop.id_shop=' . (int) $context->shop->id . ')
 			LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il
 				ON (image_shop.`id_image` = il.`id_image` AND il.`id_lang` = ' . (int) $idLang . ')
+            LEFT JOIN `' . _DB_PREFIX_ . 'product_sale` psales
+					ON psales.`id_product` = p.`id_product`
 			LEFT JOIN `' . _DB_PREFIX_ . 'manufacturer` m
 				ON (m.`id_manufacturer` = p.`id_manufacturer`)
 			' . Product::sqlStock('p', 0);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      |  Add sorting by sales to manufacturer page. In fact default order is also used there.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Remove faceted search module, choose order by sales in bo, go to a manufacturer page in front
| UI Tests          |  
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/issues/37773 and follow https://github.com/PrestaShop/PrestaShop/issues/37431
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/37430
| Sponsor company   | Creabilis.com
