### PR TITLE
Refactor Warehouse::getProductLocation()

### DIFF
--- a/classes/stock/Warehouse.php
+++ b/classes/stock/Warehouse.php
@@ -307,8 +307,6 @@ class WarehouseCore extends ObjectModel
     public static function getProductWarehouseList($id_product, $id_product_attribute = 0, $id_shop = null)
     {
         // if it's a pack, returns warehouses if and only if some products use the advanced stock management
-        $share_stock = false;
-        $shop_group_id = false;
         if ($id_shop === null) {
             if (Shop::getContext() == Shop::CONTEXT_GROUP) {
                 $shop_group = Shop::getContextShopGroup();
@@ -326,7 +324,7 @@ class WarehouseCore extends ObjectModel
         }
 
         if ($share_stock && $shop_group_id) {
-            $ids_shop = Shop::getShops(true, (int) $shop_group_id, true);
+            $ids_shop = Shop::getShops(true, $shop_group_id, true);
         } else {
             $ids_shop = [(int) $id_shop];
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | 
$share_stock = false; + $shop_group_id = false; will be redefined in below rows, so not necessary set here (phpstan is complaining and phpstorm as well)......  - (int) $shop_group_id = Unnecessary, integer is already set above in all cases, it's just that integer to integer is being cast unnecessarily.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/