### PR TITLE
Fix: carrier logo preview size

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/_carrier.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_carrier.scss
@@ -1,4 +1,4 @@
-$component: 'carrier';
+$component: "carrier" !default;
 
 .#{$component} {
   &__logo {

--- a/admin-dev/themes/new-theme/scss/pages/_carrier.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_carrier.scss
@@ -1,0 +1,10 @@
+$component: 'carrier';
+
+.#{$component} {
+  &__logo {
+    max-width: var(--#{$cdk}size-128);
+    max-height: var(--#{$cdk}size-128);
+    padding: var(--#{$cdk}size-4);
+    border: var(--#{$cdk}size-1) solid var(--#{$cdk}primary-400);
+  }
+}

--- a/admin-dev/themes/new-theme/scss/theme.scss
+++ b/admin-dev/themes/new-theme/scss/theme.scss
@@ -92,7 +92,6 @@
 @import "pages/translation_page";
 @import "pages/product_preferences";
 @import "pages/admin_api";
-@import "pages/discount";
 @import "pages/carrier";
 
 // Main Layout

--- a/admin-dev/themes/new-theme/scss/theme.scss
+++ b/admin-dev/themes/new-theme/scss/theme.scss
@@ -92,6 +92,8 @@
 @import "pages/translation_page";
 @import "pages/product_preferences";
 @import "pages/admin_api";
+@import "pages/discount";
+@import "pages/carrier";
 
 // Main Layout
 @import "pages/modules";

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
@@ -92,6 +92,7 @@ class GeneralSettings extends TranslatorAwareType
             ])
             ->add('logo_preview', ImagePreviewType::class, [
                 'label' => $this->trans('Logo', 'Admin.Global'),
+                'image_class' => 'img-fluid carrier__logo',
             ])
             ->add('logo', FileType::class, [
                 'label' => null,

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -763,15 +763,13 @@
 
       {# If there is only one error then display it without popover #}
     {%- else -%}
-      <div class="d-inline-block text-danger align-top">
+      <div class="d-inline-block align-baseline text-danger mt-1" role="alert">
         <i class="material-icons form-error-icon">error_outline</i>
-      </div>
-      <div class="d-inline-block">
+
         {% for error in errors %}
-          <div class="text-danger">
-            <p> {{ error.messageTemplate|trans(error.messageParameters, 'form_error') }}
-            </p>
-          </div>
+          <span>
+            {{ error.messageTemplate|trans(error.messageParameters, 'form_error') }}
+          </span>
         {%- endfor -%}
       </div>
     {%- endif -%}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Add size limitation on preview logo and improve error display.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow the issue : https://github.com/PrestaShop/PrestaShop/issues/39025
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16145944581
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39025
| Related PRs       | --
| Sponsor company   | @PrestaShopCorp

![Capture d’écran 2025-07-07 à 16 13 32](https://github.com/user-attachments/assets/cbfad6e5-ff7f-43ac-9e50-df8745dd4553)
![image](https://github.com/user-attachments/assets/2d98dc72-670e-4b5e-bcab-c2fe577200df)

