### PR TITLE
Remove docker compose version, it is obsolete

### DIFF
--- a/docker-compose.mariadb.yml
+++ b/docker-compose.mariadb.yml
@@ -1,5 +1,3 @@
-version: '2.1'
-
 volumes:
   db-data:
 

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -1,5 +1,3 @@
-version: '2.1'
-
 services:
   phpmyadmin:
     image: phpmyadmin/phpmyadmin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.1'
-
 volumes:
   db-data:
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove obsolete version from docker-compose.yml files. See https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-top-level-element-obsolete
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | run `docker compose up` and notice that there is not deprecation warning about the version 
| UI Tests          | n/a
| Fixed issue or discussion?     | -
| Related PRs       | 
| Sponsor company   | 
