### PR TITLE
Improve OpenApi configuration to include OAuth scopes dynamically

### DIFF
--- a/app/config/admin-api/config.yml
+++ b/app/config/admin-api/config.yml
@@ -23,11 +23,6 @@ api_platform:
   mapping:
     paths:
       - '%kernel.project_dir%/src/PrestaShopBundle/ApiPlatform/Resources'
-  swagger:
-    api_keys:
-      JWT:
-        name: Authorization
-        type: header
   oauth:
     enabled: true
     type: 'oauth2'

--- a/app/config/admin-api/config.yml
+++ b/app/config/admin-api/config.yml
@@ -28,3 +28,8 @@ api_platform:
       JWT:
         name: Authorization
         type: header
+  oauth:
+    enabled: true
+    type: 'oauth2'
+    flow: 'clientCredentials'
+    tokenUrl: '/admin-api/access_token'

--- a/app/config/admin/config.yml
+++ b/app/config/admin/config.yml
@@ -27,3 +27,8 @@ api_platform:
     # This is used to allow using the Swagger UI in HTML presentation
     html: [ 'text/html' ]
     json: [ 'application/json' ]
+  oauth:
+    enabled: true
+    type: 'oauth2'
+    flow: 'clientCredentials'
+    tokenUrl: '/admin-api/access_token'

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -73,7 +73,7 @@ monolog:
   handlers:
     main:
       type: rotating_file
-      max_files: '%env(PS_LOG_MAX_FILES)%'
+      max_files: '%env(int:PS_LOG_MAX_FILES)%'
       path: '%env(PS_LOG_OUTPUT)%'
       level: notice
     legacy:

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -9,7 +9,7 @@ monolog:
   handlers:
     main:
       type: rotating_file
-      max_files: '%env(PS_LOG_MAX_FILES)%'
+      max_files: '%env(int:PS_LOG_MAX_FILES)%'
       path: '%env(PS_LOG_OUTPUT)%'
       level: debug
       channels: [ "!event" ]

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -21,7 +21,7 @@ monolog:
       handler: nested
     nested:
       type: rotating_file
-      max_files: '%env(PS_LOG_MAX_FILES)%'
+      max_files: '%env(int:PS_LOG_MAX_FILES)%'
       path: '%env(PS_LOG_OUTPUT)%'
       level: debug
     console:

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -32,7 +32,7 @@ monolog:
   handlers:
     main:
       type: rotating_file
-      max_files: '%env(PS_LOG_MAX_FILES)%'
+      max_files: '%env(int:PS_LOG_MAX_FILES)%'
       path: '%env(PS_LOG_OUTPUT)%'
       level: debug
       channels: [ "!event" ]

--- a/src/PrestaShopBundle/ApiPlatform/Scopes/ApiResourceScopesExtractorFactory.php
+++ b/src/PrestaShopBundle/ApiPlatform/Scopes/ApiResourceScopesExtractorFactory.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\ApiPlatform\Scopes;
+
+use ApiPlatform\Metadata\Resource\Factory\AttributesResourceMetadataCollectionFactory;
+use PrestaShop\PrestaShop\Adapter\Environment;
+
+class ApiResourceScopesExtractorFactory
+{
+    public static function build(string $environmentName, string $moduleDir, array $installedModules, array $enabledModules, string $projectDir): ApiResourceScopesExtractor
+    {
+        return new ApiResourceScopesExtractor(
+            new AttributesResourceMetadataCollectionFactory(),
+            new Environment('dev' === $environmentName, $environmentName),
+            $moduleDir,
+            $installedModules,
+            $enabledModules,
+            $projectDir,
+        );
+    }
+}

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/ApiPlatformCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/ApiPlatformCompilerPass.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\DependencyInjection\Compiler;
+
+use PrestaShopBundle\ApiPlatform\Scopes\ApiResourceScopesExtractorFactory;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ApiPlatformCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $scopes = [];
+        if ($container->hasParameter('api_platform.oauth.scopes')) {
+            $scopes = $container->getParameter('api_platform.oauth.scopes');
+        }
+
+        // The service is not accessible during early compiler phase so build it manually
+        $apiResourceScopesExtractor = ApiResourceScopesExtractorFactory::build(
+            $container->getParameter('kernel.environment'),
+            $container->getParameter('prestashop.module_dir'),
+            $container->getParameter('prestashop.installed_modules'),
+            $container->getParameter('prestashop.active_modules'),
+            $container->getParameter('kernel.project_dir'),
+        );
+        foreach ($apiResourceScopesExtractor->getEnabledApiResourceScopes() as $apiResourceScope) {
+            foreach ($apiResourceScope->getScopes() as $scope) {
+                $scopes[$scope] = $scope;
+            }
+        }
+
+        $container->setParameter('api_platform.oauth.scopes', $scopes);
+    }
+}

