### PR TITLE
Fix webservice sql error

### DIFF
--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -676,7 +676,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
 
     protected function manageCustomizationImages()
     {
-        $normal_image_sizes = ImageType::getImagesTypes($this->imageType);
+        $normal_image_sizes = ImageType::getImagesTypes();
         if (empty($this->wsObject->urlSegment[2])) {
             $results = Db::getInstance()->executeS('SELECT DISTINCT `id_cart` FROM `' . _DB_PREFIX_ . 'customization`');
             $ids = [];


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.2.x
| Description?      | Fatal error: Uncaught PDOException: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'customizations' in 'where clause' in classes/db/DbPDO.php:149
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/38483
| Deprecations?     | no
| How to test?      | try to get customization image from web service ex: api/images/customizations/1533/40/13
| Sponsor company   | THERSANE.

Tests ui: https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/14591637048
