### PR TITLE
Fix: Address Fields Disappear After Changing Country on Checkout Page

### DIFF
--- a/themes/_core/js/address.js
+++ b/themes/_core/js/address.js
@@ -8,13 +8,14 @@ import prestashop from 'prestashop';
  * @param selectors
  */
 function handleCountryChange(selectors) {
-  $('body').on('change', selectors.country, () => {
+  $('body').on('change', selectors.country, (event) => {
     const requestData = {
       id_country: $(selectors.country).val(),
       id_address: $(`${selectors.address} form`).data('id-address'),
     };
     const getFormViewUrl = $(`${selectors.address} form`).data('refresh-url');
     const formFieldsSelector = `${selectors.address} input`;
+    const target = $(event.target);
 
     $.post(getFormViewUrl, requestData).then((resp) => {
       const inputs = [];
@@ -24,7 +25,7 @@ function handleCountryChange(selectors) {
         inputs[$(this).prop('name')] = $(this).val();
       });
 
-      $(selectors.address).replaceWith(resp.address_form);
+      $(target.closest(selectors.address)).replaceWith(resp.address_form);
 
       // Restore fields values
       $(formFieldsSelector).each(function () {


### PR DESCRIPTION
Used `event.target` to dynamically identify the element triggering the country change. Replaced `selectors.address` with `closest(selectors.address)` to correctly update the form without relying on global selectors.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | see: https://github.com/PrestaShop/PrestaShop/issues/38250
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see: https://github.com/PrestaShop/PrestaShop/issues/38250
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/13898834725
| Fixed issue or discussion?     | Fixes #38250
| Related PRs       | 
| Sponsor company   | @Codencode 
