### PR TITLE
Fix LegacyControllerContextBuilder to use physicalUri

### DIFF
--- a/src/Core/Context/LegacyControllerContextBuilder.php
+++ b/src/Core/Context/LegacyControllerContextBuilder.php
@@ -90,7 +90,7 @@ class LegacyControllerContextBuilder
             $table,
             $this->requestStack->getCurrentRequest() ?: Request::createFromGlobals(),
             $employeeLanguageId,
-            $this->shopContext->getBaseURI(),
+            $this->shopContext->getPhysicalUri(),
             $this->adminFolderName,
             $this->languageContext->isRTL(),
             $this->psVersion,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fix LegacyControllerContextBuilder to use physicalUri instead of baseUri for admin purpose only!
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #38794 
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/15302189165 🟢
| Fixed issue or discussion?     | Fixes #38794
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
