### PR TITLE
Fix: Misleading maximum attachment upload size in configure/advanced/administration

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdministrationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdministrationController.php
@@ -41,6 +41,7 @@ use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Tools;
 
 /**
  * Responsible of "Configure > Advanced Parameters > Administration" page display.
@@ -251,6 +252,16 @@ class AdministrationController extends FrameworkBundleAdminController
                 return $this->trans(
                     'The SameSite=None attribute is only available in secure mode.',
                     'Admin.Advparameters.Notification'
+                );
+            case FormDataProvider::ERROR_MAX_SIZE_ATTACHED_FILES:
+                return $this->trans(
+                    '%s is invalid. Please enter an integer between %s and %s.',
+                    'Admin.Advparameters.Notification',
+                    [
+                        $this->getFieldLabel($error->getFieldName()),
+                        0,
+                        (Tools::getMaxUploadSize() / 1048576),
+                    ]
                 );
         }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/FormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/FormDataProvider.php
@@ -38,6 +38,7 @@ final class FormDataProvider implements FormDataProviderInterface
     public const ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO = 1;
     public const ERROR_COOKIE_LIFETIME_MAX_VALUE_EXCEEDED = 2;
     public const ERROR_COOKIE_SAMESITE_NONE = 3;
+    public const ERROR_MAX_SIZE_ATTACHED_FILES = 4;
 
     /**
      * @var DataConfigurationInterface

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaDataProvider.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
 use PrestaShopBundle\Form\Exception\DataProviderException;
 use PrestaShopBundle\Form\Exception\InvalidConfigurationDataError;
 use PrestaShopBundle\Form\Exception\InvalidConfigurationDataErrorCollection;
+use Tools;
 
 /**
  * This class is responsible of managing the data manipulated using Upload Quota form
@@ -80,8 +81,8 @@ final class UploadQuotaDataProvider implements FormDataProviderInterface
 
         if (isset($data[UploadQuotaType::FIELD_MAX_SIZE_ATTACHED_FILES])) {
             $maxSizeAttachedFile = $data[UploadQuotaType::FIELD_MAX_SIZE_ATTACHED_FILES];
-            if (!is_numeric($maxSizeAttachedFile) || $maxSizeAttachedFile < 0) {
-                $errors->add(new InvalidConfigurationDataError(FormDataProvider::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, UploadQuotaType::FIELD_MAX_SIZE_ATTACHED_FILES));
+            if (!is_numeric($maxSizeAttachedFile) || $maxSizeAttachedFile < 0 || Tools::convertBytes($maxSizeAttachedFile . 'm') > Tools::getMaxUploadSize()) {
+                $errors->add(new InvalidConfigurationDataError(FormDataProvider::ERROR_MAX_SIZE_ATTACHED_FILES, UploadQuotaType::FIELD_MAX_SIZE_ATTACHED_FILES));
             }
         }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
@@ -34,6 +34,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Tools;
 
 class UploadQuotaType extends TranslatorAwareType
 {
@@ -71,7 +72,7 @@ class UploadQuotaType extends TranslatorAwareType
                         'Set the maximum size allowed for attachment files (in megabytes). This value has to be lower than or equal to the maximum file upload allotted by your server (currently: %size% MB).',
                         'Admin.Advparameters.Help',
                         [
-                            '%size%' => $configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE'),
+                            '%size%' => round(Tools::getMaxUploadSize() / 1048576)
                         ]
                     ),
                     'unit' => $this->trans('megabytes', 'Admin.Advparameters.Feature'),


### PR DESCRIPTION
Added check on 'Maximum size for attached files' using Tools::getMaxUploadSize()

This change validates that the 'Maximum size for attached files' does not exceed the server's 'upload_max_filesize' and 'post_max_size' settings.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | see: https://github.com/PrestaShop/PrestaShop/issues/38543
| Type?             | bug fix
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see: https://github.com/PrestaShop/PrestaShop/issues/38543 (Note: The system enforces the smaller value between `upload_max_filesize` and `post_max_size`)
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16112902493
| Fixed issue or discussion?     | Fixes #38543
| Related PRs       | 
| Sponsor company   | @Codencode 
