### PR TITLE
Improve `GridQueryBuilder::getCountQueryBuilder` to prevent duplication

### DIFF
--- a/src/Core/Grid/Query/Api/HookQueryBuilder.php
+++ b/src/Core/Grid/Query/Api/HookQueryBuilder.php
@@ -71,7 +71,7 @@ final class HookQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
-        $qb->select('COUNT(h.id_hook)');
+        $qb->select('COUNT(DISTINCT h.id_hook)');
 
         return $qb;
     }

--- a/src/Core/Grid/Query/CategoryQueryBuilder.php
+++ b/src/Core/Grid/Query/CategoryQueryBuilder.php
@@ -127,7 +127,7 @@ final class CategoryQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
-        $qb->select('COUNT(c.id_category)');
+        $qb->select('COUNT(DISTINCT c.id_category)');
 
         return $qb;
     }

--- a/src/Core/Grid/Query/CustomerBoughtProductQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerBoughtProductQueryBuilder.php
@@ -77,7 +77,7 @@ final class CustomerBoughtProductQueryBuilder extends AbstractDoctrineQueryBuild
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
         return $this->getQueryBuilder($searchCriteria->getFilters())
-            ->select('COUNT(od.`id_order_detail`)');
+            ->select('COUNT(DISTINCT od.`id_order_detail`)');
     }
 
     /**

--- a/src/Core/Grid/Query/CustomerGroupsQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerGroupsQueryBuilder.php
@@ -87,7 +87,7 @@ class CustomerGroupsQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
-        return $this->getCustomerGroupsQueryBuilder($searchCriteria)->select('COUNT(g.id_group)');
+        return $this->getCustomerGroupsQueryBuilder($searchCriteria)->select('COUNT(DISTINCT g.id_group)');
     }
 
     /**

--- a/src/Core/Grid/Query/CustomerQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerQueryBuilder.php
@@ -98,7 +98,7 @@ final class CustomerQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $countQueryBuilder = $this->getCustomerQueryBuilder($searchCriteria)
-            ->select('COUNT(*)');
+            ->select('COUNT(DISTINCT c.`id_customer`)');
 
         return $countQueryBuilder;
     }

--- a/src/Core/Grid/Query/CustomerViewedProductQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerViewedProductQueryBuilder.php
@@ -91,7 +91,7 @@ final class CustomerViewedProductQueryBuilder extends AbstractDoctrineQueryBuild
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
         return $this->getQueryBuilder($searchCriteria->getFilters())
-            ->select('COUNT(cp.`id_product`)');
+            ->select('COUNT(DISTINCT cp.`id_product`)');
     }
 
     /**

--- a/src/Core/Grid/Query/EmailLogsQueryBuilder.php
+++ b/src/Core/Grid/Query/EmailLogsQueryBuilder.php
@@ -76,7 +76,7 @@ final class EmailLogsQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
-        $qb->select('COUNT(m.id_mail)');
+        $qb->select('COUNT(DISTINCT m.id_mail)');
 
         return $qb;
     }

--- a/src/Core/Grid/Query/EmployeeQueryBuilder.php
+++ b/src/Core/Grid/Query/EmployeeQueryBuilder.php
@@ -91,7 +91,7 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $countQueryBuilder = $this->getEmployeeQueryBuilder($searchCriteria)
-            ->select('COUNT(e.id_profile)');
+            ->select('COUNT(DISTINCT e.id_profile)');
 
         return $countQueryBuilder;
     }

--- a/src/Core/Grid/Query/ImageTypeQueryBuilder.php
+++ b/src/Core/Grid/Query/ImageTypeQueryBuilder.php
@@ -96,7 +96,7 @@ class ImageTypeQueryBuilder extends AbstractDoctrineQueryBuilder
         }
 
         return $this->getQueryBuilder($searchCriteria)
-            ->select('COUNT(it.id_image_type)')
+            ->select('COUNT(DISTINCT it.id_image_type)')
             ->from($this->dbPrefix . 'image_type', 'it');
     }
 

--- a/src/Core/Grid/Query/LanguageQueryBuilder.php
+++ b/src/Core/Grid/Query/LanguageQueryBuilder.php
@@ -75,7 +75,7 @@ final class LanguageQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
-        return $this->getLanguageQueryBuilder($searchCriteria)->select('COUNT(id_lang)');
+        return $this->getLanguageQueryBuilder($searchCriteria)->select('COUNT(DISTINCT id_lang)');
     }
 
     /**

--- a/src/Core/Grid/Query/LogQueryBuilder.php
+++ b/src/Core/Grid/Query/LogQueryBuilder.php
@@ -82,7 +82,7 @@ final class LogQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
         $queryBuilder = $this->getQueryBuilder()
-            ->select('COUNT(lg.id_log)')
+            ->select('COUNT(DISTINCT lg.id_log)')
             ->from($this->dbPrefix . 'log', 'lg');
         $this->applyAssociatedQueries($queryBuilder);
 

--- a/src/Core/Grid/Query/MerchandiseReturnQueryBuilder.php
+++ b/src/Core/Grid/Query/MerchandiseReturnQueryBuilder.php
@@ -93,7 +93,7 @@ final class MerchandiseReturnQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         return $this->getMerchandiseReturnQueryBuilder($searchCriteria)
-            ->select('COUNT(r.id_order_return)');
+            ->select('COUNT(DISTINCT r.id_order_return)');
     }
 
     /**

--- a/src/Core/Grid/Query/MetaQueryBuilder.php
+++ b/src/Core/Grid/Query/MetaQueryBuilder.php
@@ -92,7 +92,7 @@ final class MetaQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
-        $qb->select('COUNT(m.`id_meta`)');
+        $qb->select('COUNT(DISTINCT m.`id_meta`)');
 
         return $qb;
     }

--- a/src/Core/Grid/Query/Monitoring/EmptyCategoryQueryBuilder.php
+++ b/src/Core/Grid/Query/Monitoring/EmptyCategoryQueryBuilder.php
@@ -110,7 +110,7 @@ final class EmptyCategoryQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
-        $qb->select('COUNT(c.id_category)');
+        $qb->select('COUNT(DISTINCT c.id_category)');
 
         return $qb;
     }

--- a/src/Core/Grid/Query/OrderMessageQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderMessageQueryBuilder.php
@@ -105,7 +105,7 @@ final class OrderMessageQueryBuilder implements DoctrineQueryBuilderInterface
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->buildBaseQuery($searchCriteria);
-        $qb->select('COUNT(om.id_order_message)');
+        $qb->select('COUNT(DISTINCT om.id_order_message)');
 
         return $qb;
     }

--- a/src/Core/Grid/Query/OrderQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderQueryBuilder.php
@@ -117,7 +117,7 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
     {
         $qb = $this->getBaseQueryBuilder($searchCriteria->getFilters());
         $qb = $this->applyNewCustomerFilter($qb, $searchCriteria->getFilters());
-        $qb->select('count(o.id_order)');
+        $qb->select('count(DISTINCT o.id_order)');
 
         return $qb;
     }

--- a/src/Core/Grid/Query/OrderReturnStatesQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderReturnStatesQueryBuilder.php
@@ -93,7 +93,7 @@ final class OrderReturnStatesQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $countQueryBuilder = $this->getOrderReturnStatesQueryBuilder($searchCriteria)
-            ->select('COUNT(*)');
+            ->select('COUNT(DISTINCT ors.`id_order_return_state`)');
 
         return $countQueryBuilder;
     }

--- a/src/Core/Grid/Query/OrderStatesQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderStatesQueryBuilder.php
@@ -97,7 +97,7 @@ final class OrderStatesQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $countQueryBuilder = $this->getOrderStatesQueryBuilder($searchCriteria)
-            ->select('COUNT(*)');
+            ->select('COUNT(DISTINCT os.`id_order_state`)');
 
         return $countQueryBuilder;
     }

--- a/src/Core/Grid/Query/OutstandingQueryBuilder.php
+++ b/src/Core/Grid/Query/OutstandingQueryBuilder.php
@@ -104,7 +104,7 @@ final class OutstandingQueryBuilder implements DoctrineQueryBuilderInterface
      */
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
-        return $this->getBaseQueryBuilder($searchCriteria)->select('COUNT(oi.id_order_invoice)');
+        return $this->getBaseQueryBuilder($searchCriteria)->select('COUNT(DISTINCT oi.id_order_invoice)');
     }
 
     /**

--- a/src/Core/Grid/Query/ProductCombinationQueryBuilder.php
+++ b/src/Core/Grid/Query/ProductCombinationQueryBuilder.php
@@ -105,7 +105,7 @@ final class ProductCombinationQueryBuilder extends AbstractDoctrineQueryBuilder
         }
 
         return $this->getCombinationsQueryBuilder($searchCriteria)
-            ->select('COUNT(pa.id_product_attribute)')
+            ->select('COUNT(DISTINCT pa.id_product_attribute)')
         ;
     }
 

--- a/src/Core/Grid/Query/ProductQueryBuilder.php
+++ b/src/Core/Grid/Query/ProductQueryBuilder.php
@@ -135,7 +135,7 @@ class ProductQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
         $qb = $this->getQueryBuilder($searchCriteria);
-        $qb->select('COUNT(p.`id_product`)');
+        $qb->select('COUNT(DISTINCT p.`id_product`)');
 
         return $qb;
     }

--- a/src/Core/Grid/Query/ProfileQueryBuilder.php
+++ b/src/Core/Grid/Query/ProfileQueryBuilder.php
@@ -85,7 +85,7 @@ final class ProfileQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters())
-            ->select('COUNT(p.id_profile)')
+            ->select('COUNT(DISTINCT p.id_profile)')
         ;
 
         return $qb;

--- a/src/Core/Grid/Query/RequestSqlQueryBuilder.php
+++ b/src/Core/Grid/Query/RequestSqlQueryBuilder.php
@@ -75,7 +75,7 @@ final class RequestSqlQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(?SearchCriteriaInterface $searchCriteria = null)
     {
         $countQueryBuilder = $this->buildQueryBySearchCriteria($searchCriteria);
-        $countQueryBuilder->select('COUNT(rs.id_request_sql)');
+        $countQueryBuilder->select('COUNT(DISTINCT rs.id_request_sql)');
 
         return $countQueryBuilder;
     }

--- a/src/Core/Grid/Query/Security/Session/CustomerQueryBuilder.php
+++ b/src/Core/Grid/Query/Security/Session/CustomerQueryBuilder.php
@@ -81,7 +81,7 @@ class CustomerQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
         return $this->getQueryBuilder($searchCriteria->getFilters())
-            ->select('COUNT(cs.id_customer_session)')
+            ->select('COUNT(DISTINCT cs.id_customer_session)')
         ;
     }
 

--- a/src/Core/Grid/Query/Security/Session/EmployeeQueryBuilder.php
+++ b/src/Core/Grid/Query/Security/Session/EmployeeQueryBuilder.php
@@ -81,7 +81,7 @@ class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
         return $this->getQueryBuilder($searchCriteria->getFilters())
-            ->select('COUNT(es.id_employee_session)')
+            ->select('COUNT(DISTINCT es.id_employee_session)')
         ;
     }
 

--- a/src/Core/Grid/Query/TitleQueryBuilder.php
+++ b/src/Core/Grid/Query/TitleQueryBuilder.php
@@ -85,7 +85,7 @@ class TitleQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
-        return $this->getTitleQueryBuilder($searchCriteria)->select('COUNT(g.id_gender)');
+        return $this->getTitleQueryBuilder($searchCriteria)->select('COUNT(DISTINCT g.id_gender)');
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Avoid duplication in query count.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Make sure that grids fork fine and nbr of elements is correct.
| UI Tests          | ~
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | Evolutive
