### PR TITLE
Fix favicon path

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1706,7 +1706,7 @@ class FrontControllerCore extends Controller
             'logo' => self::configuredImageUrl('PS_LOGO', $psImageUrl),
             'logo_details' => $this->getShopLogo(),
             'stores_icon' => self::configuredImageUrl('PS_STORES_ICON', $psImageUrl),
-            'favicon' => self::configuredImageUrl('PS_STORES_ICON', $psImageUrl),
+            'favicon' => self::configuredImageUrl('PS_FAVICON', $psImageUrl),
             'favicon_update_time' => Configuration::get('PS_IMG_UPDATE_TIME'),
 
             'address' => [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | https://github.com/PrestaShop/PrestaShop/pull/32941 broke favicon path, this fixes it.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Test favicon leads to /img/favicon.ico.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38925
| Related PRs       | 
| Sponsor company   | 
