### PR TITLE
Client API - Help card is not displayed in sidebar as it should

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdminAPIController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdminAPIController.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdminAPIController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdminAPIController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -242,6 +243,7 @@ class AdminAPIController extends PrestaShopAdminController
             'layoutHeaderToolbarBtn' => $this->getApiClientsToolbarButtons(),
             'isAdminAPIMultistoreDisabled' => $isAdminAPIMultistoreDisabled,
             'configurationForm' => $configurationForm,
+            'enableSidebar' => true,
         ]);
     }
 
@@ -357,7 +359,6 @@ class AdminAPIController extends PrestaShopAdminController
     private function isAdminAPIMultistoreDisabled(): bool
     {
         return !$this->getFeatureFlagStateChecker()->isEnabled(FeatureFlagSettings::FEATURE_FLAG_ADMIN_API_MULTISTORE)
-            && $this->getShopContext()->isMultiShopEnabled()
-        ;
+            && $this->getShopContext()->isMultiShopEnabled();
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fix enable sidebar in the back office of the advanced parameters / Admin API page
| Type?             | bug fix 
| Category?         |  BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to the back office, on the advanced parameters / Admin API page page and click on the Help button.  Help should open in a sidebar
| UI Tests          | https://github.com/seiwan/ga.tests.ui.pr/actions/runs/15904194557.
| Fixed issue or discussion?     | Fixes #36570
| Related PRs       | None
| Sponsor company   | PrestaShop