### PR TITLE
Remove price round mode from admin UI

### DIFF
--- a/.github/workflows/api-module.yml
+++ b/.github/workflows/api-module.yml
@@ -65,10 +65,6 @@ jobs:
       - name: Composer Install
         run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
 
-      - name: Update phpunit version
-        if: ${{ startsWith(matrix.php, '8.') }}
-        run: COMPOSER_PROCESS_TIMEOUT=600 composer update -w --ignore-platform-reqs --no-interaction phpunit/phpunit
-
       # Front assets are needed for the theme to be installed and image types to be inserted in DB, admin assets required
       # because some built files (like preload.html.twig) are included and cause errors when absent
       - name: Build all assets

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -65,10 +65,6 @@ jobs:
       - name: Composer Install
         run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
 
-      - name: Update phpunit version
-        if: ${{ startsWith(matrix.php, '8.') }}
-        run: COMPOSER_PROCESS_TIMEOUT=600 composer update -w --ignore-platform-reqs --no-interaction phpunit/phpunit
-
       # Front assets are needed for the theme to be installed and image types to be inserted in DB, admin assets required especially
       # because some built files (like preload.html.twig) are included and cause errors when absent
       - name: Build all assets

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -123,12 +123,8 @@ jobs:
       - name: Composer Install
         run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
 
-      - name: Update phpunit version
-        if: ${{ startsWith(matrix.php, '8.') }}
-        run: COMPOSER_PROCESS_TIMEOUT=600 composer update -w --ignore-platform-reqs --no-interaction phpunit/phpunit
-
       - name: Run phpunit
-        run: ./vendor/phpunit/phpunit/phpunit -c tests/Unit/phpunit.xml
+        run: composer run-script unit-tests --timeout=0
         env:
           SYMFONY_DEPRECATIONS_HELPER: disabled
 

--- a/classes/ImageType.php
+++ b/classes/ImageType.php
@@ -87,17 +87,21 @@ class ImageTypeCore extends ObjectModel
      *
      * @param string|null $type Image type
      * @param bool $orderBySize
+     * @param string|null $theme Theme name
      *
      * @return array Image type definitions
      *
      * @throws PrestaShopDatabaseException
      */
