### PR TITLE
Fix: product carrier delete

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -255,14 +255,19 @@ class CarrierCore extends ObjectModel
      */
     public function delete()
     {
-        if (!parent::delete()) {
-            return false;
-        }
-        Carrier::cleanPositions();
+        if ($this->isUsed()) {
+            return parent::softDelete() && Carrier::cleanPositions();
+        } else {
+            if (!parent::delete()) {
+                return false;
+            }
 
-        return Db::getInstance()->delete('cart_rule_carrier', 'id_carrier = ' . (int) $this->id) &&
-                Db::getInstance()->delete('module_carrier', 'id_reference = ' . (int) $this->id_reference) &&
-                $this->deleteTaxRulesGroup(Shop::getShops(true, null, true));
+            Carrier::cleanPositions();
+
+            return Db::getInstance()->delete('cart_rule_carrier', 'id_carrier = ' . (int) $this->id) &&
+                    Db::getInstance()->delete('module_carrier', 'id_reference = ' . (int) $this->id_reference) &&
+                    $this->deleteTaxRulesGroup(Shop::getShops(true, null, true));
+        }
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Fix inconsistency between Back Office and Web Service when deleting a product carrier.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| UI tests | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/14038314804
| How to test?      |  Delete a product carrier via the Web Service and check if the carrier still exists in the database.
| Fixed issue or discussion?     | Fixes #38317
| Sponsor company   | PrestaShop
