### PR TITLE
CustomerAddressForm : Set a minimum length in HTML5

### DIFF
--- a/classes/form/AbstractForm.php
+++ b/classes/form/AbstractForm.php
@@ -158,7 +158,7 @@ abstract class AbstractFormCore implements FormInterface
                     );
 
                     continue;
-                } elseif (!$this->checkFieldLength($field)) {
+                } elseif (!$this->checkFieldMaxLength($field)) {
                     $field->addError(
                         $this->translator->trans(
                             'The %1$s field is too long (%2$d chars max).',
@@ -166,15 +166,31 @@ abstract class AbstractFormCore implements FormInterface
                             'Shop.Notifications.Error'
                         )
                     );
+                } elseif (!$this->checkFieldMinLength($field)) {
+                    $field->addError(
+                        $this->translator->trans(
+                            'The %1$s field is too short (%2$d chars min).',
+                            [$field->getLabel(), $field->getMinLength()],
+                            'Shop.Notifications.Error'
+                        )
+                    );
                 }
             } else {
                 if (!$field->getValue()) {
                     continue;
-                } elseif (!$this->checkFieldLength($field)) {
+                } elseif (!$this->checkFieldMaxLength($field)) {
                     $field->addError(
                         $this->translator->trans(
                             'The %1$s field is too long (%2$d chars max).',
                             [$field->getLabel(), $field->getMaxLength()],
+                            'Shop.Notifications.Error'
+                        )
+                    );
+                } elseif (!$this->checkFieldMinLength($field)) {
+                    $field->addError(
+                        $this->translator->trans(
+                            'The %1$s field is too short (%2$d chars min).',
+                            [$field->getLabel(), $field->getMinLength()],
                             'Shop.Notifications.Error'
                         )
                     );
@@ -248,13 +264,41 @@ abstract class AbstractFormCore implements FormInterface
     /**
      * Validate field length
      *
+     * @deprecated Since 9.0 and will be removed in 10.0 - Please use `checkFieldMaxLength`
+     *
      * @param FormField $field the field to check
      *
      * @return bool
      */
     protected function checkFieldLength($field)
     {
+        return $this->checkFieldMaxLength($field);
+    }
+
+    /**
+     * Validate field length
+     *
+     * @param FormField $field the field to check
+     *
+     * @return bool
+     */
+    protected function checkFieldMaxLength(FormField $field): bool
+    {
         $error = $field->getMaxLength() != null && Tools::strlen($field->getValue()) > (int) $field->getMaxLength();
+
+        return !$error;
+    }
+
+    /**
+     * Validate field length
+     *
+     * @param FormField $field the field to check
+     *
+     * @return bool
+     */
+    protected function checkFieldMinLength(FormField $field): bool
+    {
+        $error = $field->getMinLength() != null && Tools::strlen($field->getValue()) < (int) $field->getMinLength();
 
         return !$error;
     }

--- a/classes/form/CustomerAddressFormatter.php
+++ b/classes/form/CustomerAddressFormatter.php
@@ -90,6 +90,10 @@ class CustomerAddressFormatterCore implements FormFormatterInterface
                     if ($this->country->need_zip_code) {
                         $formField->setRequired(true);
                     }
+
+                    $formField->setMinLength(
+                        strlen($this->country->zip_code_format)
+                    );
                 } elseif ($field === 'phone') {
                     $formField->setType('tel');
                 } elseif ($field === 'dni' && null !== $this->country) {

--- a/classes/form/FormField.php
+++ b/classes/form/FormField.php
@@ -31,6 +31,10 @@ class FormFieldCore
     private $label = '';
     private $value = null;
     private $availableValues = [];
+    /**
+     * @var int|null
+     */
+    private $minLength = null;
     private $maxLength = null;
     private $errors = [];
     private $constraints = [];
@@ -53,6 +57,7 @@ class FormFieldCore
             'label' => $this->getLabel(),
             'value' => $this->getValue(),
             'availableValues' => $this->getAvailableValues(),
+            'minLength' => $this->getMinLength(),
             'maxLength' => $this->getMaxLength(),
             'errors' => $this->getErrors(),
             'autocomplete' => $this->getAutocompleteAttribute(),
@@ -140,6 +145,18 @@ class FormFieldCore
         $this->availableValues[$availableValue] = $label;
 
         return $this;
+    }
+
+    public function setMinLength(?int $min): self
+    {
+        $this->minLength = $min;
+
+        return $this;
+    }
+
+    public function getMinLength(): ?int
+    {
+        return $this->minLength;
     }
 
     public function setMaxLength($max)

--- a/tests/Unit/Classes/form/AbstractFormTest.php
+++ b/tests/Unit/Classes/form/AbstractFormTest.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\form;
+
+use AbstractForm;
+use FormField;
+use FormFormatterInterface;
+use PHPUnit\Framework\TestCase;
+use Smarty;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class AbstractFormTest extends TestCase
+{
+    /**
+     * @dataProvider dataProviderValidateMinLength
+     */
+    public function testValidateMinLength(array $fields, array $values, bool $isValidated, array $errors): void
+    {
+        $form = $this->getMockAbstractForm($fields);
+        foreach ($values as $fieldKey => $fieldValue) {
+            $form->setValue($fieldKey, $fieldValue);
+        }
+
+        self::assertEquals($isValidated, $form->validate());
+        self::assertEquals($errors, $form->getErrors());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function dataProviderValidateMinLength(): array
+    {
+        return [
+            // Required field but empty
+            [
+                ['field' => (new FormField())->setName('field')->setRequired(true)],
+                ['field' => null],
+                false,
+                [
+                    '' => [],
+                    'field' => ['Required field'],
+                ],
+            ],
+            // Required field (min length)
+            [
+                ['field' => (new FormField())->setName('field')->setRequired(true)->setMinLength(5)],
+                ['field' => 'abc'],
+                false,
+                [
+                    '' => [],
+                    'field' => ['The %1$s field is too short (%2$d chars min).'],
+                ],
+            ],
+            // Required field (max length)
+            [
+                ['field' => (new FormField())->setName('field')->setRequired(true)->setMaxLength(5)],
+                ['field' => 'abcdef'],
+                false,
+                [
+                    '' => [],
+                    'field' => ['The %1$s field is too long (%2$d chars max).'],
+                ],
+            ],
+            // Not Required field but empty
+            [
+                ['field' => (new FormField())->setName('field')->setRequired(false)],
+                ['field' => null],
+                true,
+                [
+                    '' => [],
+                    'field' => [],
+                ],
+            ],
+            // Not Required field (min length)
+            [
+                ['field' => (new FormField())->setName('field')->setRequired(false)->setMinLength(5)],
+                ['field' => 'abc'],
+                false,
+                [
+                    '' => [],
+                    'field' => ['The %1$s field is too short (%2$d chars min).'],
+                ],
+            ],
+            // Not Required field (max length)
+            [
+                ['field' => (new FormField())->setName('field')->setRequired(false)->setMaxLength(5)],
+                ['field' => 'abcdef'],
+                false,
+                [
+                    '' => [],
+                    'field' => ['The %1$s field is too long (%2$d chars max).'],
+                ],
+            ],
+        ];
+    }
+
+    protected function getMockAbstractForm(array $fields): AbstractForm
+    {
+        $mockSmarty = $this->getMockBuilder(Smarty::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockTranslatorInterface = $this->getMockBuilder(TranslatorInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockTranslatorInterface
+            ->method('trans')
+            ->willReturnArgument(0);
+        $mockFormFormatterInterface = $this->getMockBuilder(FormFormatterInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $class = new class($mockSmarty, $mockTranslatorInterface, $mockFormFormatterInterface) extends AbstractForm {
+            public function fillWith(array $params = [])
+            {
+                $this->formFields = $params;
+            }
+
+            public function getTemplateVariables()
+            {
+            }
+
+            public function submit()
+            {
+            }
+        };
+
+        $class->fillWith($fields);
+
+        return $class;
+    }
+}

--- a/tests/Unit/Classes/form/FormFieldTest.php
+++ b/tests/Unit/Classes/form/FormFieldTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\form;
+
+use FormField;
+use PHPUnit\Framework\TestCase;
+
+class FormFieldTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $formField = new FormField();
+
+        self::assertEquals(null, $formField->getMinLength());
+        self::assertEquals([
+            'name' => '',
+            'type' => 'text',
+            'required' => false,
+            'label' => '',
+            'value' => null,
+            'availableValues' => [],
+            'minLength' => null,
+            'maxLength' => null,
+            'errors' => [],
+            'autocomplete' => '',
+        ], $formField->toArray());
+    }
+
+    public function testMinLength(): void
+    {
+        $expectedValue = rand(0, 1000);
+        $formField = new FormField();
+        $formField->setMinLength($expectedValue);
+
+        self::assertEquals($expectedValue, $formField->getMinLength());
+        self::assertEquals([
+            'name' => '',
+            'type' => 'text',
+            'required' => false,
+            'label' => '',
+            'value' => null,
+            'availableValues' => [],
+            'minLength' => $expectedValue,
+            'maxLength' => null,
+            'errors' => [],
+            'autocomplete' => '',
+        ], $formField->toArray());
+
+        $formField->setMinLength(null);
+
+        self::assertEquals(null, $formField->getMinLength());
+        self::assertEquals([
+            'name' => '',
+            'type' => 'text',
+            'required' => false,
+            'label' => '',
+            'value' => null,
+            'availableValues' => [],
+            'minLength' => null,
+            'maxLength' => null,
+            'errors' => [],
+            'autocomplete' => '',
+        ], $formField->toArray());
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | CustomerAddressForm : Set a minimum length in HTML5
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | 1. Login to user account on FO<br>2. Go to section address<br>3. Edit any adress<br>4. Fill there "1234" to postcode (where is format for example NNNNN)<br>5. Click on submit<br>6. You will see HTML5 Error about postcode.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #37303
| Related PRs       | PrestaShop/classic-theme/pull/172<br />PrestaShop/hummingbird/pull/712
| Sponsor company   | lefevre.dev
