### PR TITLE
Fix display of Nav Bar with NULL icons

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/nav_bar.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/nav_bar.html.twig
@@ -52,7 +52,7 @@
           {% set level1Name = level1.class_name %}
         {% endif %}
 
-        {% if level1.icon is not same as '' %}
+        {% if level1.icon is not empty %}
 
           <li class="link-levelone{% if level1.current %} link-levelone-active{% endif %}" data-submenu="{{ level1.id_tab }}" id="tab-{{ level1.class_name }}">
             <a href="{{ level1Href }}" class="link" >

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/nav_bar.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/nav_bar.html.twig
@@ -52,7 +52,7 @@
           {% set level1Name = level1.class_name %}
         {% endif %}
 
-        {% if level1.icon is not same as '' %}
+        {% if level1.icon is not empty %}
 
           <li class="link-levelone{% if level1.current %} link-levelone-active{% endif %}" data-submenu="{{ level1.id_tab }}" id="tab-{{ level1.class_name }}">
             <a href="{{ level1Href }}" class="link" >


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fix the display of the whole nav bar when `Tab`s have an icon set as NULL. This acceptable value makes the entries disappearing from the nav bar.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | No
| Deprecations?     | No
| How to test?      | On PrestaShop v9, change all your existing tabs to set empty icons as NULL with the following SQL request: `update PREFIX_tab set icon = NULL where icon = '';`. After a refresh of the BO, the entries will be missing.
| UI Tests          | /
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38937
| Related PRs       | /
| Sponsor company   | @PrestaShopCorp

### Expected result:

![Capture d’écran du 2025-07-03 11-39-44](https://github.com/user-attachments/assets/90453e18-a00f-4ddc-a97f-cdf44ef51b29)

### PrestaShop v9 with tabs having icon as `NULL`

![Capture d’écran du 2025-07-03 11-40-15](https://github.com/user-attachments/assets/892f2b86-2816-481a-9213-ad3abc1f32f8)
