### PR TITLE
Allow refund on an order of a deleted customer 

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -395,7 +395,7 @@ class CustomerCore extends ObjectModel
         Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'message WHERE id_customer=' . (int) $this->id);
         Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'specific_price WHERE id_customer=' . (int) $this->id);
 
-        $carts = Db::getInstance()->executeS('SELECT id_cart FROM ' . _DB_PREFIX_ . 'cart WHERE id_customer=' . (int) $this->id);
+        $carts = Db::getInstance()->executeS('SELECT id_cart FROM ' . _DB_PREFIX_ . 'cart WHERE id_customer=' . (int) $this->id . ' AND id_cart NOT IN (SELECT id_cart FROM `' . _DB_PREFIX_ . 'orders`)');
         if ($carts) {
             foreach ($carts as $cart) {
                 Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'cart WHERE id_cart=' . (int) $cart['id_cart']);

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -115,8 +115,8 @@ class OrderSlipCreator
             $customer = new Customer((int) $order->id_customer);
 
             if (!empty($customer->email)) {
-                    // @todo: use private method to send mail
-                    $params = [
+                // @todo: use private method to send mail
+                $params = [
                     '{lastname}' => $customer->lastname,
                     '{firstname}' => $customer->firstname,
                     '{id_order}' => $order->id,

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -114,39 +114,41 @@ class OrderSlipCreator
 
             $customer = new Customer((int) $order->id_customer);
 
-            // @todo: use private method to send mail
-            $params = [
-                '{lastname}' => $customer->lastname,
-                '{firstname}' => $customer->firstname,
-                '{id_order}' => $order->id,
-                '{order_name}' => $order->getUniqReference(),
-            ];
-
-            $orderLanguage = $order->getAssociatedLanguage();
-
-            // @todo: use a dedicated Mail class (see #13945)
-            // @todo: remove this @and have a proper error handling
-            @Mail::Send(
-                (int) $orderLanguage->getId(),
-                'credit_slip',
-                $this->translator->trans(
-                    'New credit slip regarding your order',
-                    [],
-                    'Emails.Subject',
-                    $orderLanguage->locale
-                ),
-                $params,
-                $customer->email,
-                $customer->firstname . ' ' . $customer->lastname,
-                null,
-                null,
-                null,
-                null,
-                _PS_MAIL_DIR_,
-                true,
-                (int) $order->id_shop
-            );
-
+            if (!empty($customer->email)) {
+                    // @todo: use private method to send mail
+                    $params = [
+                    '{lastname}' => $customer->lastname,
+                    '{firstname}' => $customer->firstname,
+                    '{id_order}' => $order->id,
+                    '{order_name}' => $order->getUniqReference(),
+                ];
+                
+                $orderLanguage = $order->getAssociatedLanguage();
+                
+                // @todo: use a dedicated Mail class (see #13945)
+                // @todo: remove this @and have a proper error handling
+                @Mail::Send(
+                    (int) $orderLanguage->getId(),
+                    'credit_slip',
+                    $this->translator->trans(
+                        'New credit slip regarding your order',
+                        [],
+                        'Emails.Subject',
+                        $orderLanguage->locale
+                    ),
+                    $params,
+                    $customer->email,
+                    $customer->firstname . ' ' . $customer->lastname,
+                    null,
+                    null,
+                    null,
+                    null,
+                    _PS_MAIL_DIR_,
+                    true,
+                    (int) $order->id_shop
+                );
+            }
+            
             /** @var OrderDetail $orderDetail */
             foreach ($orderRefundSummary->getOrderDetails() as $orderDetail) {
                 if ($this->configuration->get('PS_ADVANCED_STOCK_MANAGEMENT')) {

--- a/src/Adapter/Order/Refund/VoucherGenerator.php
+++ b/src/Adapter/Order/Refund/VoucherGenerator.php
@@ -143,25 +143,27 @@ class VoucherGenerator
         // @todo: use private method to send mail and later a decoupled mail sender
         $orderLanguage = $order->getAssociatedLanguage();
 
-        @Mail::Send(
-            (int) $orderLanguage->getId(),
-            'voucher',
-            $this->translator->trans(
-                'New voucher for your order #%s',
-                [$order->reference],
-                'Emails.Subject',
-                $orderLanguage->locale
-            ),
-            $params,
-            $customer->email,
-            $customer->firstname . ' ' . $customer->lastname,
-            null,
-            null,
-            null,
-            null,
-            _PS_MAIL_DIR_,
-            true,
-            (int) $order->id_shop
-        );
+        if (!empty($customer->email)) {
+            @Mail::Send(
+                (int) $orderLanguage->getId(),
+                'voucher',
+                $this->translator->trans(
+                    'New voucher for your order #%s',
+                    [$order->reference],
+                    'Emails.Subject',
+                    $orderLanguage->locale
+                ),
+                $params,
+                $customer->email,
+                $customer->firstname . ' ' . $customer->lastname,
+                null,
+                null,
+                null,
+                null,
+                _PS_MAIL_DIR_,
+                true,
+                (int) $order->id_shop
+            );
+        }
     }
 }


### PR DESCRIPTION
…ustomers

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Don't delete cart associated to orders, don't send email to deleted customers
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See in the issue
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38579
| Related PRs       | 
| Sponsor company   | Creabilis.com

In fact, in refund action, the context is recreated from the cart, so the cart has to be there.
Other issues : the process try to send email to deleted customer (email empty), this PR fix this too