### PR TITLE
Fix: Query to select most used tax rule is simply ridicoulous

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -8009,17 +8009,12 @@ class ProductCore extends ObjectModel
     public static function getIdTaxRulesGroupMostUsed()
     {
         return Db::getInstance()->getValue(
-            'SELECT id_tax_rules_group
-            FROM (
-                SELECT COUNT(*) n, product_shop.id_tax_rules_group
-                FROM ' . _DB_PREFIX_ . 'product p
-                ' . Shop::addSqlAssociation('product', 'p') . '
-                JOIN ' . _DB_PREFIX_ . 'tax_rules_group trg ON (product_shop.id_tax_rules_group = trg.id_tax_rules_group)
-                WHERE trg.active = 1 AND trg.deleted = 0
-                GROUP BY product_shop.id_tax_rules_group
-                ORDER BY n DESC
-                LIMIT 1
-            ) most_used'
+            'SELECT product_shop.id_tax_rules_group
+            FROM ' . _DB_PREFIX_ . 'product_shop product_shop
+            INNER JOIN ' . _DB_PREFIX_ . 'tax_rules_group trg ON product_shop.id_tax_rules_group = trg.id_tax_rules_group
+            WHERE trg.active = 1 AND trg.deleted = 0 AND product_shop.id_shop IN (' . implode(', ', Shop::getContextListShopID()) . ')
+            GROUP BY product_shop.id_tax_rules_group
+            ORDER BY COUNT(*) DESC'
         );
     }
 

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1722,7 +1722,8 @@ CREATE TABLE IF NOT EXISTS `PREFIX_product_shop` (
   ),
   KEY `indexed` (
     `indexed`, `active`, `id_product`
-  )
+  ),
+  INDEX `shop_tax` (`id_shop`, `id_tax_rules_group`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 
 /* list of product attributes (E.g. : color) */


### PR DESCRIPTION
Added index `shop_tax` to the table `product_shop` and optimized the query of the method `Product::getIdTaxRulesGroupMostUsed()`

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | The query in the Product::getIdTaxRulesGroupMostUsed() method, in the case of a database with many products, makes the insertion of a new product very slow (This was noticed by @matteolavaggi).
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/38095 and see: https://github.com/PrestaShop/PrestaShop/pull/38251#issuecomment-2747196930
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #38095
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/1272
| Sponsor company   | @Codencode 