### PR TITLE
Update panel-complex.html DOM text reinterpreted as HTML

### DIFF
--- a/admin-dev/themes/default/example/components/panels-complex.html
+++ b/admin-dev/themes/default/example/components/panels-complex.html
@@ -15,7 +15,7 @@
      <i class="process-icon-refresh"></i>
      </span>
      </a>
-     <a class="list-toolbar-btn" href="javascript:void(0);" onclick="$('.leadin').first().append('<div class=\'alert alert-info\'>' + $('#sql_query_tax_rules_group').val() + '</div>'); $(this).attr('onclick', '');">
+     <a class="list-toolbar-btn" href="javascript:void(0);" onclick="$('.leadin').first().append($('<div class=\'alert alert-info\'></div>').text($('#sql_query_tax_rules_group').val())); $(this).attr('onclick', '');">
      <span class="label-tooltip" data-toggle="tooltip" data-original-title="Voir la requête SQL" data-html="true" data-placement="top">
      <i class="process-icon-terminal"></i>
      </span>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | DOM text reinterpreted as HTML is reinterpreted as HTML without escaping meta-characters. Extracting text from a DOM node and interpreting it as HTML can lead to a cross-site scripting vulnerability.
| Type?             |  improvement 
| Category?         |  CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI
| UI Tests          | 
| Related PRs       | 
| Sponsor company   | 