### PR TITLE
formField class add attributes disabled

### DIFF
--- a/classes/form/FormField.php
+++ b/classes/form/FormField.php
@@ -38,6 +38,12 @@ class FormFieldCore
     private $maxLength = null;
     private $errors = [];
     private $constraints = [];
+
+    /**
+     * @var bool
+     */
+    private $disabled = false;
+
     private $attr = [];
 
     /**
@@ -64,6 +70,7 @@ class FormFieldCore
             'errors' => $this->getErrors(),
             'autocomplete' => $this->getAutocompleteAttribute(),
             'attr' => $this->getAttr(),
+            'disabled' => $this->getDisabled(),
         ];
 
         Hook::exec('additionalHtmlAttributesFormFields', ['formFieldArray' => &$formField]);
@@ -234,6 +241,18 @@ class FormFieldCore
     public function getAutocompleteAttribute(): string
     {
         return $this->autocomplete;
+    }
+
+    public function getDisabled(): bool
+    {
+        return $this->disabled;
+    }
+
+    public function setDisabled(bool $disabled): self
+    {
+        $this->disabled = $disabled;
+
+        return $this;
     }
 
     /**

--- a/classes/form/FormField.php
+++ b/classes/form/FormField.php
@@ -248,7 +248,7 @@ class FormFieldCore
         return $this->disabled;
     }
 
-    public function setDisabled(bool $disabled): self
+    public function setDisabled(bool $disabled): FormFieldCore
     {
         $this->disabled = $disabled;
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      |  Add html attribute disabled to formField
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create module hook on additionalCustomerFormFields set firstname at disabled true, $field->setDisabled(true);, need to upgrade the tpl file form-fields.tpl to add case of disabled attribute
| Sponsor company   | Griiv
