### PR TITLE
Add missing function strpos for smarty templates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "prestashop/blockreassurance": "^5",
         "prestashop/blockwishlist": "^3.0",
         "prestashop/circuit-breaker": "^4.0",
-        "prestashop/classic": "^3.0.0",
+        "prestashop/classic": "dev-fix-deprecations",
         "prestashop/contactform": "^4",
         "prestashop/dashactivity": "^2",
         "prestashop/dashgoals": "^2",
@@ -206,6 +206,10 @@
         "vincentlanglet/twig-cs-fixer": "^3.1"
     },
     "repositories": {
+        "classic": {
+            "type": "vcs",
+            "url": "https://github.com/jolelievre/classic-theme.git"
+        },
         "php-sql-parser": {
             "type": "vcs",
             "url": "https://github.com/PrestaShop/PHP-SQL-Parser"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a437daf13df2ad2a93100ebe8685f931",
+    "content-hash": "7b8097e6a8fa01503221ab8861d195c0",
     "packages": [
         {
             "name": "api-platform/core",
@@ -4658,16 +4658,16 @@
         },
         {
             "name": "prestashop/classic",
-            "version": "3.0.1",
+            "version": "dev-fix-deprecations",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PrestaShop/classic-theme.git",
-                "reference": "532b0470d13b1d73e32e5806d2bc0b68cdbe7a44"
+                "url": "https://github.com/jolelievre/classic-theme.git",
+                "reference": "e8267eb86ea86429ccabc5c3e531b0c431aaa323"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/classic-theme/zipball/532b0470d13b1d73e32e5806d2bc0b68cdbe7a44",
-                "reference": "532b0470d13b1d73e32e5806d2bc0b68cdbe7a44",
+                "url": "https://api.github.com/repos/jolelievre/classic-theme/zipball/e8267eb86ea86429ccabc5c3e531b0c431aaa323",
+                "reference": "e8267eb86ea86429ccabc5c3e531b0c431aaa323",
                 "shasum": ""
             },
             "require-dev": {
@@ -4675,7 +4675,6 @@
                 "symfony/yaml": "~4.4 || ^5.0"
             },
             "type": "prestashop-theme",
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "AFL-3.0"
             ],
@@ -4691,9 +4690,9 @@
             ],
             "description": "Classic theme for develop PrestaShop version",
             "support": {
-                "source": "https://github.com/PrestaShop/classic-theme/tree/3.0.1"
+                "source": "https://github.com/jolelievre/classic-theme/tree/fix-deprecations"
             },
-            "time": "2025-01-29T15:34:57+00:00"
+            "time": "2025-03-18T15:37:09+00:00"
         },
         {
             "name": "prestashop/contactform",
@@ -18222,6 +18221,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "prestashop/classic": 20,
         "prestashop/ps_apiresources": 20
     },
     "prefer-stable": true,

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -127,6 +127,7 @@ smartyRegisterFunction($smarty, 'modifier', 'strstr', 'strstr');
 smartyRegisterFunction($smarty, 'modifier', 'strtolower', 'strtolower');
 smartyRegisterFunction($smarty, 'modifier', 'strval', 'strval');
 smartyRegisterFunction($smarty, 'modifier', 'substr', 'substr');
+smartyRegisterFunction($smarty, 'modifier', 'strpos', 'strpos');
 smartyRegisterFunction($smarty, 'modifier', 'trim', 'trim');
 smartyRegisterFunction($smarty, 'modifier', 'ucfirst', 'ucfirst');
 smartyRegisterFunction($smarty, 'modifier', 'urlencode', 'urlencode');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Add missing function strpos for smarty templates
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See issue, after install you shouldn't see the deprecation notices on the product page anymore
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/13927461473
| Fixed issue or discussion?     | Fixes #37722 and #38053
| Related PRs       | Fix on classic theme https://github.com/PrestaShop/classic-theme/pull/165
| Sponsor company   | Your company or customer's name goes here (if applicable).

This issue is fixed with two PRs
- this one
- a PR on classic theme https://github.com/PrestaShop/classic-theme/pull/165

The classic theme has been forced to use the fix PR so both can be validated at the same time. If QA is ok on this one it will also validate the PR on the module and it can be merged. The fix will be included in the next match for classic theme