-    public static function getImagesTypes($type = null, $orderBySize = false)
+    public static function getImagesTypes($type = null, $orderBySize = false, $theme = null)
     {
-        if (!isset(self::$images_types_cache[$type])) {
+        if (!isset(self::$images_types_cache[$type][$theme])) {
             $where = 'WHERE 1';
             if (!empty($type)) {
                 $where .= ' AND `' . bqSQL($type) . '` = 1 ';
+            }
+            if (null !== $theme) {
+                $where .= ' AND `theme_name` = \'' . pSQL($theme) . '\' OR `theme_name` IS NULL';
             }
 
             if ($orderBySize) {
@@ -106,10 +110,10 @@ class ImageTypeCore extends ObjectModel
                 $query = 'SELECT * FROM `' . _DB_PREFIX_ . 'image_type` ' . $where . ' ORDER BY `name` ASC';
             }
 
-            self::$images_types_cache[$type] = Db::getInstance()->executeS($query);
+            self::$images_types_cache[$type][$theme] = Db::getInstance()->executeS($query);
         }
 
-        return self::$images_types_cache[$type];
+        return self::$images_types_cache[$type][$theme];
     }
 
     /**

--- a/composer.lock
+++ b/composer.lock
@@ -13450,16 +13450,16 @@
         },
         {
             "name": "symfony/ux-twig-component",
-            "version": "v2.24.0",
+            "version": "v2.25.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/ux-twig-component.git",
-                "reference": "48a46e4c6215d41cc97ba8dff0cff21ea9b255a8"
+                "reference": "d20da25517fc09d147897d02819a046f0a0f6735"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/ux-twig-component/zipball/48a46e4c6215d41cc97ba8dff0cff21ea9b255a8",
-                "reference": "48a46e4c6215d41cc97ba8dff0cff21ea9b255a8",
+                "url": "https://api.github.com/repos/symfony/ux-twig-component/zipball/d20da25517fc09d147897d02819a046f0a0f6735",
+                "reference": "d20da25517fc09d147897d02819a046f0a0f6735",
                 "shasum": ""
             },
             "require": {
@@ -13468,7 +13468,7 @@
                 "symfony/deprecation-contracts": "^2.2|^3.0",
                 "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
                 "symfony/property-access": "^5.4|^6.0|^7.0",
-                "twig/twig": "^3.8"
+                "twig/twig": "^3.10.3"
             },
             "conflict": {
                 "symfony/config": "<5.4.0"
@@ -13513,7 +13513,7 @@
                 "twig"
             ],
             "support": {
-                "source": "https://github.com/symfony/ux-twig-component/tree/v2.24.0"
+                "source": "https://github.com/symfony/ux-twig-component/tree/v2.25.2"
             },
             "funding": [
                 {
@@ -13529,7 +13529,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-21T20:14:36+00:00"
+            "time": "2025-05-20T13:06:01+00:00"
         },
         {
             "name": "symfony/validator",

--- a/composer.lock
+++ b/composer.lock
@@ -5265,12 +5265,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_apiresources.git",
-                "reference": "6049c52f5e5e7b3c0aaa9c170e3cc7db794ff03e"
+                "reference": "451d58de0bc096af725ba96b62d2f69aaf78d109"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_apiresources/zipball/6049c52f5e5e7b3c0aaa9c170e3cc7db794ff03e",
-                "reference": "6049c52f5e5e7b3c0aaa9c170e3cc7db794ff03e",
+                "url": "https://api.github.com/repos/PrestaShop/ps_apiresources/zipball/451d58de0bc096af725ba96b62d2f69aaf78d109",
+                "reference": "451d58de0bc096af725ba96b62d2f69aaf78d109",
                 "shasum": ""
             },
             "require": {
@@ -5307,7 +5307,7 @@
             "support": {
                 "source": "https://github.com/PrestaShop/ps_apiresources/tree/dev"
             },
-            "time": "2025-04-24T08:34:30+00:00"
+            "time": "2025-05-23T15:40:20+00:00"
         },
         {
             "name": "prestashop/ps_banner",

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -316,6 +316,8 @@ class AdminShopControllerCore extends AdminController
      */
     protected function afterAdd($new_shop)
     {
+        $this->enableTheme($new_shop);
+
         $import_data = Tools::getValue('importData', []);
 
         // The root category should be at least imported
@@ -342,6 +344,8 @@ class AdminShopControllerCore extends AdminController
      */
     protected function afterUpdate($new_shop)
     {
+        $this->enableTheme($new_shop);
+
         $categories = Tools::getValue('categoryBox');
 
         if (!is_array($categories)) {
@@ -364,6 +368,29 @@ class AdminShopControllerCore extends AdminController
         }
 
         return parent::afterUpdate($new_shop);
+    }
+
+    /**
+     * @param Shop $shop
+     *
+     * @return void
+     */
+    protected function enableTheme($shop)
+    {
+        // We must avoid the fact that enable theme with Theme Manager will set theme into the shop too!
+
+        // Save initial shop context
+        $initialShop = $this->context->shop;
+        // Set new shop into the context, just for ThemeManagerBuilder
+        $this->context->shop = $shop;
+        (new ThemeManagerBuilder($this->context, Db::getInstance()))
+            ->build()
+            ->enable($shop->theme_name);
+        // Restore initial shop into the context
+        $this->context->shop = $initialShop;
+
+        // Clear cache!
+        Tools::clearCache();
     }
 
     public function getList($id_lang, $order_by = null, $order_way = null, $start = 0, $limit = null, $id_lang_shop = false)

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -24,7 +24,7 @@ needs please refer to https://devdocs.prestashop.com/ for more information.
 Changelog for PrestaShop 9
 
 ####################################
-#   v9.0.0 RC 1 - (2024-05-02)
+#   v9.0.0 RC 1 - (2024-05-23)
 ####################################
 
 - Back Office:
@@ -34,6 +34,9 @@ Changelog for PrestaShop 9
     - #38400: Enable api platform path scanning for entity (by @tleon)
     - #37638: Switch carrier feature flag to stable and enabled by default (by @jolelievre)
   - Improvement:
+    - #38755: API operations filtered when CQRS classes not found (by @jolelievre)
+    - #38736: Improve multi shop permissions (by @jolelievre)
+    - #38712: Prevent data from hooks from overriding local translated module data (by @jolelievre)
     - #38557: Improve OpenApi configuration to include OAuth scopes dynamically (by @jolelievre)
     - #38526: UI tests adaptation for classic  (by @jolelievre)
     - #38502: Optimise anonymous route checking (by @jolelievre)
@@ -44,6 +47,14 @@ Changelog for PrestaShop 9
     - #38073: Check mail template directory before reading (by @matthieu-rolland)
     - #38142: Fix: improve link styling for better identification – issue #38122 (by @tblivet)
   - Bug fix:
+    - #38745: Enabling theme of add/update shop in a multistore context (by @boherm)
+    - #38048: Fix: Unable to configure a module that utilizes a modern controller (by @Codencode)
+    - #38731: Fix showcase-card image for attribute page (by @boherm)
+    - #38599: Fixed Order States Provider for Order Listing (by @Progi1984)
+    - #38251: Fix: Query to select most used tax rule is simply ridicoulous (by @Codencode)
+    - #38703: Revert modification in OrderLazyArray that breaks the UI tests (by @jolelievre)
+    - #38572: Fix spinner on mobile resolution (by @boherm)
+    - #38323: Fix: Webservice link_rewrite validation error on Product creation due to Tools::str2url in PS8 (by @Codencode)
     - #37996: Fix: BO Employee - Setting More as default page cannot load the page (by @Codencode)
     - #37874: Fix: BO > Movements - Search results is undefined and loads forever (by @Codencode)
     - #38027: Fix: BO export - Cannot export subcategories (by @Codencode)
@@ -82,9 +93,14 @@ Changelog for PrestaShop 9
   - Refactoring:
     - #38093: Improve message on exception (by @Hlavtox)
 - Front Office:
+  - New feature:
+    - #38691: Add hook displayCartExtraProductInfo to display cart extra product information (by @jf-viguier)
+    - #38371: Feat - Add hook actionCartDuplicate (by @unlocomqx)
   - Improvement:
     - #38488: Add new hook actionGetPdfRenderer to use a custom inherited tcpdf ren… (by @Markus-Gurkcity)
   - Bug fix:
+    - #38679: Filter out modules that return empty payment options (by @jolelievre)
+    - #38552: Use id_customization for matching cart and order products (by @unlocomqx)
     - #38265: Fix and refactor category controller for non existent categories (by @Hlavtox)
     - #38257: Fix: Address Fields Disappear After Changing Country on Checkout Page (by @Codencode)
     - #38303: Add missing function strpos for smarty templates (by @jolelievre)
@@ -98,6 +114,11 @@ Changelog for PrestaShop 9
     - #38467: Single file XLF catalog (by @jolelievre)
     - #37947: Add new hook in object presenter (by @web-cooking-factory)
   - Improvement:
+    - #38767: Fix image type entity (by @boherm)
+    - #38765: Preliminary steps for RC (by @jolelievre)
+    - #38694: Updated PrestaShop Packages (by @github-actions[bot])
+    - #38576: Update Symfony components after 6.4.21 release (by @nicosomb)
+    - #38583: Update changelog 9.0.0 RC 1 (by @jolelievre)
     - #37535: Add path parameter to Htaccess Create action hook - #37534 (by @Pliciweb)
     - #38527: Add support for {categories} keyword in category seo urls, Fixes #38181 (by @tswfi)
     - #37611: Remove configuration of AEUC_LABEL_TAX_INC_EXC from module ps_legalco… (by @Markus-Gurkcity)
@@ -111,6 +132,8 @@ Changelog for PrestaShop 9
     - #37964: Fixed license header (by @mattgoud)
     - #37943: Chore: [release-8.2.1] - composer : update classic-theme package to 2… (by @mattgoud)
   - Bug fix:
+    - #38701: Stabilize composer create test db (by @jolelievre)
+    - #38633: Improve language for installer and downgrade league/oauth2-server to 8.5 (by @boherm)
     - #38575: Update dependencies (by @jolelievre)
     - #38498: Remove dynamic county access (by @jolelievre)
     - #38482: Remove carrier display on pdf for virtual orders (by @boherm)
@@ -122,6 +145,8 @@ Changelog for PrestaShop 9
     - #37890: Fix preview mode for combination products (by @boherm)
 - Installer:
   - Improvement:
+    - #38764: Update default catalog 9.0.x (by @ps-jarvis)
+    - #38698: Block execution while cache clear is running in install endpoints (by @jolelievre)
     - #38501: Update default catalog 9.0.x (by @ps-jarvis)
     - #38235: Display the error reported by the module when the installation of PrestaShop fails because of it (by @Quetzacoalt91)
     - #38077: Add demo product env parameter for cli install via docker (by @matthieu-rolland)
@@ -132,6 +157,13 @@ Changelog for PrestaShop 9
     - #38341: Fix: product carrier delete (by @fox-john)
 - Tests:
   - Improvement:
+    - #38747: Functional Tests : Bump `@prestashop-core/ui-testing` (by @Progi1984)
+    - #38733: Functional Tests : Migrate `@utils/globals` into `ui-testing-library` (by @Progi1984)
+    - #38714: Functional Tests : Migrate to `@prestashop-core/ui-testing` (Part 8) (by @Progi1984)
+    - #38689: Functional Tests : Bump @prestashop-core/ui-testing (by @Progi1984)
+    - #38620: Functional Tests : Migrate to `@prestashop-core/ui-testing` (Part 7) (by @Progi1984)
+    - #38595: Functional Tests : Bump `@prestashop-core/ui-testing` (by @Progi1984)
+    - #38436: Functional Tests : Stabilisation "functional:FO:hummingbird:08-12" (by @Progi1984)
     - #38569: Stabilize UI tests for new product module (by @jolelievre)
     - #38564: Stabilize tests UI for modules, especially faceted search (by @jolelievre)
     - #38547: Stabilize UI tests for brand and supplier (by @jolelievre)
@@ -167,7 +199,6 @@ Changelog for PrestaShop 9
     - #38226: Functional Tests : Stabilisation "functional:BO:shop-parameters:05-07" (by @Progi1984)
     - #38210: Functional Tests : Stabilisation "functional:FO:hummingbird:08-12" (by @Progi1984)
     - #38205: Functional Tests : Stabilisation "functional:BO:catalog:07-08" (by @Progi1984)
-
 
 ####################################
 #   v9.0.0 Beta 1 - (2024-02-03)

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -2835,7 +2835,7 @@ CREATE TABLE `PREFIX_image_type` (
   `suppliers`     TINYINT(1) DEFAULT 1 NOT NULL,
   `stores`        TINYINT(1) DEFAULT 1 NOT NULL,
   `theme_name`    VARCHAR(255) DEFAULT NULL,
-  UNIQUE KEY `UNIQ_907C95215E237E06` (`name`, `theme_name`),
+  UNIQUE KEY `UNIQ_907C95215E237E0614E48A3B` (`name`, `theme_name`),
   PRIMARY KEY (`id_image_type`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -2834,7 +2834,8 @@ CREATE TABLE `PREFIX_image_type` (
   `manufacturers` TINYINT(1) DEFAULT 1 NOT NULL,
   `suppliers`     TINYINT(1) DEFAULT 1 NOT NULL,
   `stores`        TINYINT(1) DEFAULT 1 NOT NULL,
-  UNIQUE KEY `UNIQ_907C95215E237E06` (`name`),
+  `theme_name`    VARCHAR(255) DEFAULT NULL,
+  UNIQUE KEY `UNIQ_907C95215E237E06` (`name`, `theme_name`),
   PRIMARY KEY (`id_image_type`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -5428,7 +5428,7 @@
       <title>Triggers after getting product attributes groups</title>
       <description>Allows to modify product attributes groups after they are retrieved from the database.</description>
     </hook>
-	  <hook id="actionGetPdfRenderer">
+    <hook id="actionGetPdfRenderer">
       <name>actionGetPdfRenderer</name>
       <title>Provide a PDF renderer</title>
       <description>This hook allows to provide a custom PDF renderer to generate PDF files</description>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -742,7 +742,7 @@ parameters:
 
 		-
 			message: "#^Namespace Db is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
-			count: 2
+			count: 3
 			path: src/Core/Image/ImageTypeRepository.php
 
 		-

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Adapter\Image;
 
 use Category;
 use Configuration;
+use Context;
 use Image;
 use ImageManager;
 use ImageType;
@@ -212,6 +213,11 @@ class ImageRetriever
 
         // Check and generate each thumbnail size
         $image_types = ImageType::getImagesTypes($type, true);
+
+        // Filter image types by theme name
+        $currentTheme = Context::getContext()->shop->theme_name;
+        $image_types = array_filter($image_types, fn (array $imageType) => $imageType['theme_name'] === null || $imageType['theme_name'] === $currentTheme);
+
         foreach ($image_types as $image_type) {
             $sources = [];
             $formattedName = ImageType::getFormattedName('small');
@@ -364,9 +370,15 @@ class ImageRetriever
             ['type' => 'stores', 'dir' => _PS_STORE_IMG_DIR_],
         ];
 
+        // Get current theme
+        $currentTheme = Context::getContext()->shop->theme_name;
+
         foreach ($objectsToRegenerate as $object) {
             // Get all image types present on shops for this object
             $imageTypes = ImageType::getImagesTypes($object['type'], true);
+
+            // Filter image types by theme name
+            $imageTypes = array_filter($imageTypes, fn (array $imageType) => $imageType['theme_name'] === null || $imageType['theme_name'] === $currentTheme);
 
             // We get the "no image available" in the folder of the object
             $originalImagePath = implode(DIRECTORY_SEPARATOR, [

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -212,11 +212,8 @@ class ImageRetriever
         }
 
         // Check and generate each thumbnail size
-        $image_types = ImageType::getImagesTypes($type, true);
-
-        // Filter image types by theme name
         $currentTheme = Context::getContext()->shop->theme_name;
-        $image_types = array_filter($image_types, fn (array $imageType) => $imageType['theme_name'] === null || $imageType['theme_name'] === $currentTheme);
+        $image_types = ImageType::getImagesTypes($type, true, $currentTheme);
 
         foreach ($image_types as $image_type) {
             $sources = [];
@@ -375,10 +372,7 @@ class ImageRetriever
 
         foreach ($objectsToRegenerate as $object) {
             // Get all image types present on shops for this object
-            $imageTypes = ImageType::getImagesTypes($object['type'], true);
-
-            // Filter image types by theme name
-            $imageTypes = array_filter($imageTypes, fn (array $imageType) => $imageType['theme_name'] === null || $imageType['theme_name'] === $currentTheme);
+            $imageTypes = ImageType::getImagesTypes($object['type'], true, $currentTheme);
 
             // We get the "no image available" in the folder of the object
             $originalImagePath = implode(DIRECTORY_SEPARATOR, [

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -63,7 +63,7 @@ class OrderSlipCreator
     private $translator;
 
     /** @var OrderSlip
-     * 
+     * @var OrderSlip
      */
     private $orderSlipCreated;
 

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -67,7 +67,6 @@ class OrderSlipCreator
      */
     private $orderSlipCreated;
 
-
     /**
      * @param ConfigurationInterface $configuration
      * @param TranslatorInterface $translator

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -46,6 +46,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 use TaxCalculator;
 use TaxManagerFactory;
 use Tools;
+use OrderSlip;
 
 /**
  * Class OrderSlipCreator is responsible of creating an OrderSlip for a refund
@@ -61,6 +62,12 @@ class OrderSlipCreator
      * @var TranslatorInterface
      */
     private $translator;
+
+    /** @var OrderSlip
+     * 
+     */
+    private $orderSlipCreated;
+
 
     /**
      * @param ConfigurationInterface $configuration
@@ -109,7 +116,7 @@ class OrderSlipCreator
                 'order' => $order,
                 'productList' => $orderRefundSummary->getProductRefunds(),
                 'qtyList' => $fullQuantityList,
-                'orderSlipCreated' => $orderSlipCreated,
+                'orderSlipCreated' => $this->orderSlipCreated,
             ], null, false, true, false, $order->id_shop);
 
             $customer = new Customer((int) $order->id_customer);
@@ -166,7 +173,7 @@ class OrderSlipCreator
      * @param bool $add_tax
      * @param int $precision
      *
-     * @return bool|OrderSlip
+     * @return bool
      *
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
@@ -330,11 +337,13 @@ class OrderSlipCreator
 
         $res = true;
 
+        $this->orderSlipCreated = $orderSlip;
+
         foreach ($product_list as $product) {
             $res &= $this->addProductOrderSlip((int) $orderSlip->id, $product);
         }
 
-        return (!(bool)$res) ?? $orderSlip;
+        return (bool) $res;
     }
 
     /**

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -109,6 +109,7 @@ class OrderSlipCreator
                 'order' => $order,
                 'productList' => $orderRefundSummary->getProductRefunds(),
                 'qtyList' => $fullQuantityList,
+                'orderSlipCreated' => $orderSlipCreated,
             ], null, false, true, false, $order->id_shop);
 
             $customer = new Customer((int) $order->id_customer);

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -62,7 +62,7 @@ class OrderSlipCreator
      */
     private $translator;
 
-    /** @var OrderSlip
+    /**
      * @var OrderSlip
      */
     private $orderSlipCreated;

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -46,7 +46,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 use TaxCalculator;
 use TaxManagerFactory;
 use Tools;
-use OrderSlip;
 
 /**
  * Class OrderSlipCreator is responsible of creating an OrderSlip for a refund

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -166,7 +166,7 @@ class OrderSlipCreator
      * @param bool $add_tax
      * @param int $precision
      *
-     * @return bool
+     * @return bool|OrderSlip
      *
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
@@ -334,7 +334,7 @@ class OrderSlipCreator
             $res &= $this->addProductOrderSlip((int) $orderSlip->id, $product);
         }
 
-        return (bool) $res;
+        return (!(bool)$res) ?? $orderSlip;
     }
 
     /**

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -180,7 +180,7 @@ class ThemeManager implements AddonManagerInterface
                 ->doDisableModules($theme->get('global_settings.modules.to_disable', []))
                 ->doEnableModules($theme->getModulesToEnable())
                 ->doResetModules($theme->get('global_settings.modules.to_reset', []))
-                ->doApplyImageTypes($theme->get('global_settings.image_types', []))
+                ->doApplyImageTypes($theme->get('global_settings.image_types', []), $name)
                 ->doHookModules($theme->get('global_settings.hooks.modules_to_hook', []));
 
             $theme->onEnable();
@@ -369,9 +369,9 @@ class ThemeManager implements AddonManagerInterface
      *
      * @return self
      */
-    private function doApplyImageTypes(array $types): self
+    private function doApplyImageTypes(array $types, ?string $theme_name): self
     {
-        $this->imageTypeRepository->setTypes($types);
+        $this->imageTypeRepository->setTypes($types, $theme_name);
 
         return $this;
     }

--- a/src/Core/Domain/ImageSettings/QueryHandler/GetImageTypeForEditingHandler.php
+++ b/src/Core/Domain/ImageSettings/QueryHandler/GetImageTypeForEditingHandler.php
@@ -67,7 +67,8 @@ final class GetImageTypeForEditingHandler implements GetImageTypeForEditingHandl
             (bool) $imageType->isCategories(),
             (bool) $imageType->isManufacturers(),
             (bool) $imageType->isSuppliers(),
-            (bool) $imageType->isStores()
+            (bool) $imageType->isStores(),
+            $imageType->getThemeName(),
         );
     }
 }

--- a/src/Core/Domain/ImageSettings/QueryResult/EditableImageType.php
+++ b/src/Core/Domain/ImageSettings/QueryResult/EditableImageType.php
@@ -44,6 +44,7 @@ class EditableImageType
         private readonly bool $manufacturers,
         private readonly bool $suppliers,
         private readonly bool $stores,
+        private readonly ?string $themeName,
     ) {
     }
 
@@ -90,5 +91,10 @@ class EditableImageType
     public function isStores(): bool
     {
         return $this->stores;
+    }
+
+    public function getThemeName(): ?string
+    {
+        return $this->themeName;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/ImageTypeFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ImageTypeFormDataProvider.php
@@ -60,6 +60,7 @@ final class ImageTypeFormDataProvider implements FormDataProviderInterface
             'manufacturers' => $result->isManufacturers(),
             'suppliers' => $result->isSuppliers(),
             'stores' => $result->isStores(),
+            'themeName' => $result->getThemeName(),
         ];
     }
 
@@ -77,6 +78,7 @@ final class ImageTypeFormDataProvider implements FormDataProviderInterface
             'manufacturers' => false,
             'suppliers' => false,
             'stores' => false,
+            'themeName' => null,
         ];
     }
 }

--- a/src/Core/Grid/Definition/Factory/ImageTypeGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ImageTypeGridDefinitionFactory.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\StatusColumn;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
+use PrestaShopBundle\Form\Admin\Type\ThemeChoiceType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -87,6 +88,13 @@ final class ImageTypeGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ->setName($this->trans('ID', [], 'Admin.Global'))
                     ->setOptions([
                         'field' => 'id_image_type',
+                    ])
+            )
+            ->add(
+                (new DataColumn('theme_name'))
+                    ->setName($this->trans('Theme', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'theme_name',
                     ])
             )
             ->add(
@@ -208,6 +216,10 @@ final class ImageTypeGridDefinitionFactory extends AbstractGridDefinitionFactory
                         'required' => false,
                     ])
                     ->setAssociatedColumn('id_image_type')
+            )
+            ->add(
+                (new Filter('theme_name', ThemeChoiceType::class))
+                    ->setAssociatedColumn('theme_name')
             )
             ->add(
                 (new Filter('name', TextType::class))

--- a/src/Core/Grid/Query/ImageTypeQueryBuilder.php
+++ b/src/Core/Grid/Query/ImageTypeQueryBuilder.php
@@ -129,6 +129,7 @@ class ImageTypeQueryBuilder extends AbstractDoctrineQueryBuilder
             'manufacturers',
             'suppliers',
             'stores',
+            'theme_name',
         ];
 
         foreach ($criteria->getFilters() as $filterName => $filterValue) {
@@ -136,7 +137,7 @@ class ImageTypeQueryBuilder extends AbstractDoctrineQueryBuilder
                 continue;
             }
 
-            if ($filterName === 'name') {
+            if ($filterName === 'name' || $filterName === 'theme_name') {
                 $builder->andwhere('it.' . $filterName . ' like :' . $filterName);
                 $builder->setparameter($filterName, '%' . $filterValue . '%');
             } else {

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSCommand.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSCommand.php
@@ -149,7 +149,8 @@ class CQRSCommand extends AbstractCQRSOperation
         unset($passedArguments['CQRSCommandMapping']);
 
         // By default, the CQRS command is used as the input base class as it contains the exact available parameters for this operation
-        if (empty($passedArguments['input']) && !empty($passedArguments['extraProperties']['CQRSCommand'])) {
+        // Exception in case the class doesn't exist we don't force the input because InputOutputResourceMetadataCollectionFactory will raise an exception when the resources are parsed
+        if (empty($passedArguments['input']) && !empty($passedArguments['extraProperties']['CQRSCommand']) && class_exists($passedArguments['extraProperties']['CQRSCommand'])) {
             $passedArguments['input'] = $passedArguments['extraProperties']['CQRSCommand'];
         }
 

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/Resource/Factory/CQRSNotFoundMetadataCollectionFactoryDecorator.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/Resource/Factory/CQRSNotFoundMetadataCollectionFactoryDecorator.php
@@ -69,10 +69,10 @@ class CQRSNotFoundMetadataCollectionFactoryDecorator implements ResourceMetadata
             foreach ($operations as $key => $operation) {
                 $extraProperties = $operation->getExtraProperties();
 
-                if (isset($extraProperties['CQRSQuery']) && !class_exists($extraProperties['CQRSQuery'])) {
+                if ($operations->has($key) && isset($extraProperties['CQRSQuery']) && !class_exists($extraProperties['CQRSQuery'])) {
                     $operations->remove($key);
                 }
-                if (isset($extraProperties['CQRSCommand']) && !class_exists($extraProperties['CQRSCommand'])) {
+                if ($operations->has($key) && isset($extraProperties['CQRSCommand']) && !class_exists($extraProperties['CQRSCommand'])) {
                     $operations->remove($key);
                 }
             }

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/Resource/Factory/CQRSNotFoundMetadataCollectionFactoryDecorator.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/Resource/Factory/CQRSNotFoundMetadataCollectionFactoryDecorator.php
@@ -32,27 +32,23 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
-use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagManager;
-use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
-use Throwable;
 
 /**
  * This factory decorates the ApiPlatform default resource factory. It looks into each operation and checks
- * if the extra property experimentalOperation is set to true, if its is then the operation should be filtered out
- * in production environment. This means the operation is not visible in Swagger, and it's not used to generate the
- * api routing, so it's not usable at all.
+ * if the extra property contains some CQRS commands and/or queries. If they are not found the operation/endpoint
+ * is removed.
+ *
+ * The purpose for this clean is that we can have a single ps_apiresources module that contains definitions for
+ * endpoints based on 9.1 commands for example, the endpoints would not work on 9.0 so they are filtered out.
  *
  * Scope extraction is also impacted by this filtering, meaning if a scope is only associated to experimental operations
  * it won't be available in prod mode at all, unless you enable the related feature flag.
- *
- * In dev mode all operations are kept though.
  */
-class ExperimentalOperationsMetadataCollectionFactoryDecorator implements ResourceMetadataCollectionFactoryInterface
+class CQRSNotFoundMetadataCollectionFactoryDecorator implements ResourceMetadataCollectionFactoryInterface
 {
     public function __construct(
         private readonly ResourceMetadataCollectionFactoryInterface $decorated,
         private readonly bool $isDebug,
-        private readonly FeatureFlagManager $featureFlagManager,
     ) {
     }
 
@@ -62,7 +58,7 @@ class ExperimentalOperationsMetadataCollectionFactoryDecorator implements Resour
         $resourceMetadataCollection = $this->decorated->create($resourceClass);
 
         // In debug mode we filter nothing, in prod mode we do unless the forcing configuration is enabled
-        if ($this->isDebug || $this->areExperimentalEndpointsEnabled()) {
+        if ($this->isDebug) {
             return $resourceMetadataCollection;
         }
 
@@ -72,28 +68,16 @@ class ExperimentalOperationsMetadataCollectionFactoryDecorator implements Resour
             /** @var Operation $operation */
             foreach ($operations as $key => $operation) {
                 $extraProperties = $operation->getExtraProperties();
-                if (isset($extraProperties['experimentalOperation']) && $extraProperties['experimentalOperation'] === true) {
+
+                if (isset($extraProperties['CQRSQuery']) && !class_exists($extraProperties['CQRSQuery'])) {
+                    $operations->remove($key);
+                }
+                if (isset($extraProperties['CQRSCommand']) && !class_exists($extraProperties['CQRSCommand'])) {
                     $operations->remove($key);
                 }
             }
         }
 
         return $resourceMetadataCollection;
-    }
-
-    /**
-     * This decorator is implied during cache clearing which would fail when the shop is not installed
-     * because the DB config is not set up yet. So we protected the feature flag fetching in a try/catch
-     * and return false (default value) in case of an error.
-     *
-     * @return bool
-     */
-    private function areExperimentalEndpointsEnabled(): bool
-    {
-        try {
-            return $this->featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_ADMIN_API_EXPERIMENTAL_ENDPOINTS);
-        } catch (Throwable) {
-            return false;
-        }
     }
 }

--- a/src/PrestaShopBundle/Command/UpdateLicensesCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateLicensesCommand.php
@@ -127,6 +127,7 @@ class UpdateLicensesCommand extends Command
                 // admin folders
                 'admin-dev/filemanager',
                 'admin-dev/themes/default/public/',
+                'admin-dev/themes/default/example',
                 'admin-dev/themes/new-theme/public/',
                 // js dependencies
                 'js/tiny_mce',

--- a/src/PrestaShopBundle/Entity/ImageType.php
+++ b/src/PrestaShopBundle/Entity/ImageType.php
@@ -89,6 +89,11 @@ class ImageType
      */
     private bool $stores;
 
+    /**
+     * @ORM\Column(name="theme_name", type="string", length=255)
+     */
+    private ?string $themeName;
+
     public function getId(): int
     {
         return $this->id;
@@ -186,6 +191,18 @@ class ImageType
     public function setStores(bool $stores): static
     {
         $this->stores = $stores;
+
+        return $this;
+    }
+
+    public function getThemeName(): ?string
+    {
+        return $this->themeName;
+    }
+
+    public function setThemeName(?string $themeName): static
+    {
+        $this->themeName = $themeName;
 
         return $this;
     }

--- a/src/PrestaShopBundle/Entity/ImageType.php
+++ b/src/PrestaShopBundle/Entity/ImageType.php
@@ -34,9 +34,9 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 /**
  * @ORM\Entity(repositoryClass="PrestaShopBundle\Entity\Repository\ImageTypeRepository")
  *
- * @ORM\Table(uniqueConstraints={@ORM\UniqueConstraint(name="image_type_name", columns={"name"})})
+ * @ORM\Table(uniqueConstraints={@ORM\UniqueConstraint(columns={"name","theme_name"})})
  *
- * @UniqueEntity("name")
+ * @UniqueEntity({"name", "theme_name"})
  */
 class ImageType
 {

--- a/src/PrestaShopBundle/EventListener/API/Context/CurrencyContextListener.php
+++ b/src/PrestaShopBundle/EventListener/API/Context/CurrencyContextListener.php
@@ -1,4 +1,28 @@
 <?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
 
 namespace PrestaShopBundle\EventListener\API\Context;
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -141,23 +141,6 @@ class PreferencesType extends TranslatorAwareType
                     'Admin.Shopparameters.Help'
                 ),
             ])
-            ->add(
-                'price_round_mode', ChoiceType::class, [
-                    'placeholder' => false,
-                    'choices' => [
-                        'Round up away from zero, when it is half way there (recommended)' => $configuration->get('PS_ROUND_HALF_UP'),
-                        'Round down towards zero, when it is half way there' => $configuration->get('PS_ROUND_HALF_DOWN'),
-                        'Round towards the next even value' => $configuration->get('PS_ROUND_HALF_EVEN'),
-                        'Round towards the next odd value' => $configuration->get('PS_ROUND_HALF_ODD'),
-                        'Round up to the nearest value' => $configuration->get('PS_ROUND_UP'),
-                        'Round down to the nearest value' => $configuration->get('PS_ROUND_DOWN'),
-                    ],
-                    'label' => $this->trans('Round mode', 'Admin.Shopparameters.Feature'),
-                    'help' => $this->trans(
-                        'You can choose among 6 different ways of rounding prices. "Round up away from zero ..." is the recommended behavior.',
-                        'Admin.Shopparameters.Help'
-                    ),
-                ])
             ->add('price_round_type', ChoiceType::class, [
                 'placeholder' => false,
                 'choices' => [

--- a/src/PrestaShopBundle/Form/Admin/Type/ThemeChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ThemeChoiceType.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\Form\Admin\Type;
+
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Class ThemeChoiceType is responsible for providing themes choices.
+ */
+class ThemeChoiceType extends TranslatorAwareType
+{
+    /**
+     * @param FormChoiceProviderInterface $themesChoiceProvider
+     * @param TranslatorInterface $translator
+     * @param array<int, array<string, mixed>> $locales
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        private readonly FormChoiceProviderInterface $themesChoiceProvider,
+    ) {
+        parent::__construct($translator, $locales);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'choices' => $this->themesChoiceProvider->getChoices(),
+            'required' => false,
+            'placeholder' => $this->trans('All', 'Admin.Global'),
+            'choice_translation_domain' => false,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent(): string
+    {
+        return ChoiceType::class;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
@@ -91,7 +91,17 @@ services:
     decorates: api_platform.metadata.resource.metadata_collection_factory
     autowire: true
     arguments:
-      $innerFactory: '@.inner'
+      $decorated: '@.inner'
+      $isDebug: '%kernel.debug%'
+
+  # This decorator allows filtering the available ApiPlatform resources when they are base on non existing CQRS classes
+  PrestaShopBundle\ApiPlatform\Metadata\Resource\Factory\CQRSNotFoundMetadataCollectionFactoryDecorator:
+    # It is important to decorate early in the decoration chain, because InputOutputResourceMetadataCollectionFactory checks the existence
+    # of input classes and throws an exception before this one has the chance to clean the CQRS not found
+    decorates: api_platform.metadata.resource.metadata_collection_factory.attributes
+    autowire: true
+    arguments:
+      $decorated: '@.inner'
       $isDebug: '%kernel.debug%'
 
   # This service depends on ResourceMetadataCollectionFactoryInterface (auto wired) and can extract the scopes defined on operations

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -601,6 +601,10 @@ services:
     arguments:
       $featureChoiceProvider: '@PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\FeaturesChoiceProvider'
 
+  PrestaShopBundle\Form\Admin\Type\ThemeChoiceType:
+    arguments:
+      $themesChoiceProvider: '@PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemeByNameChoiceProvider'
+
   form.type.sell.product.event_listener.categories_listener:
     alias: 'PrestaShopBundle\Form\Admin\Sell\Product\EventListener\CategoriesListener'
     public: true

--- a/tests/Integration/ApiPlatform/DisabledEndpointsTest.php
+++ b/tests/Integration/ApiPlatform/DisabledEndpointsTest.php
@@ -228,5 +228,19 @@ class DisabledEndpointsTest extends ApiTestCase
             '/test/cqrs/command/not_found',
             'filtered_command_scope',
         ];
+
+        yield 'endpoint with CQRS command AND query not found, filtered on prod' => [
+            false,
+            'PUT',
+            '/test/cqrs/query_and_command/not_found',
+            'filtered_query_command_scope',
+        ];
+
+        yield 'endpoint with CQRS command AND query not found, still present on dev' => [
+            true,
+            'PUT',
+            '/test/cqrs/query_and_command/not_found',
+            'filtered_query_command_scope',
+        ];
     }
 }

--- a/tests/Resources/ApiPlatform/Resources/ApiTest.php
+++ b/tests/Resources/ApiPlatform/Resources/ApiTest.php
@@ -31,6 +31,7 @@ namespace Tests\Resources\ApiPlatform\Resources;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
 
 #[ApiResource(
@@ -53,6 +54,16 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
             scopes: ['experimental_scope'],
             CQRSQueryMapping: ApiTest::QUERY_MAPPING,
             experimentalOperation: true,
+        ),
+        new CQRSGet(
+            uriTemplate: '/test/cqrs/query/not_found',
+            CQRSQuery: 'PrestaShop\PrestaShop\Core\Domain\Product\Query\NotFoundQuery',
+            scopes: ['filtered_query_scope'],
+        ),
+        new CQRSCreate(
+            uriTemplate: '/test/cqrs/command/not_found',
+            CQRSCommand: 'PrestaShop\PrestaShop\Core\Domain\Product\Query\NotFoundCommand',
+            scopes: ['filtered_command_scope'],
         ),
     ],
 )]

--- a/tests/Resources/ApiPlatform/Resources/ApiTest.php
+++ b/tests/Resources/ApiPlatform/Resources/ApiTest.php
@@ -33,6 +33,7 @@ use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
 
 #[ApiResource(
     operations: [
@@ -62,8 +63,14 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
         ),
         new CQRSCreate(
             uriTemplate: '/test/cqrs/command/not_found',
-            CQRSCommand: 'PrestaShop\PrestaShop\Core\Domain\Product\Query\NotFoundCommand',
+            CQRSCommand: 'PrestaShop\PrestaShop\Core\Domain\Product\Command\NotFoundCommand',
             scopes: ['filtered_command_scope'],
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/test/cqrs/query_and_command/not_found',
+            CQRSCommand: 'PrestaShop\PrestaShop\Core\Domain\Product\Command\NotFoundCommand',
+            CQRSQuery: 'PrestaShop\PrestaShop\Core\Domain\Product\Query\NotFoundQuery',
+            scopes: ['filtered_query_command_scope'],
         ),
     ],
 )]

--- a/tests/UI/campaigns/functional/API/02_endpoints/09_product/04_patchProductId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/09_product/04_patchProductId.ts
@@ -1,8 +1,10 @@
 import testContext from '@utils/testContext';
 import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
 import {createProductTest, deleteProductTest} from '@commonTests/BO/catalog/product';
+import {disableEcoTaxTest, enableEcoTaxTest} from '@commonTests/BO/international/ecoTax';
 import {expect} from 'chai';
 
+import {faker} from '@faker-js/faker';
 import {
   type APIRequestContext,
   boApiClientsPage,
@@ -12,8 +14,17 @@ import {
   boProductsPage,
   boProductsCreatePage,
   boProductsCreateTabDescriptionPage,
+  boProductsCreateTabDetailsPage,
+  boProductsCreateTabOptionsPage,
+  boProductsCreateTabPricingPage,
+  boProductsCreateTabSEOPage,
+  boProductsCreateTabShippingPage,
+  boProductsCreateTabStocksPage,
   type BrowserContext,
+  dataBrands,
+  dataCategories,
   dataLanguages,
+  dataTaxRules,
   FakerAPIClient,
   FakerProduct,
   type Page,
@@ -43,13 +54,12 @@ describe('API : PATCH /product/{productId}', async () => {
     type: 'standard',
     status: true,
   });
-  const patchProduct: FakerProduct = new FakerProduct({
-    type: 'virtual',
-    status: false,
-  });
+
+  // Pre Condition : Enable ecotax
+  enableEcoTaxTest(`${baseContext}_preTest_0`);
 
   // Pre Condition : Create a product
-  createProductTest(createProduct, `${baseContext}_preTest_0`);
+  createProductTest(createProduct, `${baseContext}_preTest_1`);
 
   describe('API : PATCH /product/{productId}', async () => {
     before(async function () {
@@ -183,30 +193,210 @@ describe('API : PATCH /product/{productId}', async () => {
     });
 
     [
-      // @todo : https://github.com/PrestaShop/PrestaShop/issues/35626
-      /*{
-        propertyName: 'type',
-        propertyValue: patchProduct.type,
-      },*/
       {
         propertyName: 'active',
-        propertyValue: patchProduct.status,
+        propertyValue: false,
       },
       {
-        propertyName: 'names',
+        propertyName: 'additionalShippingCost',
+        propertyValue: faker.number.float({fractionDigits: 2}),
+      },
+      // @todo : https://github.com/PrestaShop/PrestaShop/issues/38787
+      /*{
+        propertyName: 'availableDate',
+        propertyValue: faker.date.future(),
+      },*/
+      {
+        propertyName: 'availableForOrder',
+        propertyValue: false,
+      },
+      {
+        propertyName: 'availableLaterLabels',
         propertyValue: {
-          [dataLanguages.english.locale]: patchProduct.name,
-          [dataLanguages.french.locale]: patchProduct.nameFR,
+          [dataLanguages.english.locale]: faker.lorem.sentence(),
+          [dataLanguages.french.locale]: faker.lorem.sentence(),
         },
+      },
+      {
+        propertyName: 'availableNowLabels',
+        propertyValue: {
+          [dataLanguages.english.locale]: faker.lorem.sentence(),
+          [dataLanguages.french.locale]: faker.lorem.sentence(),
+        },
+      },
+      {
+        propertyName: 'condition',
+        propertyValue: 'used',
+      },
+      {
+        propertyName: 'deliveryTimeInStockNotes',
+        propertyValue: {
+          [dataLanguages.english.locale]: faker.lorem.sentence(),
+          [dataLanguages.french.locale]: faker.lorem.sentence(),
+        },
+      },
+      {
+        propertyName: 'deliveryTimeOutOfStockNotes',
+        propertyValue: {
+          [dataLanguages.english.locale]: faker.lorem.sentence(),
+          [dataLanguages.french.locale]: faker.lorem.sentence(),
+        },
+      },
+      {
+        propertyName: 'deliveryTimeNoteType',
+        propertyValue: 2,
+      },
+      {
+        propertyName: 'depth',
+        propertyValue: faker.number.float({fractionDigits: 2}),
       },
       {
         propertyName: 'descriptions',
         propertyValue: {
-          [dataLanguages.english.locale]: patchProduct.description,
-          [dataLanguages.french.locale]: patchProduct.descriptionFR,
+          [dataLanguages.english.locale]: faker.lorem.sentence(),
+          [dataLanguages.french.locale]: faker.lorem.sentence(),
         },
       },
-    ].forEach((data: { propertyName: string, propertyValue: boolean|string|object}) => {
+      // @todo : https://github.com/PrestaShop/PrestaShop/issues/38788
+      /*{
+        propertyName: 'ean13',
+        propertyValue: '3700436072813',
+      },*/
+      {
+        propertyName: 'ecotaxTaxExcluded',
+        propertyValue: faker.number.float({fractionDigits: 2}),
+      },
+      {
+        propertyName: 'gtin',
+        propertyValue: '3234567890126',
+      },
+      {
+        propertyName: 'height',
+        propertyValue: faker.number.float({fractionDigits: 2}),
+      },
+      {
+        propertyName: 'isbn',
+        propertyValue: '978-3-16-148410-0',
+      },
+      {
+        propertyName: 'linkRewrites',
+        propertyValue: {
+          [dataLanguages.english.locale]: faker.lorem.slug(),
+          [dataLanguages.french.locale]: faker.lorem.slug(),
+        },
+      },
+      {
+        propertyName: 'lowStockThreshold',
+        propertyValue: faker.number.int({min: 0, max: 12345}),
+      },
+      {
+        propertyName: 'manufacturerId',
+        propertyValue: dataBrands.brand_2.id,
+      },
+      {
+        propertyName: 'metaDescriptions',
+        propertyValue: {
+          [dataLanguages.english.locale]: faker.lorem.sentence(),
+          [dataLanguages.french.locale]: faker.lorem.sentence(),
+        },
+      },
+      {
+        propertyName: 'metaTitles',
+        propertyValue: {
+          [dataLanguages.english.locale]: faker.lorem.sentence(),
+          [dataLanguages.french.locale]: faker.lorem.sentence(),
+        },
+      },
+      {
+        propertyName: 'minimalQuantity',
+        propertyValue: faker.number.int({min: 0, max: 12345}),
+      },
+      {
+        propertyName: 'mpn',
+        propertyValue: faker.string.alphanumeric({length: 15}).toString(),
+      },
+      {
+        propertyName: 'names',
+        propertyValue: {
+          [dataLanguages.english.locale]: faker.lorem.sentence(),
+          [dataLanguages.french.locale]: faker.lorem.sentence(),
+        },
+      },
+      {
+        propertyName: 'onlineOnly',
+        propertyValue: true,
+      },
+      {
+        propertyName: 'onSale',
+        propertyValue: false,
+      },
+      {
+        propertyName: 'packStockType',
+        propertyValue: 3,
+      },
+      {
+        propertyName: 'priceTaxExcluded',
+        propertyValue: faker.number.float({fractionDigits: 2}),
+      },
+      {
+        propertyName: 'redirectOption',
+        propertyValue: {
+          redirectType: '301-category',
+          redirectTarget: dataCategories.art.id,
+        },
+      },
+      {
+        propertyName: 'reference',
+        propertyValue: faker.string.alphanumeric({length: 15}),
+      },
+      {
+        propertyName: 'shortDescriptions',
+        propertyValue: {
+          [dataLanguages.english.locale]: faker.lorem.sentences(5),
+          [dataLanguages.french.locale]: faker.lorem.sentence(5),
+        },
+      },
+      {
+        propertyName: 'showCondition',
+        propertyValue: true,
+      },
+      {
+        propertyName: 'showPrice',
+        propertyValue: true,
+      },
+      {
+        propertyName: 'taxRulesGroupId',
+        propertyValue: dataTaxRules.at(-1)!.id,
+      },
+      {
+        propertyName: 'unitPriceTaxExcluded',
+        propertyValue: faker.number.float({fractionDigits: 2}),
+      },
+      {
+        propertyName: 'unity',
+        propertyValue: 'per kilo',
+      },
+      {
+        propertyName: 'upc',
+        propertyValue: '72527273070',
+      },
+      {
+        propertyName: 'visibility',
+        propertyValue: 'search',
+      },
+      {
+        propertyName: 'width',
+        propertyValue: faker.number.float({fractionDigits: 2}),
+      },
+      {
+        propertyName: 'weight',
+        propertyValue: faker.number.float({fractionDigits: 2}),
+      },
+      {
+        propertyName: 'wholesalePrice',
+        propertyValue: faker.number.float({fractionDigits: 2}),
+      },
+    ].forEach((data: { propertyName: string, propertyValue: boolean|string|number|object|any}) => {
       describe(`Update the property \`${data.propertyName}\` with API and check in BO`, async () => {
         it('should request the endpoint /product/{productId}', async function () {
           await testContext.addContextItem(this, 'testIdentifier', `requestEndpoint${data.propertyName}`, baseContext);
@@ -225,14 +415,21 @@ describe('API : PATCH /product/{productId}', async () => {
           expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
 
           jsonResponse = await apiResponse.json();
-          expect(jsonResponse).to.have.property(data.propertyName);
-          expect(jsonResponse[data.propertyName]).to.deep.equal(data.propertyValue);
+          if (data.propertyName === 'redirectOption') {
+            expect(jsonResponse).to.have.property('redirectTarget');
+            expect(jsonResponse.redirectTarget).to.deep.equal(data.propertyValue.redirectTarget);
+            expect(jsonResponse).to.have.property('redirectType');
+            expect(jsonResponse.redirectType).to.deep.equal(data.propertyValue.redirectType);
+          } else {
+            expect(jsonResponse).to.have.property(data.propertyName);
+            expect(jsonResponse[data.propertyName]).to.deep.equal(data.propertyValue);
+          }
         });
 
         it('should check the JSON Response keys', async function () {
           await testContext.addContextItem(this, 'testIdentifier', `checkResponseKeys${data.propertyName}`, baseContext);
 
-          expect(jsonResponse).to.have.all.keys(
+          const jsonResponseKeys: string[] = [
             'active',
             'additionalShippingCost',
             'availableForOrder',
@@ -287,27 +484,125 @@ describe('API : PATCH /product/{productId}', async () => {
             'weight',
             'wholesalePrice',
             'width',
-          );
+          ];
+
+          if (jsonResponse.redirectType !== 'default') {
+            jsonResponseKeys.push('redirectTarget');
+          }
+          expect(jsonResponse).to.have.all.keys(jsonResponseKeys);
         });
 
         it(`should check that the property "${data.propertyName}"`, async function () {
           await testContext.addContextItem(this, 'testIdentifier', `checkProperty${data.propertyName}`, baseContext);
 
-          await boApiClientsCreatePage.reloadPage(page);
+          await boProductsCreatePage.reloadPage(page);
 
-          if (data.propertyName === 'type') {
-            const valueProperty = await boProductsCreatePage.getProductType(page);
-            expect(valueProperty).to.equal(data.propertyValue);
-          } else if (data.propertyName === 'active') {
+          if (data.propertyName === 'active') {
             const valueProperty = await boProductsCreatePage.getProductStatus(page);
             expect(valueProperty).to.equal(data.propertyValue);
-          } else if (data.propertyName === 'names') {
-            const valuePropertyEN = await boProductsCreatePage.getProductName(page, dataLanguages.english.isoCode);
-            const valuePropertyFR = await boProductsCreatePage.getProductName(page, dataLanguages.french.isoCode);
+          } else if (data.propertyName === 'additionalShippingCost') {
+            await boProductsCreatePage.goToTab(page, 'shipping');
+
+            const valueProperty = parseFloat(
+              await boProductsCreateTabShippingPage.getValue(page, 'additional_shipping_cost'),
+            ).toFixed(2);
+            expect(parseFloat(valueProperty)).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'availableDate') {
+            await boProductsCreatePage.goToTab(page, 'stock');
+
+            const valueProperty = await boProductsCreateTabStocksPage.getValue(page, 'available_date');
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'availableForOrder') {
+            await boProductsCreatePage.goToTab(page, 'options');
+
+            const valueProperty = await boProductsCreateTabOptionsPage.getValue(page, 'available_for_order');
+            expect(valueProperty).to.equal(data.propertyValue ? '1' : '0');
+          } else if (data.propertyName === 'availableLaterLabels') {
+            await boProductsCreatePage.goToTab(page, 'stock');
+
+            const valuePropertyEN = await boProductsCreateTabStocksPage.getValue(
+              page,
+              'available_later',
+              dataLanguages.english.id.toString(),
+            );
+            const valuePropertyFR = await boProductsCreateTabStocksPage.getValue(
+              page,
+              'available_later',
+              dataLanguages.french.id.toString(),
+            );
             expect({
               [dataLanguages.english.locale]: valuePropertyEN,
               [dataLanguages.french.locale]: valuePropertyFR,
             }).to.deep.equal(data.propertyValue);
+          } else if (data.propertyName === 'availableNowLabels') {
+            await boProductsCreatePage.goToTab(page, 'stock');
+
+            const valuePropertyEN = await boProductsCreateTabStocksPage.getValue(
+              page,
+              'available_now',
+              dataLanguages.english.id.toString(),
+            );
+            const valuePropertyFR = await boProductsCreateTabStocksPage.getValue(
+              page,
+              'available_now',
+              dataLanguages.french.id.toString(),
+            );
+            expect({
+              [dataLanguages.english.locale]: valuePropertyEN,
+              [dataLanguages.french.locale]: valuePropertyFR,
+            }).to.deep.equal(data.propertyValue);
+          } else if (data.propertyName === 'condition') {
+            await boProductsCreatePage.goToTab(page, 'details');
+
+            const valueProperty = await boProductsCreateTabDetailsPage.getValue(page, 'condition');
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'deliveryTimeInStockNotes') {
+            await boProductsCreatePage.goToTab(page, 'shipping');
+
+            const valuePropertyEN = await boProductsCreateTabShippingPage.getValue(
+              page,
+              'delivery_in_stock',
+              dataLanguages.english.id.toString(),
+            );
+            const valuePropertyFR = await boProductsCreateTabShippingPage.getValue(
+              page,
+              'delivery_in_stock',
+              dataLanguages.french.id.toString(),
+            );
+            expect({
+              [dataLanguages.english.locale]: valuePropertyEN,
+              [dataLanguages.french.locale]: valuePropertyFR,
+            }).to.deep.equal(data.propertyValue);
+          } else if (data.propertyName === 'deliveryTimeOutOfStockNotes') {
+            await boProductsCreatePage.goToTab(page, 'shipping');
+
+            const valuePropertyEN = await boProductsCreateTabShippingPage.getValue(
+              page,
+              'delivery_out_stock',
+              dataLanguages.english.id.toString(),
+            );
+            const valuePropertyFR = await boProductsCreateTabShippingPage.getValue(
+              page,
+              'delivery_out_stock',
+              dataLanguages.french.id.toString(),
+            );
+            expect({
+              [dataLanguages.english.locale]: valuePropertyEN,
+              [dataLanguages.french.locale]: valuePropertyFR,
+            }).to.deep.equal(data.propertyValue);
+          } else if (data.propertyName === 'deliveryTimeNoteType') {
+            await boProductsCreatePage.goToTab(page, 'shipping');
+
+            const valueProperty = parseInt(
+              await boProductsCreateTabShippingPage.getValue(page, 'additional_delivery_times'),
+              10,
+            );
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'depth') {
+            await boProductsCreatePage.goToTab(page, 'shipping');
+
+            const valueProperty = parseFloat(await boProductsCreateTabShippingPage.getValue(page, 'depth'));
+            expect(valueProperty).to.equal(data.propertyValue);
           } else if (data.propertyName === 'descriptions') {
             const valuePropertyEN = await boProductsCreateTabDescriptionPage.getValue(
               page,
@@ -323,6 +618,204 @@ describe('API : PATCH /product/{productId}', async () => {
               [dataLanguages.english.locale]: valuePropertyEN,
               [dataLanguages.french.locale]: valuePropertyFR,
             }).to.deep.equal(data.propertyValue);
+          } else if (data.propertyName === 'ean13') {
+            await boProductsCreatePage.goToTab(page, 'details');
+
+            const valueProperty = await boProductsCreateTabDetailsPage.getValue(page, 'ean13');
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'ecotaxTaxExcluded') {
+            await boProductsCreatePage.goToTab(page, 'pricing');
+
+            const valueProperty = parseFloat(
+              await boProductsCreateTabPricingPage.getValue(page, 'ecotax'),
+            ).toFixed(2);
+            expect(parseFloat(valueProperty)).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'gtin') {
+            await boProductsCreatePage.goToTab(page, 'details');
+
+            const valueProperty = await boProductsCreateTabDetailsPage.getValue(page, 'ean13');
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'height') {
+            await boProductsCreatePage.goToTab(page, 'shipping');
+
+            const valueProperty = parseFloat(await boProductsCreateTabShippingPage.getValue(page, 'height'));
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'isbn') {
+            await boProductsCreatePage.goToTab(page, 'details');
+
+            const valueProperty = await boProductsCreateTabDetailsPage.getValue(page, 'isbn');
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'linkRewrites') {
+            await boProductsCreatePage.goToTab(page, 'seo');
+            const valuePropertyEN = await boProductsCreateTabSEOPage.getValue(
+              page,
+              'link_rewrite',
+              dataLanguages.english.id.toString(),
+            );
+            const valuePropertyFR = await boProductsCreateTabSEOPage.getValue(
+              page,
+              'link_rewrite',
+              dataLanguages.french.id.toString(),
+            );
+            expect({
+              [dataLanguages.english.locale]: valuePropertyEN,
+              [dataLanguages.french.locale]: valuePropertyFR,
+            }).to.deep.equal(data.propertyValue);
+          } else if (data.propertyName === 'lowStockThreshold') {
+            await boProductsCreatePage.goToTab(page, 'stock');
+
+            const valueProperty = parseInt(await boProductsCreateTabStocksPage.getValue(page, 'low_stock_threshold'), 10);
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'manufacturerId') {
+            const valueProperty = parseInt(await boProductsCreateTabDescriptionPage.getValue(page, 'manufacturer'), 10);
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'metaDescriptions') {
+            await boProductsCreatePage.goToTab(page, 'seo');
+            const valuePropertyEN = await boProductsCreateTabSEOPage.getValue(
+              page,
+              'meta_description',
+              dataLanguages.english.id.toString(),
+            );
+            const valuePropertyFR = await boProductsCreateTabSEOPage.getValue(
+              page,
+              'meta_description',
+              dataLanguages.french.id.toString(),
+            );
+            expect({
+              [dataLanguages.english.locale]: valuePropertyEN,
+              [dataLanguages.french.locale]: valuePropertyFR,
+            }).to.deep.equal(data.propertyValue);
+          } else if (data.propertyName === 'metaTitles') {
+            await boProductsCreatePage.goToTab(page, 'seo');
+            const valuePropertyEN = await boProductsCreateTabSEOPage.getValue(
+              page,
+              'meta_title',
+              dataLanguages.english.id.toString(),
+            );
+            const valuePropertyFR = await boProductsCreateTabSEOPage.getValue(
+              page,
+              'meta_title',
+              dataLanguages.french.id.toString(),
+            );
+            expect({
+              [dataLanguages.english.locale]: valuePropertyEN,
+              [dataLanguages.french.locale]: valuePropertyFR,
+            }).to.deep.equal(data.propertyValue);
+          } else if (data.propertyName === 'minimalQuantity') {
+            await boProductsCreatePage.goToTab(page, 'stock');
+
+            const valueProperty = parseInt(await boProductsCreateTabStocksPage.getValue(page, 'minimal_quantity'), 10);
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'mpn') {
+            await boProductsCreatePage.goToTab(page, 'details');
+
+            const valueProperty = await boProductsCreateTabDetailsPage.getValue(page, 'mpn');
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'names') {
+            const valuePropertyEN = await boProductsCreatePage.getProductName(page, dataLanguages.english.isoCode);
+            const valuePropertyFR = await boProductsCreatePage.getProductName(page, dataLanguages.french.isoCode);
+            expect({
+              [dataLanguages.english.locale]: valuePropertyEN,
+              [dataLanguages.french.locale]: valuePropertyFR,
+            }).to.deep.equal(data.propertyValue);
+          } else if (data.propertyName === 'onlineOnly') {
+            await boProductsCreatePage.goToTab(page, 'options');
+
+            const valueProperty = await boProductsCreateTabOptionsPage.getValue(page, 'online_only');
+            expect(valueProperty).to.equal(data.propertyValue ? '1' : '0');
+          } else if (data.propertyName === 'onSale') {
+            await boProductsCreatePage.goToTab(page, 'pricing');
+
+            const valueProperty = await boProductsCreateTabPricingPage.getValue(page, 'on_sale');
+            expect(valueProperty).to.equal(data.propertyValue ? '1' : '0');
+          } else if (data.propertyName === 'packStockType') {
+            // Not tested
+          } else if (data.propertyName === 'priceTaxExcluded') {
+            await boProductsCreatePage.goToTab(page, 'pricing');
+
+            const valueProperty = parseFloat(await boProductsCreateTabPricingPage.getValue(page, 'price'));
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'redirectOption') {
+            await boProductsCreatePage.goToTab(page, 'seo');
+
+            const valuePropertyType = await boProductsCreateTabSEOPage.getValue(page, 'redirect_type');
+            const valuePropertyTarget = parseInt(await boProductsCreateTabSEOPage.getValue(page, 'id_type_redirected'), 10);
+            expect({
+              redirectType: valuePropertyType,
+              redirectTarget: valuePropertyTarget,
+            }).to.deep.equal(data.propertyValue);
+          } else if (data.propertyName === 'reference') {
+            await boProductsCreatePage.goToTab(page, 'details');
+
+            const valueProperty = await boProductsCreateTabDetailsPage.getValue(page, 'reference');
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'shortDescriptions') {
+            const valuePropertyEN = await boProductsCreateTabDescriptionPage.getValue(
+              page,
+              'summary',
+              dataLanguages.english.id.toString(),
+            );
+            const valuePropertyFR = await boProductsCreateTabDescriptionPage.getValue(
+              page,
+              'summary',
+              dataLanguages.french.id.toString(),
+            );
+            expect({
+              [dataLanguages.english.locale]: valuePropertyEN,
+              [dataLanguages.french.locale]: valuePropertyFR,
+            }).to.deep.equal(data.propertyValue);
+          } else if (data.propertyName === 'showCondition') {
+            await boProductsCreatePage.goToTab(page, 'details');
+
+            const valueProperty = await boProductsCreateTabDetailsPage.getValue(page, 'show_condition');
+            expect(valueProperty).to.equal(data.propertyValue ? '1' : '0');
+          } else if (data.propertyName === 'showPrice') {
+            await boProductsCreatePage.goToTab(page, 'options');
+
+            const valueProperty = await boProductsCreateTabOptionsPage.getValue(page, 'show_price');
+            expect(valueProperty).to.equal(data.propertyValue ? '1' : '0');
+          } else if (data.propertyName === 'taxRulesGroupId') {
+            await boProductsCreatePage.goToTab(page, 'pricing');
+
+            const valueProperty = parseInt(await boProductsCreateTabPricingPage.getValue(page, 'id_tax_rules_group'), 10);
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'unitPriceTaxExcluded') {
+            await boProductsCreatePage.goToTab(page, 'pricing');
+
+            const valueProperty = parseFloat(await boProductsCreateTabPricingPage.getValue(page, 'unit_price'));
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'unity') {
+            await boProductsCreatePage.goToTab(page, 'pricing');
+
+            const valueProperty = await boProductsCreateTabPricingPage.getValue(page, 'unity');
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'upc') {
+            await boProductsCreatePage.goToTab(page, 'details');
+
+            const valueProperty = await boProductsCreateTabDetailsPage.getValue(page, 'upc');
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'visibility') {
+            await boProductsCreatePage.goToTab(page, 'options');
+
+            const valueProperty = await boProductsCreateTabOptionsPage.getValue(page, 'visibility');
+            expect(valueProperty).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'width') {
+            await boProductsCreatePage.goToTab(page, 'shipping');
+
+            const valueProperty = parseFloat(await boProductsCreateTabShippingPage.getValue(page, 'width')).toFixed(2);
+            expect(parseFloat(valueProperty)).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'weight') {
+            await boProductsCreatePage.goToTab(page, 'shipping');
+
+            const valueProperty = parseFloat(await boProductsCreateTabShippingPage.getValue(page, 'weight')).toFixed(2);
+            expect(parseFloat(valueProperty)).to.equal(data.propertyValue);
+          } else if (data.propertyName === 'wholesalePrice') {
+            await boProductsCreatePage.goToTab(page, 'pricing');
+
+            const valueProperty = parseFloat(await boProductsCreateTabPricingPage.getValue(page, 'wholesale_price')).toFixed(2);
+            expect(parseFloat(valueProperty)).to.equal(data.propertyValue);
+          } else {
+            throw new Error(`The property ${data.propertyName} is not managed`);
           }
         });
       });
@@ -330,8 +823,11 @@ describe('API : PATCH /product/{productId}', async () => {
   });
 
   // Pre-condition: Delete a product
-  deleteProductTest(patchProduct, `${baseContext}_postTest_0`);
+  deleteProductTest(createProduct, `${baseContext}_postTest_0`);
+
+  // Pre-condition: Delete a product
+  disableEcoTaxTest(`${baseContext}_postTest_1`);
 
   // Pre-condition: Delete an API Client
-  deleteAPIClientTest(`${baseContext}_postTest_1`);
+  deleteAPIClientTest(`${baseContext}_postTest_2`);
 });

--- a/tests/Unit/Core/Domain/ImageSettings/QueryResult/EditableImageTypeTest.php
+++ b/tests/Unit/Core/Domain/ImageSettings/QueryResult/EditableImageTypeTest.php
@@ -47,6 +47,7 @@ class EditableImageTypeTest extends TestCase
             true,
             true,
             true,
+            'theme_name',
         );
 
         self::assertSame($imageTypeId, $instance->getImageTypeId());
@@ -58,5 +59,6 @@ class EditableImageTypeTest extends TestCase
         self::assertTrue($instance->isManufacturers());
         self::assertTrue($instance->isSuppliers());
         self::assertTrue($instance->isStores());
+        self::assertSame('theme_name', $instance->getThemeName());
     }
 }

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSCommandTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSCommandTest.php
@@ -30,11 +30,17 @@ namespace Tests\Unit\PrestaShopBundle\ApiPlatform\Metadata;
 
 use ApiPlatform\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\AddProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCommand;
 use PrestaShopBundle\ApiPlatform\Processor\CommandProcessor;
 
 class CQRSCommandTest extends TestCase
 {
+    public const VALID_COMMAND_CLASS = AddProductCommand::class;
+    public const OTHER_VALID_COMMAND_CLASS = UpdateProductCommand::class;
+    public const INVALID_COMMAND_CLASS = 'My\\Namespace\\MyCommand';
+
     public function testDefaultConstructor(): void
     {
         // Without any parameters
@@ -101,66 +107,66 @@ class CQRSCommandTest extends TestCase
 
     public function testCQRSCommand(): void
     {
-        // CQRS query parameters in constructor
+        // CQRS command parameters in constructor
         $operation = new CQRSCommand(
-            CQRSCommand: 'My\\Namespace\\MyCommand',
+            CQRSCommand: self::VALID_COMMAND_CLASS,
         );
         $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
         $this->assertNull($operation->getProvider());
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // Extra properties parameters in constructor
         $operation = new CQRSCommand(
-            extraProperties: ['CQRSCommand' => 'My\\Namespace\\MyCommand'],
+            extraProperties: ['CQRSCommand' => self::VALID_COMMAND_CLASS],
         );
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // Extra properties AND CQRS query parameters in constructor, both values are equals no problem
         $operation = new CQRSCommand(
-            extraProperties: ['CQRSCommand' => 'My\\Namespace\\MyCommand'],
-            CQRSCommand: 'My\\Namespace\\MyCommand',
+            extraProperties: ['CQRSCommand' => self::VALID_COMMAND_CLASS],
+            CQRSCommand: self::VALID_COMMAND_CLASS,
         );
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // Use with method, returned object is a clone All values are replaced
-        $operation2 = $operation->withCQRSCommand('My\\Namespace\\MyOtherCommand');
+        $operation2 = $operation->withCQRSCommand(self::OTHER_VALID_COMMAND_CLASS);
         $this->assertNotEquals($operation2, $operation);
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyOtherCommand'], $operation2->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyOtherCommand', $operation2->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyOtherCommand', $operation2->getInput());
+        $this->assertEquals(['CQRSCommand' => self::OTHER_VALID_COMMAND_CLASS], $operation2->getExtraProperties());
+        $this->assertEquals(self::OTHER_VALID_COMMAND_CLASS, $operation2->getCQRSCommand());
+        $this->assertEquals(self::OTHER_VALID_COMMAND_CLASS, $operation2->getInput());
 
         // Initial operation not modified of course
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // When input is manually specified it is kept over the CQRSCommand
         $operationInput = new CQRSCommand(
-            input: 'My\\Namespace\\MyOtherCommand',
-            CQRSCommand: 'My\\Namespace\\MyCommand',
+            input: self::OTHER_VALID_COMMAND_CLASS,
+            CQRSCommand: self::VALID_COMMAND_CLASS,
         );
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operationInput->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operationInput->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyOtherCommand', $operationInput->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operationInput->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operationInput->getCQRSCommand());
+        $this->assertEquals(self::OTHER_VALID_COMMAND_CLASS, $operationInput->getInput());
         // Clone value keeps the initial different input value
         $operationInput2 = $operationInput->withCQRSCommand('My\\Namespace\\MyThirdCommand');
         $this->assertNotEquals($operationInput2, $operationInput);
         $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyThirdCommand'], $operationInput2->getExtraProperties());
         $this->assertEquals('My\\Namespace\\MyThirdCommand', $operationInput2->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyOtherCommand', $operationInput2->getInput());
+        $this->assertEquals(self::OTHER_VALID_COMMAND_CLASS, $operationInput2->getInput());
 
         // When both values are specified, but they are different trigger an exception
         $caughtException = null;
         try {
             new CQRSCommand(
-                extraProperties: ['CQRSCommand' => 'My\\Namespace\\MyCommand'],
-                CQRSCommand: 'My\\Namespace\\MyOtherCommand',
+                extraProperties: ['CQRSCommand' => self::VALID_COMMAND_CLASS],
+                CQRSCommand: self::OTHER_VALID_COMMAND_CLASS,
             );
         } catch (InvalidArgumentException $e) {
             $caughtException = $e;
@@ -169,6 +175,16 @@ class CQRSCommandTest extends TestCase
         $this->assertNotNull($caughtException);
         $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
         $this->assertEquals('Specifying an extra property CQRSCommand and a CQRSCommand argument that are different is invalid', $caughtException->getMessage());
+
+        // CQRS command parameters in constructor that does not exist is not forced as the input
+        $operation = new CQRSCommand(
+            CQRSCommand: self::INVALID_COMMAND_CLASS,
+        );
+        $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
+        $this->assertNull($operation->getProvider());
+        $this->assertEquals(['CQRSCommand' => self::INVALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::INVALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertNull($operation->getInput());
     }
 
     public function testCQRSCommandMapping(): void
@@ -410,7 +426,7 @@ class CQRSCommandTest extends TestCase
                 'scopes' => ['master_scope'],
                 'CQRSCommandMapping' => $commandMapping,
             ],
-            CQRSCommand: 'My\\Namespace\\MyCommand',
+            CQRSCommand: self::VALID_COMMAND_CLASS,
             scopes: ['scope1', 'scope2'],
             CQRSQueryMapping: $queryMapping,
             ApiResourceMapping: $resourceMapping,
@@ -419,14 +435,14 @@ class CQRSCommandTest extends TestCase
         $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
         $this->assertEquals(null, $operation->getProvider());
         $this->assertEquals('My\\Namespace\\MyQuery', $operation->getCQRSQuery());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
         $this->assertEquals($commandMapping, $operation->getCQRSCommandMapping());
         $this->assertEquals($queryMapping, $operation->getCQRSQueryMapping());
         $this->assertEquals($resourceMapping, $operation->getApiResourceMapping());
         $this->assertEquals(['master_scope', 'scope1', 'scope2'], $operation->getScopes());
         $this->assertEquals([
             'CQRSQuery' => 'My\\Namespace\\MyQuery',
-            'CQRSCommand' => 'My\\Namespace\\MyCommand',
+            'CQRSCommand' => self::VALID_COMMAND_CLASS,
             'scopes' => ['master_scope', 'scope1', 'scope2'],
             'CQRSQueryMapping' => $queryMapping,
             'ApiResourceMapping' => $resourceMapping,
@@ -479,14 +495,14 @@ class CQRSCommandTest extends TestCase
         // The original object has not been modified
         $this->assertEquals(null, $operation->getProvider());
         $this->assertEquals('My\\Namespace\\MyQuery', $operation->getCQRSQuery());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
         $this->assertEquals($commandMapping, $operation->getCQRSCommandMapping());
         $this->assertEquals($queryMapping, $operation->getCQRSQueryMapping());
         $this->assertEquals($resourceMapping, $operation->getApiResourceMapping());
         $this->assertEquals(['master_scope', 'scope1', 'scope2'], $operation->getScopes());
         $this->assertEquals([
             'CQRSQuery' => 'My\\Namespace\\MyQuery',
-            'CQRSCommand' => 'My\\Namespace\\MyCommand',
+            'CQRSCommand' => self::VALID_COMMAND_CLASS,
             'scopes' => ['master_scope', 'scope1', 'scope2'],
             'CQRSQueryMapping' => $queryMapping,
             'ApiResourceMapping' => $resourceMapping,

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSCreateTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSCreateTest.php
@@ -30,11 +30,18 @@ namespace Tests\Unit\PrestaShopBundle\ApiPlatform\Metadata;
 
 use ApiPlatform\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\AddProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCommand;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use PrestaShopBundle\ApiPlatform\Processor\CommandProcessor;
 
 class CQRSCreateTest extends TestCase
 {
+    public const VALID_COMMAND_CLASS = AddProductCommand::class;
+    public const OTHER_VALID_COMMAND_CLASS = UpdateProductCommand::class;
+    public const INVALID_COMMAND_CLASS = 'My\\Namespace\\MyCommand';
+
     public function testDefaultConstructor(): void
     {
         // Without any parameters
@@ -101,32 +108,32 @@ class CQRSCreateTest extends TestCase
 
     public function testCQRSCommand(): void
     {
-        // CQRS query parameters in constructor
+        // CQRS command parameters in constructor
         $operation = new CQRSCreate(
-            CQRSCommand: 'My\\Namespace\\MyCommand',
+            CQRSCommand: self::VALID_COMMAND_CLASS,
         );
         $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
         $this->assertNull($operation->getProvider());
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // Extra properties parameters in constructor
         $operation = new CQRSCreate(
-            extraProperties: ['CQRSCommand' => 'My\\Namespace\\MyCommand'],
+            extraProperties: ['CQRSCommand' => self::VALID_COMMAND_CLASS],
         );
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // Extra properties AND CQRS query parameters in constructor, both values are equals no problem
         $operation = new CQRSCreate(
-            extraProperties: ['CQRSCommand' => 'My\\Namespace\\MyCommand'],
-            CQRSCommand: 'My\\Namespace\\MyCommand',
+            extraProperties: ['CQRSCommand' => self::VALID_COMMAND_CLASS],
+            CQRSCommand: self::VALID_COMMAND_CLASS,
         );
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // Use with method, returned object is a clone All values are replaced
         $operation2 = $operation->withCQRSCommand('My\\Namespace\\MyOtherCommand');
@@ -135,17 +142,17 @@ class CQRSCreateTest extends TestCase
         $this->assertEquals('My\\Namespace\\MyOtherCommand', $operation2->getCQRSCommand());
         $this->assertEquals('My\\Namespace\\MyOtherCommand', $operation2->getInput());
         // Initial operation not modified of course
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // When input is manually specified it is kept over the CQRSCommand
         $operationInput = new CQRSCreate(
             input: 'My\\Namespace\\MyOtherCommand',
-            CQRSCommand: 'My\\Namespace\\MyCommand',
+            CQRSCommand: self::VALID_COMMAND_CLASS,
         );
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operationInput->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operationInput->getCQRSCommand());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operationInput->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operationInput->getCQRSCommand());
         $this->assertEquals('My\\Namespace\\MyOtherCommand', $operationInput->getInput());
         // Clone value keeps the initial different input value
         $operationInput2 = $operationInput->withCQRSCommand('My\\Namespace\\MyThirdCommand');
@@ -158,7 +165,7 @@ class CQRSCreateTest extends TestCase
         $caughtException = null;
         try {
             new CQRSCreate(
-                extraProperties: ['CQRSCommand' => 'My\\Namespace\\MyCommand'],
+                extraProperties: ['CQRSCommand' => self::VALID_COMMAND_CLASS],
                 CQRSCommand: 'My\\Namespace\\MyOtherCommand',
             );
         } catch (InvalidArgumentException $e) {
@@ -168,6 +175,16 @@ class CQRSCreateTest extends TestCase
         $this->assertNotNull($caughtException);
         $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
         $this->assertEquals('Specifying an extra property CQRSCommand and a CQRSCommand argument that are different is invalid', $caughtException->getMessage());
+
+        // CQRS command parameters in constructor that does not exist is not forced as the input
+        $operation = new CQRSCommand(
+            CQRSCommand: self::INVALID_COMMAND_CLASS,
+        );
+        $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
+        $this->assertNull($operation->getProvider());
+        $this->assertEquals(['CQRSCommand' => self::INVALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::INVALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertNull($operation->getInput());
     }
 
     public function testCQRSQuery(): void

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSPartialUpdateTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSPartialUpdateTest.php
@@ -30,11 +30,18 @@ namespace Tests\Unit\PrestaShopBundle\ApiPlatform\Metadata;
 
 use ApiPlatform\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\AddProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCommand;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
 use PrestaShopBundle\ApiPlatform\Processor\CommandProcessor;
 
 class CQRSPartialUpdateTest extends TestCase
 {
+    public const VALID_COMMAND_CLASS = AddProductCommand::class;
+    public const OTHER_VALID_COMMAND_CLASS = UpdateProductCommand::class;
+    public const INVALID_COMMAND_CLASS = 'My\\Namespace\\MyCommand';
+
     public function testDefaultConstructor(): void
     {
         // Without any parameters
@@ -108,65 +115,65 @@ class CQRSPartialUpdateTest extends TestCase
 
     public function testCQRSCommand(): void
     {
-        // CQRS query parameters in constructor
+        // CQRS command parameters in constructor
         $operation = new CQRSPartialUpdate(
-            CQRSCommand: 'My\\Namespace\\MyCommand',
+            CQRSCommand: self::VALID_COMMAND_CLASS,
         );
         $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
         $this->assertNull($operation->getProvider());
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // Extra properties parameters in constructor
         $operation = new CQRSPartialUpdate(
-            extraProperties: ['CQRSCommand' => 'My\\Namespace\\MyCommand'],
+            extraProperties: ['CQRSCommand' => self::VALID_COMMAND_CLASS],
         );
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // Extra properties AND CQRS query parameters in constructor, both values are equals no problem
         $operation = new CQRSPartialUpdate(
-            extraProperties: ['CQRSCommand' => 'My\\Namespace\\MyCommand'],
-            CQRSCommand: 'My\\Namespace\\MyCommand',
+            extraProperties: ['CQRSCommand' => self::VALID_COMMAND_CLASS],
+            CQRSCommand: self::VALID_COMMAND_CLASS,
         );
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // Use with method, returned object is a clone All values are replaced
-        $operation2 = $operation->withCQRSCommand('My\\Namespace\\MyOtherCommand');
+        $operation2 = $operation->withCQRSCommand(self::OTHER_VALID_COMMAND_CLASS);
         $this->assertNotEquals($operation2, $operation);
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyOtherCommand'], $operation2->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyOtherCommand', $operation2->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyOtherCommand', $operation2->getInput());
+        $this->assertEquals(['CQRSCommand' => self::OTHER_VALID_COMMAND_CLASS], $operation2->getExtraProperties());
+        $this->assertEquals(self::OTHER_VALID_COMMAND_CLASS, $operation2->getCQRSCommand());
+        $this->assertEquals(self::OTHER_VALID_COMMAND_CLASS, $operation2->getInput());
         // Initial operation not modified of course
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // When input is manually specified it is kept over the CQRSCommand
         $operationInput = new CQRSPartialUpdate(
-            input: 'My\\Namespace\\MyOtherCommand',
-            CQRSCommand: 'My\\Namespace\\MyCommand',
+            input: self::OTHER_VALID_COMMAND_CLASS,
+            CQRSCommand: self::VALID_COMMAND_CLASS,
         );
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operationInput->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operationInput->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyOtherCommand', $operationInput->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operationInput->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operationInput->getCQRSCommand());
+        $this->assertEquals(self::OTHER_VALID_COMMAND_CLASS, $operationInput->getInput());
         // Clone value keeps the initial different input value
         $operationInput2 = $operationInput->withCQRSCommand('My\\Namespace\\MyThirdCommand');
         $this->assertNotEquals($operationInput2, $operationInput);
         $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyThirdCommand'], $operationInput2->getExtraProperties());
         $this->assertEquals('My\\Namespace\\MyThirdCommand', $operationInput2->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyOtherCommand', $operationInput2->getInput());
+        $this->assertEquals(self::OTHER_VALID_COMMAND_CLASS, $operationInput2->getInput());
 
         // When both values are specified, but they are different trigger an exception
         $caughtException = null;
         try {
             new CQRSPartialUpdate(
-                extraProperties: ['CQRSCommand' => 'My\\Namespace\\MyCommand'],
-                CQRSCommand: 'My\\Namespace\\MyOtherCommand',
+                extraProperties: ['CQRSCommand' => self::VALID_COMMAND_CLASS],
+                CQRSCommand: self::OTHER_VALID_COMMAND_CLASS,
             );
         } catch (InvalidArgumentException $e) {
             $caughtException = $e;
@@ -175,6 +182,16 @@ class CQRSPartialUpdateTest extends TestCase
         $this->assertNotNull($caughtException);
         $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
         $this->assertEquals('Specifying an extra property CQRSCommand and a CQRSCommand argument that are different is invalid', $caughtException->getMessage());
+
+        // CQRS command parameters in constructor that does not exist is not forced as the input
+        $operation = new CQRSCommand(
+            CQRSCommand: self::INVALID_COMMAND_CLASS,
+        );
+        $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
+        $this->assertNull($operation->getProvider());
+        $this->assertEquals(['CQRSCommand' => self::INVALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::INVALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertNull($operation->getInput());
     }
 
     public function testCQRSQuery(): void

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSUpdateTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSUpdateTest.php
@@ -30,11 +30,18 @@ namespace Tests\Unit\PrestaShopBundle\ApiPlatform\Metadata;
 
 use ApiPlatform\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\AddProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCommand;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
 use PrestaShopBundle\ApiPlatform\Processor\CommandProcessor;
 
 class CQRSUpdateTest extends TestCase
 {
+    public const VALID_COMMAND_CLASS = AddProductCommand::class;
+    public const OTHER_VALID_COMMAND_CLASS = UpdateProductCommand::class;
+    public const INVALID_COMMAND_CLASS = 'My\\Namespace\\MyCommand';
+
     public function testDefaultConstructor(): void
     {
         // Without any parameters
@@ -104,65 +111,65 @@ class CQRSUpdateTest extends TestCase
 
     public function testCQRSCommand(): void
     {
-        // CQRS query parameters in constructor
+        // CQRS command parameters in constructor
         $operation = new CQRSUpdate(
-            CQRSCommand: 'My\\Namespace\\MyCommand',
+            CQRSCommand: self::VALID_COMMAND_CLASS,
         );
         $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
         $this->assertNull($operation->getProvider());
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // Extra properties parameters in constructor
         $operation = new CQRSUpdate(
-            extraProperties: ['CQRSCommand' => 'My\\Namespace\\MyCommand'],
+            extraProperties: ['CQRSCommand' => self::VALID_COMMAND_CLASS],
         );
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // Extra properties AND CQRS query parameters in constructor, both values are equals no problem
         $operation = new CQRSUpdate(
-            extraProperties: ['CQRSCommand' => 'My\\Namespace\\MyCommand'],
-            CQRSCommand: 'My\\Namespace\\MyCommand',
+            extraProperties: ['CQRSCommand' => self::VALID_COMMAND_CLASS],
+            CQRSCommand: self::VALID_COMMAND_CLASS,
         );
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // Use with method, returned object is a clone All values are replaced
-        $operation2 = $operation->withCQRSCommand('My\\Namespace\\MyOtherCommand');
+        $operation2 = $operation->withCQRSCommand(self::OTHER_VALID_COMMAND_CLASS);
         $this->assertNotEquals($operation2, $operation);
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyOtherCommand'], $operation2->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyOtherCommand', $operation2->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyOtherCommand', $operation2->getInput());
+        $this->assertEquals(['CQRSCommand' => self::OTHER_VALID_COMMAND_CLASS], $operation2->getExtraProperties());
+        $this->assertEquals(self::OTHER_VALID_COMMAND_CLASS, $operation2->getCQRSCommand());
+        $this->assertEquals(self::OTHER_VALID_COMMAND_CLASS, $operation2->getInput());
         // Initial operation not modified of course
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operation->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operation->getInput());
 
         // When input is manually specified it is kept over the CQRSCommand
         $operationInput = new CQRSUpdate(
-            input: 'My\\Namespace\\MyOtherCommand',
-            CQRSCommand: 'My\\Namespace\\MyCommand',
+            input: self::OTHER_VALID_COMMAND_CLASS,
+            CQRSCommand: self::VALID_COMMAND_CLASS,
         );
-        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyCommand'], $operationInput->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyCommand', $operationInput->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyOtherCommand', $operationInput->getInput());
+        $this->assertEquals(['CQRSCommand' => self::VALID_COMMAND_CLASS], $operationInput->getExtraProperties());
+        $this->assertEquals(self::VALID_COMMAND_CLASS, $operationInput->getCQRSCommand());
+        $this->assertEquals(self::OTHER_VALID_COMMAND_CLASS, $operationInput->getInput());
         // Clone value keeps the initial different input value
         $operationInput2 = $operationInput->withCQRSCommand('My\\Namespace\\MyThirdCommand');
         $this->assertNotEquals($operationInput2, $operationInput);
         $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyThirdCommand'], $operationInput2->getExtraProperties());
         $this->assertEquals('My\\Namespace\\MyThirdCommand', $operationInput2->getCQRSCommand());
-        $this->assertEquals('My\\Namespace\\MyOtherCommand', $operationInput2->getInput());
+        $this->assertEquals(self::OTHER_VALID_COMMAND_CLASS, $operationInput2->getInput());
 
         // When both values are specified, but they are different trigger an exception
         $caughtException = null;
         try {
             new CQRSUpdate(
-                extraProperties: ['CQRSCommand' => 'My\\Namespace\\MyCommand'],
-                CQRSCommand: 'My\\Namespace\\MyOtherCommand',
+                extraProperties: ['CQRSCommand' => self::VALID_COMMAND_CLASS],
+                CQRSCommand: self::OTHER_VALID_COMMAND_CLASS,
             );
         } catch (InvalidArgumentException $e) {
             $caughtException = $e;
@@ -171,6 +178,16 @@ class CQRSUpdateTest extends TestCase
         $this->assertNotNull($caughtException);
         $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
         $this->assertEquals('Specifying an extra property CQRSCommand and a CQRSCommand argument that are different is invalid', $caughtException->getMessage());
+
+        // CQRS command parameters in constructor that does not exist is not forced as the input
+        $operation = new CQRSCommand(
+            CQRSCommand: self::INVALID_COMMAND_CLASS,
+        );
+        $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
+        $this->assertNull($operation->getProvider());
+        $this->assertEquals(['CQRSCommand' => self::INVALID_COMMAND_CLASS], $operation->getExtraProperties());
+        $this->assertEquals(self::INVALID_COMMAND_CLASS, $operation->getCQRSCommand());
+        $this->assertNull($operation->getInput());
     }
 
     public function testCQRSQuery(): void

--- a/translations/default/AdminActions.xlf
+++ b/translations/default/AdminActions.xlf
@@ -75,7 +75,7 @@
       <trans-unit id="3fa8c89ef63fbb7056fc1d8d1b67f97a">
         <source>Add new product</source>
         <target>Add new product</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1259]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1381]</note>
       </trans-unit>
       <trans-unit id="b1c94ca2fbc3e78fc30069c8d0f01680">
         <source>All</source>
@@ -570,7 +570,7 @@
       <trans-unit id="92a8f0b9d28a89b480bd1d29f46f0484">
         <source>Generator</source>
         <target>Generator</target>
-        <note>File: src/PrestaShopBundle/Twig/Layout/MenuBuilder.php [Line: 238]</note>
+        <note>File: src/PrestaShopBundle/Twig/Layout/MenuBuilder.php [Line: 245]</note>
       </trans-unit>
       <trans-unit id="5f075ae3e1f9d0382bb8c4632991f96f">
         <source>Go</source>
@@ -610,7 +610,7 @@
       <trans-unit id="4ee29ca12c7d126654bd0e5275de6135">
         <source>List</source>
         <target>List</target>
-        <note>File: src/PrestaShopBundle/Twig/Layout/MenuBuilder.php [Line: 208]</note>
+        <note>File: src/PrestaShopBundle/Twig/Layout/MenuBuilder.php [Line: 215]</note>
       </trans-unit>
       <trans-unit id="f19dbf2edb3a0bd74b0524d960ff21eb">
         <source>Load</source>
@@ -635,7 +635,7 @@
       <trans-unit id="dae8ace18bdcbcc6ae5aece263e14fe8">
         <source>Options</source>
         <target>Options</target>
-        <note>File: src/PrestaShopBundle/Twig/Layout/MenuBuilder.php [Line: 233]</note>
+        <note>File: src/PrestaShopBundle/Twig/Layout/MenuBuilder.php [Line: 240]</note>
       </trans-unit>
       <trans-unit id="01fda57aa6c7e9f07f5aa36b108e95cb">
         <source>Order by</source>
@@ -730,7 +730,7 @@
       <trans-unit id="6292ce39a4afe11e8ecfaf95b27ac3fb">
         <source>Search Height</source>
         <target>Search Height</target>
-        <note>File: src/Core/Grid/Definition/Factory/ImageTypeGridDefinitionFactory.php [Line: 236]</note>
+        <note>File: src/Core/Grid/Definition/Factory/ImageTypeGridDefinitionFactory.php [Line: 248]</note>
       </trans-unit>
       <trans-unit id="14b65dabcecbbcb0724ed1efe27c6335">
         <source>Search ID</source>
@@ -745,12 +745,12 @@
       <trans-unit id="7c480b91e2c6ef389674bec0e31458e5">
         <source>Search Name</source>
         <target>Search Name</target>
-        <note>File: src/Core/Grid/Definition/Factory/ImageTypeGridDefinitionFactory.php [Line: 216]</note>
+        <note>File: src/Core/Grid/Definition/Factory/ImageTypeGridDefinitionFactory.php [Line: 228]</note>
       </trans-unit>
       <trans-unit id="1d85b1967f24e16f6517f005918c5f2c">
         <source>Search Width</source>
         <target>Search Width</target>
-        <note>File: src/Core/Grid/Definition/Factory/ImageTypeGridDefinitionFactory.php [Line: 226]</note>
+        <note>File: src/Core/Grid/Definition/Factory/ImageTypeGridDefinitionFactory.php [Line: 238]</note>
       </trans-unit>
       <trans-unit id="e3ff649d2ad58aafa4adee523917e380">
         <source>Search address</source>

--- a/translations/default/AdminAdvparametersFeature.xlf
+++ b/translations/default/AdminAdvparametersFeature.xlf
@@ -260,7 +260,7 @@
       <trans-unit id="775a3ab6add326ef93f2382f49f9e500">
         <source>Attribute groups</source>
         <target>Attribute groups</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 589]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 616]</note>
       </trans-unit>
       <trans-unit id="fdab87b387380c9bac4c542c90f1ce24">
         <source>Available fields</source>
@@ -280,7 +280,7 @@
       <trans-unit id="cf173b732a2a0377698d631db6185836">
         <source>Available quantities for sale</source>
         <target>Available quantities for sale</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 586]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 613]</note>
       </trans-unit>
       <trans-unit id="b1897515d548a960afe49ecf66a29021">
         <source>Average</source>
@@ -370,7 +370,7 @@
       <trans-unit id="3b8c8bf8ab2226d5a44454a20ad7fafb">
         <source>Cart rules</source>
         <target>Cart rules</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 595]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 622]</note>
       </trans-unit>
       <trans-unit id="e5bfab8b7f97b8f0b19ad7e393d7c566">
         <source>Catalog price rules</source>
@@ -390,7 +390,7 @@
       <trans-unit id="e91dd9bbca6e42bb85c0f2d94aaee995">
         <source>Check your configuration</source>
         <target>Check your configuration</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 200]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 201]</note>
       </trans-unit>
       <trans-unit id="657645fae83ad1673b25d3c027b77ed8">
         <source>Choose among product images by position (1,2,3...)</source>
@@ -400,7 +400,7 @@
       <trans-unit id="1d92a46c4e14c43c3096d85c9f26fc4e">
         <source>Choose data to import</source>
         <target>Choose data to import</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 627]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 654]</note>
       </trans-unit>
       <trans-unit id="b70c07744607bb44ce5a520716a7f8ed">
         <source>Choose from history / FTP</source>
@@ -410,7 +410,7 @@
       <trans-unit id="80f6b81a57a2d0130fc0c998a03d3cf9">
         <source>Choose the source store</source>
         <target>Choose the source store</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 619]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 646]</note>
       </trans-unit>
       <trans-unit id="dc30bc0c7914db5918da4263fce93ad2">
         <source>Clear</source>
@@ -475,7 +475,7 @@
       <trans-unit id="5e3d6d040d8a81befd75127d526646bc">
         <source>Contact information</source>
         <target>Contact information</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 573]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 600]</note>
       </trans-unit>
       <trans-unit id="57c6b2481e04c5d88b6b54e7b7167554">
         <source>Cookie SameSite</source>
@@ -500,7 +500,7 @@
       <trans-unit id="b5b3eed3efd6cfebfea270066a1e1f9b">
         <source>Current theme in use:</source>
         <target>Current theme in use:</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 140]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 141]</note>
       </trans-unit>
       <trans-unit id="d37c2bf1bd3143847fca087b354f920e">
         <source>Customer ID</source>
@@ -605,7 +605,7 @@
       <trans-unit id="c4e9522d7b3c8c652f7f0333ff436eec">
         <source>Defined</source>
         <target>Defined</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 172]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 173]</note>
       </trans-unit>
       <trans-unit id="6c0c2b9ec9a4188db4cfd4f8a0fee415">
         <source>Delete (DELETE)</source>
@@ -670,7 +670,7 @@
       <trans-unit id="a66b5528ae08e780a5df59ae913c66e7">
         <source>Discount prices</source>
         <target>Discount prices</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 576]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 603]</note>
       </trans-unit>
       <trans-unit id="48d6c0804dd92fb5463bba154a8a747f">
         <source>Discount to (yyyy-mm-dd)</source>
@@ -775,7 +775,7 @@
       <trans-unit id="8a7363b823dce00b3b1b7e62ca1d777d">
         <source>Encryption:</source>
         <target>Encryption:</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 178]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 179]</note>
       </trans-unit>
       <trans-unit id="b482b125161bc9e84d12df83251ebf2d">
         <source>Enter a password between %d and %d characters</source>
@@ -925,7 +925,7 @@
       <trans-unit id="c8cfbbbe4253e14390b2b14d7e60d9c8">
         <source>Import data</source>
         <target>Import data</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 612]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 639]</note>
       </trans-unit>
       <trans-unit id="99104e1966b34f0320d33c5892946a82">
         <source>Import data from another shop</source>
@@ -1005,7 +1005,7 @@
       <trans-unit id="d5c0bb5c1df152c6fe45bd07e303cb69">
         <source>List of changed files</source>
         <target>List of changed files</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 248]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 249]</note>
       </trans-unit>
       <trans-unit id="060925963c8da7da85dde6013ee4998b">
         <source>List of overrides</source>
@@ -1040,12 +1040,12 @@
       <trans-unit id="4e37aa2987c0876f7f7b2104927df1a1">
         <source>Mail configuration</source>
         <target>Mail configuration</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 147]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 148]</note>
       </trans-unit>
       <trans-unit id="aee55e0ed7a06f68ed5e13f235a8bfd8">
         <source>Mail method:</source>
         <target>Mail method:</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 156]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 157]</note>
       </trans-unit>
       <trans-unit id="0cb76cb9ab6f7b3a35122d6a3ef65da5">
         <source>Manage your team</source>
