### PR TITLE
BO Countries : Set two fields `call_prefix` & `zip_code_format` as non-required

### DIFF
--- a/controllers/admin/AdminCountriesController.php
+++ b/controllers/admin/AdminCountriesController.php
@@ -221,7 +221,6 @@ class AdminCountriesControllerCore extends AdminController
                     'name' => 'call_prefix',
                     'maxlength' => 3,
                     'class' => 'uppercase',
-                    'required' => true,
                     'hint' => $this->trans('International call prefix, (e.g. 1 for United States).', [], 'Admin.International.Help'),
                 ],
                 [
@@ -272,7 +271,6 @@ class AdminCountriesControllerCore extends AdminController
                     'type' => 'text',
                     'label' => $this->trans('ZIP/Postal code format', [], 'Admin.International.Feature'),
                     'name' => 'zip_code_format',
-                    'required' => true,
                     'desc' => $this->trans('Indicate the format of the postal code: use L for a letter, N for a number, and C for the country\'s ISO 3166-1 alpha-2 code. For example, NNNNN for the United States, France, Poland and many other; LNNNNLLL for Argentina, etc. If you do not want PrestaShop to verify the postal code for this country, leave it blank.', [], 'Admin.International.Help'),
                 ],
                 [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | BO Countries : Set two fields `call_prefix` & `zip_code_format` as non-required<br />As explained by @Eolia, Country can have no zip code format, and the call prefix is not used in any part of the code (it seems to be informational).
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: 
| UI Tests          | :dolphin: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/15462616437<br/>:seal: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/15462622082
| Fixed issue or discussion?     | Fixes #27390
| Related PRs       | N/A
| Sponsor company   | lefevre.dev