### PR TITLE
Fix: Problem generating ZIP with tools/build/CreateRelease.php inside Docker container (php:8.1-cli on Windows 10)

### DIFF
--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -327,10 +327,7 @@ class ReleaseCreator
         if (file_exists("{$this->tempProjectPath}")) {
             exec("rm -rf $argTmpDestination");
         }
-        exec("mkdir $argTmpDestination && \
-            cd {$argProjectPath} && \
-            git archive HEAD | tar -xC {$argTmpDestination} && \
-            cd -");
+        exec("mkdir $argTmpDestination && cd {$argProjectPath} && git archive HEAD | tar -xC {$argTmpDestination} && cd -");
         $this->consoleWriter->displayText(" DONE{$this->lineSeparator}", ConsoleWriter::COLOR_GREEN);
 
         return $this;
@@ -542,10 +539,7 @@ class ReleaseCreator
         $this->consoleWriter->displayText("Running composer install...", ConsoleWriter::COLOR_YELLOW);
         $argProjectPath = escapeshellarg($this->tempProjectPath);
         $autoloaderSuffix = md5($this->version);
-        $command = "cd {$argProjectPath} \
-            && export SYMFONY_ENV=prod \
-            && composer config autoloader-suffix {$autoloaderSuffix} \
-            && composer install --no-dev --optimize-autoloader --no-interaction 2>&1";
+        $command = "cd {$argProjectPath} && export SYMFONY_ENV=prod && composer config autoloader-suffix {$autoloaderSuffix} && composer install --no-dev --optimize-autoloader --no-interaction 2>&1";
         exec($command, $output, $returnCode);
         if (!empty($output)) {
             $logPath = __DIR__ . '/../../../var/logs/composer-install.log';
@@ -797,9 +791,7 @@ class ReleaseCreator
         $argTempProjectPath = escapeshellarg($this->tempProjectPath);
         $argInstallerZipFilename = escapeshellarg($installerZipFilename);
         $argProjectPath = escapeshellarg($this->projectPath);
-        $cmd = "cd {$argTempProjectPath} \
-            && zip --symlinks -rq {$argInstallerZipFilename} . \
-            && cd -";
+        $cmd = "cd {$argTempProjectPath} && zip --symlinks -rq {$argInstallerZipFilename} . && cd -";
         exec($cmd);
 
         if ($this->useInstaller) {


### PR DESCRIPTION
In Docker on Windows, the multi-line 'exec' command is not recognized.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | see: https://github.com/PrestaShop/PrestaShop/issues/38967
| Type?             | bug fix 
| Category?         | IN 
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | see: https://github.com/PrestaShop/PrestaShop/issues/38967
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #38967
| Related PRs       | 
| Sponsor company   | @Codencode 
