### PR TITLE
Deprecate price compare global-scope functions

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1548,9 +1548,9 @@ class ToolsCore
         unset($row);
 
         if (Tools::strtolower($order_way) == 'desc') {
-            uasort($array, 'cmpPriceDesc');
+            uasort($array, fn ($a, $b) => $b['price_tmp'] <=> $a['price_tmp']);
         } else {
-            uasort($array, 'cmpPriceAsc');
+            uasort($array, fn ($a, $b) => $a['price_tmp'] <=> $b['price_tmp']);
         }
         foreach ($array as &$row) {
             unset($row['price_tmp']);
@@ -3997,9 +3997,16 @@ exit;
  * @param array{"price_tmp": float} $b
  *
  * @return int
+ *
+ * @deprecated Since 9.0 and will be removed in 10.0
  */
 function cmpPriceAsc($a, $b)
 {
+    @trigger_error(sprintf(
+        '%s is deprecated since 9.0 and will be removed in 10.0.',
+        __FUNCTION__
+    ), E_USER_DEPRECATED);
+
     return $a['price_tmp'] <=> $b['price_tmp'];
 }
 
@@ -4008,8 +4015,15 @@ function cmpPriceAsc($a, $b)
  * @param array{"price_tmp": float} $b
  *
  * @return int
+ *
+ * @deprecated Since 9.0 and will be removed in 10.0
  */
 function cmpPriceDesc($a, $b)
 {
+    @trigger_error(sprintf(
+        '%s is deprecated since 9.0 and will be removed in 10.0.',
+        __FUNCTION__
+    ), E_USER_DEPRECATED);
+
     return $b['price_tmp'] <=> $a['price_tmp'];
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Deprecates the `cmpPriceAsc` and `cmpPriceDesc` functions declared in classes/Tools.php.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | Run tests / Changes are equivalent/self-explanatory. Does not require changes to test files since the two functions are just deprecated and not removed.
| UI Tests          | N/A
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | WAM

In the classes/Tools.php file, two functions used as callbacks for sort functions, `cmpPriceAsc` and `cmpPriceDesc`, are declared in the global namespace.

Turns out that these functions are only called once in the core. This pull request replaces these named functions by equivalent closures.

This pull request should not require any changes to test files since it does not remove those functions, but merely deprecates them.