### PR TITLE
Fix multistore disabling

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -206,7 +206,8 @@ class PreferencesType extends TranslatorAwareType
                     ),
                 ])
             ->add('multishop_feature_active', SwitchType::class, [
-                'disabled' => !$this->isContextDependantOptionEnabled(),
+                // Disable the checkbox if multistore feature is active and at least 2 shops exist (@see PrestaShop/PrestaShop/Adapter/Feature/MultistoreFeature)
+                'disabled' => $this->isMultistoreUsed,
                 'label' => $this->trans('Enable Multistore', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans(
                     'The multistore feature allows you to manage several front offices from a single back office. If this feature is enabled, a Multistore page is available in the Advanced Parameters menu.',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | To avoid some multistores behaviours, we need to disable the possibility to disable multistore feature,<br> when we have more than 1 store in database.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Login to the BO<br>2. Enable multistore in `Shop Parameters > General`.<br>3. Create another store<br>4. Go to `Shop Parameters > General` and notice that the checkbox to disable multistore is disabled in all context (also for single / group / all stores).<br>5. Then delete the previously added store.<br>6. Go back to the `Shop Parameters > General` page to notice that the checkbox are enable again!
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/12711198510
| Fixed issue or discussion?     | Fixes #37320 
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
