### PR TITLE
Add missing Content-Type header in stock quantity update request

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/store/actions.ts
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/store/actions.ts
@@ -188,6 +188,7 @@ export const updateQtyByProductId = async ({commit}: {commit: Commit}, payload: 
   try {
     const res = await fetch(url, {
       method: 'POST',
+      headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({delta}),
     });
     const datas = await res.json();
@@ -206,6 +207,7 @@ export const updateQtyByProductsId = async ({commit, state}: {commit: Commit, st
   try {
     const res = await fetch(url, {
       method: 'POST',
+      headers: {'Content-Type': 'application/json'},
       body: JSON.stringify(productsQty),
     });
     const datas = await res.json();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x 
| Description?      | When updating product quantities from the admin panel, the outgoing POST request does not include the Content-Type: application/json header, even though the request body is JSON. On servers with ModSecurity enabled, such requests are blocked with a 403 Forbidden error because they appear to contain JSON but lack the appropriate content type header. This PR adds Content-Type headers for stock management update requests. 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable ModSecurity on your server. Go to Catalog -> Stock and update product quantity (both by using single item and bulk action)
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/15853536864
| Fixed issue or discussion?     | Fixes #38965 
| Related PRs       | -
| Sponsor company   | -