### PR TITLE
Stabilize composer create test db

### DIFF
--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -372,6 +372,7 @@ class Install extends AbstractInstall
         $context = Context::getContext();
         $context->shop = new Shop(1);
         Shop::setContext(Shop::CONTEXT_SHOP, 1);
+        Configuration::resetStaticCache();
         Configuration::loadConfiguration();
         if (!isset($context->language) || !Validate::isLoadedObject($context->language)) {
             $context->language = new Language('en');
@@ -461,6 +462,9 @@ class Install extends AbstractInstall
 
         $flip_languages = array_flip($languages);
         $id_lang = (!empty($flip_languages[$this->language->getLanguageIso()])) ? $flip_languages[$this->language->getLanguageIso()] : 1;
+
+        Configuration::resetStaticCache();
+        Configuration::loadConfiguration();
         Configuration::updateGlobalValue('PS_LANG_DEFAULT', $id_lang);
         Configuration::updateGlobalValue('PS_VERSION_DB', _PS_INSTALL_VERSION_);
         Configuration::updateGlobalValue('PS_INSTALL_VERSION', _PS_INSTALL_VERSION_);
@@ -765,6 +769,7 @@ class Install extends AbstractInstall
         }
 
         Context::getContext()->shop = new Shop(1);
+        Configuration::resetStaticCache();
         Configuration::loadConfiguration();
 
         $id_country = (int) Country::getByIso($data['shop_country']);

--- a/tests/bin/create-test-db.php
+++ b/tests/bin/create-test-db.php
@@ -63,6 +63,11 @@ $modelDatabase->createDatabase(_DB_SERVER_, _DB_NAME_, _DB_USER_, _DB_PASSWD_);
 
 $install->clearDatabase(false);
 checkInstallationErrors($install, $logger);
+
+// Clear configuration in case DB was installed when this script is launched or else it keeps cached data that prevents
+// updating the database
+Configuration::resetStaticCache();
+
 if (!$install->installDatabase(true)) {
     exit(1);
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Stabilize composer create test db while inserting default shop and languages data
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI and UI tests green, run `composer create-test-db` multiple times, the `PS_LANG_DEFAULT` must always be correctly filled with `1`, even when the DB is already filled before running the command
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/15021842425
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
