### PR TITLE
Fix: Multistore: CMS page error on new empty store creation

### DIFF
--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -24,6 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\ValueObject\CmsPageCategoryId;
 use PrestaShopBundle\Utils\Tree;
 
 /**
@@ -315,16 +316,43 @@ class AdminShopControllerCore extends AdminController
 
         // The root category should be at least imported
         $new_shop->copyShopData((int) Tools::getValue('importFromShop'), $import_data);
+        $useImportData = Tools::getValue('useImportData');
+        $db = Db::getInstance(_PS_USE_SQL_SLAVE_);
 
         // copy default data
-        if (!Tools::getValue('useImportData') || (is_array($import_data) && !isset($import_data['group']))) {
+        if (!$useImportData || (is_array($import_data) && !isset($import_data['group']))) {
             $sql = 'INSERT INTO `' . _DB_PREFIX_ . 'group_shop` (`id_shop`, `id_group`)
-					VALUES
-					(' . (int) $new_shop->id . ', ' . (int) Configuration::get('PS_UNIDENTIFIED_GROUP') . '),
-					(' . (int) $new_shop->id . ', ' . (int) Configuration::get('PS_GUEST_GROUP') . '),
-					(' . (int) $new_shop->id . ', ' . (int) Configuration::get('PS_CUSTOMER_GROUP') . ')
-				';
-            Db::getInstance()->execute($sql);
+                    VALUES
+                    (' . (int) $new_shop->id . ', ' . (int) Configuration::get('PS_UNIDENTIFIED_GROUP') . '),
+                    (' . (int) $new_shop->id . ', ' . (int) Configuration::get('PS_GUEST_GROUP') . '),
+                    (' . (int) $new_shop->id . ', ' . (int) Configuration::get('PS_CUSTOMER_GROUP') . ')
+                ';
+            $db->execute($sql);
+        }
+
+        if (!$useImportData || (is_array($import_data) && !isset($import_data['cms']))) {
+            $allLangs = Language::getLanguages(false);
+
+            $db->insert(
+                'cms_category_shop',
+                [
+                    'id_cms_category' => CmsPageCategoryId::ROOT_CMS_PAGE_CATEGORY_ID,
+                    'id_shop' => (int) $new_shop->id,
+                ]
+            );
+
+            foreach ($allLangs as $lang) {
+                $db->insert(
+                    'cms_category_lang',
+                    [
+                        'id_cms_category' => CmsPageCategoryId::ROOT_CMS_PAGE_CATEGORY_ID,
+                        'id_lang' => (int) $lang['id_lang'],
+                        'id_shop' => (int) $new_shop->id,
+                        'name' => 'Home',
+                        'link_rewrite' => 'home',
+                    ]
+                );
+            }
         }
 
         return parent::afterAdd($new_shop);


### PR DESCRIPTION
Added association of CmsCategory to the new shop in case of non-import of "CMS pages".

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | see: https://github.com/PrestaShop/PrestaShop/issues/38528
| Type?             | bug fix
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see: https://github.com/PrestaShop/PrestaShop/issues/38528.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/15393309388
| Fixed issue or discussion?     | Fixes #38528
| Related PRs       | 
| Sponsor company   | @Codencode 
