### PR TITLE
[github action & workflows] change node version and add prestashop 8.2 in matrix for cron-docker-build

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -9,7 +9,7 @@ inputs:
   NODE_VERSION:
     required: false
     description: Node Version to Build Themes
-    default: 16.20.1
+    default: 14.21.3
   ENABLE_SSL:
     required: false
     description: True to Run with SSL

--- a/.github/actions/ui-test/action.yml
+++ b/.github/actions/ui-test/action.yml
@@ -17,7 +17,7 @@ inputs:
   NODE_VERSION:
     required: false
     description: Node Version for tests
-    default: '16'
+    default: '14'
   INSTALL_BROWSERS:
     required: false
     description: True To Install Browsers

--- a/.github/workflows/cron_docker_build.yml
+++ b/.github/workflows/cron_docker_build.yml
@@ -19,6 +19,7 @@ jobs:
           - 7.4
           - 8.0
           - 8.1
+          - 8.2
         base:
           - apache
           - fpm

--- a/.github/workflows/cron_js_routing.yml
+++ b/.github/workflows/cron_js_routing.yml
@@ -22,9 +22,9 @@ jobs:
           - 1.7.8.x
         include:
           - BRANCH: develop
-            node: 16
+            node: 20
           - BRANCH: 8.0.x
-            node: 16
+            node: 14
           - BRANCH: 1.7.8.x
             node: 14
 

--- a/.github/workflows/cron_nightly_build.yml
+++ b/.github/workflows/cron_nightly_build.yml
@@ -24,9 +24,9 @@ jobs:
           - 1.7.8.x
         include:
           - BRANCH: develop
-            node: 16
+            node: 20
           - BRANCH: 8.0.x
-            node: 16
+            node: 14
           - BRANCH: 1.7.8.x
             node: 14
 

--- a/.github/workflows/ui_tests_code_checks.yml
+++ b/.github/workflows/ui_tests_code_checks.yml
@@ -12,8 +12,8 @@ defaults:
     working-directory: ./tests/UI/
 
 env:
-  NODE_VERSION: '16'
-  NPM_VERSION: '7'
+  NODE_VERSION: '14'
+  NPM_VERSION: '6'
 
 concurrency:
   group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
- node `14` for `8.2.x`
- node `20` for `develop`
- cron docker build : add PrestaShop `8.2 `in matrix

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      |see #37880
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | note the success of the PR's tests on the 8.2.x branch
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | Fixes #37880
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
