### PR TITLE
BO : Theme : Export current theme > Protect directories

### DIFF
--- a/src/Core/Addon/Theme/ThemeExporter.php
+++ b/src/Core/Addon/Theme/ThemeExporter.php
@@ -76,6 +76,7 @@ class ThemeExporter
         $this->copyTheme($theme->getDirectory(), $cacheDir);
         $this->copyModuleDependencies((array) $theme->get('dependencies.modules'), $cacheDir);
         $this->copyTranslations($theme, $cacheDir);
+        $this->protectDirectory($cacheDir);
 
         $finalFile = $this->configuration->get('_PS_ALL_THEMES_DIR_') . DIRECTORY_SEPARATOR . $theme->getName() . '.zip';
         $this->createZip($cacheDir, $finalFile);
@@ -89,7 +90,7 @@ class ThemeExporter
      * @param string $themeDir
      * @param string $cacheDir
      */
-    private function copyTheme($themeDir, $cacheDir)
+    private function copyTheme(string $themeDir, string $cacheDir): void
     {
         $fileList = Finder::create()
             ->files()
@@ -152,7 +153,7 @@ class ThemeExporter
      *
      * @return bool
      */
-    private function createZip($sourceDir, $destinationFileName)
+    private function createZip(string $sourceDir, string $destinationFileName): bool
     {
         $zip = new ZipArchive();
         $zip->open($destinationFileName, ZipArchive::CREATE);
@@ -167,5 +168,22 @@ class ThemeExporter
         }
 
         return $zip->close();
+    }
+
+    protected function protectDirectory(string $cacheDir): void
+    {
+        $dirs = Finder::create()
+            ->directories()
+            ->in($cacheDir)
+            ->exclude(['node_modules']);
+
+        $fs = new Filesystem();
+        foreach ($dirs as $dir) {
+            // Copy file
+            $fs->copy(
+                $this->configuration->get('_PS_ALL_THEMES_DIR_') . DIRECTORY_SEPARATOR . 'index.php',
+                $dir->getRealPath() . DIRECTORY_SEPARATOR . 'index.php'
+            );
+        }
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | BO : Theme : Export current theme > Protect directories & Add dot files
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to BO<br>2. Go to Design > Theme & Logo<br>3. Export current theme (Classic)<br>4. **BEFORE** : In the ZIP, there are no index.php in each directories<br>4. **AFTER** : In the ZIP, there are index.php in each directories file<br>
| UI Tests          | :heavy_check_mark: 
| Fixed issue or discussion?     | Fixes #38936
| Related PRs       | N/A
| Sponsor company   | lefevre.dev