### PR TITLE
Remove dynamic county access

### DIFF
--- a/classes/LocalizationPack.php
+++ b/classes/LocalizationPack.php
@@ -280,7 +280,6 @@ class LocalizationPackCore
 
                     // Default values
                     $id_state = (int) isset($rule_attributes['iso_code_state']) ? State::getIdByIso(strtoupper($rule_attributes['iso_code_state'])) : 0;
-                    $id_county = 0;
                     $zipcode_from = 0;
                     $zipcode_to = 0;
                     $behavior = $rule_attributes['behavior'];
@@ -297,7 +296,6 @@ class LocalizationPackCore
                     $tr->id_tax_rules_group = $trg->id;
                     $tr->id_country = $id_country;
                     $tr->id_state = $id_state;
-                    $tr->id_county = $id_county;
                     $tr->zipcode_from = $zipcode_from;
                     $tr->zipcode_to = $zipcode_to;
                     $tr->behavior = (string) $behavior;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Remove dynamic access to a property that no longer exists
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/14511751815
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
