### PR TITLE
Remove getCasters override not necessary anymore with SF 6.4

### DIFF
--- a/src/PrestaShopBundle/DataCollector/HookDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/HookDataCollector.php
@@ -26,15 +26,10 @@
 
 namespace PrestaShopBundle\DataCollector;
 
-use DateTimeInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
-use Symfony\Component\VarDumper\Caster\CutStub;
-use Symfony\Component\VarDumper\Caster\ReflectionCaster;
-use Symfony\Component\VarDumper\Cloner\Stub;
 use Throwable;
-use TypeError;
 
 /**
  * Collect all information about Legacy hooks and make it available
@@ -151,39 +146,5 @@ final class HookDataCollector extends DataCollector
         }
 
         return $hooksList;
-    }
-
-    /**
-     * @return callable[] The casters to add to the cloner
-     */
-    protected function getCasters()
-    {
-        $casters = [
-            '*' => function ($v, array $a, Stub $s, $isNested) {
-                if (!$v instanceof Stub) {
-                    $b = $a;
-                    foreach ($a as $k => $v) {
-                        if (!\is_object($v) || $v instanceof DateTimeInterface || $v instanceof Stub) {
-                            continue;
-                        }
-
-                        try {
-                            $a[$k] = $s = new CutStub($v);
-
-                            if ($b[$k] === $s) {
-                                // we've hit a non-typed reference
-                                $a[$k] = $v;
-                            }
-                        } catch (TypeError $e) {
-                            // we've hit a typed reference
-                        }
-                    }
-                }
-
-                return $a;
-            },
-        ] + ReflectionCaster::UNSET_CLOSURE_FILE_INFO;
-
-        return $casters;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This modification was brought in this initial PR on 8.2 https://github.com/PrestaShop/PrestaShop/pull/37928 and backported on the 9.0.x branch via the merge PR https://github.com/PrestaShop/PrestaShop/pull/38975 Bit the modification is actually copied from more recent Symfont versions, this override is no longer required with Symfony 6.4 as a base on PrestaShop 9.0
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/16146343973
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
