### PR TITLE
Use id_customization for matching cart and order products

### DIFF
--- a/src/Adapter/Presenter/Order/OrderLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderLazyArray.php
@@ -208,6 +208,7 @@ class OrderLazyArray extends AbstractLazyArray
             foreach ($cartProducts['products'] as $cartProduct) {
                 if (($cartProduct['id_product'] === $orderProduct['id_product'])
                     && ($cartProduct['id_product_attribute'] === $orderProduct['id_product_attribute'])
+                    && ($cartProduct['id_customization'] === $orderProduct['id_customization'])
                 ) {
                     if (isset($cartProduct['attributes'])) {
                         $orderProduct['attributes'] = $cartProduct['attributes'];


### PR DESCRIPTION
Fixes #38529 

This solves a bug where the same image is displayed for various customizations even though a module has overridden the product image differently based on the customization ID.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Use id_customization for matching order and cart products
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check #38529 
| UI Tests          | https://github.com/unlocomqx/ga.tests.ui.pr/actions/runs/14729004867
| Fixed issue or discussion?     | Fixes #38529 
| Related PRs       | --
| Sponsor company   | --
