### PR TITLE
Added field "Module name" to admin carrier list

### DIFF
--- a/src/Core/Grid/Definition/Factory/CarrierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CarrierGridDefinitionFactory.php
@@ -149,6 +149,13 @@ class CarrierGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ])
             )
             ->add(
+                (new DataColumn('external_module_name'))
+                    ->setName($this->trans('Module name', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'external_module_name',
+                    ])
+            )
+            ->add(
                 (new ActionColumn('actions'))
                     ->setName($this->trans('Actions', [], 'Admin.Global'))
                     ->setOptions([
@@ -207,6 +214,13 @@ class CarrierGridDefinitionFactory extends AbstractGridDefinitionFactory
             ->add(
                 (new Filter('position', ReorderPositionsButtonType::class))
                     ->setAssociatedColumn('position')
+            )
+            ->add(
+                (new Filter('external_module_name', TextType::class))
+                    ->setAssociatedColumn('external_module_name')
+                    ->setTypeOptions([
+                        'required' => false,
+                    ])
             )
             ->add(
                 (new Filter('actions', SearchAndResetType::class))

--- a/src/Core/Grid/Definition/Factory/CarrierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CarrierGridDefinitionFactory.php
@@ -88,11 +88,7 @@ class CarrierGridDefinitionFactory extends AbstractGridDefinitionFactory
         $this->connection = $connection;
         $this->dbPrefix = $dbPrefix;
 
-        $sql = 'SELECT count(external_module_name)
-                FROM ' . $this->dbPrefix . 'carrier
-                WHERE deleted = 0 AND external_module_name != ""';
-
-        $this->showExternalModuleColumn = (int) $this->connection->fetchOne($sql) > 0;
+        $this->showExternalModuleColumn = $this->hasActiveExternalModuleCarriers();
     }
 
     /**
@@ -354,5 +350,14 @@ class CarrierGridDefinitionFactory extends AbstractGridDefinitionFactory
             ->add(
                 $this->buildBulkDeleteAction('admin_carriers_bulk_delete')
             );
+    }
+
+    protected function hasActiveExternalModuleCarriers()
+    {
+        $sql = 'SELECT count(external_module_name)
+                FROM ' . $this->dbPrefix . 'carrier
+                WHERE deleted = 0 AND external_module_name != ""';
+
+        return (int) $this->connection->fetchOne($sql) > 0;
     }
 }

--- a/src/Core/Grid/Definition/Factory/CarrierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CarrierGridDefinitionFactory.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
+use Doctrine\DBAL\Connection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
@@ -44,6 +45,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\PositionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ToggleColumn;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Form\Admin\Type\ReorderPositionsButtonType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
@@ -58,6 +60,40 @@ class CarrierGridDefinitionFactory extends AbstractGridDefinitionFactory
     use BulkDeleteActionTrait;
 
     public const GRID_ID = 'carrier';
+
+    /**
+     * @var string
+     */
+    protected $dbPrefix;
+
+    /**
+     * @var Connection
+     */
+    protected $connection;
+
+    /**
+     * @var bool
+     */
+    protected $showExternalModuleColumn;
+
+    /**
+     * @param HookDispatcherInterface $hookDispatcher
+     */
+    public function __construct(
+        HookDispatcherInterface $hookDispatcher,
+        $dbPrefix,
+        Connection $connection
+    ) {
+        parent::__construct($hookDispatcher);
+        $this->connection = $connection;
+        $this->dbPrefix = $dbPrefix;
+
+        $sql = 'SELECT count(external_module_name)
+                FROM ' . $this->dbPrefix . 'carrier
+                WHERE deleted = 0 AND external_module_name != ""';
+
+        $this->showExternalModuleColumn = (int) $this->connection->fetchOne($sql) > 0;
+    }
 
     /**
      * {@inheritdoc}
@@ -80,7 +116,9 @@ class CarrierGridDefinitionFactory extends AbstractGridDefinitionFactory
      */
     protected function getColumns()
     {
-        return (new ColumnCollection())
+        $columns = new ColumnCollection();
+
+        $columns
             ->add(
                 (new BulkActionColumn('bulk'))
                     ->setOptions([
@@ -147,14 +185,20 @@ class CarrierGridDefinitionFactory extends AbstractGridDefinitionFactory
                         'update_method' => 'POST',
                         'update_route' => 'admin_carriers_update_position',
                     ])
-            )
-            ->add(
-                (new DataColumn('external_module_name'))
-                    ->setName($this->trans('Module name', [], 'Admin.Global'))
-                    ->setOptions([
-                        'field' => 'external_module_name',
-                    ])
-            )
+            );
+
+        if ($this->showExternalModuleColumn) {
+            $columns
+                ->add(
+                    (new DataColumn('external_module_name'))
+                        ->setName($this->trans('Module name', [], 'Admin.Global'))
+                        ->setOptions([
+                            'field' => 'external_module_name',
+                        ])
+                );
+        }
+
+        $columns
             ->add(
                 (new ActionColumn('actions'))
                     ->setName($this->trans('Actions', [], 'Admin.Global'))
@@ -162,6 +206,8 @@ class CarrierGridDefinitionFactory extends AbstractGridDefinitionFactory
                         'actions' => $this->getRowActions(),
                     ])
             );
+
+        return $columns;
     }
 
     /**
@@ -169,7 +215,9 @@ class CarrierGridDefinitionFactory extends AbstractGridDefinitionFactory
      */
     protected function getFilters()
     {
-        return (new FilterCollection())
+        $filters = new FilterCollection();
+
+        $filters
             ->add(
                 (new Filter('id_carrier', TextType::class))
                     ->setAssociatedColumn('id_carrier')
@@ -214,14 +262,20 @@ class CarrierGridDefinitionFactory extends AbstractGridDefinitionFactory
             ->add(
                 (new Filter('position', ReorderPositionsButtonType::class))
                     ->setAssociatedColumn('position')
-            )
-            ->add(
-                (new Filter('external_module_name', TextType::class))
-                    ->setAssociatedColumn('external_module_name')
-                    ->setTypeOptions([
-                        'required' => false,
-                    ])
-            )
+            );
+
+        if ($this->showExternalModuleColumn) {
+            $filters
+                ->add(
+                    (new Filter('external_module_name', TextType::class))
+                        ->setAssociatedColumn('external_module_name')
+                        ->setTypeOptions([
+                            'required' => false,
+                        ])
+                );
+        }
+
+        $filters
             ->add(
                 (new Filter('actions', SearchAndResetType::class))
                     ->setAssociatedColumn('actions')
@@ -233,6 +287,8 @@ class CarrierGridDefinitionFactory extends AbstractGridDefinitionFactory
                         'redirect_route' => 'admin_carriers_index',
                     ])
             );
