### PR TITLE
Fix: BO > Carriers - Exception thrown Invalid Carrier url. Got "@"

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
@@ -39,6 +39,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Url;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class GeneralSettings extends TranslatorAwareType
@@ -111,6 +112,11 @@ class GeneralSettings extends TranslatorAwareType
                 'label' => $this->trans('Tracking URL', 'Admin.Shipping.Feature'),
                 'label_help_box' => $this->trans('Delivery tracking URL: Type \'@\' where the tracking number should appear. It will be automatically replaced by the tracking number.', 'Admin.Shipping.Help'),
                 'help' => $this->trans('For example: \'http://example.com/track.php?num=@\' with \'@\' where the tracking number should appear.', 'Admin.Shipping.Help'),
+                'constraints' => [
+                    new Url([
+                        'message' => $this->trans('Please enter a valid URL.', 'Admin.Notifications.Error'),
+                    ]),
+                ],
             ])
             ->add('group_access', MaterialChoiceTableType::class, [
                 'label' => $this->trans('Group access', 'Admin.Shipping.Feature'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | In carriers, when I add a Tracking URL with just "@" and Save I have an exception.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/37783
| UI Tests          |  https://github.com/paulnoelcholot/testing_pr/actions/runs/12785877534
| Fixed issue or discussion?     | Fixes #37783
| Sponsor company   | @Codencode 
