### PR TITLE
Block execution while cache clear is running in install endpoints

### DIFF
--- a/install-dev/index.php
+++ b/install-dev/index.php
@@ -43,6 +43,9 @@ if (
 require_once dirname(__FILE__).DIRECTORY_SEPARATOR.'init.php';
 require_once(__DIR__).DIRECTORY_SEPARATOR.'autoload.php';
 
+define('_PS_APP_ID_', AdminKernel::APP_ID);
+PrestaShop\PrestaShop\Core\Util\CacheClearLocker::waitUntilUnlocked(_PS_ENV_, _PS_APP_ID_);
+
 try {
     if (_PS_MODE_DEV_) {
         Symfony\Component\ErrorHandler\Debug::enable();

--- a/install-dev/index_cli.php
+++ b/install-dev/index_cli.php
@@ -52,6 +52,9 @@ Datas::getInstance()->getAndCheckArgs($argv);
 require_once dirname(__FILE__).'/init.php';
 require_once(__DIR__).DIRECTORY_SEPARATOR.'autoload.php';
 
+define('_PS_APP_ID_', AdminKernel::APP_ID);
+PrestaShop\PrestaShop\Core\Util\CacheClearLocker::waitUntilUnlocked(_PS_ENV_, _PS_APP_ID_);
+
 try {
     require_once _PS_INSTALL_PATH_.'classes/controllerConsole.php';
     InstallControllerConsole::execute($argc, $argv);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Block execution while cache clear is running in install endpoints
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/15016953976
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
