### PR TITLE
Added subquery to identify employees not linked to any shop

### DIFF
--- a/src/Core/Grid/Query/EmployeeQueryBuilder.php
+++ b/src/Core/Grid/Query/EmployeeQueryBuilder.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Query;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
@@ -51,6 +52,11 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
     private $contextShopIds;
 
     /**
+     * @var ShopContext
+     */
+    private $shopContext;
+
+    /**
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
@@ -62,13 +68,15 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
         $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
         $contextIdLang,
-        array $contextShopIds
+        array $contextShopIds,
+        ShopContext $shopContext
     ) {
         parent::__construct($connection, $dbPrefix);
 
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
         $this->contextIdLang = $contextIdLang;
         $this->contextShopIds = $contextShopIds;
+        $this->shopContext = $shopContext;
     }
 
     /**
@@ -103,18 +111,6 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     private function getEmployeeQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
-        $sub = $this->connection->createQueryBuilder()
-            ->select('1')
-            ->from($this->dbPrefix . 'employee_shop', 'es')
-            ->where('e.id_employee = es.id_employee')
-            ->andWhere('es.id_shop IN (:context_shop_ids)');
-
-        // Subquery to identify employees not linked to any shop
-        $missingShopLinkSubquery = $this->connection->createQueryBuilder()
-            ->select('1')
-            ->from($this->dbPrefix . 'employee_shop', 'es')
-            ->where('e.id_employee = es.id_employee');
-
         $qb = $this->connection->createQueryBuilder()
             ->from($this->dbPrefix . 'employee', 'e')
             ->leftJoin(
@@ -122,14 +118,34 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
                 $this->dbPrefix . 'profile_lang',
                 'pl',
                 'e.id_profile = pl.id_profile AND pl.id_lang = ' . (int) $this->contextIdLang
-            )
-            ->andWhere('EXISTS (' . $sub->getSQL() . ')')
-            ->orWhere('NOT EXISTS (' . $missingShopLinkSubquery->getSQL() . ')')
-            ->setParameter('context_shop_ids', $this->contextShopIds, Connection::PARAM_INT_ARRAY);
+            );
+
+        $this->addShopContextRestriction($qb);
 
         $this->applyFilters($qb, $searchCriteria->getFilters());
 
         return $qb;
+    }
+
+    /**
+     * Adds the shop context restriction to the QueryBuilder when required.
+     *
+     * @param QueryBuilder $qb
+     */
+    private function addShopContextRestriction(QueryBuilder $qb): void
+    {
+        if ($this->shopContext->isAllShopContext()) {
+            return;
+        }
+
+        $sub = $this->connection->createQueryBuilder()
+            ->select('1')
+            ->from($this->dbPrefix . 'employee_shop', 'es')
+            ->where('e.id_employee = es.id_employee')
+            ->andWhere('es.id_shop IN (:context_shop_ids)');
+
+        $qb->andWhere('EXISTS (' . $sub->getSQL() . ')')
+            ->setParameter('context_shop_ids', $this->contextShopIds, Connection::PARAM_INT_ARRAY);
     }
 
     /**

--- a/src/Core/Grid/Query/EmployeeQueryBuilder.php
+++ b/src/Core/Grid/Query/EmployeeQueryBuilder.php
@@ -109,6 +109,12 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
             ->where('e.id_employee = es.id_employee')
             ->andWhere('es.id_shop IN (:context_shop_ids)');
 
+        // Subquery to identify employees not linked to any shop
+        $missingShopLinkSubquery = $this->connection->createQueryBuilder()
+            ->select('1')
+            ->from($this->dbPrefix . 'employee_shop', 'es')
+            ->where('e.id_employee = es.id_employee');
+
         $qb = $this->connection->createQueryBuilder()
             ->from($this->dbPrefix . 'employee', 'e')
             ->leftJoin(
@@ -118,6 +124,7 @@ final class EmployeeQueryBuilder extends AbstractDoctrineQueryBuilder
                 'e.id_profile = pl.id_profile AND pl.id_lang = ' . (int) $this->contextIdLang
             )
             ->andWhere('EXISTS (' . $sub->getSQL() . ')')
+            ->orWhere('NOT EXISTS (' . $missingShopLinkSubquery->getSQL() . ')')
             ->setParameter('context_shop_ids', $this->contextShopIds, Connection::PARAM_INT_ARRAY);
 
         $this->applyFilters($qb, $searchCriteria->getFilters());

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -67,6 +67,7 @@ services:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
       - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
       - "@=service('prestashop.adapter.legacy.context').getContext().shop.getContextListShopID()"
+      - '@PrestaShop\PrestaShop\Core\Context\ShopContext'
     public: true
 
   prestashop.core.grid.query_builder.contact:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | see https://github.com/PrestaShop/PrestaShop/issues/35094 - Note: The issue also occurs on the 9.0.x branch, so I performed the rebase by moving the PR to 9.0.x because PRs are no longer being merged on version 8.2.x.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create a employee in _Advanced parameters > Teams > Employee_ <br>2. Retrieve the ID of the newly created user (e.g., 2)<BR> 3. Access phpMyAdmin <br>4. In the `employee_shop` table, delete the records where `id_employee` = the newly created Employee ID <br>5. Return to Advanced parameters > Teams > Employee (you do not need to log in again)  <br>6. You should still see the newly created user displayed<br>
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/21135935007
| Fixed issue or discussion?     | Fixes #35094
| Related PRs       | 
| Sponsor company   | Codencode  snc
