### PR TITLE
Fix: BO - Product Page - Display all features in feature choice, even if two features have the same name

### DIFF
--- a/src/Adapter/Form/ChoiceProvider/FeaturesChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/FeaturesChoiceProvider.php
@@ -31,6 +31,7 @@ namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
 use PrestaShop\PrestaShop\Adapter\Feature\Repository\FeatureRepository;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 
 class FeaturesChoiceProvider implements FormChoiceProviderInterface
@@ -60,24 +61,18 @@ class FeaturesChoiceProvider implements FormChoiceProviderInterface
 
         $contextLangId = (int) $this->legacyContext->getLanguage()->getId();
 
-        $features = $this->featureRepository->getFeaturesByLang($contextLangId);
-        $this->cacheFeatureChoices = [];
-        $uniqueNames = [];
-        foreach ($features as $feature) {
-            $featureName = $feature['localized_names'][$this->contextLanguageId];
-
-            // each feature name must be unique
-            $uniqueName = $featureName;
-            $occurrence = 1;
-            while (in_array($uniqueName, $uniqueNames)) {
-                $occurrence++;
-                $uniqueName = $featureName . ' (' . $occurrence . ')';
-            }
-            $uniqueNames[] = $uniqueName;
-
-            $this->cacheFeatureChoices[$uniqueName] = $feature['id_feature'];
+        $features = [];
+        foreach ($this->featureRepository->getFeaturesByLang($contextLangId) as $feature) {
+            $features[] = [
+                'id_feature' => $feature['id_feature'],
+                'name' => $feature['localized_names'][$contextLangId],
+            ];
         }
 
-        return $this->cacheFeatureChoices;
+        return $this->cacheFeatureChoices = FormChoiceFormatter::formatFormChoices(
+            $features,
+            'id_feature',
+            'name'
+        );
     }
 }

--- a/src/Adapter/Form/ChoiceProvider/FeaturesChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/FeaturesChoiceProvider.php
@@ -62,8 +62,20 @@ class FeaturesChoiceProvider implements FormChoiceProviderInterface
 
         $features = $this->featureRepository->getFeaturesByLang($contextLangId);
         $this->cacheFeatureChoices = [];
+        $uniqueNames = [];
         foreach ($features as $feature) {
-            $this->cacheFeatureChoices[$feature['localized_names'][$contextLangId]] = $feature['id_feature'];
+            $featureName = $feature['localized_names'][$this->contextLanguageId];
+
+            // each feature name must be unique
+            $uniqueName = $featureName;
+            $occurrence = 1;
+            while (in_array($uniqueName, $uniqueNames)) {
+                $occurrence++;
+                $uniqueName = $featureName . ' (' . $occurrence . ')';
+            }
+            $uniqueNames[] = $uniqueName;
+
+            $this->cacheFeatureChoices[$uniqueName] = $feature['id_feature'];
         }
 
         return $this->cacheFeatureChoices;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When two features have the same name, only one is displayed in product edition page and an error is show when saving. This fix display all features.
| Type?             | bug fix
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create 2 features with the same name, edit a product, only one appears. With the fix two appear
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/PrestaShop/issues/37893
| Sponsor company   | 