@@ -1140,7 +1140,7 @@
       <trans-unit id="f71429893913cde74dcacde3d283626e">
         <source>Meta information</source>
         <target>Meta information</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 583]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 610]</note>
       </trans-unit>
       <trans-unit id="ac0b7d0703609cbbfa09b53f8d793d29">
         <source>Minimal quantity</source>
@@ -1175,7 +1175,7 @@
       <trans-unit id="b71593973c58bb41eb302d037f6b1230">
         <source>Module hooks</source>
         <target>Module hooks</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 582]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 609]</note>
       </trans-unit>
       <trans-unit id="bf17ac149e2e7a530c677e9bd51d3fd2">
         <source>Modules</source>
@@ -1320,7 +1320,7 @@
       <trans-unit id="f8b1369a8e9d90da0cae0b11049309af">
         <source>Not defined</source>
         <target>Not defined</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 174]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 175]</note>
       </trans-unit>
       <trans-unit id="3b0649c72650c313a357338dcdfb64ec">
         <source>Note</source>
@@ -1360,7 +1360,7 @@
       <trans-unit id="0297eee5a43818dda6ad1e1b36f08965">
         <source>Optional parameters:</source>
         <target>Optional parameters:</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 229]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 230]</note>
       </trans-unit>
       <trans-unit id="0133c7a0fa55069df27f8d9be2c6ab89">
         <source>Order states</source>
