### PR TITLE
Fix: Multishop: Deleting and recreating a combination removes the shared reference (new Product Page V2)

### DIFF
--- a/src/Adapter/Product/Combination/Repository/CombinationRepository.php
+++ b/src/Adapter/Product/Combination/Repository/CombinationRepository.php
@@ -237,6 +237,31 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
     }
 
     /**
+     * @param CombinationId $combinationId
+     *
+     * @return string
+     */
+    private function getCombinationReference(CombinationId $combinationId): string
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->select('pa.reference')
+            ->from($this->dbPrefix . 'product_attribute', 'pa')
+            ->andWhere('pa.id_product_attribute = :combinationId')
+            ->setParameter('combinationId', $combinationId->getValue())
+        ;
+
+        $result = $qb->execute()->fetchAssociative();
+        $reference = '';
+
+        if (!empty($result['reference'])) {
+            $reference = $result['reference'];
+        }
+
+        return $reference;
+    }
+
+    /**
      * Creates a new combination in product_attribute_shop assuming it already exists in product_attribute table
      *
      * @param CombinationId $combinationId
@@ -251,6 +276,7 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
         $combination->force_id = true;
         $combination->id_product = $productId->getValue();
         $combination->default_on = false;
+        $combination->reference = $this->getCombinationReference($combinationId);
 
         $this->updateObjectModelForShops($combination, [$shopId], CannotUpdateCombinationException::class);
     }

--- a/src/Adapter/Product/Combination/Repository/CombinationRepository.php
+++ b/src/Adapter/Product/Combination/Repository/CombinationRepository.php
@@ -252,13 +252,8 @@ class CombinationRepository extends AbstractMultiShopObjectModelRepository
         ;
 
         $result = $qb->execute()->fetchAssociative();
-        $reference = '';
 
-        if (!empty($result['reference'])) {
-            $reference = $result['reference'];
-        }
-
-        return $reference;
+        return $result['reference'] ?? '';
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | see: https://github.com/PrestaShop/PrestaShop/issues/37840 - Note: The issue also occurs on the 9.0.x branch, so I performed the rebase by moving the PR to 9.0.x because PRs are no longer being merged on version 8.2.x.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |1. Set up a multishop configuration with at least two shops (e.g., B2C and B2B).<br/>2. Create a product with an active combination shared across both shops:<br/>Size: S<br/>Reference: REFERENCE<br/>3. Delete the combination from the B2B shop.<br/>4. Recreate the same combination in the B2B shop. 5. Check that the combination has **REFERENCE** as its reference.<br/> For more info see: https://github.com/PrestaShop/PrestaShop/issues/37840
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/18774894264
| Fixed issue or discussion?     | Fixes #37840
| Sponsor company   | Codencode snc
