### PR TITLE
Improved management of the most used Tax Rules Group with 90-day caching

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -8004,23 +8004,50 @@ class ProductCore extends ObjectModel
     }
 
     /**
-     * @return string TaxRulesGroup identifier most used
+     * @return int TaxRulesGroup identifier most used
      */
     public static function getIdTaxRulesGroupMostUsed()
     {
-        return Db::getInstance()->getValue(
-            'SELECT id_tax_rules_group
-            FROM (
-                SELECT COUNT(*) n, product_shop.id_tax_rules_group
-                FROM ' . _DB_PREFIX_ . 'product p
-                ' . Shop::addSqlAssociation('product', 'p') . '
-                JOIN ' . _DB_PREFIX_ . 'tax_rules_group trg ON (product_shop.id_tax_rules_group = trg.id_tax_rules_group)
-                WHERE trg.active = 1 AND trg.deleted = 0
-                GROUP BY product_shop.id_tax_rules_group
-                ORDER BY n DESC
-                LIMIT 1
-            ) most_used'
-        );
+        $taxRulesGroupId = (int) Configuration::get('PS_TAX_RULES_GROUP_MOST_USED');
+        $lastUpdate = Configuration::get('PS_TAX_RULES_GROUP_MOST_USED_LAST_UPD');
+
+        $shouldUpdate = false;
+
+        if ($lastUpdate) {
+            try {
+                $dateLastUpdate = new DateTime($lastUpdate);
+                $dateInterval = $dateLastUpdate->diff(new DateTime());
+
+                if ($dateInterval->days > 90) {
+                    $shouldUpdate = true;
+                }
+            } catch (Exception $exception) {
+                $shouldUpdate = true;
+            }
+        } else {
+            $shouldUpdate = true;
+        }
+
+        if ($taxRulesGroupId === 0 || $shouldUpdate) {
+            $taxRulesGroupId = (int) Db::getInstance()->getValue(
+                'SELECT id_tax_rules_group
+                FROM (
+                    SELECT COUNT(*) n, product_shop.id_tax_rules_group
+                    FROM ' . _DB_PREFIX_ . 'product p
+                    ' . Shop::addSqlAssociation('product', 'p') . '
+                    JOIN ' . _DB_PREFIX_ . 'tax_rules_group trg ON (product_shop.id_tax_rules_group = trg.id_tax_rules_group)
+                    WHERE trg.active = 1 AND trg.deleted = 0
+                    GROUP BY product_shop.id_tax_rules_group
+                    ORDER BY n DESC
+                    LIMIT 1
+                ) most_used'
+            );
+
+            Configuration::updateValue('PS_TAX_RULES_GROUP_MOST_USED', $taxRulesGroupId);
+            Configuration::updateValue('PS_TAX_RULES_GROUP_MOST_USED_LAST_UPD', date('Y-m-d H:i:s'));
+        }
+
+        return $taxRulesGroupId;
     }
 
     /**


### PR DESCRIPTION
Saved the most used Tax Rules Group ID in Configuration to avoid repeated queries. Added a caching mechanism: the ID is recalculated only if more than 90 days have passed since the last update.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | The query in the Product::getIdTaxRulesGroupMostUsed() method, in the case of a database with many products, makes the insertion of a new product very slow (This was noticed by @matteolavaggi). I added a "caching" system to execute this query fewer times.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | When adding a new product, the system retrieves the ID from the "PS_TAX_RULES_GROUP_MOST_USED" configuration. This configuration is updated if more than 90 days have passed.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #38095
| Related PRs       | 
| Sponsor company   | @Codencode 
