### PR TITLE
fix #38223: tools spread amount for AverageTaxOfProductsTaxCalculator

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3708,7 +3708,14 @@ exit;
         }
 
         $sort_function = function ($a, $b) use ($column) {
-            return $b[$column] > $a[$column] ? 1 : -1;
+            if (
+                is_array($a)
+                && isset($a[$column])
+            ) {
+                return $b[$column] > $a[$column] ? 1 : -1;
+            } else {
+                return $b > $a ? 1 : -1;
+            }
         };
 
         uasort($rows, $sort_function);
@@ -3729,7 +3736,14 @@ exit;
                 $adjustment_factor += $sign * 1 / $unit;
             }
 
-            $row[$column] += $adjustment_factor;
+            if (
+                is_array($row)
+                && isset($row[$column])
+            ) {
+                $row[$column] += $adjustment_factor;
+            } else {
+                $row += $adjustment_factor;
+            }
 
             ++$position;
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.0
| Description?      | Please see the description in this issue: https://github.com/PrestaShop/PrestaShop/issues/38223
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Please see the description in this issue: https://github.com/PrestaShop/PrestaShop/issues/38223
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | Fixes #38223 
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
