### PR TITLE
New hook at TOP of customer my account section - displayCustomerAccountTop

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -281,6 +281,11 @@
       <title>Customer account displayed in Front Office</title>
       <description>This hook displays new elements on the customer account page</description>
     </hook>
+    <hook id="displayCustomerAccountTop">
+      <name>displayCustomerAccountTop</name>
+      <title>Customer account displayed in Front Office (Top part)</title>
+      <description>This hook displays new elements on the customer account page on Top</description>
+    </hook>
     <hook id="actionOrderSlipAdd">
       <name>actionOrderSlipAdd</name>
       <title>Order slip creation</title>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | We have hook "displayCustomerAccount" but it's in bottom of my account section, but we need top section as well, so this hook can help module developers to do something like that, check screenshot.
| Type?             | improvement
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | https://github.com/florine2623/testing_pr/actions/runs/15416815078
| Fixed issue or discussion?     | 
| Related PRs       | (https://github.com/PrestaShop/classic-theme/pull/171)  + https://github.com/PrestaShop/hummingbird/pull/701
| Sponsor company   | https://www.openservis.cz/


![asdsad](https://github.com/user-attachments/assets/71b3b91c-6d19-4073-a215-0097e5e1ee79)

