### PR TITLE
Fix: Unable to configure a module that utilizes a modern controller

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -205,6 +205,13 @@ class ToolsCore
         $link = Context::getContext()->link;
         if (!preg_match('@^https?://@i', $url) && $link) {
             $baseUrl = rtrim($link->getAdminBaseLink(), '/');
+
+            // Removes physical_uri from baseUrl to avoid duplicate admin path
+            $physicalUri = Context::getContext()->shop->physical_uri;
+            if (str_starts_with($url, $physicalUri)) {
+                $url = substr($url, strlen($physicalUri));
+            }
+
             if (!str_contains($url, basename(_PS_ADMIN_DIR_))) {
                 $baseUrl .= '/' . basename(_PS_ADMIN_DIR_);
             }

--- a/tests/Integration/Classes/ToolsTest.php
+++ b/tests/Integration/Classes/ToolsTest.php
@@ -45,11 +45,14 @@ class ToolsTest extends TestCase
      *
      * @param string $url
      * @param string $expected
+     * @param string $physicalUri
      *
      * @return void
      */
-    public function testSanitizeAdminUrl(string $url, string $expected): void
+    public function testSanitizeAdminUrl(string $url, string $expected, string $physicalUri = ''): void
     {
+        // Override the mocked shop in context
+        static::getContext()->shop->physical_uri = $physicalUri;
         $this->assertEquals($expected, Tools::sanitizeAdminUrl($url));
     }
 
@@ -93,6 +96,62 @@ class ToolsTest extends TestCase
         yield 'external url' => [
             'http://www.prestahop-project.org',
             'http://www.prestahop-project.org',
+        ];
+
+        // Now test use cases where the shop is installed in a sub folder so physical URI is not empty
+        yield 'shop with physical uri, url does not contain it' => [
+            '/admin-dev/modules/blockwishlist/configuration',
+            'http://localhost/shop_sub_folder/admin-dev/modules/blockwishlist/configuration',
+            '/shop_sub_folder',
+        ];
+
+        yield 'shop with physical uri, url does not contain it nor the admin folder' => [
+            '/modules/blockwishlist/configuration',
+            'http://localhost/shop_sub_folder/admin-dev/modules/blockwishlist/configuration',
+            '/shop_sub_folder',
+        ];
+
+        yield 'shop with physical uri, url already contains it at the beginning' => [
+            '/shop_sub_folder/admin-dev/modules/blockwishlist/configuration',
+            'http://localhost/shop_sub_folder/admin-dev/modules/blockwishlist/configuration',
+            // Works with trailing / also
+            '/shop_sub_folder/',
+        ];
+
+        yield 'shop with physical uri, url already contains it but in the middle' => [
+            '/admin-dev/modules/blockwishlist/shop_sub_folder/configuration',
+            'http://localhost/shop_sub_folder/admin-dev/modules/blockwishlist/shop_sub_folder/configuration',
+            '/shop_sub_folder',
+        ];
+
+        yield 'shop with physical uri, absolute url' => [
+            'http://localhost/shop_sub_folder/admin-dev/modules/blockwishlist/shop_sub_folder/configuration',
+            'http://localhost/shop_sub_folder/admin-dev/modules/blockwishlist/shop_sub_folder/configuration',
+            '/shop_sub_folder',
+        ];
+
+        yield 'shop with physical uri, url starting with index.php' => [
+            'index.php?controller=AdminModules',
+            'http://localhost/shop_sub_folder/admin-dev/index.php?controller=AdminModules',
+            '/shop_sub_folder',
+        ];
+
+        yield 'shop with physical uri, url starting with /admin-dev/index.php' => [
+            '/admin-dev/index.php?controller=AdminModules',
+            'http://localhost/shop_sub_folder/admin-dev/index.php?controller=AdminModules',
+            '/shop_sub_folder',
+        ];
+
+        yield 'shop with physical uri, url starting with /shop_sub_folder/admin-dev/index.php' => [
+            '/shop_sub_folder/admin-dev/index.php?controller=AdminModules',
+            'http://localhost/shop_sub_folder/admin-dev/index.php?controller=AdminModules',
+            '/shop_sub_folder',
+        ];
+
+        yield 'shop with physical uri, external url' => [
+            'http://www.prestahop-project.org',
+            'http://www.prestahop-project.org',
+            '/shop_sub_folder',
         ];
     }
 }


### PR DESCRIPTION
In case of installation in a subfolder, "physical_uri" is added twice.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | When PrestaShop is installed in a subfolder, the "physical_uri" field is added twice in the configuration URL of a module that uses the modern configuration page.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see https://github.com/PrestaShop/PrestaShop/issues/38045
| UI Tests          |  https://github.com/paulnoelcholot/testing_pr/actions/runs/15156649630
| Fixed issue or discussion?     | Fixes #38045
| Related PRs       | 
| Sponsor company   | @Codencode 
