### PR TITLE
feat: Improve Docker run script use case handling for Maildev configuration

### DIFF
--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -152,9 +152,13 @@ fi
 
 if [ $PS_USE_DOCKER_MAILDEV -eq 1 ]; then
     echo "\n* Configuring emails to use maildev ..."
-    runuser -g www-data -u www-data -- php /var/www/html/bin/console prestashop:config set PS_MAIL_METHOD --value "2"
-    runuser -g www-data -u www-data -- php /var/www/html/bin/console prestashop:config set PS_MAIL_SERVER --value "maildev"
-    runuser -g www-data -u www-data -- php /var/www/html/bin/console prestashop:config set PS_MAIL_SMTP_PORT --value "1025"
+    if [ $PS_INSTALL_AUTO -ne 1 ]; then
+        echo 'warning: PrestaShop is not yet installed. Skipping mail configuration.'
+    else
+        runuser -g www-data -u www-data -- php /var/www/html/bin/console prestashop:config set PS_MAIL_METHOD --value "2"
+        runuser -g www-data -u www-data -- php /var/www/html/bin/console prestashop:config set PS_MAIL_SERVER --value "maildev"
+        runuser -g www-data -u www-data -- php /var/www/html/bin/console prestashop:config set PS_MAIL_SMTP_PORT --value "1025"
+    fi
 fi
 
 if [ $BLACKFIRE_ENABLE -eq 1 ]; then

--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -93,7 +93,7 @@ elif [ "$DB_SERVER" != "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
         echo "\n* DB server $DB_SERVER is available, let's continue !"
 fi
 
-# From now, stop at error
+# From now on, stop at error
 set -e
 
 if [ $PS_DEV_MODE -ne 1 ]; then
@@ -152,12 +152,12 @@ fi
 
 if [ $PS_USE_DOCKER_MAILDEV -eq 1 ]; then
     echo "\n* Configuring emails to use maildev ..."
-    if [ $PS_INSTALL_AUTO -ne 1 ]; then
-        echo 'warning: PrestaShop is not yet installed. Skipping mail configuration.'
-    else
+    if runuser -g www-data -u www-data -- php /var/www/html/bin/console prestashop:config get PS_MAIL_METHOD; then
         runuser -g www-data -u www-data -- php /var/www/html/bin/console prestashop:config set PS_MAIL_METHOD --value "2"
         runuser -g www-data -u www-data -- php /var/www/html/bin/console prestashop:config set PS_MAIL_SERVER --value "maildev"
         runuser -g www-data -u www-data -- php /var/www/html/bin/console prestashop:config set PS_MAIL_SMTP_PORT --value "1025"
+    else
+        echo 'warning: PrestaShop is not yet installed or properly initialized. Skipping maildev configuration.'
     fi
 fi
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | When starting PrestaShop from a container and configuring PS_USE_DOCKER_MAILDEV, if PrestaShop has not been installed properly or initialized yet the action will fail with an error on the console saying it cannot connect to the database. Instead lets make it clear in the output by skipping the step and letting the script continue.
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Start PrestaShop the docker-compose way but set PS_INSTALL_AUTO to 0 and PS_USE_DOCKER_MAILDEV to 1
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | N/A
