### PR TITLE
Fix: Employee::isLoggedBack() returns null is Legacy Controller

### DIFF
--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -27,6 +27,7 @@ use PrestaShop\PrestaShop\Adapter\CoreException;
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Crypto\Hashing;
+use PrestaShopBundle\Security\Admin\SessionEmployeeProvider;
 
 /**
  * Class EmployeeCore.
@@ -464,7 +465,16 @@ class EmployeeCore extends ObjectModel
         }
         $userProvider = $container->get('prestashop.user_provider');
 
-        return $userProvider->getUser() !== null;
+        if ($userProvider->getUser() !== null) {
+            return true;
+        } else {
+            $sessionEmployeeProvider = ServiceLocator::get(SessionEmployeeProvider::class);
+            $employee = $sessionEmployeeProvider->getEmployeeFromSession(
+                $container->get('request_stack')->getCurrentRequest()
+            );
+
+            return $employee !== null;
+        }
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | `Employee::isLoggedBack()` returns `false` when called in a Legacy admin controller.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `Execute Context::getContext()->employee->isLoggedBack()` in a legacy controller in the admin and verify that it returns `true`.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #38047
| Related PRs       |
| Sponsor company   | @Codencode 
