### PR TITLE
Use current ISO 3166-2:IR codes for Iranian provinces

### DIFF
--- a/localization/ir.xml
+++ b/localization/ir.xml
@@ -4,37 +4,37 @@
 		<currency name="Rial" iso_code="IRR" iso_code_num="364" sign="ریال" blank="1" format="4" decimals="0" />
 	</currencies>
 	<states>
-		<state name="آذربایجان شرقی" iso_code="01" country="IR" zone="Asia" />
-		<state name="آذربایجان غربی" iso_code="02" country="IR" zone="Asia" />
-		<state name="اردبیل" iso_code="03" country="IR" zone="Asia" />
-		<state name="البرز" iso_code="32" country="IR" zone="Asia" />
-		<state name="اصفهان" iso_code="04" country="IR" zone="Asia" />
-		<state name="ایلام" iso_code="05" country="IR" zone="Asia" />
-		<state name="بوشهر" iso_code="06" country="IR" zone="Asia" />
-		<state name="تهران" iso_code="07" country="IR" zone="Asia" />
-		<state name="چهارمحال و بختیاری" iso_code="08" country="IR" zone="Asia" />
-		<state name="خراسان جنوبی" iso_code="29" country="IR" zone="Asia" />
-		<state name="خراسان رضوی" iso_code="30" country="IR" zone="Asia" />
-		<state name="خراسان شمالی" iso_code="31" country="IR" zone="Asia" />
-		<state name="خوزستان" iso_code="10" country="IR" zone="Asia" />
-		<state name="زنجان" iso_code="11" country="IR" zone="Asia" />
-		<state name="سمنان" iso_code="12" country="IR" zone="Asia" />
-		<state name="سیستان و بلوچستان" iso_code="13" country="IR" zone="Asia" />
-		<state name="فارس" iso_code="14" country="IR" zone="Asia" />
-		<state name="قزوین" iso_code="28" country="IR" zone="Asia" />
-		<state name="قم" iso_code="26" country="IR" zone="Asia" />
-		<state name="کردستان" iso_code="16" country="IR" zone="Asia" />
-		<state name="کرمان" iso_code="15" country="IR" zone="Asia" />
-		<state name="کرمانشاه" iso_code="17" country="IR" zone="Asia" />
-		<state name="کهگیلویه و بویراحمد" iso_code="18" country="IR" zone="Asia" />
-		<state name="گلستان" iso_code="27" country="IR" zone="Asia" />
-		<state name="گیلان" iso_code="19" country="IR" zone="Asia" />
-		<state name="لرستان" iso_code="20" country="IR" zone="Asia" />
-		<state name="مازندران" iso_code="21" country="IR" zone="Asia" />
-		<state name="مرکزی" iso_code="22" country="IR" zone="Asia" />
-		<state name="هرمزگان" iso_code="23" country="IR" zone="Asia" />
-		<state name="همدان" iso_code="24" country="IR" zone="Asia" />
-		<state name="یزد" iso_code="25" country="IR" zone="Asia" />
+		<state name="آذربایجان شرقی" iso_code="AZS" country="IR" zone="Asia" />
+    <state name="آذربایجان غربی" iso_code="AZG" country="IR" zone="Asia" />
+    <state name="اردبیل" iso_code="ARD" country="IR" zone="Asia" />
+    <state name="البرز" iso_code="ALB" country="IR" zone="Asia" />
+    <state name="اصفهان" iso_code="ESF" country="IR" zone="Asia" />
+    <state name="ایلام" iso_code="ILM" country="IR" zone="Asia" />
+    <state name="بوشهر" iso_code="BUS" country="IR" zone="Asia" />
+    <state name="تهران" iso_code="TEH" country="IR" zone="Asia" />
+    <state name="چهارمحال و بختیاری" iso_code="CHB" country="IR" zone="Asia" />
+    <state name="خراسان جنوبی" iso_code="KHS" country="IR" zone="Asia" />
+    <state name="خراسان رضوی" iso_code="KHR" country="IR" zone="Asia" />
+    <state name="خراسان شمالی" iso_code="KHN" country="IR" zone="Asia" />
+    <state name="خوزستان" iso_code="KHZ" country="IR" zone="Asia" />
+    <state name="زنجان" iso_code="ZAN" country="IR" zone="Asia" />
+    <state name="سمنان" iso_code="SEM" country="IR" zone="Asia" />
+    <state name="سیستان و بلوچستان" iso_code="SBL" country="IR" zone="Asia" />
+    <state name="فارس" iso_code="FAR" country="IR" zone="Asia" />
+    <state name="قزوین" iso_code="QAZ" country="IR" zone="Asia" />
+    <state name="قم" iso_code="QOM" country="IR" zone="Asia" />
+    <state name="کردستان" iso_code="KRD" country="IR" zone="Asia" />
+    <state name="کرمان" iso_code="KRM" country="IR" zone="Asia" />
+    <state name="کرمانشاه" iso_code="KSH" country="IR" zone="Asia" />
+    <state name="کهگیلویه و بویراحمد" iso_code="KOH" country="IR" zone="Asia" />
+    <state name="گلستان" iso_code="GOL" country="IR" zone="Asia" />
+    <state name="گیلان" iso_code="GIL" country="IR" zone="Asia" />
+    <state name="لرستان" iso_code="LOR" country="IR" zone="Asia" />
+    <state name="مازندران" iso_code="MAZ" country="IR" zone="Asia" />
+    <state name="مرکزی" iso_code="MKZ" country="IR" zone="Asia" />
+    <state name="هرمزگان" iso_code="HRM" country="IR" zone="Asia" />
+    <state name="همدان" iso_code="HDN" country="IR" zone="Asia" />
+    <state name="یزد" iso_code="YZD" country="IR" zone="Asia" />
 	</states>
 	<languages>
 		<language iso_code="fa" is_rtl="1" name="پارسی (Persian)" />


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Updates the state codes of the 31 Iranian provinces in `localization/ir.xml` to the current ISO 3166-2:IR codes (`IR-00` to `IR-30`). Details below.
| Type?             | improvement
| Category?         | LO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See "How to test" below.
| UI Tests          | n/a: localization data only, no code change
| Fixed issue or discussion?     | n/a
| Related PRs       | Same change proposed in PrestaShop/LocalizationFiles
| Sponsor company   | Rahkarnet

