### PR TITLE
fix: properly check restriction checkboxes when all items are selecte…

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
@@ -144,7 +144,7 @@
 		{if ($countries.unselected|@count) + ($countries.selected|@count) > 1}
 			<p class="checkbox">
 				<label>
-					<input type="checkbox" id="country_restriction" name="country_restriction" value="1" {if $countries.unselected|@count}checked="checked"{/if} />
+					<input type="checkbox" id="country_restriction" name="country_restriction" value="1" {if $countries.selected|@count}checked="checked"{/if} />
 					{l s='Country selection' d='Admin.Catalog.Feature'}
 				</label>
 			</p>
@@ -179,7 +179,7 @@
 		{if ($carriers.unselected|@count) + ($carriers.selected|@count) > 1}
 			<p class="checkbox">
 				<label>
-					<input type="checkbox" id="carrier_restriction" name="carrier_restriction" value="1" {if $carriers.unselected|@count}checked="checked"{/if} />
+					<input type="checkbox" id="carrier_restriction" name="carrier_restriction" value="1" {if $carriers.selected|@count}checked="checked"{/if} />
 					{l s='Carrier selection' d='Admin.Catalog.Feature'}
 				</label>
 			</p>
@@ -213,7 +213,7 @@
 		{if ($groups.unselected|@count) + ($groups.selected|@count) > 1}
 			<p class="checkbox">
 				<label>
-					<input type="checkbox" id="group_restriction" name="group_restriction" value="1" {if $groups.unselected|@count}checked="checked"{/if} />
+					<input type="checkbox" id="group_restriction" name="group_restriction" value="1" {if $groups.selected|@count}checked="checked"{/if} />
 					{l s='Customer group selection' d='Admin.Catalog.Feature'}
 				</label>
 			</p>
@@ -247,7 +247,7 @@
 		{if ($cart_rules.unselected|@count) + ($cart_rules.selected|@count) > 0}
 			<p class="checkbox">
 				<label>
-					<input type="checkbox" id="cart_rule_restriction" name="cart_rule_restriction" value="1" {if $cart_rules.unselected|@count}checked="checked"{/if} />
+					<input type="checkbox" id="cart_rule_restriction" name="cart_rule_restriction" value="1" {if $cart_rules.selected|@count}checked="checked"{/if} />
 					{l s='Compatibility with other cart rules' d='Admin.Catalog.Feature'}
 				</label>
 			</p>

--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -255,12 +255,17 @@ $('#cart_rule_form').on('submit', () => {
   if ($('#customerFilter').val() == '') $('#id_customer').val('0');
 
   for (i in restrictions) {
-    $(`#${restrictions[i]}_select_2 option`).each(function (i) {
-      $(this).prop('selected', true);
-    });
+    const select1Length = $(`#${restrictions[i]}_select_1 option`).length;
+    const select2Options = $(`#${restrictions[i]}_select_2 option`);
+
+    if (select1Length > 0 || select2Options.length > 0) {
+      select2Options.each(function () {
+        $(this).prop('selected', true);
+      });
+    }
   }
 
-  $('.product_rule_toselect option').each(function (i) {
+  $('.product_rule_toselect option').each(function () {
     $(this).prop('selected', true);
   });
 });

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1752,7 +1752,7 @@ class CartRuleCore extends ObjectModel
         }
 
         if (!Validate::isLoadedObject($this) || $this->{$type . '_restriction'} == 0) {
-            $array['selected'] = Db::getInstance()->executeS('
+            $array['unselected'] = Db::getInstance()->executeS('
 			SELECT t.*' . ($i18n ? ', tl.*' : '') . ', 1 as selected
 			FROM `' . _DB_PREFIX_ . $type . '` t
 			' . ($i18n ? 'LEFT JOIN `' . _DB_PREFIX_ . $type . '_lang` tl ON (t.id_' . $type . ' = tl.id_' . $type . ' AND tl.id_lang = ' . (int) Context::getContext()->language->id . ')' : '') . '


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes the issue where the restriction checkbox in the cart rules back office is not checked when all items (e.g. countries) are selected. Tested on PrestaShop 9. The checkbox now correctly reflects the selection status after saving.  
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In the back office, go to cart rules restrictions. Select all items (e.g. all countries). Save the cart rule. The restriction checkbox should now be checked after saving. Previously, it was unchecked even if all items were selected.  
| UI Tests          | Not applicable / None
| Fixed issue or discussion?     | Fixes #38800
| Related PRs       | None
| Sponsor company   | Evolutive