### PR TITLE
Display the error reported by the module when the installation of PrestaShop fails because of it

### DIFF
--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -1051,16 +1051,17 @@ class Install extends AbstractInstall
             }
 
             if (!$moduleActionIsExecuted) {
-                $moduleErrors = [
-                    str_replace(
-                        '%module%',
-                        $module_name,
-                        $errorMessage
-                    ),
+                $moduleErrors = [str_replace(
+                    '%module%',
+                    $module_name,
+                    $errorMessage
+                ),
                 ];
 
                 if (!empty($moduleException)) {
                     $moduleErrors[] = $moduleException;
+                } else {
+                    $moduleErrors[] = $moduleManager->getError($module_name);
                 }
 
                 $errors[$module_name] = $moduleErrors;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | When the installation of PrestaShop fails because a module reported at least one error (see https://github.com/PrestaShop/PrestaShop/pull/36612), let's display it on the installer report.  
| Type?             | improvement
| Category?         | IN
| BC breaks?        | No
| Deprecations?     | No
| How to test?      | Try installing a shop with autoupgrade v6 present in the modules folder. The installation will fail because `autoupgrade` module cannot be installed.
| Fixed issue or discussion?     | /
| Related PRs       | Related to https://github.com/PrestaShop/autoupgrade/pull/1223, where the module was fixed as well.
| Sponsor company   | @PrestaShopCorp


## When installing via CLI:

### Without the PR:

```
root@654fba389194:/var/www/html#         runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe"         --password="$ADMIN_PASSWD" --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY         --all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL

Errors :
Cannot install module "autoupgrade"
```
We did not know if the issue was coming from PrestaShop or Update Assistant.

### With the PR:

```
root@654fba389194:/var/www/html#         runuser -g www-data -u www-data -- php -d memory_limit=-1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER         --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe"         --password="$ADMIN_PASSWD" --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY         --all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL

Errors :
Cannot install module "autoupgrade"
This version of PrestaShop cannot be upgraded: the PS_ADMIN_DIR constant is missing.
```

Even if the reported error is not crystal clear, a quick look leads us to the module source code where this error is triggered by a missing constant, unavailable in the installation context (equivalent to a false positive).

