### PR TITLE
Add hooks on Module enable/disable/upgrade

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -719,6 +719,10 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function upgradeModuleVersion($name, $version)
     {
+        if(isset(static::$modules_cache[$name]['upgrade']) && static::$modules_cache[$name]['upgrade']['success'] == true) {
+            Hook::exec('actionModuleUpgradeAfter', ['module_name' => $name, 'old_version' => static::$modules_cache[$name]['upgrade']['upgraded_from'], 'new_version' => $version]);
+        }
+
         return Db::getInstance()->execute('
             UPDATE `' . _DB_PREFIX_ . 'module` m
             SET m.`version` = \'' . pSQL($version) . '\'
@@ -992,6 +996,8 @@ abstract class ModuleCore implements ModuleInterface
      */
     public function enable($force_all = false)
     {
+        Hook::exec('actionModuleEnable', ['module' => $this]);
+
         // Retrieve all shops where the module is enabled
         $list = Shop::getContextListShopID();
         if (!$this->id || !is_array($list)) {
@@ -1152,6 +1158,8 @@ abstract class ModuleCore implements ModuleInterface
      */
     public function disable($force_all = false)
     {
+        Hook::exec('actionModuleDisable', ['module' => $this]);
+
         $result = true;
         if ($this->getOverrides() != null) {
             $result &= $this->uninstallOverrides();

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -719,14 +719,16 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function upgradeModuleVersion($name, $version)
     {
-        if(isset(static::$modules_cache[$name]['upgrade']) && static::$modules_cache[$name]['upgrade']['success'] == true) {
-            Hook::exec('actionModuleUpgradeAfter', ['module_name' => $name, 'old_version' => static::$modules_cache[$name]['upgrade']['upgraded_from'], 'new_version' => $version]);
-        }
-
-        return Db::getInstance()->execute('
+        $result = Db::getInstance()->execute('
             UPDATE `' . _DB_PREFIX_ . 'module` m
             SET m.`version` = \'' . pSQL($version) . '\'
             WHERE m.`name` = \'' . pSQL($name) . '\'');
+        
+        if(isset(static::$modules_cache[$name]['upgrade']) && true == static::$modules_cache[$name]['upgrade']['success']) {
+            Hook::exec('actionModuleUpgradeAfter', ['module_name' => $name, 'old_version' => static::$modules_cache[$name]['upgrade']['upgraded_from'], 'new_version' => $version]);
+        }
+
+        return $result;
     }
 
     /**

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -723,7 +724,7 @@ abstract class ModuleCore implements ModuleInterface
             UPDATE `' . _DB_PREFIX_ . 'module` m
             SET m.`version` = \'' . pSQL($version) . '\'
             WHERE m.`name` = \'' . pSQL($name) . '\'');
-        
+
         if (isset(static::$modules_cache[$name]['upgrade']) && true == static::$modules_cache[$name]['upgrade']['success']) {
             Hook::exec('actionModuleUpgradeAfter', ['module_name' => $name, 'old_version' => static::$modules_cache[$name]['upgrade']['upgraded_from'], 'new_version' => $version]);
         }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -724,7 +724,7 @@ abstract class ModuleCore implements ModuleInterface
             SET m.`version` = \'' . pSQL($version) . '\'
             WHERE m.`name` = \'' . pSQL($name) . '\'');
         
-        if(isset(static::$modules_cache[$name]['upgrade']) && true == static::$modules_cache[$name]['upgrade']['success']) {
+        if (isset(static::$modules_cache[$name]['upgrade']) && true == static::$modules_cache[$name]['upgrade']['success']) {
             Hook::exec('actionModuleUpgradeAfter', ['module_name' => $name, 'old_version' => static::$modules_cache[$name]['upgrade']['upgraded_from'], 'new_version' => $version]);
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | For developers, freelancers, or web agencies responsible for maintaining a PrestaShop site, managing modules can be a source of frustration: Merchants who use the store sometimes update modules on their own, which can lead to errors or malfunctions after the update. To monitor this kind of action, it can be useful to have hooks placed on module activation, deactivation, or update. By hooking into these events, you can, for example, send alerts via email or to Slack channels. This allows the maintenance team to see what actions were taken and respond efficiently to fix any issues. As a developer at the web agency Kiwik, we currently use overrides of the Module class, but it would be cleaner to have hooks to avoid using overrides.
| Type?             | new feature
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/discussions/38838
| Related PRs       | 
| Sponsor company   | Kiwik
