### PR TITLE
Fix: BO > Carriers - Exception thrown Carrier cannot be both shipping handling and free

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataHandler/CarrierFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CarrierFormDataHandler.php
@@ -80,6 +80,11 @@ class CarrierFormDataHandler implements FormDataHandlerInterface
 
     public function update($id, array $data)
     {
+        // If the courier has no costs, 'has_additional_handling_fee' must be false.
+        if ((bool) $data['shipping_settings']['is_free'] === true) {
+            $data['shipping_settings']['has_additional_handling_fee'] = false;
+        }
+
         // First, we need to update the general settings of the carrier
         $command = new EditCarrierCommand($id);
         $command


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | In a non-Free shipping carrier, when I add a Zone without adding a price, an exception is thrown.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see #37786 
| UI Tests          |
| Fixed issue or discussion?     | Fixes #37786 
| Related PRs       | 
| Sponsor company   | @Codencode 
