### PR TITLE
Problem with decimal separator and eco-tax on Combination Form

### DIFF
--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -380,6 +380,12 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
             $form_data['combinations'][$k]['attribute_wholesale_price'] = abs(
                 $this->floatParser->fromString($combination['attribute_wholesale_price'])
             );
+
+            if (isset($combination['attribute_ecotax'])) {
+                $form_data['combinations'][$k]['attribute_ecotax'] = abs(
+                    $this->floatParser->fromString($combination['attribute_ecotax'])
+                );
+            }
         }
 
         //map suppliers


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Correction for combination ecotax (specifically in languages having "," as a decimal separator)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Save a decimal eco tax (in a language have "," as a decimal separator), and then edit the combination again without changing ecotax, without my bugfix it will be set to 0.0000
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | WEB PREMIERE
