### PR TITLE
Fix preview mode for combination products

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -544,7 +544,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 false,
                 false,
                 true,
-                $this->isPreview() ? ['preview' => '1'] : []
+                $this->isPreview() ? [
+                    'preview' => '1',
+                    'id_employee' => Tools::getValue('id_employee'),
+                    'adtoken' => Tools::getValue('adtoken'),
+                ] : []
             ),
             'product_minimal_quantity' => $minimalProductQuantity,
             'product_has_combinations' => !empty($this->combinations),

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -135,7 +135,9 @@ function updateProduct(event, eventType, updateUrl) {
   }
 
   if (preview !== null) {
-    preview = `&preview=${preview}`;
+    const adtoken = psGetRequestParameter('adtoken');
+    const idEmployee = psGetRequestParameter('id_employee');
+    preview = `&preview=${preview}&adtoken=${adtoken}&id_employee=${idEmployee}`;
   } else {
     preview = '';
   }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Add `adtoken` and `id_employee` to url on switching combination in previewed product.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #37652
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/13048397639
| Fixed issue or discussion?     | Fixes #37652
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
