### PR TITLE
Tax rule group country edition

### DIFF
--- a/controllers/admin/AdminTaxRulesGroupController.php
+++ b/controllers/admin/AdminTaxRulesGroupController.php
@@ -515,7 +515,7 @@ class AdminTaxRulesGroupControllerCore extends AdminController
         $this->deleteTaxRule([Tools::getValue('id_tax_rule')]);
     }
 
-    protected function displayAjaxUpdateTaxRule()
+    public function displayAjaxUpdateTaxRule()
     {
         if ($this->access('view')) {
             $id_tax_rule = Tools::getValue('id_tax_rule');

--- a/src/PrestaShopBundle/Command/SecurityAttributeLinterCommand.php
+++ b/src/PrestaShopBundle/Command/SecurityAttributeLinterCommand.php
@@ -69,7 +69,6 @@ final class SecurityAttributeLinterCommand extends Command
         'admin_common_reset_search_by_filter_id',
         'admin_common_secured_file_image_reader',
         'admin_common_sidebar',
-        'admin_country_states',
         'admin_currencies_update_live_exchange_rates',
         'admin_emails_send_test',
         'admin_employees_change_form_language',

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/state.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/state.yml
@@ -5,6 +5,14 @@ admin_country_states:
     _controller: PrestaShopBundle\Controller\Admin\Improve\International\StateController::getStatesAction
     _legacy_controller: AdminStates
 
+admin_country_states_options:
+  path: /country-states-options
+  methods: [ GET ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Improve\International\StateController::getLegacyStatesOptionsAction
+    _legacy_controller: AdminStates
+    _legacy_link: AdminStates:states
+
 admin_states_index:
   path: /
   methods: [ GET ]


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fix tax rule group country edition, two ajax calls were not responding anymore:<br>- `AdminTaxRulesGroup::displayAjaxUpdateTaxRule` because the method was protected and not callable anymore<br>- legacy call on `AdminStates` that build and return the list of options was not migrated in the new Symfony `StateController`
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | ~
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/13842578885
| Fixed issue or discussion?     | Fixes #37749
| Related PRs       | ~
| Sponsor company   | ~
