### PR TITLE
Fix auto-removing from cart inactive and/or out of quantities and/or expired cart rules

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -47,6 +47,7 @@ class CartRuleCore extends ObjectModel
      * @var array
      */
     protected static $only_one_gift = [];
+    public static $skipInitialCartRuleValidityChecks = false;
 
     public $id;
     public $name;
@@ -754,7 +755,7 @@ class CartRuleCore extends ObjectModel
         //  - the cart rule can now be disabled but it was at the time it was applied, so it doesn't need to be removed
         //  - the current date is not in the range any more but it was at the time
         //  - the quantity is now zero but it was not when it was added
-        if (!$alreadyInCart) {
+        if (!self::$skipInitialCartRuleValidityChecks) {
             if (!$this->active) {
                 return (!$display_error) ? false : $this->trans('This voucher is disabled', [], 'Shop.Notifications.Error');
             }

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -314,6 +314,8 @@ abstract class PaymentModuleCore extends Module
         }
         // Make sure CartRule caches are empty
         CartRule::cleanCache();
+        // Skip initial cart rule validity checks so that inactive
+        CartRule::$skipInitialCartRuleValidityChecks = true;
         $cart_rules = $this->context->cart->getCartRules();
         foreach ($cart_rules as $cart_rule) {
             $rule = new CartRule((int) $cart_rule['obj']->id);

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -314,7 +314,6 @@ abstract class PaymentModuleCore extends Module
         }
         // Make sure CartRule caches are empty
         CartRule::cleanCache();
-        // Skip initial cart rule validity checks so that inactive
         CartRule::$skipInitialCartRuleValidityChecks = true;
         $cart_rules = $this->context->cart->getCartRules();
         foreach ($cart_rules as $cart_rule) {

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -133,6 +133,7 @@ class OrderAmountUpdater
         ;
 
         try {
+            CartRule::$skipInitialCartRuleValidityChecks = true;
             // @todo: use https://github.com/PrestaShop/decimal for price computations
             $computingPrecision = $this->getPrecisionFromCart($cart);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Customers were able to complete the checkout process with inactive / out of quantity / expired cart rules applied to the cart when they were valid. This PR fixes this unwanted behaviour.
| Type?             | bug fix / improvement
| Category?         | FO / CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Apply any voucher to the cart in frontoffice, either deactivate / put quantities at 0 / make it expired, see that in frontoffice the cart rule is removed automatically by reloading the page.
| UI Tests          |
| Fixed issue or discussion?     | Fixes #26235
| Related PRs       |
| Sponsor company   | [www.hostinato.it](http://www.hostinato.it/)
