### PR TITLE
fixed bug when template not exist in module

### DIFF
--- a/classes/tree/Tree.php
+++ b/classes/tree/Tree.php
@@ -516,12 +516,16 @@ class TreeCore
     }
 
     /**
-     * @param string|array $directory
+     * @param string|array|null $directory
      *
      * @return string|array
      */
     private function _normalizeDirectory($directory)
     {
+        if (empty($directory)) {
+            return DIRECTORY_SEPARATOR;
+        }
+        
         $last = $directory[strlen($directory) - 1];
 
         if (in_array($last, ['/', '\\'])) {

--- a/classes/tree/TreeToolbar.php
+++ b/classes/tree/TreeToolbar.php
@@ -208,6 +208,10 @@ class TreeToolbarCore implements ITreeToolbarCore
 
     private function _normalizeDirectory($directory)
     {
+        if (empty($directory)) {
+            return DIRECTORY_SEPARATOR;
+        }
+        
         $last = $directory[strlen($directory) - 1];
 
         if (in_array($last, ['/', '\\'])) {

--- a/classes/tree/TreeToolbarButton.php
+++ b/classes/tree/TreeToolbarButton.php
@@ -210,6 +210,9 @@ abstract class TreeToolbarButtonCore
 
     private function _normalizeDirectory($directory)
     {
+        if (empty($directory)) {
+            return DIRECTORY_SEPARATOR;
+        }
         $last = $directory[strlen($directory) - 1];
 
         if (in_array($last, ['/', '\\'])) {


### PR DESCRIPTION
when trying to config a moudle and template directory not exist , it fails on Tree classes and throw exceptions.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x 
| Description?      | when trying to configure a module with "categories" field , and there is no templates directory in the module , it breaks and throw exceptions. it's being caused because the _normalizeDirectory function doesn't have a fallback incase the directory is empty. when there is falback for empty directory it uses the default template and no exception is being throwed
| Type?             | bug fix
| Category?         |  BO 
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | create a or use a module without template that uses category field. upload if it's new. click "configure" for the module 
| UI Tests          |
| Fixed issue or discussion?     | Fixes #38321 
| Related PRs       | 
| Sponsor company   | 