### PR TITLE
Fix: Multishop - error loading CMS pages removed from the default shop

### DIFF
--- a/src/Adapter/EntityMapper.php
+++ b/src/Adapter/EntityMapper.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Adapter;
 use Cache;
 use Db;
 use DbQuery;
+use Language;
 use ObjectModel;
 use ObjectModelCore;
 use PrestaShopDatabaseException;
@@ -87,6 +88,17 @@ class EntityMapper
                                     }
 
                                     $object_datas[$key][$row['id_lang']] = $value;
+                                }
+                            }
+                        }
+                    } else {
+                        // Initialize multilingual fields with empty values for each language.
+                        // This prevents errors when _lang records are missing (e.g. entity deleted from a shop but accessed in "all shops" context).
+                        $languages = Language::getLanguages();
+                        foreach ($entity_defs['fields'] as $key => $field) {
+                            if (!empty($field['lang'])) {
+                                foreach ($languages as $language) {
+                                    $object_datas[$key][$language['id_lang']] = '';
                                 }
                             }
                         }


### PR DESCRIPTION
Added initialization of multilingual fields when _lang records are missing in multishop contex

When an entity is deleted from the default shop but accessed in "all shops" context, the corresponding _lang records may be missing. This update initializes multilingual fields with empty values for each language, avoiding errors or undefined index issues during data loading.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | When an entity is deleted from the default shop but accessed in **all shops** context, the corresponding `_lang` records may be missing. This update initializes multilingual fields with empty values for each language, avoiding errors or undefined index issues during data loading. See: https://github.com/PrestaShop/PrestaShop/issues/38722 - Note: The issue also occurs on the 9.0.x branch, so I performed the rebase by moving the PR to 9.0.x because PRs are no longer being merged on version 8.2.x.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See: https://github.com/PrestaShop/PrestaShop/issues/38722
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/18840094261
| Fixed issue or discussion?     | Fixes #38722
| Related PRs       | 
| Sponsor company   | Codencode snc
