### PR TITLE
Fix carrier ID for modules

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3648,7 +3648,14 @@ class CartCore extends ObjectModel
             return false;
         }
 
-        if ($module->id_carrier) {
+        /*
+         * If the module has an id_carrier property, we set it to the current carrier ID.
+         *
+         * We need to check if the property exists because not all carrier modules have this property.
+         * Those that extend CarrierModule have it automatically, but those extendind regular Module may not.
+         */
+        /** @phpstan-ignore-next-line */
+        if (property_exists($module, 'id_carrier')) {
             $module->id_carrier = $carrier->id;
         }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3654,7 +3654,7 @@ class CartCore extends ObjectModel
          * We need to check if the property exists because not all carrier modules have this property.
          * Those that extend CarrierModule have it automatically, but those extending regular Module may not.
          */
-        /** @phpstan-ignore-next-line */
+        /* @phpstan-ignore-next-line */
         if (property_exists($module, 'id_carrier')) {
             $module->id_carrier = $carrier->id;
         }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3652,7 +3652,7 @@ class CartCore extends ObjectModel
          * If the module has an id_carrier property, we set it to the current carrier ID.
          *
          * We need to check if the property exists because not all carrier modules have this property.
-         * Those that extend CarrierModule have it automatically, but those extendind regular Module may not.
+         * Those that extend CarrierModule have it automatically, but those extending regular Module may not.
          */
         /** @phpstan-ignore-next-line */
         if (property_exists($module, 'id_carrier')) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fixes regression from https://github.com/PrestaShop/PrestaShop/pull/29116 when the $module->id_carrier was not set because it was never filled in.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Auto test
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/15894000087
| Fixed issue or discussion?     | Slack thread https://prestashop.slack.com/archives/CTKG1NKAP/p1750792040291409 and Fixes https://github.com/PrestaShop/PrestaShop/issues/38207
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.
