### PR TITLE
Fix: [Bug] Missing attributes autoplay, loop, muted, and playsinline in the video tag within Tools::purifyHTML()

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3959,6 +3959,10 @@ exit;
                         'poster' => 'URI',
                         'preload' => 'Enum#auto,metadata,none',
                         'controls' => 'Bool',
+                        'autoplay' => 'Bool',
+                        'loop' => 'Bool',
+                        'muted' => 'Bool',
+                        'playsinline' => 'Bool',
                     ]);
                     $def->addElement('source', 'Block', 'Flow', 'Common', [
                         'src' => 'URI',


### PR DESCRIPTION
Added the following attributes to the <video> tag in Tools::purifyHTML():
- autoplay
- loop
- muted
- playsinline

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | see: https://github.com/PrestaShop/PrestaShop/issues/37967
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | [Indicate how to verify that this change works as expected.](see: https://github.com/PrestaShop/PrestaShop/issues/37967)
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/13264487041 ✅ 
| Fixed issue or discussion?     | Fixes #37967
| Related PRs       | 
| Sponsor company   | @Codencode 
