### PR TITLE
Stock managment category filter bug

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/header/filters/filter-component.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/header/filters/filter-component.vue
@@ -156,20 +156,31 @@
         return this.list;
       },
       onCheck(obj: any): void {
-        const itemLabel = obj.item[this.label];
+        const itemId = obj.item[this.itemId];
         const filterType = this.hasChildren ? 'category' : 'supplier';
-
+      
+        const updateSelection = (items: Array<any>) => {
+          items.forEach(item => {
+            if (item[this.itemId] === itemId) {
+              item.selected = obj.checked;
+            }
+            if (item.children) {
+              updateSelection(item.children);
+            }
+          });
+        };
+        
+        updateSelection(this.list);
+      
         if (obj.checked) {
-          this.tags.push(itemLabel);
+          this.tags.push(obj.item[this.label]);
         } else {
-          const index = this.tags.indexOf(itemLabel);
+          const index = this.tags.indexOf(obj.item[this.label]);
           this.tags.splice(index, 1);
         }
-        if (this.tags.length) {
-          this.$emit('active', this.filterList(this.tags), filterType);
-        } else {
-          this.$emit('active', [], filterType);
-        }
+      
+        const filteredList = this.filterList(this.tags);
+        this.$emit('active', filteredList, filterType);
       },
       onTyping(val: string): void {
         this.currentVal = val.toLowerCase();
@@ -189,17 +200,18 @@
       },
       filterList(tags: Array<any>): Array<number> {
         const idList: Array<number> = [];
-        const {categoryList} = this.$store.state;
-        const list = this.hasChildren ? categoryList : this.list;
+        const list = this.list;
 
-        list.map((data: Record<string, any>) => {
-          const isInIdList = idList.indexOf(Number(data[this.itemId])) === -1;
-
-          if (tags.indexOf(data[this.label]) !== -1 && isInIdList) {
-            idList.push(Number(data[this.itemId]));
+        const checkCategory = (category: Record<string, any>) => {
+          if (category.selected === true) {
+            idList.push(Number(category[this.itemId]));
           }
-          return idList;
-        });
+          if (category.children) {
+            category.children.forEach(checkCategory);
+          }
+        };
+
+        list.forEach(checkCategory);
         return idList;
       },
     },

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/header/filters/filter-component.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/header/filters/filter-component.vue
@@ -158,9 +158,8 @@
       onCheck(obj: any): void {
         const itemId = obj.item[this.itemId];
         const filterType = this.hasChildren ? 'category' : 'supplier';
-      
         const updateSelection = (items: Array<any>) => {
-          items.forEach(item => {
+          items.forEach((item) => {
             if (item[this.itemId] === itemId) {
               item.selected = obj.checked;
             }
@@ -169,16 +168,13 @@
             }
           });
         };
-        
-        updateSelection(this.list);
-      
+        updateSelection(this.list); 
         if (obj.checked) {
           this.tags.push(obj.item[this.label]);
         } else {
           const index = this.tags.indexOf(obj.item[this.label]);
           this.tags.splice(index, 1);
         }
-      
         const filteredList = this.filterList(this.tags);
         this.$emit('active', filteredList, filterType);
       },
@@ -200,7 +196,7 @@
       },
       filterList(tags: Array<any>): Array<number> {
         const idList: Array<number> = [];
-        const list = this.list;
+        const {list} = this;
 
         const checkCategory = (category: Record<string, any>) => {
           if (category.selected === true) {

--- a/admin-dev/themes/new-theme/js/app/pages/stock/store/actions.ts
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/store/actions.ts
@@ -43,12 +43,13 @@ export const getStock = async ({commit}: {commit: Commit}, payload: Record<strin
     low_stock: payload.low_stock,
   }, isParamInvalid));
 
-  if (payload.suppliers) {
-    payload.suppliers.forEach((v: string) => params.append('supplier_id[]', v));
+  if (payload.categories && payload.categories.length > 0) {
+    payload.categories.forEach((category: any) => {
+      const categoryId = category.id_category || category;
+      params.append('category_id[]', categoryId.toString());
+    });
   }
-  if (payload.categories) {
-    payload.categories.forEach((v: string) => params.append('category_id[]', v));
-  }
+
   const fetchUrl = `${url}${url.includes('?') ? '&' : '?'}${params.toString()}`;
 
   try {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.2.x
| Description?      | On backoffice in stock management . when filtering the products by categories, it was in including categories that are not selected when they have the same name.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | create subcategories with products that have the same name but have different parents. select one of the subcategories in stock management filter . verify that only on subcategory product is being showed.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #38344 
| Related PRs       | 
| Sponsor company   |