### PR TITLE
Fix: prestashop don't display Title of product, category meta title, meta description

### DIFF
--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -297,8 +297,7 @@ class MetaCore extends ObjectModel
      */
     public static function getMetaTags($idLang, $pageName, $title = '')
     {
-        if (Configuration::get('PS_SHOP_ENABLE')
-            || IpUtils::checkIp(Tools::getRemoteAddr(), explode(',', Configuration::get('PS_MAINTENANCE_IP')))) {
+        if (Configuration::get('PS_SHOP_ENABLE') || Tools::isAllowedToBypassMaintenance()) {
             if ($pageName == 'product' && ($idProduct = Tools::getValue('id_product'))) {
                 return Meta::getProductMetas($idProduct, $idLang, $pageName);
             } elseif ($pageName == 'category' && ($idCategory = Tools::getValue('id_category'))) {

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -40,6 +40,7 @@ use PrestaShop\PrestaShop\Core\Security\PasswordGenerator;
 use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator;
 use PrestaShop\PrestaShop\Core\Util\String\StringModifier;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\IpUtils;
 use Symfony\Component\HttpFoundation\Request;
 
 class ToolsCore
@@ -4238,6 +4239,25 @@ exit;
         }
 
         return $array;
+    }
+
+    /**
+     * Checks if the current visitor is allowed to view the page even if maintenace mode is on, either via IP whitelist or being logged in in backoffice.
+     */
+    public static function isAllowedToBypassMaintenance()
+    {
+        $is_admin = (int) (new Cookie('psAdmin'))->id_employee;
+        $maintenance_allow_admins = (bool) Configuration::get('PS_MAINTENANCE_ALLOW_ADMINS');
+        if ($is_admin && $maintenance_allow_admins) {
+            return true;
+        }
+
+        $allowed_ips = array_map('trim', explode(',', Configuration::get('PS_MAINTENANCE_IP')));
+        if (IpUtils::checkIp(Tools::getRemoteAddr(), $allowed_ips)) {
+            return true;
+        }
+
+        return false;
     }
 }
 

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -807,9 +807,7 @@ class FrontControllerCore extends Controller
         if ($this->maintenance == true || !(int) Configuration::get('PS_SHOP_ENABLE')) {
             $this->maintenance = true;
 
-            $is_admin = (int) (new Cookie('psAdmin'))->id_employee;
-            $maintenance_allow_admins = (bool) Configuration::get('PS_MAINTENANCE_ALLOW_ADMINS');
-            if ($is_admin && $maintenance_allow_admins) {
+            if (Tools::isAllowedToBypassMaintenance()) {
                 return;
             }
 


### PR DESCRIPTION
Added a check to allow administrators to view the correct meta tags even when the shop is in maintenance mode. Now, if the PS_MAINTENANCE_ALLOW_ADMINS option is enabled and the user is a logged-in administrator, the getMetaTags function will return the appropriate metadata for the requested pages.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | When new shop is under maintanace mode admin can see FO, but all product, category won't show Title, Meta title, meta description. When you put yourself on list of IP for maintanace it all came back and display correctly. This is nasty thig that I spent 3 hours to fount out on forum that somebody already pos it. But i didn't find this report on Github..
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see https://github.com/PrestaShop/PrestaShop/issues/37954
| UI Tests          | https://github.com/paulnoelcholot/testing_pr/actions/runs/13410555293
| Fixed issue or discussion?     | Fixes #37954
| Related PRs       | 
| Sponsor company   | @Codencode 
