### PR TITLE
Fix: MaterialChoiceTableType does not render help text

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -831,6 +831,7 @@
       </table>
     </div>
   {% endapply %}
+  {{ block('form_help') }}
 {% endblock material_choice_table_widget %}
 
 {% block material_multiple_choice_table_widget %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | The help text for the `MaterialChoiceTableType` input is not being rendered.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see: https://github.com/PrestaShop/PrestaShop/issues/37940
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #37940
| Related PRs       |
| Sponsor company   | @Codencode 