@@ -1480,7 +1480,7 @@
       <trans-unit id="4ae24b703273d53941a17737bb2b1a9a">
         <source>Product combinations</source>
         <target>Product combinations</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 585]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 612]</note>
       </trans-unit>
       <trans-unit id="21f7b5b011f253b35340528b7f190282">
         <source>Product creation date</source>
@@ -1550,7 +1550,7 @@
       <trans-unit id="a3810ddb5a67e550cb3ca9c1cffce800">
         <source>Required parameters:</source>
         <target>Required parameters:</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 210]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 211]</note>
       </trans-unit>
       <trans-unit id="fc51ea2f3761abe2201b06a33f75748e">
         <source>Reversed words aren't much harder to guess</source>
@@ -1585,12 +1585,12 @@
       <trans-unit id="037373672dd4a89426144d40f2e8ad91">
         <source>SMTP password:</source>
         <target>SMTP password:</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 170]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 171]</note>
       </trans-unit>
       <trans-unit id="599303a627bf19148eedd5fe29112729">
         <source>SMTP port:</source>
         <target>SMTP port:</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 181]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 182]</note>
       </trans-unit>
       <trans-unit id="bdd48fb41b9d0a4a1051fa22a87eb5a2">
         <source>SMTP server</source>
@@ -1600,7 +1600,7 @@
       <trans-unit id="33b3f142e242a624cb69a5f5f689039d">
         <source>SMTP server:</source>
         <target>SMTP server:</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 159]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 160]</note>
       </trans-unit>
       <trans-unit id="a7bfd8847270913b15396380c3627d76">
         <source>SMTP username</source>
