### PR TITLE
Update StockManager.php

### DIFF
--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -159,23 +159,41 @@ class StockManager
             ';
         }
 
-        $updateReservedQuantityQuery .= '
-            SET sa.reserved_quantity = (
-                SELECT SUM(od.product_quantity - od.product_quantity_refunded)
-                FROM {table_prefix}orders o
-                INNER JOIN {table_prefix}order_detail od ON od.id_order = o.id_order
-                INNER JOIN {table_prefix}order_state os ON os.id_order_state = o.current_state
-                WHERE o.id_shop = :shop_id AND
-                os.shipped != 1 AND (
-                    o.valid = 1 OR (
-                        os.id_order_state != :error_state AND
-                        os.id_order_state != :cancellation_state
+        $updateReservedQuantityQuery = '
+        UPDATE {table_prefix}stock_available sa
+        LEFT JOIN (
+            SELECT 
+                od.product_id,
+                od.product_attribute_id,
+                SUM(
+                    GREATEST(0, 
+                        CAST(od.product_quantity AS SIGNED) - CAST(od.product_quantity_refunded AS SIGNED)
                     )
-                ) AND sa.id_product = od.product_id AND
-                sa.id_product_attribute = od.product_attribute_id
-                GROUP BY od.product_id, od.product_attribute_id
-            )
-            WHERE sa.id_shop = :shop_id
+                ) AS new_reserved_quantity
+            FROM 
+                {table_prefix}order_detail od
+            INNER JOIN 
+                {table_prefix}orders o ON od.id_order = o.id_order
+            INNER JOIN 
+                {table_prefix}order_state os ON os.id_order_state = o.current_state
+            WHERE 
+                o.id_shop = :shop_id
+                AND os.shipped != 1 
+                AND (
+                    o.valid = 1 
+                    OR (
+                        os.id_order_state != :error_state 
+                        AND os.id_order_state != :cancellation_state
+                    )
+                )
+            GROUP BY 
+                od.product_id, od.product_attribute_id
+        ) calculated_quantity ON sa.id_product = calculated_quantity.product_id 
+            AND sa.id_product_attribute = calculated_quantity.product_attribute_id
+        SET 
+            sa.reserved_quantity = IFNULL(calculated_quantity.new_reserved_quantity, 0)
+        WHERE 
+            sa.id_shop = :shop_id
         ';
 
         $strParams = [


### PR DESCRIPTION
<html><head></head><body><h1>Fix for issue #37338: BIGINT UNSIGNED value out of range error</h1>

Questions | Answers
-- | --
Branch? | develop
Description? | Fix SQLSTATE[22003]: Numeric value out of range error that occurs during order validation when product_quantity_refunded exceeds product_quantity
Type? | bug fix
Category? | BO
BC breaks? | no
Deprecations? | no
How to test? | See testing steps below
UI Tests | <!-- Please run UI tests and paste here the link to the run -->
Fixed issue or discussion? | Fixes #37338
Related PRs | N/A
Sponsor company | <!-- Your company name -->


<h2>Description</h2>
<p>This PR fixes a SQL error that occurs during order validation when the quantity refunded is greater than the ordered quantity, resulting in a negative value which is incompatible with UNSIGNED integers in the database.</p>
<p>The error occurs specifically in the <code>updateReservedProductQuantity</code> method of the <code>StockManager</code> class, when the calculation <code>product_quantity - product_quantity_refunded</code> results in a negative value, which is not allowed for BIGINT UNSIGNED columns.</p>
<h2>Technical solution</h2>
<p>The solution implements a CASE statement to ensure we never subtract a larger value from a smaller one:</p>
<pre><code class="language-sql">SUM(
    CASE 
        WHEN od.product_quantity &gt;= od.product_quantity_refunded 
        THEN od.product_quantity - od.product_quantity_refunded
        ELSE 0
    END
) AS new_reserved_quantity
</code></pre>
<p>This ensures that the result is always non-negative, preventing the UNSIGNED value out of range error.</p>
<h2>How to test</h2>
<ol>
<li>
<p><strong>Setup prerequisites:</strong></p>
<ul>
<li>Install PrestaShop with demo data</li>
<li>Enable the "Payment by Check" module</li>
</ul>
</li>
<li>
<p><strong>Reproduce the issue:</strong></p>
<ul>
<li>Place an order using the "Payment by Check" payment method for any product</li>
<li>Go to the order in the back office and mark it as "Payment accepted"</li>
<li>Go to "Merchandise Returns" and enable merchandise returns</li>
<li>Create a merchandise return for the order, requesting a refund for more units than were actually ordered</li>
<li>Process the merchandise return and approve the refund</li>
<li>Try to place another order with the same product</li>
<li>The error will occur during checkout validation</li>
</ul>
</li>
<li>
<p><strong>Verify the fix:</strong></p>
<ul>
<li>Apply this patch</li>
<li>Repeat the steps above</li>
<li>The checkout process should complete without errors</li>
<li>Verify that stock management still works correctly with the updated query</li>
</ul>
</li>
</ol>
<h2>Additional notes</h2>
<p>This issue occurs because PrestaShop allows setting refunded quantities that can be higher than ordered quantities in some circumstances. While this fix addresses the SQL error, the root cause (allowing refunded quantities to exceed ordered quantities) may need to be addressed separately.</p></body></html>