### PR TITLE
Fix link color in popover

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_tooltip.scss
+++ b/admin-dev/themes/new-theme/scss/components/_tooltip.scss
@@ -18,3 +18,7 @@
     }
   }
 }
+
+.popover .popover-body a {
+  color: var(--#{$cdk}primary-400);
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fix link color in popover to avoid the fact that they aren't visible.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #37781 
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/13523856832
| Fixed issue or discussion?     | Fixes #37781 
| Related PRs       | ~
| Sponsor company   | PrestaShop SA

## Before this fix
![image](https://github.com/user-attachments/assets/733a35b9-415b-48ce-9857-f21dd8cbf70d)

## After
![image](https://github.com/user-attachments/assets/93b64879-6ede-4c05-9982-bdc20c5ef0ec)

