### PR TITLE
Avoid excessive PHP DEBUG logs in production.

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1039,7 +1039,7 @@ class HookCore extends ObjectModel
             if ($registeredHookId === $id_hook) {
                 // The module is registered to the canonical (proper) hook name
                 $registeredHookName = $hook_name;
-            } else {
+            } elseif (_PS_MODE_DEV_) {
                 // The module is registered to an alias
                 $registeredHookName = static::getNameById(
                     $hookRegistration['id_hook']

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1039,22 +1039,24 @@ class HookCore extends ObjectModel
             if ($registeredHookId === $id_hook) {
                 // The module is registered to the canonical (proper) hook name
                 $registeredHookName = $hook_name;
-            } elseif (_PS_MODE_DEV_) {
+            } else {
                 // The module is registered to an alias
                 $registeredHookName = static::getNameById(
                     $hookRegistration['id_hook']
                 );
 
                 // We throw an error - aliases are deprecated.
-                trigger_error(
-                    sprintf(
-                        'The hook "%s" is deprecated, please use "%s" instead in module "%s".',
-                        $registeredHookName,
-                        $hook_name,
-                        $hookRegistration['module']
-                    ),
-                    E_USER_DEPRECATED
-                );
+                if (_PS_MODE_DEV_) {
+                    trigger_error(
+                        sprintf(
+                            'The hook "%s" is deprecated, please use "%s" instead in module "%s".',
+                            $registeredHookName,
+                            $hook_name,
+                            $hookRegistration['module']
+                        ),
+                        E_USER_DEPRECATED
+                    );
+                }
             }
 
             // Check conditions to execute the module


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Avoid excessive PHP DEBUG logs in production..
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | UI tests green
| UI Tests          | N/A
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | Evolutive

## Key Reasons to Avoid Excessive Logging in Production

- **`Performance Impact`** 
- **`Log Noise Hides Real Issues`** 
- **`Disk Space Overload`** 
