### PR TITLE
Add new Hook actionGetUrlInvoice

### DIFF
--- a/controllers/front/HistoryController.php
+++ b/controllers/front/HistoryController.php
@@ -87,10 +87,10 @@ class HistoryControllerCore extends FrontController
      */
     public static function getUrlToInvoice(Order $order, Context $context)
     {
-        $customUrlToInvoice = "";
+        $customUrlToInvoice = '';
         $customUrlToInvoice = Hook::exec('actionGetUrlInvoice', ['order' => $order]);
 
-        if ($customUrlToInvoice!='' && Validate::isUrl($customUrlToInvoice)) {
+        if ($customUrlToInvoice != '' && Validate::isUrl($customUrlToInvoice)) {
             return $customUrlToInvoice;
         }
 

--- a/controllers/front/HistoryController.php
+++ b/controllers/front/HistoryController.php
@@ -87,7 +87,11 @@ class HistoryControllerCore extends FrontController
      */
     public static function getUrlToInvoice(Order $order, Context $context)
     {
-        $url_to_invoice = '';
+        $url_to_invoice = Hook::exec('actionGetUrlInvoice', ['order' => $order]);
+
+        if (Validate::isUrl($url_to_invoice)) {
+            return $url_to_invoice;
+        }
 
         if ((bool) Configuration::get('PS_INVOICE') && OrderState::invoiceAvailable($order->current_state) && count($order->getInvoicesCollection())) {
             $params = [

--- a/controllers/front/HistoryController.php
+++ b/controllers/front/HistoryController.php
@@ -87,7 +87,7 @@ class HistoryControllerCore extends FrontController
      */
     public static function getUrlToInvoice(Order $order, Context $context)
     {
-        $url_to_invoice = "";
+        $customUrlToInvoice = "";
         $customUrlToInvoice = Hook::exec('actionGetUrlInvoice', ['order' => $order]);
 
         if ($customUrlToInvoice!='' && Validate::isUrl($customUrlToInvoice)) {

--- a/controllers/front/HistoryController.php
+++ b/controllers/front/HistoryController.php
@@ -87,10 +87,11 @@ class HistoryControllerCore extends FrontController
      */
     public static function getUrlToInvoice(Order $order, Context $context)
     {
-        $url_to_invoice = Hook::exec('actionGetUrlInvoice', ['order' => $order]);
+        $url_to_invoice = "";
+        $customUrlToInvoice = Hook::exec('actionGetUrlInvoice', ['order' => $order]);
 
-        if (Validate::isUrl($url_to_invoice)) {
-            return $url_to_invoice;
+        if ($customUrlToInvoice!='' && Validate::isUrl($customUrlToInvoice)) {
+            return $customUrlToInvoice;
         }
 
         if ((bool) Configuration::get('PS_INVOICE') && OrderState::invoiceAvailable($order->current_state) && count($order->getInvoicesCollection())) {

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -4928,6 +4928,11 @@
       <title>PDF Invoice - Render</title>
       <description>This hook is called when a PDF invoice is rendered from the Front Office and the Back Office</description>
     </hook>
+    <hook id="actionGetUrlInvoice">
+      <name>actionGetUrlInvoice</name>
+      <title>Url Invoice</title>
+      <description>This hook can be used to define a link from a third-party solution to the order invoice in the order history page.</description>
+    </hook>
     <hook id="actionPresentObject">
       <name>actionPresentObject</name>
       <title>Object Presenter</title>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop  9.0.x 
| Description?      | this hook allows you to customise the url of the invoice for an order whose link is displayed in the order history page. With more and more ERP systems connected, e-retailers want to make available invoices that are no longer PrestaShop invoices.
| Type?             | new feature 
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | to test this, you need to create a module that will use this hook and redefine the url of an invoice
| UI Tests          | 
| Fixed issue or discussion?     | new feature
| Related PRs       | 
| Sponsor company   | Velcome Group
