### PR TITLE
fix: Error when changing order status in multishop with separate warehouse

### DIFF
--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -46,8 +46,17 @@ class StockManager
      *
      * @return StockAvailable
      */
-    public function getStockAvailableByProduct($product, $id_product_attribute = null, $id_shop = null)
+    public function getStockAvailableByProduct($product, $id_product_attribute = null, $id_shop = null, $params = [])
     {
+
+        if ((empty($id_shop) || $id_shop === 0) && isset($params['id_order'])) {
+            $id_order = (int) $params['id_order'];
+            $order = new \Order($id_order);
+            if (\Validate::isLoadedObject($order)) {
+                $id_shop = (int) $order->id_shop;
+            } 
+        }
+        
         $stockAvailable = $this->newStockAvailable($this->getStockAvailableIdByProductId($product->id, $id_product_attribute, $id_shop));
 
         if (!$stockAvailable->id) {

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -49,7 +49,7 @@ class StockManager
     public function getStockAvailableByProduct($product, $id_product_attribute = null, $id_shop = null, $params = [])
     {
 
-        if ((empty($id_shop) || $id_shop === 0) && isset($params['id_order'])) {
+        if (empty($id_shop) && isset($params['id_order'])) {
             $id_order = (int) $params['id_order'];
             $order = new \Order($id_order);
             if (\Validate::isLoadedObject($order)) {

--- a/src/Core/Stock/StockManager.php
+++ b/src/Core/Stock/StockManager.php
@@ -387,7 +387,7 @@ class StockManager
 
         if ($product->id) {
             $stockManager = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\StockManager');
-            $stockAvailable = $stockManager->getStockAvailableByProduct($product, $productAttributeId, $params['id_shop'] ?? null);
+            $stockAvailable = $stockManager->getStockAvailableByProduct($product, $productAttributeId, $params['id_shop'] ?? null, $params);
 
             if ($stockAvailable->id) {
                 $stockMvt = new StockMvt();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | this fix resolve the bug in a multishop scenario with separate warehouse #38869
| Type?             | bug fix 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | changing order status updates correct rows on stock_available when "All stores" is selected
| Fixed issue or discussion?     | Fixes #38869
| Sponsor company   | Audes Group
