### PR TITLE
BO : Product Form : Use the correct configuration for the Max Filesize

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1570,7 +1570,7 @@ services:
     autoconfigure: true
     arguments:
       $locales: "@=service('prestashop.adapter.legacy.context').getLanguages()"
-      $maxFileSizeInMegabytes: "@=service('prestashop.adapter.legacy.configuration').getInt('PS_ATTACHMENT_MAXIMUM_SIZE')"
+      $maxFileSizeInMegabytes: "@=service('prestashop.adapter.legacy.configuration').getInt('PS_LIMIT_UPLOAD_FILE_VALUE')"
       $router: "@router"
       $virtualProductFileListener: '@PrestaShopBundle\Form\Admin\Sell\Product\EventListener\VirtualProductFileListener'
     tags:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | BO : Product Form : Use the correct configuration for the Max Filesize
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to BO > Advanced Parameters > Administration >  Upload quota section<br>2. Set the field Maximum size for attached files : 2<br>3. Set the field Maximum size for a downloadable product :1<br>4. Click Save button<br>5. Go to BO > Catalog > Products > click on **New product** button > choose virtual product > click **Add new product** button<br>6. Go to **virtual product** tab > switch Add downloadable file to **yes**<br>7. Choose a file with size over than 2 Mo > See error message<br>See attached screenshot:<br>![image](https://github.com/PrestaShop/PrestaShop/assets/92626242/612e4e44-b721-45dc-ae3c-f12e9f93370f)<br>8. Choose another file with size over than 1 and  less than2 Mo (1.5 Mo for exp )> **BEFORE** : Successful update (The file chosen should not be accepted since his size is over than 1Mo already fixed in step 3 )/ **AFTER** : error message :tada: 
| Fixed issue or discussion?     | Fixes #33189
| Related PRs       | N/A
| Sponsor company   | lefevre.dev