### PR TITLE
Add new hook actionValidateField

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1057,6 +1057,12 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
         $this->cacheFieldsRequiredDatabase();
         $data = $this->def['fields'][$field];
 
+        $errorMessage = null;
+        Hook::exec('actionValidateField', ['object' => $this, 'definition' => &$data, 'field' => $field, 'value' => $value, 'id_lang' => $id_lang, 'skip' => &$skip, 'human_errors' => $human_errors, 'errorMessage' => &$errorMessage]);
+        if (empty($errorMessage) === false) {
+            return $errorMessage;
+        }
+
         // Check if field is required
         $required_fields = $this->getCachedFieldsRequiredDatabase();
         if (!$id_lang || $id_lang == $ps_lang_default) {

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1057,6 +1057,7 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
         $this->cacheFieldsRequiredDatabase();
         $data = $this->def['fields'][$field];
 
+        /** @var ?string $errorMessage */
         $errorMessage = null;
         Hook::exec('actionValidateField', ['object' => $this, 'definition' => &$data, 'field' => $field, 'value' => $value, 'id_lang' => $id_lang, 'skip' => &$skip, 'human_errors' => $human_errors, 'errorMessage' => &$errorMessage]);
         if (empty($errorMessage) === false) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | We often need customization of object model validation for simple things like a too long size...
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Here a basic sample usage: <br>    public function hookActionValidateField($params) <br>    { <br>        // In this case, we want to limit the size of firstname because our logistics system accept only 25 characters. <br>        if ($params['object'] instanceof \Customer && $params['field'] === 'firstname') { <br>            $params['definition']['size'] = 25; <br>        } <br>        // In this case, we want only  <br>        if ($params['object'] instanceof \Address && $params['field'] === 'vat_number') { <br>            $params['skip'] = ['validate']; // to skip <br>            if (MycustomValidate::isVatNumberVIES($params['value']) === false) { // your own validation <br>                $params['errorMessage'] = 'The VAT number must validated by VIES database'; <br>            } <br>        } <br>    } <br>
| UI Tests          | nc
| Fixed issue or discussion?     | Fixes #38556
| Related PRs       | nc
| Sponsor company   | @202-ecommerce 
