### PR TITLE
Fix legacy context initialisation inconsistencies

### DIFF
--- a/app/config/admin/services.yml
+++ b/app/config/admin/services.yml
@@ -71,11 +71,11 @@ services:
   PrestaShopBundle\EventListener\Admin\Context\CountryContextListener: ~
   PrestaShopBundle\EventListener\Admin\Context\LegacyControllerContextListener: ~
 
-  PrestaShopBundle\EventListener\Admin\Context\LegacyContextListener:
+  PrestaShopBundle\EventListener\Admin\Context\LegacyContextSubscriber:
+    autowire: true
+    autoconfigure: true
     arguments:
       $legacyBuilders: !tagged_iterator core.legacy_context_builder
-    tags:
-      - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
 
   # SSL middleware
   PrestaShopBundle\EventListener\Admin\SSLMiddlewareListener:

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -206,6 +206,11 @@ parameters:
 			path: src/Core/Context/CountryContextBuilder.php
 
 		-
+			message: "#^Class ObjectModel is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/Core/Context/CountryContextBuilder.php
+
+		-
 			message: "#^Namespace Country is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 1
 			path: src/Core/Context/CountryContextBuilder.php
@@ -213,6 +218,11 @@ parameters:
 		-
 			message: "#^Class Currency is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 2
+			path: src/Core/Context/CurrencyContextBuilder.php
+
+		-
+			message: "#^Class ObjectModel is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
 			path: src/Core/Context/CurrencyContextBuilder.php
 
 		-
@@ -226,9 +236,29 @@ parameters:
 			path: src/Core/Context/EmployeeContextBuilder.php
 
 		-
+			message: "#^Class ObjectModel is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/Core/Context/EmployeeContextBuilder.php
+
+		-
 			message: "#^Namespace Employee is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 1
 			path: src/Core/Context/EmployeeContextBuilder.php
+
+		-
+			message: "#^Class Language is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 2
+			path: src/Core/Context/LanguageContextBuilder.php
+
+		-
+			message: "#^Class ObjectModel is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/Core/Context/LanguageContextBuilder.php
+
+		-
+			message: "#^Namespace Language is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/Core/Context/LanguageContextBuilder.php
 
 		-
 			message: "#^Namespace Language is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
@@ -244,6 +274,16 @@ parameters:
 			message: "#^Namespace Tools is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 3
 			path: src/Core/Context/LegacyControllerContextBuilder.php
+
+		-
+			message: "#^Namespace ObjectModel is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/Core/Context/LegacyObjectCheckerTrait.php
+
+		-
+			message: "#^Class ObjectModel is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/Core/Context/ShopContextBuilder.php
 
 		-
 			message: "#^Class Shop is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"