@@ -1610,7 +1610,7 @@
       <trans-unit id="5489d25adfc42d3aadcb90b679405bda">
         <source>SMTP username:</source>
         <target>SMTP username:</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 162]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 163]</note>
       </trans-unit>
       <trans-unit id="dddc702fcffceb2ac77291954897d747">
         <source>SQL query</source>
@@ -1765,12 +1765,12 @@
       <trans-unit id="76c01eed328aa2411b18f007c77d2eeb">
         <source>Shop URL:</source>
         <target>Shop URL:</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 134]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 135]</note>
       </trans-unit>
       <trans-unit id="24c5ec8e15ae9467ee0f820610512d67">
         <source>Shop path:</source>
         <target>Shop path:</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 137]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 138]</note>
       </trans-unit>
       <trans-unit id="bed5e315d09dedac517831b95571a7f4">
         <source>Short keyboard patterns are easy to guess</source>
@@ -1860,7 +1860,7 @@
       <trans-unit id="d38c99665bd92e632c7ad19e47d1222d">
         <source>Store groups list</source>
         <target>Store groups list</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 895]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 922]</note>
       </trans-unit>
       <trans-unit id="3aea774cdcd8f2c45549f10758a71323">
         <source>Store information</source>
@@ -1930,7 +1930,7 @@
       <trans-unit id="6fab199dbf5a4155871fb0d5dbfa9827">
         <source>Tax rules groups</source>
         <target>Tax rules groups</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 592]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 619]</note>
       </trans-unit>
       <trans-unit id="278c491bdd8a53618c149c4ac790da34">
         <source>Template</source>
