### PR TITLE
Cast $orderMessage['message'] as string to prevent fatal error.

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -711,7 +711,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
 
             $messages[] = new OrderMessageForViewing(
                 (int) $orderMessage['id_customer_message'],
-                $orderMessage['message'],
+                (string) $orderMessage['message'],
                 new OrderMessageDateForViewing(
                     new DateTimeImmutable($orderMessage['date_add']),
                     $this->context->language->date_format_full


### PR DESCRIPTION
Cast $orderMessage['message'] as string, when used as $message parameter to OrderMessageForViewing() constructor, because that parameter is declared as string, but $orderMessage['message'] it can be sometimes not strictly a string.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Prevent "must be of type string" fatal error when viewing order details in BO.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Use your imagination.
| UI Tests          | Not necessary.
| Fixed issue or discussion?     | Fixes #38602
| Related PRs       | No.
| Sponsor company   | José Carlos PHP.
