### PR TITLE
New Hook: actionGetPdfRenderer to use a custom inherited tcpdf renderer

### DIFF
--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -75,7 +75,13 @@ class PDFCore
      */
     public function __construct($objects, $template, $smarty, $orientation = 'P')
     {
-        $this->pdf_renderer = new PDFGenerator((bool) Configuration::get('PS_PDF_USE_CACHE'), $orientation);
+        $this->pdf_renderer = $this->getPdfRendererFromModules($template, $orientation);
+
+        // if no module wants to provide a pdf renderer, then the core feature is used
+        if (null === $this->pdf_renderer) {
+            $this->pdf_renderer = new PDFGenerator((bool) Configuration::get('PS_PDF_USE_CACHE'), $orientation);
+        }
+
         $this->template = $template;
 
         /*
@@ -234,5 +240,38 @@ class PDFCore
         }
 
         return !empty($this->filename);
+    }
+
+    /**
+     * Get the PDF renderer from modules.
+     *
+     * @param string $template
+     * @param string $orientation
+     *
+     * @return TCPDF|null
+     */
+    private function getPdfRendererFromModules($template, $orientation)
+    {
+        $renderers = Hook::exec(
+            'actionGetPdfRenderer',
+            [
+                'template' => $template,
+                'orientation' => $orientation
+            ],
+            null,
+            true
+        );
+
+        if (!is_array($renderers)) {
+            $renderers = [];
+        }
+
+        foreach ($renderers as $renderer) {
+            if ($renderer instanceof TCPDF) {
+                return $renderer;
+            }
+        }
+
+        return null;
     }
 }

--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -35,7 +35,7 @@ class PDFCore
     public $filename;
 
     /**
-     * @var PDFGenerator
+     * @var TCPDF
      */
     public $pdf_renderer;
 
@@ -75,11 +75,13 @@ class PDFCore
      */
     public function __construct($objects, $template, $smarty, $orientation = 'P')
     {
-        $this->pdf_renderer = $this->getPdfRendererFromModules($template, $orientation);
+        $pdfRendererFromModules = $this->getPdfRendererFromModules($template, $orientation);
 
         // if no module wants to provide a pdf renderer, then the core feature is used
-        if (null === $this->pdf_renderer) {
+        if (null === $pdfRendererFromModules) {
             $this->pdf_renderer = new PDFGenerator((bool) Configuration::get('PS_PDF_USE_CACHE'), $orientation);
+        } else {
+            $this->pdf_renderer = $pdfRendererFromModules;
         }
 
         $this->template = $template;

--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -258,7 +258,7 @@ class PDFCore
             'actionGetPdfRenderer',
             [
                 'template' => $template,
-                'orientation' => $orientation
+                'orientation' => $orientation,
             ],
             null,
             true

--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -35,7 +35,7 @@ class PDFCore
     public $filename;
 
     /**
-     * @var TCPDF
+     * @var PDFGenerator
      */
     public $pdf_renderer;
 
@@ -250,7 +250,7 @@ class PDFCore
      * @param string $template
      * @param string $orientation
      *
-     * @return TCPDF|null
+     * @return PDFGenerator|null
      */
     private function getPdfRendererFromModules($template, $orientation)
     {
@@ -269,7 +269,7 @@ class PDFCore
         }
 
         foreach ($renderers as $renderer) {
-            if ($renderer instanceof TCPDF) {
+            if ($renderer instanceof PDFGenerator) {
                 return $renderer;
             }
         }

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -5403,5 +5403,10 @@
       <title>Modify search term identifiable object data after creating it</title>
       <description>This hook allows to modify search term identifiable object forms data after it was created</description>
     </hook>
+    <hook id="actionGetPdfRenderer">
+      <name>actionGetPdfRenderer</name>
+      <title>Provide a PDF renderer</title>
+      <description>This hook allows to provide a custom PDF renderer to generate PDF files</description>
+    </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I introduce a new hook. With this you are able to use a custom renderer for pdf files instead of the default PDFGenerator
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Crete a new module to trigger this hook.
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -
