### PR TITLE
Verify if category exists before accessing it

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1967,7 +1967,8 @@ class CategoryCore extends ObjectModel
             $shop = Context::getContext()->shop;
         }
 
-        if (!$interval = Category::getInterval($shop->getCategory())) {
+        // Verify we got the interval of shop category
+        if (empty($interval = Category::getInterval($shop->getCategory()))) {
             return false;
         }
 
@@ -1990,14 +1991,21 @@ class CategoryCore extends ObjectModel
             $shop = Context::getContext()->shop;
         }
 
-        if (!$interval = Category::getInterval($shop->getCategory())) {
+        // Verify we got the interval of shop category
+        if (empty($interval = Category::getInterval($shop->getCategory()))) {
             return false;
         }
+
         $sql = new DbQuery();
         $sql->select('c.`nleft`, c.`nright`');
         $sql->from('category', 'c');
         $sql->where('c.`id_category` = ' . (int) $idCategory);
         $row = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($sql);
+
+        // If it doesn't exist, we can end up right here
+        if (empty($row)) {
+            return false;
+        }
 
         return $row['nleft'] >= $interval['nleft'] && $row['nright'] <= $interval['nright'];
     }

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -45,6 +45,7 @@ class LinkCore
     protected $ssl_enable;
     protected $urlShopId = null;
 
+    // Categories that will not be used for URL rewriting
     protected static $category_disable_rewrite = null;
 
     /**
@@ -67,6 +68,7 @@ class LinkCore
             define('_PS_BASE_URL_SSL_', Tools::getShopDomainSsl(true));
         }
 
+        // Define categories that will not be used for URL rewriting
         if (Link::$category_disable_rewrite === null) {
             Link::$category_disable_rewrite = [
                 Configuration::get('PS_HOME_CATEGORY'),
@@ -229,9 +231,12 @@ class LinkCore
             $product = $this->getProductObject($product, $idLang, $idShop);
             $params['category'] = (!$category) ? $product->category : $category;
             $cats = [];
+            /*
+             * We will use all categories in the path of the default category,
+             * with two exceptions - the root category and the home category.
+             */
             foreach ($product->getParentCategories($idLang) as $cat) {
                 if (!in_array($cat['id_category'], Link::$category_disable_rewrite)) {
-                    // remove root and home category from the URL
                     $cats[] = $cat['link_rewrite'];
                 }
             }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7458,7 +7458,11 @@ class ProductCore extends ObjectModel
             $id_lang = Context::getContext()->language->id;
         }
 
-        $interval = Category::getInterval($this->id_category_default);
+        // Verify we got the interval, the category may not exist at all
+        if (empty($interval = Category::getInterval($this->id_category_default))) {
+            return [];
+        }
+
         $sql = new DbQuery();
         $sql->from('category', 'c');
         $sql->leftJoin('category_lang', 'cl', 'c.id_category = cl.id_category AND id_lang = ' . (int) $id_lang . Shop::addSqlRestrictionOnLang('cl'));


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | God knows what people have in their databases. This verifies if we got sensible data for nleft and nright interval.  Having the database wrong breaks other things, but at least majority of the errors disappear. Doesn't hurt.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable debug mode. Go to SEO & URLs a setup a product route like this - `{categories:/}{id}{-:id_product_attribute}-{rewrite}.html`. Choose a product. Go to phpmyadmin and set `id_category_default` of the product to `0` in `ps_products` and `ps_product_shop`. Visit the product, see errors like `Warning:  Trying to access array offset on false in blabla/classes/Category.php on line 2002`. Apply the PR, errors on top of page disappear.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/15910913801
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39004
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.
