### PR TITLE
OrderSlipCreator Hook actionOrderSlipAdd => add order slip object to hook param

### DIFF
--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -63,7 +63,7 @@ class OrderSlipCreator
     private $translator;
 
     /** @var OrderSlip
-     * 
+     * @var OrderSlip
      */
     private $orderSlipCreated;
 

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -67,7 +67,6 @@ class OrderSlipCreator
      */
     private $orderSlipCreated;
 
-
     /**
      * @param ConfigurationInterface $configuration
      * @param TranslatorInterface $translator

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -46,6 +46,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 use TaxCalculator;
 use TaxManagerFactory;
 use Tools;
+use OrderSlip;
 
 /**
  * Class OrderSlipCreator is responsible of creating an OrderSlip for a refund
@@ -61,6 +62,12 @@ class OrderSlipCreator
      * @var TranslatorInterface
      */
     private $translator;
+
+    /** @var OrderSlip
+     * 
+     */
+    private $orderSlipCreated;
+
 
     /**
      * @param ConfigurationInterface $configuration
@@ -109,7 +116,7 @@ class OrderSlipCreator
                 'order' => $order,
                 'productList' => $orderRefundSummary->getProductRefunds(),
                 'qtyList' => $fullQuantityList,
-                'orderSlipCreated' => $orderSlipCreated,
+                'orderSlipCreated' => $this->orderSlipCreated,
             ], null, false, true, false, $order->id_shop);
 
             $customer = new Customer((int) $order->id_customer);
@@ -166,7 +173,7 @@ class OrderSlipCreator
      * @param bool $add_tax
      * @param int $precision
      *
-     * @return bool|OrderSlip
+     * @return bool
      *
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
@@ -330,11 +337,13 @@ class OrderSlipCreator
 
         $res = true;
 
+        $this->orderSlipCreated = $orderSlip;
+
         foreach ($product_list as $product) {
             $res &= $this->addProductOrderSlip((int) $orderSlip->id, $product);
         }
 
-        return (!(bool)$res) ?? $orderSlip;
+        return (bool) $res;
     }
 
     /**

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -109,6 +109,7 @@ class OrderSlipCreator
                 'order' => $order,
                 'productList' => $orderRefundSummary->getProductRefunds(),
                 'qtyList' => $fullQuantityList,
+                'orderSlipCreated' => $orderSlipCreated,
             ], null, false, true, false, $order->id_shop);
 
             $customer = new Customer((int) $order->id_customer);

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -62,7 +62,7 @@ class OrderSlipCreator
      */
     private $translator;
 
-    /** @var OrderSlip
+    /**
      * @var OrderSlip
      */
     private $orderSlipCreated;

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -46,7 +46,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 use TaxCalculator;
 use TaxManagerFactory;
 use Tools;
-use OrderSlip;
 
 /**
  * Class OrderSlipCreator is responsible of creating an OrderSlip for a refund

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -166,7 +166,7 @@ class OrderSlipCreator
      * @param bool $add_tax
      * @param int $precision
      *
-     * @return bool
+     * @return bool|OrderSlip
      *
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
@@ -334,7 +334,7 @@ class OrderSlipCreator
             $res &= $this->addProductOrderSlip((int) $orderSlip->id, $product);
         }
 
-        return (bool) $res;
+        return (!(bool)$res) ?? $orderSlip;
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | When a order slip is created from the BO, the hook actionOrderSlipAdd is executed, 
| Type?             | improvement
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a refund or partial refund on a order, hook a module on actionOrderSlipAdd and check parameters
| Sponsor company   | Griiv