### PR TITLE
Add support for {categories} keyword in category seo urls, Fixes #38181

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -67,6 +67,7 @@ class DispatcherCore
                 'id' => ['regexp' => '[0-9]+', 'param' => 'id_category'],
                 'rewrite' => ['regexp' => self::REWRITE_PATTERN],
                 'meta_title' => ['regexp' => '[_a-zA-Z0-9-\pL]*'],
+                'categories' => ['regexp' => '[/_a-zA-Z0-9-\pL]*'],
             ],
         ],
         'supplier_rule' => [

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -457,6 +457,19 @@ class LinkCore
             $category = $this->getCategoryObject($category, $idLang);
             $params['meta_title'] = Tools::str2url($category->getFieldByLang('meta_title'));
         }
+        if ($dispatcher->hasKeyword($rule, $idLang, 'categories', $idShop)) {
+            $category = $this->getCategoryObject($category, $idLang);
+            $cats = [];
+            foreach (array_reverse($category->getParentsCategories($idLang)) as $cat) {
+                if ($cat['id_category'] == $category->id) {
+                    continue;
+                }
+                if (!in_array($cat['id_category'], Link::$category_disable_rewrite)) {
+                    $cats[] = $cat['link_rewrite'];
+                }
+            }
+            $params['categories'] = implode('/', $cats);
+        }
 
         return $url . Dispatcher::getInstance()->createUrl($rule, $idLang, $params, $this->allow, '', $idShop);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Add {categories} keyword support for category SEO urls. This allows adding parent categories to the SEO url for nicer url structure.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | For category SEO urls add {categories:/} keyword like products have. ReAdd the categories into ps_mainmenu, check that subcategory gets its parent categories in the url.
| UI Tests          | https://github.com/nicosomb/ga.tests.ui.pr/actions/runs/14642504261
| Fixed issue or discussion?     | Fixes #38181
| Related PRs       | 
| Sponsor company   | 


this is agains 9.0.x as requested here: https://github.com/PrestaShop/PrestaShop/pull/38182#issuecomment-2815598808