### PR TITLE
Make carrier name translatable

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -527,7 +527,7 @@ class CarrierCore extends ObjectModel
             return [];
         }
 
-        $sql = 'SELECT c.*, cl.delay
+        $sql = 'SELECT c.*, cl.name, cl.delay
                 FROM `' . _DB_PREFIX_ . 'carrier` c
                 LEFT JOIN `' . _DB_PREFIX_ . 'carrier_lang` cl ON (c.`id_carrier` = cl.`id_carrier` AND cl.`id_lang` = ' . (int) $id_lang . Shop::addSqlRestrictionOnLang('cl') . ')
                 LEFT JOIN `' . _DB_PREFIX_ . 'carrier_zone` cz ON (cz.`id_carrier` = c.`id_carrier`)' .

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -54,7 +54,7 @@ class CarrierCore extends ObjectModel
     /** @var int common id for carrier historization */
     public $id_reference;
 
-    /** @var string Name */
+    /** @var string[]|string Name */
     public $name;
 
     /** @var string URL with a '@' for */
@@ -130,7 +130,6 @@ class CarrierCore extends ObjectModel
         'fields' => [
             /* Classic fields */
             'id_reference' => ['type' => self::TYPE_INT],
-            'name' => ['type' => self::TYPE_STRING, 'validate' => 'isCarrierName', 'required' => true, 'size' => 64],
             'active' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'required' => true],
             'is_free' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'url' => ['type' => self::TYPE_STRING, 'validate' => 'isAbsoluteUrl', 'size' => 255],
@@ -150,6 +149,7 @@ class CarrierCore extends ObjectModel
             'deleted' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
 
             /* Lang fields */
