### PR TITLE
Fix query builder to find translations by key in Backoffice during the translations saving process

### DIFF
--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -242,7 +242,7 @@ class TranslationService
                 ->createQueryBuilder('t')
                 ->where('t.lang = :lang')->setParameter('lang', $lang)
                 ->andWhere('t.domain = :domain')->setParameter('domain', $domain)
-                ->andWhere('t.key LIKE :key')->setParameter('key', $key)
+                ->andWhere('t.key = :key')->setParameter('key', $key)
             ;
             if ($theme !== null) {
                 $queryBuilder->andWhere('t.theme = :theme')->setParameter('theme', $theme);


### PR DESCRIPTION
| Questions                  | Answers
| -----------------------    | -------------------------------------------------------
| Branch?                    | 8.2.x
| Description?               | This PR fixes some rare cases where the saving of some translations are impossible using the Backoffice interface. Specifically, whenever you had two or more similar (starting with the same text) translation keys within the same domain, where each one is using a % character (eg. '%s') in their key, this will create an unwanted behaviour where you will be able to traslate just one key, because the query will pull a result everytime since it's using LIKE with the special %s character. I'm proposing to change the LIKE operator to an equal sign, since we must find the exact match by translation key.
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | Create two similar translations keys within the same domain, either in a .tpl file or in a module (doesn't matter). Eg: "Hello %s, welcome back" and "Hello %s". Try to translate them.
| UI Tests                   |
| Fixed issue or discussion? | Fixes #38422 
| Related PRs       |
| Sponsor company   | [www.hostinato.it](http://www.hostinato.it/)