### PR TITLE
fix Open mobile menu, get a black screen #38456

### DIFF
--- a/admin-dev/themes/default/scss/partials/_nav.scss
+++ b/admin-dev/themes/default/scss/partials/_nav.scss
@@ -432,7 +432,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 1999;
+  z-index: 1000;
   display: none;
   width: 100%;
   height: 100%;

--- a/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
@@ -456,7 +456,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 1999;
+  z-index: 1000;
   display: none;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | fix Open mobile menu, get a black screen #38456
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | use tablet or mobile phone o use the simulator in browser; login in backoffice; click on hamburger  menu; now you can click on menu items
| UI Tests          | --
| Fixed issue or discussion?     | Fixes #38456
| Related PRs       | -
| Sponsor company   | https://www.bwlab.it
