### PR TITLE
Fix pdf takes 20 seconds to generate behind cloudflare

### DIFF
--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -147,7 +147,7 @@ abstract class HTMLTemplateCore
         }
 
         $this->smarty->assign([
-            'logo_path' => Tools::getShopProtocol() . Tools::getMediaServer(_PS_IMG_) . _PS_IMG_ . $logo,
+            'logo_path' => $logo ? _PS_IMG_DIR_ . $logo : null,
             'img_ps_dir' => Tools::getShopProtocol() . Tools::getMediaServer(_PS_IMG_) . _PS_IMG_,
             'img_update_time' => Configuration::get('PS_IMG_UPDATE_TIME'),
             'date' => $this->date,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  Pass the logo as a file path on disk instead of an url
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | Generate a pdf, with and without a logo setup
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | Fixes #36414


Explanation:

The logo is already a file path and we are sure that it exists on the disk (see `getLogo` function), but somehow the decision to send it as a url was made
See also the `getLogo` function of another pdf which already returns it as a path https://github.com/PrestaShop/PrestaShop/blob/d2435189faf4e0abd2218770998a2b96dc5fd545/classes/pdf/HTMLTemplateSupplyOrderForm.php#L121-L132
vs
https://github.com/PrestaShop/PrestaShop/blob/d2435189faf4e0abd2218770998a2b96dc5fd545/classes/pdf/HTMLTemplate.php#L112-L127

This means that a curl request has to be made in TCPDF to retrieve this image logo. This process is VERY SLOW in some hosting setup (30 seconds for a single image when behind cloudflare for some reason)

We can instead pass it a path on disk directly and the file content is fetched correctly in mere microseconds

This effectively improves the pdf generation speed by a lot