### PR TITLE
Relax validation rules for first batch of characters

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -175,7 +175,7 @@ class ValidateCore
      */
     public static function isCarrierName($name)
     {
-        return empty($name) || preg_match('/^[^<>;=#{}]*$/u', $name);
+        return empty($name) || preg_match('/^[^<>{}]*$/u', $name);
     }
 
     /**
@@ -242,7 +242,7 @@ class ValidateCore
      */
     public static function isMailName($mail_name)
     {
-        return is_string($mail_name) && preg_match('/^[^<>;=#{}]*$/u', $mail_name);
+        return is_string($mail_name) && preg_match('/^[^<>{}]*$/u', $mail_name);
     }
 
     /**
@@ -377,7 +377,7 @@ class ValidateCore
      */
     public static function isCatalogName($name)
     {
-        return preg_match('/^[^<>;=#{}]*$/u', $name);
+        return preg_match('/^[^<>{}]*$/u', $name);
     }
 
     /**
@@ -469,7 +469,7 @@ class ValidateCore
      */
     public static function isValidSearch($search)
     {
-        return preg_match('/^[^<>;=#{}]{0,64}$/u', $search);
+        return preg_match('/^[^<>{}]{0,64}$/u', $search);
     }
 
     /**
@@ -481,7 +481,7 @@ class ValidateCore
      */
     public static function isGenericName($name)
     {
-        return empty($name) || preg_match('/^[^<>={}]*$/u', $name);
+        return empty($name) || preg_match('/^[^<>{}]*$/u', $name);
     }
 
     /**

--- a/controllers/admin/AdminCountriesController.php
+++ b/controllers/admin/AdminCountriesController.php
@@ -199,7 +199,7 @@ class AdminCountriesControllerCore extends AdminController
                     'name' => 'name',
                     'lang' => true,
                     'required' => true,
-                    'hint' => $this->trans('Country name', [], 'Admin.International.Feature') . ' - ' . $this->trans('Invalid characters:', [], 'Admin.Global') . ' &lt;&gt;;=#{} ',
+                    'hint' => $this->trans('Country name', [], 'Admin.International.Feature') . ' - ' . $this->trans('Invalid characters:', [], 'Admin.Global') . ' &lt;&gt;{} ',
                 ],
                 [
                     'type' => 'text',

--- a/controllers/admin/AdminQuickAccessesController.php
+++ b/controllers/admin/AdminQuickAccessesController.php
@@ -87,7 +87,7 @@ class AdminQuickAccessesControllerCore extends AdminController
                     'lang' => true,
                     'maxlength' => 32,
                     'required' => true,
-                    'hint' => $this->trans('Forbidden characters:', [], 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                    'hint' => $this->trans('Forbidden characters:', [], 'Admin.Notifications.Info') . ' &lt;&gt;{}',
                 ],
                 [
                     'type' => 'text',

--- a/controllers/admin/AdminSearchConfController.php
+++ b/controllers/admin/AdminSearchConfController.php
@@ -415,7 +415,7 @@ class AdminSearchConfControllerCore extends AdminController
                     'required' => true,
                     'hint' => [
                         $this->trans('Enter each alias separated by a comma (e.g. \'prestshop,preztashop,prestasohp\').', [], 'Admin.Shopparameters.Help'),
-                        $this->trans('Forbidden characters: &lt;&gt;;=#{}', [], 'Admin.Shopparameters.Help'),
+                        $this->trans('Forbidden characters: &lt;&gt;{}', [], 'Admin.Shopparameters.Help'),
                     ],
                 ],
                 [

--- a/controllers/admin/AdminTabsController.php
+++ b/controllers/admin/AdminTabsController.php
@@ -153,7 +153,7 @@ class AdminTabsControllerCore extends AdminController
                     'name' => 'name',
                     'lang' => true,
                     'required' => true,
-                    'hint' => $this->trans('Invalid characters:', [], 'Admin.Notifications.Info') . ' &lt;&gt;;=#{}',
+                    'hint' => $this->trans('Invalid characters:', [], 'Admin.Notifications.Info') . ' &lt;&gt;{}',
                 ],
                 [
                     'type' => 'text',

--- a/controllers/admin/AdminTaxRulesGroupController.php
+++ b/controllers/admin/AdminTaxRulesGroupController.php
@@ -183,7 +183,7 @@ class AdminTaxRulesGroupControllerCore extends AdminController
                     'label' => $this->trans('Name', [], 'Admin.Global'),
                     'name' => 'name',
                     'required' => true,
-                    'hint' => $this->trans('Invalid characters:', [], 'Admin.Notifications.Info') . ' <>;=#{}',
+                    'hint' => $this->trans('Invalid characters:', [], 'Admin.Notifications.Info') . ' <>{}',
                 ],
                 [
                     'type' => 'switch',

--- a/src/Adapter/Customer/Group/Validate/CustomerGroupValidator.php
+++ b/src/Adapter/Customer/Group/Validate/CustomerGroupValidator.php
@@ -144,7 +144,7 @@ class CustomerGroupValidator extends AbstractObjectModelValidator
                 GroupConstraintException::NAME_TOO_LONG
             );
         }
-        if (false === preg_match('/^[^<>={}]*$/u', $name)) {
+        if (false === preg_match('/^[^<>{}]*$/u', $name)) {
             throw new GroupConstraintException(
                 'Customer group name cannot contain these characters: < > = { }',
                 GroupConstraintException::INVALID_NAME

--- a/src/Core/ConstraintValidator/TypedRegexValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexValidator.php
@@ -49,8 +49,8 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class TypedRegexValidator extends ConstraintValidator
 {
-    public const CATALOG_CHARS = '<>;=#{}';
-    public const GENERIC_NAME_CHARS = '<>={}';
+    public const CATALOG_CHARS = '<>{}';
+    public const GENERIC_NAME_CHARS = '<>{}';
     public const MESSAGE_CHARS = '<>{}';
     public const NAME_CHARS = '0-9!<>,;?=+()@#"{}_$%:';
 
@@ -117,9 +117,9 @@ class TypedRegexValidator extends ConstraintValidator
             case TypedRegex::TYPE_NAME:
                 return '/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u';
             case TypedRegex::TYPE_CATALOG_NAME:
-                return '/^[^<>;=#{}]*$/u';
+                return '/^[^<>{}]*$/u';
             case TypedRegex::TYPE_GENERIC_NAME:
-                return '/^[^<>={}]*$/u';
+                return '/^[^<>{}]*$/u';
             case TypedRegex::TYPE_CITY_NAME:
                 return '/^[^!<>;?=+@#"°{}_$%]*$/u';
             case TypedRegex::TYPE_ADDRESS:

--- a/src/Core/Domain/CmsPageCategory/Command/AbstractCmsPageCategoryCommand.php
+++ b/src/Core/Domain/CmsPageCategory/Command/AbstractCmsPageCategoryCommand.php
@@ -33,8 +33,8 @@ use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryC
  */
 abstract class AbstractCmsPageCategoryCommand
 {
-    public const CATEGORY_NAME_REGEX_PATTERN = '/^[^<>;=#{}]*$/u';
-    public const GENERIC_NAME_REGEX_PATTERN = '/^[^<>={}]*$/u';
+    public const CATEGORY_NAME_REGEX_PATTERN = '/^[^<>{}]*$/u';
+    public const GENERIC_NAME_REGEX_PATTERN = '/^[^<>{}]*$/u';
 
     /**
      * Checks if given names matches pattern.

--- a/src/Core/Domain/Contact/Command/AbstractContactCommand.php
+++ b/src/Core/Domain/Contact/Command/AbstractContactCommand.php
@@ -52,7 +52,7 @@ abstract class AbstractContactCommand
      */
     protected function assertIsGenericName($value)
     {
-        return preg_match('/^[^<>={}]*$/u', $value);
+        return preg_match('/^[^<>{}]*$/u', $value);
     }
 
     /**

--- a/src/Core/Domain/Contact/Command/AddContactCommand.php
+++ b/src/Core/Domain/Contact/Command/AddContactCommand.php
@@ -171,7 +171,7 @@ class AddContactCommand extends AbstractContactCommand
 
         foreach ($localisedTitles as $title) {
             if (!$this->assertIsGenericName($title)) {
-                throw new ContactConstraintException(sprintf('Expected value %s to match given regex /^[^<>={}]*$/u but failed', var_export($title, true)), ContactConstraintException::INVALID_TITLE);
+                throw new ContactConstraintException(sprintf('Expected value %s to match given regex /^[^<>{}]*$/u but failed', var_export($title, true)), ContactConstraintException::INVALID_TITLE);
             }
         }
     }

--- a/src/Core/Domain/Contact/Command/EditContactCommand.php
+++ b/src/Core/Domain/Contact/Command/EditContactCommand.php
@@ -108,7 +108,7 @@ class EditContactCommand extends AbstractContactCommand
 
         foreach ($localisedTitles as $title) {
             if (!$this->assertIsGenericName($title)) {
-                throw new ContactConstraintException(sprintf('Expected value %s to match given regex /^[^<>={}]*$/u but failed', var_export($title, true)), ContactConstraintException::INVALID_TITLE);
+                throw new ContactConstraintException(sprintf('Expected value %s to match given regex /^[^<>{}]*$/u but failed', var_export($title, true)), ContactConstraintException::INVALID_TITLE);
             }
         }
 

--- a/src/Core/Domain/Contact/Exception/ContactConstraintException.php
+++ b/src/Core/Domain/Contact/Exception/ContactConstraintException.php
@@ -32,7 +32,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Contact\Exception;
 class ContactConstraintException extends ContactException
 {
     /**
-     * @var int - error is raised when preg match fails to validate according to regex /^[^<>={}]*$/u
+     * @var int - error is raised when preg match fails to validate according to regex /^[^<>{}]*$/u
      */
     public const INVALID_TITLE = 1;
 

--- a/src/Core/Domain/Meta/Command/AbstractMetaCommand.php
+++ b/src/Core/Domain/Meta/Command/AbstractMetaCommand.php
@@ -42,7 +42,7 @@ abstract class AbstractMetaCommand
      */
     protected function assertNameMatchesRegexPattern($languageId, $value, $constraintErrorCode)
     {
-        $regex = '/^[^<>={}]*$/u';
+        $regex = '/^[^<>{}]*$/u';
 
         if ($value && !preg_match($regex, $value)) {
             throw new MetaConstraintException(sprintf('Value "%s" for language id %s did not passed the regex expression: %s', $value, $languageId, $regex), $constraintErrorCode);

--- a/src/Core/Domain/Order/Payment/Command/AddPaymentCommand.php
+++ b/src/Core/Domain/Order/Payment/Command/AddPaymentCommand.php
@@ -42,7 +42,7 @@ class AddPaymentCommand
     /**
      * @var string
      */
-    public const INVALID_CHARACTERS_NAME = '<>={}';
+    public const INVALID_CHARACTERS_NAME = '<>{}';
 
     /**
      * @var string

--- a/src/Core/Domain/Product/ValueObject/LocalizedTags.php
+++ b/src/Core/Domain/Product/ValueObject/LocalizedTags.php
@@ -36,7 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintExcepti
  */
 class LocalizedTags
 {
-    public const VALID_TAG_PATTERN = '/^[^<>={}]*$/u';
+    public const VALID_TAG_PATTERN = '/^[^<>{}]*$/u';
 
     /**
      * @var LanguageId

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
@@ -91,7 +91,7 @@ class ContactType extends TranslatorAwareType
                 'options' => [
                     'constraints' => [
                         new Regex([
-                            'pattern' => '/^[^<>={}]*$/u',
+                            'pattern' => '/^[^<>{}]*$/u',
                             'message' => $this->trans(
                                 '%s is invalid.',
                                 'Admin.Notifications.Error'

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaType.php
@@ -120,7 +120,7 @@ class MetaType extends AbstractType
                     ],
                     'constraints' => [
                         new Regex([
-                            'pattern' => '/^[^<>={}]*$/u',
+                            'pattern' => '/^[^<>{}]*$/u',
                             'message' => $this->trans(
                                 '%s is invalid.',
                                 [],
@@ -149,7 +149,7 @@ class MetaType extends AbstractType
                     ],
                     'constraints' => [
                         new Regex([
-                            'pattern' => '/^[^<>={}]*$/u',
+                            'pattern' => '/^[^<>{}]*$/u',
                             'message' => $this->trans(
                                 '%s is invalid.',
                                 [],

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -88,7 +88,7 @@ class CmsPageType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $invalidCharsText = sprintf('%s <>={}', $this->trans('Invalid characters:', 'Admin.Notifications.Info'));
+        $invalidCharsText = sprintf('%s <>{}', $this->trans('Invalid characters:', 'Admin.Notifications.Info'));
 
         $builder
             ->add('page_category_id', MaterialChoiceTreeType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Catalog/FeatureType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Catalog/FeatureType.php
@@ -59,7 +59,7 @@ class FeatureType extends TranslatorAwareType
                         ]),
                     ],
                 ],
-                'help' => $this->trans('Invalid characters: %chars%', 'Admin.Notifications.Info', ['%chars%' => '<>={}']),
+                'help' => $this->trans('Invalid characters: %chars%', 'Admin.Notifications.Info', ['%chars%' => '<>{}']),
             ])
             ->add('shop_association', ShopChoiceTreeType::class, [
                 'label' => $this->trans('Store association', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Catalog/FeatureValueType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Catalog/FeatureValueType.php
@@ -67,7 +67,7 @@ class FeatureValueType extends TranslatorAwareType
                         new Length(['max' => FeatureValueSettings::VALUE_MAX_LENGTH]),
                     ],
                 ],
-                'help' => $this->trans('Invalid characters: %chars%', 'Admin.Notifications.Info', ['%chars%' => '<>={}']),
+                'help' => $this->trans('Invalid characters: %chars%', 'Admin.Notifications.Info', ['%chars%' => '<>{}']),
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Manufacturer/ManufacturerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Manufacturer/ManufacturerType.php
@@ -71,8 +71,8 @@ class ManufacturerType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $invalidCharactersForCatalogLabel = $this->trans('Invalid characters:', 'Admin.Global') . '<>;=#{}';
-        $invalidCharactersForNameLabel = $this->trans('Invalid characters:', 'Admin.Global') . '<>={}';
+        $invalidCharactersForCatalogLabel = $this->trans('Invalid characters:', 'Admin.Global') . '<>{}';
+        $invalidCharactersForNameLabel = $this->trans('Invalid characters:', 'Admin.Global') . '<>{}';
 
         $builder
             ->add('name', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
@@ -102,7 +102,7 @@ class HeaderType extends TranslatorAwareType
                                 'message' => $this->trans(
                                     'This field contains invalid characters: %invalidCharacters%',
                                     'Admin.Catalog.Feature',
-                                    ['%invalidCharacters%' => '<>;=#{}']
+                                    ['%invalidCharacters%' => '<>{}']
                                 ),
                             ]
                         ),

--- a/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
@@ -49,7 +49,7 @@ Feature: Add basic product from Back Office (BO)
 
   Scenario: I add a product with invalid characters in name
     When I add product "product2" with following information:
-      | name[en-US] | T-shirt #1 |
+      | name[en-US] | T-shirt <3 |
       | type        | standard   |
     Then I should get error that product name is invalid
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_basic_information.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_basic_information.feature
@@ -34,7 +34,7 @@ Feature: Update product basic information from Back Office (BO)
       | locale | value              |
       | en-US  | photo of funny mug |
     When I update product "product1" with following values:
-      | name[en-US] | #hashtagmug |
+      | name[en-US] | lovemug<3 |
     Then I should get error that product name is invalid
     And product "product1" localized "name" should be:
       | locale | value              |

--- a/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
@@ -498,7 +498,7 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
     public function getInvalidCharactersForCatalogNameType(): array
     {
         return [
-            ['<'], ['>'], [';'], ['='], ['#'], ['{'], ['}'],
+            ['<'], ['>'], ['{'], ['}'],
         ];
     }
 
@@ -508,7 +508,7 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
     public function getInvalidCharactersForGenericNameType(): array
     {
         return [
-            ['<'], ['>'], ['='], ['{'], ['}'],
+            ['<'], ['>'], ['{'], ['}'],
         ];
     }
 

--- a/tests/Unit/Core/Domain/CmsPageCategory/Command/AddCmsPageCategoryCommandTest.php
+++ b/tests/Unit/Core/Domain/CmsPageCategory/Command/AddCmsPageCategoryCommandTest.php
@@ -38,14 +38,12 @@ class AddCmsPageCategoryCommandTest extends TestCase
         $this->expectException(CmsPageCategoryConstraintException::class);
         $this->expectExceptionCode(CmsPageCategoryConstraintException::INVALID_CATEGORY_NAME);
 
-        $incorrectName = [
-            1 => 'hashtag #',
-        ];
-
         $command = new AddCmsPageCategoryCommand(
-            $incorrectName,
             [
-                1 => 'hashtag',
+                1 => 'somecategoryname >',
+            ],
+            [
+                1 => 'somecategoryname',
             ],
             1,
             true
@@ -59,10 +57,10 @@ class AddCmsPageCategoryCommandTest extends TestCase
         $incorrectId = '1';
         $command = new AddCmsPageCategoryCommand(
             [
-                1 => 'hashtag',
+                1 => 'somecategoryname',
             ],
             [
-                1 => 'hashtag',
+                1 => 'somecategoryname',
             ],
             /* @phpstan-ignore-next-line */
             $incorrectId,
@@ -90,7 +88,7 @@ class AddCmsPageCategoryCommandTest extends TestCase
         $command = new AddCmsPageCategoryCommand([], [], 1, false);
 
         $command->setLocalisedMetaDescription([
-            1 => '=object=',
+            1 => '{object}',
         ]);
     }
 }

--- a/tests/Unit/Core/Domain/CmsPageCategory/Command/EditCmsPageCategoryCommandTest.php
+++ b/tests/Unit/Core/Domain/CmsPageCategory/Command/EditCmsPageCategoryCommandTest.php
@@ -41,7 +41,7 @@ class EditCmsPageCategoryCommandTest extends TestCase
         $command = new EditCmsPageCategoryCommand(1);
 
         $command->setLocalisedName([
-            1 => 'name with #',
+            1 => 'name with >',
         ]);
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Adapts naming validation rules and allows more characters. Starting with the safe ones `=`, `#` and `;` - more info below.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to save a product or manufacturer name with a hashtag.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/15879546262
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38434
| Related PRs       | 
| Sponsor company   | 

### In this PR
- `=` If rendered anywehere, for example in URL context, must be already escaped. Million other characters could break the URL.
- `#` If rendered anywehere, for example in URL context, must be already escaped. Million other characters could break the URL.
- `;` If rendered anywhere, like in JS, must be already escaped, because `"`, `'` or many other characters are allowed.

### In the future
- `{}` Is easy to add - if rendered anywhere, like in JS, must be already escaped, because `"`, `'` or many other characters are allowed.
- `<>` Will need a check, because they could mess up HTML if accidentaly rendered unescaped. Smarty and twig do it automatically, but just to be sure.