### PR TITLE
Fix BO hook dispatcher to correctly handle recursive `dispatch()` calls

### DIFF
--- a/src/Adapter/Hook/HookDispatcher.php
+++ b/src/Adapter/Hook/HookDispatcher.php
@@ -30,11 +30,6 @@ use Symfony\Contracts\EventDispatcher\Event;
 class HookDispatcher extends EventDispatcher implements HookDispatcherInterface
 {
     /**
-     * @var array
-     */
-    private $renderingContent = [];
-
-    /**
      * @var RequestStack
      */
     private $requestStack;
@@ -136,6 +131,8 @@ class HookDispatcher extends EventDispatcher implements HookDispatcherInterface
      */
     protected function doDispatch($listeners, $eventName, Event $event)
     {
+        $hookContent = [];
+
         foreach ($listeners as $listener) {
             // removes $this to parameters. Hooks should not have access to dispatcher
             ob_start();
@@ -145,12 +142,11 @@ class HookDispatcher extends EventDispatcher implements HookDispatcherInterface
             if ($event instanceof RenderingHookEvent) {
                 $listenerName = $event->popListener() ?: $listener[1];
 
-                $this->renderingContent[$listenerName] = $event->popContent();
+                $hookContent[$listenerName] = $event->popContent();
             }
         }
         if ($event instanceof RenderingHookEvent) {
-            $event->setContent($this->renderingContent);
-            $this->renderingContent = [];
+            $event->setContent($hookContent);
         }
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Storing partial results returned by listeners in the `$renderingContent` property can cause the intermediate results to be added to the wrong event object. The property is not used outside of the `doDispatch()` method. Replacing it with a local variable prevents the problem.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | The module attached in #38173 might be helpful.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #38173
| Related PRs       | N/A
| Sponsor company   | N/A
