### PR TITLE
Add hook displayCartExtraProductInfo to display cart extra product information

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -636,6 +636,11 @@
       <title>Alter template vars on the fly</title>
       <description>This hook is called when Mail::send() is called</description>
     </hook>
+    <hook id="displayCartExtraProductInfo">
+      <name>displayCartExtraProductInfo</name>
+      <title>Extra information in shopping cart product line</title>
+      <description>This hook adds extra information to the product lines, in the shopping cart</description>
+    </hook>
     <hook id="displayCartExtraProductActions">
       <name>displayCartExtraProductActions</name>
       <title>Extra buttons in shopping cart</title>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | This hook adds extra information to the product lines, in the shopping cart
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Display something in this hook
| UI Tests          | 
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/discussions/38692
| Related PRs       | here in classic https://github.com/PrestaShop/classic-theme/pull/170 and in Hummingbird https://github.com/PrestaShop/hummingbird/pull/699, autoupgrade PR - https://github.com/PrestaShop/autoupgrade/pull/1364
| Sponsor company   | Creabilis.com

I'll add the hook here in classic's cart-detailed-product-line.tpl https://github.com/PrestaShop/classic-theme/blob/628cf2cc03f35bf886152ad4b46eeb38f8ddb2e9/templates/checkout/_partials/cart-detailed-product-line.tpl#L123