@@ -2137,7 +2137,7 @@
       <trans-unit id="339b1acb0d1f26923dc4545a9f749ab3">
         <source>Webservice accounts</source>
         <target>Webservice accounts</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 588]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 615]</note>
       </trans-unit>
       <trans-unit id="2ab627ad288e54ed2712f137ceb37a37">
         <source>Webservice is enabled. Main entry point is</source>
@@ -2182,12 +2182,12 @@
       <trans-unit id="0398efcdf22e008d4ab53cc6eeab7a71">
         <source>You are using /usr/sbin/sendmail</source>
         <target>You are using /usr/sbin/sendmail</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 152]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 153]</note>
       </trans-unit>
       <trans-unit id="cffa72aaebae1bd90bbe1b8d827ecb1c">
         <source>You are using your own SMTP parameters.</source>
         <target>You are using your own SMTP parameters.</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 156]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 157]</note>
       </trans-unit>
       <trans-unit id="2d29e91503465ed72170623f37458e32">
         <source>You must enter another domain, or subdomain, in order to use cookieless static content.</source>
@@ -2202,12 +2202,12 @@
       <trans-unit id="8746097684bc64be8b7eff424c4debdb">
         <source>Your information</source>
         <target>Your information</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 189]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 190]</note>
       </trans-unit>
       <trans-unit id="11eb3e792866d1433dd4ca9d7e49b5ac">
         <source>Your web browser:</source>
         <target>Your web browser:</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 193]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 194]</note>
       </trans-unit>
       <trans-unit id="2c111a587b8e6a65856ac7933d76bdce">
         <source>megabytes</source>

--- a/translations/default/AdminAdvparametersHelp.xlf
+++ b/translations/default/AdminAdvparametersHelp.xlf
@@ -135,17 +135,17 @@
       <trans-unit id="d916f5b0696f10712fad55220707fab9">
         <source>Click here to display the URLs of the %name% shop</source>
         <target>Click here to display the URLs of the %name% shop</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 847]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 874]</note>
       </trans-unit>
       <trans-unit id="01af4d9c4808ce3ccd662c0e5ef7f203">
         <source>Click here to display the list of shop groups</source>
         <target>Click here to display the list of shop groups</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 899]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 926]</note>
       </trans-unit>
       <trans-unit id="41ff4b3ea277bdc597fce74850a85510">
         <source>Click here to display the shops in the %name% shop group</source>
         <target>Click here to display the shops in the %name% shop group</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 825]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 852]</note>
       </trans-unit>
       <trans-unit id="7dda1e48a0dcceda4b3e9ce35271cc2c">
         <source>Click on "None" to disable log alerts by email or enter the recipients of these emails in the following field.</source>
@@ -574,7 +574,7 @@
       <trans-unit id="c127560c7252928dc38d9a0ebf312ba4">
         <source>Use this option to associate data (products, modules, etc.) the same way for each selected shop.</source>
         <target>Use this option to associate data (products, modules, etc.) the same way for each selected shop.</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 630]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 657]</note>
       </trans-unit>
       <trans-unit id="0eaadb4fcb48a0a0ed7bc9868be9fbaa">
         <source>Warning</source>

--- a/translations/default/AdminAdvparametersNotification.xlf
+++ b/translations/default/AdminAdvparametersNotification.xlf
@@ -195,12 +195,12 @@
       <trans-unit id="c49d6d58d1c98f34a15bbd169f82961a">
         <source>Changed/missing files have been detected.</source>
         <target>Changed/missing files have been detected.</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 261]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 262]</note>
       </trans-unit>
       <trans-unit id="d5df5b42d8fa5fed36fbd1cda0112f40">
         <source>Checking files...</source>
         <target>Checking files...</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 251]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 252]</note>
       </trans-unit>
       <trans-unit id="726f1a9982e9ced2818f72090683e077">
         <source>Configure your server to allow file uploads.</source>
