### PR TITLE
Bug fix : #34057 modify order_conf email to repair HTML editing

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1494,6 +1494,16 @@ class AdminTranslationsControllerCore extends AdminController
                         $content = htmlspecialchars_decode($content);
                         // replace correct end of line
                         $content = str_replace("\r\n", PHP_EOL, $content);
+
+                        // In the order confirmation email, products and discounts variables are removed from the table by TinyMCE, this hack corrects that move
+                        if ($mail_name == 'order_conf') {
+                            $content = str_replace("{products}", "", $content);
+                            $content = str_replace("{discounts}", "", $content);
+			                // classic theme
+                            $content = str_replace('<tr class="conf_body after_products">', '{products}{discounts}<tr class="conf_body after_products">', $content);
+			                // modern theme
+			                $content = str_replace('<tr class="order_summary after_products">', '{products}{discounts}<tr class="order_summary after_products">', $content);
+                        }
                     }
 
                     if (Validate::isCleanHTML($content)) {

--- a/mails/themes/classic/core/order_conf.html.twig
+++ b/mails/themes/classic/core/order_conf.html.twig
@@ -62,7 +62,7 @@
 {discounts_txt}
 {% endif %}
 
-        <tr class="conf_body">
+        <tr class="conf_body after_products">
           <td bgcolor="#f8f8f8" colspan="4" style="border:1px solid #D6D4D4;">
             <table class="table">
               <tr>

--- a/mails/themes/modern/core/order_conf.html.twig
+++ b/mails/themes/modern/core/order_conf.html.twig
@@ -190,7 +190,7 @@
                                     {% if templateType == 'txt' %}
 {discounts_txt}
 {% endif %}
-                                    <tr class="order_summary">
+                                    <tr class="order_summary after_products">
                                       <td bgcolor="#FDFDFD" colspan="3" align="{{ align_right }}">
                                         {{ 'Products'|trans({}, 'Emails.Body', locale)|raw }}
                                       </td>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In the order confirmation email, products and discounts variables are removed from the table by TinyMCE, this hack corrects that move by adding a class to localize their "good" place
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Translate "order_conf" email in back-office
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | Fixes #34057
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
