### PR TITLE
Fix profiler working with arrays

### DIFF
--- a/tools/profiling/Profiler.php
+++ b/tools/profiling/Profiler.php
@@ -162,6 +162,10 @@ class Profiler
             return $var;
         }
 
+        if (is_array($var)) {
+            return $var;
+        }
+
         return (string) $var;
     }
 

--- a/tools/profiling/Profiler.php
+++ b/tools/profiling/Profiler.php
@@ -154,7 +154,7 @@ class Profiler
      *
      * @param mixed $var
      *
-     * @return string|object
+     * @return string|object|array
      */
     private function getVarData($var)
     {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Avoids error with casting array into a string. Memory usages stayed the same before and after the fix, should work properly.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See issue
| UI Tests          | https://github.com/paulnoelcholot/testing_pr/actions/runs/13918527051
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/36738
| Related PRs       | 
| Sponsor company   | 
