### PR TITLE
Fix: BO - Product Page - Redirection type - Category without image generate 404 call

### DIFF
--- a/src/Adapter/Category/CategoryDataProvider.php
+++ b/src/Adapter/Category/CategoryDataProvider.php
@@ -246,11 +246,18 @@ class CategoryDataProvider
         $results = [];
         foreach ($searchCategories as $category) {
             $breadCrumb = $this->getBreadCrumb($category['id_category']);
+
+            if (file_exists(_PS_CAT_IMG_DIR_ . $category['id_category'] . '.jpg')) {
+                $image = Context::getContext()->link->getCatImageLink($category['name'], $category['id_category']);
+            } else {
+                $image = Context::getContext()->link->getMediaLink(_THEME_CAT_DIR_ . Context::getContext()->language->iso_code . '-default-category_default.jpg');
+            }
+
             $results[] = [
                 'id' => $category['id_category'],
                 'name' => ($nameAsBreadCrumb ? $breadCrumb : $category['name']),
                 'breadcrumb' => $breadCrumb,
-                'image' => Context::getContext()->link->getCatImageLink($category['name'], $category['id_category']),
+                'image' => $image,
             ];
         }
 

--- a/src/Adapter/Category/Repository/CategoryPreviewRepository.php
+++ b/src/Adapter/Category/Repository/CategoryPreviewRepository.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Category\Repository;
 
+use Language;
 use PrestaShop\PrestaShop\Adapter\Image\ImagePathFactory;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Category\QueryResult\CategoryPreview;
@@ -82,7 +83,12 @@ class CategoryPreviewRepository
         );
         $names = explode(static::BREADCRUMB_SEPARATOR, $breadcrumb);
         $name = $names[count($names) - 1] ?? $names[0];
-        $imagePath = $this->categoryImagePathFactory->getPath($categoryId->getValue());
+
+        if (file_exists(_PS_CAT_IMG_DIR_ . $categoryId->getValue() . '.jpg')) {
+            $imagePath = $this->categoryImagePathFactory->getPath($categoryId->getValue());
+        } else {
+            $imagePath = $this->categoryImagePathFactory->getPath(Language::getIsoById($languageId->getValue()) . '-default-category_default');
+        }
 
         return new CategoryPreview(
             $categoryId->getValue(),

--- a/src/Adapter/Image/ImagePathFactory.php
+++ b/src/Adapter/Image/ImagePathFactory.php
@@ -45,12 +45,12 @@ class ImagePathFactory
     }
 
     /**
-     * @param int $entityId
+     * @param int|string $imageName
      *
      * @return string
      */
-    public function getPath(int $entityId): string
+    public function getPath(int|string $imageName): string
     {
-        return sprintf('%s/%s.jpg', $this->pathToBaseDir, $entityId);
+        return sprintf('%s/%s.jpg', $this->pathToBaseDir, $imageName);
     }
 }

--- a/src/Adapter/Image/ImagePathFactory.php
+++ b/src/Adapter/Image/ImagePathFactory.php
@@ -49,7 +49,7 @@ class ImagePathFactory
      *
      * @return string
      */
-    public function getPath(int|string $imageName): string
+    public function getPath($imageName): string
     {
         return sprintf('%s/%s.jpg', $this->pathToBaseDir, $imageName);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | When you choose a category as the redirection type when the product is disabled, the category listing also displays an image even if it's not administered, and this generates a 404.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see https://github.com/PrestaShop/PrestaShop/issues/37875
| UI Tests          | https://github.com/paulnoelcholot/testing_pr/actions/runs/13410487942
| Fixed issue or discussion?     | Fixes #37875
| Related PRs       | 
| Sponsor company   | @Codencode 