### PR TITLE
Fix mail theme scanner when used on a module folder

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/core/mail_template.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/mail_template.yml
@@ -7,6 +7,8 @@ services:
 
   prestashop.core.mail_template.theme_folder_scanner:
     class: 'PrestaShop\PrestaShop\Core\MailTemplate\FolderThemeScanner'
+    arguments:
+      $moduleDirectory: '%modules_dir%'
 
   PrestaShop\PrestaShop\Core\MailTemplate\FolderThemeCatalog:
     arguments:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fix mail theme scanner when used on a module folder
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Test with the example module (see related PR)
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/13931648525
| Fixed issue or discussion?     | Fixes #38299
| Related PRs       | https://github.com/PrestaShop/example-modules/pull/200
| Sponsor company   | ~
