### PR TITLE
Fix: Issue with multilingual translations

### DIFF
--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -63,7 +63,7 @@ trait PrestaShopTranslatorTrait
             $locale = null;
         }
 
-        if ($this->shouldFallbackToLegacyModuleTranslation($id, $domain)) {
+        if ($this->shouldFallbackToLegacyModuleTranslation($id, $domain, $locale)) {
             return $this->translateUsingLegacySystem($id, $parameters, $domain, $locale);
         }
 
@@ -172,16 +172,17 @@ trait PrestaShopTranslatorTrait
      *
      * @param string $message Message to translate
      * @param ?string $domain Translation domain
+     * @param ?string $locale Locale
      *
      * @return bool
      */
-    private function shouldFallbackToLegacyModuleTranslation(string $message, ?string $domain): bool
+    private function shouldFallbackToLegacyModuleTranslation(string $message, ?string $domain, ?string $locale): bool
     {
         return
             'Modules.' === substr($domain ?? '', 0, 8)
             && (
                 !method_exists($this, 'getCatalogue')
-                || !$this->getCatalogue()->has($message, $this->normalizeDomain($domain))
+                || !$this->getCatalogue($locale)->has($message, $this->normalizeDomain($domain))
             )
             ;
     }


### PR DESCRIPTION
…:shouldFallbackToLegacyModuleTranslation()

The method PrestaShopTranslatorTrait::shouldFallbackToLegacyModuleTranslation() must take into account the "locale" parameter in order to load the "Catalogue" for the appropriate "locale".

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | see: https://github.com/PrestaShop/PrestaShop/issues/38154
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see: https://github.com/PrestaShop/PrestaShop/issues/38154
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/13676680559
| Fixed issue or discussion?     | Fixes #38154
| Related PRs       | 
| Sponsor company   | @Codencode 
