### PR TITLE
Fix 500 error on create product with id_default_category to 0

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7263,8 +7263,10 @@ class ProductCore extends ObjectModel
             'WHERE `id_category` = ' . (int) $this->id_category_default . '  ' .
             'ORDER BY `position`'
         );
+        
+        $sizeResult = count($result);
 
-        if ($position > count($result)) {
+        if ($position > $sizeResult && $sizeResult > 0) {
             WebserviceRequest::getInstance()->setError(
                 500,
                 $this->trans(


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | When we create a product from ws, if id_default_category is at 0, impossible to create the product error "'You cannot set a position greater than the total number of products in the category, starting at 1.',". It's normal category with id 0 not existe so the first position is 0..
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a product with body xml and set id_default_category to 0
| Sponsor company   | Griiv
