### PR TITLE
Add .WEBP extensions to back office openable attachments

### DIFF
--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -543,6 +543,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
             '.jpeg' => 'image/jpeg',
             '.gif' => 'image/gif',
             '.jpg' => 'image/jpeg',
+            '.webp' => 'image/webp',
         ];
 
         $extension = false;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |   9.0.x
| Description?      |  Adds webp extension to permit opening files from backoffice when added from contactform module (webp support had been added in recent versions)
| Type?             | bug fix 
| Category?         |  BO 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Check #35278 before / applying this one
| UI Tests          | 
| Fixed issue or discussion?     | Fixes ##35278
| Related PRs       | 
| Sponsor company   |
