### PR TITLE
Remove link in help message for product stock option

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockOptionsType.php
@@ -33,31 +33,10 @@ use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Validator\Constraints\Type;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 class StockOptionsType extends TranslatorAwareType
 {
-    /**
-     * @var RouterInterface
-     */
-    private $router;
-
-    /**
-     * @param TranslatorInterface $translator
-     * @param array $locales
-     * @param RouterInterface $router
-     */
-    public function __construct(
-        TranslatorInterface $translator,
-        array $locales,
-        RouterInterface $router
-    ) {
-        parent::__construct($translator, $locales);
-        $this->router = $router;
-    }
-
     /**
      * {@inheritDoc}
      */
@@ -76,15 +55,8 @@ class StockOptionsType extends TranslatorAwareType
             ->add('low_stock_threshold', NumberType::class, [
                 'label' => $this->trans('Receive a low stock alert by email', 'Admin.Catalog.Feature'),
                 'label_help_box' => $this->trans(
-                    'The email will be sent to all users who have access to the Stock page. To modify permissions, go to [1]Advanced Parameters > Team[/1].',
+                    'The email will be sent to all users who have access to the Stock page. To modify permissions, go to Advanced Parameters > Team.',
                     'Admin.Catalog.Help',
-                    [
-                        '[1]' => sprintf(
-                            '<a target="_blank" href="%s">',
-                            $this->router->generate('admin_employees_index')
-                        ),
-                        '[/1]' => '</a>',
-                    ]
                 ),
                 'constraints' => [
                     new Type(['type' => 'numeric']),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Remove link in help message for product stock option
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See issue, there is no more link in the tooltip so the text is visible
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/13787485795
| Fixed issue or discussion?     | Fixes #37781
| Related PRs       | ~
| Sponsor company   | ~
