### PR TITLE
Add hook on Configuration updateValue

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -438,13 +438,13 @@ class ConfigurationCore extends ObjectModel
      */
     public static function updateValue($key, $values, $html = false, $idShopGroup = null, $idShop = null)
     {
-        if (!is_array($values)) {
-            $values = [$values];
-        }
-        foreach ($values as $lang => $value) {
-            $storedValue = Configuration::get($key, $lang, $idShopGroup, $idShop, null);
-            Hook::exec('actionConfigurationUpdateBefore', ['name' => $key, 'current_value' => $storedValue, 'new_value' => $value]);
-        }
+        Hook::exec('actionConfigurationUpdateValueBefore', [
+          'key' => $key,
+          'values' => $values,
+          'html' => $html,
+          'idShopGroup' => $idShopGroup,
+          'idShop' => $idShop,
+        ]);
 
         if (!Validate::isConfigName($key)) {
             die(Tools::displayError(Context::getContext()->getTranslator()->trans('[%s] is not a valid configuration key', [Tools::htmlentitiesUTF8($key)], 'Admin.Notifications.Error')));

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -439,11 +440,11 @@ class ConfigurationCore extends ObjectModel
     public static function updateValue($key, $values, $html = false, $idShopGroup = null, $idShop = null)
     {
         Hook::exec('actionConfigurationUpdateValueBefore', [
-          'key' => $key,
-          'values' => $values,
-          'html' => $html,
-          'idShopGroup' => $idShopGroup,
-          'idShop' => $idShop,
+            'key' => $key,
+            'values' => $values,
+            'html' => $html,
+            'idShopGroup' => $idShopGroup,
+            'idShop' => $idShop,
         ]);
 
         if (!Validate::isConfigName($key)) {

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -438,6 +438,14 @@ class ConfigurationCore extends ObjectModel
      */
     public static function updateValue($key, $values, $html = false, $idShopGroup = null, $idShop = null)
     {
+        if (!is_array($values)) {
+            $values = [$values];
+        }
+        foreach ($values as $lang => $value) {
+            $storedValue = Configuration::get($key, $lang, $idShopGroup, $idShop, null);
+            Hook::exec('actionConfigurationUpdateBefore', ['name' => $key, 'current_value' => $storedValue, 'new_value' => $value]);
+        }
+
         if (!Validate::isConfigName($key)) {
             die(Tools::displayError(Context::getContext()->getTranslator()->trans('[%s] is not a valid configuration key', [Tools::htmlentitiesUTF8($key)], 'Admin.Notifications.Error')));
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The problem<br/>For developers, freelancers, or web agencies responsible for maintaining a PrestaShop site, managing modules can be a source of frustration:Merchants who use the store sometimes update modules on their own, which can lead to errors or malfunctions after the update.<br/><br/>The solution<br/>To monitor this kind of action, it can be useful to have hooks placed on module activation, deactivation, or update.<br/>By hooking into these events, you can, for example, send alerts via email or to Slack channels.<br/>This allows the maintenance team to see what actions were taken and respond efficiently to fix any issues.<br/><br/>Alternatives<br/>As a developer at the web agency Kiwik, we currently use overrides of the Module class, but it would be cleaner to have hooks to avoid using overrides.
| Type?             | improvement 
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/16025371375
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/discussions/38955
| Related PRs       | 
| Sponsor company   | Kiwik
