### PR TITLE
Fix: Hook actionAttributeCombinationSave never triggered

### DIFF
--- a/src/Adapter/Product/Combination/Create/CombinationCreator.php
+++ b/src/Adapter/Product/Combination/Create/CombinationCreator.php
@@ -113,7 +113,7 @@ class CombinationCreator
         AttributeGroupRepository $attributeGroupRepository,
         AttributeRepository $attributeRepository,
         DefaultCombinationUpdater $defaultCombinationUpdater,
-        HookDispatcherInterface $hookDispatcher,
+        HookDispatcherInterface $hookDispatcher
     ) {
         $this->combinationGenerator = $combinationGenerator;
         $this->combinationRepository = $combinationRepository;

--- a/src/Adapter/Product/Combination/Create/CombinationCreator.php
+++ b/src/Adapter/Product/Combination/Create/CombinationCreator.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Combination\Create;
 
-use Hook;
 use PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository;
 use PrestaShop\PrestaShop\Adapter\AttributeGroup\Repository\AttributeGroupRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository;
@@ -47,6 +46,7 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopCollection;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Product\Combination\Generator\CombinationGeneratorInterface;
 use PrestaShopException;
 use Product;
@@ -94,6 +94,11 @@ class CombinationCreator
     private $defaultCombinationUpdater;
 
     /**
+     * @var HookDispatcherInterface
+     */
+    private $hookDispatcher;
+
+    /**
      * @param CombinationGeneratorInterface $combinationGenerator
      * @param CombinationRepository $combinationRepository
      * @param ProductRepository $productRepository
@@ -107,7 +112,8 @@ class CombinationCreator
         StockAvailableRepository $stockAvailableRepository,
         AttributeGroupRepository $attributeGroupRepository,
         AttributeRepository $attributeRepository,
-        DefaultCombinationUpdater $defaultCombinationUpdater
+        DefaultCombinationUpdater $defaultCombinationUpdater,
+        HookDispatcherInterface $hookDispatcher,
     ) {
         $this->combinationGenerator = $combinationGenerator;
         $this->combinationRepository = $combinationRepository;
@@ -116,6 +122,7 @@ class CombinationCreator
         $this->defaultCombinationUpdater = $defaultCombinationUpdater;
         $this->attributeGroupRepository = $attributeGroupRepository;
         $this->attributeRepository = $attributeRepository;
+        $this->hookDispatcher = $hookDispatcher;
     }
 
     /**
@@ -279,7 +286,11 @@ class CombinationCreator
 
         try {
             $this->combinationRepository->saveProductAttributeAssociation($combinationId, $generatedCombination);
-            Hook::exec('actionAttributeCombinationSave', ['id_product_attribute' => (int) $combination->id, 'id_attributes' => $generatedCombination]);
+
+            $this->hookDispatcher->dispatchWithParameters(
+                'actionAttributeCombinationSave',
+                ['id_product_attribute' => (int) $combination->id, 'id_attributes' => $generatedCombination]
+            );
         } catch (CoreException $e) {
             foreach ($shopIds as $shopId) {
                 $this->combinationRepository->delete($combinationId, ShopConstraint::shop($shopId->getValue()));

--- a/src/Adapter/Product/Combination/Create/CombinationCreator.php
+++ b/src/Adapter/Product/Combination/Create/CombinationCreator.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Combination\Create;
 
+use Hook;
 use PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository;
 use PrestaShop\PrestaShop\Adapter\AttributeGroup\Repository\AttributeGroupRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository;
@@ -278,6 +279,7 @@ class CombinationCreator
 
         try {
             $this->combinationRepository->saveProductAttributeAssociation($combinationId, $generatedCombination);
+            Hook::exec('actionAttributeCombinationSave', ['id_product_attribute' => (int) $combination->id, 'id_attributes' => $generatedCombination]);
         } catch (CoreException $e) {
             foreach ($shopIds as $shopId) {
                 $this->combinationRepository->delete($combinationId, ShopConstraint::shop($shopId->getValue()));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | see: https://github.com/PrestaShop/PrestaShop/issues/38615 - Note: The issue also occurs on the 9.0.x branch, so I performed the rebase by moving the PR to 9.0.x because PRs are no longer being merged on version 8.2.x.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | 1. Install this module [issue38615.zip](https://github.com/user-attachments/files/23113954/issue38615.zip) - 2. add a combination to a product - 3. refresh the page and see the message: "Hook ActionAttributeCombinationSave executed".
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/18772528803
| Fixed issue or discussion?     | Fixes #38615
| Related PRs       | 
| Sponsor company   | Codencode snc
