### PR TITLE
bug fix copyFromPost that remove overrided object model definitions

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3725,10 +3725,9 @@ class AdminControllerCore extends Controller
         }
 
         /* Multilingual fields */
-        $class_vars = get_class_vars(get_class($object));
         $fields = [];
-        if (isset($class_vars['definition']['fields'])) {
-            $fields = $class_vars['definition']['fields'];
+        if (isset($object::$definition['fields'])) {
+            $fields = $object::$definition['fields'];
         }
 
         foreach ($fields as $field => $params) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | php 8.1 change get_class_vars behavior and don't instanciate class anymore
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Override an object model and add a new multilang field in $definition, call copyFromPost and see that the definition don't have this new field in php 8.1. You can test this with my demo module here https://github.com/jf-viguier/demooverridelegacycontroller/releases
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/14078282742
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/issues/38380
| Sponsor company   | Creabilis.com


You can understand the change here https://github.com/php/php-src/issues/13835
Issue on php here : https://github.com/php/php-src/issues/13835