### PR TITLE
Improve combination images speed

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2639,6 +2639,11 @@ class ProductCore extends ObjectModel
             return false;
         }
 
+        // If this product does not have any combinations, no need to do any queries
+        if ($this->getProductType() != ProductType::TYPE_COMBINATIONS) {
+            return false;
+        }
+
         $result = Db::getInstance()->executeS(
             'SELECT pai.`id_image`, pai.`id_product_attribute`, il.`legend`
             FROM `' . _DB_PREFIX_ . 'product_attribute_image` pai


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | It's a waste of resources to ask the database for combination images if there are none. I put 19 products to cart, reduces number of queries from 868 to 830.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Automatic test could be sufficient.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/15893988357
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 
