### PR TITLE
Another level of protection for Tools::unSerialize (allowed_classes => false) + refacto

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3447,7 +3447,7 @@ exit;
      *
      * @return mixed|null            Unserialized data or false on failure
      */
-    public static function unSerialize(string $serialized, bool $allowObjects = false)
+    public static function unSerialize($serialized, $allowObjects = false)
     {
         // Only allow if it's a string
         if (!is_string($serialized)) {
@@ -3456,12 +3456,12 @@ exit;
 
         // Check for potentially malicious serialized objects
         if (!$allowObjects) {
-        if (strpos($serialized, 'O:') !== false && preg_match('/(^|;|{|})O:[0-9]+:"/', $serialized)) {
-            return false;
-        }
-        
-        // Use native protection only if we disallow objects
-        return @unserialize($serialized, ['allowed_classes' => false]);
+            if (str_contains($serialized, 'O:') && preg_match('/(^|;|{|})O:[0-9]+:"/', $serialized)) {
+                return false;
+            }
+
+            // Use native protection only if we disallow objects
+            return @unserialize($serialized, ['allowed_classes' => false]);
         }
 
         // Otherwise allow objects as usual

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3460,8 +3460,8 @@ exit;
             return false;
         }
         
-            // Use native protection only if we disallow objects
-            return @unserialize($serialized, ['allowed_classes' => false]);
+        // Use native protection only if we disallow objects
+        return @unserialize($serialized, ['allowed_classes' => false]);
         }
 
         // Otherwise allow objects as usual

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3442,7 +3442,7 @@ exit;
     public static function unSerialize($serialized, $object = false)
     {
         if (is_string($serialized) && (strpos($serialized, 'O:') === false || !preg_match('/(^|;|{|})O:[0-9]+:"/', $serialized)) && !$object || $object) {
-            return @unserialize($serialized);
+            return @unserialize($serialized, ['allowed_classes' => false]);
         }
 
         return false;

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3442,10 +3442,10 @@ exit;
     /**
      * Safely unserializes input string with protection against object injection.
      *
-     * @param string $serialized     Serialized string to decode
-     * @param bool   $allowObjects   Whether to allow object unserialization
+     * @param string $serialized Serialized string to decode
+     * @param bool $allowObjects Whether to allow object unserialization
      *
-     * @return mixed|null            Unserialized data or false on failure
+     * @return mixed|null Unserialized data or false on failure
      */
     public static function unSerialize($serialized, $allowObjects = false)
     {

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3439,13 +3439,33 @@ exit;
         return false;
     }
 
-    public static function unSerialize($serialized, $object = false)
+    /**
+     * Safely unserializes input string with protection against object injection.
+     *
+     * @param string $serialized     Serialized string to decode
+     * @param bool   $allowObjects   Whether to allow object unserialization
+     *
+     * @return mixed|null            Unserialized data or false on failure
+     */
+    public static function unSerialize(string $serialized, bool $allowObjects = false)
     {
-        if (is_string($serialized) && (strpos($serialized, 'O:') === false || !preg_match('/(^|;|{|})O:[0-9]+:"/', $serialized)) && !$object || $object) {
+        // Only allow if it's a string
+        if (!is_string($serialized)) {
+            return false;
+        }
+
+        // Check for potentially malicious serialized objects
+        if (!$allowObjects) {
+        if (strpos($serialized, 'O:') !== false && preg_match('/(^|;|{|})O:[0-9]+:"/', $serialized)) {
+            return false;
+        }
+        
+            // Use native protection only if we disallow objects
             return @unserialize($serialized, ['allowed_classes' => false]);
         }
 
-        return false;
+        // Otherwise allow objects as usual
+        return @unserialize($serialized);
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Check below.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/


**DESCRIPTION:**
The 'allowed_classes' => false option provides fundamental protection against PHP Object Deserialization attacks, where an attacker attempts to unserialize malicious objects.
Although we already implement custom checks using strpos and preg_match, I consider it safer to also use this native PHP feature, as it is specifically designed for this purpose.
Security should never rely on assumptions — **just because we haven’t found an exploit doesn’t mean one doesn’t exist.**

For that reason, both protection layers are included in this PR.

Additionally, I **refactored** the original function for better readability and to prevent potential unexpected behavior in the future.

**multiple person verification is required to prevent any problem in new code and refacto**

