### PR TITLE
OrderSlipCreator, Hook actionOrderSlipAdd => add order slip object to…

### DIFF
--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -109,6 +109,7 @@ class OrderSlipCreator
                 'order' => $order,
                 'productList' => $orderRefundSummary->getProductRefunds(),
                 'qtyList' => $fullQuantityList,
+                'orderSlipCreated' => $orderSlipCreated,
             ], null, false, true, false, $order->id_shop);
 
             $customer = new Customer((int) $order->id_customer);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 9.0.x / 8.2.x
| Description?      | When a order slip is created from the BO, the hook actionOrderSlipAdd is executed, 
| Type?             | bug fix / improvement / new feature / refacto
| Category?         | BO / CO /
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a refund or partial refund on a order, hook a module on actionOrderSlipAdd and check parameters
| Sponsor company   | Griiv