### PR TITLE
Backport improved profiler from v9

### DIFF
--- a/tools/profiling/Controller.php
+++ b/tools/profiling/Controller.php
@@ -27,6 +27,11 @@ abstract class Controller extends ControllerCore
 {
     protected $profiler = null;
 
+    /**
+     * @var string|null
+     */
+    public $outPutHtml;
+
     public function __construct()
     {
         $this->profiler = Profiler::getInstance();

--- a/tools/profiling/Profiler.php
+++ b/tools/profiling/Profiler.php
@@ -73,7 +73,14 @@ class Profiler
 
     private function __construct()
     {
-        $this->startTime = microtime(true);
+        global $start_time;
+        if (isset($_SERVER['REQUEST_TIME_FLOAT'])) {
+            $this->startTime = (float) $_SERVER['REQUEST_TIME_FLOAT'];
+        } elseif (!empty($start_time)) {
+            $this->startTime = $start_time;
+        } else {
+            $this->startTime = microtime(true);
+        }
     }
 
     /**
@@ -147,11 +154,15 @@ class Profiler
      *
      * @param mixed $var
      *
-     * @return string|object
+     * @return string|object|array
      */
     private function getVarData($var)
     {
         if (is_object($var)) {
+            return $var;
+        }
+
+        if (is_array($var)) {
             return $var;
         }
 

--- a/tools/profiling/Tools.php
+++ b/tools/profiling/Tools.php
@@ -25,7 +25,7 @@
  */
 class Tools extends ToolsCore
 {
-    public static function redirect($url, $base_uri = __PS_BASE_URI__, Link $link = null, $headers = null)
+    public static function redirect($url, $base_uri = __PS_BASE_URI__, ?Link $link = null, $headers = null)
     {
         if (!$link) {
             $link = Context::getContext()->link;
@@ -73,7 +73,7 @@ class Tools extends ToolsCore
         if (empty($default_controller)) {
             $default_controller = 'AdminDashboard';
         }
-        $controllers = Dispatcher::getControllers([_PS_ADMIN_DIR_ . '/tabs/', _PS_ADMIN_CONTROLLER_DIR_, _PS_OVERRIDE_DIR_ . 'controllers/admin/']);
+        $controllers = Dispatcher::getControllers([_PS_ADMIN_CONTROLLER_DIR_, _PS_OVERRIDE_DIR_ . 'controllers/admin/']);
         if (!isset($controllers[strtolower($default_controller)])) {
             $default_controller = 'adminnotfound';
         }
@@ -95,7 +95,7 @@ class Tools extends ToolsCore
                 $controller->setRedirectAfter($url);
                 $controller->run();
                 Context::getContext()->controller = $controller;
-                die();
+                die;
             } catch (PrestaShopException $e) {
                 $e->displayMessage();
             }

--- a/tools/profiling/templates/functions/mysql-version.tpl
+++ b/tools/profiling/templates/functions/mysql-version.tpl
@@ -23,9 +23,9 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *}
 {function name=mysql_version}
-  {if version_compare($version, '5.5') < 0}
+  {if version_compare($version, '5.6') < 0}
     <span class="danger">{$data} (Upgrade strongly recommended)</span>
-  {elseif version_compare($version, '5.6') < 0}
+  {elseif version_compare($version, '5.7') < 0}
     <span class="warning">{$data} (Consider upgrading)</span>
   {else}
     <span class="success">{$data} (OK)</span>

--- a/tools/profiling/templates/functions/php-version.tpl
+++ b/tools/profiling/templates/functions/php-version.tpl
@@ -23,9 +23,9 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *}
 {function name=php_version}
-  {if version_compare($version, '7.1') <= 0}
+  {if version_compare($version, '8.1') <= 0}
     <span class="danger">{$data} (Upgrade strongly recommended)</span>
-  {elseif version_compare($version, '7.4') <= 0}
+  {elseif version_compare($version, '8.2') <= 0}
     <span class="warning">{$data} (Consider upgrading)</span>
   {else}
     <span class="success">{$data} (OK)</span>

--- a/tools/profiling/templates/functions/php-version.tpl
+++ b/tools/profiling/templates/functions/php-version.tpl
@@ -23,9 +23,9 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *}
 {function name=php_version}
-  {if version_compare($version, '8.1') <= 0}
+  {if version_compare($version, '8.0', '<')}
     <span class="danger">{$data} (Upgrade strongly recommended)</span>
-  {elseif version_compare($version, '8.2') <= 0}
+  {elseif version_compare($version, '8.1', '<')}
     <span class="warning">{$data} (Consider upgrading)</span>
   {else}
     <span class="success">{$data} (OK)</span>

--- a/tools/profiling/templates/redirect.tpl
+++ b/tools/profiling/templates/redirect.tpl
@@ -25,7 +25,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <script src="//code.jquery.com/jquery-3.5.1.min.js"></script>
+    <script src="//code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"></script>
     <link href="//maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" rel="stylesheet" type="text/css"/>
   </head>

--- a/tools/profiling/templates/stopwatch.tpl
+++ b/tools/profiling/templates/stopwatch.tpl
@@ -48,7 +48,7 @@
         <tr>
           <td>{$data['id']}</td>
           <td class="pre" style="max-width: 60vw"><pre>{preg_replace("/(^[\s]*)/m", "", htmlspecialchars($data['query'], ENT_NOQUOTES, 'utf-8', false))}</pre></td>
-          <td data-value="{$data['time']}">
+          <td data-value="{sprintf('%01.6f', $data['time'])}">
             {load_time data=($data['time'])}
           </td>
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | To better compare performance between versions, this backports improved profiler from never version. The new version better measures the initialization phase of the request because of `REQUEST_TIME_FLOAT`. 
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Automatic test
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   |
