### PR TITLE
Use all slave servers equally, instead of using the 1st one twice as much

### DIFF
--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -229,7 +229,9 @@ abstract class DbCore
             $id_server = 0;
         } else {
             ++$id;
-            $id_server = ($total_servers > 2 && ($id % $total_servers) != 0) ? $id % $total_servers : 1;
+
+            $slave_count = $total_servers - 1;
+            $id_server = ($id % $slave_count) + 1;
         }
 
         if (!isset(self::$instance[$id_server])) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The current algorithm, when Db::getInstance is called with the "master" parameter set as "false", cycles through the master server and the slave(s), and if it hits the master, falls back onto the first slave. This PR only cycles through slave servers, which means the first slave gets as much load as the others, and not double.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |  log which $id_server is used each time the method is called with $master = false, and count. On a 2 slaves setup, before the change, out of 100 we get 67 returns of 1 and 33 returns of 2. After, we're at 50/50
| UI Tests          | https://github.com/kookline/ga.tests.ui.pr/actions/runs/15494202416 <br/>https://github.com/kookline/ga.tests.ui.pr/actions/runs/15494213579   
| Fixed issue or discussion?     |  no
| Related PRs       |  N/A
| Sponsor company   | Kookline
