### PR TITLE
Generate category thumbnail for demo data on install

### DIFF
--- a/src/PrestaShopBundle/Install/XmlLoader.php
+++ b/src/PrestaShopBundle/Install/XmlLoader.php
@@ -789,6 +789,22 @@ class XmlLoader
                     );
                 }
             }
+
+            // Special cas for categories that now have two different images for cover and thumbnail,
+            // we use the source to generate a thumbnail by default
+            if ($entity === 'category') {
+                $sourceCategoryImage = $from_path . $identifier . '.' . $extension;
+                if (file_exists($sourceCategoryImage)) {
+                    $categoryThumbnailPath = _PS_IMG_DIR_ . $p . DIRECTORY_SEPARATOR . $entity_id . '_thumb.jpg';
+                    // Same way to generate as in CategoryThumbnailImageUploader
+                    ImageManager::resize(
+                        $sourceCategoryImage,
+                        $categoryThumbnailPath,
+                        null,
+                        null
+                    );
+                }
+            }
         }
         Image::moveToNewFileSystem();
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Handle special case during fixtures installation, the category thumbnail must be created manually based on the original source
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Fresh install your shop, the thumbnail in the category pages should now be visible on demo categories
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #37939
| Related PRs       | 
| Sponsor company   | 
