### PR TITLE
Add idShop cache value for getLinkRewrite Category and Category CMS

### DIFF
--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -498,25 +498,33 @@ class CMSCategoryCore extends ObjectModel
         }
     }
 
-    public static function getLinkRewrite($id_cms_category, $id_lang)
+    /**
+     * Get the rewrite link of the given CMS Category.
+     *
+     * @param int $idCMSCategory CMS Category ID
+     * @param int $idLang Language ID
+     * @param int|null $idShop Shop ID
+     *
+     * @return bool|string
+     */
+    public static function getLinkRewrite($idCMSCategory, $idLang, ?int $idShop = null)
     {
-        if (!Validate::isUnsignedId($id_cms_category) || !Validate::isUnsignedId($id_lang)) {
+        if (!Validate::isUnsignedId($idCMSCategory) || !Validate::isUnsignedId($idLang)) {
             return false;
         }
 
-        if (isset(self::$_links[$id_cms_category . '-' . $id_lang])) {
-            return self::$_links[$id_cms_category . '-' . $id_lang];
+        $idShop = $idShop ?? Context::getContext()->shop->id;
+
+        if (!isset(self::$_links[$idCMSCategory . '-' . $idLang . '-' . $idShop])) {
+            self::$_links[$idCMSCategory . '-' . $idLang . '-' . $idShop] = Db::getInstance()->getValue('
+    		SELECT `link_rewrite`
+    		FROM `' . _DB_PREFIX_ . 'cms_category_lang`
+    		WHERE `id_lang` = ' . (int) $idLang . '
+    		' . Shop::addSqlRestrictionOnLang(null, $idShop) . '
+    		AND `id_cms_category` = ' . (int) $idCMSCategory);
         }
 
-        $result = Db::getInstance()->getRow('
-		SELECT cl.`link_rewrite`
-		FROM `' . _DB_PREFIX_ . 'cms_category` c
-		LEFT JOIN `' . _DB_PREFIX_ . 'cms_category_lang` cl ON c.`id_cms_category` = cl.`id_cms_category`
-		WHERE `id_lang` = ' . (int) $id_lang . '
-		AND c.`id_cms_category` = ' . (int) $id_cms_category);
-        self::$_links[$id_cms_category . '-' . $id_lang] = $result['link_rewrite'];
-
-        return $result['link_rewrite'];
+        return self::$_links[$idCMSCategory . '-' . $idLang . '-' . $idShop];
     }
 
     public function getLink(?Link $link = null)

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1353,25 +1353,28 @@ class CategoryCore extends ObjectModel
      *
      * @param int $idCategory Category ID
      * @param int $idLang Language ID
+     * @param int|null $idShop Shop ID
      *
-     * @return bool|mixed
+     * @return bool|string
      */
-    public static function getLinkRewrite($idCategory, $idLang)
+    public static function getLinkRewrite($idCategory, $idLang, ?int $idShop = null)
     {
         if (!Validate::isUnsignedId($idCategory) || !Validate::isUnsignedId($idLang)) {
             return false;
         }
 
-        if (!isset(self::$_links[$idCategory . '-' . $idLang])) {
-            self::$_links[$idCategory . '-' . $idLang] = Db::getInstance()->getValue('
-			SELECT cl.`link_rewrite`
-			FROM `' . _DB_PREFIX_ . 'category_lang` cl
+        $idShop = $idShop ?? Context::getContext()->shop->id;
+
+        if (!isset(self::$_links[$idCategory . '-' . $idLang . '-' . $idShop])) {
+            self::$_links[$idCategory . '-' . $idLang . '-' . $idShop] = Db::getInstance()->getValue('
+			SELECT `link_rewrite`
+			FROM `' . _DB_PREFIX_ . 'category_lang`
 			WHERE `id_lang` = ' . (int) $idLang . '
-			' . Shop::addSqlRestrictionOnLang('cl') . '
-			AND cl.`id_category` = ' . (int) $idCategory);
+			' . Shop::addSqlRestrictionOnLang(null, $idShop) . '
+			AND `id_category` = ' . (int) $idCategory);
         }
 
-        return self::$_links[$idCategory . '-' . $idLang];
+        return self::$_links[$idCategory . '-' . $idLang . '-' . $idShop];
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Category link cache doesn't take shopId as a parameter
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See issue
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/32704176392
| Fixed issue or discussion?     | Fixes #36794
| Sponsor company   | @Touxten


Old PR close : https://github.com/PrestaShop/PrestaShop/pull/37496