@@ -435,7 +435,7 @@
       <trans-unit id="a2db667abfde7a08ee094d460102f268">
         <source>Missing files</source>
         <target>Missing files</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 259]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 260]</note>
       </trans-unit>
       <trans-unit id="804206afa5249349d8bfea4cc78c48d7">
         <source>Never restore a backup on a live site.</source>
@@ -450,7 +450,7 @@
       <trans-unit id="4757718002cbae6feee5c372b66b6a29">
         <source>No change has been detected in your files.</source>
         <target>No change has been detected in your files.</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 262]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 263]</note>
       </trans-unit>
       <trans-unit id="8c9067e52e4440d8a20e74fdc745b0c6">
         <source>No file was uploaded.</source>
@@ -480,7 +480,7 @@
       <trans-unit id="e0aa021e21dddbd6d8cecec71e9cf564">
         <source>OK</source>
         <target>OK</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 225]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 226]</note>
       </trans-unit>
       <trans-unit id="2cb84ea6e832a3190d3ad11a3e1f415c">
         <source>Only non-accented characters, numbers, and the following special characters are allowed: %allowed_characters%</source>
@@ -495,7 +495,7 @@
       <trans-unit id="2ad1ffcbe2184ed25baa66baece8908b">
         <source>Please fix the following error(s)</source>
         <target>Please fix the following error(s)</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 230]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 231]</note>
       </trans-unit>
       <trans-unit id="0869c85782ee2481b83a9f580a09e963">
         <source>PrestaShop is not responsible for your database, its backups and/or recovery.</source>
@@ -860,7 +860,7 @@
       <trans-unit id="b5871613cbf4ab8b21d528ff2576fcbf">
         <source>Updated files</source>
         <target>Updated files</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 260]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig [Line: 261]</note>
       </trans-unit>
       <trans-unit id="6e17621d481059924339f91ed431a116">
         <source>Validating data...</source>
@@ -930,7 +930,7 @@
       <trans-unit id="cf52c411b5659457074fd9962435307f">
         <source>You need to select at least the root category.</source>
         <target>You need to select at least the root category.</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 696]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 723]</note>
       </trans-unit>
       <trans-unit id="99c8acd81f347dd6268fda9bf9e61b97">
         <source>You should back up your data on a regular basis (both files and database).</source>

--- a/translations/default/AdminCatalogFeature.xlf
+++ b/translations/default/AdminCatalogFeature.xlf
@@ -450,7 +450,7 @@
       <trans-unit id="1379a6b19242372c1f23cc9adedfcdd6">
         <source>Category root</source>
         <target>Category root</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 490]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 517]</note>
       </trans-unit>
       <trans-unit id="4ae362f049719078c429941bed5dd440">
         <source>Category thumbnail</source>
@@ -1710,7 +1710,7 @@
       <trans-unit id="77eb276f5dcdf4fbca854e908216f7b2">
         <source>Price (tax incl.)</source>
         <target>Price (tax incl.)</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 770]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 841]</note>
       </trans-unit>
       <trans-unit id="9d20a93036ba910dd75ffbcec173798e">
         <source>Price per unit</source>
@@ -1985,7 +1985,7 @@
       <trans-unit id="a4838f49c5701e128d7695c3dc45083c">
         <source>Select a store</source>
         <target>Select a store</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1493]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1615]</note>
       </trans-unit>
       <trans-unit id="ba7144e008dfcd7a273108647d7d5153">
         <source>Select all values ({valuesNb})</source>

--- a/translations/default/AdminCatalogNotification.xlf
+++ b/translations/default/AdminCatalogNotification.xlf
@@ -115,7 +115,7 @@
       <trans-unit id="b49b6a333fc4422d8fbfad546c47b97c">
         <source>Error for product %product_id%: %error_message%</source>
         <target>Error for product %product_id%: %error_message%</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1362]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1484]</note>
       </trans-unit>
       <trans-unit id="8a23b9ee3a4502a0de3fc32c5ba7aa65">
         <source>Failed to copy the file.</source>
@@ -400,7 +400,7 @@
       <trans-unit id="323970e84c7dc4bc7432a513f09959b6">
         <source>To put this product online, please enter a name.</source>
         <target>To put this product online, please enter a name.</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1410]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1532]</note>
       </trans-unit>
       <trans-unit id="60df675f17670057ec657783db03d35e">
         <source>Unable to resize one or more of your pictures.</source>
@@ -420,7 +420,7 @@
       <trans-unit id="ee5c982526f2e7b8e72b282dc590aafd">
         <source>When redirecting towards a product you must select a target product.</source>
         <target>When redirecting towards a product you must select a target product.</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1405]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1527]</note>
       </trans-unit>
       <trans-unit id="b50f440e3c9f14988bd0086683e77095">
         <source>You cannot remove this category because one of your shops uses it as a root category.</source>
@@ -430,12 +430,12 @@
       <trans-unit id="30a367ba686890c829937e768d588b8f">
         <source>You cannot set 0 or a negative position, the minimum is 1.</source>
         <target>You cannot set 0 or a negative position, the minimum is 1.</target>
-        <note>File: classes/Product.php [Line: 6849]</note>
+        <note>File: classes/Product.php [Line: 6860]</note>
       </trans-unit>
       <trans-unit id="cf99dad7d7306d9ac01ba5a2e2d2c715">
         <source>You cannot set a position greater than the total number of products in the category, starting at 1.</source>
         <target>You cannot set a position greater than the total number of products in the category, starting at 1.</target>
-        <note>File: classes/Product.php [Line: 6870]</note>
+        <note>File: classes/Product.php [Line: 6881]</note>
       </trans-unit>
       <trans-unit id="e602c06958cd934ccc238913f51282aa">
         <source>You must select some products before</source>

--- a/translations/default/AdminDesignFeature.xlf
+++ b/translations/default/AdminDesignFeature.xlf
@@ -305,7 +305,7 @@
       <trans-unit id="453aceb005ceaf54a47da15fee8b2a26">
         <source>Pages</source>
         <target>Pages</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 572]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 599]</note>
       </trans-unit>
       <trans-unit id="1f6162e1430a8d5020bf4c20dc02499f">
         <source>Pages in category "%name%"</source>
@@ -390,7 +390,7 @@
       <trans-unit id="d721757161f7f70c5b0949fdb6ec2c30">
         <source>Theme</source>
         <target>Theme</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 555]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 582]</note>
       </trans-unit>
       <trans-unit id="8ed22009aa8884b512b3e3a85d1aeb87">
         <source>Theme to adapt</source>

--- a/translations/default/AdminGlobal.xlf
+++ b/translations/default/AdminGlobal.xlf
@@ -45,7 +45,7 @@
       <trans-unit id="e99ebe78e30bf7cb8286aea720bb4ac6">
         <source>(deleted)</source>
         <target>(deleted)</target>
-        <note>File: src/Core/Form/ChoiceProvider/OrderStateByIdChoiceProvider.php [Line: 113]</note>
+        <note>File: src/Core/Form/ChoiceProvider/OrderStateByIdChoiceProvider.php [Line: 140]</note>
       </trans-unit>
       <trans-unit id="21034ae6d01a83e702839a72ba8a77b0">
         <source>(tax excl.)</source>
@@ -650,7 +650,7 @@
       <trans-unit id="703ddad7cc7f884b4ebf6b79dac842e6">
         <source>Edit color</source>
         <target>Edit color</target>
-        <note>File: src/PrestaShopBundle/Resources/views/Admin/Component/Layout/multistore_header.html.twig [Line: 102]</note>
+        <note>File: src/PrestaShopBundle/Resources/views/Admin/Component/Layout/multistore_header.html.twig [Line: 104]</note>
       </trans-unit>
       <trans-unit id="7f1db674f32b8f6d6795d6abe0d9e941">
         <source>Edit specific price</source>
@@ -1621,6 +1621,11 @@
         <source>Texture</source>
         <target>Texture</target>
         <note>File: src/PrestaShopBundle/Form/Admin/Sell/Catalog/AttributeType.php [Line: 118]</note>
+      </trans-unit>
+      <trans-unit id="d721757161f7f70c5b0949fdb6ec2c30">
+        <source>Theme</source>
+        <target>Theme</target>
+        <note>File: src/Core/Grid/Definition/Factory/ImageTypeGridDefinitionFactory.php [Line: 95]</note>
       </trans-unit>
       <trans-unit id="b78a3223503896721cca1303f776159b">
         <source>Title</source>

--- a/translations/default/AdminLoginFeature.xlf
+++ b/translations/default/AdminLoginFeature.xlf
@@ -40,7 +40,7 @@
       <trans-unit id="bfb30c807cd2ae0ece3a44d2e8cbf74d">
         <source>You have been logged out for security reasons</source>
         <target>You have been logged out for security reasons</target>
-        <note>File: src/PrestaShopBundle/EventListener/Admin/EmployeeSessionSubscriber.php [Line: 221]</note>
+        <note>File: src/PrestaShopBundle/EventListener/Admin/EmployeeSessionSubscriber.php [Line: 227]</note>
       </trans-unit>
     </body>
   </file>

--- a/translations/default/AdminNavigationMenu.xlf
+++ b/translations/default/AdminNavigationMenu.xlf
@@ -460,7 +460,7 @@
       <trans-unit id="4c99c66c65d5cc7f1c5ef76302aa9988">
         <source>Image Settings</source>
         <target>Image Settings</target>
-        <note>File: src/Core/Grid/Definition/Factory/ImageTypeGridDefinitionFactory.php [Line: 70]</note>
+        <note>File: src/Core/Grid/Definition/Factory/ImageTypeGridDefinitionFactory.php [Line: 71]</note>
       </trans-unit>
       <trans-unit id="fff0d600f8a0b5e19e88bfb821dd1157">
         <source>Images</source>
@@ -875,7 +875,7 @@
       <trans-unit id="068f80c7519d0528fb08e82137a72131">
         <source>Products</source>
         <target>Products</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 160]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 161]</note>
       </trans-unit>
       <trans-unit id="4f32a32dea642737580dd71cdfd8d3c0">
         <source>Quick Access</source>

--- a/translations/default/AdminNotificationsError.xlf
+++ b/translations/default/AdminNotificationsError.xlf
@@ -15,7 +15,7 @@
       <trans-unit id="0fec856489067e4d21aa315324c441dc">
         <source>%1$s is too long. Maximum length: %2$d</source>
         <target>%1$s is too long. Maximum length: %2$d</target>
-        <note>File: classes/ObjectModel.php [Line: 1215]</note>
+        <note>File: classes/ObjectModel.php [Line: 1218]</note>
       </trans-unit>
       <trans-unit id="ecdb1f330299c20ac9897cd73f92c8cd">
         <source>%1$s on line %2$s in file %3$s</source>
@@ -155,7 +155,7 @@
       <trans-unit id="d9b5b2302d57f3d13d5387ba9c99daae">
         <source>An error occurred while creating an object.</source>
         <target>An error occurred while creating an object.</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 713]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 740]</note>
       </trans-unit>
       <trans-unit id="7f290594963a303db17a5e21dc4cf0b7">
         <source>An error occurred while deleting the object.</source>
@@ -205,12 +205,12 @@
       <trans-unit id="e8ae00af8575f645bf6e4358f120cba3">
         <source>An unexpected error occurred. [%type% code %code%]</source>
         <target>An unexpected error occurred. [%type% code %code%]</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/PrestaShopAdminController.php [Line: 240]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/PrestaShopAdminController.php [Line: 274]</note>
       </trans-unit>
       <trans-unit id="5ab1978ae9ce868183a34316327be062">
         <source>An unexpected error occurred. [%type% code %code%]: %message%</source>
         <target>An unexpected error occurred. [%type% code %code%]: %message%</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/PrestaShopAdminController.php [Line: 229]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/PrestaShopAdminController.php [Line: 263]</note>
       </trans-unit>
       <trans-unit id="fa7f44fdd62689c43d0f8f372ce5d1e5">
         <source>Attribute color is invalid </source>
@@ -226,6 +226,26 @@
         <source>Attribute name is invalid</source>
         <target>Attribute name is invalid</target>
         <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeController.php [Line: 358]</note>
+      </trans-unit>
+      <trans-unit id="e332bf6bafc5d3dc35a650b13e169728">
+        <source>Authorization not allowed for all stores.</source>
+        <target>Authorization not allowed for all stores.</target>
+        <note>File: src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php [Line: 280]</note>
+      </trans-unit>
+      <trans-unit id="6e338cdc7323a043140583ef4d6555cd">
+        <source>Authorization not allowed for this group of stores.</source>
+        <target>Authorization not allowed for this group of stores.</target>
+        <note>File: src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php [Line: 292]</note>
+      </trans-unit>
+      <trans-unit id="4a907d14cc0943cc2d44515f07267f18">
+        <source>Authorization not allowed for this store context.</source>
+        <target>Authorization not allowed for this store context.</target>
+        <note>File: src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php [Line: 298]</note>
+      </trans-unit>
+      <trans-unit id="96a01e03fa91cafcf72ee464ee7b718e">
+        <source>Authorization not allowed for this store.</source>
+        <target>Authorization not allowed for this store.</target>
+        <note>File: src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php [Line: 286]</note>
       </trans-unit>
       <trans-unit id="ee77ea46b0c548ed60eadf31bdd68613">
         <source>Bad SQL query</source>
@@ -370,7 +390,7 @@
       <trans-unit id="355f26b47eff3302c93a1c49676f078e">
         <source>Fatal error</source>
         <target>Fatal error</target>
-        <note>File: classes/Tools.php [Line: 1019]</note>
+        <note>File: classes/Tools.php [Line: 1026]</note>
       </trans-unit>
       <trans-unit id="bcfa9fd034fffbe5aa1a9c9e306386f1">
         <source>Fatal error: The module directory does not exist.</source>
@@ -625,27 +645,27 @@
       <trans-unit id="95be38fc18a46111194e2cba0649504a">
         <source>Product price is invalid</source>
         <target>Product price is invalid</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1395]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1517]</note>
       </trans-unit>
       <trans-unit id="b64b49fceb6719b964e08084a3997eba">
         <source>Product price per unit is invalid</source>
         <target>Product price per unit is invalid</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1400]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1522]</note>
       </trans-unit>
       <trans-unit id="872d428c40b36bba9fc5fafaa76c6f22">
         <source>Property %1$s has a bad value (allowed values are: %2$s).</source>
         <target>Property %1$s has a bad value (allowed values are: %2$s).</target>
-        <note>File: classes/ObjectModel.php [Line: 1072]</note>
+        <note>File: classes/ObjectModel.php [Line: 1075]</note>
       </trans-unit>
       <trans-unit id="fed3c8d832129d27b64c34fe410e7346">
         <source>Property %s is empty.</source>
         <target>Property %s is empty.</target>
-        <note>File: classes/ObjectModel.php [Line: 1058]</note>
+        <note>File: classes/ObjectModel.php [Line: 1061]</note>
       </trans-unit>
       <trans-unit id="6938fc7c0e5b0b07a6ba370bcb84bbd3">
         <source>Property %s is not valid</source>
         <target>Property %s is not valid</target>
-        <note>File: classes/ObjectModel.php [Line: 1146]</note>
+        <note>File: classes/ObjectModel.php [Line: 1149]</note>
       </trans-unit>
       <trans-unit id="2fe13fdedc51b372d555f49493993a7e">
         <source>Reduction value "%value%" is invalid. Allowed values from 0 to %max%</source>
@@ -830,7 +850,7 @@
       <trans-unit id="2674ff1d6f5ff826dae13cd4db1ca9b0">
         <source>The length of property %1$s is currently %2$d chars. It must be between %3$d and %4$d chars.</source>
         <target>The length of property %1$s is currently %2$d chars. It must be between %3$d and %4$d chars.</target>
-        <note>File: classes/ObjectModel.php [Line: 1095]</note>
+        <note>File: classes/ObjectModel.php [Line: 1098]</note>
       </trans-unit>
       <trans-unit id="c2c0814b9cbcdf57b426000de541d20f">
         <source>The object cannot be loaded (or found).</source>
@@ -865,12 +885,12 @@
       <trans-unit id="36fa50f9470229a5409dead853a3ad60">
         <source>The range of property %1$s is currently %2$d. It must be between %3$d and %4$d.</source>
         <target>The range of property %1$s is currently %2$d. It must be between %3$d and %4$d.</target>
-        <note>File: classes/ObjectModel.php [Line: 1113]</note>
+        <note>File: classes/ObjectModel.php [Line: 1116]</note>
       </trans-unit>
       <trans-unit id="cc8f0fe2d629bd1810331b1a265914ec">
         <source>The selected condition must be different in each field to set an order of priority.</source>
         <target>The selected condition must be different in each field to set an order of priority.</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1427]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1549]</note>
       </trans-unit>
       <trans-unit id="8f29c70fd66f50ce28b727cd40c6a3a3">
         <source>The selected date range is not valid.</source>
@@ -885,7 +905,7 @@
       <trans-unit id="1348633590e241b276cdbb7ceaeb8295">
         <source>The selected value belongs to another feature.</source>
         <target>The selected value belongs to another feature.</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1421]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1543]</note>
       </trans-unit>
       <trans-unit id="ae8e757923a42d666e5c0fdf59fda545">
         <source>The uploaded file exceeds %s</source>
@@ -1020,7 +1040,7 @@
       <trans-unit id="a7eca295291f53a23ab7ba0a9c7fd9de">
         <source>This functionality has been disabled.</source>
         <target>This functionality has been disabled.</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/PrestaShopAdminController.php [Line: 400]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/PrestaShopAdminController.php [Line: 455]</note>
       </trans-unit>
       <trans-unit id="a3084b5f93d22e573824af3ca8f58b73">
         <source>This key has already been used.</source>
