### PR TITLE
Use set_charset instead of SET NAMES

### DIFF
--- a/classes/db/DbMySQLi.php
+++ b/classes/db/DbMySQLi.php
@@ -82,7 +82,7 @@ class DbMySQLiCore extends Db
         }
 
         // UTF-8 support
-        if (!$this->link->query('SET NAMES utf8mb4')) {
+        if (!$this->link->set_charset('utf8mb4')) {
             throw new PrestaShopDatabaseException(Context::getContext()->getTranslator()->trans(
                 'PrestaShop Fatal error: no utf-8 support. Please check your server configuration.',
                 [],

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -70,7 +70,6 @@ class DbPDOCore extends Db
             [
                 PDO::ATTR_TIMEOUT => $timeout,
                 PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
-                PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
                 PDO::MYSQL_ATTR_MULTI_STATEMENTS => _PS_ALLOW_MULTI_STATEMENTS_QUERIES_,
             ]
         );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | While, technically, this is safe from SQL injection, it's not wise to do it this way. Since this project doesn't use prepared statements, PHP needs to know what charset is set. Using `SET NAMES` PHP is left in the dark. When using `set_charset` PHP saves the connection charset and sends `SET NAMES` to the server. Also, PDO does the same when `charset` is specified in DSN.
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Just keep using it as normal
| UI Tests          | No UI changes
| Fixed issue or discussion?     | No
| Related PRs       | None
| Sponsor company   | None
