### PR TITLE
Rename `emailField` to `field` for aligning the variable name with its actual purpose

### DIFF
--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -206,9 +206,9 @@ class CustomerFormCore extends AbstractForm
      */
     protected function validateFieldLength($fieldName, $maximumLength, $violationMessage)
     {
-        $emailField = $this->getField($fieldName);
-        if (strlen($emailField->getValue()) > $maximumLength) {
-            $emailField->addError($violationMessage);
+        $field = $this->getField($fieldName);
+        if (strlen($field->getValue()) > $maximumLength) {
+            $field->addError($violationMessage);
         }
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This tiny refactor improves code readability and consistency by aligning the variable name with its actual purpose.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No test output afected.
| UI Tests          | No test output afected.
| Related PRs       | No related PR
| Sponsor company   | Your company or customer's name goes here (if applicable).
