### PR TITLE
Fix ajax process and legacy shop context init

### DIFF
--- a/app/config/admin/services.yml
+++ b/app/config/admin/services.yml
@@ -50,26 +50,18 @@ services:
     tags:
       - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
 
-  # Priority is set after Symfony LocaleListener but before LocaleAwareListener
-  PrestaShopBundle\EventListener\Admin\UserLocaleListener:
-    autowire: true
-    arguments:
-      - "@prestashop.adapter.legacy.configuration"
-      - "@prestashop.core.admin.lang.repository"
-    tags:
-      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 15 }
+  # Locale listener to define translator locale correctly
+  PrestaShopBundle\EventListener\Admin\UserLocaleSubscriber: ~
 
-  PrestaShopBundle\EventListener\Admin\DemoModeEnabledListener:
-    autowire: true
-    autoconfigure: true
+  PrestaShopBundle\EventListener\Admin\DemoModeEnabledListener: ~
 
   # Context listeners, these are event subscribers, so they define their priority themselves
-  PrestaShopBundle\EventListener\Admin\Context\EmployeeContextListener: ~
-  PrestaShopBundle\EventListener\Admin\Context\LanguageContextListener: ~
-  PrestaShopBundle\EventListener\Admin\Context\ShopContextListener: ~
-  PrestaShopBundle\EventListener\Admin\Context\CurrencyContextListener: ~
-  PrestaShopBundle\EventListener\Admin\Context\CountryContextListener: ~
-  PrestaShopBundle\EventListener\Admin\Context\LegacyControllerContextListener: ~
+  PrestaShopBundle\EventListener\Admin\Context\EmployeeContextSubscriber: ~
+  PrestaShopBundle\EventListener\Admin\Context\LanguageContextSubscriber: ~
+  PrestaShopBundle\EventListener\Admin\Context\ShopContextSubscriber: ~
+  PrestaShopBundle\EventListener\Admin\Context\CurrencyContextSubscriber: ~
+  PrestaShopBundle\EventListener\Admin\Context\CountryContextSubscriber: ~
+  PrestaShopBundle\EventListener\Admin\Context\LegacyControllerContextSubscriber: ~
 
   PrestaShopBundle\EventListener\Admin\Context\LegacyContextSubscriber:
     autowire: true

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1441,8 +1441,23 @@ parameters:
 			path: src/PrestaShopBundle/Routing/LegacyRouterChecker.php
 
 		-
+			message: "#^Class Shop is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 8
+			path: src/PrestaShopBundle/Routing/LegacyRouterChecker.php
+
+		-
+			message: "#^Namespace AdminController is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/PrestaShopBundle/Routing/LegacyRouterChecker.php
+
+		-
 			message: "#^Namespace Dispatcher is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 3
+			path: src/PrestaShopBundle/Routing/LegacyRouterChecker.php
+
+		-
+			message: "#^Namespace Shop is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 6
 			path: src/PrestaShopBundle/Routing/LegacyRouterChecker.php
 
 		-

--- a/src/PrestaShopBundle/EventListener/Admin/Context/LanguageContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/LanguageContextSubscriber.php
@@ -29,23 +29,30 @@ declare(strict_types=1);
 namespace PrestaShopBundle\EventListener\Admin\Context;
 
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
-use PrestaShop\PrestaShop\Core\Context\CurrencyContextBuilder;
+use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
- * Listener dedicated to set up Currency context for the Back-Office/Admin application.
+ * Listener dedicated to set up Language context for the Back-Office/Admin application.
  */
