### PR TITLE
Change default product type to TYPE_STANDARD

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -371,12 +371,9 @@ class ProductCore extends ObjectModel
     public $pack_quantity;
 
     /**
-     * For now default value remains undefined, to keep compatibility with page v1 and former products.
-     * But once the v2 is merged the default value should be ProductType::TYPE_STANDARD
-     *
      * @var string
      */
-    public $product_type = ProductType::TYPE_UNDEFINED;
+    public $product_type = ProductType::TYPE_STANDARD;
 
     /**
      * @var int
@@ -473,7 +470,7 @@ class ProductCore extends ObjectModel
             'product_type' => [
                 'type' => self::TYPE_STRING,
                 'validate' => 'isGenericName',
-                // For now undefined value is still allowed, in 179 we should use ProductType::AVAILABLE_TYPES here
+                // TYPE_UNDEFINED is here to support legacy products that have no type set
                 'values' => [
                     ProductType::TYPE_STANDARD,
                     ProductType::TYPE_PACK,
@@ -481,8 +478,7 @@ class ProductCore extends ObjectModel
                     ProductType::TYPE_COMBINATIONS,
                     ProductType::TYPE_UNDEFINED,
                 ],
-                // This default value should be replaced with ProductType::TYPE_STANDARD in 179 when the v2 page is fully migrated
-                'default' => ProductType::TYPE_UNDEFINED,
+                'default' => ProductType::TYPE_STANDARD,
             ],
 
             /* Shop fields */

--- a/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
@@ -25,14 +25,14 @@ Feature: Legacy products have consistent product type through dynamic checking (
     Given there is a product in the catalog named "Standard Product" with a price of 15.0 and 100 items in stock
     Then there is a product "standard_product" with name "Standard Product"
     And product "standard_product" type should be standard
-    And product "standard_product" persisted type should be undefined
+    And product "standard_product" persisted type should be standard
     And product "standard_product" dynamic type should be standard
 
   Scenario: I create a product and add combinations using legacy methods, its product type should be combinations
     Given there is a product in the catalog named "Product With Combinations" with a price of 15.0 and 100 items in stock
     Then there is a product "product_with_combinations" with name "Product With Combinations"
     And product "product_with_combinations" type should be standard
-    And product "product_with_combinations" persisted type should be undefined
+    And product "product_with_combinations" persisted type should be standard
     And product "Product With Combinations" has combinations with following details:
       | reference | quantity | attributes         |
       | whiteM    | 150      | Size:M;Color:White |
@@ -45,7 +45,7 @@ Feature: Legacy products have consistent product type through dynamic checking (
     Given there is a product in the catalog named "Virtual Product" with a price of 15.0 and 100 items in stock
     Then there is a product "virtual_product" with name "Virtual Product"
     And product "virtual_product" type should be standard
-    And product "virtual_product" persisted type should be undefined
+    And product "virtual_product" persisted type should be standard
     And product "virtual_product" dynamic type should be standard
     Given product "Virtual Product" is virtual
     Then product "virtual_product" type should be virtual
@@ -57,7 +57,7 @@ Feature: Legacy products have consistent product type through dynamic checking (
     And there is a product in the catalog named "Product in pack" with a price of 15.0 and 100 items in stock
     Then there is a product "pack_product" with name "Pack Product"
     And product "pack_product" type should be standard
-    And product "pack_product" persisted type should be undefined
+    And product "pack_product" persisted type should be standard
     And product "pack_product" dynamic type should be standard
     Given product "Pack Product" is a pack containing 10 items of product "Product in pack"
     Then product "Pack Product" is considered as a pack
@@ -69,5 +69,5 @@ Feature: Legacy products have consistent product type through dynamic checking (
     Given there is a product in the catalog named "Undefined Product" with a price of 15.0 and 100 items in stock
     Then there is a product "undefined_product" with name "Undefined Product"
     And product "undefined_product" type should be standard
-    And product "undefined_product" persisted type should be undefined
+    And product "undefined_product" persisted type should be standard
     And product "undefined_product" dynamic type should be standard


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | It was forgotten to change the default product type once v1 product page is gone. This fixes it.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Auto test
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/15900949203 🟢 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.
