### PR TITLE
Revert modification in OrderLazyArray that breaks the UI tests

### DIFF
--- a/src/Adapter/Presenter/Order/OrderLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderLazyArray.php
@@ -208,7 +208,6 @@ class OrderLazyArray extends AbstractLazyArray
             foreach ($cartProducts['products'] as $cartProduct) {
                 if (($cartProduct['id_product'] === $orderProduct['id_product'])
                     && ($cartProduct['id_product_attribute'] === $orderProduct['id_product_attribute'])
-                    && ($cartProduct['id_customization'] === $orderProduct['id_customization'])
                 ) {
                     if (isset($cartProduct['attributes'])) {
                         $orderProduct['attributes'] = $cartProduct['attributes'];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Revert modification in OrderLazyArray that breaks the UI tests from PR https://github.com/PrestaShop/PrestaShop/pull/38552
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/15022657588
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~

## Caused regression

The fix from https://github.com/PrestaShop/PrestaShop/pull/38552 causes some regressions, some UI test scenarios are failing, the PR was merged besides the tests failing. Here is an example of the product image not being displayed in order confirmation:
![Capture d’écran 2025-05-14 à 15 49 25](https://github.com/user-attachments/assets/0faab072-a9b5-4c68-bb91-34103ab688a2)

With the extra line removed it's correctly displayed again:
![Capture d’écran 2025-05-14 à 15 51 27](https://github.com/user-attachments/assets/0a683d2b-965c-4e5a-86ce-97e2d9a24f26)

I'm not saying the fix is not relevant but it needs to be searched more in depth to avoid creating side effects. Sorry I don't have time to fix it so I need to revert it because this is falling all our UI tests and prevents us from merging the branch 8.2.x into 9.0.x.

The bug was not detected by UI tests on 8.2.x because this part was tested only in 9.0.x branch which highlighted the problem.