-class CurrencyContextListener implements EventSubscriberInterface
+class LanguageContextSubscriber implements EventSubscriberInterface
 {
+    /**
+     * Priority lower than EmployeeContextListener so that EmployeeContext is correctly initialized
+     */
+    public const KERNEL_REQUEST_PRIORITY = EmployeeContextSubscriber::KERNEL_REQUEST_PRIORITY - 1;
+
     /**
      * Priority higher than Symfony router listener (which is 32)
      */
     public const BEFORE_ROUTER_PRIORITY = 33;
 
     public function __construct(
-        private readonly CurrencyContextBuilder $currencyContextBuilder,
+        private readonly LanguageContextBuilder $languageContextBuilder,
+        private readonly EmployeeContext $employeeContext,
         private readonly ConfigurationInterface $configuration,
     ) {
     }
@@ -54,17 +61,32 @@ class CurrencyContextListener implements EventSubscriberInterface
     {
         return [
             KernelEvents::REQUEST => [
-                ['onKernelRequest', self::BEFORE_ROUTER_PRIORITY],
+                ['initDefaultLanguageContext', self::BEFORE_ROUTER_PRIORITY],
+                ['initLanguageContext', self::KERNEL_REQUEST_PRIORITY],
             ],
         ];
     }
 
-    public function onKernelRequest(RequestEvent $event): void
+    public function initDefaultLanguageContext(RequestEvent $event): void
     {
         if (!$event->isMainRequest()) {
             return;
         }
 
-        $this->currencyContextBuilder->setCurrencyId((int) $this->configuration->get('PS_CURRENCY_DEFAULT'));
+        $defaultLanguageId = (int) $this->configuration->get('PS_LANG_DEFAULT');
+        $this->languageContextBuilder->setDefaultLanguageId($defaultLanguageId);
+        $this->languageContextBuilder->setLanguageId($defaultLanguageId);
+    }
+
+    public function initLanguageContext(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        if ($this->employeeContext->getEmployee()) {
+            // Use the employee language if available
+            $this->languageContextBuilder->setLanguageId($this->employeeContext->getEmployee()->getLanguageId());
+        }
     }
 }

--- a/src/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextSubscriber.php
@@ -41,7 +41,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * of the legacy Context singleton dependency, but many hooks and code still depend on it, so we propose
  * this alternative dedicated context that is mostly useful for legacy pages.
  */
-class LegacyControllerContextListener implements EventSubscriberInterface
+class LegacyControllerContextSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private readonly LegacyControllerContextBuilder $legacyControllerContextBuilder,

--- a/src/PrestaShopBundle/EventListener/Admin/UserLocaleSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/UserLocaleSubscriber.php
@@ -31,16 +31,30 @@ use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
 use PrestaShopBundle\Security\Admin\SessionEmployeeInterface;
 use PrestaShopBundle\Security\Admin\SessionEmployeeProvider;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
 