--- a/src/PrestaShopBundle/PrestaShopBundle.php
+++ b/src/PrestaShopBundle/PrestaShopBundle.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle;
 
 use AppKernel;
+use PrestaShopBundle\DependencyInjection\Compiler\ApiPlatformCompilerPass;
 use PrestaShopBundle\DependencyInjection\Compiler\CommandAndQueryCollectorPass;
 use PrestaShopBundle\DependencyInjection\Compiler\CommandAndQueryRegisterPass;
 use PrestaShopBundle\DependencyInjection\Compiler\DynamicRolePass;
@@ -93,5 +94,6 @@ class PrestaShopBundle extends Bundle
         $container->addCompilerPass(new GridDefinitionServiceIdsCollectorPass());
         $container->addCompilerPass(new IdentifiableObjectFormTypesCollectorPass());
         $container->addCompilerPass(new TestEnvironmentPass());
+        $container->addCompilerPass(new ApiPlatformCompilerPass());
     }
 }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/admin_api.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/admin_api.yml
@@ -52,3 +52,7 @@ api_platform_doc:
   # because we don't want the API endpoints to be accessible from the back-office but via its
   # dedicated admin-api base endpoint
   resource: "@ApiPlatformBundle/Resources/config/routing/docs.xml"
+
+api_platform_jsonld:
+  # We only load the routing for JSON-LD as it's used by OpenApi
+  resource: "@ApiPlatformBundle/Resources/config/routing/jsonld.xml"

--- a/tests/Integration/PrestaShopBundle/ApiPlatform/CQRSOpenApiFactoryTest.php
+++ b/tests/Integration/PrestaShopBundle/ApiPlatform/CQRSOpenApiFactoryTest.php
@@ -29,6 +29,7 @@ namespace Tests\Integration\PrestaShopBundle\ApiPlatform;
 use ApiPlatform\OpenApi\Factory\OpenApiFactoryInterface;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\SecurityScheme;
+use ApiPlatform\OpenApi\Model\Server;
 use ApiPlatform\OpenApi\OpenApi;
 use ArrayObject;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -41,6 +42,9 @@ class CQRSOpenApiFactoryTest extends KernelTestCase
         $openApiFactory = $this->getContainer()->get(OpenApiFactoryInterface::class);
         /** @var OpenApi $openApi */
         $openApi = $openApiFactory->__invoke();
+
+        $this->assertEquals([new Server('/admin-api')], $openApi->getServers());
+
         $security = $openApi->getSecurity();
         $this->assertEquals([['oauth' => []]], $security);
 
@@ -67,6 +71,74 @@ class CQRSOpenApiFactoryTest extends KernelTestCase
             $this->assertNotEmpty($clientCredentialsFlow->getScopes()[$scope]);
             $this->assertEquals($scopeDefinition, $clientCredentialsFlow->getScopes()[$scope]);
         }
