### PR TITLE
Fix AdminOrders OrderSlip amount value

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -486,10 +486,10 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
                     $document->id
                 );
                 $amount = $this->locale->formatPrice(
-                    $document->total_products_tax_incl + $document->total_shipping_tax_incl,
+                    $document->amount + $document->shipping_cost_amount,
                     $currency->iso_code
                 );
-                $numericAmount = $document->total_products_tax_incl + $document->total_shipping_tax_incl;
+                $numericAmount = $document->amount + $document->shipping_cost_amount;
             }
 
             $documentsForViewing[] = new OrderDocumentForViewing(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  Fix the OrderSlip amount on the AdminOrder Documents tab.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Create by code a new OrderSlip with OrderSlip::create(), using param 4 as a float number and param 5 as "true" (Check #37805 for more details)
| Fixed issue or discussion?     | Fixes #37805 