### PR TITLE
Enabling theme of add/update shop in a multistore context

### DIFF
--- a/classes/ImageType.php
+++ b/classes/ImageType.php
@@ -87,17 +87,21 @@ class ImageTypeCore extends ObjectModel
      *
      * @param string|null $type Image type
      * @param bool $orderBySize
+     * @param string|null $theme Theme name
      *
      * @return array Image type definitions
      *
      * @throws PrestaShopDatabaseException
      */
-    public static function getImagesTypes($type = null, $orderBySize = false)
+    public static function getImagesTypes($type = null, $orderBySize = false, $theme = null)
     {
-        if (!isset(self::$images_types_cache[$type])) {
+        if (!isset(self::$images_types_cache[$type][$theme])) {
             $where = 'WHERE 1';
             if (!empty($type)) {
                 $where .= ' AND `' . bqSQL($type) . '` = 1 ';
+            }
+            if (null !== $theme) {
+                $where .= ' AND `theme_name` = \'' . pSQL($theme) . '\' OR `theme_name` IS NULL';
             }
 
             if ($orderBySize) {
@@ -106,10 +110,10 @@ class ImageTypeCore extends ObjectModel
                 $query = 'SELECT * FROM `' . _DB_PREFIX_ . 'image_type` ' . $where . ' ORDER BY `name` ASC';
             }
 
-            self::$images_types_cache[$type] = Db::getInstance()->executeS($query);
+            self::$images_types_cache[$type][$theme] = Db::getInstance()->executeS($query);
         }
 
-        return self::$images_types_cache[$type];
+        return self::$images_types_cache[$type][$theme];
     }
 
     /**

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -316,6 +316,8 @@ class AdminShopControllerCore extends AdminController
      */
     protected function afterAdd($new_shop)
     {
+        $this->enableTheme($new_shop);
+
         $import_data = Tools::getValue('importData', []);
 
         // The root category should be at least imported
@@ -342,6 +344,8 @@ class AdminShopControllerCore extends AdminController
      */
     protected function afterUpdate($new_shop)
     {
+        $this->enableTheme($new_shop);
+
         $categories = Tools::getValue('categoryBox');
 
         if (!is_array($categories)) {
@@ -364,6 +368,29 @@ class AdminShopControllerCore extends AdminController
         }
 
         return parent::afterUpdate($new_shop);
+    }
+
+    /**
+     * @param Shop $shop
+     *
+     * @return void
+     */
+    protected function enableTheme($shop)
+    {
+        // We must avoid the fact that enable theme with Theme Manager will set theme into the shop too!
+
+        // Save initial shop context
+        $initialShop = $this->context->shop;
+        // Set new shop into the context, just for ThemeManagerBuilder
+        $this->context->shop = $shop;
+        (new ThemeManagerBuilder($this->context, Db::getInstance()))
+            ->build()
+            ->enable($shop->theme_name);
+        // Restore initial shop into the context
+        $this->context->shop = $initialShop;
+
+        // Clear cache!
+        Tools::clearCache();
     }
 
     public function getList($id_lang, $order_by = null, $order_way = null, $start = 0, $limit = null, $id_lang_shop = false)

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -2834,7 +2834,8 @@ CREATE TABLE `PREFIX_image_type` (
   `manufacturers` TINYINT(1) DEFAULT 1 NOT NULL,
   `suppliers`     TINYINT(1) DEFAULT 1 NOT NULL,
   `stores`        TINYINT(1) DEFAULT 1 NOT NULL,
-  UNIQUE KEY `UNIQ_907C95215E237E06` (`name`),
+  `theme_name`    VARCHAR(255) DEFAULT NULL,
+  UNIQUE KEY `UNIQ_907C95215E237E06` (`name`, `theme_name`),
   PRIMARY KEY (`id_image_type`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -742,7 +742,7 @@ parameters:
 
 		-
 			message: "#^Namespace Db is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
-			count: 2
+			count: 3
 			path: src/Core/Image/ImageTypeRepository.php
 
 		-

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Adapter\Image;
 
 use Category;
 use Configuration;
+use Context;
 use Image;
 use ImageManager;
 use ImageType;
@@ -212,6 +213,11 @@ class ImageRetriever
 
         // Check and generate each thumbnail size
         $image_types = ImageType::getImagesTypes($type, true);
+
+        // Filter image types by theme name
+        $currentTheme = Context::getContext()->shop->theme_name;
+        $image_types = array_filter($image_types, fn (array $imageType) => $imageType['theme_name'] === null || $imageType['theme_name'] === $currentTheme);
+
         foreach ($image_types as $image_type) {
             $sources = [];
             $formattedName = ImageType::getFormattedName('small');
@@ -364,9 +370,15 @@ class ImageRetriever
             ['type' => 'stores', 'dir' => _PS_STORE_IMG_DIR_],
         ];
 
+        // Get current theme
+        $currentTheme = Context::getContext()->shop->theme_name;
+
         foreach ($objectsToRegenerate as $object) {
             // Get all image types present on shops for this object
             $imageTypes = ImageType::getImagesTypes($object['type'], true);
+
+            // Filter image types by theme name
+            $imageTypes = array_filter($imageTypes, fn (array $imageType) => $imageType['theme_name'] === null || $imageType['theme_name'] === $currentTheme);
 
             // We get the "no image available" in the folder of the object
             $originalImagePath = implode(DIRECTORY_SEPARATOR, [

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -212,11 +212,8 @@ class ImageRetriever
         }
 
         // Check and generate each thumbnail size
-        $image_types = ImageType::getImagesTypes($type, true);
-
-        // Filter image types by theme name
         $currentTheme = Context::getContext()->shop->theme_name;
-        $image_types = array_filter($image_types, fn (array $imageType) => $imageType['theme_name'] === null || $imageType['theme_name'] === $currentTheme);
+        $image_types = ImageType::getImagesTypes($type, true, $currentTheme);
 
         foreach ($image_types as $image_type) {
             $sources = [];
@@ -375,10 +372,7 @@ class ImageRetriever
 
         foreach ($objectsToRegenerate as $object) {
             // Get all image types present on shops for this object
-            $imageTypes = ImageType::getImagesTypes($object['type'], true);
-
-            // Filter image types by theme name
-            $imageTypes = array_filter($imageTypes, fn (array $imageType) => $imageType['theme_name'] === null || $imageType['theme_name'] === $currentTheme);
+            $imageTypes = ImageType::getImagesTypes($object['type'], true, $currentTheme);
 
             // We get the "no image available" in the folder of the object
             $originalImagePath = implode(DIRECTORY_SEPARATOR, [

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -180,7 +180,7 @@ class ThemeManager implements AddonManagerInterface
                 ->doDisableModules($theme->get('global_settings.modules.to_disable', []))
                 ->doEnableModules($theme->getModulesToEnable())
                 ->doResetModules($theme->get('global_settings.modules.to_reset', []))
-                ->doApplyImageTypes($theme->get('global_settings.image_types', []))
+                ->doApplyImageTypes($theme->get('global_settings.image_types', []), $name)
                 ->doHookModules($theme->get('global_settings.hooks.modules_to_hook', []));
 
             $theme->onEnable();
@@ -369,9 +369,9 @@ class ThemeManager implements AddonManagerInterface
      *
      * @return self
      */
-    private function doApplyImageTypes(array $types): self
+    private function doApplyImageTypes(array $types, ?string $theme_name): self
     {
-        $this->imageTypeRepository->setTypes($types);
+        $this->imageTypeRepository->setTypes($types, $theme_name);
 
         return $this;
     }

--- a/src/Core/Domain/ImageSettings/QueryHandler/GetImageTypeForEditingHandler.php
+++ b/src/Core/Domain/ImageSettings/QueryHandler/GetImageTypeForEditingHandler.php
@@ -67,7 +67,8 @@ final class GetImageTypeForEditingHandler implements GetImageTypeForEditingHandl
             (bool) $imageType->isCategories(),
             (bool) $imageType->isManufacturers(),
             (bool) $imageType->isSuppliers(),
-            (bool) $imageType->isStores()
+            (bool) $imageType->isStores(),
+            $imageType->getThemeName(),
         );
     }
 }

--- a/src/Core/Domain/ImageSettings/QueryResult/EditableImageType.php
+++ b/src/Core/Domain/ImageSettings/QueryResult/EditableImageType.php
@@ -44,6 +44,7 @@ class EditableImageType
         private readonly bool $manufacturers,
         private readonly bool $suppliers,
         private readonly bool $stores,
+        private readonly ?string $themeName,
     ) {
     }
 
@@ -90,5 +91,10 @@ class EditableImageType
     public function isStores(): bool
     {
         return $this->stores;
+    }
+
+    public function getThemeName(): ?string
+    {
+        return $this->themeName;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/ImageTypeFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ImageTypeFormDataProvider.php
@@ -60,6 +60,7 @@ final class ImageTypeFormDataProvider implements FormDataProviderInterface
             'manufacturers' => $result->isManufacturers(),
             'suppliers' => $result->isSuppliers(),
             'stores' => $result->isStores(),
+            'themeName' => $result->getThemeName(),
         ];
     }
 
@@ -77,6 +78,7 @@ final class ImageTypeFormDataProvider implements FormDataProviderInterface
             'manufacturers' => false,
             'suppliers' => false,
             'stores' => false,
+            'themeName' => null,
         ];
     }
 }

--- a/src/Core/Grid/Definition/Factory/ImageTypeGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ImageTypeGridDefinitionFactory.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\StatusColumn;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
+use PrestaShopBundle\Form\Admin\Type\ThemeChoiceType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -87,6 +88,13 @@ final class ImageTypeGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ->setName($this->trans('ID', [], 'Admin.Global'))
                     ->setOptions([
                         'field' => 'id_image_type',
+                    ])
+            )
+            ->add(
+                (new DataColumn('theme_name'))
+                    ->setName($this->trans('Theme', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'theme_name',
                     ])
             )
             ->add(
@@ -208,6 +216,10 @@ final class ImageTypeGridDefinitionFactory extends AbstractGridDefinitionFactory
                         'required' => false,
                     ])
                     ->setAssociatedColumn('id_image_type')
