### PR TITLE
Fix performance issue linked to HookModuleFilter PR

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Hook\HookModuleFilter;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 class HookCore extends ObjectModel
 {
@@ -1118,8 +1119,9 @@ class HookCore extends ObjectModel
     }
 
     /**
-     * @return HookModuleFilter|null
+     * @return HookModuleFilter
      * @throws \PrestaShop\PrestaShop\Core\Exception\ContainerNotFoundException
+     * @throws ServiceNotFoundException
      */
     private static function getHookModuleFilter()
     {

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1129,13 +1129,7 @@ class HookCore extends ObjectModel
             $serviceContainer = ContainerBuilder::getContainer('front', _PS_MODE_DEV_);
         }
 
-        try {
-            $hookModuleFilter = $serviceContainer->get(HookModuleFilter::class);
-        } catch (Exception $e) {
-            return null;
-        }
-
-        return $hookModuleFilter;
+        return $serviceContainer->get(HookModuleFilter::class);
     }
 
     /**

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -765,10 +765,7 @@ class HookCore extends ObjectModel
         }
 
         $hookModuleFilter = self::getHookModuleFilter();
-
-        if (!empty($hookModuleFilter) && !empty($modulesToInvoke)) {
-            $modulesToInvoke = $hookModuleFilter->filterHookModuleExecList($modulesToInvoke, $hookName);
-        }
+        $modulesToInvoke = $hookModuleFilter->filterHookModuleExecList($modulesToInvoke, $hookName);
 
         return !empty($modulesToInvoke) ? $modulesToInvoke : false;
     }

--- a/src/PrestaShopBundle/Resources/config/services/core/common.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/common.yml
@@ -3,5 +3,6 @@ imports:
 
 services:
   PrestaShop\PrestaShop\Core\Hook\HookModuleFilter:
+    public: true
     arguments:
       - !tagged core.hook_module_exec_filter


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | The `HookModuleFilter` service was private, which would trigger an exception when the BO tried to reach it. (thank you @Codencode for catching this !)
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | - [Download test module](https://github.com/user-attachments/files/17958166/demodoctrine.zip)<br> - Unzip in the modules folder, install via the module manager page in back office<br>- In FO, check that the module ps_linklist doesn't display its links in the footer.<br>- (don't mind the name of the module, I took an existing example module as a basis)
| UI Tests          | https://github.com/matthieu-rolland/ga.tests.ui.pr/actions/runs/13012266734
| Fixed issue or discussion?     | Fixes #37913
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/37125
| Sponsor company   | PrestaShop