### PR TITLE
Fix: Issue with JS and CSS cache clearing in multishop context

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -657,6 +657,20 @@ class MediaCore
         Configuration::updateValue('PS_CCCJS_VERSION', ++$version);
         $version = (int) Configuration::get('PS_CCCCSS_VERSION');
         Configuration::updateValue('PS_CCCCSS_VERSION', ++$version);
+
+        if (Shop::getContext() != Shop::CONTEXT_SHOP) {
+            foreach (Shop::getShops() as $shop) {
+                if (Configuration::hasKey('PS_CCCJS_VERSION', null, null, (int) $shop['id_shop'])) {
+                    $version = (int) Configuration::get('PS_CCCJS_VERSION', null, null, (int) $shop['id_shop']);
+                    Configuration::updateValue('PS_CCCJS_VERSION', ++$version, false, null, (int) $shop['id_shop']);
+                }
+
+                if (Configuration::hasKey('PS_CCCCSS_VERSION', null, null, (int) $shop['id_shop'])) {
+                    $version = (int) Configuration::get('PS_CCCCSS_VERSION', null, null, (int) $shop['id_shop']);
+                    Configuration::updateValue('PS_CCCCSS_VERSION', ++$version, false, null, (int) $shop['id_shop']);
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Added update of "PS_CCCJS_VERSION" and "PS_CCCCSS_VERSION" configurations in case of cache reset for "All stores"

In a multishop setup, if the cache for "All stores" is cleared, the system updates the "PS_CCCJS_VERSION" and "PS_CCCCSS_VERSION" configurations for each individual shop.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | see https://github.com/PrestaShop/PrestaShop/issues/38135
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see https://github.com/PrestaShop/PrestaShop/issues/38135
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/13626582946/job/38092740861 ✅ 
| Fixed issue or discussion?     | Fixes #38135
| Related PRs       |
| Sponsor company   | @Codencode 
