### PR TITLE
Hide spinner if no ajax in progress

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -716,11 +716,9 @@ $(function()
     });
 
   // Ensure the spinner is hidden if no AJAX requests are running when the page loads
-  $(document).ready(function() {
-    if ($.active === 0) {
-      $('#ajax_running').hide();
-    }
-  });
+  if ($.active === 0) {
+    $('#ajax_running').hide();
+  }
 
   //Check filters value on submit filter
   $("[name='submitFilter']").on('click', function(event) {

--- a/js/admin.js
+++ b/js/admin.js
@@ -715,6 +715,13 @@ $(function()
       clearTimeout(ajax_running_timeout);
     });
 
+  // Ensure the spinner is hidden if no AJAX requests are running when the page loads
+  $(document).ready(function() {
+    if ($.active === 0) {
+      $('#ajax_running').hide();
+    }
+  });
+
   //Check filters value on submit filter
   $("[name='submitFilter']").on('click', function(event) {
     var list_id = $(this).data('list-id');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fix infinitely displayed ajax spinner if no response.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Uninstall all modules that do ajax requests in BO, disable backoffice order notifications, visit a legacy page like groups. See blue spinner. With this, OK. Ping @kpodemski he knows the bug.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/13965563319
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38134
| Related PRs       | 
| Sponsor company   |
