### PR TITLE
Modify the shipment creation & remove order duplication for different carrier

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3228,7 +3228,6 @@ class CartCore extends ObjectModel
             'without_tax' => 0,
         ];
         $delivery_option_list = $this->getDeliveryOptionList($default_country);
-
         foreach ($delivery_option as $id_address => $key) {
             if (!isset($delivery_option_list[$id_address]) || !isset($delivery_option_list[$id_address][$key])) {
                 continue;

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3228,6 +3228,7 @@ class CartCore extends ObjectModel
             'without_tax' => 0,
         ];
         $delivery_option_list = $this->getDeliveryOptionList($default_country);
+
         foreach ($delivery_option as $id_address => $key) {
             if (!isset($delivery_option_list[$id_address]) || !isset($delivery_option_list[$id_address][$key])) {
                 continue;

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -351,12 +351,10 @@ abstract class PaymentModuleCore extends Module
 
         $productsHandleByCarrier = [];
         $idAddress = null;
-        $carrierId = null;
 
         foreach ($package_list as $id_address => $packageByAddress) {
             $idAddress = $id_address;
             foreach ($packageByAddress as $id_package => $package) {
-                $carrierId = $package['id_carrier'];
                 if ($this->isFeatureFlagIsEnabledForMultiShipment()) {
                     $productsHandleByCarrier[$package['id_carrier']] = $package['product_list'];
                 } else {
@@ -404,7 +402,7 @@ abstract class PaymentModuleCore extends Module
                 self::DEBUG_MODE,
                 $order_status,
                 $id_order_state,
-                $carrierId,
+                null,
                 true
             );
             $order = $orderData['order'];

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -386,8 +386,7 @@ abstract class PaymentModuleCore extends Module
                     $productsByCarriers[$package['id_carrier']]['product_list'] = $package['product_list'];
                 }
             }
-            // We create a single order that contains all the products
-            $orderData = $this->createOrderFromCartForMultiShipment(
+            $orderData = $this->createOrderFromCart(
                 $this->context->cart,
                 $this->context->currency,
                 $productsByCarriers,
@@ -409,8 +408,6 @@ abstract class PaymentModuleCore extends Module
             $order = $orderData['order'];
             $order_list[] = $order;
             $order_detail_list[] = $orderData['orderDetail'];
-            // Now we create the multiple shipments
-            $this->addShipmentToOrder($order, $orderData['productsByCarriers']);
         }
         // The country can only change if the address used for the calculation is the delivery address, and if multi-shipping is activated
         if (Configuration::get('PS_TAX_ADDRESS_TYPE') == 'id_address_delivery' && isset($context_country)) {
@@ -1007,7 +1004,15 @@ abstract class PaymentModuleCore extends Module
         $carrierId = null,
     ) {
         $order = new Order();
-        $order->product_list = $productList;
+        if (!$this->isFeatureFlagIsEnabledForMultiShipment()) {
+            $order->product_list = $productList;
+        } else {
+            foreach ($productList as $products) {
+                foreach ($products['product_list'] as $product) {
+                    $order->product_list[] = $product;
+                }
+            }
+        }
 
         $computingPrecision = Context::getContext()->getComputingPrecision();
 
@@ -1068,14 +1073,34 @@ abstract class PaymentModuleCore extends Module
             $computingPrecision
         );
         $order->total_discounts = $order->total_discounts_tax_incl;
-        $order->total_shipping_tax_excl = Tools::ps_round(
-            (float) $cart->getPackageShippingCost($carrierId, false, null, $order->product_list),
-            $computingPrecision
-        );
+
         $order->total_shipping_tax_incl = Tools::ps_round(
-            (float) $cart->getPackageShippingCost($carrierId, true, null, $order->product_list),
+            (float) abs($cart->getOrderTotal(true, Cart::ONLY_SHIPPING, $order->product_list, null)),
             $computingPrecision
         );
+
+        $order->total_shipping_tax_excl = Tools::ps_round(
+            (float) abs($cart->getOrderTotal(false, Cart::ONLY_SHIPPING, $order->product_list, null)),
+            $computingPrecision
+        );
+
+        // loop for each carrier to store the shipping cost
+        if ($this->isFeatureFlagIsEnabledForMultiShipment()) {
+            foreach ($productList as $carrierId => $product) {
+                $totalShippingTaxExcl = Tools::ps_round(
+                    (float) abs($cart->getOrderTotal(false, Cart::ONLY_SHIPPING, $order->product_list, $carrierId)),
+                    $computingPrecision
+                );
+                $totalShippingTaxIncl = Tools::ps_round(
+                    (float) abs($cart->getOrderTotal(true, Cart::ONLY_SHIPPING, $order->product_list, $carrierId)),
+                    $computingPrecision
+                );
+
+                $productList[$carrierId]['total_shipping_tax_excl'] = $totalShippingTaxExcl;
+                $productList[$carrierId]['total_shipping_tax_incl'] = $totalShippingTaxIncl;
+            }
+        }
+
         $order->total_shipping = $order->total_shipping_tax_incl;
 
         if (null !== $carrier && Validate::isLoadedObject($carrier)) {
@@ -1156,6 +1181,10 @@ abstract class PaymentModuleCore extends Module
             $order_carrier->shipping_cost_tax_excl = (float) $order->total_shipping_tax_excl;
             $order_carrier->shipping_cost_tax_incl = (float) $order->total_shipping_tax_incl;
             $order_carrier->add();
+        }
+
+        if ($this->isFeatureFlagIsEnabledForMultiShipment()) {
+            $this->addShipmentToOrder($order, $productList);
         }
 
         return ['order' => $order, 'orderDetail' => $order_detail];
@@ -1305,194 +1334,6 @@ abstract class PaymentModuleCore extends Module
         }
 
         return $cart_rules_list;
-    }
-
-    private function createOrderFromCartForMultiShipment(
-        Cart $cart,
-        Currency $currency,
-        $productList,
-        $addressId,
-        $context,
-        $reference,
-        $secure_key,
-        $payment_method,
-        $name,
-        $dont_touch_amount,
-        $amount_paid,
-        $warehouseId,
-        $cart_total_paid,
-        $debug,
-        $order_status,
-        $id_order_state,
-        $carrierId = null
-    ) {
-        $order = new Order();
-        foreach ($productList as $products) {
-            foreach ($products['product_list'] as $product) {
-                $order->product_list[] = $product;
-            }
-        }
-
-        $computingPrecision = Context::getContext()->getComputingPrecision();
-
-        if (Configuration::get('PS_TAX_ADDRESS_TYPE') == 'id_address_delivery') {
-            $address = new Address((int) $addressId);
-            $context->country = new Country((int) $address->id_country, (int) $cart->id_lang);
-            if (!$context->country->active) {
-                throw new PrestaShopException('The delivery address country is not active.');
-            }
-        }
-
-        $carrier = null;
-        if (!$cart->isVirtualCart() && isset($carrierId)) {
-            $carrier = new Carrier((int) $carrierId, (int) $cart->id_lang);
-            $order->id_carrier = (int) $carrier->id;
-            $carrierId = (int) $carrier->id;
-        } else {
-            $order->id_carrier = 0;
-            $carrierId = 0;
-        }
-
-        $order->id_customer = (int) $cart->id_customer;
-        $order->id_address_invoice = (int) $cart->id_address_invoice;
-        $order->id_address_delivery = (int) $addressId;
-        $order->id_currency = $currency->id;
-        $order->id_lang = (int) $cart->id_lang;
-        $order->id_cart = (int) $cart->id;
-        $order->reference = $reference;
-        $order->id_shop = (int) $context->shop->id;
-        $order->id_shop_group = (int) $context->shop->id_shop_group;
-
-        $order->secure_key = ($secure_key ? pSQL($secure_key) : pSQL($context->customer->secure_key));
-        $order->payment = $payment_method;
-        if (isset($name)) {
-            $order->module = $name;
-        }
-        $order->recyclable = $cart->recyclable;
-        $order->gift = (bool) $cart->gift;
-        $order->gift_message = $cart->gift_message;
-        $order->conversion_rate = $currency->conversion_rate;
-        $amount_paid = !$dont_touch_amount ? Tools::ps_round((float) $amount_paid, $computingPrecision) : $amount_paid;
-        $order->total_paid_real = 0;
-
-        $order->total_products = Tools::ps_round(
-            (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS, $order->product_list, $carrierId),
-            $computingPrecision
-        );
-        $order->total_products_wt = Tools::ps_round(
-            (float) $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS, $order->product_list, $carrierId),
-            $computingPrecision
-        );
-        $order->total_discounts_tax_excl = Tools::ps_round(
-            (float) abs($cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS, $order->product_list, $carrierId)),
-            $computingPrecision
-        );
-        $order->total_discounts_tax_incl = Tools::ps_round(
-            (float) abs($cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS, $order->product_list, $carrierId)),
-            $computingPrecision
-        );
-        $order->total_discounts = $order->total_discounts_tax_incl;
-
-        // to get the right price for shipping cost inside the order
-        foreach ($productList as $key => $product) {
-            $totalShippingTaxExcl = Tools::ps_round(
-                (float) $cart->getPackageShippingCost($key, false, null, $order->product_list),
-                $computingPrecision
-            );
-            $totalShippingTaxIncl = Tools::ps_round(
-                (float) $cart->getPackageShippingCost($key, true, null, $order->product_list),
-                $computingPrecision
-            );
-            $order->total_shipping_tax_excl += $totalShippingTaxExcl;
-            $order->total_shipping_tax_incl += $totalShippingTaxIncl;
-
-            $productList[$key]['total_shipping_tax_excl'] = $totalShippingTaxExcl;
-            $productList[$key]['total_shipping_tax_incl'] = $totalShippingTaxIncl;
-        }
-
-        $order->total_shipping = $order->total_shipping_tax_incl;
-
-        if (null !== $carrier && Validate::isLoadedObject($carrier)) {
-            $order->carrier_tax_rate = $carrier->getTaxesRate(new Address((int) $cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')}));
-        }
-
-        $order->total_wrapping_tax_excl = Tools::ps_round(
-            (float) abs($cart->getOrderTotal(false, Cart::ONLY_WRAPPING, $order->product_list, $carrierId)),
-            $computingPrecision
-        );
-        $order->total_wrapping_tax_incl = Tools::ps_round(
-            (float) abs($cart->getOrderTotal(true, Cart::ONLY_WRAPPING, $order->product_list, $carrierId)),
-            $computingPrecision
-        );
-        $order->total_wrapping = $order->total_wrapping_tax_incl;
-
-        $order->total_paid_tax_excl = Tools::ps_round(
-            (float) $cart->getOrderTotal(false, Cart::BOTH, $order->product_list, $carrierId),
-            $computingPrecision
-        );
-        $order->total_paid_tax_incl = Tools::ps_round(
-            (float) $cart->getOrderTotal(true, Cart::BOTH, $order->product_list, $carrierId),
-            $computingPrecision
-        );
-        $order->total_paid = $order->total_paid_tax_incl;
-        $order->round_mode = (int) Configuration::get('PS_PRICE_ROUND_MODE');
-        $order->round_type = (int) Configuration::get('PS_ROUND_TYPE');
-
-        $order->invoice_date = '0000-00-00 00:00:00';
-        $order->delivery_date = '0000-00-00 00:00:00';
-
-        if ($debug) {
-            PrestaShopLogger::addLog('PaymentModule::validateOrder - Order is about to be added', 1, null, 'Cart', (int) $cart->id, true);
-        }
-
-        // Creating order
-        $result = $order->add();
-
-        if (!$result) {
-            PrestaShopLogger::addLog('PaymentModule::validateOrder - Order cannot be created', 3, null, 'Cart', (int) $cart->id, true);
-            throw new PrestaShopException('Can\'t save Order');
-        }
-
-        // Amount paid by customer is not the right one -> Status = payment error
-        // We don't use the following condition to avoid the float precision issues : https://www.php.net/manual/en/language.types.float.php
-        // if ($order->total_paid != $order->total_paid_real)
-        // We use number_format in order to compare two string
-        if ($order_status->logable
-            && number_format(
-                $cart_total_paid,
-                $computingPrecision
-            ) != number_format(
-                $amount_paid,
-                $computingPrecision
-            )
-        ) {
-            $id_order_state = Configuration::get('PS_OS_ERROR');
-        }
-
-        if ($debug) {
-            PrestaShopLogger::addLog('PaymentModule::validateOrder - OrderDetail is about to be added', 1, null, 'Cart', (int) $cart->id, true);
-        }
-
-        // Insert new Order detail list using cart for the current order
-        $order_detail = new OrderDetail(null, null, $context);
-        $order_detail->createList($order, $cart, $id_order_state, $order->product_list, 0, true);
-
-        if ($debug) {
-            PrestaShopLogger::addLog('PaymentModule::validateOrder - OrderCarrier is about to be added', 1, null, 'Cart', (int) $cart->id, true);
-        }
-
-        // Adding an entry in order_carrier table
-        if (null !== $carrier) {
-            $order_carrier = new OrderCarrier();
-            $order_carrier->id_order = (int) $order->id;
-            $order_carrier->id_carrier = $carrierId;
-            $order_carrier->weight = (float) $order->getTotalWeight();
-            $order_carrier->shipping_cost_tax_excl = (float) $order->total_shipping_tax_excl;
-            $order_carrier->shipping_cost_tax_incl = (float) $order->total_shipping_tax_incl;
-            $order_carrier->add();
-        }
-
-        return ['order' => $order, 'orderDetail' => $order_detail, 'productsByCarriers' => $productList];
     }
 
     private function addShipmentToOrder(Order $order, array $productsByCarrier)

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1010,7 +1010,7 @@ abstract class PaymentModuleCore extends Module
         if (!$isFeatureFlagIsEnabledForMultiShipment) {
             $order->product_list = $productList;
         } else {
-            foreach($productList as $products) {
+            foreach ($productList as $products) {
                 foreach ($products as $product) {
                     $order->product_list[] = $product;
                 }

--- a/src/Adapter/Shipment/OrderShipmentCreator.php
+++ b/src/Adapter/Shipment/OrderShipmentCreator.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Shipment;
 
 use Order;
+use OrderCarrier;
 use OrderDetail;
 use PrestaShopBundle\Entity\Repository\ShipmentRepository;
 use PrestaShopBundle\Entity\Shipment;
@@ -59,6 +60,19 @@ class OrderShipmentCreator
             $shipment->setDeliveredAt(null);
             $shipment->setShippedAt(null);
             $shipment->setCancelledAt(null);
+
+            $productWeight = array_map(function ($product) {
+                return $product['weight'] * $product['quantity'];
+            }, $products['product_list']);
+
+            // add OrderCarrier here for keep the compatibility for legacy
+            $orderCarrier = new OrderCarrier();
+            $orderCarrier->id_order = (int) $order->id;
+            $orderCarrier->id_carrier = $carrierId;
+            $orderCarrier->weight = (float) $productWeight[0];
+            $orderCarrier->shipping_cost_tax_excl = (float) $products['total_shipping_tax_excl'];
+            $orderCarrier->shipping_cost_tax_incl = (float) $products['total_shipping_tax_incl'];
+            $orderCarrier->add();
 
             // match products with order details to get quantities & orderDetailId
             foreach (OrderDetail::getList($order->id) as $orderDetailProduct) {

--- a/src/Adapter/Shipment/OrderShipmentCreator.php
+++ b/src/Adapter/Shipment/OrderShipmentCreator.php
@@ -54,15 +54,15 @@ class OrderShipmentCreator
             $shipment->setCarrierId((int) $carrierId);
             $shipment->setAddressId((int) $order->id_address_delivery);
             $shipment->setTrackingNumber(null);
-            $shipment->setShippingCostTaxExcluded((float) $order->total_shipping_tax_excl);
-            $shipment->setShippingCostTaxIncluded((float) $order->total_shipping_tax_incl);
+            $shipment->setShippingCostTaxExcluded((float) $products['total_shipping_tax_excl']);
+            $shipment->setShippingCostTaxIncluded((float) $products['total_shipping_tax_incl']);
             $shipment->setDeliveredAt(null);
             $shipment->setShippedAt(null);
             $shipment->setCancelledAt(null);
 
             // match products with order details to get quantities & orderDetailId
             foreach (OrderDetail::getList($order->id) as $orderDetailProduct) {
-                foreach ($products as $product) {
+                foreach ($products['product_list'] as $product) {
                     if ($product['id_product'] === $orderDetailProduct['product_id']) {
                         $shipmentProduct = new ShipmentProduct();
                         $shipmentProduct->setShipment($shipment);

--- a/tests/Integration/Behaviour/Features/Context/Domain/ShipmentFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ShipmentFeatureContext.php
@@ -62,18 +62,19 @@ class ShipmentFeatureContext extends AbstractDomainFeatureContext
         for ($i = 0; $i < count($data); ++$i) {
             $shipmentData = $data[$i];
             $shipment = $shipments[$i];
-            $carrierId = $this->referenceToId($data[$i]['carrier']);
+            $carrierReference = $data[$i]['carrier'];
+            $carrierId = $this->referenceToId($carrierReference);
             $addressId = $this->referenceToId($data[$i]['address']);
 
             if ($shipment->getOrderId() !== $orderId) {
                 throw new RuntimeException('Shipment [' . $shipment->getId() . '] does not belong to order [' . $orderId . ']');
             }
 
-            Assert::assertEquals($shipment->getTrackingNumber(), $shipmentData['tracking_number']);
-            Assert::assertEquals($shipment->getCarrierId(), $carrierId);
-            Assert::assertEquals($shipment->getAddressId(), $addressId);
-            Assert::assertEquals($shipment->getShippingCostTaxExcluded(), $shipmentData['shipping_cost_tax_excl']);
-            Assert::assertEquals($shipment->getShippingCostTaxIncluded(), $shipmentData['shipping_cost_tax_incl']);
+            Assert::assertEquals($shipment->getTrackingNumber(), $shipmentData['tracking_number'], 'Wrong tracking number for ' . $carrierReference);
+            Assert::assertEquals($shipment->getCarrierId(), $carrierId, 'Wrong carrier ID for ' . $carrierReference);
+            Assert::assertEquals($shipment->getAddressId(), $addressId, 'Wrong address ID for ' . $carrierReference);
+            Assert::assertEquals($shipment->getShippingCostTaxExcluded(), $shipmentData['shipping_cost_tax_excl'], 'Wrong shipping cast tax excluded for ' . $carrierReference);
+            Assert::assertEquals($shipment->getShippingCostTaxIncluded(), $shipmentData['shipping_cost_tax_incl'], 'Wrong shipping cast tax included for ' . $carrierReference);
             SharedStorage::getStorage()->set($shipmentData['shipment'], $shipment->getId());
         }
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/ZoneFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ZoneFeatureContext.php
@@ -177,6 +177,22 @@ class ZoneFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Given there is a zone :reference named :name
+     *
+     * @param string $zoneReference
+     * @param string $name
+     */
+    public function assignZoneReference(string $zoneReference, string $name): void
+    {
+        $zoneId = Zone::getIdByName($name);
+        if (empty($zoneId)) {
+            throw new RuntimeException(sprintf('Zone name %s not found', $name));
+        }
+
+        SharedStorage::getStorage()->set($zoneReference, new Zone($zoneId));
+    }
+
+    /**
      * @Given /^zone "(.*)" is (enabled|disabled)?$/
      *
      * @Then /^zone "(.*)" should be (enabled|disabled)?$/

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/products_with_different_carriers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/products_with_different_carriers.feature
@@ -1,0 +1,94 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s shipment --tags products-with-different-carriers
+@restore-all-tables-before-feature
+@products-with-different-carriers
+Feature: Product associated with different carriers
+  As a BO users
+  I want to order products associated with different carriers
+  I order them multiple order shipments are created
+
+  Background:
+    Given I enable feature flag "improved_shipment"
+    And the current currency is "USD"
+    And country "US" is enabled
+    And the module "dummy_payment" is installed
+    And I am logged in as "test@prestashop.com" employee
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And there is a zone "north_america" named "North America"
+    # Create two carriers different with prices
+    And I identify tax rules group named "US-FL Rate (6%)" as "us-fl-tax-rate"
+    When I create carrier "beer_carrier" with specified properties:
+      | name           | Beer carrier  |
+      | active         | true          |
+      | shippingMethod | price         |
+      | zones          | north_america |
+    Then I set ranges for carrier "beer_carrier" with specified properties for all shops:
+      | id_zone       | range_from | range_to | range_price |
+      | north_america | 0          | 1000     | 5           |
+    When I set tax rule "us-fl-tax-rate" for carrier "beer_carrier"
+    Then carrier "beer_carrier" should have the following properties:
+      | name         | Beer carrier    |
+      | taxRuleGroup | US-FL Rate (6%) |
+    When I create carrier "saucisson_carrier" with specified properties:
+      | name           | Saucisson carrier |
+      | active         | true              |
+      | shippingMethod | price             |
+      | zones          | north_america     |
+    Then I set ranges for carrier "saucisson_carrier" with specified properties for all shops:
+      | id_zone       | range_from | range_to | range_price |
+      | north_america | 0          | 1000     | 10          |
+    When I set tax rule "us-fl-tax-rate" for carrier "saucisson_carrier"
+    Then carrier "saucisson_carrier" should have the following properties:
+      | name         | Saucisson carrier |
+      | taxRuleGroup | US-FL Rate (6%)   |
+    # Create two products associated with different carriers
+    When I add product "bottle_of_beer" with following information:
+      | name[en-US] | bottle of beer |
+      | type        | standard       |
+    When I update product "bottle_of_beer" stock with following information:
+      | delta_quantity | 51  |
+      | location       | dtc |
+    And product "bottle_of_beer" should have following stock information:
+      | quantity | 51  |
+      | location | dtc |
+    And I assign product bottle_of_beer with following carriers:
+      | beer_carrier |
+    Then product bottle_of_beer should have following shipping information:
+      | carriers | [beer_carrier] |
+    And I enable product "bottle_of_beer"
+    When I add product "saucisson" with following information:
+      | name[en-US] | saucisson |
+      | type        | standard  |
+    When I update product "saucisson" stock with following information:
+      | delta_quantity | 42  |
+      | location       | dtc |
+    And product "saucisson" should have following stock information:
+      | quantity | 42  |
+      | location | dtc |
+    And I assign product saucisson with following carriers:
+      | saucisson_carrier |
+    Then product saucisson should have following shipping information:
+      | carriers | [saucisson_carrier] |
+    And I enable product "saucisson"
+
+  Scenario: Retrieve shipments for existing order
+    Given I create an empty cart "dummy_cart" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And I add 1 products "bottle of beer" to the cart "dummy_cart"
+    And I add 2 products "saucisson" to the cart "dummy_cart"
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+    And I reference order "bo_order1" delivery address as "US"
+    Given the order "bo_order1" should have the following shipments:
+      | shipment  | carrier           | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
+      | shipment1 | beer_carrier      |                 | US      | 5.0                    | 5.30                   |
+      | shipment2 | saucisson_carrier |                 | US      | 10.0                   | 10.50                  |
+    Then the shipment "shipment1" should have the following products:
+      | product_name   | quantity |
+      | bottle of beer | 1        |
+    Then the shipment "shipment2" should have the following products:
+      | product_name | quantity |
+      | saucisson    | 2        |

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/products_with_different_carriers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/products_with_different_carriers.feature
@@ -22,6 +22,7 @@ Feature: Product associated with different carriers
       | active         | true          |
       | shippingMethod | price         |
       | zones          | north_america |
+      | shippingHandling          | false |
     Then I set ranges for carrier "beer_carrier" with specified properties for all shops:
       | id_zone       | range_from | range_to | range_price |
       | north_america | 0          | 1000     | 5           |
@@ -34,6 +35,7 @@ Feature: Product associated with different carriers
       | active         | true              |
       | shippingMethod | price             |
       | zones          | north_america     |
+      | shippingHandling          | false     |
     Then I set ranges for carrier "saucisson_carrier" with specified properties for all shops:
       | id_zone       | range_from | range_to | range_price |
       | north_america | 0          | 1000     | 10          |
@@ -84,8 +86,8 @@ Feature: Product associated with different carriers
     And I reference order "bo_order1" delivery address as "US"
     Given the order "bo_order1" should have the following shipments:
       | shipment  | carrier           | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
-      | shipment1 | beer_carrier      |                 | US      | 7.0                    | 7.42                   |
-      | shipment2 | saucisson_carrier |                 | US      | 12.0                   | 12.72                  |
+      | shipment1 | beer_carrier      |                 | US      | 5.0                    | 5.3                   |
+      | shipment2 | saucisson_carrier |                 | US      | 10.0                   | 10.60                  |
     Then the shipment "shipment1" should have the following products:
       | product_name   | quantity |
       | bottle of beer | 1        |

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/products_with_different_carriers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/products_with_different_carriers.feature
@@ -30,20 +30,7 @@ Feature: Product associated with different carriers
     Then carrier "beer_carrier" should have the following properties:
       | name         | Beer carrier    |
       | taxRuleGroup | US-FL Rate (6%) |
-    When I create carrier "saucisson_carrier" with specified properties:
-      | name           | Saucisson carrier |
-      | active         | true              |
-      | shippingMethod | price             |
-      | zones          | north_america     |
-      | shippingHandling          | false     |
-    Then I set ranges for carrier "saucisson_carrier" with specified properties for all shops:
-      | id_zone       | range_from | range_to | range_price |
-      | north_america | 0          | 1000     | 10          |
-    When I set tax rule "us-fl-tax-rate" for carrier "saucisson_carrier"
-    Then carrier "saucisson_carrier" should have the following properties:
-      | name         | Saucisson carrier |
-      | taxRuleGroup | US-FL Rate (6%)   |
-    # Create two products associated with different carriers
+    And a carrier "default_carrier" with name "My carrier" exists
     When I add product "bottle_of_beer" with following information:
       | name[en-US] | bottle of beer |
       | type        | standard       |
@@ -68,9 +55,9 @@ Feature: Product associated with different carriers
       | quantity | 42  |
       | location | dtc |
     And I assign product saucisson with following carriers:
-      | saucisson_carrier |
+      | default_carrier |
     Then product saucisson should have following shipping information:
-      | carriers | [saucisson_carrier] |
+      | carriers | [default_carrier] |
     And I enable product "saucisson"
 
   Scenario: Retrieve shipments for existing order
@@ -87,7 +74,7 @@ Feature: Product associated with different carriers
     Given the order "bo_order1" should have the following shipments:
       | shipment  | carrier           | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
       | shipment1 | beer_carrier      |                 | US      | 5.0                    | 5.3                   |
-      | shipment2 | saucisson_carrier |                 | US      | 10.0                   | 10.60                  |
+      | shipment2 | default_carrier |                 | US      | 7.0                   | 7.42                  |
     Then the shipment "shipment1" should have the following products:
       | product_name   | quantity |
       | bottle of beer | 1        |

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/products_with_different_carriers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/products_with_different_carriers.feature
@@ -22,7 +22,7 @@ Feature: Product associated with different carriers
       | active         | true          |
       | shippingMethod | price         |
       | zones          | north_america |
-      | shippingHandling          | false |
+      # | shippingHandling          | false |
     Then I set ranges for carrier "beer_carrier" with specified properties for all shops:
       | id_zone       | range_from | range_to | range_price |
       | north_america | 0          | 1000     | 5           |
@@ -35,7 +35,7 @@ Feature: Product associated with different carriers
       | active         | true              |
       | shippingMethod | price             |
       | zones          | north_america     |
-      | shippingHandling          | false     |
+      # | shippingHandling          | false     |
     Then I set ranges for carrier "saucisson_carrier" with specified properties for all shops:
       | id_zone       | range_from | range_to | range_price |
       | north_america | 0          | 1000     | 10          |
@@ -86,8 +86,8 @@ Feature: Product associated with different carriers
     And I reference order "bo_order1" delivery address as "US"
     Given the order "bo_order1" should have the following shipments:
       | shipment  | carrier           | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
-      | shipment1 | beer_carrier      |                 | US      | 5.0                    | 5.3                   |
-      | shipment2 | saucisson_carrier |                 | US      | 10.0                   | 10.60                  |
+      | shipment1 | beer_carrier      |                 | US      | 7.0                    | 7.42                   |
+      | shipment2 | saucisson_carrier |                 | US      | 12.0                   | 12.72                  |
     Then the shipment "shipment1" should have the following products:
       | product_name   | quantity |
       | bottle of beer | 1        |

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/products_with_different_carriers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/products_with_different_carriers.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s shipment --tags products-with-different-carriers
 @restore-all-tables-before-feature
+@clear-cache-before-feature
 @products-with-different-carriers
 Feature: Product associated with different carriers
   As a BO users
@@ -30,7 +31,19 @@ Feature: Product associated with different carriers
     Then carrier "beer_carrier" should have the following properties:
       | name         | Beer carrier    |
       | taxRuleGroup | US-FL Rate (6%) |
-    And a carrier "default_carrier" with name "My carrier" exists
+    When I create carrier "saucisson_carrier" with specified properties:
+      | name           | Saucisson carrier  |
+      | active         | true          |
+      | shippingMethod | price         |
+      | zones          | north_america |
+      | shippingHandling          | false |
+    Then I set ranges for carrier "saucisson_carrier" with specified properties for all shops:
+      | id_zone       | range_from | range_to | range_price |
+      | north_america | 0          | 1000     | 10           |
+    When I set tax rule "us-fl-tax-rate" for carrier "saucisson_carrier"
+    Then carrier "saucisson_carrier" should have the following properties:
+      | name         | Saucisson carrier    |
+      | taxRuleGroup | US-FL Rate (6%) |
     When I add product "bottle_of_beer" with following information:
       | name[en-US] | bottle of beer |
       | type        | standard       |
@@ -55,9 +68,9 @@ Feature: Product associated with different carriers
       | quantity | 42  |
       | location | dtc |
     And I assign product saucisson with following carriers:
-      | default_carrier |
+      | saucisson_carrier |
     Then product saucisson should have following shipping information:
-      | carriers | [default_carrier] |
+      | carriers | [saucisson_carrier] |
     And I enable product "saucisson"
 
   Scenario: Retrieve shipments for existing order
@@ -74,7 +87,7 @@ Feature: Product associated with different carriers
     Given the order "bo_order1" should have the following shipments:
       | shipment  | carrier           | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
       | shipment1 | beer_carrier      |                 | US      | 5.0                    | 5.3                   |
-      | shipment2 | default_carrier |                 | US      | 7.0                   | 7.42                  |
+      | shipment2 | saucisson_carrier |                 | US      | 10.0                   | 10.6                  |
     Then the shipment "shipment1" should have the following products:
       | product_name   | quantity |
       | bottle of beer | 1        |

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/products_with_different_carriers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/products_with_different_carriers.feature
@@ -22,7 +22,7 @@ Feature: Product associated with different carriers
       | active         | true          |
       | shippingMethod | price         |
       | zones          | north_america |
-      # | shippingHandling          | false |
+      | shippingHandling          | false |
     Then I set ranges for carrier "beer_carrier" with specified properties for all shops:
       | id_zone       | range_from | range_to | range_price |
       | north_america | 0          | 1000     | 5           |
@@ -35,7 +35,7 @@ Feature: Product associated with different carriers
       | active         | true              |
       | shippingMethod | price             |
       | zones          | north_america     |
-      # | shippingHandling          | false     |
+      | shippingHandling          | false     |
     Then I set ranges for carrier "saucisson_carrier" with specified properties for all shops:
       | id_zone       | range_from | range_to | range_price |
       | north_america | 0          | 1000     | 10          |
@@ -86,8 +86,8 @@ Feature: Product associated with different carriers
     And I reference order "bo_order1" delivery address as "US"
     Given the order "bo_order1" should have the following shipments:
       | shipment  | carrier           | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
-      | shipment1 | beer_carrier      |                 | US      | 7.0                    | 7.42                   |
-      | shipment2 | saucisson_carrier |                 | US      | 12.0                   | 12.72                  |
+      | shipment1 | beer_carrier      |                 | US      | 5.0                    | 5.3                   |
+      | shipment2 | saucisson_carrier |                 | US      | 10.0                   | 10.60                  |
     Then the shipment "shipment1" should have the following products:
       | product_name   | quantity |
       | bottle of beer | 1        |

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/products_with_different_carriers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/products_with_different_carriers.feature
@@ -84,8 +84,8 @@ Feature: Product associated with different carriers
     And I reference order "bo_order1" delivery address as "US"
     Given the order "bo_order1" should have the following shipments:
       | shipment  | carrier           | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
-      | shipment1 | beer_carrier      |                 | US      | 5.0                    | 5.30                   |
-      | shipment2 | saucisson_carrier |                 | US      | 10.0                   | 10.50                  |
+      | shipment1 | beer_carrier      |                 | US      | 7.0                    | 7.42                   |
+      | shipment2 | saucisson_carrier |                 | US      | 12.0                   | 12.72                  |
     Then the shipment "shipment1" should have the following products:
       | product_name   | quantity |
       | bottle of beer | 1        |

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
@@ -1,5 +1,6 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s shipment
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s shipment --tags shipment
 @restore-all-tables-before-feature
+@shipment
 Feature: Retrieving shipment for orders
   As a BO users
   I want to retrieve the list of shipments associated with a specific order

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
@@ -28,7 +28,7 @@ Feature: Retrieving shipment for orders
   Scenario: Retrieve shipmets for existing order
     Given the order "bo_order1" should have the following shipments:
       | shipment  | carrier         | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
-      | shipment1 | default_carrier |                 | US      |                    7.0 |                   7.42 |
+      | shipment1 | default_carrier |                 | US      |                    0.0 |                   0.0 |
     Then the shipment "shipment1" should have the following products:
       | product_name                | quantity |
       | Mug The best is yet to come |        1 |

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/shipment.feature
@@ -28,7 +28,7 @@ Feature: Retrieving shipment for orders
   Scenario: Retrieve shipmets for existing order
     Given the order "bo_order1" should have the following shipments:
       | shipment  | carrier         | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
-      | shipment1 | default_carrier |                 | US      |                    0.0 |                   0.0 |
+      | shipment1 | default_carrier |                 | US      |                    7.0 |                   7.42 |
     Then the shipment "shipment1" should have the following products:
       | product_name                | quantity |
       | Mug The best is yet to come |        1 |

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -690,7 +690,6 @@ default:
         - "%paths.base%/Features/Scenario/Shipment"
       contexts:
         - Tests\Integration\Behaviour\Features\Context\Domain\ShipmentFeatureContext
-        - Tests\Integration\Behaviour\Features\Context\Domain\OrderFeatureContext
         - Tests\Integration\Behaviour\Features\Context\FeatureFlagFeatureContext
         - Tests\Integration\Behaviour\Features\Context\CarrierFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\Carrier\CarrierFeatureContext
@@ -729,12 +728,16 @@ default:
         - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\Product\DeleteProductFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\Product\DetailsAssertionFeatureContext
+        - Tests\Integration\Behaviour\Features\Context\Domain\Product\ShippingAssertionFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\Product\StockAssertionFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCustomizationFieldsFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductFeatureContext
+        - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateShippingFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStockFeatureContext
+        - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStatusFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\TaxFeatureContext
+        - Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext
         - Tests\Integration\Behaviour\Features\Context\EmployeeFeatureContext
         - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
         - Tests\Integration\Behaviour\Features\Context\LegacyProductFeatureContext


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Update the shipment creation. If you enable the feature flag FEATURE_FLAG_IMPROVED_SHIPMENT you have shipment created after an order. If you create an order with 2 products with different carriers, PrestaShop creates two orders with the product and the carrier associated. With the feature flag enabled, we want to add this logic with the ps_shipment & ps_shipment_products table to split or merge. For get more details see [issue](https://github.com/PrestaShop/PrestaShop/issues/38002)
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable the feature flag & choose two products. For each product, choose two different carriers and make an order. You should have only one order with both products, and the shipment will be created in the DB. (You can't see inside BO because the feature for seeing shipment inside the order page has not develop)
| UI Tests          | https://github.com/PoulainMaxime/ga.tests.ui.pr/actions/runs/15038814276
