### PR TITLE
Fix: Products CSV Export : always the first page is exported

### DIFF
--- a/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
@@ -63,6 +63,7 @@ use PrestaShopBundle\Form\Admin\Type\ShopSelectorType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Defines products grid name, its columns, actions, bulk actions and filters.
@@ -103,6 +104,8 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
      */
     private $multipleShopsChecker;
 
+    private $offset = 0;
+
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
         ConfigurationInterface $configuration,
@@ -110,7 +113,8 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
         ShopConstraintContextInterface $shopConstraintContext,
         FormFactoryInterface $formFactory,
         AccessibilityCheckerInterface $singleShopChecker,
-        AccessibilityCheckerInterface $multipleShopsChecker
+        AccessibilityCheckerInterface $multipleShopsChecker,
+        RequestStack $requestStack,
     ) {
         parent::__construct($hookDispatcher);
         $this->configuration = $configuration;
@@ -119,6 +123,12 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
         $this->formFactory = $formFactory;
         $this->singleShopChecker = $singleShopChecker;
         $this->multipleShopsChecker = $multipleShopsChecker;
+
+        $request = $requestStack->getCurrentRequest();
+
+        if ($request !== null && $request->query->has('product')) {
+            $this->offset = (int) $request->query->get('product')['offset'];
+        }
     }
 
     /**
@@ -639,6 +649,9 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ->setIcon('cloud_download')
                     ->setOptions([
                         'route' => 'admin_products_export',
+                        'route_params' => [
+                            'offset' => $this->offset
+                        ]
                     ])
             )
             ->add(

--- a/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
@@ -114,7 +114,7 @@ class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
         FormFactoryInterface $formFactory,
         AccessibilityCheckerInterface $singleShopChecker,
         AccessibilityCheckerInterface $multipleShopsChecker,
-        RequestStack $requestStack,
+        RequestStack $requestStack
     ) {
         parent::__construct($hookDispatcher);
         $this->configuration = $configuration;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -727,8 +727,9 @@ class ProductController extends FrameworkBundleAdminController
      *
      * @return CsvResponse
      */
-    public function exportAction(ProductFilters $filters)
+    public function exportAction(ProductFilters $filters, int $offset)
     {
+        $filters->set('offset', $offset);
         $productGridFactory = $this->get('prestashop.core.grid.factory.product');
         $grid = $productGridFactory->getGrid($filters);
 

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products_v2/product.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/products_v2/product.yml
@@ -35,12 +35,13 @@ admin_products_preview:
     productId: \d+
 
 admin_products_export:
-  path: /export
+  path: /export/{offset}
   methods: [ GET ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::exportAction
     _legacy_controller: AdminProducts
     _legacy_link: AdminProducts
+    offset: 0
 
 admin_products_search:
   path: /

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -305,6 +305,7 @@ services:
       - '@form.factory'
       - '@PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\ProductSingleShopAssociatedAccessibilityChecker'
       - '@PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\ProductMultipleShopsAssociatedAccessibilityChecker'
+      - '@request_stack'
     public: true
 
   prestashop.core.grid.definition.factory.product.shops:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | When exporting the product list to a CSV file, no matter the current page or the limit per page, it always export the product from the first page.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes / no
| Deprecations?     | no
| How to test?      | see https://github.com/PrestaShop/PrestaShop/issues/37847
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #37847
| Related PRs       |
| Sponsor company   | @Codencode 
