### PR TITLE
Silence some last smarty deprecations

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -43,6 +43,7 @@ $smarty->compile_check = (Configuration::get('PS_SMARTY_FORCE_COMPILE') >= _PS_S
 $smarty->debug_tpl = _PS_ALL_THEMES_DIR_ . 'debug.tpl';
 
 // Register core classes used in smarty templates or else we cannot use the constant classes
+$smarty->registerClass('Configuration', '\Configuration');
 $smarty->registerClass('Context', '\Context');
 $smarty->registerClass('ImageManager', '\ImageManager');
 $smarty->registerClass('Module', '\Module');
@@ -95,6 +96,7 @@ smartyRegisterFunction($smarty, 'modifier', 'boolval', array('Tools', 'boolval')
 smartyRegisterFunction($smarty, 'modifier', 'classname', 'smartyClassname');
 smartyRegisterFunction($smarty, 'modifier', 'classnames', 'smartyClassnames');
 smartyRegisterFunction($smarty, 'modifier', 'cleanHtml', 'smartyCleanHtml');
+smartyRegisterFunction($smarty, 'modifier', 'dump', 'dump');
 smartyRegisterFunction($smarty, 'modifier', 'end', 'smarty_endWithoutReference');
 smartyRegisterFunction($smarty, 'modifier', 'escape', 'smartyEscape');
 smartyRegisterFunction($smarty, 'modifier', 'truncate', 'smarty_modifier_truncate');
@@ -102,6 +104,7 @@ smartyRegisterFunction($smarty, 'modifier', 'truncate', 'smarty_modifier_truncat
 // Native PHP functions
 smartyRegisterFunction($smarty, 'modifier', 'addcslashes', 'addcslashes');
 smartyRegisterFunction($smarty, 'modifier', 'addslashes', 'addslashes');
+smartyRegisterFunction($smarty, 'modifier', 'array_key_first', 'array_key_first');
 smartyRegisterFunction($smarty, 'modifier', 'array_merge', 'array_merge');
 smartyRegisterFunction($smarty, 'modifier', 'array_slice', 'array_slice');
 smartyRegisterFunction($smarty, 'modifier', 'date', 'date');
@@ -121,6 +124,7 @@ smartyRegisterFunction($smarty, 'modifier', 'nl2br', 'nl2br');
 smartyRegisterFunction($smarty, 'modifier', 'print_r', 'print_r');
 smartyRegisterFunction($smarty, 'modifier', 'rand', 'rand');
 smartyRegisterFunction($smarty, 'modifier', 'sizeof', 'sizeof');
+smartyRegisterFunction($smarty, 'modifier', 'sprintf', 'sprintf');
 smartyRegisterFunction($smarty, 'modifier', 'str_replace', 'str_replace');
 smartyRegisterFunction($smarty, 'modifier', 'stripslashes', 'stripslashes');
 smartyRegisterFunction($smarty, 'modifier', 'strstr', 'strstr');
@@ -132,6 +136,7 @@ smartyRegisterFunction($smarty, 'modifier', 'trim', 'trim');
 smartyRegisterFunction($smarty, 'modifier', 'ucfirst', 'ucfirst');
 smartyRegisterFunction($smarty, 'modifier', 'urlencode', 'urlencode');
 smartyRegisterFunction($smarty, 'modifier', 'var_dump', 'var_dump');
+smartyRegisterFunction($smarty, 'modifier', 'version_compare', 'version_compare');
 smartyRegisterFunction($smarty, 'modifier', 'file_exists', 'file_exists');
 smartyRegisterFunction($smarty, 'modifier', 'strpos', 'strpos');
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | There are some deprecation warnings from smarty on each first load of templates. This adds some last allowed things to the config. Examples - Configuration class to allow getting config for display, version_compare messages coming from our profiler, dump method so we can debug without smarty complaining etc.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | I think CI is sufficient, if basic things display normally, nothing is broken.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### Example of such messages
![Snímek obrazovky 2025-06-30 102959](https://github.com/user-attachments/assets/1e7ec50a-d419-4eb6-ae3b-c86b67001824)
