### PR TITLE
Category::getParentsCategories fix with multiple root categories

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1555,7 +1555,7 @@ class CategoryCore extends ObjectModel
         if (!$context->shop->id) {
             $context->shop = new Shop((int) Configuration::get('PS_SHOP_DEFAULT'));
         }
-        if (count(Category::getCategoriesWithoutParent()) > 1) {
+        if (Shop::getContext() !== Shop::CONTEXT_SHOP && count(Category::getCategoriesWithoutParent()) > 1) {
             $context->shop->id_category = (int) Configuration::get('PS_ROOT_CATEGORY');
         }
         $idShop = $context->shop->id;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Category::getParentsCategories only returns the Root category in All shops and Shop group context
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green See below
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/13592613299 ✅ 
| Fixed issue or discussion?     | Fixes #37374
| Related PRs       | ~
| Sponsor company   | ~

### How to test
- I need a shop with multiple shops
- I create new Root categories (one is enough)
- I create a new shop which uses a different Root category newly created as its default category
- In the BO when I go into the categories list:
  - In All shops and Shop group context I see the whole breadcrumb including the category named `Root` with ID 1 so I can travel through the whole categories tree
  - In single shop context I can only see the tree sub part starting with the category assigned to my selected shop The `Root` category is not visible in the breadcrumb