### PR TITLE
Support for brand named as numbers

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/ManufacturerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/ManufacturerType.php
@@ -68,9 +68,9 @@ class ManufacturerType extends ChoiceType
     {
         parent::configureOptions($resolver);
         $manufacturers = $this->manufacturerChoiceProvider->getChoices();
-        $choices = array_merge([
+        $choices = [
             $this->trans('No brand', 'Admin.Catalog.Feature') => NoManufacturerId::NO_MANUFACTURER_ID,
-        ], $manufacturers);
+        ] + $manufacturers;
 
         $resolver->setDefaults([
             'label' => $this->trans('Brand', 'Admin.Catalog.Feature'),


### PR DESCRIPTION
From #38186 @kpodemski 
When the brand name is a number , the function array_merge change the name by the array index.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Previously, array_merge() caused issues when manufacturer names were numeric, as it reindexed keys. Switching to + preserves keys and prevents numeric names from being altered or lost.
| Type?             | bug fix
| Category?         | BO 
| BC breaks?        | no
| UI tests      | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16114789820
| Deprecations?     | no
| How to test?      | Indicated on issue #38185
| Fixed issue or discussion?     | Fixes #38185 
| Sponsor company   | boki.es
