### PR TITLE
Fix: Max password length allowed in the password policy is longer than bcrypt can handle and hardcoded max pass length for customer

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/PasswordPolicyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/PasswordPolicyType.php
@@ -62,7 +62,7 @@ class PasswordPolicyType extends TranslatorAwareType
                     'label' => $this->trans('Maximum length', 'Admin.Advparameters.Feature'),
                     'attr' => [
                         'min' => 1,
-                        'max' => 100,
+                        'max' => 72,
                     ],
                     'required' => true,
                 ]

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -216,22 +216,22 @@ class CustomerType extends TranslatorAwareType
                     'Password should be at least %length% characters long.',
                     'Admin.Notifications.Info',
                     [
-                        '%length%' => Password::MIN_LENGTH,
+                        '%length%' => $minLength,
                     ]
                 ),
                 'constraints' => [
                     new Length([
-                        'max' => Password::MAX_LENGTH,
+                        'max' => $maxLength,
                         'maxMessage' => $this->trans(
                             'This field cannot be longer than %limit% characters',
                             'Admin.Notifications.Error',
-                            ['%limit%' => Password::MAX_LENGTH]
+                            ['%limit%' => $maxLength]
                         ),
-                        'min' => Password::MIN_LENGTH,
+                        'min' => $minLength,
                         'minMessage' => $this->trans(
                             'This field cannot be shorter than %limit% characters',
                             'Admin.Notifications.Error',
-                            ['%limit%' => Password::MIN_LENGTH]
+                            ['%limit%' => $minLength]
                         ),
                     ]),
                 ],


### PR DESCRIPTION
The maximum length supported by the password_hash algorithm is 72 bytes.
See: https://www.php.net/manual/en/function.password-hash.php

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | see: https://github.com/PrestaShop/PrestaShop/issues/37898
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see: https://github.com/PrestaShop/PrestaShop/issues/37898
| UI Tests          |https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/15390565417
| Fixed issue or discussion?     | Fixes #37898
| Related PRs       | #29776
| Sponsor company   | @Codencode 
