### PR TITLE
Add hook that allows completely custom cart rule application on a cart

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1256,6 +1256,30 @@ class CartRuleCore extends ObjectModel
             return 0;
         }
 
+        /*
+         * Custom cart rule value from modules. Allows to create infinite possibilities of rules.
+         *
+         * If a module is applying a custom value using actionApplyCartRule, it should also apply
+         * the same value here.
+         */
+        $contextualValueFromModules = null;
+        Hook::exec(
+            'actionGetCartRuleContextualValue',
+            [
+                'cart_rule' => $this,
+                'use_tax' => $use_tax,
+                'context' => $context,
+                'filter' => $filter,
+                'package' => $package,
+                'use_cache' => $use_cache,
+                'contextualValueFromModules' => &$contextualValueFromModules,
+            ]
+        );
+        // @phpstan-ignore-next-line
+        if ($contextualValueFromModules !== null) {
+            return $contextualValueFromModules;
+        }
+
         // set base price that will be used for percent reductions
         if (!empty($context->virtualTotalTaxIncluded) && !empty($context->virtualTotalTaxExcluded)) {
             $basePriceForPercentReduction = $use_tax ? $context->virtualTotalTaxIncluded : $context->virtualTotalTaxExcluded;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1047,7 +1047,7 @@ parameters:
 
 		-
 			message: "#^Namespace Hook is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
-			count: 1
+			count: 2
 			path: src/Core/Cart/CartRuleCalculator.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1046,6 +1046,11 @@ parameters:
 			path: src/PrestaShopBundle/Command/AppendHooksListForSqlUpgradeFileCommand.php
 
 		-
+			message: "#^Namespace Hook is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/Core/Cart/CartRuleCalculator.php
+
+		-
 			message: "#^Namespace Validate is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 3
 			path: src/PrestaShopBundle/Command/ConfigCommand.php

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Cart;
 use Cart;
 use CartRule;
 use Currency;
+use Hook;
 use PrestaShopDatabaseException;
 
 class CartRuleCalculator
@@ -97,6 +98,31 @@ class CartRuleCalculator
         $cart = $this->calculator->getCart();
 
         if (!CartRule::isFeatureActive()) {
+            return;
+        }
+
+        /*
+         * Custom cart rule application from modules. Allows to create infinite possibilities of rules.
+         *
+         * If a module wants to apply a cart rule by it's own rules, it can use this hook.
+         * You will receive instances and data from this context, so use proper methods to apply the discounts.
+         *
+         * If any discount was applied by a module, set $isAppliedByModules to avoid further processing of the cart rule.
+         */
+        $isAppliedByModules = null;
+        Hook::exec(
+            'actionApplyCartRule',
+            [
+                'cart_rule_calculator' => $this,
+                'cart_rule_data' => $cartRuleData,
+                'cart_rule' => $cartRule,
+                'cart' => $cart,
+                'with_free_shipping' => $withFreeShipping,
+                'is_applied_by_modules' => &$isAppliedByModules,
+            ]
+        );
+        // @phpstan-ignore-next-line
+        if ($isAppliedByModules) {
             return;
         }
 
@@ -347,5 +373,29 @@ class CartRuleCalculator
     public function getCartRulesData()
     {
         return $this->cartRules;
+    }
+
+    /**
+     * @return Calculator
+     */
+    public function getCalculator()
+    {
+        return $this->calculator;
+    }
+
+    /**
+     * @return CartRowCollection
+     */
+    public function getCartRows()
+    {
+        return $this->cartRows;
+    }
+
+    /**
+     * @return Fees
+     */
+    public function getFees()
+    {
+        return $this->fees;
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Following my previous PRs, with this, you can apply a cart rule in a completely custom way.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Use provided hooks and see how can you alter the result.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

### Usage
```php
public function hookActionApplyCartRule($params) {
  if ($this->isOurSpecialCartRuleWithCustomRules()) {
    $params['cart_rule_data']->addDiscountApplied(new AmountImmutable(1210, 1000));
    $params['is_applied_by_modules'] = true;
  }
}

public function hookActionGetCartRuleContextualValue($params) {
  if ($this->isOurSpecialCartRuleWithCustomRules()) {
    if ($params['use_tax']) {
      $params['contextualValueFromModules'] = 1210;
    } else {
      $params['contextualValueFromModules'] = 1000;
    }
  }
}
```

### Result
![Snímek obrazovky 2025-06-11 104753](https://github.com/user-attachments/assets/e75e7999-719f-4536-8078-aa80e985a154)

### Test module
[tox_cartrulevalidation.zip](https://github.com/user-attachments/files/20690503/tox_cartrulevalidation.zip)
![Snímek obrazovky 2025-06-11 140549](https://github.com/user-attachments/assets/4727815c-05b6-44d2-839c-a5ccbd504ea1)

Ping @kpodemski @jolelievre 