### PR TITLE
Fix: When I disable a feature flag, I shouldn't see the warning popin

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/feature-flag/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/feature-flag/index.ts
@@ -65,21 +65,19 @@ $(() => {
       }
     }
 
-    const modal = new ConfirmModal(
-      {
-        id: 'modal-confirm-submit-feature-flag',
-        confirmTitle: $submitButton.data('modal-title'),
-        confirmMessage: $submitButton.data('modal-message'),
-        confirmButtonLabel: $submitButton.data('modal-apply'),
-        closeButtonLabel: $submitButton.data('modal-cancel'),
-      },
-      () => {
-        $form.submit();
-      },
-    );
-
     if (oneFlagIsEnabled) {
-      modal.show();
+      new ConfirmModal(
+        {
+          id: 'modal-confirm-submit-feature-flag',
+          confirmTitle: $submitButton.data('modal-title'),
+          confirmMessage: $submitButton.data('modal-message'),
+          confirmButtonLabel: $submitButton.data('modal-apply'),
+          closeButtonLabel: $submitButton.data('modal-cancel'),
+        },
+        () => {
+          $form.submit();
+        },
+      );
     } else {
       $form.submit();
     }


### PR DESCRIPTION
The "ConfirmModal" should only be created if at least one "feature flag" is enabled.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | see: https://github.com/PrestaShop/PrestaShop/issues/38416
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see: https://github.com/PrestaShop/PrestaShop/issues/38416
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/14441968900
| Fixed issue or discussion?     | Fixes #38416
| Related PRs       | 
| Sponsor company   | @Codencode 
