### PR TITLE
fix flawed _products cache of class Cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -105,7 +105,7 @@ class CartCore extends ObjectModel
     protected static $_nbProducts = [];
     protected static $_isVirtualCart = [];
 
-    protected $_products = null;
+    protected $_products = [];
     protected static $_totalWeight = [];
     protected $_taxCalculationMethod = PS_TAX_EXC;
     protected static $_carriers = null;
@@ -305,7 +305,7 @@ class CartCore extends ObjectModel
         if (isset(self::$_totalWeight[$this->id])) {
             unset(self::$_totalWeight[$this->id]);
         }
-        $this->_products = null;
+        $this->_products = [];
 
         $return = parent::update($nullValues);
         Hook::exec('actionCartSave', ['cart' => $this]);
@@ -627,11 +627,11 @@ class CartCore extends ObjectModel
         if (!$this->id) {
             return [];
         }
-        // Product cache must be strictly compared to NULL, or else an empty cart will add dozens of queries
-        if ($this->_products !== null && !$refresh) {
+        $cacheId = (int) $id_product . '-' . (int) $id_country . '-' . (int) $fullInfos . '-' . (int) $keepOrderPrices;
+        if (isset($this->_products[$cacheId]) && !$refresh) {
             // Return product row with specified ID if it exists
             if (is_int($id_product)) {
-                foreach ($this->_products as $product) {
+                foreach ($this->_products[$cacheId] as $product) {
                     if ($product['id_product'] == $id_product) {
                         return [$product];
                     }
@@ -640,7 +640,7 @@ class CartCore extends ObjectModel
                 return [];
             }
 
-            return $this->_products;
+            return $this->_products[$cacheId];
         }
 
         // Build query
@@ -769,7 +769,7 @@ class CartCore extends ObjectModel
         Cart::cacheSomeAttributesLists($pa_ids, (int) $this->getAssociatedLanguage()->getId());
 
         if (empty($products)) {
-            $this->_products = [];
+            $this->_products[$cacheId] = [];
 
             return [];
         }
@@ -808,7 +808,7 @@ class CartCore extends ObjectModel
                 }
             }
 
-            $this->_products = [];
+            $this->_products[$cacheId] = [];
 
             foreach ($products as &$product) {
                 if (!array_key_exists('is_gift', $product)) {
@@ -836,7 +836,7 @@ class CartCore extends ObjectModel
                     $product = $this->applyProductCalculations($product, $cart_shop_context, null, $keepOrderPrices);
                 } else {
                     // Separate products given away from those manually added to cart
-                    $this->_products[] = $this->applyProductCalculations($product, $cart_shop_context, $givenAwayQuantity, $keepOrderPrices);
+                    $this->_products[$cacheId][] = $this->applyProductCalculations($product, $cart_shop_context, $givenAwayQuantity, $keepOrderPrices);
                     unset($product['is_gift']);
                     $product = $this->applyProductCalculations(
                         $product,
@@ -846,13 +846,13 @@ class CartCore extends ObjectModel
                     );
                 }
 
-                $this->_products[] = $product;
+                $this->_products[$cacheId][] = $product;
             }
         } else {
-            $this->_products = $products;
+            $this->_products[$cacheId] = $products;
         }
 
