### PR TITLE
Translation fixes

### DIFF
--- a/install-dev/fixtures/fashion/langs/fr/data/attribute.xml
+++ b/install-dev/fixtures/fashion/langs/fr/data/attribute.xml
@@ -25,13 +25,13 @@
     <name>White</name>
   </attribute>
   <attribute id="Off_White">
-    <name>Off White</name>
+    <name>Blanc cassé</name>
   </attribute>
   <attribute id="Red">
-    <name>Red</name>
+    <name>Rouge</name>
   </attribute>
   <attribute id="Black">
-    <name>Black</name>
+    <name>Noir</name>
   </attribute>
   <attribute id="Camel">
     <name>Camel</name>
@@ -40,19 +40,19 @@
     <name>Orange</name>
   </attribute>
   <attribute id="Blue">
-    <name>Blue</name>
+    <name>Bleu</name>
   </attribute>
   <attribute id="Green">
-    <name>Green</name>
+    <name>Vert</name>
   </attribute>
   <attribute id="Yellow">
-    <name>Yellow</name>
+    <name>Jaune</name>
   </attribute>
   <attribute id="Brown">
-    <name>Brown</name>
+    <name>Marron</name>
   </attribute>
   <attribute id="Pink">
-    <name>Pink</name>
+    <name>Rose</name>
   </attribute>
   <attribute id="40x60cm">
     <name>40x60cm</name>

--- a/install-dev/fixtures/fashion/langs/fr/data/attribute_group.xml
+++ b/install-dev/fixtures/fashion/langs/fr/data/attribute_group.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <entity_attribute_group>
   <attribute_group id="Size">
-    <name>Size</name>
-    <public_name>Size</public_name>
+    <name>Taille</name>
+    <public_name>Taille</public_name>
   </attribute_group>
   <attribute_group id="Color">
-    <name>Color</name>
-    <public_name>Color</public_name>
+    <name>Couleur</name>
+    <public_name>Couleur</public_name>
   </attribute_group>
   <attribute_group id="Dimension">
     <name>Dimension</name>

--- a/install-dev/fixtures/fashion/langs/fr/data/carrier.xml
+++ b/install-dev/fixtures/fashion/langs/fr/data/carrier.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <entity_carrier>
   <carrier id="My_carrier" id_shop="1">
-    <delay>Delivery next day!</delay>
+    <delay>Livraison le lendemain !</delay>
   </carrier>
   <carrier id="My_cheap_carrier" id_shop="1">
-    <delay>Achetez plus vous paierez moins!</delay>
+    <delay>Achetez plus vous paierez moins !</delay>
   </carrier>
   <carrier id="My_light_carrier" id_shop="1">
-    <delay>Panier léger, prix allégé!</delay>
+    <delay>Panier léger, prix allégé !</delay>
   </carrier>
 </entity_carrier>

--- a/install-dev/fixtures/fashion/langs/fr/data/feature_value.xml
+++ b/install-dev/fixtures/fashion/langs/fr/data/feature_value.xml
@@ -4,13 +4,13 @@
     <value>Polyester</value>
   </feature_value>
   <feature_value id="Wool">
-    <value>Wool</value>
+    <value>Laine</value>
   </feature_value>
   <feature_value id="Ceramic">
     <value>Céramique</value>
   </feature_value>
   <feature_value id="Cotton">
-    <value>Cotton</value>
+    <value>Coton</value>
   </feature_value>
   <feature_value id="Recycled_Cardboard">
     <value>Carton recycl&#xE9;</value>

--- a/src/PrestaShopBundle/Translation/DataCollectorTranslator.php
+++ b/src/PrestaShopBundle/Translation/DataCollectorTranslator.php
@@ -27,10 +27,28 @@
 namespace PrestaShopBundle\Translation;
 
 use Symfony\Component\Translation\DataCollectorTranslator as BaseTranslator;
+use Symfony\Component\Translation\Loader\LoaderInterface;
 
