### PR TITLE
fix `TextWithLengthCounterType` whe the option `input_attr` is denined

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
@@ -124,8 +124,11 @@
       </div>
     {% endif %}
 
-    {% set attr = attr|merge({'data-max-length': form.vars.max_length, maxlength: form.vars.max_length, class: 'js-countable-input'}) -%}
-    {% set attr = attr|merge(input_attr) -%}
+    {% set attr = attr|merge(input_attr|merge({
+      'data-max-length': form.vars.max_length,
+      'maxlength': form.vars.max_length,
+      'class': ('js-countable-input ' ~ (input_attr.class|default('')))|trim
+    })) %}
 
     {% if form.vars.input == 'textarea' %}
       {{- block('textarea_widget') -}}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
@@ -126,8 +126,8 @@
 
     {% set attr = attr|merge(input_attr|merge({
       'data-max-length': form.vars.max_length,
-      'maxlength': form.vars.max_length,
-      'class': ('js-countable-input ' ~ (input_attr.class|default('')))|trim
+      maxlength: form.vars.max_length,
+      class: ('js-countable-input ' ~ (input_attr.class|default('')))|trim
     })) %}
 
     {% if form.vars.input == 'textarea' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -1091,8 +1091,8 @@
 
     {% set attr = attr|merge(input_attr|merge({
       'data-max-length': form.vars.max_length,
-      'maxlength': form.vars.max_length,
-      'class': ('js-countable-input ' ~ (input_attr.class|default('')))|trim
+      maxlength: form.vars.max_length,
+      class: ('js-countable-input ' ~ (input_attr.class|default('')))|trim
     })) %}
 
     {% if form.vars.input == 'input' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -1089,8 +1089,11 @@
       </div>
     {% endif %}
 
-    {% set attr = attr|merge({'data-max-length': form.vars.max_length, maxlength: form.vars.max_length, class: 'js-countable-input'}) -%}
-    {% set attr = attr|merge(input_attr) -%}
+    {% set attr = attr|merge(input_attr|merge({
+      'data-max-length': form.vars.max_length,
+      'maxlength': form.vars.max_length,
+      'class': ('js-countable-input ' ~ (input_attr.class|default('')))|trim
+    })) %}
 
     {% if form.vars.input == 'input' %}
       {{- block('form_widget_simple') -}}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      |  The `TextWithLengthCounterType` not working whe the option `input_attr` is denined.
| Type?             | bug fix 
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See 38818
| UI Tests          | N/A
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38818
| Related PRs       | N/A
| Sponsor company   | Evolutive
