### PR TITLE
Idea: With billing disabled, the emails display "download invoice"

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/core/mail_template.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/mail_template.yml
@@ -27,7 +27,9 @@ services:
     arguments:
       - '@prestashop.core.hook.dispatcher'
       - '@prestashop.core.language.language_default_fonts_catalog'
-      - mailThemesUrl: "@=service('prestashop.adapter.legacy.context').getMailThemesUrl()"
+      -
+        mailThemesUrl: "@=service('prestashop.adapter.legacy.context').getMailThemesUrl()"
+        psInvoice: "@=service('prestashop.adapter.legacy.configuration').get('PS_INVOICE')"
 
   prestashop.core.mail_template.generator:
     class: 'PrestaShop\PrestaShop\Core\MailTemplate\MailTemplateGenerator'

--- a/src/PrestaShopBundle/Resources/config/services/core/mail_template.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/mail_template.yml
@@ -20,7 +20,9 @@ services:
     arguments:
       - '@prestashop.core.hook.dispatcher'
       - '@prestashop.core.language.language_default_fonts_catalog'
-      - mailThemesUrl: "@=service('prestashop.adapter.legacy.context').getMailThemesUrl()"
+      -
+        mailThemesUrl: "@=service('prestashop.adapter.legacy.context').getMailThemesUrl()"
+        psInvoice: "@=service('prestashop.adapter.legacy.configuration').get('PS_INVOICE')"
 
   prestashop.core.mail_template.generator:
     class: 'PrestaShop\PrestaShop\Core\MailTemplate\MailTemplateGenerator'


### PR DESCRIPTION
If billing is not enabled, the system uses the message "Follow your order on our store, go to the Order History and Details section of your customer account." instead of the message "Follow your order and download your invoice on our store, go to the Order History and Details section of your customer account."

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.2.x
| Description?      | This PR exposes the `PS_INVOICE` configuration value to email layout templates through the new `psInvoice` layout variable.<br/><br/>The variable can be used by Twig email layouts to adapt their content depending on whether PrestaShop's native invoice generation is enabled.<br/><br/>This PR does not directly modify the email templates. The corresponding MJML template changes are implemented in: PrestaShop/mjml-theme-converter#37<br/><br/>Some email templates currently tell customers that they can download their invoice from their customer account, even when native invoice generation is disabled in PrestaShop.<br/><br/>The email templates need access to the `PS_INVOICE` configuration value so that the appropriate wording can be selected when the layouts are generated.
| Type?             | improvement 
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | This PR must be tested together with PrestaShop/mjml-theme-converter#37. <br/><br/>1. Enable native invoice generation.<br/>2. Generate the email templates.<br/>3. Verify that the generated templates contain the message mentioning the invoice download.<br/>4. Disable native invoice generation.<br/>5. Regenerate the email templates.<br/>6. Verify that the generated templates contain the alternative message without the invoice download reference.
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/29644614420
| Fixed issue or discussion?     | Fixes #38357
| Related PRs       | https://github.com/PrestaShop/mjml-theme-converter/pull/37
| Sponsor company   | @Codencode 
