### PR TITLE
Ensure specific prices are deleted safely on customer deletion by validating passed ID

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -384,6 +384,10 @@ class CustomerCore extends ObjectModel
      */
     public function delete()
     {
+        if (empty((int) $this->id)) {
+            return false;
+        }
+
         if (!count(Order::getCustomerOrders((int) $this->id))) {
             $addresses = $this->getAddresses((int) Configuration::get('PS_LANG_DEFAULT'));
             foreach ($addresses as $address) {
@@ -393,12 +397,7 @@ class CustomerCore extends ObjectModel
         }
         Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'customer_group` WHERE `id_customer` = ' . (int) $this->id);
         Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'message WHERE id_customer=' . (int) $this->id);
-
-        // Remove specific prices only if we got some sensible ID of a customer.
-        // If we would pass zero or null further below, it would delete all non-customer-restricted specific prices.
-        if (!empty((int) $this->id)) {
-            Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'specific_price WHERE id_customer=' . (int)$this->id);
-        }
+        Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'specific_price WHERE id_customer=' . (int) $this->id);
 
         $carts = Db::getInstance()->executeS('SELECT id_cart FROM ' . _DB_PREFIX_ . 'cart WHERE id_customer=' . (int) $this->id . ' AND id_cart NOT IN (SELECT id_cart FROM `' . _DB_PREFIX_ . 'orders`)');
         if ($carts) {

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -393,7 +393,12 @@ class CustomerCore extends ObjectModel
         }
         Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'customer_group` WHERE `id_customer` = ' . (int) $this->id);
         Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'message WHERE id_customer=' . (int) $this->id);
-        Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'specific_price WHERE id_customer=' . (int) $this->id);
+
+        // Remove specific prices only if we got some sensible ID of a customer.
+        // If we would pass zero or null further below, it would delete all non-customer-restricted specific prices.
+        if (!empty((int) $this->id)) {
+            Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'specific_price WHERE id_customer=' . (int)$this->id);
+        }
 
         $carts = Db::getInstance()->executeS('SELECT id_cart FROM ' . _DB_PREFIX_ . 'cart WHERE id_customer=' . (int) $this->id . ' AND id_cart NOT IN (SELECT id_cart FROM `' . _DB_PREFIX_ . 'orders`)');
         if ($carts) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Read below
| Type?             | bug fix
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. In the back office, add one or more specific prices (to any product) without specifying a customer restriction (applicable to all customer)<br>2. Anywhere in the code (e.g., in the initContent of IndexController or in the displayHeader hook of a module), add following code : `(new Customer())->delete();`<br>3. Reload the page corresponding to where you put previous code (e.g., the home page in FO)<br>4. Go back in BO to the product on which you created the specific prices => they should still exist (before fix, they would have been deleted)
| UI Tests          | not applicable
| Fixed issue or discussion?     | #38879
| Related PRs       | none
| Sponsor company   | Ukoo

## What this change is about
Calling the delete() method on an empty instance of Customer ObjectModel leads to the deletion **of all** the shop's specific prices that are not restricted to any customer (id_customer = 0).
This corresponds to the majority of specific prices in most cases, so this issue is quite annoying and can have dramatic consequences for the shop sales and marketing campaigns if it happens and is not addressed quickly by restoring a backup.

## How to reproduce
The following codes will cause the issue:
```php
(new Customer())->delete();
(new Customer(null))->delete();
(new Customer(0))->delete();
(new Customer('a string'))->delete(); // argument is casted as integer in the method
```

## Solution
The correct behavior is already used for the deletion of the cart rules associated with the removed customer, here: CartRule::deleteByIdCustomer().

```php
public static function deleteByIdCustomer($id_customer)
{
    // Remove cart rules only if we got some sensible ID of a customer.
    // If we would pass zero further below, it would delete all non-customer-restricted cart rules.
    if (empty($id_customer)) {
        return false;
    }

    $return = true;
    $cart_rules = new PrestaShopCollection('CartRule');
    $cart_rules->where('id_customer', '=', $id_customer);
    foreach ($cart_rules as $cart_rule) {
        $return &= $cart_rule->delete();
    }

    return $return;
}
```

Here, we test that the customer ID passed as an argument of the constructor is not empty before proceeding with the deletion.
So we only need to do the same for specific prices.