### PR TITLE
Wipe @since tags that serve no value anymore

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -598,8 +598,6 @@ class AddressCore extends ObjectModel
     /**
      * Returns Address ID for a given Supplier ID.
      *
-     * @since 1.5.0
-     *
      * @param int $id_supplier Supplier ID
      *
      * @return int $id_address Address ID

--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -642,8 +642,6 @@ class AddressFormatCore extends ObjectModel
      * @param int $idCountry Country ID
      *
      * @return false|string|null Address format
-     *
-     * @since 1.7.0
      */
     protected function getFormatDB($idCountry)
     {

--- a/classes/Alias.php
+++ b/classes/Alias.php
@@ -138,8 +138,6 @@ class AliasCore extends ObjectModel
     /**
      * This method is allowed to know if a feature is used or active.
      *
-     * @since 1.5.0.1
-     *
      * @return bool
      */
     public static function isFeatureActive()
@@ -153,8 +151,6 @@ class AliasCore extends ObjectModel
      * @param int $idAlias Alias ID
      *
      * @return bool
-     *
-     * @since 1.5.6.0
      */
     public static function aliasExists($idAlias)
     {

--- a/classes/CMS.php
+++ b/classes/CMS.php
@@ -336,8 +336,6 @@ class CMSCore extends ObjectModel
      * Method required for new PrestaShop Core.
      *
      * @return string
-     *
-     * @since 1.7.0
      */
     public static function getRepositoryClassName()
     {

--- a/classes/CMSRole.php
+++ b/classes/CMSRole.php
@@ -48,8 +48,6 @@ class CMSRoleCore extends ObjectModel
 
     /**
      * @return string
-     *
-     * @since 1.7.0
      */
     public static function getRepositoryClassName()
     {

--- a/classes/CSV.php
+++ b/classes/CSV.php
@@ -27,8 +27,6 @@
 /**
  * Simple class to output CSV data
  * Uses CollectionCore.
- *
- * @since 1.5
  */
 class CSVCore
 {

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -250,7 +250,6 @@ class CarrierCore extends ObjectModel
     }
 
     /**
-     * @since 1.5.0
      * @see ObjectModel::delete()
      */
     public function delete()
@@ -888,8 +887,6 @@ class CarrierCore extends ObjectModel
     /**
      * Gets a specific group.
      *
-     * @since 1.5.0
-     *
      * @return array Group
      */
     public function getGroups()
@@ -1298,8 +1295,6 @@ class CarrierCore extends ObjectModel
     /**
      * Returns the Tax rates associated to the Carrier.
      *
-     * @since 1.5
-     *
      * @param Address $address Address optional
      *
      * @return float Total Tax rate for this Carrier
@@ -1318,8 +1313,6 @@ class CarrierCore extends ObjectModel
     /**
      * Returns the taxes calculator associated to the carrier.
      *
-     * @since 1.5
-     *
      * @param Address $address Address
      *
      * @return TaxCalculator|AverageTaxOfProductsTaxCalculator Tax calculator object
@@ -1337,8 +1330,6 @@ class CarrierCore extends ObjectModel
 
     /**
      * This tricky method generates a SQL clause to check if ranged data are overloaded by multishop.
-     *
-     * @since 1.5.0
      *
      * @param string $range_table Range table
      *
@@ -1371,8 +1362,6 @@ class CarrierCore extends ObjectModel
 
     /**
      * Moves a carrier.
-     *
-     * @since 1.5.0
      *
      * @param bool $way Up (1) or Down (0)
      * @param int|null $position Current position of the Carrier
@@ -1420,8 +1409,6 @@ class CarrierCore extends ObjectModel
      * Reorder Carrier positions
      * Called after deleting a Carrier.
      *
-     * @since 1.5.0
-     *
      * @return bool $return
      */
     public static function cleanPositions()
@@ -1448,8 +1435,6 @@ class CarrierCore extends ObjectModel
     /**
      * Gets the highest carrier position.
      *
-     * @since 1.5.0
-     *
      * @return int $position
      */
     public static function getHigherPosition()
@@ -1464,8 +1449,6 @@ class CarrierCore extends ObjectModel
 
     /**
      * For a given product, gets the carrier available.
-     *
-     * @since 1.5.0
      *
      * @param Product $product The id of the product, or an array with at least the package size and weight
      * @param int|null $id_warehouse Warehouse ID - not used anymore
@@ -1616,8 +1599,6 @@ class CarrierCore extends ObjectModel
 
     /**
      * Assign one (ore more) group to all carriers.
-     *
-     * @since 1.5.0
      *
      * @param int|array $id_group_list Group ID or array of Group IDs
      * @param array $exception List of Carrier IDs to ignore

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4560,8 +4560,6 @@ class CartCore extends ObjectModel
      *
      * @param bool $ignoreVirtual Ignore virtual products
      *
-     * @since 1.5.0
-     *
      * @return bool False if not all products in the cart are in stock
      */
     public function isAllProductsInStock($ignoreVirtual = false)

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1932,8 +1932,6 @@ class CategoryCore extends ObjectModel
      * @param int $id
      *
      * @return array
-     *
-     * @since 1.5.0
      */
     public static function getInterval($id)
     {
@@ -1958,8 +1956,6 @@ class CategoryCore extends ObjectModel
      * @param Shop $shop
      *
      * @return bool
-     *
-     * @since 1.5.0
      */
     public function inShop(?Shop $shop = null)
     {
@@ -1981,8 +1977,6 @@ class CategoryCore extends ObjectModel
      * @param Shop $shop Shop object
      *
      * @return bool Indicates whether the current category is a child of the Shop root category
-     *
-     * @since 1.5.0
      */
     public static function inShopStatic($idCategory, ?Shop $shop = null)
     {
@@ -2101,8 +2095,6 @@ class CategoryCore extends ObjectModel
      *
      * @return array|false Array with Category information
      *                     `false` if no Category found
-     *
-     * @since 1.7.0
      */
     public static function getCategoryInformation($idsCategory, $idLang = null)
     {

--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -453,8 +453,6 @@ class CombinationCore extends ObjectModel
     /**
      * This method is allow to know if a feature is active.
      *
-     * @since 1.5.0.1
-     *
      * @return bool
      */
     public static function isFeatureActive()
@@ -470,8 +468,6 @@ class CombinationCore extends ObjectModel
 
     /**
      * This method is allow to know if a Combination entity is currently used.
-     *
-     * @since 1.5.0.1
      *
      * @param string|null $table Name of table linked to entity
      * @param bool $hasActiveColumn True if the table has an active column
@@ -556,8 +552,6 @@ class CombinationCore extends ObjectModel
      * @param int $idProductAttribute
      *
      * @return string
-     *
-     * @since 1.5.0
      */
     public static function getPrice($idProductAttribute)
     {

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -48,8 +48,6 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  *
  * This class is responsible for holding all basic information about the environment,
  * the customer, cart, currency, language etc.
- *
- * @since 1.5.0.1
  */
 class ContextCore
 {

--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -352,8 +352,6 @@ class CookieCore
      * @param string|null $cookie Cookie content
      *
      * @return bool Indicates whether the Cookie was successfully set
-     *
-     * @since 1.7.0
      */
     protected function encryptAndSetCookie($cookie = null)
     {
@@ -473,8 +471,6 @@ class CookieCore
 
     /**
      * Check if the cookie exists.
-     *
-     * @since 1.5.0
      *
      * @return bool
      */

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1348,8 +1348,6 @@ class CustomerCore extends ObjectModel
     /**
      * Check customer information and return customer validity.
      *
-     * @since 1.5.0
-     *
      * @param bool $withGuest
      *
      * @return bool customer validity
@@ -1372,8 +1370,6 @@ class CustomerCore extends ObjectModel
 
     /**
      * Logout.
-     *
-     * @since 1.5.0
      */
     public function logout()
     {
@@ -1392,8 +1388,6 @@ class CustomerCore extends ObjectModel
     /**
      * Soft logout, delete everything that links to the customer
      * but leave there affiliate's information.
-     *
-     * @since 1.5.0
      */
     public function mylogout()
     {

--- a/classes/Customization.php
+++ b/classes/Customization.php
@@ -310,8 +310,6 @@ class CustomizationCore extends ObjectModel
     /**
      * This method is allow to know if a feature is used or active.
      *
-     * @since 1.5.0.1
-     *
      * @return bool
      */
     public static function isFeatureActive()
@@ -321,8 +319,6 @@ class CustomizationCore extends ObjectModel
 
     /**
      * This method is allow to know if a Customization entity is currently used.
-     *
-     * @since 1.5.0.1
      *
      * @param string|null $table Name of table linked to entity
      * @param bool $hasActiveColumn True if the table has an active column

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -25,9 +25,6 @@
  */
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
-/**
- * @since 1.5.0
- */
 class DispatcherCore
 {
     /**

--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -506,8 +506,6 @@ class EmployeeCore extends ObjectModel
      * @param int $idShop
      *
      * @return bool
-     *
-     * @since 1.5.0
      */
     public function hasAuthOnShop($idShop)
     {
@@ -520,8 +518,6 @@ class EmployeeCore extends ObjectModel
      * @param int $idShopGroup ShopGroup ID
      *
      * @return bool
-     *
-     * @since 1.5.0
      */
     public function hasAuthOnShopGroup($idShopGroup)
     {
@@ -544,8 +540,6 @@ class EmployeeCore extends ObjectModel
      * Get default id_shop with auth for current employee.
      *
      * @return int
-     *
-     * @since 1.5.0
      */
     public function getDefaultShopID()
     {

--- a/classes/Feature.php
+++ b/classes/Feature.php
@@ -290,8 +290,6 @@ class FeatureCore extends ObjectModel
      * This metohd is allow to know if a feature is used or active.
      *
      * @return bool
-     *
-     * @since 1.5.0.1
      */
     public static function isFeatureActive()
     {

--- a/classes/Gender.php
+++ b/classes/Gender.php
@@ -28,8 +28,6 @@ use PrestaShop\PrestaShop\Core\Domain\Title\ValueObject\Gender as ValueObjectGen
 
 /**
  * Class GenderCore.
- *
- * @since 1.5.0
  */
 class GenderCore extends ObjectModel
 {

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -254,8 +254,6 @@ class GroupCore extends ObjectModel
     /**
      * This method is allow to know if a feature is used or active.
      *
-     * @since 1.5.0.1
-     *
      * @return bool
      */
     public static function isFeatureActive()
@@ -269,8 +267,6 @@ class GroupCore extends ObjectModel
 
     /**
      * This method is allow to know if there are other groups than the default ones.
-     *
-     * @since 1.5.0.1
      *
      * @param string|null $table Name of table linked to entity
      * @param bool $has_active_column True if the table has an active column

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -310,8 +310,6 @@ class HookCore extends ObjectModel
     /**
      * Get the list of hook aliases, indexed by hook name
      *
-     * @since 1.7.1.0
-     *
      * @return array<string, array<string>> Array of hookName => hookAliases[]
      */
     private static function getAllHookAliases(): array
@@ -341,8 +339,6 @@ class HookCore extends ObjectModel
      * @param string $canonicalHookName Canonical hook name
      *
      * @return string[] List of aliases
-     *
-     * @since 1.7.1.0
      */
     private static function getHookAliasesFor(string $canonicalHookName): array
     {
@@ -414,8 +410,6 @@ class HookCore extends ObjectModel
      * @param bool $strict [default=false] Set to TRUE to avoid checking if aliases are callable as well
      *
      * @return bool
-     *
-     * @since 1.7.1.0
      */
     public static function isHookCallableOn(
         Module $module,
@@ -437,8 +431,6 @@ class HookCore extends ObjectModel
 
     /**
      * Call a hook (or one of its alternative names) on a module.
-     *
-     * @since 1.7.1.0
      *
      * @param Module $module
      * @param string $hookName
@@ -491,8 +483,6 @@ class HookCore extends ObjectModel
     /**
      * Get list of all registered hooks with modules, indexed by hook id and module id
      *
-     * @since 1.5.0
-     *
      * @return array<int, array<int, array{id_hook:string|int,title:string,description:string,'hm.position':string|int,'m.position':string|int,id_module:string,name:string,active:string|int}>>
      */
     public static function getHookModuleList()
@@ -541,8 +531,6 @@ class HookCore extends ObjectModel
 
     /**
      * Return Hooks List.
-     *
-     * @since 1.5.0
      *
      * @param int $id_hook
      * @param int|null $id_module
@@ -815,8 +803,6 @@ class HookCore extends ObjectModel
      * @return array[]|false returns an array of hook registrations, or false if the provided hook name is not registered
      *
      * @throws PrestaShopDatabaseException
-     *
-     * @since 1.5.0
      */
     public static function getHookModuleExecList($hookName = null)
     {

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -28,8 +28,6 @@
  * Class ImageManagerCore.
  *
  * This class includes functions for image manipulation
- *
- * @since 1.5.0
  */
 class ImageManagerCore
 {

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1501,8 +1501,6 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     /**
      * Check if more on than one language is activated.
      *
-     * @since 1.5.0
-     *
      * @return bool
      */
     public static function isMultiLanguageActivated($id_shop = null)

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -662,8 +662,6 @@ class LinkCore
     /**
      * Create a link to a module.
      *
-     * @since    1.5.0
-     *
      * @param string $module Module name
      * @param string $controller
      * @param array $params

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -286,8 +286,6 @@ class MetaCore extends ObjectModel
 
     /**
      * Get meta tags.
-     *
-     * @since 1.5.0
      */
     public static function getMetaTags($idLang, $pageName, $title = '')
     {
@@ -317,8 +315,6 @@ class MetaCore extends ObjectModel
      * @param string $pageName Page name
      *
      * @return array Meta tags
-     *
-     * @since 1.5.0
      */
     public static function getHomeMetas($idLang, $pageName)
     {
@@ -338,8 +334,6 @@ class MetaCore extends ObjectModel
      * @param string $pageName
      *
      * @return array
-     *
-     * @since 1.5.0
      */
     public static function getProductMetas($idProduct, $idLang, $pageName)
     {
@@ -364,8 +358,6 @@ class MetaCore extends ObjectModel
      * @param string $pageName
      *
      * @return array
-     *
-     * @since 1.5.0
      */
     public static function getCategoryMetas($idCategory, $idLang, $pageName, $title = '')
     {
@@ -405,8 +397,6 @@ class MetaCore extends ObjectModel
      * @param string $pageName
      *
      * @return array
-     *
-     * @since 1.5.0
      */
     public static function getManufacturerMetas($idManufacturer, $idLang, $pageName)
     {
@@ -432,8 +422,6 @@ class MetaCore extends ObjectModel
      * @param string $pageName
      *
      * @return array
-     *
-     * @since 1.5.0
      */
     public static function getSupplierMetas($idSupplier, $idLang, $pageName)
     {
@@ -458,8 +446,6 @@ class MetaCore extends ObjectModel
      * @param string $pageName
      *
      * @return array
-     *
-     * @since 1.5.0
      */
     public static function getCmsMetas($idCms, $idLang, $pageName)
     {
@@ -482,8 +468,6 @@ class MetaCore extends ObjectModel
      * @param string $pageName
      *
      * @return array
-     *
-     * @since 1.5.0
      */
     public static function getCmsCategoryMetas($idCmsCategory, $idLang, $pageName)
     {
@@ -498,9 +482,6 @@ class MetaCore extends ObjectModel
         return Meta::getHomeMetas($idLang, $pageName);
     }
 
-    /**
-     * @since 1.5.0
-     */
     public static function completeMetaTags($metaTags, $defaultValue, ?Context $context = null)
     {
         if (!$context) {

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -120,8 +120,6 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
 
     /**
      * @var array Contains object definition
-     *
-     * @since 1.5.0.1
      */
     public static $definition = [];
 
@@ -263,8 +261,6 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
      * Fields are not validated here, we consider they are already validated in getFields() method,
      * this is not the best solution but this is the only one possible for retro compatibility.
      *
-     * @since 1.5.0.1
-     *
      * @return array All object fields
      */
     public function getFieldsShop()
@@ -279,8 +275,6 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
 
     /**
      * Prepare multilang fields.
-     *
-     * @since 1.5.0.1
      *
      * @return array
      *
@@ -334,8 +328,6 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
 
     /**
      * Formats values of each fields.
-     *
-     * @since 1.5.0.1
      *
      * @param int $type FORMAT_COMMON or FORMAT_LANG or FORMAT_SHOP
      * @param int $id_lang If this parameter is given, only take lang fields
@@ -1022,8 +1014,6 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
     /**
      * Validate a single field.
      *
-     * @since 1.5.0.1
-     *
      * @param string $field Field name
      * @param mixed $value Field value
      * @param int|null $id_lang Language ID
@@ -1565,8 +1555,6 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
     /**
      * Checks if current object is associated to a shop.
      *
-     * @since 1.5.0.1
-     *
      * @param int|null $id_shop
      *
      * @return bool
@@ -1638,8 +1626,6 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
     /**
      * Gets the list of associated shop IDs.
      *
-     * @since 1.5.0.1
-     *
      * @return array<int, int>
      *
      * @throws PrestaShopDatabaseException
@@ -1661,8 +1647,6 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
 
     /**
      * Copies shop association data from object with specified ID.
-     *
-     * @since 1.5.0.1
      *
      * @param int $id
      *
@@ -1693,8 +1677,6 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
 
     /**
      * Checks if there is more than one entry in associated shop table for current object.
-     *
-     * @since 1.5.0.1
      *
      * @return bool
      */
@@ -1741,8 +1723,6 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
 
     /**
      * Updates a table and splits the common datas and the shop datas.
-     *
-     * @since 1.5.0.1
      *
      * @param string $classname
      * @param array $data
@@ -1889,8 +1869,6 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
     /**
      * Checks if an object type exists in the database.
      *
-     * @since 1.5.0.1
-     *
      * @param string|null $table Name of table linked to entity
      * @param bool $has_active_column True if the table has an active column
      *
@@ -1916,8 +1894,6 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
      * Fill an object with given data. Data must be an array with this syntax:
      * array(objProperty => value, objProperty2 => value, etc.).
      *
-     * @since 1.5.0.1
-     *
      * @param array $data
      * @param int|null $id_lang
      */
@@ -1937,8 +1913,6 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
 
     /**
      * Fill (hydrate) a list of objects in order to get a collection of these objects.
-     *
-     * @since 1.5.0.1
      *
      * @param string $class Class of objects to hydrate
      * @param array $datas List of data (multi-dimensional array)
@@ -2044,8 +2018,6 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
      * Return the field value for the specified language if the field is multilang,
      * else the field value.
      *
-     * @since 1.5.0.1
-     *
      * @param string $field_name
      * @param int|null $id_lang
      *
@@ -2076,8 +2048,6 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
      * Set a list of specific fields to update
      * array(field1 => true, field2 => false,
      * langfield1 => array(1 => true, 2 => false)).
-     *
-     * @since 1.5.0.1
      *
      * @param array<string, bool|array<int, bool>>|null $fields
      */

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -528,8 +528,6 @@ class PackCore extends Product
     /**
      * This method is allow to know if a feature is used or active.
      *
-     * @since 1.5.0.1
-     *
      * @return bool
      */
     public static function isFeatureActive()
@@ -539,8 +537,6 @@ class PackCore extends Product
 
     /**
      * This method is allow to know if a Pack entity is currently used.
-     *
-     * @since 1.5.0
      *
      * @param string|null $table Name of table linked to entity
      * @param bool $has_active_column True if the table has an active column

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -854,8 +854,6 @@ abstract class PaymentModuleCore extends Module
     /**
      * Allows specified payment modules to be used by a specific currency.
      *
-     * @since 1.4.5
-     *
      * @param int $id_currency
      * @param array $id_module_list
      *
@@ -889,7 +887,6 @@ abstract class PaymentModuleCore extends Module
      * List all installed and active payment modules.
      *
      * @see Module::getPaymentModules() if you need a list of module related to the user context
-     * @since 1.4.5
      *
      * @return array module information
      */

--- a/classes/PrestaShopCollection.php
+++ b/classes/PrestaShopCollection.php
@@ -26,8 +26,6 @@
 
 /**
  * Create a collection of ObjectModel objects.
- *
- * @since 1.5.0
  */
 class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
 {

--- a/classes/PrestaShopLogger.php
+++ b/classes/PrestaShopLogger.php
@@ -221,8 +221,6 @@ class PrestaShopLoggerCore extends ObjectModel
      * check if this log message already exists in database.
      *
      * @return bool true if exists
-     *
-     * @since 1.7.0
      */
     protected function isPresent()
     {

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2132,8 +2132,6 @@ class ProductCore extends ObjectModel
     /**
      * Add a product attribute.
      *
-     * @since 1.5.0.1
-     *
      * @param float $price Additional price
      * @param float $weight Additional weight
      * @param float $unit_impact Additional unit price
@@ -7101,8 +7099,6 @@ class ProductCore extends ObjectModel
     /**
      * Get all product attributes ids.
      *
-     * @since 1.5.0
-     *
      * @param int $id_product Product identifier
      * @param bool $shop_only
      *
@@ -7301,8 +7297,6 @@ class ProductCore extends ObjectModel
     /**
      * Gets the name of a given product, in the given lang.
      *
-     * @since 1.5.0
-     *
      * @param int $id_product Product identifier
      * @param int|null $id_product_attribute Attribute identifier
      * @param int|null $id_lang Language identifier
@@ -7390,8 +7384,6 @@ class ProductCore extends ObjectModel
     /**
      * For a given product, returns its real quantity.
      *
-     * @since 1.5.0
-     *
      * @param int $id_product Product identifier
      * @param int $id_product_attribute Attribute identifier
      * @param int $id_warehouse Warehouse identifier - not used anymore
@@ -7414,8 +7406,6 @@ class ProductCore extends ObjectModel
     /**
      * For a given product, tells if it uses the advanced stock management.
      *
-     * @since 1.5.0
-     *
      * @param int $id_product Product identifier
      *
      * @return bool
@@ -7434,8 +7424,6 @@ class ProductCore extends ObjectModel
 
     /**
      * This method allows to flush price cache.
-     *
-     * @since 1.5.0
      */
     public static function flushPriceCache()
     {
@@ -7445,8 +7433,6 @@ class ProductCore extends ObjectModel
 
     /**
      * Get list of parent categories.
-     *
-     * @since 1.5.0
      *
      * @param int|null $id_lang Language identifier
      *
@@ -7566,8 +7552,6 @@ class ProductCore extends ObjectModel
 
     /**
      * Get the product type (simple, virtual, pack).
-     *
-     * @since in 1.5.0
      *
      * @return int
      */

--- a/classes/ProductDownload.php
+++ b/classes/ProductDownload.php
@@ -202,8 +202,6 @@ class ProductDownloadCore extends ObjectModel
      * @param string $filename Filename physically
      *
      * @return int Product the id for this virtual product
-     *
-     * @since 1.5.0.1
      */
     public static function getIdFromFilename($filename)
     {
@@ -324,8 +322,6 @@ class ProductDownloadCore extends ObjectModel
      * This method is allow to know if a feature is used or active.
      *
      * @return bool
-     *
-     * @since 1.5.0.1
      */
     public static function isFeatureActive()
     {

--- a/classes/ProductSupplier.php
+++ b/classes/ProductSupplier.php
@@ -26,8 +26,6 @@
 
 /**
  * ProductSupplierCore class.
- *
- * @since 1.5.0
  */
 class ProductSupplierCore extends ObjectModel
 {

--- a/classes/Risk.php
+++ b/classes/Risk.php
@@ -26,8 +26,6 @@
 
 /**
  * Class RiskCore.
- *
- * @since 1.5.0
  */
 class RiskCore extends ObjectModel
 {

--- a/classes/Smarty/SmartyResourceModule.php
+++ b/classes/Smarty/SmartyResourceModule.php
@@ -26,8 +26,6 @@
 
 /**
  * Override module templates easily.
- *
- * @since 1.7.0.0
  */
 class SmartyResourceModuleCore extends Smarty_Resource_Custom
 {

--- a/classes/Smarty/SmartyResourceParent.php
+++ b/classes/Smarty/SmartyResourceParent.php
@@ -26,8 +26,6 @@
 
 /**
  * Override module templates easily.
- *
- * @since 1.7.0.0
  */
 class SmartyResourceParentCore extends Smarty_Resource_Custom
 {

--- a/classes/Smarty/TemplateFinder.php
+++ b/classes/Smarty/TemplateFinder.php
@@ -26,8 +26,6 @@
 
 /**
  * Determine the best existing template.
- *
- * @since 1.7.0.0
  */
 class TemplateFinderCore
 {

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -750,8 +750,6 @@ class SpecificPriceCore extends ObjectModel
     /**
      * This method is allow to know if a feature is used or active.
      *
-     * @since 1.5.0.1
-     *
      * @return bool
      */
     public static function isFeatureActive()

--- a/classes/Store.php
+++ b/classes/Store.php
@@ -189,8 +189,6 @@ class StoreCore extends ObjectModel
      * This method is allow to know if a store exists for AdminImportController.
      *
      * @return bool
-     *
-     * @since 1.7.0
      */
     public static function storeExists($idStore)
     {

--- a/classes/Supplier.php
+++ b/classes/Supplier.php
@@ -485,8 +485,6 @@ class SupplierCore extends ObjectModel
      * @param int $idProductAttribute
      *
      * @return array
-     *
-     * @since 1.5.0
      */
     public static function getProductInformationsBySupplier($idSupplier, $idProduct, $idProductAttribute = 0)
     {

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -635,9 +635,6 @@ class TabCore extends ObjectModel
         return parent::update($nullValues);
     }
 
-    /**
-     * @since 1.5.0
-     */
     public static function getClassNameById($idTab)
     {
         return Db::getInstance()->getValue('SELECT class_name FROM ' . _DB_PREFIX_ . 'tab WHERE id_tab = ' . (int) $idTab);

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1118,8 +1118,6 @@ class ToolsCore
      * @param string $passwd String to has
      *
      * @return string Hashed password
-     *
-     * @since 1.7.0
      */
     public static function hash($passwd)
     {
@@ -1132,8 +1130,6 @@ class ToolsCore
      * @param string $data String to encrypt
      *
      * @return string Hashed IV
-     *
-     * @since 1.7.0
      */
     public static function hashIV($data)
     {
@@ -2976,8 +2972,6 @@ exit;
     /**
      * Concat $begin and $end, add ? or & between strings.
      *
-     * @since 1.5.0
-     *
      * @param string $begin
      * @param string $end
      *
@@ -3137,8 +3131,6 @@ exit;
     /**
      * Allow to get the memory limit in octets.
      *
-     * @since 1.4.5.0
-     *
      * @return int|string the memory limit value in octet
      */
     public static function getMemoryLimit()
@@ -3150,8 +3142,6 @@ exit;
 
     /**
      * Gets the value of a configuration option in octets.
-     *
-     * @since 1.5.0
      *
      * @param string $option
      *
@@ -3239,8 +3229,6 @@ exit;
      * @param string $name module name
      *
      * @return bool true if exists
-     *
-     * @since 1.4.5.0
      */
     public static function apacheModExists($name)
     {
@@ -3347,8 +3335,6 @@ exit;
      * @param string $dir Add this to prefix output for example /path/dir/*
      *
      * @return array List of file found
-     *
-     * @since 1.5.0
      */
     public static function scandir($path, $ext = 'php', $dir = '', $recursive = false)
     {

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -26,8 +26,6 @@
 
 /**
  * Class TranslateCore.
- *
- * @since 1.5.0
  */
 class TranslateCore
 {

--- a/classes/Uploader.php
+++ b/classes/Uploader.php
@@ -382,8 +382,6 @@ class UploaderCore
      * @param bool $clearStatCache
      *
      * @return int
-     *
-     * @since 1.7.0
      */
     protected function getFileSize($filePath, $clearStatCache = false)
     {
@@ -398,8 +396,6 @@ class UploaderCore
      * @param string $var
      *
      * @return string
-     *
-     * @since 1.7.0
      */
     protected function getServerVars($var)
     {
@@ -410,8 +406,6 @@ class UploaderCore
      * @param string $directory
      *
      * @return string
-     *
-     * @since 1.7.0
      */
     protected function normalizeDirectory($directory)
     {

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -588,8 +588,6 @@ class ValidateCore
      * @param string $hashedPasswd Password to validate
      *
      * @return bool Indicates whether the given string is a valid hashed password
-     *
-     * @since 1.7.0
      */
     public static function isHashedPassword($hashedPasswd)
     {

--- a/classes/cache/CacheApc.php
+++ b/classes/cache/CacheApc.php
@@ -26,8 +26,6 @@
 
 /**
  * This class requires the PECL APC extension or PECL APCu extension to be installed.
- *
- * @since 1.5.0
  */
 class CacheApcCore extends Cache
 {

--- a/classes/cache/CacheXcache.php
+++ b/classes/cache/CacheXcache.php
@@ -26,8 +26,6 @@
 
 /**
  * This class require Xcache extension.
- *
- * @since 1.5.0
  */
 class CacheXcacheCore extends Cache
 {

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -30,8 +30,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @TODO Move undeclared variables and methods to this (base) class: $errors, $layout, checkLiveEditAccess, etc.
- *
- * @since 1.5.0
  */
 abstract class ControllerCore
 {
@@ -618,8 +616,6 @@ abstract class ControllerCore
 
     /**
      * Checks if the controller has been called from XmlHttpRequest (AJAX).
-     *
-     * @since 1.5
      *
      * @return bool
      */

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1033,8 +1033,6 @@ class FrontControllerCore extends Controller
     /**
      * Checks if token is valid.
      *
-     * @since 1.5.0.1
-     *
      * @return bool
      */
     public function isTokenValid()
@@ -1363,8 +1361,6 @@ class FrontControllerCore extends Controller
      * - /themes/default/override/layout-product-1.tpl
      * - /themes/default/override/layout-product.tpl
      * - /themes/default/layout.tpl.
-     *
-     * @since 1.5.0.13
      *
      * @return bool|string
      */

--- a/classes/controller/ModuleAdminController.php
+++ b/classes/controller/ModuleAdminController.php
@@ -23,10 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-/**
- * @since 1.5.0
- */
 abstract class ModuleAdminControllerCore extends AdminController
 {
     /** @var Module */

--- a/classes/controller/ModuleFrontController.php
+++ b/classes/controller/ModuleFrontController.php
@@ -23,10 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-/**
- * @since 1.5.0
- */
 class ModuleFrontControllerCore extends FrontController
 {
     /** @var Module */

--- a/classes/db/DbMySQLi.php
+++ b/classes/db/DbMySQLi.php
@@ -26,8 +26,6 @@
 
 /**
  * Class DbMySQLiCore.
- *
- * @since 1.5.0,1
  */
 class DbMySQLiCore extends Db
 {

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -26,8 +26,6 @@
 
 /**
  * Class DbPDOCore.
- *
- * @since 1.5.0.1
  */
 class DbPDOCore extends Db
 {

--- a/classes/db/DbQuery.php
+++ b/classes/db/DbQuery.php
@@ -26,8 +26,6 @@
 
 /**
  * SQL query builder.
- *
- * @since 1.5.0.1
  */
 class DbQueryCore
 {

--- a/classes/exception/PrestaShopDatabaseException.php
+++ b/classes/exception/PrestaShopDatabaseException.php
@@ -23,10 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-/**
- * @since 1.5.0
- */
 class PrestaShopDatabaseExceptionCore extends PrestaShopException
 {
     public function __toString()

--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -23,10 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-/**
- * @since 1.5.0
- */
 class PrestaShopExceptionCore extends Exception
 {
     /**

--- a/classes/exception/PrestaShopModuleException.php
+++ b/classes/exception/PrestaShopModuleException.php
@@ -23,10 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-/**
- * @since 1.5.0
- */
 class PrestaShopModuleExceptionCore extends PrestaShopException
 {
 }

--- a/classes/exception/PrestaShopPaymentException.php
+++ b/classes/exception/PrestaShopPaymentException.php
@@ -23,10 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-/**
- * @since 1.5.0
- */
 class PrestaShopPaymentExceptionCore extends PrestaShopException
 {
 }

--- a/classes/helper/HelperForm.php
+++ b/classes/helper/HelperForm.php
@@ -23,10 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-/**
- * @since 1.5.0
- */
 class HelperFormCore extends Helper
 {
     public $id;

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -28,9 +28,6 @@ use PrestaShop\PrestaShop\Adapter\Routing\LegacyHelperLinkBuilder;
 use PrestaShop\PrestaShop\Core\Routing\EntityLinkBuilderFactory;
 use PrestaShop\PrestaShop\Core\Routing\Exception\BuilderNotFoundException;
 
-/**
- * @since 1.5.0
- */
 class HelperListCore extends Helper
 {
     /**

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -163,8 +163,6 @@ abstract class ModuleCore implements ModuleInterface
     /** @var string Module web path (eg. '/shop/modules/modulename/') */
     protected $_path = null;
     /**
-     * @since 1.5.0.1
-     *
      * @var string Module local path (eg. '/home/prestashop/modules/modulename/')
      */
     protected $local_path = null;
@@ -962,7 +960,6 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @return bool
      *
-     * @since 1.4.1
      * @deprecated since 1.7
      * @see  PrestaShop\PrestaShop\Core\Module\ModuleManager->enable($name)
      */
@@ -1095,8 +1092,6 @@ abstract class ModuleCore implements ModuleInterface
      * @param array|string $name
      *
      * @return bool
-     *
-     * @since 1.7
      */
     public static function disableAllByName($name)
     {
@@ -1122,7 +1117,6 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @return bool
      *
-     * @since 1.4.1
      * @deprecated since 1.7
      * @see  PrestaShop\PrestaShop\Core\Module\ModuleManager->disable($name)
      */
@@ -2435,8 +2429,6 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Get realpath of a template of current module (check if template is overridden too).
      *
-     * @since 1.5.0
-     *
      * @param string $template
      *
      * @return string|null
@@ -2767,8 +2759,6 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Get module errors.
      *
-     * @since 1.5.0
-     *
      * @return array errors
      */
     public function getErrors()
@@ -2778,8 +2768,6 @@ abstract class ModuleCore implements ModuleInterface
 
     /**
      * Get module messages confirmation.
-     *
-     * @since 1.5.0
      *
      * @return array conf
      */
@@ -2791,8 +2779,6 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Get local path for module.
      *
-     * @since 1.5.0
-     *
      * @return string
      */
     public function getLocalPath()
@@ -2802,8 +2788,6 @@ abstract class ModuleCore implements ModuleInterface
 
     /**
      * Get uri path for module.
-     *
-     * @since 1.5.0
      *
      * @return string
      */

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1156,8 +1156,6 @@ class OrderCore extends ObjectModel
     }
 
     /**
-     * @since 1.5.0.1
-     *
      * @param int $id_cart_rule
      * @param string $name
      * @param array $values
@@ -1510,8 +1508,6 @@ class OrderCore extends ObjectModel
     /**
      * Get a collection of orders using reference.
      *
-     * @since 1.5.0.14
-     *
      * @param string $reference
      *
      * @return PrestaShopCollection Collection of Order
@@ -1670,8 +1666,6 @@ class OrderCore extends ObjectModel
     /**
      * This method return the ID of the previous order.
      *
-     * @since 1.5.0.1
-     *
      * @return int
      */
     public function getPreviousOrderId()
@@ -1686,8 +1680,6 @@ class OrderCore extends ObjectModel
 
     /**
      * This method return the ID of the next order.
-     *
-     * @since 1.5.0.1
      *
      * @return int
      */
@@ -1744,8 +1736,6 @@ class OrderCore extends ObjectModel
      * This method returns true if at least one order details uses the
      * One After Another tax computation method.
      *
-     * @since 1.5.0.1
-     *
      * @return bool
      */
     public function useOneAfterAnotherTaxComputationMethod()
@@ -1763,8 +1753,6 @@ class OrderCore extends ObjectModel
 
     /**
      * This method allows to get all Order Payment for the current order.
-     *
-     * @since 1.5.0.1
      *
      * @return PrestaShopCollection Collection of OrderPayment
      */
@@ -1788,8 +1776,6 @@ class OrderCore extends ObjectModel
 
     /**
      * This method allows to add a payment to the current order.
-     *
-     * @since 1.5.0.1
      *
      * @param string $amount_paid
      * @param string $payment_method
@@ -1888,8 +1874,6 @@ class OrderCore extends ObjectModel
      *
      * Get all documents linked to the current order
      *
-     * @since 1.5.0.1
-     *
      * @return array
      */
     public function getDocuments()
@@ -1947,8 +1931,6 @@ class OrderCore extends ObjectModel
     /**
      * Get all order_slips for the current order.
      *
-     * @since 1.5.0.2
-     *
      * @return PrestaShopCollection Collection of OrderSlip
      */
     public function getOrderSlipsCollection()
@@ -1961,8 +1943,6 @@ class OrderCore extends ObjectModel
 
     /**
      * Get all invoices for the current order.
-     *
-     * @since 1.5.0.1
      *
      * @return PrestaShopCollection Collection of OrderInvoice
      */
@@ -1977,8 +1957,6 @@ class OrderCore extends ObjectModel
     /**
      * Get all delivery slips for the current order.
      *
-     * @since 1.5.0.2
-     *
      * @return PrestaShopCollection Collection of OrderInvoice
      */
     public function getDeliverySlipsCollection()
@@ -1992,8 +1970,6 @@ class OrderCore extends ObjectModel
 
     /**
      * Get all not paid invoices for the current order.
-     *
-     * @since 1.5.0.2
      *
      * @return PrestaShopCollection Collection of Order invoice not paid
      */
@@ -2012,8 +1988,6 @@ class OrderCore extends ObjectModel
 
     /**
      * Get total paid.
-     *
-     * @since 1.5.0.1
      *
      * @param Currency $currency currency used for the total paid of the current order
      *
@@ -2048,8 +2022,6 @@ class OrderCore extends ObjectModel
     /**
      * Get the sum of total_paid_tax_incl of the orders with similar reference.
      *
-     * @since 1.5.0.1
-     *
      * @return float
      */
     public function getOrdersTotalPaid()
@@ -2064,8 +2036,6 @@ class OrderCore extends ObjectModel
 
     /**
      * This method allows to change the shipping cost of the current order.
-     *
-     * @since 1.5.0.1
      *
      * @param float $amount
      *
@@ -2090,8 +2060,6 @@ class OrderCore extends ObjectModel
 
     /**
      * Returns the correct product taxes breakdown.
-     *
-     * @since 1.5.0.1
      *
      * @return array
      */
@@ -2148,8 +2116,6 @@ class OrderCore extends ObjectModel
     /**
      * Returns the shipping taxes breakdown.
      *
-     * @since 1.5.0.1
-     *
      * @return array
      */
     public function getShippingTaxesBreakdown()
@@ -2173,8 +2139,6 @@ class OrderCore extends ObjectModel
      *
      * @todo
      *
-     * @since 1.5.0.1
-     *
      * @return array
      */
     public function getWrappingTaxesBreakdown()
@@ -2186,8 +2150,6 @@ class OrderCore extends ObjectModel
 
     /**
      * Returns the ecotax taxes breakdown.
-     *
-     * @since 1.5.0.1
      *
      * @return array
      */
@@ -2260,8 +2222,6 @@ class OrderCore extends ObjectModel
     }
 
     /**
-     * @since 1.5.0.4
-     *
      * @return OrderState|null null if Order haven't a state
      */
     public function getCurrentOrderState()
@@ -2285,8 +2245,6 @@ class OrderCore extends ObjectModel
 
     /**
      * Get all other orders with the same reference.
-     *
-     * @since 1.5.0.13
      */
     public function getBrother()
     {
@@ -2300,8 +2258,6 @@ class OrderCore extends ObjectModel
 
     /**
      * Get a collection of order payments.
-     *
-     * @since 1.5.0.13
      */
     public function getOrderPayments()
     {
@@ -2313,8 +2269,6 @@ class OrderCore extends ObjectModel
      *
      * With multishipping, order reference are the same for all orders made with the same cart
      * in this case this method suffix the order reference by a # and the order number
-     *
-     * @since 1.5.0.14
      */
     public function getUniqReference()
     {
@@ -2337,8 +2291,6 @@ class OrderCore extends ObjectModel
      *
      * With multishipping, order reference are the same for all orders made with the same cart
      * in this case this method suffix the order reference by a # and the order number
-     *
-     * @since 1.5.0.14
      */
     public static function getUniqReferenceOf($id_order)
     {
@@ -2351,8 +2303,6 @@ class OrderCore extends ObjectModel
      * Return id of carrier.
      *
      * Get id of the carrier used in order
-     *
-     * @since 1.5.5.0
      */
     public function getIdOrderCarrier()
     {

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -345,8 +345,6 @@ class OrderDetailCore extends ObjectModel
     /**
      * Returns the tax calculator associated to this order detail.
      *
-     * @since 1.5.0.1
-     *
      * @return TaxCalculator
      */
     public function getTaxCalculator()
@@ -356,8 +354,6 @@ class OrderDetailCore extends ObjectModel
 
     /**
      * Return the tax calculator associated to this order_detail.
-     *
-     * @since 1.5.0.1
      *
      * @param int $id_order_detail
      *
@@ -385,7 +381,6 @@ class OrderDetailCore extends ObjectModel
     /**
      * Save the tax calculator.
      *
-     * @since 1.5.0.1
      * @deprecated Functionality moved to Order::updateOrderDetailTax
      *             because we need the full order object to do a good job here.
      *             Will no longer be supported after 1.6.1

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -218,7 +218,6 @@ class OrderHistoryCore extends ObjectModel
                     // if becoming logable => adds sale
                     if ($new_os->logable && !$old_os->logable) {
                         ProductSale::addProductSale($product['product_id'], $product['product_quantity']);
-                        // @since 1.5.0 - Stock Management
                         if (!Pack::isPack($product['product_id'])
                             && in_array($old_os->id, $error_or_canceled_statuses)) {
                             StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], -(int) $product['product_quantity'], $order->id_shop);
@@ -226,8 +225,6 @@ class OrderHistoryCore extends ObjectModel
                     } elseif (!$new_os->logable && $old_os->logable) {
                         // if becoming unlogable => removes sale
                         ProductSale::removeProductSale($product['product_id'], $product['product_quantity']);
-
-                        // @since 1.5.0 - Stock Management
                         if (!Pack::isPack($product['product_id'])
                             && in_array($new_os->id, $error_or_canceled_statuses)) {
                             StockAvailable::updateQuantity($product['product_id'], $product['product_attribute_id'], (int) $product['product_quantity'], $order->id_shop);

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -325,8 +325,6 @@ class OrderInvoiceCore extends ObjectModel
      * This method returns true if at least one order details uses the
      * One After Another tax computation method.
      *
-     * @since 1.5
-     *
      * @return bool
      */
     public function useOneAfterAnotherTaxComputationMethod()
@@ -423,8 +421,6 @@ class OrderInvoiceCore extends ObjectModel
 
     /**
      * Returns the shipping taxes breakdown.
-     *
-     * @since 1.5
      *
      * @param Order $order
      *
@@ -561,8 +557,6 @@ class OrderInvoiceCore extends ObjectModel
     /**
      * Returns the ecotax taxes breakdown.
      *
-     * @since 1.5
-     *
      * @return array
      */
     public function getEcoTaxTaxesBreakdown()
@@ -591,8 +585,6 @@ class OrderInvoiceCore extends ObjectModel
     /**
      * Returns all the order invoice that match the date interval.
      *
-     * @since 1.5
-     *
      * @param string $date_from
      * @param string $date_to
      *
@@ -615,8 +607,6 @@ class OrderInvoiceCore extends ObjectModel
     }
 
     /**
-     * @since 1.5.0.3
-     *
      * @param int $id_order_state
      *
      * @return array collection of OrderInvoice
@@ -637,8 +627,6 @@ class OrderInvoiceCore extends ObjectModel
     }
 
     /**
-     * @since 1.5.0.3
-     *
      * @param string $date_from
      * @param string $date_to
      *
@@ -660,8 +648,6 @@ class OrderInvoiceCore extends ObjectModel
     }
 
     /**
-     * @since 1.5
-     *
      * @param int $id_order_invoice
      */
     public static function getCarrier($id_order_invoice)
@@ -675,8 +661,6 @@ class OrderInvoiceCore extends ObjectModel
     }
 
     /**
-     * @since 1.5
-     *
      * @param int $id_order_invoice
      */
     public static function getCarrierId($id_order_invoice)
@@ -708,8 +692,6 @@ class OrderInvoiceCore extends ObjectModel
     /**
      * Amounts of payments.
      *
-     * @since 1.5.0.2
-     *
      * @return float Total paid
      */
     public function getTotalPaid()
@@ -733,8 +715,6 @@ class OrderInvoiceCore extends ObjectModel
     /**
      * Rest Paid.
      *
-     * @since 1.5.0.2
-     *
      * @return float Rest Paid
      */
     public function getRestPaid()
@@ -748,8 +728,6 @@ class OrderInvoiceCore extends ObjectModel
 
     /**
      * Return collection of order invoice object linked to the payments of the current order invoice object.
-     *
-     * @since 1.5.0.14
      *
      * @return PrestaShopCollection|array Collection of OrderInvoice or empty array
      */
@@ -789,8 +767,6 @@ class OrderInvoiceCore extends ObjectModel
      * @param int $mod TAX_EXCL, TAX_INCL, DETAIL
      *
      * @return float|array
-     *
-     * @since 1.5.0.14
      */
     public function getSiblingTotal($mod = OrderInvoice::TAX_INCL)
     {
@@ -827,8 +803,6 @@ class OrderInvoiceCore extends ObjectModel
      * Get global rest to paid
      *    This method will return something different of the method getRestPaid if
      *    there is an other invoice linked to the payments of the current invoice.
-     *
-     * @since 1.5.0.13
      */
     public function getGlobalRestPaid()
     {
@@ -857,8 +831,6 @@ class OrderInvoiceCore extends ObjectModel
     }
 
     /**
-     * @since 1.5.0.2
-     *
      * @return bool Is paid ?
      */
     public function isPaid()
@@ -867,8 +839,6 @@ class OrderInvoiceCore extends ObjectModel
     }
 
     /**
-     * @since 1.5.0.2
-     *
      * @return PrestaShopCollection Collection of Order payment
      */
     public function getOrderPaymentCollection()
@@ -878,8 +848,6 @@ class OrderInvoiceCore extends ObjectModel
 
     /**
      * Get the formatted number of invoice.
-     *
-     * @since 1.5.0.2
      *
      * @param int $id_lang for invoice_prefix
      *
@@ -952,8 +920,6 @@ class OrderInvoiceCore extends ObjectModel
      * (because uses the whole environnement of PS classes that is not available during upgrade).
      * This method should execute once on an upgraded PrestaShop to fix all OrderInvoices in one shot.
      * This method is triggered once during a (non bulk) creation of a PDF from an OrderInvoice that is not fixed yet.
-     *
-     * @since 1.6.1.1
      */
     public static function fixAllShopAddresses()
     {

--- a/classes/order/OrderPayment.php
+++ b/classes/order/OrderPayment.php
@@ -84,8 +84,6 @@ class OrderPaymentCore extends ObjectModel
      * @param string $order_reference
      *
      * @return array
-     *
-     * @since 1.5.0.13
      */
     public static function getByOrderReference($order_reference)
     {
@@ -128,8 +126,6 @@ class OrderPaymentCore extends ObjectModel
      * Return order invoice object linked to the payment.
      *
      * @param int $id_order Order Id
-     *
-     * @since 1.5.0.13
      */
     public function getOrderInvoice($id_order)
     {

--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -23,10 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-/**
- * @since 1.5
- */
 abstract class HTMLTemplateCore
 {
     /**

--- a/classes/pdf/HTMLTemplateDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateDeliverySlip.php
@@ -26,9 +26,6 @@
 
 use PrestaShop\PrestaShop\Core\Util\Sorter;
 
-/**
- * @since 1.5
- */
 class HTMLTemplateDeliverySlipCore extends HTMLTemplate
 {
     /**

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -26,9 +26,6 @@
 
 use PrestaShop\PrestaShop\Core\Util\Sorter;
 
-/**
- * @since 1.5
- */
 class HTMLTemplateInvoiceCore extends HTMLTemplate
 {
     /**

--- a/classes/pdf/HTMLTemplateOrderReturn.php
+++ b/classes/pdf/HTMLTemplateOrderReturn.php
@@ -23,10 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-/**
- * @since 1.5
- */
 class HTMLTemplateOrderReturnCore extends HTMLTemplate
 {
     /**

--- a/classes/pdf/HTMLTemplateOrderSlip.php
+++ b/classes/pdf/HTMLTemplateOrderSlip.php
@@ -26,9 +26,6 @@
 
 use PrestaShop\PrestaShop\Core\Util\Sorter;
 
-/**
- * @since 1.5
- */
 class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
 {
     /**

--- a/classes/pdf/HTMLTemplateSupplyOrderForm.php
+++ b/classes/pdf/HTMLTemplateSupplyOrderForm.php
@@ -25,7 +25,6 @@
  */
 
 /**
- * @since 1.5
  * @deprecated since 9.0 and will be removed in 10.0, stock is now managed by new logic
  */
 class HTMLTemplateSupplyOrderFormCore extends HTMLTemplate

--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -23,10 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-/**
- * @since 1.5
- */
 class PDFCore
 {
     /**

--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -23,10 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-/**
- * @since 1.5
- */
 class PDFGeneratorCore extends TCPDF
 {
     public const DEFAULT_FONT = 'helvetica';

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -28,9 +28,6 @@ use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
-/**
- * @since 1.5.0
- */
 class ShopCore extends ObjectModel
 {
     /** @var int ID of shop group */

--- a/classes/shop/ShopGroup.php
+++ b/classes/shop/ShopGroup.php
@@ -23,10 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-/**
- * @since 1.5.0
- */
 class ShopGroupCore extends ObjectModel
 {
     public $name;

--- a/classes/stock/Stock.php
+++ b/classes/stock/Stock.php
@@ -27,7 +27,6 @@
 /**
  * Represents the products kept in warehouses.
  *
- * @since 1.5.0
  * @deprecated since 9.0 and will be removed in 10.0, stock is now managed by new logic
  */
 class StockCore extends ObjectModel

--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -29,8 +29,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Stock\StockSettings;
 /**
  * Represents quantities available
  * It is either synchronized with Stock or manualy set by the seller.
- *
- * @since 1.5.0
  */
 class StockAvailableCore extends ObjectModel
 {

--- a/classes/stock/StockManager.php
+++ b/classes/stock/StockManager.php
@@ -27,7 +27,6 @@
 /**
  * StockManager : implementation of StockManagerInterface.
  *
- * @since 1.5.0
  * @deprecated since 9.0 and will be removed in 10.0, stock is now managed by new logic
  */
 class StockManagerCore implements StockManagerInterface

--- a/classes/stock/StockManagerFactory.php
+++ b/classes/stock/StockManagerFactory.php
@@ -27,7 +27,6 @@
 /**
  * StockManagerFactory : factory of stock manager
  *
- * @since 1.5.0
  * @deprecated since 9.0 and will be removed in 10.0, stock is now managed by new logic
  */
 class StockManagerFactoryCore

--- a/classes/stock/StockManagerInterface.php
+++ b/classes/stock/StockManagerInterface.php
@@ -27,7 +27,6 @@
 /**
  * StockManagerInterface : defines a way to manage stock.
  *
- * @since 1.5.0
  * @deprecated since 9.0 and will be removed in 10.0, stock is now managed by new logic
  */
 interface StockManagerInterface

--- a/classes/stock/StockManagerModule.php
+++ b/classes/stock/StockManagerModule.php
@@ -25,7 +25,6 @@
  */
 
 /**
- * @since 1.5.0
  * @deprecated since 9.0 and will be removed in 10.0, stock is now managed by new logic
  */
 abstract class StockManagerModuleCore extends Module

--- a/classes/stock/StockMvt.php
+++ b/classes/stock/StockMvt.php
@@ -25,7 +25,8 @@
  */
 
 /**
- * @since 1.5.0 Defines stock movements
+ * Defines stock movements
+ *
  * @deprecated since 9.0 and will be removed in 10.0, this object model is no longer needed
  */
 class StockMvtCore extends ObjectModel
@@ -43,29 +44,21 @@ class StockMvtCore extends ObjectModel
     public $id_employee;
 
     /**
-     * @since 1.5.0
-     *
      * @var string The first name of the employee responsible of the movement
      */
     public $employee_firstname;
 
     /**
-     * @since 1.5.0
-     *
      * @var string The last name of the employee responsible of the movement
      */
     public $employee_lastname;
 
     /**
-     * @since 1.5.0
-     *
      * @var int The stock id on wtich the movement is applied
      */
     public $id_stock;
 
     /**
-     * @since 1.5.0
-     *
      * @var int the quantity of product with is moved
      */
     public $physical_quantity;
@@ -81,43 +74,31 @@ class StockMvtCore extends ObjectModel
     public $id_order = null;
 
     /**
-     * @since 1.5.0
-     *
      * @var int detrmine if the movement is a positive or negative operation
      */
     public $sign;
 
     /**
-     * @since 1.5.0
-     *
      * @var int Used when the movement is due to a supplier order
      */
     public $id_supply_order = null;
 
     /**
-     * @since 1.5.0
-     *
      * @var float Last value of the weighted-average method
      */
     public $last_wa = null;
 
     /**
-     * @since 1.5.0
-     *
      * @var float Current value of the weighted-average method
      */
     public $current_wa = null;
 
     /**
-     * @since 1.5.0
-     *
      * @var float The unit price without tax of the product associated to the movement
      */
     public $price_te;
 
     /**
-     * @since 1.5.0
-     *
      * @var int Refers to an other id_stock_mvt : used for LIFO/FIFO implementation in StockManager
      */
     public $referer;
@@ -161,8 +142,6 @@ class StockMvtCore extends ObjectModel
     /**
      * Gets the negative (decrements the stock) stock mvts that correspond to the given order, for :
      * the given product, in the given quantity.
-     *
-     * @since 1.5.0
      *
      * @param int $id_order
      * @param int $id_product
@@ -211,8 +190,6 @@ class StockMvtCore extends ObjectModel
 
     /**
      * For a given product, gets the last positive stock mvt.
-     *
-     * @since 1.5.0
      *
      * @param int $id_product
      * @param int $id_product_attribute Use 0 if the product does not have attributes

--- a/classes/stock/StockMvtReason.php
+++ b/classes/stock/StockMvtReason.php
@@ -48,7 +48,6 @@ class StockMvtReasonCore extends ObjectModel
     public $deleted = false;
 
     /**
-     * @since 1.5.0
      * @see ObjectModel::$definition
      */
     public static $definition = [
@@ -101,8 +100,6 @@ class StockMvtReasonCore extends ObjectModel
     /**
      * Same as StockMvtReason::getStockMvtReasons(), ignoring a specific lists of ids.
      *
-     * @since 1.5.0
-     *
      * @param int $id_lang
      * @param array $ids_ignore
      * @param int $sign optional
@@ -129,8 +126,6 @@ class StockMvtReasonCore extends ObjectModel
 
     /**
      * For a given id_stock_mvt_reason, tells if it exists.
-     *
-     * @since 1.5.0
      *
      * @param int $id_stock_mvt_reason
      *

--- a/classes/stock/StockMvtWS.php
+++ b/classes/stock/StockMvtWS.php
@@ -27,7 +27,6 @@
 /**
  * Webservice entity for stock movements.
  *
- * @since 1.5.0
  * @deprecated since 9.0 and will be removed in 10.0, this object model is no longer needed
  */
 class StockMvtWSCore extends ObjectModelCore

--- a/classes/stock/SupplyOrder.php
+++ b/classes/stock/SupplyOrder.php
@@ -25,7 +25,6 @@
  */
 
 /**
- * @since 1.5.0
  * @deprecated since 9.0 and will be removed in 10.0
  */
 class SupplyOrderCore extends ObjectModel

--- a/classes/stock/SupplyOrderDetail.php
+++ b/classes/stock/SupplyOrderDetail.php
@@ -27,7 +27,6 @@
 /**
  * Represents one product ordered.
  *
- * @since 1.5.0
  * @deprecated since 9.0 and will be removed in 10.0
  */
 class SupplyOrderDetailCore extends ObjectModel

--- a/classes/stock/SupplyOrderHistory.php
+++ b/classes/stock/SupplyOrderHistory.php
@@ -25,7 +25,6 @@
  */
 
 /**
- * @since 1.5.0
  * @deprecated since 9.0 and will be removed in 10.0
  */
 class SupplyOrderHistoryCore extends ObjectModel

--- a/classes/stock/SupplyOrderReceiptHistory.php
+++ b/classes/stock/SupplyOrderReceiptHistory.php
@@ -27,7 +27,6 @@
 /**
  * History of receipts.
  *
- * @since 1.5.0
  * @deprecated since 9.0 and will be removed in 10.0
  */
 class SupplyOrderReceiptHistoryCore extends ObjectModel

--- a/classes/stock/SupplyOrderState.php
+++ b/classes/stock/SupplyOrderState.php
@@ -25,7 +25,6 @@
  */
 
 /**
- * @since 1.5.0
  * @deprecated since 9.0 and will be removed in 10.0
  */
 class SupplyOrderStateCore extends ObjectModel

--- a/classes/stock/Warehouse.php
+++ b/classes/stock/Warehouse.php
@@ -27,7 +27,6 @@
 /**
  * Holds Stock.
  *
- * @since 1.5.0
  * @deprecated since 9.0 and will be removed in 10.0
  */
 class WarehouseCore extends ObjectModel

--- a/classes/stock/WarehouseProductLocation.php
+++ b/classes/stock/WarehouseProductLocation.php
@@ -24,7 +24,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 /**
- * @since 1.5.0
  * @deprecated since 9.0 and will be removed in 10.0
  */
 class WarehouseProductLocationCore extends ObjectModel

--- a/classes/tax/TaxCalculator.php
+++ b/classes/tax/TaxCalculator.php
@@ -25,8 +25,6 @@
  */
 
 /**
- * @since 1.5.0
- *
  * TaxCaculator is responsible of the tax computation
  */
 class TaxCalculatorCore

--- a/classes/tax/TaxManagerFactory.php
+++ b/classes/tax/TaxManagerFactory.php
@@ -23,10 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-/**
- * @since 1.5
- */
 class TaxManagerFactoryCore
 {
     protected static $cache_tax_manager;

--- a/classes/tax/TaxRulesTaxManager.php
+++ b/classes/tax/TaxRulesTaxManager.php
@@ -25,9 +25,6 @@
  */
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;
 
-/**
- * @since 1.5.0.1
- */
 class TaxRulesTaxManagerCore implements TaxManagerInterface
 {
     public $address;

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -109,8 +109,6 @@ class AdminImportControllerCore extends AdminController
             $this->trans('Store contacts', [], 'Admin.Advparameters.Feature'),
         ];
 
-        // @since 1.5.0
-
         $this->entities = array_flip($this->entities);
 
         switch ((int) Tools::getValue('entity')) {
@@ -3673,7 +3671,6 @@ class AdminImportControllerCore extends AdminController
     }
 
     /**
-     * @since 1.5.0
      * @deprecated Since 9.0 and will be removed in 10.0
      */
     public function supplyOrdersImport($offset = false, $limit = false, $validateOnly = false)

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2108,8 +2108,6 @@ class AdminTranslationsControllerCore extends AdminController
     /**
      * Get each informations for each mails found in the folder $dir.
      *
-     * @since 1.4.0.14
-     *
      * @param string $dir
      * @param string $group_name
      *
@@ -2177,8 +2175,6 @@ class AdminTranslationsControllerCore extends AdminController
     /**
      * Get content of the mail file.
      *
-     * @since 1.4.0.14
-     *
      * @param string $dir
      * @param string $file
      *
@@ -2198,8 +2194,6 @@ class AdminTranslationsControllerCore extends AdminController
     /**
      * Display mails in html format.
      * This was create for factorize the html displaying.
-     *
-     * @since 1.4.0.14
      *
      * @param array $mails
      * @param array $all_subject_mail
@@ -2324,8 +2318,6 @@ class AdminTranslationsControllerCore extends AdminController
     /**
      * Just build the html structure for display txt mails.
      *
-     * @since 1.4.0.14
-     *
      * @param array $content With english and language needed contents
      * @param string $lang ISO code of the needed language
      * @param string $mail_name Name of the file to translate (same for txt and html files)
@@ -2356,8 +2348,6 @@ class AdminTranslationsControllerCore extends AdminController
 
     /**
      * Just build the html structure for display html mails.
-     *
-     * @since 1.4.0.14
      *
      * @param array $content With english and language needed contents
      * @param string $lang ISO code of the needed language
@@ -2874,8 +2864,6 @@ class AdminTranslationsControllerCore extends AdminController
 
     /**
      * Parse PDF class.
-     *
-     * @since 1.4.5.0
      *
      * @param string $file_path File to parse
      * @param string $file_type Type of file

--- a/src/Core/Domain/Currency/Exception/InvalidUnofficialCurrencyException.php
+++ b/src/Core/Domain/Currency/Exception/InvalidUnofficialCurrencyException.php
@@ -42,8 +42,6 @@ class InvalidUnofficialCurrencyException extends CurrencyException
      * @param string $isoCode Invalid currency ISO code
      * @param int $code [optional] The Exception code
      * @param Throwable $previous [optional] The previous throwable used for the exception chaining
-     *
-     * @since 5.1.0
      */
     public function __construct($message, $isoCode, $code = 0, ?Throwable $previous = null)
     {

--- a/tests/Resources/modules_tests/override_for_unit_test/classes/Cart.php
+++ b/tests/Resources/modules_tests/override_for_unit_test/classes/Cart.php
@@ -23,8 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-
 class Cart extends CartCore
 {
     public const BOTH = 999;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Cleaned up old `@since 1.5` comments. These were added for stuff introduced in like 2010, and nobody cares anymore. They're just noise at this point, because the code that stayed is actively used.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is sufficient
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.
