### PR TITLE
New Hook: actionPaymentModuleProductVarTplAfter

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -482,6 +482,13 @@ abstract class PaymentModuleCore extends Module
                     }
                 }
 
+                Hook::exec('actionPaymentModuleProductVarTplAfter', [
+                    'product_var_tpl' => &$product_var_tpl,
+                    'product' => $product,
+                    'order' => $order,
+                    'context' => $this->context
+                ]);
+
                 $product_var_tpl_list[] = $product_var_tpl;
                 // Check if is not a virtual product for the displaying of shipping
                 if (!$product['is_virtual']) {

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -41,6 +41,11 @@
       <title>Payment confirmation</title>
       <description>This hook displays new elements after the payment is validated</description>
     </hook>
+    <hook id="actionPaymentModuleProductVarTplAfter">
+      <name>actionPaymentModuleProductVarTplAfter</name>
+      <title>Triggers after product data is prepared for e-mail template</title>
+      <description>Allows to modify product data in e-mail template.</description>
+    </hook>
     <hook id="displayPaymentReturn">
       <name>displayPaymentReturn</name>
       <title>Payment return</title>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Add the `actionPaymentModuleProductVarTplAfter` hook to allow modification of product template variables, e.g. to add the product image. Currently, I don’t see a way to achieve this without overriding the `validateOrder` method.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Register a new hook in your module, modify `product_var_tpl`, and update `order_conf_product_list.tpl` in the mails folder to use this modification. Then, place an order and check if the changes are reflected.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/14516531896
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | Arkonsoft
