### PR TITLE
Fix Customer threads messages for multiple products

### DIFF
--- a/classes/CustomerMessage.php
+++ b/classes/CustomerMessage.php
@@ -39,6 +39,9 @@ class CustomerMessageCore extends ObjectModel
     /** @var int */
     public $id_employee;
 
+    /** @var int */
+    public $id_product;
+
     /** @var string */
     public $message;
 
@@ -71,6 +74,7 @@ class CustomerMessageCore extends ObjectModel
         'primary' => 'id_customer_message',
         'fields' => [
             'id_employee' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
+            'id_product' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
             'id_customer_thread' => ['type' => self::TYPE_INT],
             'ip_address' => ['type' => self::TYPE_STRING, 'validate' => 'isIp2Long', 'size' => 16],
             'message' => ['type' => self::TYPE_HTML, 'required' => true, 'size' => FormattedTextareaType::LIMIT_MEDIUMTEXT_UTF8_MB4, 'validate' => 'isCleanHtml'],
@@ -88,6 +92,9 @@ class CustomerMessageCore extends ObjectModel
         'fields' => [
             'id_employee' => [
                 'xlink_resource' => 'employees',
+            ],
+            'id_product' => [
+                'xlink_resource' => 'products',
             ],
             'id_customer_thread' => [
                 'xlink_resource' => 'customer_threads',

--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -86,6 +86,7 @@ class OrderDetailControllerCore extends FrontController
 
                     $cm->id_customer_thread = $ct->id;
                     $cm->message = $msgText;
+                    $cm->id_product = $id_product;
                     $client_ip_address = Tools::getRemoteAddr();
                     $cm->ip_address = (string) ip2long($client_ip_address);
                     $cm->add();

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -662,6 +662,7 @@ CREATE TABLE `PREFIX_customer_message` (
   `id_customer_message` int(10) unsigned NOT NULL auto_increment,
   `id_customer_thread` int(11) DEFAULT NULL,
   `id_employee` int(10) unsigned DEFAULT NULL,
+  `id_product` int(10) unsigned DEFAULT NULL,
   `message` MEDIUMTEXT NOT NULL,
   `file_name` varchar(18) DEFAULT NULL,
   `ip_address` varchar(16) DEFAULT NULL,
@@ -672,7 +673,8 @@ CREATE TABLE `PREFIX_customer_message` (
   `read` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_customer_message`),
   KEY `id_customer_thread` (`id_customer_thread`),
-  KEY `id_employee` (`id_employee`)
+  KEY `id_employee` (`id_employee`),
+  KEY `id_product` (`id_product`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 
 /* store the header of already fetched emails from imap support messaging */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | See #15711, to fix this issue, we need to add `id_product` in customer message and save the selected product id in this column.<br>The current templates in FO and BO works well with this fix.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | See #15711 
| UI Tests          |  https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/12927230565
| Fixed issue or discussion?     | Fixes #15711 
| Related PRs       | First attempt in #37713 
| Sponsor company   | PrestaShop SA
