### PR TITLE
Show all carriers in the delivery option when FEATURE_FLAG_IMPROVED_SHIPMENT is enabled

### DIFF
--- a/classes/checkout/CheckoutSession.php
+++ b/classes/checkout/CheckoutSession.php
@@ -23,21 +23,24 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
+use PrestaShop\PrestaShop\Adapter\Shipment\DeliveryOptionsInterface;
+
 class CheckoutSessionCore
 {
     /** @var Context */
     protected $context;
-    /** @var DeliveryOptionsFinder */
-    protected $deliveryOptionsFinder;
+    /** @var DeliveryOptionsInterface */
+    protected $deliveryOptions;
 
     /**
      * @param Context $context
-     * @param DeliveryOptionsFinder $deliveryOptionsFinder
+     * @param DeliveryOptionsInterface $deliveryOptions
      */
-    public function __construct(Context $context, DeliveryOptionsFinder $deliveryOptionsFinder)
+    public function __construct(Context $context, DeliveryOptionsInterface $deliveryOptions)
     {
         $this->context = $context;
-        $this->deliveryOptionsFinder = $deliveryOptionsFinder;
+        $this->deliveryOptions = $deliveryOptions;
     }
 
     /**
@@ -150,12 +153,12 @@ class CheckoutSessionCore
 
     public function getSelectedDeliveryOption()
     {
-        return $this->deliveryOptionsFinder->getSelectedDeliveryOption();
+        return $this->deliveryOptions->getSelectedDeliveryOption();
     }
 
     public function getDeliveryOptions()
     {
-        return $this->deliveryOptionsFinder->getDeliveryOptions();
+        return $this->deliveryOptions->getDeliveryOptions();
     }
 
     public function setRecyclable($option)

--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -23,6 +24,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -46,23 +48,22 @@ class DeliveryOptionsFinderCore
         $this->priceFormatter = $priceFormatter;
     }
 
-    private function isFreeShipping($cart, array $carrier)
+    private function isFreeShipping(array $deliveryOption)
     {
-        $free_shipping = false;
+        if ($deliveryOption['is_free']) {
+            return true;
+        }
 
-        if ($carrier['is_free']) {
-            $free_shipping = true;
-        } else {
-            foreach ($cart->getCartRules() as $rule) {
-                if ($rule['free_shipping'] && !$rule['carrier_restriction']) {
-                    $free_shipping = true;
+        $cart = $this->context->cart;
 
-                    break;
-                }
+        foreach ($cart->getCartRules() as $rule) {
+            if ($rule['free_shipping'] && !$rule['carrier_restriction']) {
+                return true;
+                break;
             }
         }
 
-        return $free_shipping;
+        return false;
     }
 
     public function getSelectedDeliveryOption()
@@ -76,67 +77,99 @@ class DeliveryOptionsFinderCore
         $include_taxes = !Product::getTaxCalculationMethod((int) $this->context->cart->id_customer) && (int) Configuration::get('PS_TAX');
         $display_taxes_label = (Configuration::get('PS_TAX') && $this->context->country->display_tax_label);
 
-        $carriers_available = [];
+        if (empty($deliveryOptions[$this->context->cart->id_address_delivery])) {
+            return [];
+        }
 
-        if (isset($delivery_option_list[$this->context->cart->id_address_delivery])) {
-            foreach ($delivery_option_list[$this->context->cart->id_address_delivery] as $id_carriers_list => $carriers_list) {
-                foreach ($carriers_list as $carriers) {
-                    if (is_array($carriers)) {
-                        foreach ($carriers as $carrier) {
-                            $carrier = array_merge($carrier, $this->objectPresenter->present($carrier['instance']));
-                            $delay = $carrier['delay'][$this->context->language->id];
-                            unset($carrier['instance'], $carrier['delay']);
-                            $carrier['delay'] = $delay;
-                            if ($this->isFreeShipping($this->context->cart, $carriers_list)) {
-                                $carrier['price'] = $this->translator->trans(
-                                    'Free',
-                                    [],
-                                    'Shop.Theme.Checkout'
-                                );
-                            } else {
-                                if ($include_taxes) {
-                                    $carrier['price'] = $this->priceFormatter->format($carriers_list['total_price_with_tax']);
-                                    if ($display_taxes_label) {
-                                        $carrier['price'] = $this->translator->trans(
-                                            '%price% tax incl.',
-                                            ['%price%' => $carrier['price']],
-                                            'Shop.Theme.Checkout'
-                                        );
-                                    }
-                                } else {
-                                    $carrier['price'] = $this->priceFormatter->format($carriers_list['total_price_without_tax']);
-                                    if ($display_taxes_label) {
-                                        $carrier['price'] = $this->translator->trans(
-                                            '%price% tax excl.',
-                                            ['%price%' => $carrier['price']],
-                                            'Shop.Theme.Checkout'
-                                        );
-                                    }
-                                }
-                            }
+        $formattedDeliveryOptions = [];
 
-                            if (count($carriers) > 1) {
-                                $carrier['label'] = $carrier['price'];
-                            } else {
-                                $carrier['label'] = $carrier['name'] . ' - ' . $carrier['delay'] . ' - ' . $carrier['price'];
-                            }
+        foreach ($currentAddressDeliveryOptions as $deliveryOptionId => $deliveryOption) {
+            $formattedDeliveryOption = end($deliveryOption['carrier_list']);
+            $formattedDeliveryOption = array_merge($formattedDeliveryOption, $this->objectPresenter->present($formattedDeliveryOption['instance']));
+            unset($formattedDeliveryOption['instance']);
 
-                            // If carrier related to a module, check for additionnal data to display
-                            $carrier['extraContent'] = '';
-                            if ($carrier['is_module']) {
-                                if ($moduleId = Module::getModuleIdByName($carrier['external_module_name'])) {
-                                    // Hook called only for the module concerned
-                                    $carrier['extraContent'] = Hook::exec('displayCarrierExtraContent', ['carrier' => $carrier], $moduleId);
-                                }
-                            }
+            $carriersDetails = $this->getCarriersDetails($deliveryOption);
+            $formattedDeliveryOption = array_merge($formattedDeliveryOption, $carriersDetails);
 
-                            $carriers_available[$id_carriers_list] = $carrier;
-                        }
-                    }
-                }
+            $formattedDeliveryOption['price'] = $this->getPriceToDisplay($deliveryOption);
+            $formattedDeliveryOption['label'] = $formattedDeliveryOption['price'];
+
+            $formattedDeliveryOptions[$deliveryOptionId] = $formattedDeliveryOption;
+        }
+
+        return $formattedDeliveryOptions;
+    }
+
+    private function getCarriersDetails($deliveryOption)
+    {
+        $carriers = $deliveryOption['carrier_list'];
+
+        if (count($carriers) === 1) {
+            return [
+                'id' => $carriers[0]['instance']->id,
+                'label' => $carriers[0]['label'],
+                'name' => $carriers[0]['instance']->name,
+                'delay' => $carriers[0]['instance']->delay[$this->context->language->id],
+            ];
+        }
+
+        $names = [];
+        $delays = [];
+        $extraContent = [];
+
+        foreach ($carriers as $carrier) {
+            $names[] = $carrier['instance']->name;
+            $delays[] = $carrier['instance']->delay[$this->context->language->id];
+            $extraContent[$carrier['instance']->id] = Hook::exec('displayCarrierExtraContent', ['carrier' => $carrier['instance']], Module::getModuleIdByName($carrier['instance']->id));
+        }
+
+        return [
+            'id' => end($carriers)['instance']->id,
+            'name' => implode(', ', $names),
+            'delay' => implode(', ', $delays),
+            'extraContent' => $extraContent,
+        ];
+    }
+
+    private function getPriceToDisplay($deliveryOption)
+    {
+        if ($this->isFreeShipping($deliveryOption)) {
+            return $this->translator->trans(
+                'Free',
+                [],
+                'Shop.Theme.Checkout'
+            );
+        }
+
+        if ($this->shouldIncludeTaxes()) {
+            $price = $this->priceFormatter->format($deliveryOption['total_price_with_tax']);
+            if ($this->shouldDisplayTaxesLabel()) {
+                $label = '%price% tax incl.';
+            }
+        } else {
+            $price = $this->priceFormatter->format($deliveryOption['total_price_without_tax']);
+            if ($this->shouldDisplayTaxesLabel()) {
+                $label = '%price% tax excl.';
             }
         }
 
-        return $carriers_available;
+        return $this->translator->trans(
+            $label ?? '%price%',
+            ['%price%' => $price],
+            'Shop.Theme.Checkout'
+        );
+    }
+
+    private function shouldIncludeTaxes()
+    {
+        return !Product::getTaxCalculationMethod((int) $this->context->cart->id_customer)
+            && (int) Configuration::get('PS_TAX');
+    }
+
+    private function shouldDisplayTaxesLabel()
+    {
+        return Configuration::get('PS_TAX')
+            && $this->context->country->display_tax_label
+            && !Configuration::get('AEUC_LABEL_TAX_INC_EXC');
     }
 }

--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -24,12 +23,12 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
 use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
+use PrestaShop\PrestaShop\Adapter\Shipment\DeliveryOptionsInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class DeliveryOptionsFinderCore
+class DeliveryOptionsFinderCore implements DeliveryOptionsInterface
 {
     private $context;
     private $objectPresenter;
@@ -48,22 +47,23 @@ class DeliveryOptionsFinderCore
         $this->priceFormatter = $priceFormatter;
     }
 
-    private function isFreeShipping(array $deliveryOption)
+    private function isFreeShipping($cart, array $carrier)
     {
-        if ($deliveryOption['is_free']) {
-            return true;
-        }
+        $free_shipping = false;
 
-        $cart = $this->context->cart;
+        if ($carrier['is_free']) {
+            $free_shipping = true;
+        } else {
+            foreach ($cart->getCartRules() as $rule) {
+                if ($rule['free_shipping'] && !$rule['carrier_restriction']) {
+                    $free_shipping = true;
 
-        foreach ($cart->getCartRules() as $rule) {
-            if ($rule['free_shipping'] && !$rule['carrier_restriction']) {
-                return true;
-                break;
+                    break;
+                }
             }
         }
 
-        return false;
+        return $free_shipping;
     }
 
     public function getSelectedDeliveryOption()
@@ -77,99 +77,68 @@ class DeliveryOptionsFinderCore
         $include_taxes = !Product::getTaxCalculationMethod((int) $this->context->cart->id_customer) && (int) Configuration::get('PS_TAX');
         $display_taxes_label = (Configuration::get('PS_TAX') && $this->context->country->display_tax_label);
 
-        if (empty($deliveryOptions[$this->context->cart->id_address_delivery])) {
-            return [];
-        }
+        $carriers_available = [];
 
-        $formattedDeliveryOptions = [];
+        if (isset($delivery_option_list[$this->context->cart->id_address_delivery])) {
+            foreach ($delivery_option_list[$this->context->cart->id_address_delivery] as $id_carriers_list => $carriers_list) {
+                foreach ($carriers_list as $carriers) {
+                    if (is_array($carriers)) {
+                        foreach ($carriers as $carrier) {
+                            $carrier = array_merge($carrier, $this->objectPresenter->present($carrier['instance']));
+                            $delay = $carrier['delay'][$this->context->language->id];
+                            unset($carrier['instance'], $carrier['delay']);
+                            $carrier['delay'] = $delay;
+                            if ($this->isFreeShipping($this->context->cart, $carriers_list)) {
+                                $carrier['price'] = $this->translator->trans(
+                                    'Free',
+                                    [],
+                                    'Shop.Theme.Checkout'
+                                );
+                            } else {
+                                if ($include_taxes) {
+                                    $carrier['price'] = $this->priceFormatter->format($carriers_list['total_price_with_tax']);
+                                    if ($display_taxes_label) {
+                                        $carrier['price'] = $this->translator->trans(
+                                            '%price% tax incl.',
+                                            ['%price%' => $carrier['price']],
+                                            'Shop.Theme.Checkout'
+                                        );
+                                    }
+                                } else {
+                                    $carrier['price'] = $this->priceFormatter->format($carriers_list['total_price_without_tax']);
+                                    if ($display_taxes_label) {
+                                        $carrier['price'] = $this->translator->trans(
+                                            '%price% tax excl.',
+                                            ['%price%' => $carrier['price']],
+                                            'Shop.Theme.Checkout'
+                                        );
+                                    }
+                                }
+                            }
 
-        foreach ($currentAddressDeliveryOptions as $deliveryOptionId => $deliveryOption) {
-            $formattedDeliveryOption = end($deliveryOption['carrier_list']);
-            $formattedDeliveryOption = array_merge($formattedDeliveryOption, $this->objectPresenter->present($formattedDeliveryOption['instance']));
-            unset($formattedDeliveryOption['instance']);
+                            if (count($carriers) > 1) {
+                                $carrier['label'] = $carrier['price'];
+                            } else {
+                                $carrier['label'] = $carrier['name'] . ' - ' . $carrier['delay'] . ' - ' . $carrier['price'];
+                            }
 
-            $carriersDetails = $this->getCarriersDetails($deliveryOption);
-            $formattedDeliveryOption = array_merge($formattedDeliveryOption, $carriersDetails);
+                            // If carrier related to a module, check for additionnal data to display
+                            $carrier['extraContent'] = '';
+                            if ($carrier['is_module']) {
+                                if ($moduleId = Module::getModuleIdByName($carrier['external_module_name'])) {
+                                    // Hook called only for the module concerned
+                                    $carrier['extraContent'] = Hook::exec('displayCarrierExtraContent', ['carrier' => $carrier], $moduleId);
+                                }
+                            }
 
-            $formattedDeliveryOption['price'] = $this->getPriceToDisplay($deliveryOption);
-            $formattedDeliveryOption['label'] = $formattedDeliveryOption['price'];
-
-            $formattedDeliveryOptions[$deliveryOptionId] = $formattedDeliveryOption;
-        }
-
-        return $formattedDeliveryOptions;
-    }
-
-    private function getCarriersDetails($deliveryOption)
-    {
-        $carriers = $deliveryOption['carrier_list'];
-
-        if (count($carriers) === 1) {
-            return [
-                'id' => $carriers[0]['instance']->id,
-                'label' => $carriers[0]['label'],
-                'name' => $carriers[0]['instance']->name,
-                'delay' => $carriers[0]['instance']->delay[$this->context->language->id],
-            ];
-        }
-
-        $names = [];
-        $delays = [];
-        $extraContent = [];
-
-        foreach ($carriers as $carrier) {
-            $names[] = $carrier['instance']->name;
-            $delays[] = $carrier['instance']->delay[$this->context->language->id];
-            $extraContent[$carrier['instance']->id] = Hook::exec('displayCarrierExtraContent', ['carrier' => $carrier['instance']], Module::getModuleIdByName($carrier['instance']->id));
-        }
-
-        return [
-            'id' => end($carriers)['instance']->id,
-            'name' => implode(', ', $names),
-            'delay' => implode(', ', $delays),
-            'extraContent' => $extraContent,
-        ];
-    }
-
-    private function getPriceToDisplay($deliveryOption)
-    {
-        if ($this->isFreeShipping($deliveryOption)) {
-            return $this->translator->trans(
-                'Free',
-                [],
-                'Shop.Theme.Checkout'
-            );
-        }
-
-        if ($this->shouldIncludeTaxes()) {
-            $price = $this->priceFormatter->format($deliveryOption['total_price_with_tax']);
-            if ($this->shouldDisplayTaxesLabel()) {
-                $label = '%price% tax incl.';
-            }
-        } else {
-            $price = $this->priceFormatter->format($deliveryOption['total_price_without_tax']);
-            if ($this->shouldDisplayTaxesLabel()) {
-                $label = '%price% tax excl.';
+                            $carriers_available[$id_carriers_list] = $carrier;
+                        }
+                    }
+                }
             }
         }
 
-        return $this->translator->trans(
-            $label ?? '%price%',
-            ['%price%' => $price],
-            'Shop.Theme.Checkout'
-        );
-    }
-
-    private function shouldIncludeTaxes()
-    {
-        return !Product::getTaxCalculationMethod((int) $this->context->cart->id_customer)
-            && (int) Configuration::get('PS_TAX');
-    }
-
-    private function shouldDisplayTaxesLabel()
-    {
-        return Configuration::get('PS_TAX')
-            && $this->context->country->display_tax_label
-            && !Configuration::get('AEUC_LABEL_TAX_INC_EXC');
+        dump($carriers_available);
+        return $carriers_available;
     }
 }

--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -24,7 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
 use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Shipment\DeliveryOptionsInterface;

--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -138,7 +138,6 @@ class DeliveryOptionsFinderCore implements DeliveryOptionsInterface
             }
         }
 
-        dump($carriers_available);
         return $carriers_available;
     }
 }

--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -23,6 +24,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Shipment\DeliveryOptionsInterface;

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -25,12 +25,12 @@
  */
 
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
+use PrestaShop\PrestaShop\Adapter\Shipment\DeliveryOptionsProvider;
 use PrestaShop\PrestaShop\Core\Checkout\TermsAndConditions;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 use PrestaShop\PrestaShop\Core\Foundation\Templating\RenderableProxy;
 use PrestaShopBundle\Translation\TranslatorComponent;
-use PrestaShop\PrestaShop\Adapter\Shipment\DeliveryOptionsProvider;
-use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
-use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 
 class OrderControllerCore extends FrontController
 {

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -28,6 +28,9 @@ use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Core\Checkout\TermsAndConditions;
 use PrestaShop\PrestaShop\Core\Foundation\Templating\RenderableProxy;
 use PrestaShopBundle\Translation\TranslatorComponent;
+use PrestaShop\PrestaShop\Adapter\Shipment\DeliveryOptionsProvider;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 
 class OrderControllerCore extends FrontController
 {
@@ -118,12 +121,24 @@ class OrderControllerCore extends FrontController
      */
     public function getCheckoutSession(): CheckoutSession
     {
-        $deliveryOptionsFinder = new DeliveryOptionsFinder(
-            $this->context,
-            $this->getTranslator(),
-            $this->objectPresenter,
-            new PriceFormatter()
-        );
+        /** @var FeatureFlagStateCheckerInterface $featureFlagManager */
+        $featureFlagManager = $this->get(FeatureFlagStateCheckerInterface::class);
+
+        if ($featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT)) {
+            $deliveryOptionsFinder = new DeliveryOptionsProvider(
+                $this->context,
+                $this->getTranslator(),
+                $this->objectPresenter,
+                new PriceFormatter()
+            );
+        } else {
+            $deliveryOptionsFinder = new DeliveryOptionsFinder(
+                $this->context,
+                $this->getTranslator(),
+                $this->objectPresenter,
+                new PriceFormatter()
+            );
+        }
 
         $session = new CheckoutSession(
             $this->context,

--- a/src/Adapter/Shipment/DeliveryOptionsInterface.php
+++ b/src/Adapter/Shipment/DeliveryOptionsInterface.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Shipment;
+
+interface DeliveryOptionsInterface
+{
+    public function getSelectedDeliveryOption();
+
+    public function getDeliveryOptions();
+}

--- a/src/Adapter/Shipment/DeliveryOptionsProvider.php
+++ b/src/Adapter/Shipment/DeliveryOptionsProvider.php
@@ -28,10 +28,10 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Shipment;
 
-use Hook;
-use Module;
 use Context;
 use DeliveryOptionsFinderCore;
+use Hook;
+use Module;
 use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use Symfony\Contracts\Translation\TranslatorInterface;

--- a/src/Adapter/Shipment/DeliveryOptionsProvider.php
+++ b/src/Adapter/Shipment/DeliveryOptionsProvider.php
@@ -68,7 +68,6 @@ class DeliveryOptionsProvider implements DeliveryOptionsInterface
         foreach ($cart->getCartRules() as $rule) {
             if ($rule['free_shipping'] && !$rule['carrier_restriction']) {
                 return true;
-                break;
             }
         }
 

--- a/src/Adapter/Shipment/DeliveryOptionsProvider.php
+++ b/src/Adapter/Shipment/DeliveryOptionsProvider.php
@@ -123,9 +123,13 @@ class DeliveryOptionsProvider implements DeliveryOptionsInterface
         $delays = [];
         $extraContent = '';
 
+        // If carrier related to a module, check for additionnal data to display
         foreach ($carriers as $carrier) {
             $names[] = $carrier['instance']->name;
             $delays[] = $carrier['instance']->delay[$this->context->language->id];
+
+            // if more than on carrier are in the same delivery options then concatenate
+            // all extracontent
             $extraContent .= Hook::exec('displayCarrierExtraContent', ['carrier' => $carrier['instance']], Module::getModuleIdByName($carrier['instance']->id));
         }
 
@@ -147,14 +151,14 @@ class DeliveryOptionsProvider implements DeliveryOptionsInterface
             );
         }
 
-        if ($this->isTaxesIsIncluded()) {
+        if ($this->isPriceDisplayedWithTax()) {
             $price = $this->priceFormatter->format($deliveryOption['total_price_with_tax']);
-            if ($this->isTaxesLabelIsDisplayed()) {
+            if ($this->areTaxesLabelIsDisplayed()) {
                 $label = '%price% tax incl.';
             }
         } else {
             $price = $this->priceFormatter->format($deliveryOption['total_price_without_tax']);
-            if ($this->isTaxesLabelIsDisplayed()) {
+            if ($this->areTaxesLabelIsDisplayed()) {
                 $label = '%price% tax excl.';
             }
         }
@@ -166,13 +170,13 @@ class DeliveryOptionsProvider implements DeliveryOptionsInterface
         );
     }
 
-    private function isTaxesIsIncluded()
+    private function isPriceDisplayedWithTax()
     {
         return !Product::getTaxCalculationMethod((int) $this->context->cart->id_customer)
             && (int) Configuration::get('PS_TAX');
     }
 
-    private function isTaxesLabelIsDisplayed()
+    private function areTaxesLabelIsDisplayed()
     {
         return Configuration::get('PS_TAX')
             && $this->context->country->display_tax_label

--- a/src/Adapter/Shipment/DeliveryOptionsProvider.php
+++ b/src/Adapter/Shipment/DeliveryOptionsProvider.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Shipment;
+
+use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
+use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
+use PrestaShop\PrestaShop\Adapter\Shipment\DeliveryOptionsInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Context;
+use Product;
+use Configuration;
+use Hook;
+use Module;
+
+class DeliveryOptionsProvider implements DeliveryOptionsInterface
+{
+    private $context;
+    private $objectPresenter;
+    private $translator;
+    private $priceFormatter;
+
+    public function __construct(
+        Context $context,
+        TranslatorInterface $translator,
+        ObjectPresenter $objectPresenter,
+        PriceFormatter $priceFormatter
+    ) {
+        $this->context = $context;
+        $this->objectPresenter = $objectPresenter;
+        $this->translator = $translator;
+        $this->priceFormatter = $priceFormatter;
+    }
+
+    private function isFreeShipping(array $deliveryOption)
+    {
+        if ($deliveryOption['is_free']) {
+            return true;
+        }
+
+        $cart = $this->context->cart;
+
+        foreach ($cart->getCartRules() as $rule) {
+            if ($rule['free_shipping'] && !$rule['carrier_restriction']) {
+                return true;
+                break;
+            }
+        }
+
+        return false;
+    }
+
+    public function getSelectedDeliveryOption()
+    {
+        return current($this->context->cart->getDeliveryOption(null, false, false));
+    }
+
+    public function getDeliveryOptions()
+    {
+        $deliveryOptions = $this->context->cart->getDeliveryOptionList();
+        $currentAddressDeliveryOptions = $deliveryOptions[$this->context->cart->id_address_delivery];
+
+        if (empty($deliveryOptions[$this->context->cart->id_address_delivery])) {
+            return [];
+        }
+
+        $formattedDeliveryOptions = [];
+
+        foreach ($currentAddressDeliveryOptions as $deliveryOptionId => $deliveryOption) {
+            $formattedDeliveryOption = end($deliveryOption['carrier_list']);
+            $formattedDeliveryOption = array_merge($formattedDeliveryOption, $this->objectPresenter->present($formattedDeliveryOption['instance']));
+            unset($formattedDeliveryOption['instance']);
+
+            $carriersDetails = $this->getCarriersDetails($deliveryOption);
+            $formattedDeliveryOption = array_merge($formattedDeliveryOption, $carriersDetails);
+
+            $formattedDeliveryOption['price'] = $this->getPriceToDisplay($deliveryOption);
+            $formattedDeliveryOption['label'] = $formattedDeliveryOption['price'];
+
+            $formattedDeliveryOptions[$deliveryOptionId] = $formattedDeliveryOption;
+        }
+
+        return $formattedDeliveryOptions;
+    }
+
+    private function getCarriersDetails($deliveryOption)
+    {
+        $carriers = $deliveryOption['carrier_list'];
+
+        if (count($carriers) === 1) {
+            return [
+                'id' => $carriers[0]['instance']->id,
+                'label' => $carriers[0]['label'],
+                'name' => $carriers[0]['instance']->name,
+                'delay' => $carriers[0]['instance']->delay[$this->context->language->id],
+            ];
+        }
+
+        $names = [];
+        $delays = [];
+        $extraContent = '';
+
+        foreach ($carriers as $carrier) {
+            $names[] = $carrier['instance']->name;
+            $delays[] = $carrier['instance']->delay[$this->context->language->id];
+            $extraContent .= Hook::exec('displayCarrierExtraContent', ['carrier' => $carrier['instance']], Module::getModuleIdByName($carrier['instance']->id));
+        }
+
+        return [
+            'id' => end($carriers)['instance']->id,
+            'name' => implode(', ', $names),
+            'delay' => implode(', ', $delays),
+            'extraContent' => $extraContent,
+        ];
+    }
+
+    private function getPriceToDisplay($deliveryOption)
+    {
+        if ($this->isFreeShipping($deliveryOption)) {
+            return $this->translator->trans(
+                'Free',
+                [],
+                'Shop.Theme.Checkout'
+            );
+        }
+
+        if ($this->isTaxesIsIncluded()) {
+            $price = $this->priceFormatter->format($deliveryOption['total_price_with_tax']);
+            if ($this->isTaxesLabelIsDisplayed()) {
+                $label = '%price% tax incl.';
+            }
+        } else {
+            $price = $this->priceFormatter->format($deliveryOption['total_price_without_tax']);
+            if ($this->isTaxesLabelIsDisplayed()) {
+                $label = '%price% tax excl.';
+            }
+        }
+
+        return $this->translator->trans(
+            $label ?? '%price%',
+            ['%price%' => $price],
+            'Shop.Theme.Checkout'
+        );
+    }
+
+    private function isTaxesIsIncluded()
+    {
+        return !Product::getTaxCalculationMethod((int) $this->context->cart->id_customer)
+            && (int) Configuration::get('PS_TAX');
+    }
+
+    private function isTaxesLabelIsDisplayed()
+    {
+        return Configuration::get('PS_TAX')
+            && $this->context->country->display_tax_label
+            && !Configuration::get('AEUC_LABEL_TAX_INC_EXC');
+    }
+}

--- a/src/Adapter/Shipment/DeliveryOptionsProvider.php
+++ b/src/Adapter/Shipment/DeliveryOptionsProvider.php
@@ -28,15 +28,14 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Shipment;
 
-use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
-use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
-use PrestaShop\PrestaShop\Adapter\Shipment\DeliveryOptionsInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
-use Context;
-use Product;
 use Configuration;
+use Context;
 use Hook;
 use Module;
+use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
+use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
+use Product;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DeliveryOptionsProvider implements DeliveryOptionsInterface
 {


### PR DESCRIPTION
## Description

This pull request modifies the behavior of delivery method display in the front office when multiple carriers are involved in a single delivery method (multiple shipments).

Previously, the display of individual carriers within a delivery method was suppressed when more than one carrier was associated to the delivery method -> only the last carrier in the array will be displayed to the end customer. This pull request introduces a conditional display mechanism controlled by the `FEATURE_FLAG_IMPROVED_SHIPMENT`.

When the `FEATURE_FLAG_IMPROVED_SHIPMENT` is enabled (configurable in `Advanced Parameters -> New & Experimental Features`), the system will now explicitly show the individual carriers associated with a selected delivery method.

This is a preliminary design. Further enhancements to the presentation and user experience will be addressed in subsequent updates, including potential theme modifications to better accommodate the display of multiple carriers (shipments) within a delivery option.

![image](https://github.com/user-attachments/assets/2e4645e3-a0ef-442d-b422-b363161e7686)

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Indicate how to verify that this change works as expected.
| UI Tests          |  https://github.com/Nakahiru/ga.tests.ui.pr/actions/runs/17553993160
| Fixed issue or discussion?     | none
| Related PRs       | none
| Sponsor company   | -
