### PR TITLE
Fix issue with count on string

### DIFF
--- a/src/Adapter/Presenter/Product/ProductListingLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductListingLazyArray.php
@@ -57,7 +57,7 @@ class ProductListingLazyArray extends ProductLazyArray
     protected function shouldEnableAddToCartButton(array $product, ProductPresentationSettings $settings)
     {
         if (isset($product['attributes'])
-            && count($product['attributes']) > 0
+            && !empty($product['attributes'])
             && !$settings->allow_add_variant_to_cart_from_listing) {
             return false;
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | In this [commit](https://github.com/PrestaShop/PrestaShop/commit/d3729d73e76cfbcd8a286f01c24e1a8eb4e7aeda), we addressed an issue where `attributes` could sometimes be a string instead of an array. This caused problems because, in the `ProductListingLazyArray`, we were treating `attributes` as if it were always an array. This led to a `TypeError`. To make the code more robust, we replaced `count() > 0` with `empty()`. However, we first need to understand why `attributes` is sometimes an array and other times a string. From what I can tell, the issue stems from the caching mechanism in `Product.php`, specifically in the `getProductProperties` function. Here, `$row` is cached regardless of whether `attributes` is a string or an array. In the `FrontController`, the `assignGeneralPurposeVariables` function sends `$cart` to the cart presenter. In turn, the presenter’s `applyProductCalculations` function sets `attributes` as a string. This works correctly because the `FrontController` and view templates don’t seem to call functions in the `ProductListingLazyArray`. However, when the `getProductProperties` function is called again, the cached version of `$row` is returned, and `attributes` remains a string (since the cache key hasn’t changed). This suggests that the root cause of this issue lies deeper and should be addressed at its source. Nonetheless, this fix should still be applied to ensure the `ProductListingLazyArray.php` handles cases where `attributes` is a string. 
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run the cart presenter with a product in it (adding a product to the cart should suffice). After that, run the ProductPresenter with the same product, so it will be retrieved directly from the cache. This behavior can be observed, for example, in the [ets_crossell](https://addons.prestashop.com/en/cross-selling-product-bundles/28596-cross-selling-pro-upsell-shopping-cart-all-pages.html) module. In the module controller, this occurs in the `productsForTemplate` function.
| UI Tests          | https://github.com/paulnoelcholot/testing_pr/actions/runs/12929583595
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 
