### PR TITLE
Fix: Cannot use 'type' => 'file' on HelperOptions on PS 9.0.x

### DIFF
--- a/classes/helper/HelperUploader.php
+++ b/classes/helper/HelperUploader.php
@@ -214,14 +214,14 @@ class HelperUploaderCore extends Uploader
                 . DIRECTORY_SEPARATOR . $controller_name . DIRECTORY_SEPARATOR . $this->getTemplateDirectory() . $template)) {
             return $this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(0)) . 'controllers'
                 . DIRECTORY_SEPARATOR . $controller_name . DIRECTORY_SEPARATOR . $this->getTemplateDirectory() . $template;
-        } elseif (file_exists($this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(0))
-                . $this->getTemplateDirectory() . $template)) {
-            return $this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(0))
-                . $this->getTemplateDirectory() . $template;
         } elseif (file_exists($this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(1))
                 . $this->getTemplateDirectory() . $template)) {
             return $this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(1))
                     . $this->getTemplateDirectory() . $template;
+        } elseif (file_exists($this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(0))
+                . $this->getTemplateDirectory() . $template)) {
+            return $this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(0))
+                . $this->getTemplateDirectory() . $template;
         } else {
             return $this->getTemplateDirectory() . $template;
         }

--- a/classes/helper/HelperUploader.php
+++ b/classes/helper/HelperUploader.php
@@ -214,14 +214,14 @@ class HelperUploaderCore extends Uploader
                 . DIRECTORY_SEPARATOR . $controller_name . DIRECTORY_SEPARATOR . $this->getTemplateDirectory() . $template)) {
             return $this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(0)) . 'controllers'
                 . DIRECTORY_SEPARATOR . $controller_name . DIRECTORY_SEPARATOR . $this->getTemplateDirectory() . $template;
-        } elseif (file_exists($this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(1))
-                . $this->getTemplateDirectory() . $template)) {
-            return $this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(1))
-                    . $this->getTemplateDirectory() . $template;
         } elseif (file_exists($this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(0))
                 . $this->getTemplateDirectory() . $template)) {
             return $this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(0))
                 . $this->getTemplateDirectory() . $template;
+        } elseif (file_exists($this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(1))
+                . $this->getTemplateDirectory() . $template)) {
+            return $this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(1))
+                    . $this->getTemplateDirectory() . $template;
         } else {
             return $this->getTemplateDirectory() . $template;
         }

--- a/src/PrestaShopBundle/Controller/Admin/LegacyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/LegacyController.php
@@ -116,7 +116,10 @@ class LegacyController extends PrestaShopAdminController
         header('Cache-Control: no-store, no-cache');
 
         $smarty = $this->legacyContext->getSmarty();
-        $smarty->setTemplateDir(_PS_BO_ALL_THEMES_DIR_ . 'default/template/');
+        $smarty->setTemplateDir([
+            _PS_BO_ALL_THEMES_DIR_ . 'default/template/',
+            _PS_OVERRIDE_DIR_ . 'controllers' . DIRECTORY_SEPARATOR . 'admin' . DIRECTORY_SEPARATOR . 'templates',
+        ]);
 
         $isAjaxRequest = (bool) $request->get('ajax');
         if ($isAjaxRequest) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | see #38133
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see #38133
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/15438873126
| Fixed issue or discussion?     | Resolves #38133 Resolves #38321
| Related PRs       | #38006
| Sponsor company   | @Codencode 
