### PR TITLE
Fix: New product catalog does not load images in multi-store

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/image/dropzone/Dropzone.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/image/dropzone/Dropzone.vue
@@ -290,6 +290,18 @@
           this.initDropZone();
 
           images.forEach((image: Dropzone.DropzoneMockFile) => {
+            // If you're editing a product assigned to one shop,
+            // but you're logged into the admin using the URL of a different shop (in multishop mode),
+            // update the image domain to match the current window location (window.location.origin)
+            // to avoid loading issues or CORS blocks in the browser.
+            const url = new URL(image.image_url);
+
+            if (url.origin !== window.location.origin) {
+              url.protocol = window.location.protocol;
+              url.host = window.location.host;
+              image.image_url = url.toString();
+            }
+
             this.dropzone?.displayExistingFile(image, image.image_url);
           });
         } catch (error) {


### PR DESCRIPTION
If you're editing a product assigned to one shop, but you're logged into the admin using the URL of a different shop (in multishop mode), update the image domain to match the current window location (window.location.origin) to avoid loading issues or CORS blocks in the browser.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.2.x
| Description?      | see: https://github.com/PrestaShop/PrestaShop/issues/38032
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see: https://github.com/PrestaShop/PrestaShop/issues/38032
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16935481357
| Fixed issue or discussion?     | Fixes #38032, Fixes #34898
| Related PRs       | #35947
| Sponsor company   | @Codencode 
