### PR TITLE
fix: remove backslashes for checkout step identifier

### DIFF
--- a/classes/checkout/AbstractCheckoutStep.php
+++ b/classes/checkout/AbstractCheckoutStep.php
@@ -172,10 +172,10 @@ abstract class AbstractCheckoutStepCore implements CheckoutStepInterface
 
     public function getIdentifier()
     {
-        $classNameWithouBackslash = str_replace('\\', '', get_class($this));
+        $classNameWithoutBackslash = str_replace('\\', '', get_class($this));
 
         // SomeClassNameLikeThis => some-class-name-like-this
-        return Tools::camelCaseToKebabCase($classNameWithouBackslash);
+        return Tools::camelCaseToKebabCase($classNameWithoutBackslash);
     }
 
     public function getDataToPersist()

--- a/classes/checkout/AbstractCheckoutStep.php
+++ b/classes/checkout/AbstractCheckoutStep.php
@@ -172,8 +172,10 @@ abstract class AbstractCheckoutStepCore implements CheckoutStepInterface
 
     public function getIdentifier()
     {
+        $classNameWithouBackslash = str_replace('\\', '', get_class($this));
+
         // SomeClassNameLikeThis => some-class-name-like-this
-        return Tools::camelCaseToKebabCase(get_class($this));
+        return Tools::camelCaseToKebabCase($classNameWithouBackslash);
     }
 
     public function getDataToPersist()


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This pull request remove backslashes in checkout step identifiers. The full namespace is kept to preserving consistency<br>When a checkout step is added and this checkout step is a class using namespace, the checkout step identifier generated by AbstractCheckoutStep is a non valid html identifier.<br>This identifier contain the class name with full namespace, but use of backslash for html identifier create non valid CSS identifiers (which breaks javascript and css selectors).
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install module attached in issue, initiate the checkout process and check that generated identifier doesn't contain backslash
| UI Tests          | https://github.com/bibips/ga.tests.ui.pr/actions/runs/15920293609
| Fixed issue or discussion?     | Fixes #39011
| Related PRs       |
| Sponsor company   |