+/**
+ * This is the decorator of the framework DataCollectorTranslator service, it is required mostly
+ * for the PrestaShopTranslatorTrait that handles fallback on legacy translation system when useful.
+ *
+ * We need to explicitly implement some method even if they are just proxies because the TranslatorLanguageLoader
+ * checks their presence before calling them.
+ */
 class DataCollectorTranslator extends BaseTranslator implements TranslatorInterface
 {
     use PrestaShopTranslatorTrait;
+
+    public function addLoader(string $format, LoaderInterface $loader)
+    {
+        return $this->__call('addLoader', [$format, $loader]);
+    }
+
+    public function addResource(string $format, mixed $resource, string $locale, ?string $domain = null)
+    {
+        return $this->__call('addResource', [$format, $resource, $locale, $domain]);
+    }
 
     /**
      * {@inheritdoc}

--- a/tests/Integration/Behaviour/Features/Scenario/Attribute/Shop/list_multishop_attribute_groups.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Attribute/Shop/list_multishop_attribute_groups.feature
@@ -11,7 +11,7 @@ Feature: Attribute Group
     And attribute group "color" named "Color" in en language exists
     And attribute group "dimension" named "Dimension" in en language exists
     And attribute group "paper_type" named "Paper Type" in en language exists
-    And attribute "grey" named "Grey" in en language exists
+    And attribute "gray" named "Gray" in en language exists
     And attribute "taupe" named "Taupe" in en language exists
     And attribute "beige" named "Beige" in en language exists
     And attribute "white" named "White" in en language exists
@@ -41,7 +41,7 @@ Feature: Attribute Group
     And attribute group "color" is not associated to shops "shop2"
     And attribute group "dimension" is not associated to shops "shop2"
     And attribute group "paper_type" is not associated to shops "shop2"
-    And attribute "grey" is not associated to shops "shop2"
+    And attribute "gray" is not associated to shops "shop2"
     And attribute "taupe" is not associated to shops "shop2"
     And attribute "beige" is not associated to shops "shop2"
     And attribute "white" is not associated to shops "shop2"
@@ -85,7 +85,7 @@ Feature: Attribute Group
       | XL          |       | 3        | xl        |
     And the attribute group "color" should have the following attributes for shops "shop1":
       | name[en-US] | color   | position | reference |
-      | Grey        | #AAB2BD | 0        | grey      |
+      | Gray        | #AAB2BD | 0        | gray      |
       | Taupe       | #CFC4A6 | 1        | taupe     |
       | Beige       | #f5f5dc | 2        | beige     |
       | White       | #ffffff | 3        | white     |

--- a/tests/Integration/Behaviour/Features/Scenario/Attribute/list_attribute_groups.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Attribute/list_attribute_groups.feature
@@ -16,7 +16,7 @@ Feature: Attribute Group
     And attribute "m" named "M" in en language exists
     And attribute "l" named "L" in en language exists
     And attribute "xl" named "XL" in en language exists
-    And attribute "grey" named "Grey" in en language exists
+    And attribute "gray" named "Gray" in en language exists
     And attribute "taupe" named "Taupe" in en language exists
     And attribute "beige" named "Beige" in en language exists
     And attribute "white" named "White" in en language exists
@@ -47,7 +47,7 @@ Feature: Attribute Group
       | XL          |       | 3        | xl        |
     And the attribute group "color" should have the following attributes:
       | name[en-US] | color   | position | reference |
-      | Grey        | #AAB2BD | 0        | grey      |
+      | Gray        | #AAB2BD | 0        | gray      |
       | Taupe       | #CFC4A6 | 1        | taupe     |
       | Beige       | #f5f5dc | 2        | beige     |
       | White       | #ffffff | 3        | white     |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Improve translator catalog updates during the processes that update the XLF catalog themselves, this improves (among other things):<br/>- installation with multiple languages (the menu was not correctly translated in all languages in the Tab DB)<br/>- importing a new localization pack, the Tab element that use a module wording were not correctly updated
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/14066048488
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~

### How to test

1. Install the shop with CLI command to force a language different from the country selected, this forces the installation of two different languages during the install process (I'm not sure if it's doable with the web interface), you must make sure that your cache folder is empty and that you have no zip and no folders for any languages in the `translations` folder
2. CLI command `php install-dev/index_cli.php  --language=en --country=fr --db_create=1` (you may need additional parameters for the DB settings, the domain, the email and stuff but that's related to your environment and how you're used to test)
3. Log in the BO you should be in English by default, go to your profile and change the language of your employee to French
4. The menu is translated because during the install process the catalogues were not available therefore the DB is filled with english values
5. The form itself is not translated, because the catalogue was not available when the translator created its cache and now it's empty for french until cache is cleared
6. Clear the cache (by removing the `var/cache/*` folders for example), refresh the page now at least the form labels are translated, but the menu content from DB is still not translated

Perform this same steps with the PR now (make sure to remove the cache and downloaded cataloged in translation folder both the zip and the language folder) Retry the full install both problems should be fixed:
- the menu is correctly translated in all languages
- when you switch your language the whole BO is correctly translated without cleaning the cache