### PR TITLE
TextWithLengthCounterType : Support for existing CSS class

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
@@ -124,8 +124,8 @@
       </div>
     {% endif %}
 
-    {% set attr = attr|merge({'data-max-length': form.vars.max_length, maxlength: form.vars.max_length, class: 'js-countable-input'}) -%}
     {% set attr = attr|merge(input_attr) -%}
+    {% set attr = attr|merge({'data-max-length': form.vars.max_length, maxlength: form.vars.max_length, class: (attr.class|default('') ~ ' js-countable-input')|trim}) -%}
 
     {% if form.vars.input == 'textarea' %}
       {{- block('textarea_widget') -}}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -1089,8 +1089,8 @@
       </div>
     {% endif %}
 
-    {% set attr = attr|merge({'data-max-length': form.vars.max_length, maxlength: form.vars.max_length, class: 'js-countable-input'}) -%}
     {% set attr = attr|merge(input_attr) -%}
+    {% set attr = attr|merge({'data-max-length': form.vars.max_length, maxlength: form.vars.max_length, class: (attr.class|default('') ~ ' js-countable-input')|trim}) -%}
 
     {% if form.vars.input == 'input' %}
       {{- block('form_widget_simple') -}}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | `TextWithLengthCounterType` : Support for existing CSS class
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: 
| UI Tests          | :dolphin: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/15141795747 :green_circle: <br/>:seal: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/15141802195 :green_circle: 
| Fixed issue or discussion?     | Fixes #37994
| Related PRs       | N/A
| Sponsor company   | lefevre.dev