### PR TITLE
Add CMS Page preview link in listing in BO

### DIFF
--- a/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
@@ -184,6 +184,17 @@ class CmsPageDefinitionFactory extends AbstractGridDefinitionFactory
                                 'id_cms',
                                 Request::METHOD_DELETE
                             )
+                        )
+                        ->add((new LinkRowAction('preview'))
+                            ->setName($this->trans('Preview', [], 'Admin.Actions'))
+                            ->setIcon('remove_red_eye')
+                            ->setOptions([
+                                'route' => 'admin_cms_pages_preview',
+                                'route_param_name' => 'cmsPageId',
+                                'route_param_field' => 'id_cms',
+                                'clickable_row' => true,
+                                'target' => '_blank',
+                            ])
                         ),
                 ])
             )

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -846,6 +846,24 @@ class CmsPageController extends PrestaShopAdminController
     }
 
     /**
+     * The redirection URL is generation thanks to the ProductPreviewProvider however it can't be used in the grid
+     * since the LinkRowAction expects a symfony route, so this action is merely used as a proxy for symfony routing
+     * and redirects to the appropriate product preview url.
+     *
+     * @return RedirectResponse
+     */
+    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))")]
+    public function previewAction(
+        int $cmsPageId,
+        #[Autowire(service: 'prestashop.adapter.shop.url.cms_provider')]
+        CmsProvider $previewUrlProvider,
+    ): RedirectResponse {
+        $previewUrl = $previewUrlProvider->getUrl($cmsPageId);
+
+        return $this->redirect($previewUrl);
+    }
+
+    /**
      * This function is used for redirecting to the specific cms page category page. It uses bulk action ids which
      * share the same parent cms category in all cases.
      *

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
@@ -34,6 +34,18 @@ admin_cms_pages_edit:
   requirements:
     cmsPageId: \d+
 
+admin_cms_pages_preview:
+  path: /{cmsPageId}/preview
+  methods: [ GET ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\Design\CmsPageController::previewAction'
+    _legacy_controller: AdminCmsContent
+    _legacy_link: AdminCmsContent:preview
+    _legacy_parameters:
+      id_cms: cmsPageId
+  requirements:
+    cmsPageId: \d+
+
 admin_cms_pages_toggle:
   path: /{cmsId}/toggle-status
   methods: POST


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds a preview link for CMS Pages in listing in BO
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go in BO > Design > Pages => Pages section, click on the three dots next to edit link for a CMS page, click on Preview, it should open a new window with the page in FO.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/14441776899
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | Evolutive
