### PR TITLE
Symfony remember me lifetime is linked to the BO config

### DIFF
--- a/app/config/admin/security.yml
+++ b/app/config/admin/security.yml
@@ -35,7 +35,7 @@ security:
         success_handler: PrestaShopBundle\Security\Admin\AdminAuthenticationSuccessHandler
       remember_me:
         secret: "%kernel.secret%"
-        lifetime: 3600
+        lifetime: "%prestashop.admin_cookie_lifetime%"
         remember_me_parameter: stay_logged_in
         signature_properties: [ 'password' ]
       logout:

--- a/src/Adapter/GeneralConfiguration.php
+++ b/src/Adapter/GeneralConfiguration.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter;
 
 use Cookie;
+use PrestaShop\PrestaShop\Adapter\Cache\Clearer\SymfonyCacheClearer;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Http\CookieOptions;
 
@@ -35,24 +36,11 @@ use PrestaShop\PrestaShop\Core\Http\CookieOptions;
  */
 class GeneralConfiguration implements DataConfigurationInterface
 {
-    /**
-     * @var Configuration
-     */
-    private $configuration;
-
-    /**
-     * @var Cookie
-     */
-    private $cookie;
-
-    /**
-     * @param Configuration $configuration
-     * @param Cookie $cookie
-     */
-    public function __construct(Configuration $configuration, Cookie $cookie)
-    {
-        $this->configuration = $configuration;
-        $this->cookie = $cookie;
+    public function __construct(
+        private readonly Configuration $configuration,
+        private readonly Cookie $cookie,
+        private readonly SymfonyCacheClearer $symfonyCacheClearer,
+    ) {
     }
 
     /**
@@ -90,6 +78,9 @@ class GeneralConfiguration implements DataConfigurationInterface
                 // Clear checksum to force the refresh
                 $this->cookie->checksum = '';
                 $this->cookie->write();
+
+                // Since the DB value PS_COOKIE_LIFETIME_BO impacts the Symfony security configuration we need to clear the cache
+                $this->symfonyCacheClearer->clear();
             }
         }
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -85,6 +85,7 @@ services:
 
   prestashop.adapter.general.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\GeneralConfiguration'
+    autowire: true
     arguments:
       - '@prestashop.adapter.legacy.configuration'
       - '@=service("prestashop.adapter.legacy.context").getContext().cookie'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Dynamically update the remember me lifetime framework configuration based on the configuration saved in DB editable via the BO
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Change the value in Advanced parameters > Administration > Lifetime of back office cookies This should impact how long you can stay logged in the BO (expressed in hours)
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/13659381224
| Fixed issue or discussion?     | Fixes #38120
| Related PRs       | ~
| Sponsor company   | ~