+            )
+            ->add(
+                (new Filter('theme_name', ThemeChoiceType::class))
+                    ->setAssociatedColumn('theme_name')
             )
             ->add(
                 (new Filter('name', TextType::class))

--- a/src/Core/Grid/Query/ImageTypeQueryBuilder.php
+++ b/src/Core/Grid/Query/ImageTypeQueryBuilder.php
@@ -129,6 +129,7 @@ class ImageTypeQueryBuilder extends AbstractDoctrineQueryBuilder
             'manufacturers',
             'suppliers',
             'stores',
+            'theme_name',
         ];
 
         foreach ($criteria->getFilters() as $filterName => $filterValue) {
@@ -136,7 +137,7 @@ class ImageTypeQueryBuilder extends AbstractDoctrineQueryBuilder
                 continue;
             }
 
-            if ($filterName === 'name') {
+            if ($filterName === 'name' || $filterName === 'theme_name') {
                 $builder->andwhere('it.' . $filterName . ' like :' . $filterName);
                 $builder->setparameter($filterName, '%' . $filterValue . '%');
             } else {

--- a/src/PrestaShopBundle/Entity/ImageType.php
+++ b/src/PrestaShopBundle/Entity/ImageType.php
@@ -89,6 +89,11 @@ class ImageType
      */
     private bool $stores;
 
+    /**
+     * @ORM\Column(name="theme_name", type="string", length=255)
+     */
+    private ?string $themeName;
+
     public function getId(): int
     {
         return $this->id;
@@ -186,6 +191,18 @@ class ImageType
     public function setStores(bool $stores): static
     {
         $this->stores = $stores;
+
+        return $this;
+    }
+
+    public function getThemeName(): ?string
+    {
+        return $this->themeName;
+    }
+
+    public function setThemeName(?string $themeName): static
+    {
+        $this->themeName = $themeName;
 
         return $this;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/ThemeChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ThemeChoiceType.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\Form\Admin\Type;
+
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Class ThemeChoiceType is responsible for providing themes choices.
+ */
+class ThemeChoiceType extends TranslatorAwareType
+{
+    /**
+     * @param FormChoiceProviderInterface $themesChoiceProvider
+     * @param TranslatorInterface $translator
+     * @param array<int, array<string, mixed>> $locales
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        private readonly FormChoiceProviderInterface $themesChoiceProvider,
+    ) {
+        parent::__construct($translator, $locales);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'choices' => $this->themesChoiceProvider->getChoices(),
+            'required' => false,
+            'placeholder' => $this->trans('All', 'Admin.Global'),
+            'choice_translation_domain' => false,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent(): string
+    {
+        return ChoiceType::class;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -601,6 +601,10 @@ services:
     arguments:
       $featureChoiceProvider: '@PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\FeaturesChoiceProvider'
 
+  PrestaShopBundle\Form\Admin\Type\ThemeChoiceType:
+    arguments:
+      $themesChoiceProvider: '@PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameChoiceProvider'
+
   form.type.sell.product.event_listener.categories_listener:
     alias: 'PrestaShopBundle\Form\Admin\Sell\Product\EventListener\CategoriesListener'
     public: true

--- a/tests/Unit/Core/Domain/ImageSettings/QueryResult/EditableImageTypeTest.php
+++ b/tests/Unit/Core/Domain/ImageSettings/QueryResult/EditableImageTypeTest.php
@@ -47,6 +47,7 @@ class EditableImageTypeTest extends TestCase
             true,
             true,
             true,
+            'theme_name',
         );
 
         self::assertSame($imageTypeId, $instance->getImageTypeId());
@@ -58,5 +59,6 @@ class EditableImageTypeTest extends TestCase
         self::assertTrue($instance->isManufacturers());
         self::assertTrue($instance->isSuppliers());
         self::assertTrue($instance->isStores());
+        self::assertSame('theme_name', $instance->getThemeName());
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | When we are in a multistore context and we add new shop with humminbird (or another theme!), images types aren't installed.<br>It doesn't work neither on updating a existing shop.<br><br>**NOTE:** I've done a little hack about the context, because ThemeManager get the current shop in the context (that will is always the first in this pages!) and set the enabled theme in this shop. So, the theme will change also in the first shop!!
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable multistore<br>2. Create a new shop with hummingbird.<br>3. Go to image type settings and see all new image types in list (default_% for hummingbird!)<br>4. Set url to this new shop and go to the FO.<br>5. Images must be loaded properly!
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/15205809023
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | PrestaShop SA

**Before this fix**
![image](https://github.com/user-attachments/assets/076401d5-25f8-46f6-9af4-b3d081c905d6)