-class UserLocaleListener
+class UserLocaleSubscriber implements EventSubscriberInterface
 {
+    public const USER_LOCALE_PRIORITY = 15;
+
     public function __construct(
         private readonly ShopConfigurationInterface $configuration,
         private readonly LanguageRepositoryInterface $langRepository,
         private readonly Security $security,
         private readonly SessionEmployeeProvider $sessionEmployeeProvider,
     ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Priority is set after Symfony LocaleListener, so it can override Symfony default locale
+            // setting based on request attributes, but before LocaleAwareListener where the translator
+            // locale is set, so we can define the chosen locale based on PrestaShop logic
+            KernelEvents::REQUEST => [['onKernelRequest', self::USER_LOCALE_PRIORITY]],
+        ];
     }
 
     /**

--- a/src/PrestaShopBundle/Security/Admin/SessionEmployeeProvider.php
+++ b/src/PrestaShopBundle/Security/Admin/SessionEmployeeProvider.php
@@ -33,7 +33,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
  * This service is able to get the logged in employee info from the Symfony sessions,
- * it is exactly doing the same thing as the internal ContextListener but "manually"
+ * it is exactly doing the same thing as the internal Symfony ContextListener but "manually"
  *
  * This is useful for listeners that are executed before the ContextListener, so they
  * can init some contexts based on employee data for example.
@@ -54,8 +54,8 @@ class SessionEmployeeProvider
     }
 
     /**
-     * Most of this code is inspired from the ContextListener, it's just that we need to get the employee
-     * before the firewall listener in order to preset the PrestaShop contexts.
+     * Most of this code is inspired from the Symfony ContextListener, it's just that we need
+     * to get the employee before the firewall listener in order to preset the PrestaShop contexts.
      */
     public function getEmployeeFromSession(?Request $request = null): ?SessionEmployeeInterface
     {

--- a/src/PrestaShopBundle/Twig/Layout/SmartyVariablesFiller.php
+++ b/src/PrestaShopBundle/Twig/Layout/SmartyVariablesFiller.php
@@ -106,6 +106,7 @@ class SmartyVariablesFiller
             'pic_dir' => $this->templateVariables->getBaseUrl() . 'upload/',
             'img_base_path' => $this->templateVariables->getBaseUrl() . basename(_PS_ADMIN_DIR_) . '/',
             'multishop_context' => $this->legacyControllerContext->multishop_context,
+            'bootstrap' => false,
         ];
 
         $smartyVariablesAlias = [

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/CountryContextSubscriberTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/CountryContextSubscriberTest.php
@@ -29,29 +29,29 @@ declare(strict_types=1);
 namespace Tests\Unit\PrestaShopBundle\EventListener\Admin\Context;
 
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
-use PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository;
-use PrestaShop\PrestaShop\Core\Context\CurrencyContextBuilder;
+use PrestaShop\PrestaShop\Adapter\Country\Repository\CountryRepository;
+use PrestaShop\PrestaShop\Core\Context\CountryContextBuilder;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
-use PrestaShopBundle\EventListener\Admin\Context\CurrencyContextListener;
+use PrestaShopBundle\EventListener\Admin\Context\CountryContextSubscriber;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\Unit\PrestaShopBundle\EventListener\ContextEventListenerTestCase;
 
-class CurrencyContextListenerTest extends ContextEventListenerTestCase
+class CountryContextSubscriberTest extends ContextEventListenerTestCase
 {
     public function testKernelRequest(): void
     {
-        $currencyContextBuilder = new CurrencyContextBuilder(
-            $this->createMock(CurrencyRepository::class),
+        $countryContextBuilder = new CountryContextBuilder(
+            $this->createMock(CountryRepository::class),
             $this->createMock(ContextStateManager::class),
-            $this->createMock(LanguageContext::class)
+            $this->createMock(LanguageContext::class),
         );
-        $listener = new CurrencyContextListener(
-            $currencyContextBuilder,
-            $this->mockConfiguration(['PS_CURRENCY_DEFAULT' => 42]),
+        $listener = new CountryContextSubscriber(
+            $countryContextBuilder,
+            $this->mockConfiguration(['PS_COUNTRY_DEFAULT' => 42]),
         );
 
         $event = $this->createRequestEvent(new Request());
         $listener->onKernelRequest($event);
-        $this->assertEquals(42, $this->getPrivateField($currencyContextBuilder, 'currencyId'));
+        $this->assertEquals(42, $this->getPrivateField($countryContextBuilder, 'countryId'));
     }
 }

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/CurrencyContextSubscriberTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/CurrencyContextSubscriberTest.php
@@ -29,29 +29,29 @@ declare(strict_types=1);
 namespace Tests\Unit\PrestaShopBundle\EventListener\Admin\Context;
 
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
-use PrestaShop\PrestaShop\Adapter\Country\Repository\CountryRepository;
-use PrestaShop\PrestaShop\Core\Context\CountryContextBuilder;
+use PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository;
+use PrestaShop\PrestaShop\Core\Context\CurrencyContextBuilder;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
-use PrestaShopBundle\EventListener\Admin\Context\CountryContextListener;
+use PrestaShopBundle\EventListener\Admin\Context\CurrencyContextSubscriber;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\Unit\PrestaShopBundle\EventListener\ContextEventListenerTestCase;
 
-class CountryContextListenerTest extends ContextEventListenerTestCase
+class CurrencyContextSubscriberTest extends ContextEventListenerTestCase
 {
     public function testKernelRequest(): void
     {
-        $countryContextBuilder = new CountryContextBuilder(
-            $this->createMock(CountryRepository::class),
+        $currencyContextBuilder = new CurrencyContextBuilder(
+            $this->createMock(CurrencyRepository::class),
             $this->createMock(ContextStateManager::class),
-            $this->createMock(LanguageContext::class),
+            $this->createMock(LanguageContext::class)
         );
-        $listener = new CountryContextListener(
-            $countryContextBuilder,
-            $this->mockConfiguration(['PS_COUNTRY_DEFAULT' => 42]),
+        $listener = new CurrencyContextSubscriber(
+            $currencyContextBuilder,
+            $this->mockConfiguration(['PS_CURRENCY_DEFAULT' => 42]),
         );
 
         $event = $this->createRequestEvent(new Request());
         $listener->onKernelRequest($event);
-        $this->assertEquals(42, $this->getPrivateField($countryContextBuilder, 'countryId'));
+        $this->assertEquals(42, $this->getPrivateField($currencyContextBuilder, 'currencyId'));
     }
 }

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/EmployeeContextSubscriberTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/EmployeeContextSubscriberTest.php
@@ -32,13 +32,13 @@ use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Adapter\Employee\EmployeeRepository;
 use PrestaShop\PrestaShop\Core\Context\EmployeeContextBuilder;
 use PrestaShopBundle\Entity\Employee\Employee;
-use PrestaShopBundle\EventListener\Admin\Context\EmployeeContextListener;
+use PrestaShopBundle\EventListener\Admin\Context\EmployeeContextSubscriber;
 use PrestaShopBundle\Security\Admin\SessionEmployeeProvider;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\Unit\PrestaShopBundle\EventListener\ContextEventListenerTestCase;
 
-class EmployeeContextListenerTest extends ContextEventListenerTestCase
+class EmployeeContextSubscriberTest extends ContextEventListenerTestCase
 {
     public function testEmployeeNotFound(): void
     {
@@ -47,7 +47,7 @@ class EmployeeContextListenerTest extends ContextEventListenerTestCase
             $this->createMock(EmployeeRepository::class),
             $this->createMock(ContextStateManager::class),
         );
-        $listener = new EmployeeContextListener(
+        $listener = new EmployeeContextSubscriber(
             $employeeBuilder,
             $this->createMock(Security::class),
             $this->createMock(SessionEmployeeProvider::class),
@@ -66,7 +66,7 @@ class EmployeeContextListenerTest extends ContextEventListenerTestCase
         $employeeMock->method('getId')->willReturn(51);
         $securityMock = $this->createMock(Security::class);
         $securityMock->method('getUser')->willReturn($employeeMock);
-        $listener = new EmployeeContextListener(
+        $listener = new EmployeeContextSubscriber(
             $employeeBuilder,
             $securityMock,
             $this->createMock(SessionEmployeeProvider::class),
@@ -89,7 +89,7 @@ class EmployeeContextListenerTest extends ContextEventListenerTestCase
         $sessionEmployeeProvider = $this->createMock(SessionEmployeeProvider::class);
         $sessionEmployeeProvider->method('getEmployeeFromSession')->willReturn($employeeMock);
 
-        $listener = new EmployeeContextListener(
+        $listener = new EmployeeContextSubscriber(
             $employeeBuilder,
             $this->createMock(Security::class),
             $sessionEmployeeProvider,

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LanguageContextSubscriberTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LanguageContextSubscriberTest.php
@@ -36,11 +36,11 @@ use PrestaShop\PrestaShop\Core\Context\EmployeeContext;
 use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
 use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
 use PrestaShop\PrestaShop\Core\Localization\Locale\RepositoryInterface;
-use PrestaShopBundle\EventListener\Admin\Context\LanguageContextListener;
+use PrestaShopBundle\EventListener\Admin\Context\LanguageContextSubscriber;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\Unit\PrestaShopBundle\EventListener\ContextEventListenerTestCase;
 
-class LanguageContextListenerTest extends ContextEventListenerTestCase
+class LanguageContextSubscriberTest extends ContextEventListenerTestCase
 {
     private const EMPLOYEE_CONTEXT_LANGUAGE_ID = 42;
     private const DEFAULT_CONFIGURATION_LANGUAGE_ID = 99;
@@ -53,7 +53,7 @@ class LanguageContextListenerTest extends ContextEventListenerTestCase
             $this->createMock(ContextStateManager::class),
             $this->createMock(ObjectModelLanguageRepository::class)
         );
-        $listener = new LanguageContextListener(
+        $listener = new LanguageContextSubscriber(
             $languageContextBuilder,
             $this->mockEmployeeContext(self::EMPLOYEE_CONTEXT_LANGUAGE_ID),
             $this->mockConfiguration(),
@@ -72,7 +72,7 @@ class LanguageContextListenerTest extends ContextEventListenerTestCase
             $this->createMock(ContextStateManager::class),
             $this->createMock(ObjectModelLanguageRepository::class)
         );
-        $listener = new LanguageContextListener(
+        $listener = new LanguageContextSubscriber(
             $languageContextBuilder,
             $this->createMock(EmployeeContext::class),
             $this->mockConfiguration(['PS_LANG_DEFAULT' => self::DEFAULT_CONFIGURATION_LANGUAGE_ID]),

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextSubscriberTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextSubscriberTest.php
@@ -33,14 +33,14 @@ use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Context\LegacyControllerContextBuilder;
 use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShopBundle\Entity\Repository\TabRepository;
-use PrestaShopBundle\EventListener\Admin\Context\LegacyControllerContextListener;
+use PrestaShopBundle\EventListener\Admin\Context\LegacyControllerContextSubscriber;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Tests\Unit\PrestaShopBundle\EventListener\ContextEventListenerTestCase;
 use Twig\Environment;
 
-class LegacyControllerContextListenerTest extends ContextEventListenerTestCase
+class LegacyControllerContextSubscriberTest extends ContextEventListenerTestCase
 {
     /**
      * @dataProvider getControllerNameValues
@@ -51,7 +51,7 @@ class LegacyControllerContextListenerTest extends ContextEventListenerTestCase
     public function testControllerName(Request $request, string $expectedControllerName): void
     {
         $builder = $this->getBuilder();
-        $legacyControllerContextListener = new LegacyControllerContextListener($builder);
+        $legacyControllerContextListener = new LegacyControllerContextSubscriber($builder);
         $legacyControllerContextListener->onKernelRequest($this->createRequestEvent($request));
         $this->assertEquals($expectedControllerName, $this->getPrivateField($builder, 'controllerName'));
         $this->assertEquals(null, $this->getPrivateField($builder, 'redirectionUrl'));
@@ -83,7 +83,7 @@ class LegacyControllerContextListenerTest extends ContextEventListenerTestCase
     public function testRedirectionUrl(): void
     {
         $builder = $this->getBuilder();
-        $legacyControllerContextListener = new LegacyControllerContextListener($builder);
+        $legacyControllerContextListener = new LegacyControllerContextSubscriber($builder);
         $legacyControllerContextListener->onKernelRequest($this->createRequestEvent(new Request(['back' => 'index.php?toto=tata'])));
         $this->assertEquals('index.php?toto=tata', $this->getPrivateField($builder, 'redirectionUrl'));
     }

--- a/tests/Unit/PrestaShopBundle/EventListener/ContextEventListenerTestCase.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/ContextEventListenerTestCase.php
@@ -63,7 +63,7 @@ abstract class ContextEventListenerTestCase extends KernelTestCase
         return $reflectionProperty->getValue($object);
     }
 
-    protected function mockLegacyContext(array $cookieValues): LegacyContext|MockObject
+    protected function mockLegacyContext(array $cookieValues = []): LegacyContext|MockObject
     {
         $cookie = new TestCookie();
         foreach ($cookieValues as $cookieKey => $cookieValue) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fix ajax process and legacy shop context init
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | UI tests green and CI green Maybe QA by dev see related issues, you can use the related PR on quality assurance module to validate the bug related to `ajaxProcess` methods For the multi shop bug you'll need to add a `preProcess` method in the module and use XDebug to check the Shop context state when we reach this method
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/14576103872
| Fixed issue or discussion?     | Fixes #38485 Fixes #38442
| Related PRs       | https://github.com/PrestaShop/ps_qualityassurance/pull/50
| Sponsor company   | ~
