### PR TITLE
Improve cart performance by avoiding wiping a cache when not needed

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -104,6 +104,7 @@ class CartCore extends ObjectModel
     protected static $_isVirtualCart = [];
 
     protected $_products = null;
+    protected $_products_with_separated_gifts = null;
     protected static $_totalWeight = [];
     protected $_taxCalculationMethod = PS_TAX_EXC;
     protected static $_carriers = null;
@@ -180,8 +181,14 @@ class CartCore extends ObjectModel
 
     protected $addressFactory;
 
+    /**
+     * @deprecated since 9.1.0 - it doesn't do anything and will be removed
+     */
     protected $shouldSplitGiftProductsQuantity = false;
 
+    /**
+     * @deprecated since 9.1.0 - it doesn't do anything and will be removed
+     */
     protected $shouldExcludeGiftsDiscount = false;
 
     public const ONLY_PRODUCTS = 1;
@@ -247,6 +254,16 @@ class CartCore extends ObjectModel
         static::$cacheMultiAddressDelivery = [];
     }
 
+    public function resetProductRelatedStaticCache()
+    {
+        if (isset(self::$_nbProducts[$this->id])) {
+            unset(self::$_nbProducts[$this->id]);
+        }
+        if (isset(self::$_totalWeight[$this->id])) {
+            unset(self::$_totalWeight[$this->id]);
+        }
+    }
+
     /**
      * Set Tax calculation method.
      */
