### PR TITLE
Fix datacollector caster for reference object property including smarty cache_locking fatal error

### DIFF
--- a/src/PrestaShopBundle/DataCollector/HookDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/HookDataCollector.php
@@ -29,6 +29,9 @@ namespace PrestaShopBundle\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\VarDumper\Caster\CutStub;
+use Symfony\Component\VarDumper\Caster\ReflectionCaster;
+use Symfony\Component\VarDumper\Cloner\Stub;
 
 /**
  * Collect all information about Legacy hooks and make it available
@@ -154,5 +157,39 @@ final class HookDataCollector extends DataCollector
         }
 
         return $hooksList;
+    }
+
+    /**
+     * @return callable[] The casters to add to the cloner
+     */
+    protected function getCasters()
+    {
+        $casters = [
+            '*' => function ($v, array $a, Stub $s, $isNested) {
+                if (!$v instanceof Stub) {
+                    $b = $a;
+                    foreach ($a as $k => $v) {
+                        if (!\is_object($v) || $v instanceof \DateTimeInterface || $v instanceof Stub) {
+                            continue;
+                        }
+
+                        try {
+                            $a[$k] = $s = new CutStub($v);
+
+                            if ($b[$k] === $s) {
+                                // we've hit a non-typed reference
+                                $a[$k] = $v;
+                            }
+                        } catch (\TypeError $e) {
+                            // we've hit a typed reference
+                        }
+                    }
+                }
+
+                return $a;
+            },
+        ] + ReflectionCaster::UNSET_CLOSURE_FILE_INFO;
+
+        return $casters;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      |  Fix datacollector caster for reference object property including smarty cache_locking fatal error. it's a back port of https://github.com/symfony/symfony/pull/54072 merged in SF 5, 6 and 7
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See issue
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/14664552774
| Fixed issue or discussion?     |  Fixes #37927, Fixes #35155
| Related PRs       | https://github.com/symfony/symfony/pull/54072
| Sponsor company   | creabilis.com
