### PR TITLE
Fix product filters for csv export

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -729,6 +729,7 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function exportAction(ProductFilters $filters)
     {
+        $filters = new ProductFilters($filters->getShopConstraint(), ['limit' => null] + $filters->all());
         $productGridFactory = $this->get('prestashop.core.grid.factory.product');
         $grid = $productGridFactory->getGrid($filters);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | We had some problems in product csv export because of filters.<br>So, we need here to keep initial grid filters (to search by name for instance...) but remove limit!<br>(It's seems that we have this same fixed behaviour in category, but maybe it could be nice to recheck this export everywhere else!)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #37847 
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/13109914288
| Fixed issue or discussion?     | Fixes #37847
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
