### PR TITLE
Empty the labels "totalPriceText" and "availableText".

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-add.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-add.ts
@@ -322,11 +322,15 @@ export default class OrderProductAdd {
           orderProductId: params.product_id,
           newRow: response,
         });
+        this.totalPriceText.html('');
+        this.availableText.html('');
       },
       (response) => {
         this.productAddActionBtn.prop('disabled', false);
         this.invoiceSelect.prop('disabled', false);
         this.combinationsSelect.prop('disabled', false);
+        this.totalPriceText.html('');
+        this.availableText.html('');
 
         if (response.responseJSON && response.responseJSON.message) {
           $.growl.error({message: response.responseJSON.message});


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | When I add 2 different products to an existing cart, the second time product will have a price displayed, even though I haven't chosen my product yet.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see: https://github.com/PrestaShop/PrestaShop/issues/37981
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/13245314009 ✅ 
| Fixed issue or discussion?     | Fixes #37981
| Related PRs       | I
| Sponsor company   | @Codencode 
