### PR TITLE
Add new hook `actionCartRuleCheckValidityBefore`

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -705,6 +705,30 @@ class CartRuleCore extends ObjectModel
         if (!CartRule::isFeatureActive()) {
             return false;
         }
+
+        // Return a false value or error message (string) if the cart rule is not valid, true otherwise
+        $hookBeforeResult = Hook::exec(
+            hook_name: 'actionCartRuleCheckValidityBefore',
+            hook_args: [
+                'cart_rule' => $this,
+                'context' => $context,
+                'already_in_cart' => $alreadyInCart,
+                'display_error' => $display_error,
+                'check_carrier' => $check_carrier,
+                'use_order_prices' => $useOrderPrices,
+            ],
+            array_return: true
+        );
+
+        // There may be multiple modules that need to validate the cart rule, so we need iterate over the results
+        if (is_array($hookBeforeResult)) {
+            foreach ($hookBeforeResult as $moduleResult) {
+                if ($moduleResult === false || is_string($moduleResult)) {
+                    return $moduleResult;
+                }
+            }
+        }
+
         $cart = $context->cart;
 
         // All these checks are necessary when you add the cart rule the first time, so when it's not in cart yet

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -4539,5 +4539,10 @@
       <title>Triggers when returning AJAX response</title>
       <description>Allows to modify AJAX response of controllers using ajaxRender method.</description>
     </hook>
+    <hook id="actionCartRuleCheckValidityBefore">
+      <name>actionCartRuleCheckValidityBefore</name>
+      <title>Triggers before validating cart rule</title>
+      <description>Allows to add custom validation logic before validating cart rule.</description>
+    </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | New hook actionCartRuleCheckValidityBefore for custom cart rule validation
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install the hook in the module and return false or an error message. Then try adding the discount code to the cart. If you get the error you configured - everything works. Then return true, or return nothing at all, and check if the native validation runs.
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | Arkonsoft


Adding a new hook that allows you to add custom validation to the discount code before the native validation. This can be used to create custom rules for using discount codes (e.g., limit codes in the shopping cart). In my case, I had to do override when I made custom mechanics for handling gift cards redeemed with discount codes, because I had to block the use of a gift card if a gift card was added in the shopping cart as a product (it would come to a paradox that a gift card was purchased with another gift card which generates a lot of problems on the accounting side. 

As there may be more than one module that adds custom validation, the hook returns an array. Then we check if any of the modules returned an error message or false. If yes - we return this value, in case of successful validation we pass the process on to the native validation.

I used the parameter names available in php 8+ to make the code immune to parameter changes in the Hook::exec method in the future.
