### PR TITLE
Remove price round mode from the admin UI

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -141,23 +141,6 @@ class PreferencesType extends TranslatorAwareType
                     'Admin.Shopparameters.Help'
                 ),
             ])
-            ->add(
-                'price_round_mode', ChoiceType::class, [
-                    'placeholder' => false,
-                    'choices' => [
-                        'Round up away from zero, when it is half way there (recommended)' => $configuration->get('PS_ROUND_HALF_UP'),
-                        'Round down towards zero, when it is half way there' => $configuration->get('PS_ROUND_HALF_DOWN'),
-                        'Round towards the next even value' => $configuration->get('PS_ROUND_HALF_EVEN'),
-                        'Round towards the next odd value' => $configuration->get('PS_ROUND_HALF_ODD'),
-                        'Round up to the nearest value' => $configuration->get('PS_ROUND_UP'),
-                        'Round down to the nearest value' => $configuration->get('PS_ROUND_DOWN'),
-                    ],
-                    'label' => $this->trans('Round mode', 'Admin.Shopparameters.Feature'),
-                    'help' => $this->trans(
-                        'You can choose among 6 different ways of rounding prices. "Round up away from zero ..." is the recommended behavior.',
-                        'Admin.Shopparameters.Help'
-                    ),
-                ])
             ->add('price_round_type', ChoiceType::class, [
                 'placeholder' => false,
                 'choices' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Only one price round mode actually makes sense and every user changing this setting will get into trouble. I suggest to remove the setting from the admin UI for 9.0 and then finally the config setting itself for version 10
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | Price round mode is not available any more at admin-dev/configure/shop/preferences/preferences
| UI Tests          | tbd
| Fixed issue or discussion?     | tbd
| Related PRs       | -
| Sponsor company   | headissue GmbH
