### PR TITLE
Load module translation catalogues for all present modules

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -151,13 +151,21 @@ abstract class AppKernel extends Kernel
     {
         $loader->load($this->getKernelConfigPath());
 
-        $activeModules = $this->getModuleRepository()->getActiveModules();
-        // We only load translations and services of active modules (not simply installed)
+        $presentModules = $this->getModuleRepository()->getPresentModules();
+        // We only load translations of present modules (so their wording is usable during installation)
         $moduleTranslationsPaths = [];
+        foreach ($presentModules as $presentModule) {
+            $modulePath = _PS_MODULE_DIR_ . $presentModule;
+            $translationsPath = sprintf('%s/translations', $modulePath);
+            if (is_dir($translationsPath)) {
+                $moduleTranslationsPaths[] = $translationsPath;
+            }
+        }
+
+        $activeModules = $this->getModuleRepository()->getActiveModules();
+        // We only load services of active modules (not simply installed)
         foreach ($activeModules as $activeModulePath) {
             $modulePath = _PS_MODULE_DIR_ . $activeModulePath;
-            $translationsPath = sprintf('%s/translations', $modulePath);
-
             $configFiles = [
                 sprintf('%s/config/services.yml', $modulePath),
                 sprintf('%s/config/admin/services.yml', $modulePath),
@@ -169,10 +177,6 @@ abstract class AppKernel extends Kernel
                 if (is_file($file)) {
                     $loader->load($file);
                 }
-            }
-
-            if (is_dir($translationsPath)) {
-                $moduleTranslationsPaths[] = $translationsPath;
             }
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -801,6 +801,11 @@ parameters:
 			path: src/Core/Module/ModuleInterface.php
 
 		-
+			message: "#^Namespace Language is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 2
+			path: src/Core/Module/ModuleManager.php
+
+		-
 			message: "#^Namespace Module is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 5
 			path: src/Core/Module/ModuleManager.php

--- a/src/Adapter/Module/Repository/ModuleRepository.php
+++ b/src/Adapter/Module/Repository/ModuleRepository.php
@@ -140,18 +140,9 @@ class ModuleRepository extends AbstractObjectModelRepository
      */
     public function getPresentModules(): array
     {
-        if (!defined('_DB_PREFIX_')) {
-            return []; // getActiveModules() can be called during install BEFORE the database configuration has been defined
-        }
-
         $presentModules = [];
-        try {
-            foreach ($this->getModulesFromFolder() as $moduleName => $modulePath) {
-                $presentModules[] = $moduleName;
-            }
-        } catch (Exception) {
-            // DO nothing. getPresentModules() can be called during install BEFORE the database configuration has been defined
-            return [];
+        foreach ($this->getModulesFromFolder() as $moduleName => $modulePath) {
+            $presentModules[] = $moduleName;
         }
 
         return $presentModules;

--- a/src/Adapter/Module/Repository/ModuleRepository.php
+++ b/src/Adapter/Module/Repository/ModuleRepository.php
@@ -59,6 +59,11 @@ class ModuleRepository extends AbstractObjectModelRepository
     private $installedModulesPaths;
 
     /**
+     * @var array
+     */
+    private $presentModulesPaths;
+
+    /**
      * @var string
      */
     protected $rootDir;
@@ -126,6 +131,30 @@ class ModuleRepository extends AbstractObjectModelRepository
         }
 
         return $activeModules;
+    }
+
+    /**
+     * Return present modules (even if those not installed in DB).
+     *
+     * @return array
+     */
+    public function getPresentModules(): array
+    {
+        if (!defined('_DB_PREFIX_')) {
+            return []; // getActiveModules() can be called during install BEFORE the database configuration has been defined
+        }
+
+        $presentModules = [];
+        try {
+            foreach ($this->getModulesFromFolder() as $moduleName => $modulePath) {
+                $presentModules[] = $moduleName;
+            }
+        } catch (Exception) {
+            // DO nothing. getPresentModules() can be called during install BEFORE the database configuration has been defined
+            return [];
+        }
+
+        return $presentModules;
     }
 
     /**
@@ -206,6 +235,24 @@ class ModuleRepository extends AbstractObjectModelRepository
         }
 
         return $this->activeModulesPaths;
+    }
+
+    /**
+     * Returns present module file paths.
+     *
+     * @return array<string, string> File paths indexed by module name
+     */
+    public function getPresentModulesPaths(): array
+    {
+        if (null === $this->presentModulesPaths) {
+            $this->presentModulesPaths = [];
+
+            foreach ($this->getModulesFromFolder() as $moduleName => $modulePath) {
+                $this->presentModulesPaths[$moduleName] = $modulePath;
+            }
+        }
+
+        return $this->presentModulesPaths;
     }
 
     /**

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -52,6 +52,7 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Routing\Loader\YamlFileLoader;
 use Symfony\Component\Routing\Router;
+use Symfony\Component\Translation\Loader\XliffFileLoader;
 
 class ModuleManagerBuilder
 {
@@ -118,7 +119,10 @@ class ModuleManagerBuilder
                     new SourceHandlerFactory(),
                     self::$translator,
                     new NullDispatcher(),
-                    new HookManager()
+                    new HookManager(),
+                    _PS_MODULE_DIR_,
+                    new XliffFileLoader(),
+                    null
                 );
             }
         }

--- a/src/PrestaShopBundle/Resources/config/services/core/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/module.yml
@@ -34,6 +34,8 @@ services:
       $moduleDataProvider: '@prestashop.adapter.data_provider.module'
       $adminModuleDataProvider: '@prestashop.core.admin.data_provider.module_interface'
       $hookManager: '@prestashop.adapter.hook.manager'
+      $modulesDir: '%prestashop.module_dir%'
+      $xliffFileLoader: '@translation.loader.xliff'
 
   PrestaShop\PrestaShop\Core\Module\SourceHandler\ZipSourceHandler:
     autowire: true

--- a/tests/Unit/Core/Module/ModuleManagerTest.php
+++ b/tests/Unit/Core/Module/ModuleManagerTest.php
@@ -40,6 +40,7 @@ use PrestaShop\PrestaShop\Core\Module\ModuleManager;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
 use PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerFactory;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Translation\Loader\XliffFileLoader;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ModuleManagerTest extends TestCase
@@ -79,6 +80,9 @@ class ModuleManagerTest extends TestCase
                 $translatorMock,
                 $this->createMock(EventDispatcherInterface::class),
                 $this->createMock(HookManager::class),
+                _PS_MODULE_DIR_,
+                new XliffFileLoader(),
+                null,
             ])
             ->onlyMethods(['upgradeMigration'])
             ->getMock()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | During the installation of a module the translation catalog is loaded so it's available (among other things) for the multi lang tab creation
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | ~
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/13806182696
| Fixed issue or discussion?     | Fixes #30241
| Related PRs       | https://github.com/PrestaShopCorp/ps_classic_edition/pull/53
| Sponsor company   | ~

### How to test

Install this module  [ps_classic_edition.zip](https://github.com/user-attachments/files/19167003/ps_classic_edition.zip) that modifies the menu on the left in the BO. Without this PR the tab `Welcome` and `Home` are not correctly translated, with the PR both tabs are correctly translated in French (optionally also in Spanish and Italian)

