### PR TITLE
Add new FO hook for additional content in cart product lines

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -845,16 +845,6 @@ class CartCore extends ObjectModel
                 }
 
                 $this->_products[] = $product;
-
-                // Add hook for additional content on each cart product line
-                $additionalContent = Hook::exec('displayCartProductLineAdditionalContent', [
-                    'product' => $product,
-                    'cart' => $this
-                ], null, true);
-
-                if (!empty($additionalContent)) {
-                    $product['additional_content'] = $additionalContent;
-                }
             }
         } else {
             $this->_products = $products;

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -845,6 +845,16 @@ class CartCore extends ObjectModel
                 }
 
                 $this->_products[] = $product;
+
+                // Add hook for additional content on each cart product line
+                $additionalContent = Hook::exec('displayCartProductLineAdditionalContent', [
+                    'product' => $product,
+                    'cart' => $this
+                ], null, true);
+
+                if (!empty($additionalContent)) {
+                    $product['additional_content'] = $additionalContent;
+                }
             }
         } else {
             $this->_products = $products;

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -5403,10 +5403,10 @@
       <title>Modify search term identifiable object data after creating it</title>
       <description>This hook allows to modify search term identifiable object forms data after it was created</description>
     </hook>
-    <hook id="displayCartProductLineAdditionalContent">
-      <name>displayCartProductLineAdditionalContent</name>
-      <title>Display cart product line additional content</title>
-      <description>This hook is called when the cart product line additional content is displayed</description>
+    <hook id="actionCartProductLineAdditionalContent">
+      <name>actionCartProductLineAdditionalContent</name>
+      <title>Enrich products with additional data via hook</title>
+      <description>This hook allows to add additional content and data to products in the shopping cart</description>
     </hook>
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -5403,5 +5403,10 @@
       <title>Modify search term identifiable object data after creating it</title>
       <description>This hook allows to modify search term identifiable object forms data after it was created</description>
     </hook>
+    <hook id="displayCartProductLineAdditionalContent">
+      <name>displayCartProductLineAdditionalContent</name>
+      <title>Display cart product line additional content</title>
+      <description>This hook is called when the cart product line additional content is displayed</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -129,6 +129,15 @@ class CartLazyArray extends AbstractLazyArray
         // And add customizations made
         $this->products = $this->cartPresenter->addCustomizedData($presentedProducts, $this->cart);
 
+        // Execute hook to allow modules to add additional content to each product line
+        foreach ($this->products as &$product) {
+            \Hook::exec('actionCartProductLineAdditionalContent', [
+                'product' => &$product,
+                'cart' => $this->cart,
+            ], null, true);
+        }
+        unset($product); // Unset reference to avoid potential issues
+
         return $this->products;
     }
 

--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -131,7 +131,7 @@ class CartLazyArray extends AbstractLazyArray
 
         // Execute hook to allow modules to add additional content to each product line
         foreach ($this->products as &$product) {
-            \Hook::exec('actionCartProductLineAdditionalContent', [
+            Hook::exec('actionCartProductLineAdditionalContent', [
                 'product' => &$product,
                 'cart' => $this->cart,
             ], null, true);


### PR DESCRIPTION
The new hook `actionCartProductLineAdditionalContent` introduces enhanced flexibility for product display in the cart, offering significant advantages for both theme developers and module creators:

### Key Benefits

#### For Theme Developers
- Ability to customize cart product presentation without core modifications
- Enhanced control over product information layout in the cart
- Possibility to add theme-specific product details (e.g., custom badges, labels)
- Better integration with various design systems and frameworks
- Simplified responsive design implementation for cart items

#### For Module Developers
- Direct integration point for product-specific features
- Ability to display:
  - Real-time stock status
  - Delivery time estimates
  - Product customization options
  - Warranty information
  - Cross-selling suggestions
  - Product-specific promotions
  - Custom attributes and features

### Technical Implementation Advantages
- Clean separation of concerns
- No override requirements
- Standardized integration point
- Performance-optimized implementation
- Full access to product and cart context

### Use Cases Examples
1. Stock Management Modules
   - Display real-time inventory levels
   - Show warehouse location
   - indicate restock dates

2. Shipping Modules
   - Show delivery time estimates
   - Display shipping restrictions
   - Present handling requirements

3. Product Enhancement Modules
   - Display product certifications
   - Show eco-friendly badges
   - Present product ratings

This enhancement significantly improves PrestaShop's extensibility while maintaining clean code architecture and providing developers with more tools to create enhanced shopping experiences.
| Questions | Answers |
| --------- | ------- |
| Branch? | develop |
| Description? | Introduced a new hook, `actionCartProductLineAdditionalContent`, to allow for the inclusion of additional content for each product line in the cart. This enhances the cart's extensibility by enabling developers to customize the display of product information. |
| Type? | improvement |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | 1. Install the module [qahookactioncartproductlineadditionalcontent.zip](https://github.com/user-attachments/files/19531434/qahookactioncartproductlineadditionalcontent.zip)<br><br>2. In `themes/the_current/templates/checkout/_partials/cart-detailed-product-line.tpl` after:<br><pre>{block name='hook_cart_extra_product_actions'}<br>    {hook h='displayCartExtraProductActions' product=$product}<br>{/block}</pre><br>Add:<br><pre>{if isset($product.additional_info)}<br>    &lt;div class="product-line__additional-info"&gt;<br>        {foreach from=$product.additional_info key="key" item="info"}<br>            {foreach from=$info item="value"}<br>                &lt;div class="product-line__additional-info-item"&gt;<br>                    &lt;span class="label"&gt;{$key}:&lt;/span&gt;<br>                    &lt;span class="value"&gt;{$value}&lt;/span&gt;<br>                &lt;/div&gt;<br>            {/foreach}<br>        {/foreach}<br>    &lt;/div&gt;<br>{/if}</pre> |
| Fixed issue or discussion? | https://github.com/PrestaShop/PrestaShop/discussions/38368 |
