### PR TITLE
Update default admin credentials in docker-compose.yml and improve README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ docker compose up
 
 Then reach your shop on this URL: http://localhost:8001
 
-Or the backoffice on this URL: http://localhost:8001/admin-dev (default access credentials: admin@prestashop.com / prestashop)
+Or the backoffice on this URL: http://localhost:8001/admin-dev (default access credentials: demo@prestashop.com / Correct Horse Battery Staple)
 
 You can customize the admin credentials by setting the following environment variables before running docker compose:
 ```
 export ADMIN_MAIL=your-email@example.com
-export ADMIN_PASSWD=your-secure-password
+export ADMIN_PASSWD=Your-Secure-Password
 docker compose up
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,16 @@ docker compose up
 
 Then reach your shop on this URL: http://localhost:8001
 
-Docker will bind your port 8001 to the web server. If you want to use other port, open and modify the file `docker-compose.yml`.
+Or the backoffice on this URL: http://localhost:8001/admin-dev (default access credentials: admin@prestashop.com / prestashop)
+
+You can customize the admin credentials by setting the following environment variables before running docker compose:
+```
+export ADMIN_MAIL=your-email@example.com
+export ADMIN_PASSWD=your-secure-password
+docker compose up
+```
+
+Docker will bind your port **8001** to the web server. If you want to use other port, open and modify the file `docker-compose.yml`.
 MySQL credentials can also be found and modified in this file if needed.
 
 **Note:**  Before auto-installing PrestaShop, this container checks the file *app/config/parameters.php* does not exist on startup.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,8 @@ services:
       PS_ENABLE_SSL: ${PS_ENABLE_SSL:-0}
       PS_ERASE_DB: ${PS_ERASE_DB:-0}
       PS_USE_DOCKER_MAILDEV: ${PS_USE_DOCKER_MAILDEV:-1}
-      ADMIN_MAIL: ${ADMIN_MAIL:-demo@prestashop.com}
-      ADMIN_PASSWD: ${ADMIN_PASSWD:-Correct Horse Battery Staple}
+      ADMIN_MAIL: ${ADMIN_MAIL:-admin@prestashop.com}
+      ADMIN_PASSWD: ${ADMIN_PASSWD:-prestashop}
       BLACKFIRE_ENABLE: ${BLACKFIRE_ENABLE:-0}
       BLACKFIRE_SERVER_ID: ${BLACKFIRE_SERVER_ID:-0}
       BLACKFIRE_SERVER_TOKEN: ${BLACKFIRE_SERVER_TOKEN:-0}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,8 @@ services:
       PS_ENABLE_SSL: ${PS_ENABLE_SSL:-0}
       PS_ERASE_DB: ${PS_ERASE_DB:-0}
       PS_USE_DOCKER_MAILDEV: ${PS_USE_DOCKER_MAILDEV:-1}
-      ADMIN_MAIL: ${ADMIN_MAIL:-admin@prestashop.com}
-      ADMIN_PASSWD: ${ADMIN_PASSWD:-prestashop}
+      ADMIN_MAIL: ${ADMIN_MAIL:-demo@prestashop.com}
+      ADMIN_PASSWD: ${ADMIN_PASSWD:-Correct Horse Battery Staple}
       BLACKFIRE_ENABLE: ${BLACKFIRE_ENABLE:-0}
       BLACKFIRE_SERVER_ID: ${BLACKFIRE_SERVER_ID:-0}
       BLACKFIRE_SERVER_TOKEN: ${BLACKFIRE_SERVER_TOKEN:-0}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Use the same authentication as PrestaShop Flashlight by default
| Type?             | improvement 
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `docker compose up`

PrestaShopFlashlight default authentication:
https://github.com/PrestaShop/prestashop-flashlight/blob/main/assets/hydrate.sh#L16-L17