--- a/src/Core/Context/CountryContextBuilder.php
+++ b/src/Core/Context/CountryContextBuilder.php
@@ -36,6 +36,8 @@ use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 
 class CountryContextBuilder implements LegacyContextBuilderInterface
 {
+    use LegacyObjectCheckerTrait;
+
     private ?int $countryId = null;
 
     private ?LegacyCountry $legacyCountry = null;
@@ -70,7 +72,11 @@ class CountryContextBuilder implements LegacyContextBuilderInterface
     public function buildLegacyContext(): void
     {
         $this->assertArguments();
-        $this->contextStateManager->setCountry($this->getLegacyCountry());
+
+        // Only update the legacy context when the country is not the expected one, if not leave the context unchanged
+        if ($this->legacyObjectNeedsUpdate($this->contextStateManager->getContext()->country, (int) $this->getLegacyCountry()->id)) {
+            $this->contextStateManager->setCountry($this->getLegacyCountry());
+        }
     }
 
     public function setCountryId(?int $countryId): self
@@ -92,7 +98,7 @@ class CountryContextBuilder implements LegacyContextBuilderInterface
 
     private function getLegacyCountry(): LegacyCountry
     {
-        if (!$this->legacyCountry) {
+        if ($this->legacyObjectNeedsUpdate($this->legacyCountry, $this->countryId)) {
             $this->legacyCountry = $this->countryRepository->get(new CountryId($this->countryId));
         }
 

--- a/src/Core/Context/CurrencyContextBuilder.php
+++ b/src/Core/Context/CurrencyContextBuilder.php
@@ -36,6 +36,8 @@ use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 
 class CurrencyContextBuilder implements LegacyContextBuilderInterface
 {
+    use LegacyObjectCheckerTrait;
+
     private ?int $currencyId = null;
 
     private ?LegacyCurrency $legacyCurrency = null;
@@ -75,7 +77,10 @@ class CurrencyContextBuilder implements LegacyContextBuilderInterface
     public function buildLegacyContext(): void
     {
         $this->assertArguments();
-        $this->contextStateManager->setCurrency($this->getLegacyCurrency());
+        // Only update the legacy context when the currency is not the expected one, if not leave the context unchanged
+        if ($this->legacyObjectNeedsUpdate($this->contextStateManager->getContext()->currency, (int) $this->getLegacyCurrency()->id)) {
+            $this->contextStateManager->setCurrency($this->getLegacyCurrency());
+        }
     }
 
     public function setCurrencyId(int $currencyId)
@@ -97,7 +102,7 @@ class CurrencyContextBuilder implements LegacyContextBuilderInterface
 
     private function getLegacyCurrency(): LegacyCurrency
     {
-        if (!$this->legacyCurrency) {
+        if ($this->legacyObjectNeedsUpdate($this->legacyCurrency, $this->currencyId)) {
             $this->legacyCurrency = $this->currencyRepository->get(new CurrencyId($this->currencyId));
         }
 

--- a/src/Core/Context/EmployeeContextBuilder.php
+++ b/src/Core/Context/EmployeeContextBuilder.php
@@ -37,6 +37,8 @@ use PrestaShop\PrestaShop\Adapter\Employee\EmployeeRepository;
  */
 class EmployeeContextBuilder implements LegacyContextBuilderInterface
 {
+    use LegacyObjectCheckerTrait;
+
     private ?int $employeeId = null;
     private ?LegacyEmployee $legacyEmployee = null;
 
@@ -74,8 +76,8 @@ class EmployeeContextBuilder implements LegacyContextBuilderInterface
     {
         $legacyEmployee = $this->getLegacyEmployee();
         if (!empty($legacyEmployee)) {
-            $contextEmployee = $this->contextStateManager->getContext()->employee;
-            if (null === $contextEmployee || empty($contextEmployee->id)) {
+            // Only update the legacy context when the employee is not the expected one, if not leave the context unchanged
+            if ($this->legacyObjectNeedsUpdate($this->contextStateManager->getContext()->employee, (int) $legacyEmployee->id)) {
                 $this->contextStateManager->setEmployee($legacyEmployee);
             }
         }
@@ -90,7 +92,7 @@ class EmployeeContextBuilder implements LegacyContextBuilderInterface
 
     private function getLegacyEmployee(): ?LegacyEmployee
     {
-        if (!$this->legacyEmployee && !empty($this->employeeId)) {
+        if ($this->legacyObjectNeedsUpdate($this->legacyEmployee, $this->employeeId)) {
             $this->legacyEmployee = $this->employeeRepository->get($this->employeeId);
         }
 

--- a/src/Core/Context/LegacyObjectCheckerTrait.php
+++ b/src/Core/Context/LegacyObjectCheckerTrait.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Context;
+
+use ObjectModel;
+
+/**
+ * Method shared between builders to check when a legacy object needs to be updated, mostly to update
+ * the internal class local field that caches the legacy object model or when we check if the legacy
+ * Context fields are in sync with the expected value from the builder.
+ */
+trait LegacyObjectCheckerTrait
+{
+    protected function legacyObjectNeedsUpdate(?ObjectModel $objectModel, ?int $expectedId): bool
+    {
+        return !empty($expectedId) && (empty($objectModel) || (int) $objectModel->id !== $expectedId);
+    }
+}

--- a/src/PrestaShopBundle/Service/DataProvider/UserProvider.php
+++ b/src/PrestaShopBundle/Service/DataProvider/UserProvider.php
@@ -27,17 +27,22 @@
 namespace PrestaShopBundle\Service\DataProvider;
 
 use PrestaShopBundle\Entity\Employee\Employee;
+use PrestaShopBundle\Security\Admin\SessionEmployeeProvider;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Old convenient way to access User, if exists. Prefer using the Security service to get the connected user.
+ * This service is only used in legacy context now.
  */
 class UserProvider
 {
     public function __construct(
         private readonly Security $security,
+        private readonly SessionEmployeeProvider $sessionEmployeeProvider,
+        private readonly RequestStack $requestStack,
     ) {
     }
 
@@ -49,6 +54,16 @@ class UserProvider
         $user = $this->security->getUser();
         if ($user instanceof Employee) {
             return $user;
+        }
+
+        // Since this service is used in legacy context it may be called early in the process when the FirewallListener has not been
+        // executed yet, therefore the Security::getUser still returns null, so we use this fallback to unserialize an Employee
+        // entity from the session token for backward compatibility
+        if ($this->requestStack->getCurrentRequest()) {
+            $sessionEmployee = $this->sessionEmployeeProvider->getEmployeeFromSession($this->requestStack->getCurrentRequest());
+            if ($sessionEmployee instanceof Employee) {
+                return $sessionEmployee;
+            }
         }
 
         return null;

--- a/tests/Unit/Core/Context/LanguageContextBuilderTest.php
+++ b/tests/Unit/Core/Context/LanguageContextBuilderTest.php
@@ -77,6 +77,7 @@ class LanguageContextBuilderTest extends TestCase
     public function testBuildLegacyContext(): void
     {
         $objectModelLanguage = $this->mockObjectModelLanguage();
+        $objectModelLanguage->id = 42;
         $objectModelLanguage->method('getId')->willReturn(42);
         $contextManagerMock = $this->createMock(ContextStateManager::class);
         $objectModelLanguageMock = $this->mockObjectModelLanguageRepository($objectModelLanguage);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | - improve `UserProvider` service used only in legacy environment so that it is more resilient in calls that happen too soon in the request workflow<br>- make all Context builders more resilient and check more the legacy context values to see if updates are needed
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See issue https://github.com/PrestaShop/PrestaShop/issues/38047#issuecomment-2669177928 + CI green and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/13539948264 ✅ 
| Fixed issue or discussion?     | Fixes #38047
| Related PRs       | Should replace https://github.com/PrestaShop/PrestaShop/pull/38051
| Sponsor company   | ~
