### PR TITLE
Use module version instead of XML

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -554,7 +554,7 @@ abstract class ModuleCore implements ModuleInterface
         if ($upgrade_detail['available_upgrade']) {
             $translator = Context::getContext()->getTranslator();
             if ($upgrade_detail['success']) {
-                $this->_confirmations[] = $translator->trans('Current version: %s', [self::getModuleVersion($this)], 'Admin.Modules.Notification');
+                $this->_confirmations[] = $translator->trans('Current version: %s', [$this->version], 'Admin.Modules.Notification');
                 $this->_confirmations[] = $translator->trans('%d file update applied', [$upgrade_detail['number_upgraded']], 'Admin.Modules.Notification');
 
                 return;
@@ -586,9 +586,8 @@ abstract class ModuleCore implements ModuleInterface
     public static function initUpgradeModule($module)
     {
         if ($module->installed && empty($module->database_version)) {
-            $moduleVersion = self::getModuleVersion($module);
-            Module::upgradeModuleVersion($module->name, $moduleVersion);
-            $module->database_version = $moduleVersion;
+            Module::upgradeModuleVersion($module->name, $module->version);
+            $module->database_version = $module->version;
         }
 
         if ($module->database_version == $module->version) {
@@ -737,8 +736,7 @@ abstract class ModuleCore implements ModuleInterface
     {
         static::$modules_cache[$module->name]['upgrade']['upgraded_from'] = $module->database_version;
         // Check the version of the module with the registered one and look if any upgrade file exist
-        $moduleVersion = self::getModuleVersion($module);
-        if (Tools::version_compare($moduleVersion, $module->database_version, '>')) {
+        if (Tools::version_compare($module->version, $module->database_version, '>')) {
             /*
              * $old_version variable is saved on purpose here, because calling Module::getInstanceByName will wipe
              * the $module->database_version information from the object.
@@ -746,7 +744,7 @@ abstract class ModuleCore implements ModuleInterface
             $old_version = $module->database_version;
             $module = Module::getInstanceByName($module->name);
             if ($module instanceof Module) {
-                return $module->loadUpgradeVersionList($module->name, $moduleVersion, $old_version);
+                return $module->loadUpgradeVersionList($module->name, $module->version, $old_version);
             }
         }
 
@@ -1584,7 +1582,6 @@ abstract class ModuleCore implements ModuleInterface
                         $item->$k = (string) $v;
                     }
 
-                    $item->version = self::getModuleVersion($item);
                     $item->displayName = stripslashes(Translate::getModuleTranslation((string) $xml_module->name, Module::configXmlStringFormat($xml_module->displayName), (string) $xml_module->name));
                     $item->description = stripslashes(Translate::getModuleTranslation((string) $xml_module->name, Module::configXmlStringFormat($xml_module->description), (string) $xml_module->name));
                     $item->author = stripslashes(Translate::getModuleTranslation((string) $xml_module->name, Module::configXmlStringFormat($xml_module->author), (string) $xml_module->name));
@@ -1638,7 +1635,7 @@ abstract class ModuleCore implements ModuleInterface
                         $item->id = (int) $tmp_module->id;
                         $item->warning = $tmp_module->warning;
                         $item->name = $tmp_module->name;
-                        $item->version = self::getModuleVersion($tmp_module);
+                        $item->version = $tmp_module->version;
                         $item->tab = $tmp_module->tab;
                         $item->displayName = $tmp_module->displayName;
                         $item->description = isset($tmp_module->description) ? stripslashes($tmp_module->description) : null;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Revert https://github.com/PrestaShop/PrestaShop/commit/26e6fb1ccc6eb1a9f460970710c3d5da00a6d059 as there is no reason to use a duplicate source of truth that doesn't have to be up to date all the time.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Automatic test.
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38957
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.
