### PR TITLE
Feat - Add hook actionCartDuplicate

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4482,10 +4482,8 @@ class CartCore extends ObjectModel
             return false;
         }
 
-        $cart = new Cart($this->id);
-        $cart->id = null;
-        $cart->id_shop = $this->id_shop;
-        $cart->id_shop_group = $this->id_shop_group;
+        /** @var Cart $cart */
+        $cart = $this->duplicateObject();
 
         if (!Customer::customerHasAddress((int) $cart->id_customer, (int) $cart->id_address_delivery)) {
             $cart->id_address_delivery = (int) Address::getFirstCustomerAddressId((int) $cart->id_customer);
@@ -4499,9 +4497,9 @@ class CartCore extends ObjectModel
             $cart->secure_key = Cart::$_customer->secure_key;
         }
 
-        $cart->add();
+        $cart->save();
 
-        if (!Validate::isLoadedObject($cart)) {
+        if (!$cart || !Validate::isLoadedObject($cart)) {
             return false;
         }
 
@@ -4610,6 +4608,8 @@ class CartCore extends ObjectModel
                 false
             );
         }
+
+        Hook::exec('actionDuplicateCartData', ['oldCardId' => $this->id, 'newCartId' => $cart->id]);
 
         return ['cart' => $cart, 'success' => $success];
     }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4499,7 +4499,7 @@ class CartCore extends ObjectModel
 
         $cart->save();
 
-        if (!$cart || !Validate::isLoadedObject($cart)) {
+        if (!Validate::isLoadedObject($cart)) {
             return false;
         }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4499,6 +4499,12 @@ class CartCore extends ObjectModel
 
         $cart->save();
 
+        // clear checkout session data so that the customer can start a new checkout
+        Db::getInstance()->execute(
+            'UPDATE ' . _DB_PREFIX_ . 'cart SET checkout_session_data = NULL
+                WHERE id_cart = ' . (int) $cart->id
+        );
+
         if (!Validate::isLoadedObject($cart)) {
             return false;
         }

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -753,6 +753,9 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
         $object_duplicated = new $definition['classname']((int) $object_id);
         $object_duplicated->duplicateShops((int) $this->id);
 
+        Hook::exec('actionObjectDuplicateAfter', ['oldObject' => $this, 'newObject' => $object_duplicated]);
+        Hook::exec('actionObject' . $this->getFullyQualifiedName() . 'DuplicateAfter', ['oldObject' => $this, 'newObject' => $object_duplicated]);
+
         return $object_duplicated;
     }
 

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -111,6 +111,11 @@
       <title>Cart creation and update</title>
       <description>This hook is displayed when a product is added to the cart or if the cart's content is modified</description>
     </hook>
+    <hook id="actionDuplicateCartData">
+      <name>actionDuplicateCartData</name>
+      <title>Cart duplication</title>
+      <description>This hook is triggered after all the cart related data has been duplicated</description>
+    </hook>
     <hook id="actionAuthentication">
       <name>actionAuthentication</name>
       <title>Successful customer authentication</title>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -171,6 +171,11 @@
       <title>Product deletion</title>
       <description>This hook is called when a product is deleted</description>
     </hook>
+    <hook id="actionObjectDuplicateAfter">
+      <name>actionObjectDuplicateAfter</name>
+      <title>After duplicating an object</title>
+      <description>This hook is called after duplicating an object by the core.</description>
+    </hook>
     <hook id="actionObjectProductInCartDeleteBefore">
       <name>actionObjectProductInCartDeleteBefore</name>
       <title>Cart product removal</title>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |8.2.x
| Description?      | The hook `actionCartDuplicate` allows modules to duplicate any data that might be related to the old cart
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | [Sample code](https://gist.github.com/unlocomqx/54563ad60fbbe530d6939a72c164b03e)
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/14691876763
| Fixed issue or discussion?     | --
| Related PRs       | --
| Sponsor company   | --