@@ -1040,7 +1060,7 @@
       <trans-unit id="9ddbf7ca8d42128f5a6875b6b90252f7">
         <source>This product cannot be changed into a pack because it is already associated to another pack.</source>
         <target>This product cannot be changed into a pack because it is already associated to another pack.</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1434]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1556]</note>
       </trans-unit>
       <trans-unit id="5b5d79a83148583db9a987bc0dbb6265">
         <source>This product is already in the invoice [1], please edit the quantity instead.</source>
@@ -1105,7 +1125,7 @@
       <trans-unit id="1448270fc6dbabe70584c87fa27cc96f">
         <source>Validation function not found: %s.</source>
         <target>Validation function not found: %s.</target>
-        <note>File: classes/ObjectModel.php [Line: 1128]</note>
+        <note>File: classes/ObjectModel.php [Line: 1131]</note>
       </trans-unit>
       <trans-unit id="7b59b1211b3e9edf7619901949bce29b">
         <source>Value cannot be 0.</source>
@@ -1115,7 +1135,7 @@
       <trans-unit id="cc360e6a888c0d7ff56efeff9e7dab9f">
         <source>You cannot associate the same feature value more than once.</source>
         <target>You cannot associate the same feature value more than once.</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1416]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1538]</note>
       </trans-unit>
       <trans-unit id="d2de9e264ff4f0e711d809f00da76e45">
         <source>You cannot change a main URL to a non-main URL. You have to set another URL as your Main URL for the selected shop.</source>
@@ -1230,7 +1250,7 @@
       <trans-unit id="9599d22695068a773c0f10ea1fd26a74">
         <source>Your entry in field %1$s (language %2$s) exceeds max length %3$d chars (incl. html tags).</source>
         <target>Your entry in field %1$s (language %2$s) exceeds max length %3$d chars (incl. html tags).</target>
-        <note>File: classes/ObjectModel.php [Line: 1089]</note>
+        <note>File: classes/ObjectModel.php [Line: 1092]</note>
       </trans-unit>
       <trans-unit id="2b73839c76b07fdd994e444e0c7e75ad">
         <source>Your uploaded file might exceed the [1]upload_max_filesize[/1] and the [1]post_max_size[/1] directives in [1]php.ini[/1], please check your server configuration.</source>
@@ -1260,7 +1280,7 @@
       <trans-unit id="ee66f9c9930cb33d2a5dde9b240d3f7e">
         <source>is required.</source>
         <target>is required.</target>
-        <note>File: classes/ObjectModel.php [Line: 1208]</note>
+        <note>File: classes/ObjectModel.php [Line: 1211]</note>
       </trans-unit>
     </body>
   </file>

--- a/translations/default/AdminNotificationsInfo.xlf
+++ b/translations/default/AdminNotificationsInfo.xlf
@@ -90,17 +90,22 @@
       <trans-unit id="0269f018a765e0d969747a1871c109a1">
         <source>This page is only compatible in a single-store context. Please select a store in the multistore header.</source>
         <target>This page is only compatible in a single-store context. Please select a store in the multistore header.</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1474]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1596]</note>
       </trans-unit>
       <trans-unit id="d522a12a111ad26cc15c16da99cebef6">
         <source>This product is not associated with the store selected in the multistore header, please select another one.</source>
         <target>This product is not associated with the store selected in the multistore header, please select another one.</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1457]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1579]</note>
       </trans-unit>
       <trans-unit id="cf302b9739d595c09a469b014afff252">
         <source>This secret value will only be displayed once. Don't forget to make a copy in a secure location.</source>
         <target>This secret value will only be displayed once. Don't forget to make a copy in a secure location.</target>
         <note>File: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdminAPIController.php [Line: 255]</note>
+      </trans-unit>
+      <trans-unit id="e9df95cdd14a4718719f351af1b50d46">
+        <source>You have been automatically switched to your default store.</source>
+        <target>You have been automatically switched to your default store.</target>
+        <note>File: src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php [Line: 151]</note>
       </trans-unit>
     </body>
   </file>

--- a/translations/default/AdminNotificationsSuccess.xlf
+++ b/translations/default/AdminNotificationsSuccess.xlf
@@ -65,7 +65,7 @@
       <trans-unit id="63cca4f457cad586dc9495a2e671b745">
         <source>Successful duplication</source>
         <target>Successful duplication</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1202]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 1324]</note>
       </trans-unit>
       <trans-unit id="d4eab6753f9f3d4b57580427264beaa6">
         <source>Successful update</source>
@@ -185,7 +185,7 @@
       <trans-unit id="b33f41d62d6358d2af05d739ac193889">
         <source>Your store context has been automatically modified.</source>
         <target>Your store context has been automatically modified.</target>
-        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 467]</note>
+        <note>File: src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php [Line: 468]</note>
       </trans-unit>
       <trans-unit id="e27a3fee7c315373637c37dc3d62811d">
         <source>Your symbol and format customizations have been successfully reset for this language.</source>

--- a/translations/default/AdminShopparametersFeature.xlf
+++ b/translations/default/AdminShopparametersFeature.xlf
@@ -676,7 +676,7 @@ Customer service</target>
       <trans-unit id="f6b1039cb72d674bc7b90f98c2a982d2">
         <source>It will only be applied to the multistore header to highlight your shop context.</source>
         <target>It will only be applied to the multistore header to highlight your shop context.</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 436]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 463]</note>
       </trans-unit>
       <trans-unit id="fb374d62bc0877340fc4aa056ae01550">
         <source>It will only be applied to this group of shops, each store will keep its individual color.</source>
@@ -1311,7 +1311,7 @@ Customer service</target>
       <trans-unit id="4493e821e06072415518bd7ae4077996">
         <source>Shop group</source>
         <target>Shop group</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 480]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 507]</note>
       </trans-unit>
       <trans-unit id="e93c33bd1341ab74195430daeb63db13">
         <source>Shop name</source>

--- a/translations/default/AdminShopparametersHelp.xlf
+++ b/translations/default/AdminShopparametersHelp.xlf
@@ -90,7 +90,7 @@
       <trans-unit id="f0f7416fad0a9c9fc3163cabe68393c1">
         <source>By selecting associated categories, you are choosing to share the categories between shops. Once associated between shops, any alteration of this category will impact every shop.</source>
         <target>By selecting associated categories, you are choosing to share the categories between shops. Once associated between shops, any alteration of this category will impact every shop.</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 546]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 573]</note>
       </trans-unit>
       <trans-unit id="bd92437d0543aa142ccea7c021c9efe9">
         <source>Catalog mode disables the shopping cart on your store. Visitors will be able to browse your products catalog, but not buy them.</source>
@@ -255,7 +255,7 @@
       <trans-unit id="1561fa99e3814c72f5206ab48b472335">
         <source>Follow [1]this link[/1] to edit the shop name used on the front office.</source>
         <target>Follow [1]this link[/1] to edit the shop name used on the front office.</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 413]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 440]</note>
       </trans-unit>
       <trans-unit id="99de37a1ed381af8c01ccb18f70b1427">
         <source>For instance, "contacts" for http://example.com/shop/contacts to redirect to http://example.com/shop/contact-form.php</source>
@@ -550,12 +550,12 @@
       <trans-unit id="5c85aec638229f60a035c7a6ab3623c8">
         <source>This field does not refer to the shop name visible in the front office.</source>
         <target>This field does not refer to the shop name visible in the front office.</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 412]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 439]</note>
       </trans-unit>
       <trans-unit id="fce5f624e66bd2e2f0296fc3bd2a8f64">
         <source>This is the root category of the store that you've created. To define a new root category for your store, [1]please click here[/1].</source>
         <target>This is the root category of the store that you've created. To define a new root category for your store, [1]please click here[/1].</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 491]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 518]</note>
       </trans-unit>
       <trans-unit id="5f6092eeaf31414a503b747005ceedc5">
         <source>This option defines how much different can the alternative words found by fuzzy search be. Or, how many characters can be different/missing/added. The default value is 5.</source>
@@ -640,7 +640,7 @@
       <trans-unit id="92aaf3cf7e8f1434886a8887e102391b">
         <source>You can't edit the shop group because the current shop belongs to a group with the "share" option enabled.</source>
         <target>You can't edit the shop group because the current shop belongs to a group with the "share" option enabled.</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 481]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 508]</note>
       </trans-unit>
       <trans-unit id="744c64016466dfc0166c805ee96446e4">
         <source>[1]Make[/1] sure partner offers are not set as required in the [2]Customers[/2] section of the back office before disabling them. Otherwise, new customers won't be able to create an account and [1]proceed[/1] to checkout.</source>

--- a/translations/default/AdminShopparametersNotification.xlf
+++ b/translations/default/AdminShopparametersNotification.xlf
@@ -125,7 +125,7 @@
       <trans-unit id="e3651705f1156de17be5bf1943c480b3">
         <source>Please create some sub-categories for this root category.</source>
         <target>Please create some sub-categories for this root category.</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 348]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 352]</note>
       </trans-unit>
       <trans-unit id="1ce1e6f9c90563443b73f4ee8c51479d">
         <source>The Base URI is not valid.</source>
@@ -185,7 +185,7 @@
       <trans-unit id="18f086b62387b20309c709bbf9fe4fdb">
         <source>Warning: You won't be able to change the group of this shop if this shop belongs to a group with one of these options activated: Share Customers, Share Quantities or Share Orders.</source>
         <target>Warning: You won't be able to change the group of this shop if this shop belongs to a group with one of these options activated: Share Customers, Share Quantities or Share Orders.</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 456]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 483]</note>
       </trans-unit>
       <trans-unit id="5f455758d7337262fdeedba6d54ec89f">
         <source>Wrong category ID.</source>
@@ -200,7 +200,7 @@
       <trans-unit id="1ff40978236e0d196983386376b0a5e3">
         <source>You can only move your shop to a shop group with all "share" options disabled -- or to a shop group with no customers/orders.</source>
         <target>You can only move your shop to a shop group with all "share" options disabled -- or to a shop group with no customers/orders.</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 458]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 485]</note>
       </trans-unit>
       <trans-unit id="b869af59d40b52d2ad275c9f5ed81461">
         <source>You cannot delete this shop (customer and/or order dependency)</source>
@@ -225,7 +225,7 @@
       <trans-unit id="cf52c411b5659457074fd9962435307f">
         <source>You need to select at least the root category.</source>
         <target>You need to select at least the root category.</target>
-        <note>File: controllers/admin/AdminShopController.php [Line: 356]</note>
+        <note>File: controllers/admin/AdminShopController.php [Line: 360]</note>
       </trans-unit>
       <trans-unit id="a4a9b66d4d26374454cf20fb1edf996d">
         <source>You should also comply with the syntax:</source>

--- a/translations/default/Install.xlf
+++ b/translations/default/Install.xlf
@@ -5,7 +5,7 @@
       <trans-unit id="e1120cceb6bcfd9596161e3912b2ad9d">
         <source>"%class%" must be an instance of "InstallXmlLoader"</source>
         <target>"%class%" must be an instance of "InstallXmlLoader"</target>
-        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 1107]</note>
+        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 1112]</note>
       </trans-unit>
       <trans-unit id="13cd0b09fa253a2b524ca2345638aacf">
         <source>%file% file is not writable (check permissions)</source>
@@ -65,17 +65,17 @@
       <trans-unit id="258057c839ab36aa9e3bb60550348c5e">
         <source>Cannot copy flag language "%flag%"</source>
         <target>Cannot copy flag language "%flag%"</target>
-        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 669]</note>
+        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 673]</note>
       </trans-unit>
       <trans-unit id="27654955bc85150712aa0bc53bcc6224">
         <source>Cannot create admin account</source>
         <target>Cannot create admin account</target>
-        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 879]</note>
+        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 884]</note>
       </trans-unit>
       <trans-unit id="f726c29f41d9b6ab3d61f6f4e41959a3">
         <source>Cannot create group shop</source>
         <target>Cannot create group shop</target>
-        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 550]</note>
+        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 554]</note>
       </trans-unit>
       <trans-unit id="44a700a0c9496b4436c16c5e46351707">
         <source>Cannot create image "%1$s" for entity "%2$s"</source>
@@ -105,12 +105,12 @@
       <trans-unit id="19de782cabcc5cc12fa9730264cd5325">
         <source>Cannot create shop</source>
         <target>Cannot create shop</target>
-        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 565]</note>
+        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 569]</note>
       </trans-unit>
       <trans-unit id="90ae323fee3fa743290c6ebdbd7fea65">
         <source>Cannot create shop URL</source>
         <target>Cannot create shop URL</target>
-        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 581]</note>
+        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 585]</note>
       </trans-unit>
       <trans-unit id="8532ab270c96503d3d646da3485c251a">
         <source>Cannot create the database automatically</source>
@@ -120,22 +120,22 @@
       <trans-unit id="54c23cef7fbebba7ee1267cc0cf97b2a">
         <source>Cannot download language pack "%iso%"</source>
         <target>Cannot download language pack "%iso%"</target>
-        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 648]</note>
+        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 652]</note>
       </trans-unit>
       <trans-unit id="c2c8925b8e5c7cfc0d83fa3f7342b48d">
         <source>Cannot execute post install on module "%module%"</source>
         <target>Cannot execute post install on module "%module%"</target>
-        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 1021]</note>
+        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 1026]</note>
       </trans-unit>
       <trans-unit id="9d321a378efc308c33c5f345f623dd90">
         <source>Cannot install language "%iso%"</source>
         <target>Cannot install language "%iso%"</target>
-        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 658]</note>
+        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 662]</note>
       </trans-unit>
       <trans-unit id="26b901ba3ecdcb91823f05ce15a70ce4">
         <source>Cannot install module "%module%"</source>
         <target>Cannot install module "%module%"</target>
-        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 995]</note>
+        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 1000]</note>
       </trans-unit>
       <trans-unit id="a69c52258e44151f43f0d4bf17526d3e">
         <source>Cannot open external URLs (requires allow_url_fopen as On)</source>
@@ -315,12 +315,12 @@
       <trans-unit id="53d7a51998faa87f513eb974a2a596f2">
         <source>File "language.xml" not found for language iso "%iso%"</source>
         <target>File "language.xml" not found for language iso "%iso%"</target>
-        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 617]</note>
+        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 621]</note>
       </trans-unit>
       <trans-unit id="9972ad1ade2906747dbb39490a96b191">
         <source>File "language.xml" not valid for language iso "%iso%"</source>
         <target>File "language.xml" not valid for language iso "%iso%"</target>
-        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 621]</note>
+        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 625]</note>
       </trans-unit>
       <trans-unit id="110b26012a01ad5604e5b9ac39b585ba">
         <source>Fileinfo extension is not enabled</source>
@@ -345,7 +345,7 @@
       <trans-unit id="4a85cd1d84d691a2e0b73a5f08cd3483">
         <source>Fixtures class "%class%" not found</source>
         <target>Fixtures class "%class%" not found</target>
-        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 1100]</note>
+        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 1105]</note>
       </trans-unit>
       <trans-unit id="1725f045dbcb8e6e77a7ade8c476a879">
         <source>For security purposes, you must delete the "install" folder.</source>
@@ -715,7 +715,7 @@
       <trans-unit id="c331bfefd5fde2616161931bcc9e0c3c">
         <source>The admin folder could not be renamed into %folderName%</source>
         <target>The admin folder could not be renamed into %folderName%</target>
-        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 1217]</note>
+        <note>File: src/PrestaShopBundle/Install/Install.php [Line: 1222]</note>
       </trans-unit>
       <trans-unit id="bc4b85255c14de3bf09748a093c63529">
         <source>The default port is 3306. To use a different port, add the port number at the end of your server's address i.e ":4242".</source>

--- a/translations/default/ShopFormsHelp.xlf
+++ b/translations/default/ShopFormsHelp.xlf
@@ -30,7 +30,7 @@
       <trans-unit id="350bfcb1e3cfb28ddff48ce525d4f139">
         <source>DD</source>
         <target>DD</target>
-        <note>File: classes/Tools.php [Line: 864]</note>
+        <note>File: classes/Tools.php [Line: 871]</note>
       </trans-unit>
       <trans-unit id="20f4168399201bd498e52bafeb59b478">
         <source>Don't forget to save your customization to be able to add to cart</source>
@@ -50,7 +50,7 @@
       <trans-unit id="ad05f78187c942f9dd521605fa81f1ba">
         <source>MM</source>
         <target>MM</target>
-        <note>File: classes/Tools.php [Line: 865]</note>
+        <note>File: classes/Tools.php [Line: 872]</note>
       </trans-unit>
       <trans-unit id="9378eeabb3f4f2c5122659d50560a448">
         <source>No selected file</source>
@@ -80,7 +80,7 @@
       <trans-unit id="8df34bb962577b90d574a51ed2ca757f">
         <source>YYYY</source>
         <target>YYYY</target>
-        <note>File: classes/Tools.php [Line: 866]</note>
+        <note>File: classes/Tools.php [Line: 873]</note>
       </trans-unit>
       <trans-unit id="6ba73729cf3b0503435d54870d993e8d">
         <source>Your message here</source>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Only one price round mode actually makes sense and every user changing this setting will get into trouble. I suggest to remove the setting from the admin UI for 9.0 and then finally the config setting itself for version 10
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | Price round mode is not available any more at admin-dev/configure/shop/preferences/preferences
| UI Tests          | tbd
| Fixed issue or discussion?     | tbd
| Related PRs       | -
| Sponsor company   | headissue GmbH