### PR TITLE
Disable autofill of password for edit customer in BO

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -211,6 +211,8 @@ class CustomerType extends TranslatorAwareType
                     'data-minscore' => $minScore,
                     'data-minlength' => $minLength,
                     'data-maxlength' => $maxLength,
+                    /* Some browsers (for example Google Chrome) are totally ignoring "off" value, so we use "new-password" - which is working well for this purpose */
+                    'autocomplete' => 'new-password',
                 ],
                 'help' => $this->trans(
                     'Password should be at least %length% characters long.',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Totally same reason like in PR #35058 , now if you edit customer in BO, Chrome autofill will fill password and you can by mistake change customer password!
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Indicate how to verify that this change works as expected.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