+            'name' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isCarrierName', 'required' => true, 'size' => 64],
             'delay' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => true, 'size' => 512],
         ],
     ];

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -618,7 +618,7 @@ class CarrierCore extends ObjectModel
             ORDER BY s.`name` ASC');
 
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
-            SELECT cl.*,c.*, cl.`name` AS country, zz.`name` AS zone
+            SELECT cl.*, c.*, cl.`name` AS country, zz.`name` AS zone
             FROM `' . _DB_PREFIX_ . 'country` c' .
             Shop::addSqlAssociation('country', 'c') . '
             LEFT JOIN `' . _DB_PREFIX_ . 'country_lang` cl ON (c.`id_country` = cl.`id_country` AND cl.`id_lang` = ' . (int) $id_lang . ')

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2694,7 +2694,7 @@ class CartCore extends ObjectModel
                 // Foreach carriers of the package, calculate his price, check if it the best price, position and grade
                 foreach ($package['carrier_list'] as $id_carrier) {
                     if (!isset($carriers_instance[$id_carrier])) {
-                        $carriers_instance[$id_carrier] = new Carrier($id_carrier);
+                        $carriers_instance[$id_carrier] = new Carrier($id_carrier, (int) Context::getContext()->language->id);
                     }
 
                     $price_with_tax = $this->getPackageShippingCost((int) $id_carrier, true, $country, $package['product_list']);
@@ -2889,7 +2889,7 @@ class CartCore extends ObjectModel
                     $total_price_without_tax_with_rules = (in_array($id_carrier, $free_carriers_rules)) ? 0 : $total_price_without_tax;
 
                     if (!isset($carrier_collection[$id_carrier])) {
-                        $carrier_collection[$id_carrier] = new Carrier($id_carrier);
+                        $carrier_collection[$id_carrier] = new Carrier($id_carrier, (int) Context::getContext()->language->id);
                     }
                     $delivery_option_list[$id_address][$key]['carrier_list'][$id_carrier]['instance'] = $carrier_collection[$id_carrier];
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2694,7 +2694,7 @@ class CartCore extends ObjectModel
                 // Foreach carriers of the package, calculate his price, check if it the best price, position and grade
                 foreach ($package['carrier_list'] as $id_carrier) {
                     if (!isset($carriers_instance[$id_carrier])) {
-                        $carriers_instance[$id_carrier] = new Carrier($id_carrier, (int) Context::getContext()->language->id);
+                        $carriers_instance[$id_carrier] = new Carrier($id_carrier);
                     }
 
                     $price_with_tax = $this->getPackageShippingCost((int) $id_carrier, true, $country, $package['product_list']);
@@ -2889,7 +2889,7 @@ class CartCore extends ObjectModel
                     $total_price_without_tax_with_rules = (in_array($id_carrier, $free_carriers_rules)) ? 0 : $total_price_without_tax;
 
                     if (!isset($carrier_collection[$id_carrier])) {
-                        $carrier_collection[$id_carrier] = new Carrier($id_carrier, (int) Context::getContext()->language->id);
+                        $carrier_collection[$id_carrier] = new Carrier($id_carrier);
                     }
                     $delivery_option_list[$id_address][$key]['carrier_list'][$id_carrier]['instance'] = $carrier_collection[$id_carrier];
 

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1706,8 +1706,8 @@ class CartRuleCore extends ObjectModel
 			' . (in_array($type, ['carrier', 'shop']) ? ' AND t.deleted = 0' : '') . '
 			' . ($type == 'cart_rule' ? 'AND t.id_cart_rule != ' . (int) $this->id : '') .
                 $shop_list .
-                (in_array($type, ['carrier', 'shop']) ? ' ORDER BY t.name ASC ' : '') .
-                (in_array($type, ['country', 'group', 'cart_rule']) && $i18n ? ' ORDER BY tl.name ASC ' : '') .
+                (in_array($type, ['shop']) ? ' ORDER BY t.name ASC ' : '') .
+                (in_array($type, ['carrier', 'country', 'group', 'cart_rule']) && $i18n ? ' ORDER BY tl.name ASC ' : '') .
                 $sql_limit);
         } else {
             if ($type == 'cart_rule') {
@@ -1722,8 +1722,8 @@ class CartRuleCore extends ObjectModel
 				WHERE 1 ' . ($active_only ? ' AND t.active = 1' : '') .
                     $shop_list
                     . (in_array($type, ['carrier', 'shop']) ? ' AND t.deleted = 0' : '') .
-                    (in_array($type, ['carrier', 'shop']) ? ' ORDER BY t.name ASC ' : '') .
-                    (in_array($type, ['country', 'group']) && $i18n ? ' ORDER BY tl.name ASC ' : '') .
+                    (in_array($type, ['shop']) ? ' ORDER BY t.name ASC ' : '') .
+                    (in_array($type, ['carrier', 'country', 'group']) && $i18n ? ' ORDER BY tl.name ASC ' : '') .
                     $sql_limit,
                     false
                 );

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -614,7 +614,7 @@ abstract class PaymentModuleCore extends Module
                 $delivery = new Address((int) $order->id_address_delivery);
                 $delivery_state = $delivery->id_state ? new State((int) $delivery->id_state) : false;
                 $invoice_state = $invoice->id_state ? new State((int) $invoice->id_state) : false;
-                $carrier = $order->id_carrier ? new Carrier($order->id_carrier) : false;
+                $carrier = $order->id_carrier ? new Carrier($order->id_carrier, (int) $this->context->language->id) : false;
                 $orderLanguage = new Language((int) $order->id_lang);
 
                 // Join PDF invoice

--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -84,9 +84,7 @@ class DeliveryOptionsFinderCore
                     if (is_array($carriers)) {
                         foreach ($carriers as $carrier) {
                             $carrier = array_merge($carrier, $this->objectPresenter->present($carrier['instance']));
-                            $delay = $carrier['delay'][$this->context->language->id];
-                            unset($carrier['instance'], $carrier['delay']);
-                            $carrier['delay'] = $delay;
+                            unset($carrier['instance']);
                             if ($this->isFreeShipping($this->context->cart, $carriers_list)) {
                                 $carrier['price'] = $this->translator->trans(
                                     'Free',

--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -85,6 +85,8 @@ class DeliveryOptionsFinderCore
                         foreach ($carriers as $carrier) {
                             $carrier = array_merge($carrier, $this->objectPresenter->present($carrier['instance']));
                             unset($carrier['instance']);
+                            $carrier['delay'] = $carrier['delay'][$this->context->language->id];
+                            $carrier['name'] = $carrier['name'][$this->context->language->id];
                             if ($this->isFreeShipping($this->context->cart, $carriers_list)) {
                                 $carrier['price'] = $this->translator->trans(
                                     'Free',

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1929,7 +1929,7 @@ class OrderCore extends ObjectModel
     public function getShipping()
     {
         return Db::getInstance()->executeS(
-            'SELECT DISTINCT oc.`id_order_invoice`, oc.`weight`, oc.`shipping_cost_tax_excl`, oc.`shipping_cost_tax_incl`, c.`url`, oc.`id_carrier`, c.`name` as `carrier_name`, oc.`date_add`, "Delivery" as `type`, "true" as `can_edit`, oc.`tracking_number`, oc.`id_order_carrier`, osl.`name` as order_state_name, c.`name` as state_name
+            'SELECT DISTINCT oc.`id_order_invoice`, oc.`weight`, oc.`shipping_cost_tax_excl`, oc.`shipping_cost_tax_incl`, c.`url`, oc.`id_carrier`, cl.`name` as `carrier_name`, oc.`date_add`, "Delivery" as `type`, "true" as `can_edit`, oc.`tracking_number`, oc.`id_order_carrier`, osl.`name` as order_state_name
             FROM `' . _DB_PREFIX_ . 'orders` o
             LEFT JOIN `' . _DB_PREFIX_ . 'order_history` oh
                 ON (o.`id_order` = oh.`id_order`)
@@ -1937,6 +1937,8 @@ class OrderCore extends ObjectModel
                 ON (o.`id_order` = oc.`id_order`)
             LEFT JOIN `' . _DB_PREFIX_ . 'carrier` c
                 ON (oc.`id_carrier` = c.`id_carrier`)
+            LEFT JOIN `' . _DB_PREFIX_ . 'carrier_lang` cl
+                ON (oc.`id_carrier` = cl.`id_carrier` AND cl.`id_lang` = ' . (int) Context::getContext()->language->id . ')
             LEFT JOIN `' . _DB_PREFIX_ . 'order_state_lang` osl
                 ON (oh.`id_order_state` = osl.`id_order_state` AND osl.`id_lang` = ' . (int) Context::getContext()->language->id . ')
             WHERE o.`id_order` = ' . (int) $this->id . '

--- a/classes/pdf/HTMLTemplateDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateDeliverySlip.php
@@ -102,7 +102,7 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
             $formatted_invoice_address = AddressFormat::generateAddress($invoice_address, [], '<br />', ' ');
         }
 
-        $carrier = new Carrier($this->order->id_carrier, Context::getContext()->language->id);
+        $carrier = new Carrier($this->order->id_carrier, (int) Context::getContext()->language->id);
         $carrier->name = ($carrier->name == '0' ? Configuration::get('PS_SHOP_NAME') : $carrier->name);
 
         $order_details = $this->order_invoice->getProducts();

--- a/classes/pdf/HTMLTemplateDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateDeliverySlip.php
@@ -102,7 +102,7 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
             $formatted_invoice_address = AddressFormat::generateAddress($invoice_address, [], '<br />', ' ');
         }
 
-        $carrier = new Carrier($this->order->id_carrier);
+        $carrier = new Carrier($this->order->id_carrier, Context::getContext()->language->id);
         $carrier->name = ($carrier->name == '0' ? Configuration::get('PS_SHOP_NAME') : $carrier->name);
 
         $order_details = $this->order_invoice->getProducts();

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -174,7 +174,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
         }
 
         $customer = new Customer((int) $this->order->id_customer);
-        $carrier = new Carrier((int) $this->order->id_carrier);
+        $carrier = new Carrier((int) $this->order->id_carrier, (int) Context::getContext()->language->id);
 
         $order_details = $this->order_invoice->getProducts();
 
@@ -394,7 +394,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
         $tax_exempt = Configuration::get('VATNUMBER_MANAGEMENT')
                             && !empty($address->vat_number)
                             && $address->id_country != Configuration::get('VATNUMBER_COUNTRY');
-        $carrier = new Carrier($this->order->id_carrier);
+        $carrier = new Carrier($this->order->id_carrier, (int) Context::getContext()->language->id);
 
         $data = [
             'tax_exempt' => $tax_exempt,

--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -207,6 +207,7 @@ class AdminCarrierWizardControllerCore extends AdminController
                         'type' => 'text',
                         'label' => $this->trans('Carrier name', [], 'Admin.Shipping.Feature'),
                         'name' => 'name',
+                        'lang' => true,
                         'required' => true,
                         'hint' => [
                             $this->trans('Allowed characters: letters, spaces and "%special_chars%".', ['%special_chars%' => '().-'], 'Admin.Shipping.Help'),

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -84,7 +84,6 @@ CREATE TABLE `PREFIX_product_attachment` (
 CREATE TABLE `PREFIX_carrier` (
   `id_carrier` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `id_reference` int(10) unsigned NOT NULL,
-  `name` varchar(64) NOT NULL,
   `url` varchar(255) DEFAULT NULL,
   `active` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `deleted` tinyint(1) unsigned NOT NULL DEFAULT '0',
@@ -114,6 +113,7 @@ CREATE TABLE `PREFIX_carrier_lang` (
   `id_carrier` int(10) unsigned NOT NULL,
   `id_shop` int(11) unsigned NOT NULL DEFAULT '1',
   `id_lang` int(10) unsigned NOT NULL,
+  `name` varchar(64) NOT NULL,
   `delay` varchar(512) DEFAULT NULL,
   PRIMARY KEY (
     `id_lang`, `id_shop`, `id_carrier`

--- a/install-dev/data/xml/carrier.xml
+++ b/install-dev/data/xml/carrier.xml
@@ -19,7 +19,6 @@
   </fields>
   <entities>
     <carrier id="carrier_1" id_reference="1" id_tax_rules_group="0" active="1" shipping_handling="0" range_behavior="0" is_free="1" shipping_external="0" need_range="0" shipping_method="0" max_width="0" max_height="0" max_depth="0" max_weight="0" grade="0">
-      <name>Click and collect</name>
     </carrier>
   </entities>
 </entity_carrier>

--- a/install-dev/fixtures/fashion/data/carrier.xml
+++ b/install-dev/fixtures/fashion/data/carrier.xml
@@ -19,15 +19,12 @@
   </fields>
   <entities>
     <carrier id="My_carrier" id_reference="2" active="1" shipping_handling="1" range_behavior="0" is_free="0" shipping_external="0" need_range="0" shipping_method="0" max_width="0" max_height="0" max_depth="0" max_weight="0.000000" grade="0">
-      <name>My carrier</name>
       <url/>
     </carrier>
     <carrier id="My_cheap_carrier" id_reference="3" active="0" shipping_handling="1" range_behavior="0" is_free="0" shipping_external="0" need_range="0" shipping_method="2" max_width="0" max_height="0" max_depth="0" max_weight="0.000000" grade="0">
-      <name>My cheap carrier</name>
       <url/>
     </carrier>
     <carrier id="My_light_carrier" id_reference="3" active="0" shipping_handling="1" range_behavior="0" is_free="0" shipping_external="0" need_range="0" shipping_method="1" max_width="0" max_height="0" max_depth="0" max_weight="0.000000" grade="0">
-      <name>My light carrier</name>
       <url/>
     </carrier>
   </entities>

--- a/install-dev/fixtures/fashion/langs/en/data/carrier.xml
+++ b/install-dev/fixtures/fashion/langs/en/data/carrier.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0"?>
 <entity_carrier>
   <carrier id="My_carrier" id_shop="1">
+    <name>My carrier</name>
     <delay>Delivery next day!</delay>
   </carrier>
   <carrier id="My_cheap_carrier" id_shop="1">
+    <name>My cheap carrier</name>
     <delay>Buy more to pay less!</delay>
   </carrier>
   <carrier id="My_light_carrier" id_shop="1">
+    <name>My light carrier</name>
     <delay>The lighter the cheaper!</delay>
   </carrier>
 </entity_carrier>

--- a/install-dev/fixtures/fashion/langs/fa/data/carrier.xml
+++ b/install-dev/fixtures/fashion/langs/fa/data/carrier.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0"?>
 <entity_carrier>
   <carrier id="My_carrier" id_shop="1">
+    <name>My carrier</name>
     <delay>تحویل روز بعد!</delay>
   </carrier>
   <carrier id="My_cheap_carrier" id_shop="1">
+    <name>My cheap carrier</name>
     <delay>بیشتر بخرید تا هزینه کمتری بپردازید!</delay>
   </carrier>
   <carrier id="My_light_carrier" id_shop="1">
+    <name>My light carrier</name>
     <delay>هرچه سبک تر ارزان تر!</delay>
   </carrier>
 </entity_carrier>

--- a/install-dev/fixtures/fashion/langs/fr/data/carrier.xml
+++ b/install-dev/fixtures/fashion/langs/fr/data/carrier.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0"?>
 <entity_carrier>
   <carrier id="My_carrier" id_shop="1">
+    <name>My carrier</name>
     <delay>Delivery next day!</delay>
   </carrier>
   <carrier id="My_cheap_carrier" id_shop="1">
+    <name>My cheap carrier</name>
     <delay>Achetez plus vous paierez moins!</delay>
   </carrier>
   <carrier id="My_light_carrier" id_shop="1">
+    <name>My light carrier</name>
     <delay>Panier léger, prix allégé!</delay>
   </carrier>
 </entity_carrier>

--- a/install-dev/langs/en/data/carrier.xml
+++ b/install-dev/langs/en/data/carrier.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <entity_carrier>
   <carrier id="carrier_1" id_shop="1">
+    <name>Click and collect</name>
     <delay>Pick up in-store</delay>
   </carrier>
 </entity_carrier>

--- a/src/Adapter/Carrier/CommandHandler/AddCarrierHandler.php
+++ b/src/Adapter/Carrier/CommandHandler/AddCarrierHandler.php
@@ -59,7 +59,7 @@ class AddCarrierHandler implements AddCarrierHandlerInterface
     {
         $carrier = new Carrier();
         // General information
-        $carrier->name = $command->getName();
+        $carrier->name = $command->getLocalizedName();
         $carrier->grade = $command->getGrade();
         $carrier->url = $command->getTrackingUrl();
         $carrier->active = $command->getActive();

--- a/src/Adapter/Carrier/CommandHandler/EditCarrierHandler.php
+++ b/src/Adapter/Carrier/CommandHandler/EditCarrierHandler.php
@@ -62,8 +62,8 @@ class EditCarrierHandler implements EditCarrierHandlerInterface
         $newCarrierId = new CarrierId($newCarrier->id);
 
         // General information
-        if (null !== $command->getName()) {
-            $newCarrier->name = $command->getName();
+        if (null !== $command->getLocalizedName()) {
+            $newCarrier->name = $command->getLocalizedName();
         }
         if (null !== $command->getGrade()) {
             $newCarrier->grade = $command->getGrade();

--- a/src/Adapter/Carrier/Validate/CarrierValidator.php
+++ b/src/Adapter/Carrier/Validate/CarrierValidator.php
@@ -101,7 +101,7 @@ class CarrierValidator extends AbstractObjectModelValidator
      */
     private function validateGeneral(Carrier $carrier): void
     {
-        $this->validateObjectModelProperty($carrier, 'name', CarrierConstraintException::class, CarrierConstraintException::INVALID_NAME);
+        $this->validateObjectModelLocalizedProperty($carrier, 'name', CarrierConstraintException::class, CarrierConstraintException::INVALID_NAME);
         $this->validateObjectModelProperty($carrier, 'grade', CarrierConstraintException::class, CarrierConstraintException::INVALID_GRADE);
         $this->validateObjectModelProperty($carrier, 'url', CarrierConstraintException::class, CarrierConstraintException::INVALID_TRACKING_URL);
         $this->validateObjectModelProperty($carrier, 'position', CarrierConstraintException::class, CarrierConstraintException::INVALID_POSITION);

--- a/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
@@ -404,7 +404,7 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
                 // make sure there is no duplicate carrier
                 $deliveryOptions[(int) $carrier->id] = new CartDeliveryOption(
                     (int) $carrier->id,
-                    $carrier->name,
+                    $carrier->name[$this->contextLangId],
                     $carrier->delay[$this->contextLangId]
                 );
             }

--- a/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
+++ b/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
@@ -216,7 +216,7 @@ final class MailPreviewVariablesBuilder
             return [];
         }
 
-        $carrier = new Carrier($order->id_carrier);
+        $carrier = new Carrier($order->id_carrier, $this->context->language->getId());
         $delivery = new Address($order->id_address_delivery);
         $invoice = new Address($order->id_address_invoice);
 

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -176,7 +176,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
     public function handle(GetOrderForViewing $query): OrderForViewing
     {
         $order = $this->getOrder($query->getOrderId());
-        $orderCarrier = new Carrier($order->id_carrier);
+        $orderCarrier = new Carrier($order->id_carrier, $this->contextLanguageId);
         $taxCalculationMethod = $this->getOrderTaxCalculationMethod($order);
 
         $isTaxIncluded = ($taxCalculationMethod == PS_TAX_INC);

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -534,7 +534,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
         $carrierModuleInfo = null;
 
         $currency = new Currency($order->id_currency);
-        $carrier = new Carrier($order->id_carrier);
+        $carrier = new Carrier($order->id_carrier, $this->contextLanguageId);
         $carrierModuleInfo = null;
 
         if ($carrier->is_module) {

--- a/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
@@ -163,7 +163,7 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
     {
         $address = new Address($order->id_address_delivery);
         $country = new Country($address->id_country);
-        $carrier = new Carrier($order->id_carrier);
+        $carrier = new Carrier($order->id_carrier, (int) $order->getAssociatedLanguage()->getId());
         $state = new State($address->id_state);
 
         $carrierName = $trackingUrl = null;

--- a/src/Adapter/Presenter/Order/OrderLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderLazyArray.php
@@ -344,7 +344,7 @@ class OrderLazyArray extends AbstractLazyArray
     {
         $order = $this->order;
 
-        $carrier = new Carrier((int) $order->id_carrier, (int) $order->getAssociatedLanguage()->getId());
+        $carrier = new Carrier((int) $order->id_carrier, (int) Context::getContext()->language->id);
         $orderCarrier = $this->objectPresenter->present($carrier);
         $orderCarrier['name'] = ($carrier->name == '0') ? Configuration::get('PS_SHOP_NAME') : $carrier->name;
         $orderCarrier['delay'] = $carrier->delay;

--- a/src/Core/Domain/Carrier/Command/AddCarrierCommand.php
+++ b/src/Core/Domain/Carrier/Command/AddCarrierCommand.php
@@ -52,7 +52,8 @@ class AddCarrierCommand
      * @throws CarrierConstraintException
      */
     public function __construct(
-        private string $name,
+        /** @var string[] $localizedName */
+        private array $localizedName,
         /** @var string[] $localizedDelay */
         private array $localizedDelay,
         private int $grade,
@@ -91,9 +92,10 @@ class AddCarrierCommand
         }
     }
 
-    public function getName(): string
+    /** @return string[] */
+    public function getLocalizedName(): array
     {
-        return $this->name;
+        return $this->localizedName;
     }
 
     /** @return string[] */

--- a/src/Core/Domain/Carrier/Command/EditCarrierCommand.php
+++ b/src/Core/Domain/Carrier/Command/EditCarrierCommand.php
@@ -41,7 +41,8 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 class EditCarrierCommand
 {
     private CarrierId $carrierId;
-    private ?string $name;
+    /** @var string[] */
+    private ?array $localizedName;
     /** @var string[] */
     private ?array $localizedDelay;
     private ?int $grade;
@@ -74,14 +75,20 @@ class EditCarrierCommand
         return $this->carrierId;
     }
 
-    public function getName(): ?string
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedName(): ?array
     {
-        return $this->name ?? null;
+        return $this->localizedName ?? null;
     }
 
-    public function setName(string $name): self
+    /**
+     * @param string[] $localizedName
+     */
+    public function setLocalizedName(array $localizedName): self
     {
-        $this->name = $name;
+        $this->localizedName = $localizedName;
 
         return $this;
     }

--- a/src/Core/Domain/Carrier/QueryResult/EditableCarrier.php
+++ b/src/Core/Domain/Carrier/QueryResult/EditableCarrier.php
@@ -35,7 +35,8 @@ class EditableCarrier
 {
     public function __construct(
         private int $carrierId,
-        private string $name,
+        /** @var string[] $name */
+        private array $name,
         private int $grade,
         private string $trackingUrl,
         private int $position,
@@ -69,7 +70,10 @@ class EditableCarrier
         return $this->carrierId;
     }
 
-    public function getName(): string
+    /**
+     * @return string[]
+     */
+    public function getLocalizedName(): array
     {
         return $this->name;
     }

--- a/src/Core/Form/IdentifiableObject/DataHandler/CarrierFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CarrierFormDataHandler.php
@@ -53,7 +53,7 @@ class CarrierFormDataHandler implements FormDataHandlerInterface
 
         /** @var CarrierId $carrierId */
         $carrierId = $this->commandBus->handle(new AddCarrierCommand(
-            $data['general_settings']['name'],
+            $data['general_settings']['localized_name'],
             $data['general_settings']['localized_delay'],
             $data['general_settings']['grade'],
             $data['general_settings']['tracking_url'] ?? '',
@@ -83,7 +83,7 @@ class CarrierFormDataHandler implements FormDataHandlerInterface
         // First, we need to update the general settings of the carrier
         $command = new EditCarrierCommand($id);
         $command
-            ->setName($data['general_settings']['name'])
+            ->setLocalizedName($data['general_settings']['localized_name'])
             ->setLocalizedDelay($data['general_settings']['localized_delay'])
             ->setGrade($data['general_settings']['grade'])
             ->setActive((bool) $data['general_settings']['active'])

--- a/src/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProvider.php
@@ -57,7 +57,7 @@ class CarrierFormDataProvider implements FormDataProviderInterface
 
         return [
             'general_settings' => [
-                'name' => $carrier->getName(),
+                'localized_name' => $carrier->getLocalizedName(),
                 'localized_delay' => $carrier->getLocalizedDelay(),
                 'active' => $carrier->isActive(),
                 'grade' => $carrier->getGrade(),

--- a/src/Core/Grid/Query/CarrierQueryBuilder.php
+++ b/src/Core/Grid/Query/CarrierQueryBuilder.php
@@ -88,7 +88,7 @@ final class CarrierQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getCarrierQueryBuilder($searchCriteria)
-            ->select('c.id_carrier, c.name, cl.delay, c.active, c.is_free, c.position')
+            ->select('c.id_carrier, cl.name, cl.delay, c.active, c.is_free, c.position')
             ->groupBy('c.id_carrier');
 
         $this->searchCriteriaApplicator
@@ -133,7 +133,7 @@ final class CarrierQueryBuilder extends AbstractDoctrineQueryBuilder
             }
 
             if ($filterName === 'name') {
-                $qb->andWhere('c.name LIKE :name');
+                $qb->andWhere('cl.name LIKE :name');
                 $qb->setParameter($filterName, '%' . $filterValue . '%');
 
                 continue;

--- a/src/Core/Grid/Query/CartQueryBuilder.php
+++ b/src/Core/Grid/Query/CartQueryBuilder.php
@@ -45,18 +45,26 @@ final class CartQueryBuilder extends AbstractDoctrineQueryBuilder
     private const CUSTOMER_ONLINE_TIME = 1800; // 30 min
 
     /**
+     * @var int
+     */
+    private $contextIdLang;
+
+    /**
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
      * @param MultistoreContextCheckerInterface $multistoreContextChecker
+     * @param int $contextIdLang
      */
     public function __construct(
         Connection $connection,
         string $dbPrefix,
         private readonly DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
         private readonly MultistoreContextCheckerInterface $multistoreContextChecker,
+        $contextIdLang
     ) {
         parent::__construct($connection, $dbPrefix);
+        $this->contextIdLang = $contextIdLang;
     }
 
     /**
@@ -69,7 +77,7 @@ final class CartQueryBuilder extends AbstractDoctrineQueryBuilder
         $qb
             ->select('c.`id_cart`')
             ->addSelect('c.`date_add`')
-            ->addSelect('ca.`name` AS carrier_name')
+            ->addSelect('cal.`name` AS carrier_name')
             ->addSelect('o.`id_order` AS id_order')
             ->addSelect('CONCAT(LEFT(cu.firstname, 1), ". ", cu.lastname) AS customer_name')
             ->addSelect('co.`id_guest` AS customer_online')
@@ -142,9 +150,9 @@ final class CartQueryBuilder extends AbstractDoctrineQueryBuilder
 
         $qb->leftJoin(
             'c',
-            $this->dbPrefix . 'carrier',
-            'ca',
-            'c.`id_carrier` = ca.`id_carrier`'
+            $this->dbPrefix . 'carrier_lang',
+            'cal',
+            'c.`id_carrier` = cal.`id_carrier` AND cal.`id_lang` = :contextLangId'
         );
 
         $qb->leftJoin(
@@ -185,6 +193,7 @@ final class CartQueryBuilder extends AbstractDoctrineQueryBuilder
         }
 
         $this->applyFilters($qb, $filters);
+        $qb->setParameter('contextLangId', $this->contextIdLang);
 
         return $qb;
     }
@@ -241,7 +250,7 @@ final class CartQueryBuilder extends AbstractDoctrineQueryBuilder
             }
 
             if ('carrier_name' === $filterName) {
-                $qb->andWhere('ca.name LIKE :' . $filterName);
+                $qb->andWhere('cal.name LIKE :' . $filterName);
                 $qb->setParameter($filterName, '%' . $filterValue . '%');
                 continue;
             }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
@@ -59,12 +59,15 @@ class GeneralSettings extends TranslatorAwareType
 
         parent::buildForm($builder, $options);
         $builder
-            ->add('name', TextType::class, [
+            ->add('localized_name', TranslatableType::class, [
+                'required' => true,
                 'label' => $this->trans('Carrier name', 'Admin.Shipping.Feature'),
                 'label_help_box' => $this->trans('Allowed characters: letters, spaces and "%special_chars%".', 'Admin.Shipping.Help', ['%special_chars%' => '().-']) . '<br/>' .
                     $this->trans('The carrier\'s name will be displayed during checkout.', 'Admin.Shipping.Help') . '<br/>' .
                     $this->trans('For in-store pickup, enter 0 to replace the carrier name with your shop name.', 'Admin.Shipping.Help'),
-                'required' => true,
+                'constraints' => [
+                    new DefaultLanguage(),
+                ],
             ])
             ->add('localized_delay', TranslatableType::class, [
                 'required' => true,

--- a/tests/Integration/Behaviour/Features/Context/Domain/Carrier/CarrierFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Carrier/CarrierFeatureContext.php
@@ -413,7 +413,7 @@ class CarrierFeatureContext extends AbstractDomainFeatureContext
     }
 
     private function createCarrierUsingCommand(
-        string $name,
+        array $name,
         array $delay,
         int $grade,
         string $trackingUrl,

--- a/tests/Integration/Behaviour/Features/Context/Domain/Carrier/CarrierFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Carrier/CarrierFeatureContext.php
@@ -77,6 +77,12 @@ class CarrierFeatureContext extends AbstractDomainFeatureContext
                 $associatedShops = [$this->getDefaultShopId()];
             }
 
+            if (!empty($properties['name'])) {
+                $name = $properties['name'];
+            } else {
+                $name = [$this->getDefaultLangId() => 'Name'];
+            }
+
             if (!empty($properties['delay'])) {
                 $delay = $properties['delay'];
             } else {
@@ -100,7 +106,7 @@ class CarrierFeatureContext extends AbstractDomainFeatureContext
             }
 
             $carrierId = $this->createCarrierUsingCommand(
-                $properties['name'],
+                $name,
                 $delay,
                 (int) ($properties['grade'] ?? 0),
                 $properties['trackingUrl'] ?? '',
@@ -197,7 +203,7 @@ class CarrierFeatureContext extends AbstractDomainFeatureContext
         $command = new EditCarrierCommand($carrierId);
         // General information
         if (isset($properties['name'])) {
-            $command->setName($properties['name']);
+            $command->setLocalizedName($properties['name']);
         }
         if (isset($properties['delay'])) {
             $command->setLocalizedDelay($properties['delay']);
@@ -291,7 +297,7 @@ class CarrierFeatureContext extends AbstractDomainFeatureContext
 
         // General information
         if (isset($data['name'])) {
-            Assert::assertEquals($data['name'], $carrier->getName());
+            Assert::assertEquals($data['name'], $carrier->getLocalizedName());
         }
         if (isset($data['grade'])) {
             Assert::assertEquals($data['grade'], $carrier->getGrade());

--- a/tests/Integration/Behaviour/Features/Scenario/Carrier/Ranges/carrier_ranges.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Carrier/Ranges/carrier_ranges.feature
@@ -22,7 +22,6 @@ Feature: Carrier ranges
   Scenario: Adding prices ranges in carrier
     When I create carrier "carrier1" with specified properties:
       | name[en-US]      | Carrier 1                          |
-      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | price                              |
       | zones            | zone1, zone2                       |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
@@ -45,7 +44,6 @@ Feature: Carrier ranges
   Scenario: Adding weight ranges in carrier
     When I create carrier "carrier1" with specified properties:
       | name[en-US]      | Carrier 1                          |
-      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | weight                             |
       | zones            | zone1, zone2                       |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
@@ -68,7 +66,6 @@ Feature: Carrier ranges
   Scenario: Adding overlapping ranges in carrier
     When I create carrier "carrier1" with specified properties:
       | name[en-US]      | Carrier 1                          |
-      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | weight                             |
       | zones            | zone1, zone2                       |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
@@ -84,7 +81,6 @@ Feature: Carrier ranges
   Scenario: Get ranges for not all shops
     When I create carrier "carrier1" with specified properties:
       | name[en-US]      | Carrier 1                          |
-      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | weight                             |
       | zones            | zone1                              |
     Then carrier "carrier1" should have the following ranges for shop "shop1":
@@ -95,7 +91,6 @@ Feature: Carrier ranges
   Scenario: Set ranges for not all shops
     When I create carrier "carrier1" with specified properties:
       | name[en-US]      | Carrier 1                          |
-      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | weight                             |
       | zones            | zone1                              |
     Then I set ranges for carrier "carrier1" with specified properties for shop "shop1":
@@ -106,7 +101,6 @@ Feature: Carrier ranges
   Scenario: Set ranges with invalid zone
     When I create carrier "carrier1" with specified properties:
       | name[en-US]      | Carrier 1                          |
-      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | weight                             |
       | zones            | zone1                              |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
@@ -117,7 +111,6 @@ Feature: Carrier ranges
   Scenario: Adding prices ranges in carrier with random sorting of ranges
     When I create carrier "carrier1" with specified properties:
       | name[en-US]      | Carrier 1                          |
-      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | price                              |
       | zones            | zone1, zone2                       |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
@@ -140,7 +133,6 @@ Feature: Carrier ranges
   Scenario: Adding prices ranges in carrier with different ranges by zones
     When I create carrier "carrier1" with specified properties:
       | name[en-US]      | Carrier 1                          |
-      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | price                              |
       | zones            | zone1, zone2                       |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
@@ -159,7 +151,6 @@ Feature: Carrier ranges
   Scenario: Adding prices ranges without zone
     When I create carrier "carrier1" with specified properties:
       | name[en-US]      | Carrier 1                          |
-      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | weight                             |
       | zones            |                                    |
     Then carrier should throw an error with error code "INVALID_ZONE_MISSING"
@@ -167,7 +158,6 @@ Feature: Carrier ranges
   Scenario: Adding negative ranges in carrier
     When I create carrier "carrier1" with specified properties:
       | name[en-US]      | Carrier 1                          |
-      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | weight                             |
       | zones            | zone1, zone2                       |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
@@ -176,7 +166,6 @@ Feature: Carrier ranges
     Then carrier should throw an error with error code "INVALID_RANGE_NEGATIVE"
     When I create carrier "carrier2" with specified properties:
       | name[en-US]      | Carrier 2                          |
-      | name[fr-FR]      | Carrier 2                          |
       | shippingMethod   | weight                             |
       | zones            | zone1, zone2                       |
     Then I set ranges for carrier "carrier2" with specified properties for all shops:

--- a/tests/Integration/Behaviour/Features/Scenario/Carrier/Ranges/carrier_ranges.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Carrier/Ranges/carrier_ranges.feature
@@ -21,7 +21,8 @@ Feature: Carrier ranges
 
   Scenario: Adding prices ranges in carrier
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | price                              |
       | zones            | zone1, zone2                       |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
@@ -43,7 +44,8 @@ Feature: Carrier ranges
 
   Scenario: Adding weight ranges in carrier
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | weight                             |
       | zones            | zone1, zone2                       |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
@@ -65,7 +67,8 @@ Feature: Carrier ranges
 
   Scenario: Adding overlapping ranges in carrier
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | weight                             |
       | zones            | zone1, zone2                       |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
@@ -80,7 +83,8 @@ Feature: Carrier ranges
 
   Scenario: Get ranges for not all shops
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | weight                             |
       | zones            | zone1                              |
     Then carrier "carrier1" should have the following ranges for shop "shop1":
@@ -90,7 +94,8 @@ Feature: Carrier ranges
 
   Scenario: Set ranges for not all shops
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | weight                             |
       | zones            | zone1                              |
     Then I set ranges for carrier "carrier1" with specified properties for shop "shop1":
@@ -100,7 +105,8 @@ Feature: Carrier ranges
 
   Scenario: Set ranges with invalid zone
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | weight                             |
       | zones            | zone1                              |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
@@ -110,7 +116,8 @@ Feature: Carrier ranges
 
   Scenario: Adding prices ranges in carrier with random sorting of ranges
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | price                              |
       | zones            | zone1, zone2                       |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
@@ -132,7 +139,8 @@ Feature: Carrier ranges
 
   Scenario: Adding prices ranges in carrier with different ranges by zones
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | price                              |
       | zones            | zone1, zone2                       |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
@@ -150,14 +158,16 @@ Feature: Carrier ranges
 
   Scenario: Adding prices ranges without zone
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | weight                             |
       | zones            |                                    |
     Then carrier should throw an error with error code "INVALID_ZONE_MISSING"
 
   Scenario: Adding negative ranges in carrier
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | shippingMethod   | weight                             |
       | zones            | zone1, zone2                       |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
@@ -165,7 +175,8 @@ Feature: Carrier ranges
       | zone1   | -5         | 100      | 10          |
     Then carrier should throw an error with error code "INVALID_RANGE_NEGATIVE"
     When I create carrier "carrier2" with specified properties:
-      | name             | Carrier 2                          |
+      | name[en-US]      | Carrier 2                          |
+      | name[fr-FR]      | Carrier 2                          |
       | shippingMethod   | weight                             |
       | zones            | zone1, zone2                       |
     Then I set ranges for carrier "carrier2" with specified properties for all shops:

--- a/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_management.feature
@@ -24,7 +24,8 @@ Feature: Carrier management
 
   Scenario: Adding new Carrier
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -78,7 +79,8 @@ Feature: Carrier management
       | payment module name | dummy_payment              |
       | status              | Awaiting bank wire payment |
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -98,17 +100,21 @@ Feature: Carrier management
     When I update order "bo_order1" Tracking number to "TEST1234" and Carrier to "carrier1"
     Then order "bo_order1" has Tracking number "TEST1234"
     When I edit carrier "carrier1" with specified properties I get a new carrier referenced as "newCarrier1":
-      | name | Carrier 1 new |
+      | name[en-US]      | Carrier 1 new   |
+      | name[fr-FR]      | Carrier 1 new   |
     Then carrier "carrier1" should have the following properties:
-      | name        | Carrier 1 |
-      | ordersCount | 1         |
+      | name[en-US]      | Carrier 1    |
+      | name[fr-FR]      | Carrier 1    |
+      | ordersCount      | 1            |
     Then carrier "newCarrier1" should have the following properties:
-      | name        | Carrier 1 new |
-      | ordersCount | 0             |
+      | name[en-US]      | Carrier 1 new   |
+      | name[fr-FR]      | Carrier 1 new   |
+      | ordersCount      | 0               |
 
   Scenario: Partially editing carrier with name and without an order linked
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -125,7 +131,7 @@ Feature: Carrier management
       | shippingMethod   | weight                             |
       | rangeBehavior    | disabled                           |
     When I edit carrier "carrier1" with specified properties I get a similar carrier called "newCarrier1":
-      | name | Carrier 1 new |
+      | name[en-US] | Carrier 1 new |
     Then carrier "carrier1" should have the following properties:
       | name             | Carrier 1 new                      |
       | grade            | 1                                  |
@@ -164,7 +170,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with grade
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -183,7 +190,8 @@ Feature: Carrier management
     When I edit carrier "carrier1" with specified properties:
       | grade | 2 |
     Then carrier "carrier1" should have the following properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 2                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 7                                  |
@@ -202,7 +210,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with tracking url
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -221,7 +230,8 @@ Feature: Carrier management
     When I edit carrier "carrier1" with specified properties:
       | trackingUrl | http://prestashop-project.org/track.php?num=@ |
     Then carrier "carrier1" should have the following properties:
-      | name             | Carrier 1                                     |
+      | name[en-US]      | Carrier 1                                     |
+      | name[fr-FR]      | Carrier 1                                     |
       | grade            | 1                                             |
       | trackingUrl      | http://prestashop-project.org/track.php?num=@ |
       | position         | 8                                             |
@@ -240,7 +250,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with position (and forced position on creation)
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 2                                  |
@@ -258,7 +269,8 @@ Feature: Carrier management
       | shippingMethod   | weight                             |
       | rangeBehavior    | disabled                           |
     Then carrier "carrier1" should have the following properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 2                                  |
@@ -277,7 +289,8 @@ Feature: Carrier management
     When I edit carrier "carrier1" with specified properties:
       | position | 4 |
     Then carrier "carrier1" should have the following properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 4                                  |
@@ -296,7 +309,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with active
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -315,7 +329,8 @@ Feature: Carrier management
     When I edit carrier "carrier1" with specified properties:
       | active | false |
     Then carrier "carrier1" should have the following properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 9                                  |
@@ -334,7 +349,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with delay
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -373,7 +389,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with width height depth weight
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -395,7 +412,8 @@ Feature: Carrier management
       | max_depth  | 5555 |
       | max_weight | 6666 |
     Then carrier "carrier1" should have the following properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 11                                 |
@@ -414,7 +432,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with group_access
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -433,7 +452,8 @@ Feature: Carrier management
     When I edit carrier "carrier1" with specified properties:
       | group_access | visitor |
     Then carrier "carrier1" should have the following properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 12                                 |
@@ -452,7 +472,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with handling shipping
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -476,7 +497,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with free shipping
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -500,7 +522,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with shipping method
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -524,7 +547,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with invalid shipping method
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -572,7 +596,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with range behavior
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -596,7 +621,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with invalid range behavior
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -618,7 +644,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with additional fees and is free already true
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -642,7 +669,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with is free and additional fees already true
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -666,7 +694,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with is free and additional fees at true
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -689,7 +718,8 @@ Feature: Carrier management
 
   Scenario: Upload logo for carrier
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -710,7 +740,8 @@ Feature: Carrier management
 
   Scenario: Upload logo for carrier then edit this carrier to delete logo.
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -734,7 +765,8 @@ Feature: Carrier management
 
   Scenario: Partially editing carrier with zones
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -758,7 +790,8 @@ Feature: Carrier management
 
   Scenario: Add a new carrier without any zone
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |
@@ -778,7 +811,8 @@ Feature: Carrier management
 
   Scenario: Edit a new carrier and delete all zone
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | active           | true                               |

--- a/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_management.feature
@@ -42,7 +42,8 @@ Feature: Carrier management
       | zones            | zone1                              |
       | rangeBehavior    | disabled                           |
     Then carrier "carrier1" should have the following properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 4                                  |
@@ -133,7 +134,8 @@ Feature: Carrier management
     When I edit carrier "carrier1" with specified properties I get a similar carrier called "newCarrier1":
       | name[en-US] | Carrier 1 new |
     Then carrier "carrier1" should have the following properties:
-      | name             | Carrier 1 new                      |
+      | name[en-US]      | Carrier 1 new                      |
+      | name[fr-FR]      | Carrier 1 new                      |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 6                                  |
@@ -151,7 +153,8 @@ Feature: Carrier management
       | shippingMethod   | weight                             |
       | rangeBehavior    | disabled                           |
     Then carrier "newCarrier1" should have the following properties:
-      | name             | Carrier 1 new                      |
+      | name[en-US]      | Carrier 1 new                      |
+      | name[fr-FR]      | Carrier 1 new                      |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 6                                  |
@@ -370,7 +373,8 @@ Feature: Carrier management
       | delay[en-US] | Shipping delay new         |
       | delay[fr-FR] | Délai de livraison nouveau |
     Then carrier "carrier1" should have the following properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 10                                 |
@@ -492,8 +496,9 @@ Feature: Carrier management
     When I edit carrier "carrier1" with specified properties:
       | shippingHandling | true |
     Then carrier "carrier1" should have the following properties:
-      | name             | Carrier 1 |
-      | shippingHandling | true      |
+      | name[en-US]      | Carrier 1   |
+      | name[fr-FR]      | Carrier 1   |
+      | shippingHandling | true        |
 
   Scenario: Partially editing carrier with free shipping
     When I create carrier "carrier1" with specified properties:
@@ -517,8 +522,9 @@ Feature: Carrier management
     When I edit carrier "carrier1" with specified properties:
       | isFree | true |
     Then carrier "carrier1" should have the following properties:
-      | name   | Carrier 1 |
-      | isFree | true      |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
+      | isFree           | true                               |
 
   Scenario: Partially editing carrier with shipping method
     When I create carrier "carrier1" with specified properties:
@@ -542,8 +548,9 @@ Feature: Carrier management
     When I edit carrier "carrier1" with specified properties:
       | shippingMethod | price |
     Then carrier "carrier1" should have the following properties:
-      | name           | Carrier 1 |
-      | shippingMethod | price     |
+      | name[en-US]    | Carrier 1                          |
+      | name[fr-FR]    | Carrier 1                          |
+      | shippingMethod | price                              |
 
   Scenario: Partially editing carrier with invalid shipping method
     When I create carrier "carrier1" with specified properties:
@@ -571,7 +578,8 @@ Feature: Carrier management
   # @debug
   # Scenario: Partially editing carrier with tax rule group
   #   When I create carrier "carrier1" with specified properties:
-  #     | name             | Carrier 1                          |
+  #     | name[en-US]      | Carrier 1                          |
+  #     | name[fr-FR]      | Carrier 1                          |
   #     | grade            | 1                                  |
   #     | trackingUrl      | http://example.com/track.php?num=@ |
   #     | position         | 2                                  |
@@ -591,7 +599,8 @@ Feature: Carrier management
   #   When I edit carrier "carrier1" with specified properties:
   #     | taxRuleGroup | US-AZ Rate (6.6%)              |
   #   Then carrier "carrier1" should have the following properties:
-  #     | name         | Carrier 1                       |
+  #     | name[en-US]      | Carrier 1                   |
+  #     | name[fr-FR]      | Carrier 1                   |
   #     | taxRuleGroup | US-AZ Rate (6.6%)               |
 
   Scenario: Partially editing carrier with range behavior
@@ -616,8 +625,9 @@ Feature: Carrier management
     When I edit carrier "carrier1" with specified properties:
       | rangeBehavior | highest_range |
     Then carrier "carrier1" should have the following properties:
-      | name          | Carrier 1     |
-      | rangeBehavior | highest_range |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
+      | rangeBehavior    | highest_range                      |
 
   Scenario: Partially editing carrier with invalid range behavior
     When I create carrier "carrier1" with specified properties:
@@ -785,8 +795,9 @@ Feature: Carrier management
     When I edit carrier "carrier1" with specified properties:
       | zones     | zone1     |
     Then carrier "carrier1" should have the following properties:
-      | name      | Carrier 1 |
-      | zones     | zone1     |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
+      | zones            | zone1                              |
 
   Scenario: Add a new carrier without any zone
     When I create carrier "carrier1" with specified properties:

--- a/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_multishop.feature
@@ -50,7 +50,8 @@ Feature: Carrier management
       | rangeBehavior    | disabled                           |
       | associatedShops  | shop1, shop3                       |
     Then carrier "carrier1" should have the following properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 2                                  |
@@ -72,7 +73,8 @@ Feature: Carrier management
     When I edit carrier "carrier1" with specified properties:
       | associatedShops | shop2, shop4 |
     And carrier "carrier1" should have the following properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 2                                  |

--- a/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_multishop.feature
@@ -30,7 +30,8 @@ Feature: Carrier management
 
   Scenario: I add carrier and define a selection of shops, I can also edit them
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 2                                  |

--- a/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_tax_rule_group_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_tax_rule_group_management.feature
@@ -15,7 +15,6 @@ Feature: Carrier Tax Rule Group management
   Scenario: Partially editing carrier with tax rule group
     When I create carrier "carrier1" with specified properties:
       | name[en-US]      | Carrier 1                          |
-      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 2                                  |
@@ -33,13 +32,12 @@ Feature: Carrier Tax Rule Group management
     And I identify tax rules group named "US-AZ Rate (6.6%)" as "us-az-tax-rate"
     When I set tax rule "us-az-tax-rate" for carrier "carrier1"
     Then carrier "carrier1" should have the following properties:
-      | name         | Carrier 1         |
-      | taxRuleGroup | US-AZ Rate (6.6%) |
+      | name[en-US]      | Carrier 1                          |
+      | taxRuleGroup     | US-AZ Rate (6.6%)                  |
 
   Scenario: Partially editing carrier with wrong tax rule group
     When I create carrier "carrier1" with specified properties:
       | name[en-US]      | Carrier 1                          |
-      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 2                                  |

--- a/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_tax_rule_group_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_tax_rule_group_management.feature
@@ -14,7 +14,8 @@ Feature: Carrier Tax Rule Group management
 
   Scenario: Partially editing carrier with tax rule group
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 2                                  |
@@ -37,7 +38,8 @@ Feature: Carrier Tax Rule Group management
 
   Scenario: Partially editing carrier with wrong tax rule group
     When I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
+      | name[fr-FR]      | Carrier 1                          |
       | grade            | 1                                  |
       | trackingUrl      | http://example.com/track.php?num=@ |
       | position         | 2                                  |

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/Restrictions/cart_rule_carrier_restriction.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/Restrictions/cart_rule_carrier_restriction.feature
@@ -24,21 +24,21 @@ Feature: Cart calculation with carrier specific cart rules
     And there is an address named "address1" with postcode "1" in state "state1"
     And there is an address named "address2" with postcode "1" in state "state2"
     And I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
       | zones            | zone1, zone2                           |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |
       | zone1   | 0          | 10000    | 3.1         |
       | zone2   | 0          | 10000    | 4.3         |
     And I create carrier "carrier2" with specified properties:
-      | name             | Carrier 2                          |
+      | name[en-US]      | Carrier 2                          |
       | zones            | zone1, zone2                           |
     Then I set ranges for carrier "carrier2" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |
       | zone1   | 0          | 10000    | 5.7         |
       | zone2   | 0          | 10000    | 6.2         |
     And I create carrier "carrier3" with specified properties:
-      | name             | Carrier 3                          |
+      | name[en-US]      | Carrier 3                          |
       | zones            | zone1, zone2                       |
     And there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     And there is a product in the catalog named "product2" with a price of 32.388 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/Restrictions/cart_rule_country_restriction.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/Restrictions/cart_rule_country_restriction.feature
@@ -23,7 +23,7 @@ Feature: Cart calculation with country specific cart rules
     And there is an address named "address-fr" with postcode "1" in state "state-fr"
     And there is an address named "address-us" with postcode "1" in state "state-us"
     And I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
       | zones            | zone1, zone2                           |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/carrier.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/carrier.feature
@@ -24,28 +24,28 @@ Feature: Cart calculation with cart rules and different carriers
     And there is an address named "address1" with postcode "1" in state "state1"
     And there is an address named "address2" with postcode "2" in state "state2"
     And I create carrier "carrier1" with specified properties:
-      | name | carrier 1 |
+      | name[en-US]      | carrier 1 |
       | zones            | zone1, zone2                           |
     And I set ranges for carrier "carrier1" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |
       | zone1   | 0          | 1000     | 3.1         |
       | zone2   | 0          | 1000     | 4.3         |
     And I create carrier "carrier2" with specified properties:
-      | name | carrier 2 |
+      | name[en-US]      | carrier 2 |
       | zones            | zone1, zone2                           |
     And I set ranges for carrier "carrier2" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |
       | zone1   | 0          | 1000     | 5.7         |
       | zone2   | 0          | 1000     | 6.2         |
     And I create carrier "carrier3" with specified properties:
-      | name | carrier 3 |
+      | name[en-US]      | carrier 3 |
       | zones            | zone1, zone2                           |
     And I set ranges for carrier "carrier3" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |
       | zone1   | 0          | 1000     | 5.7         |
       | zone2   | 0          | 1000     | 6.2         |
     And I create carrier "carrier4" with specified properties:
-      | name | carrier 4 |
+      | name[en-US]      | carrier 4 |
       | zones            | zone1, zone2                           |
     And I set ranges for carrier "carrier4" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/cart_rule_validation.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/FrontOffice/cart_rule_validation.feature
@@ -70,8 +70,8 @@ Feature: Cart rule application is validated before it is applied to cart
       | code                | rule_carrier1 |
       | discount_percentage | 50            |
     And I create carrier "carrier1" with specified properties:
-      | name | Carrier 1 |
-      | zones| zone1     |
+      | name[en-US] | Carrier 1 |
+      | zones       | zone1     |
     And I restrict following carriers for cart rule cart_rule_4:
       | restricted carriers | carrier1 |
     And I save all the restrictions for cart rule cart_rule_4

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/carrier.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/carrier.feature
@@ -13,14 +13,14 @@ Feature: Cart calculation with carriers
       | name    | zone2 |
       | enabled | true  |
     Given I create carrier "carrier1" with specified properties:
-      | name             | carrier 1                          |
+      | name[en-US]      | carrier 1                          |
       | zones            | zone1, zone2                       |
     Given I set ranges for carrier "carrier1" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |
       | zone1   | 0          | 10000    | 3.1         |
       | zone2   | 0          | 10000    | 4.3         |
     Given I create carrier "carrier2" with specified properties:
-      | name | carrier 2 |
+      | name[en-US]      | carrier 2 |
       | zones            | zone1, zone2                       |
     Given I set ranges for carrier "carrier2" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |
@@ -122,7 +122,7 @@ Feature: Cart calculation with carriers
     Given I have an empty default cart
     Given there is a product in the catalog named "product1" with a price of 151.0 and 1000 items in stock
     Given I create carrier "carrier3" with specified properties:
-      | name | carrier 3 |
+      | name[en-US]      | carrier 3                          |
       | zones            | zone1, zone2                       |
     Given I set ranges for carrier "carrier3" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/cart_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/cart_to_order.feature
@@ -34,7 +34,7 @@ Feature: Check cart to order data copy
     Given there is a customer named "customer1" whose email is "fake@prestashop.com"
     Given address "address1" is associated to customer "customer1"
     And I create carrier "carrier1" with specified properties:
-      | name | carrier 1 |
+      | name[en-US] | carrier 1 |
       | zones| zone1     |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |
@@ -74,8 +74,8 @@ Feature: Check cart to order data copy
     Given there is a customer named "customer1" whose email is "fake@prestashop.com"
     Given address "address1" is associated to customer "customer1"
     And I create carrier "carrier1" with specified properties:
-      | name | carrier 1 |
-      | zones| zone1     |
+      | name[en-US] | carrier 1 |
+      | zones       | zone1     |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |
       | zone1   | 0          | 10000    | 5.0         |
@@ -111,7 +111,7 @@ Feature: Check cart to order data copy
     Given there is a customer named "customer1" whose email is "fake@prestashop.com"
     Given address "address1" is associated to customer "customer1"
     And I create carrier "carrier1" with specified properties:
-      | name             | carrier 1                          |
+      | name[en-US]      | carrier 1                          |
       | zones            | zone1                              |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |
@@ -154,7 +154,7 @@ Feature: Check cart to order data copy
     Given there is a customer named "customer1" whose email is "fake@prestashop.com"
     Given address "address1" is associated to customer "customer1"
     And I create carrier "carrier1" with specified properties:
-      | name             | carrier 1                          |
+      | name[en-US]      | carrier 1                          |
       | zones            | zone1                              |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |
@@ -198,7 +198,7 @@ Feature: Check cart to order data copy
     Given there is a customer named "customer1" whose email is "fake@prestashop.com"
     Given address "address1" is associated to customer "customer1"
     And I create carrier "carrier1" with specified properties:
-      | name             | carrier 1                          |
+      | name[en-US]      | carrier 1                          |
       | zones            | zone1                              |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |
@@ -240,7 +240,7 @@ Feature: Check cart to order data copy
     Given there is a customer named "customer1" whose email is "fake@prestashop.com"
     Given address "address1" is associated to customer "customer1"
     And I create carrier "carrier1" with specified properties:
-      | name             | carrier 1                          |
+      | name[en-US]      | carrier 1                          |
       | zones            | zone1                              |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |
@@ -280,7 +280,7 @@ Feature: Check cart to order data copy
     Given there is a customer named "customer1" whose email is "fake@prestashop.com"
     Given address "address1" is associated to customer "customer1"
     And I create carrier "carrier1" with specified properties:
-      | name             | carrier 1                          |
+      | name[en-US]      | carrier 1                          |
       | zones            | zone1                              |
     And I set ranges for carrier "carrier1" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/delivery_options.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/delivery_options.feature
@@ -40,7 +40,7 @@ Feature: Compute correct delivery options
     Given address "address1" is associated to customer "customer1"
     # One standard carrier
     And I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]      | Carrier 1                          |
       | zones            | zone1                              |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |

--- a/tests/Integration/Behaviour/Features/Scenario/CartRule/set_carrier_restrictions.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CartRule/set_carrier_restrictions.feature
@@ -13,9 +13,9 @@ Feature: Set cart rule carrier restrictions in BO
     And language "language1" with locale "en-US" exists
     And language with iso code "en" is the default one
     And I create carrier "carrier1" with specified properties:
-      | name             | Carrier 1                          |
+      | name[en-US]             | Carrier 1                          |
     And I create carrier "carrier2" with specified properties:
-      | name             | Carrier 2                          |
+      | name[en-US]             | Carrier 2                          |
     And I add product "product1" with following information:
       | name[en-US] | bottle of beer |
       | type        | virtual        |

--- a/tests/Integration/Behaviour/Features/Scenario/CartRule/set_mixed_cart_rule_restrictions.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CartRule/set_mixed_cart_rule_restrictions.feature
@@ -27,9 +27,9 @@ Feature: Set cart rule restrictions in BO
     And supplier fashionSupplier named "Fashion supplier" exists
     And supplier accessoriesSupplier named "Accessories supplier" exists
     And I create carrier "carrier1" with specified properties:
-      | name             | carrier 1                          |
+      | name[en-US]             | carrier 1                          |
     And I create carrier "carrier2" with specified properties:
-      | name             | carrier 2                          |
+      | name[en-US]             | carrier 2                          |
     And I add new country "France" with following properties:
       | name[en-US]                | France          |
       | iso_code                   | FR              |

--- a/tests/Integration/Behaviour/Features/Scenario/Database/sql_manager.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Database/sql_manager.feature
@@ -64,7 +64,6 @@ Feature: SQL Manager
     When I request the database fields from table carrier
     Then I should get a set of database fields that contain values:
       | id_carrier      |
-      | name            |
       | shipping_method |
 
   Scenario: Save a SQL request

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_address.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_address.feature
@@ -158,7 +158,7 @@ Feature: Order from Back Office (BO)
 
   Scenario: Check shipping details after updating carrier tracking number & url
     And I create carrier "tracking-carrier" with specified properties:
-      | name        | tracking-carrier |
+      | name[en-US] | tracking-carrier |
       | trackingUrl |                  |
     And I add order "bo_order1" with the following details:
       | cart                | dummy_cart                 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
@@ -723,10 +723,10 @@ Feature: Order from Back Office (BO)
       | enabled | true  |
     And there is a country named "country1" and iso code "FR" in zone "zone1"
     And I create carrier "carrier1" with specified properties:
-      | name             | carrier 1                          |
+      | name[en-US]      | carrier 1                          |
       | zones            | zone1                              |
     And I create carrier "carrier2" with specified properties:
-      | name             | carrier 2                          |
+      | name[en-US]      | carrier 2                          |
       | zones            | zone1                              |
     Then I set ranges for carrier "carrier1" with specified properties for all shops:
       | id_zone | range_from | range_to | range_price |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_product_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_product_multishop.feature
@@ -54,9 +54,9 @@ Feature: Copy product from shop to shop.
     And single shop context is loaded
     And manufacturer studioDesign named "Studio Design" exists
     And I create carrier "carrier1" with specified properties:
-      | name | ecoCarrier |
+      | name[en-US] | ecoCarrier |
     And I create carrier "carrier2" with specified properties:
-      | name | Fast carry |
+      | name[en-US] | Fast carry |
     # Prepare a few data
     And I add new tax "us-tax-state-1" with following properties:
       | name       | US Tax (6%) |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_shipping_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_shipping_multishop.feature
@@ -36,9 +36,9 @@ Feature: Update product shipping information from Back Office (BO) for multiple 
       | delivery time out of stock notes[fr-FR] |         |
       | carriers                                | []      |
     And I create carrier "carrier1" with specified properties:
-      | name        | ecoCarrier |
+      | name[en-US]        | ecoCarrier |
     And I create carrier "carrier2" with specified properties:
-      | name        | Fast carry |
+      | name[en-US]        | Fast carry |
     When I update product "product1" with following values:
       | width                                   | 10.5                        |
       | height                                  | 6                           |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/bulk_duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/bulk_duplicate_product.feature
@@ -21,9 +21,9 @@ Feature: Duplicate product from Back Office (BO).
     And language with iso code "en" is the default one
     And language "language2" with locale "fr-FR" exists
     And I create carrier "carrier1" with specified properties:
-      | name | ecoCarrier |
+      | name[en-US] | ecoCarrier |
     And I create carrier "carrier2" with specified properties:
-      | name | Fast carry |
+      | name[en-US] | Fast carry |
     And I add new supplier supplier1 with the following properties:
       | name                    | my supplier 1      |
       | address                 | Donelaicio st. 1   |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -15,9 +15,9 @@ Feature: Duplicate product from Back Office (BO).
     And language with iso code "en" is the default one
     And language "language2" with locale "fr-FR" exists
     And I create carrier "carrier1" with specified properties:
-      | name | ecoCarrier |
+      | name[en-US] | ecoCarrier |
     And I create carrier "carrier2" with specified properties:
-      | name | Fast carry |
+      | name[en-US] | Fast carry |
     And attribute group "Color" named "Color" in en language exists
     And attribute "Red" named "Red" in en language exists
     And attribute "Blue" named "Blue" in en language exists

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_shipping.feature
@@ -20,9 +20,9 @@ Feature: Update product shipping options from Back Office (BO)
       | delivery time out of stock notes[en-US] |         |
       | carriers                                | []      |
     And I create carrier "carrier1" with specified properties:
-      | name        | ecoCarrier |
+      | name[en-US]        | ecoCarrier |
     And I create carrier "carrier2" with specified properties:
-      | name        | Fast carry |
+      | name[en-US]        | Fast carry |
     When I update product "product1" with following values:
       | width                                   | 10.5                 |
       | height                                  | 6                    |

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CarrierFormDataProviderTest.php
@@ -54,7 +54,10 @@ class CarrierFormDataProviderTest extends TestCase
 
                     return new EditableCarrier(
                         42,
-                        'Carrier name',
+                        [
+                            1 => 'Carrier name English',
+                            2 => 'Carrier name French',
+                        ],
                         5,
                         'http://track.to',
                         1,
@@ -128,7 +131,10 @@ class CarrierFormDataProviderTest extends TestCase
         $formData = $formDataProvider->getData(42);
         $this->assertEquals([
             'general_settings' => [
-                'name' => 'Carrier name',
+                'localized_name' => [
+                    1 => 'Carrier name English',
+                    2 => 'Carrier name French',
+                ],
                 'localized_delay' => [
                     1 => 'English delay',
                     2 => 'French delay',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fixes long annoyance in the ecosystem and makes carrier name translatable. I have important big clients expanding abroad and we can't have a czech carrier name in other languages. More info below.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Manual test-
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/32241
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### Regarding BC break
- There is a BC break, but not that significant. First, the name is not really used in the shipping modules for anything. All modules use id_reference to keep track of modules. Secondly, if you constructed the Carrier object with an language ID, `$carrier->name` will still give you the same results.
- V9 is an ideal time to do this, because there are already BC breaks due to symfony migration, so if we do something with carriers, let's do it at once.
- Modules that will need to be adapted are really only the ones querying carriers manually, those that show shipping price previews for example.
- No template change is required.

### Required module changes
- Name is now in `ps_carrier_lang`.
- Some places where you got `$carrier->name` as `string` will now give you an `array`.