### PR TITLE
fix(translation): getTranslator function better BO detection

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -391,10 +391,8 @@ class ContextCore
             return $this->translator;
         }
 
-        $sfContainer = SymfonyContainer::getInstance();
-
-        if ($isInstaller || null === $sfContainer) {
-            // symfony's container isn't available in front office, so we load and configure the translator component
+        if ($isInstaller || !defined('_PS_ADMIN_DIR_')) {
+            // we load and configure the translator component otherwise some theme translations would not work
             $this->translator = $this->getTranslatorFromLocale($this->language->locale);
         } else {
             $this->translator = $sfContainer->get(TranslatorInterface::class);

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -395,7 +395,7 @@ class ContextCore
             // we load and configure the translator component otherwise some theme translations would not work
             $this->translator = $this->getTranslatorFromLocale($this->language->locale);
         } else {
-            $this->translator = $sfContainer->get(TranslatorInterface::class);
+            $this->translator = SymfonyContainer::getInstance()->get(TranslatorInterface::class);
             // We need to set the locale here because in legacy BO pages, the translator is used
             // before the TranslatorListener does its job of setting the locale according to the Request object
             $this->translator->setLocale($this->language->locale);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Since the symfony container can now be loaded into the FO, it brings a bug with translation. The translation service used by the symfony container is different and some FO translations cannot work. The detection by the legacy Context class of BO/FO can be improved as it currently tests if symfony container is instanciated or not to choose if BO or FO. But as it can now be instantiated on both, the check has to be updated.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Activate the Symfony container on FO, edit some translations on BO, and verify if the translations are working on FO.
| UI Tests          | NA
| Fixed issue or discussion?     | #38041 38041
| Related PRs       | NA
| Sponsor company   | Evolutive
