### PR TITLE
Fix actionFilterDeliveryOptionList hook Cart Param

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3164,6 +3164,7 @@ class CartCore extends ObjectModel
             'actionFilterDeliveryOptionList',
             [
                 'delivery_option_list' => &$delivery_option_list,
+                'cart' => $this
             ]
         );
 


### PR DESCRIPTION
Pull request to fix a parameter issue in a hook triggered within the Cart class. Currently, the hook is called without explicitly passing the cart instance as a parameter. As a result, the Hook class injects the cart from the context, which might not correspond to the actual cart instance, potentially leading to errors.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.2.x
| Description?      | Pull request to fix a parameter issue in a hook triggered within the Cart class. Currently, the hook is called without explicitly passing the cart instance as a parameter. As a result, the Hook class injects the cart from the context, which might not correspond to the actual cart instance, potentially leading to errors.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     |  no