### PR TITLE
Cast icon to string if null

### DIFF
--- a/src/PrestaShopBundle/Twig/Layout/MenuBuilder.php
+++ b/src/PrestaShopBundle/Twig/Layout/MenuBuilder.php
@@ -141,7 +141,7 @@ class MenuBuilder
         return new MenuLink(
             name: $this->getBreadcrumbLabel($tab),
             href: $this->getLinkFromTab($tab),
-            icon: $tab->getIcon(),
+            icon: $tab->getIcon() ?? '',
         );
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fixes icons being null in the database.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open `ps_tab` and set `icon` of `AdminFeatureFlag` to `NULL`. Go to `New & Experimental features` in BO. Without this PR, you will get error in the issue. With this PR, it will work.
| UI Tests          | https://github.com/paulnoelcholot/testing_pr/actions/runs/13918502115 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38092
| Related PRs       | 
| Sponsor company   | 
