### PR TITLE
DOM text reinterpreted as HTML Update panels-complex.html

### DIFF
--- a/admin-dev/themes/default/example/components/panels-complex.html
+++ b/admin-dev/themes/default/example/components/panels-complex.html
@@ -30,6 +30,14 @@
   <script type="text/javascript">
      //<![CDATA[
      var submited = false;
+     function escapeHtml(unsafe) {
+       return unsafe
+         .replace(/&/g, "&amp;")
+         .replace(/</g, "&lt;")
+         .replace(/>/g, "&gt;")
+         .replace(/"/g, "&quot;")
+         .replace(/'/g, "&#039;");
+     }
      $(function() {
        //get reference on save link
        btn_save = $('i[class~="process-icon-save"]').parent();
@@ -69,14 +77,14 @@
              }
              submited = true;
              //add hidden input to emulate submit button click when posting the form -> field name posted
-             btn_submit.before('<input type="hidden" name="'+btn_submit.attr("name")+'" value="1" />');
+             btn_submit.before('<input type="hidden" name="'+escapeHtml(btn_submit.attr("name"))+'" value="1" />');
              $('#tax_rules_group_form').submit();
              return false;
            });
            if (btn_save_and_stay) {
              btn_save_and_stay.on('click', function() {
                //add hidden input to emulate submit button click when posting the form -> field name posted
-               btn_submit.before('<input type="hidden" name="'+btn_submit.attr("name")+'AndStay" value="1" />');
+               btn_submit.before('<input type="hidden" name="'+escapeHtml(btn_submit.attr("name"))+'AndStay" value="1" />');
                $('#tax_rules_group_form').submit();
                return false;
              });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | DOM text is reinterpreted as HTML without escaping meta-characters. Extracting text from a DOM node and interpreting it as HTML can lead to a cross-site scripting vulnerability. To fix the problem we need to ensure that the `name` attribute value is properly escaped before being inserted into the DOM. This can be achieved by using a function that escapes HTML special characters preventing any potential XSS attacks.
| Type?             |  improvement 
| Category?         |  CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI
| UI Tests          | 
| Related PRs       | 
| Sponsor company   | 