### PR TITLE
[BO] Fix error with 'categories' field type in ModuleAdminController

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/LegacyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/LegacyController.php
@@ -116,7 +116,10 @@ class LegacyController extends PrestaShopAdminController
         header('Cache-Control: no-store, no-cache');
 
         $smarty = $this->legacyContext->getSmarty();
-        $smarty->setTemplateDir(_PS_BO_ALL_THEMES_DIR_ . 'default/template/');
+        $smarty->setTemplateDir([
+            _PS_BO_ALL_THEMES_DIR_ . 'default/template/',
+            _PS_OVERRIDE_DIR_ . 'controllers/admin/templates',
+        ]);;
 
         $isAjaxRequest = (bool) $request->get('ajax');
         if ($isAjaxRequest) {

--- a/src/PrestaShopBundle/Controller/Admin/LegacyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/LegacyController.php
@@ -119,7 +119,7 @@ class LegacyController extends PrestaShopAdminController
         $smarty->setTemplateDir([
             _PS_BO_ALL_THEMES_DIR_ . 'default/template/',
             _PS_OVERRIDE_DIR_ . 'controllers/admin/templates',
-        ]);;
+        ]);
 
         $isAjaxRequest = (bool) $request->get('ajax');
         if ($isAjaxRequest) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When there is a field type "categories" in the module admin controller, there is an error
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check the bug https://github.com/PrestaShop/PrestaShop/issues/38321
| Fixed issue or discussion?     | Fixes #38321
| Sponsor company   | idnovate.com