@@ -297,13 +314,9 @@ class CartCore extends ObjectModel
     public function update($nullValues = false)
     {
         // Wipe all product-related caches, because something may just change
-        if (isset(self::$_nbProducts[$this->id])) {
-            unset(self::$_nbProducts[$this->id]);
-        }
-        if (isset(self::$_totalWeight[$this->id])) {
-            unset(self::$_totalWeight[$this->id]);
-        }
+        $this->resetProductRelatedStaticCache();
         $this->_products = null;
+        $this->_products_with_separated_gifts = null;
 
         $return = parent::update($nullValues);
         Hook::exec('actionCartSave', ['cart' => $this]);
@@ -617,19 +630,35 @@ class CartCore extends ObjectModel
      * @param int|null $id_country
      * @param bool $fullInfos
      * @param bool $keepOrderPrices When true use the Order saved prices instead of the most recent ones from catalog (if Order exists)
+     * @param bool $shouldSplitGiftProductsQuantity When true, gifts will be displayed separately. Make sure not to call this from a loop
      *
      * @return array Products
      */
-    public function getProducts($refresh = false, $id_product = false, $id_country = null, $fullInfos = true, bool $keepOrderPrices = false)
-    {
+    public function getProducts(
+        $refresh = false,
+        $id_product = false,
+        $id_country = null,
+        $fullInfos = true,
+        bool $keepOrderPrices = false,
+        bool $shouldSplitGiftProductsQuantity = false
+    ) {
+        // If the cart is not saved, then there can't be any products in it
         if (!$this->id) {
             return [];
         }
+
+        // Get cache key we will use, depending on whether we want to split gift products quantity or not
+        if ($shouldSplitGiftProductsQuantity) {
+            $cacheKey = '_products_with_separated_gifts';
+        } else {
+            $cacheKey = '_products';
+        }
+
         // Product cache must be strictly compared to NULL, or else an empty cart will add dozens of queries
-        if ($this->_products !== null && !$refresh) {
-            // Return product row with specified ID if it exists
+        if ($this->{$cacheKey} !== null && !$refresh) {
+            // If a specific product ID is requested, we will search for it in the cache.
             if (is_int($id_product)) {
-                foreach ($this->_products as $product) {
+                foreach ($this->{$cacheKey} as $product) {
                     if ($product['id_product'] == $id_product) {
                         return [$product];
                     }
@@ -638,7 +667,8 @@ class CartCore extends ObjectModel
                 return [];
             }
 
-            return $this->_products;
+            // Otherwise, we return the whole cache
+            return $this->{$cacheKey};
         }
 
         // Build query
@@ -767,7 +797,7 @@ class CartCore extends ObjectModel
         Cart::cacheSomeAttributesLists($pa_ids, (int) $this->getAssociatedLanguage()->getId());
 
         if (empty($products)) {
-            $this->_products = [];
+            $this->{$cacheKey} = [];
 
             return [];
         }
@@ -777,7 +807,7 @@ class CartCore extends ObjectModel
 
             $givenAwayProductsIds = [];
 
-            if ($this->shouldSplitGiftProductsQuantity && $refresh) {
+            if ($shouldSplitGiftProductsQuantity) {
                 $gifts = $this->getCartRules(CartRule::FILTER_ACTION_GIFT, false);
                 if (count($gifts) > 0) {
                     foreach ($gifts as $gift) {
@@ -806,7 +836,7 @@ class CartCore extends ObjectModel
                 }
             }
 
-            $this->_products = [];
+            $this->{$cacheKey} = [];
 
             foreach ($products as &$product) {
                 if (!array_key_exists('is_gift', $product)) {
@@ -834,7 +864,7 @@ class CartCore extends ObjectModel
                     $product = $this->applyProductCalculations($product, $cart_shop_context, null, $keepOrderPrices);
                 } else {
                     // Separate products given away from those manually added to cart
-                    $this->_products[] = $this->applyProductCalculations($product, $cart_shop_context, $givenAwayQuantity, $keepOrderPrices);
+                    $this->{$cacheKey}[] = $this->applyProductCalculations($product, $cart_shop_context, $givenAwayQuantity, $keepOrderPrices);
                     unset($product['is_gift']);
                     $product = $this->applyProductCalculations(
                         $product,
@@ -844,13 +874,13 @@ class CartCore extends ObjectModel
                     );
                 }
 
-                $this->_products[] = $product;
+                $this->{$cacheKey}[] = $product;
             }
         } else {
-            $this->_products = $products;
+            $this->{$cacheKey} = $products;
         }
 
-        return $this->_products;
+        return $this->{$cacheKey};
     }
 
     /**
@@ -1479,13 +1509,8 @@ class CartCore extends ObjectModel
             die(Tools::displayError(sprintf('Product with ID "%s" could not be loaded.', $id_product)));
         }
 
-        if (isset(self::$_nbProducts[$this->id])) {
-            unset(self::$_nbProducts[$this->id]);
-        }
-
-        if (isset(self::$_totalWeight[$this->id])) {
-            unset(self::$_totalWeight[$this->id]);
-        }
+        // Wipe all product-related caches, because something may just change
+        $this->resetProductRelatedStaticCache();
 
         $data = [
             'cart' => $this,
@@ -1753,13 +1778,8 @@ class CartCore extends ObjectModel
         bool $preserveGiftsRemoval = true,
         bool $useOrderPrices = false
     ) {
-        if (isset(self::$_nbProducts[$this->id])) {
-            unset(self::$_nbProducts[$this->id]);
-        }
-
-        if (isset(self::$_totalWeight[$this->id])) {
-            unset(self::$_totalWeight[$this->id]);
-        }
+        // Wipe all product-related caches, because something may just change
+        $this->resetProductRelatedStaticCache();
 
         // First, if we are deleting a product with customization, we delete it from the database
         if ((int) $id_customization) {
@@ -2171,11 +2191,7 @@ class CartCore extends ObjectModel
      */
     public function getDiscountSubtotalWithoutGifts($withTaxes = true)
     {
-        $discountSubtotal = $this->excludeGiftsDiscountFromTotal()
-            ->getOrderTotal($withTaxes, self::ONLY_DISCOUNTS);
-        $this->includeGiftsDiscountInTotal();
-
-        return $discountSubtotal;
+        return $this->getOrderTotal($withTaxes, self::ONLY_DISCOUNTS);
     }
 
     /**
@@ -4609,52 +4625,70 @@ class CartCore extends ObjectModel
     }
 
     /**
+     * @deprecated since 9.1.0 - it doesn't do anything and will be removed
+     *
      * Set flag to split lines of products given away and also manually added to cart.
      */
     protected function splitGiftsProductsQuantity()
     {
         $this->shouldSplitGiftProductsQuantity = true;
-        $this->_products = null;
 
         return $this;
     }
 
     /**
+     * @deprecated since 9.1.0 - it doesn't do anything and will be removed
+     *
      * Set flag to merge lines of products given away and also manually added to cart.
      */
     protected function mergeGiftsProductsQuantity()
     {
         $this->shouldSplitGiftProductsQuantity = false;
-        $this->_products = null;
-
-        return $this;
-    }
-
-    protected function excludeGiftsDiscountFromTotal()
-    {
-        $this->shouldExcludeGiftsDiscount = true;
-        $this->_products = null;
-
-        return $this;
-    }
-
-    protected function includeGiftsDiscountInTotal()
-    {
-        $this->shouldExcludeGiftsDiscount = false;
-        $this->_products = null;
 
         return $this;
     }
 
     /**
-     * Get products with gifts and manually added occurrences separated.
+     * @deprecated since 9.1.0 - it doesn't do anything and will be removed
+     */
+    protected function excludeGiftsDiscountFromTotal()
+    {
+        $this->shouldExcludeGiftsDiscount = true;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated since 9.1.0 - it doesn't do anything and will be removed
+     */
+    protected function includeGiftsDiscountInTotal()
+    {
+        $this->shouldExcludeGiftsDiscount = false;
+
+        return $this;
+    }
+
+    /**
+     * Get products with gifts and manually added products separated.
+     * This is now a normal display in front office.
      *
      * @return array|null
      */
     public function getProductsWithSeparatedGifts()
     {
-        $products = $this->splitGiftsProductsQuantity()
-            ->getProducts($refresh = true);
+        // These are kept for backward compatibility, modules might expect
+        // this state set to true, but it doesn't do anything anymore.
+        $this->splitGiftsProductsQuantity();
+        $products = $this->getProducts(
+            refresh: false,
+            id_product: false,
+            id_country: null,
+            fullInfos: true,
+            keepOrderPrices: false,
+            shouldSplitGiftProductsQuantity: true
+        );
+        // These are kept for backward compatibility, modules might expect
+        // this state reset to false, but it doesn't do anything anymore.
         $this->mergeGiftsProductsQuantity();
 
         return $products;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This improves performance of the cart. Read below.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Auto test should reveal everything. It's a basic functionality of the shop.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/15900937668
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### Problem
- I noticed that when 1 product is in the cart, there are 10 huge queries coming from `getProducts` method.
- Cart class is caching result of `getProducts` method to a `_products` static variable, so it does not have to load everything again and again.
- But, when doing this with separated gifts via `getProductsWithSeparatedGifts` method, it always resets this cache in `splitGiftsProductsQuantity`, for nothing.
- So you once call it normally, once with separated, once normally, once separated. So maybe if you are lucky, it's getting cached only a few times.

### Solution
- So, I made a new cache key `_products_with_separated_gifts` that will cache both types of response, so once you call it, it's cached. Until the cart is updated, if it is.
- This reduced the number of queries from 285 to 278 and load time from `145 ms` to `129 ms`.

### Technical changes
- Using `{$cacheKey}` instead of `_products`.
- For separating a gift, a function parameter is added instead of a global object state. This caused an infinite loop when doing more simmilar getProduct calls inside. See my removed comment.
- Not wiping the cache in `includeGiftsDiscountInTotal`, `excludeGiftsDiscountFromTotal`, `splitGiftsProductsQuantity`, `mergeGiftsProductsQuantity`. They either have no effect or are not needed now.
- New method `resetProductRelatedStaticCache` so the code is a bit cleaner.