### PR TITLE
Fix: bug: Legacy form sends GET request instead of POST as it should

### DIFF
--- a/src/PrestaShopBundle/Routing/Converter/LegacyUrlConverter.php
+++ b/src/PrestaShopBundle/Routing/Converter/LegacyUrlConverter.php
@@ -125,9 +125,7 @@ final class LegacyUrlConverter
         $this->router->getContext()->fromRequest($request);
         $this->checkAlreadyMatchingRoute($request->getRequestUri());
 
-        $parameters = array_merge($request->query->all(), $request->request->all());
-
-        return $this->convertByParameters($parameters);
+        return $this->convertByParameters($request->query->all());
     }
 
     /**

--- a/src/PrestaShopBundle/Routing/Converter/LegacyUrlConverter.php
+++ b/src/PrestaShopBundle/Routing/Converter/LegacyUrlConverter.php
@@ -125,7 +125,22 @@ final class LegacyUrlConverter
         $this->router->getContext()->fromRequest($request);
         $this->checkAlreadyMatchingRoute($request->getRequestUri());
 
-        return $this->convertByParameters($request->query->all());
+        // We can't use convertByParameters with the combined parameters, or the POST parameters will be added
+        // in the redirection URL, so we do check for the validity of parameters and the matching route based on
+        // all the parameters
+        $allParameters = $request->query->all() + $request->request->all();
+        if (empty($allParameters['controller'])) {
+            throw new ArgumentException('Missing required controller argument');
+        }
+
+        /** @var LegacyRoute $legacyRoute */
+        $legacyRoute = $this->findLegacyRouteNameByParameters($allParameters);
+
+        // But only query parameters are used to generate the new URL, so we clean them (remove controller, action, ...)
+        // the POST parameters will remain unchanged in the 308 redirection
+        $queryParameters = $this->convertLegacyParameters($request->query->all(), $legacyRoute);
+
+        return $this->router->generate($legacyRoute->getRouteName(), $queryParameters, UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | see #37687 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see #37687 + To make sure this doesn't break anything all the native modules configuration pages should be tested
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/12954942359
| Fixed issue or discussion?     | Fixes #37687 
| Related PRs       | 
| Sponsor company   | @Codencode 

