### PR TITLE
New order history retrieval filter

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -521,6 +521,7 @@ class OrderCore extends ObjectModel
         $paid = false;
         $shipped = false;
         $email = false;
+        
         if ($filters > 0) {
             if ($filters & OrderState::FLAG_NO_HIDDEN) {
                 $no_hidden = true;

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -521,7 +521,7 @@ class OrderCore extends ObjectModel
         $paid = false;
         $shipped = false;
         $email = false;
-        
+
         if ($filters > 0) {
             if ($filters & OrderState::FLAG_NO_HIDDEN) {
                 $no_hidden = true;

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -520,6 +520,7 @@ class OrderCore extends ObjectModel
         $delivery = false;
         $paid = false;
         $shipped = false;
+        $email = false;
         if ($filters > 0) {
             if ($filters & OrderState::FLAG_NO_HIDDEN) {
                 $no_hidden = true;
@@ -535,6 +536,9 @@ class OrderCore extends ObjectModel
             }
             if ($filters & OrderState::FLAG_SHIPPED) {
                 $shipped = true;
+            }
+            if ($filters & OrderState::FLAG_EMAIL) {
+                $email = true;
             }
         }
 
@@ -555,6 +559,7 @@ class OrderCore extends ObjectModel
             ' . ($delivery ? ' AND os.delivery = 1' : '') . '
             ' . ($paid ? ' AND os.paid = 1' : '') . '
             ' . ($shipped ? ' AND os.shipped = 1' : '') . '
+            ' . ($email ? ' AND os.send_email = 1' : '') . '
             ' . ((int) $id_order_state ? ' AND oh.`id_order_state` = ' . (int) $id_order_state : '') . '
             ORDER BY oh.date_add DESC, oh.id_order_history DESC');
             if ($no_hidden) {

--- a/classes/order/OrderState.php
+++ b/classes/order/OrderState.php
@@ -136,6 +136,7 @@ class OrderStateCore extends ObjectModel
     public const FLAG_DELIVERY = 4;  /* 00100 */
     public const FLAG_SHIPPED = 8;  /* 01000 */
     public const FLAG_PAID = 16; /* 10000 */
+    public const FLAG_EMAIL = 32; /* 100000 */
 
     /**
      * Get all available order statuses.


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add a new FLAG to OrderState and filter on order history retrieval.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Use the getHistory() function of the OrderCore class, and pass the OrderState::FLAG_EMAIL constant as $filter param value. Check that only history for statuses with "send_email" is returned.
| UI Tests | https://github.com/florine2623/testing_pr/actions/runs/15393179920
| Sponsor company   | Evolutive
