### PR TITLE
Calculate productMaxRefund based on order round type in OrderRefundCalCulator

### DIFF
--- a/src/Adapter/Order/Refund/OrderRefundCalculator.php
+++ b/src/Adapter/Order/Refund/OrderRefundCalculator.php
@@ -75,7 +75,8 @@ class OrderRefundCalculator
             $orderDetailRefunds,
             $isTaxIncluded,
             $orderDetailList,
-            $precision
+            $precision,
+            $order->round_type
         );
 
         $numberZero = new DecimalNumber('0');
@@ -165,7 +166,8 @@ class OrderRefundCalculator
         array $orderDetailRefunds,
         bool $isTaxIncluded,
         array $orderDetails,
-        int $precision
+        int $precision,
+        int $roundType
     ) {
         $productRefunds = [];
         /** @var OrderDetailRefund $orderDetailRefund */
@@ -186,7 +188,12 @@ class OrderRefundCalculator
 
             // Compute max refund by product (based on quantity left and already refunded amount)
             $productUnitPrice = $isTaxIncluded ? (float) $orderDetail->unit_price_tax_incl : (float) $orderDetail->unit_price_tax_excl;
-            $productMaxRefund = (int) $quantity * $productUnitPrice;
+
+            if ($roundType == Order::ROUND_ITEM) {
+                $productMaxRefund = (int) $quantity * Tools::ps_round($productUnitPrice, $precision);
+            } else {
+                $productMaxRefund = (int) $quantity * $productUnitPrice;
+            }
 
             // If refunded amount is null it means the whole product is refunded (used for standard refund, and return product)
             if (null === $orderDetailRefund->getRefundedAmount()) {

--- a/src/Adapter/Order/Refund/OrderRefundCalculator.php
+++ b/src/Adapter/Order/Refund/OrderRefundCalculator.php
@@ -76,7 +76,7 @@ class OrderRefundCalculator
             $isTaxIncluded,
             $orderDetailList,
             $precision,
-            $order->round_type
+            $order,
         );
 
         $numberZero = new DecimalNumber('0');
@@ -167,7 +167,7 @@ class OrderRefundCalculator
         bool $isTaxIncluded,
         array $orderDetails,
         int $precision,
-        int $roundType
+        Order $order,
     ) {
         $productRefunds = [];
         /** @var OrderDetailRefund $orderDetailRefund */
@@ -189,8 +189,8 @@ class OrderRefundCalculator
             // Compute max refund by product (based on quantity left and already refunded amount)
             $productUnitPrice = $isTaxIncluded ? (float) $orderDetail->unit_price_tax_incl : (float) $orderDetail->unit_price_tax_excl;
 
-            if ($roundType == Order::ROUND_ITEM) {
-                $productMaxRefund = (int) $quantity * Tools::ps_round($productUnitPrice, $precision);
+            if ((int) $order->round_type === Order::ROUND_ITEM) {
+                $productMaxRefund = (int) $quantity * Tools::ps_round($productUnitPrice, $precision, $order->round_mode);
             } else {
                 $productMaxRefund = (int) $quantity * $productUnitPrice;
             }


### PR DESCRIPTION
Hi,

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When a refund is made on an order with a rounding type per item, there may be a difference of a few cents, particularly when the product prices contain many decimals.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | Configure the store so that rounding is done for each item, create a product with a price like 16.4689238, order a large quantity, refund the product line, see the difference between the refund and the amount paid.
| UI Tests          | https://github.com/clement-hvt/ga.tests.ui.pr/actions/runs/15565008836
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/40271
| Related PRs       | -
| Sponsor company   | Soledis