-        return $this->_products;
+        return $this->_products[$cacheId];
     }
 
     /**
@@ -4612,7 +4612,7 @@ class CartCore extends ObjectModel
     protected function splitGiftsProductsQuantity()
     {
         $this->shouldSplitGiftProductsQuantity = true;
-        $this->_products = null;
+        $this->_products = [];
 
         return $this;
     }
@@ -4623,7 +4623,7 @@ class CartCore extends ObjectModel
     protected function mergeGiftsProductsQuantity()
     {
         $this->shouldSplitGiftProductsQuantity = false;
-        $this->_products = null;
+        $this->_products = [];
 
         return $this;
     }
@@ -4631,7 +4631,7 @@ class CartCore extends ObjectModel
     protected function excludeGiftsDiscountFromTotal()
     {
         $this->shouldExcludeGiftsDiscount = true;
-        $this->_products = null;
+        $this->_products = [];
 
         return $this;
     }
@@ -4639,7 +4639,7 @@ class CartCore extends ObjectModel
     protected function includeGiftsDiscountInTotal()
     {
         $this->shouldExcludeGiftsDiscount = false;
-        $this->_products = null;
+        $this->_products = [];
 
         return $this;
     }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -90,8 +90,12 @@ class CartCore extends ObjectModel
     protected static $_nbProducts = [];
     protected static $_isVirtualCart = [];
 
-    protected $_products = null;
-    protected $_products_with_separated_gifts = null;
+    /**
+     * Cache of getProducts() results, indexed by a key built from every argument that affects the result.
+     *
+     * @var array<string, array>
+     */
+    protected $_products = [];
     protected static $_totalWeight = [];
     protected $_taxCalculationMethod = PS_TAX_EXC;
     protected static $_carriers = null;
@@ -250,8 +254,7 @@ class CartCore extends ObjectModel
         if (isset(self::$_totalWeight[$this->id])) {
             unset(self::$_totalWeight[$this->id]);
         }