+    }
+
+    /**
+     * @dataProvider provideEndpointScopes
+     */
+    public function testEndpointScopes(string $uriPath, array $expectedScopes): void
+    {
+        /** @var OpenApiFactoryInterface $openApiFactory */
+        $openApiFactory = $this->getContainer()->get(OpenApiFactoryInterface::class);
+        /** @var OpenApi $openApi */
+        $openApi = $openApiFactory->__invoke();
+        $openApiPath = $openApi->getPaths()->getPath($uriPath);
+        $this->assertNotNull($openApiPath);
+        foreach ($expectedScopes as $httpMethod => $methodScopes) {
+            $getterMethod = 'get' . ucfirst(strtolower($httpMethod));
+            $methodOperation = $openApiPath->$getterMethod($methodScopes);
+            $this->assertInstanceOf(Operation::class, $methodOperation, 'Wrong operation for uri ' . $uriPath . ' method ' . $httpMethod);
+            $this->assertEquals([['oauth' => $methodScopes]], $methodOperation->getSecurity());
+        }
+    }
+
+    public function provideEndpointScopes(): iterable
+    {
+        yield 'API client entity' => [
+            '/api-client/{apiClientId}',
+            [
+                'get' => ['api_client_read'],
+                'patch' => ['api_client_write'],
+                'delete' => ['api_client_write'],
+            ],
+        ];
+
+        yield 'API client creation' => [
+            '/api-client',
+            [
+                'post' => ['api_client_write'],
+            ],
+        ];
+
+        yield 'API client list' => [
+            '/api-clients',
+            [
+                'get' => ['api_client_read'],
+            ],
+        ];
+
+        yield 'Product entity' => [
+            '/product/{productId}',
+            [
+                'get' => ['product_read'],
+                'patch' => ['product_write'],
+                'delete' => ['product_write'],
+            ],
+        ];
+
+        yield 'Product creation' => [
+            '/product',
+            [
+                'post' => ['product_write'],
+            ],
+        ];
+
+        yield 'Product list' => [
+            '/products',
+            [
+                'get' => ['product_read'],
+            ],
+        ];
     }
 
     /**

--- a/tests/Integration/PrestaShopBundle/ApiPlatform/CQRSOpenApiFactoryTest.php
+++ b/tests/Integration/PrestaShopBundle/ApiPlatform/CQRSOpenApiFactoryTest.php
@@ -62,10 +62,10 @@ class CQRSOpenApiFactoryTest extends KernelTestCase
 
         // We don't test all the scopes as they are gonna evolve with time, but we can test a minimum of them
         $expectedScopes = [
-            'api_client_read' => 'api_client_read',
-            'api_client_write' => 'api_client_write',
-            'product_read' => 'product_read',
-            'product_write' => 'product_write',
+            'api_client_read' => 'Read ApiClient',
+            'api_client_write' => 'Write ApiClient',
+            'product_read' => 'Read Product',
+            'product_write' => 'Write Product',
         ];
         foreach ($expectedScopes as $scope => $scopeDefinition) {
             $this->assertNotEmpty($clientCredentialsFlow->getScopes()[$scope]);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Improve OpenApi configuration to include OAuth scopes dynamically
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/14794359558
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~


### Updates

Each endpoint is now documented with its related scopes in the OpenApi definition. The full list of scopes is also returned in the `securitySchemes` component. As a result we can now authenticate and select wanted scopes in the Swagger UI:
![Capture d’écran 2025-05-02 à 12 25 31](https://github.com/user-attachments/assets/43ef4db5-484b-4ac4-80c2-a78cf076dc2d)

Which then allows to perform calls directly on the API:
![Capture d’écran 2025-05-02 à 12 26 07](https://github.com/user-attachments/assets/5cdfa2a5-c76a-4673-bdee-ebaf149bd1d6)

Sadly the Swagger UI doesn't display the required scope for each endpoint (it's a missing feature natively in this UX), however, we can see them in the Redoc:

![Capture d’écran 2025-05-02 à 12 26 39](https://github.com/user-attachments/assets/d4736e9a-5dc0-4207-976e-3445c5c08671)

