### PR TITLE
Fix: BO > Order details page - When changing pagination, Refunded column displays automatically

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -66,9 +66,9 @@
   </td>
   <td class="cellProductLocation{% if not isColumnLocationDisplayed %} d-none{% endif %}">{{ product.location }}</td>
   <td class="cellProductRefunded{% if not isColumnRefundedDisplayed %} d-none{% endif %}">
-    {% if product.quantityRefunded > 0 %}
+    {%- if product.quantityRefunded > 0 -%}
       {{ product.quantityRefunded }} ({{ product.amountRefunded }} {{ 'Refunded'|trans({}, 'Admin.Orderscustomers.Feature') }})
-    {% endif %}
+    {%- endif -%}
   </td>
   <td class="cellProductAvailableQuantity text-center{% if not isAvailableQuantityDisplayed %} d-none{% endif %}">{{ product.availableQuantity }}</td>
   <td class="cellProductTotalPrice">{{ product.totalPrice }}</td>


### PR DESCRIPTION
Removed the white spaces because OrderProductRenderer::toggleColumn() toggles the field based on whether the node is populated or not.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | When I change the pagination of my product list in the order details page, the column Refunded is automatically displayed, when it should not.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see https://github.com/PrestaShop/PrestaShop/issues/37885
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #37885
| Related PRs       | 
| Sponsor company   | @Codencode 
