### PR TITLE
Fix: Admin search by product ID results in CSV download instead of product page redirect

### DIFF
--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -104,7 +104,7 @@ class AdminSearchControllerCore extends AdminController
                 if ($searchType == 1 && Validate::isUnsignedInt((int) $this->query)) {
                     $product = new Product((int) $this->query);
                     if (Validate::isLoadedObject($product)) {
-                        Tools::redirectAdmin('index.php?tab=AdminProducts&id_product=' . (int) ($product->id) . '&token=' . Tools::getAdminTokenLite('AdminProducts'));
+                        Tools::redirectAdmin($this->context->link->getAdminLink('AdminProducts', true, ['id_product' => (int) $product->id, 'updateproduct' => '1']));
                     }
                 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | In the admin panel, when searching for a product by ID using the search bar at the top, if the entered ID matches an existing product, the system should redirect to the product page. Instead, it downloads a CSV file
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see https://github.com/PrestaShop/PrestaShop/issues/37868
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #37868
| Related PRs       |
| Sponsor company   | @Codencode 
