### PR TITLE
Add option to automatically generate text version of emails

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -627,7 +627,7 @@ class MailCore extends ObjectModel
                     $templateHtml = strtr($templateHtml, $templateVars);
                     $email->html($templateHtml);
 
-                    $templateTxt = (new PrestaShop\PrestaShop\Core\MailTemplate\Transformation\HTMLToTextTransformation)->apply($templateHtml, []);
+                    $templateTxt = (new PrestaShop\PrestaShop\Core\MailTemplate\Transformation\HTMLToTextTransformation())->apply($templateHtml, []);
                     $email->text($templateTxt);
                     break;
             }

--- a/src/Core/Email/MailOption.php
+++ b/src/Core/Email/MailOption.php
@@ -62,6 +62,12 @@ final class MailOption
     public const TYPE_BOTH = 3;
 
     /**
+     * @var int Option defines that emails should be sent in both HTML and TXT formats,
+     *          with TXT format being automatically generated from HTML content
+     */
+    public const TYPE_BOTH_AUTOMATIC_TEXT = 4;
+
+    /**
      * Class should not be initialized as its responsibility is to hold mail method options.
      */
     private function __construct()

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
@@ -98,6 +98,7 @@ class EmailConfigurationType extends TranslatorAwareType
                     $this->trans('Send email in HTML format', 'Admin.Advparameters.Feature') => MailOption::TYPE_HTML,
                     $this->trans('Send email in text format', 'Admin.Advparameters.Feature') => MailOption::TYPE_TXT,
                     $this->trans('Both', 'Admin.Advparameters.Feature') => MailOption::TYPE_BOTH,
+                    $this->trans('Both, with text format automatically generated', 'Admin.Advparameters.Feature') => MailOption::TYPE_BOTH_AUTOMATIC_TEXT,
                 ],
             ])
             ->add('log_emails', SwitchType::class, [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Simplifies email management and allows to still send both HTML and TXT version of emails, but generate TXT automatically on the fly from the HTML version. At least one management burden gone, when we still don't have twig... I use this solution for a while in production now and everything works flawlessly. The .txt template doesn't have to exist at all.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to Advanced configuration > Emails > Select `Both, with text format automatically generated`. Try to send email, should work fine.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16370284264
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### Email 
![Snímek obrazovky 2025-07-03 152744](https://github.com/user-attachments/assets/2d94cad1-704d-4b95-87b9-2823712b021c)

