### PR TITLE
Improvement: Only output username/password when PS_INSTALL_AUTO is true

### DIFF
--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -113,6 +113,15 @@ if [ $PS_DEMO_MODE -ne 0 ]; then
     sed -ie "s/define('_PS_MODE_DEMO_', false);/define('_PS_MODE_DEMO_',\ true);/g" /var/www/html/config/defines.inc.php
 fi
 
+echo "**"
+echo "** Front-office: http://${PS_DOMAIN}/"
+echo "** Back-office: http://${PS_DOMAIN}/admin-dev"
+if [ $PS_INSTALL_AUTO = 1 ]; then
+    echo "**   Login with:"
+    echo "**     username: ${ADMIN_MAIL}"
+    echo "**     password: ${ADMIN_PASSWD}"
+fi
+
 echo "\n* Almost ! Starting web server now\n";
 
 exec apache2-foreground


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When running the docker run script, at the end we output username and password to access your PrestaShop. These might not be correct when we have not enabled PS_INSTALL_AUTO. Only output that information if it is true (ie PS_INSTALL_AUTO is true hence PrestaShop has been initialized with those variables).
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run PrestaShop the docker-compose way but set PS_INSTALL_AUTO to false value. See username and password not being printed at the end of the script anymore.
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | N/A
