### PR TITLE
fixed bug for free gift button on cart rules

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -193,11 +193,14 @@ function toggleApplyDiscountTo() {
 }
 
 function toggleGiftProduct() {
-  if ($('#free_gift_on').prop('checked')) $('#free_gift_div').show(400);
-  else {
+  if ($('#free_gift_on').prop('checked')) {
+    $('#free_gift_div').show(400);
+    $('#gift_products_found').show(400);
+  } else {
     $('#gift_product').val('0');
     $('#giftProductFilter').val('');
     $('#free_gift_div').hide(200);
+    $('#gift_products_found').hide(400);
   }
 }
 


### PR DESCRIPTION
In the backoffice > Catalog > Discounts > Cart rule > Actions 
when "send a free gift" button  is off,  the search products fields are not hidden.
fixed.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.2.x
| Description?      | issue in backoffice  frontend in Discount / cart rules
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | Create a cart rule in Backoffice with free gift product. Go back to the form and disable the free gift. All Search product fields for the free gift product. should be hidden 
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | Fixes #38348
| Related PRs       | 
| Sponsor company   | 
