### PR TITLE
Revert #38054, UI tests are not ready yet

### DIFF
--- a/install-dev/install_version.php
+++ b/install-dev/install_version.php
@@ -26,7 +26,7 @@
 
 // Note this value must be hard-coded and can't import PrestaShop\PrestaShop\Core\Version::VERSION because it's loaded/used
 // in very basic scripts that don't use autoload and can't recognize the class
-define('_PS_INSTALL_VERSION_', '9.1.0');
+define('_PS_INSTALL_VERSION_', '9.0.0');
 define('_PS_INSTALL_MINIMUM_PHP_VERSION_ID_', 80100);
 define('_PS_INSTALL_MAXIMUM_PHP_VERSION_ID_', 80499);
 

--- a/src/Core/Version.php
+++ b/src/Core/Version.php
@@ -32,10 +32,10 @@ namespace PrestaShop\PrestaShop\Core;
  */
 final class Version
 {
-    public const VERSION = '9.1.0';
+    public const VERSION = '9.0.0';
     public const MAJOR_VERSION_STRING = '9';
     public const MAJOR_VERSION = 9;
-    public const MINOR_VERSION = 1;
+    public const MINOR_VERSION = 0;
     public const RELEASE_VERSION = 0;
 
     // This class should not be instanciated


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Revert #38054, UI tests are not ready yet
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see ui tests
| UI Tests          | https://github.com/nicosomb/ga.tests.ui.pr/actions/runs/13431333762 
| Fixed issue or discussion?     | N/A
| Related PRs       | #38054 
| Sponsor company   | PrestaShop SA 