+
+        return $filters;
     }
 
     protected function getGridActions()

--- a/src/Core/Grid/Query/CarrierQueryBuilder.php
+++ b/src/Core/Grid/Query/CarrierQueryBuilder.php
@@ -44,6 +44,7 @@ final class CarrierQueryBuilder extends AbstractDoctrineQueryBuilder
         'active',
         'is_free',
         'position',
+        'external_module_name',
     ];
 
     /**
@@ -88,7 +89,7 @@ final class CarrierQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getCarrierQueryBuilder($searchCriteria)
-            ->select('c.id_carrier, c.name, cl.delay, c.active, c.is_free, c.position')
+            ->select('c.id_carrier, c.name, cl.delay, c.active, c.is_free, c.position, c.external_module_name')
             ->groupBy('c.id_carrier');
 
         $this->searchCriteriaApplicator
@@ -159,6 +160,13 @@ final class CarrierQueryBuilder extends AbstractDoctrineQueryBuilder
 
                 $qb->andWhere('c.position = :position');
                 $qb->setParameter($filterName, $filterValue);
+
+                continue;
+            }
+
+            if ($filterName === 'external_module_name') {
+                $qb->andWhere('c.external_module_name LIKE :external_module_name');
+                $qb->setParameter($filterName, '%' . $filterValue . '%');
 
                 continue;
             }

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -356,6 +356,9 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CarrierGridDefinitionFactory'
     parent: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory
     public: true
+    arguments:
+      - '%database_prefix%'
+      - '@doctrine.dbal.default_connection'
 
   prestashop.core.grid.definition.factory.zone:
     class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ZoneGridDefinitionFactory'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | In the list of carriers in the admin panel, the "Module name" field is not present. By adding this field, it becomes possible to identify which carriers are managed by a module.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a module that manages a carrier for shipping cost calculation and verify that, in the list of carriers in the admin panel, the module name appears next to the corresponding carrier. I created a module to test the changes: https://github.com/user-attachments/files/20965011/pr_38042.zip
| UI Tests          | 
| Fixed issue or discussion?     |
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/38009
| Sponsor company   | @Codencode 