-        $this->_products = null;
-        $this->_products_with_separated_gifts = null;
+        $this->_products = [];
     }
 
     /**
@@ -689,28 +692,33 @@ class CartCore extends ObjectModel
             return [];
         }
 
-        // Get cache key we will use, depending on whether we want to split gift products quantity or not
-        if ($shouldSplitGiftProductsQuantity) {
-            $cacheKey = '_products_with_separated_gifts';
-        } else {
-            $cacheKey = '_products';
+        // Refreshing means the underlying data changed, so none of the cached results can be trusted anymore
+        if ($refresh) {
+            $this->_products = [];
         }
 
-        // Product cache must be strictly compared to NULL, or else an empty cart will add dozens of queries
-        if ($this->{$cacheKey} !== null && !$refresh) {
-            // If a specific product ID is requested, we will search for it in the cache.
-            if (is_int($id_product)) {
-                foreach ($this->{$cacheKey} as $product) {
-                    if ($product['id_product'] == $id_product) {
-                        return [$product];
+        // Every argument that affects the result is part of the cache key, otherwise a call would be served
+        // the result computed for different arguments (e.g. rows without full infos, or a single product)
+        $cacheKeySuffix = '-' . (int) $id_country . '-' . (int) $fullInfos . '-' . (int) $keepOrderPrices . '-' . (int) $shouldSplitGiftProductsQuantity;
+        $cacheKey = (int) $id_product . $cacheKeySuffix;
+        if (isset($this->_products[$cacheKey])) {
+            return $this->_products[$cacheKey];
+        }
+
+        // If a specific product is requested and the whole cart is already cached for the same arguments,
+        // filter the cached rows instead of running a new query
+        if ($id_product) {
+            $allProductsCacheKey = '0' . $cacheKeySuffix;
+            if (isset($this->_products[$allProductsCacheKey])) {
+                $matchingProducts = [];
+                foreach ($this->_products[$allProductsCacheKey] as $product) {
+                    if ((int) $product['id_product'] === (int) $id_product) {
+                        $matchingProducts[] = $product;
                     }
                 }
 
-                return [];
+                return $matchingProducts;
             }
-
-            // Otherwise, we return the whole cache
-            return $this->{$cacheKey};
         }
 
         // Build query
@@ -864,7 +872,7 @@ class CartCore extends ObjectModel
         Cart::cacheSomeAttributesLists($pa_ids, (int) $this->getAssociatedLanguage()->getId());
 
         if (empty($products)) {
-            $this->{$cacheKey} = [];
+            $this->_products[$cacheKey] = [];
 
             return [];
         }
@@ -903,7 +911,7 @@ class CartCore extends ObjectModel
                 }
             }
 
-            $this->{$cacheKey} = [];
+            $this->_products[$cacheKey] = [];
 
             foreach ($products as &$product) {
                 if (!array_key_exists('is_gift', $product)) {
@@ -931,7 +939,7 @@ class CartCore extends ObjectModel
                     $product = $this->applyProductCalculations($product, $cart_shop_context, null, $keepOrderPrices);
                 } else {
                     // Separate products given away from those manually added to cart
-                    $this->{$cacheKey}[] = $this->applyProductCalculations($product, $cart_shop_context, $givenAwayQuantity, $keepOrderPrices);
+                    $this->_products[$cacheKey][] = $this->applyProductCalculations($product, $cart_shop_context, $givenAwayQuantity, $keepOrderPrices);
                     unset($product['is_gift']);
                     $product = $this->applyProductCalculations(
                         $product,
@@ -941,13 +949,13 @@ class CartCore extends ObjectModel
                     );
                 }
 
-                $this->{$cacheKey}[] = $product;
+                $this->_products[$cacheKey][] = $product;
             }
         } else {
-            $this->{$cacheKey} = $products;
+            $this->_products[$cacheKey] = $products;
         }
 
-        return $this->{$cacheKey};
+        return $this->_products[$cacheKey];
     }
 
     /**

--- a/tests/Integration/Classes/CartTest.php
+++ b/tests/Integration/Classes/CartTest.php
@@ -456,4 +456,36 @@ class CartTest extends KernelTestCase
             $cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS)
         );
     }
+
+    public function testGetProductsCacheIsKeyedByArguments(): void
+    {
+        $productA = self::makeProduct('Product A', 10, self::getIdTaxRulesGroup(20));
+        $productB = self::makeProduct('Product B', 20, self::getIdTaxRulesGroup(20));
+        $cart = self::makeCart();
+        $cart->updateQty(1, $productA->id);
+        $cart->updateQty(2, $productB->id);
+
+        // Reload the cart so that its products cache is cold
+        $cart = new Cart($cart->id);
+        Context::getContext()->cart = $cart;
+
+        // Requesting a single product on a cold cache must not poison the cache of the whole cart
+        $onlyA = $cart->getProducts(false, (int) $productA->id);
+        $this->assertCount(1, $onlyA);
+        $this->assertEquals($productA->id, $onlyA[0]['id_product']);
+        $this->assertCount(2, $cart->getProducts());
+
+        // Rows without full infos must not be served from the full infos cache, and vice versa
+        $this->assertArrayHasKey('price_without_reduction', $cart->getProducts()[0]);
+        $rawProducts = $cart->getProducts(false, false, null, false);
+        $this->assertCount(2, $rawProducts);
+        $this->assertArrayNotHasKey('price_without_reduction', $rawProducts[0]);
+        $this->assertArrayHasKey('price_without_reduction', $cart->getProducts()[0]);
+
+        // A single product requested from a warm cache is filtered out of the cached cart
+        $onlyB = $cart->getProducts(false, (int) $productB->id);
+        $this->assertCount(1, $onlyB);
+        $this->assertEquals($productB->id, $onlyB[0]['id_product']);
+        $this->assertArrayHasKey('price_without_reduction', $onlyB[0]);
+    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR aims to fix the flawed internal cache for the _products array of the Cart class. That cache needs a proper formatted cache key since the cached items depend on input parameters of the getProducts() function. This also fixes a major bug I've encountered with the native getOrderTotal() function which uses getProducts() internally
| Type?             | bug fix / improvement
| Category?         | FO / BO / WS / CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a cart with 2 different products. Call the getProducts() method with a specific $idProduct as input parameter, then call the getProducts() function again with different parameters (or not parameter at all) -> see that the results are now coherent and taking into account the input parameters everytime you call this function.
| Fixed issue or discussion?     | Fixes #22425 
| Sponsor company   | www.hostinato.it