### Why

ISO renumbered the Iranian subdivisions on 2020-11-24 (change history of ISO 3166-2:IR on the ISO Online Browsing Platform: https://www.iso.org/obp/ui/#iso:code:3166:IR). `ir.xml` still has the numbers from before that change, without the country prefix, so `07` is Tehran in PrestaShop while `IR-07` is Fars in the current standard.

The new values use the `IR-NN` form of the packs that already have numeric ISO codes (`at`, `dk`, `gr`, `jp`, `my`, `th`) and pass `Validate::isStateIsoCode()`. Only the `iso_code` attributes change; names, zones and the rest of the file stay as they are.

The first commit of this PR used three-letter codes (`TEH`, `AZS`…). Those are not ISO codes, and this update replaces them.

### Codes

| Province | Before | After |
|---|---|---|
| Markazi (مرکزی) | `22` | `IR-00` |
| Gilan (گیلان) | `19` | `IR-01` |
| Mazandaran (مازندران) | `21` | `IR-02` |
| East Azerbaijan (آذربایجان شرقی) | `01` | `IR-03` |
| West Azerbaijan (آذربایجان غربی) | `02` | `IR-04` |
| Kermanshah (کرمانشاه) | `17` | `IR-05` |
| Khuzestan (خوزستان) | `10` | `IR-06` |
| Fars (فارس) | `14` | `IR-07` |
| Kerman (کرمان) | `15` | `IR-08` |
| Razavi Khorasan (خراسان رضوی) | `30` | `IR-09` |
| Isfahan (اصفهان) | `04` | `IR-10` |
| Sistan and Baluchestan (سیستان و بلوچستان) | `13` | `IR-11` |
| Kurdistan (کردستان) | `16` | `IR-12` |
| Hamadan (همدان) | `24` | `IR-13` |
| Chaharmahal and Bakhtiari (چهارمحال و بختیاری) | `08` | `IR-14` |
| Lorestan (لرستان) | `20` | `IR-15` |
| Ilam (ایلام) | `05` | `IR-16` |
| Kohgiluyeh and Boyer-Ahmad (کهگیلویه و بویراحمد) | `18` | `IR-17` |
| Bushehr (بوشهر) | `06` | `IR-18` |
| Zanjan (زنجان) | `11` | `IR-19` |
| Semnan (سمنان) | `12` | `IR-20` |
| Yazd (یزد) | `25` | `IR-21` |
| Hormozgan (هرمزگان) | `23` | `IR-22` |
| Tehran (تهران) | `07` | `IR-23` |
| Ardabil (اردبیل) | `03` | `IR-24` |
| Qom (قم) | `26` | `IR-25` |
| Qazvin (قزوین) | `28` | `IR-26` |
| Golestan (گلستان) | `27` | `IR-27` |
| North Khorasan (خراسان شمالی) | `31` | `IR-28` |
| South Khorasan (خراسان جنوبی) | `29` | `IR-29` |
| Alborz (البرز) | `32` | `IR-30` |

### Shops that already have the Iranian states

`LocalizationPack::_installStates()` finds an existing state by `iso_code` only. A shop that has the Iranian states with the old codes and imports the Iran pack again with "States" selected gets a second copy of each province: tested on 9.1.5, 31 states become 62. Fresh installs and shops without Iranian states are not affected, and importing twice on those adds nothing.

### How to test

1. On a shop without Iranian states, go to International > Localization > Import a localization pack. Choose Iran in "Localization pack you want to import", select only "States" in "Content to import", set "Download pack data" to No, and import.
2. Go to International > Locations > States and filter by Iran: 31 states with codes `IR-00` to `IR-30` (for example Tehran `IR-23`, Fars `IR-07`).
3. Import the pack again the same way: there are still 31 states.