### PR TITLE
Create-shipment-tab

### DIFF
--- a/src/Core/Grid/Action/Row/Type/Shipment/AdditionalShipmentRowAction.php
+++ b/src/Core/Grid/Action/Row/Type/Shipment/AdditionalShipmentRowAction.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\Shipment;
+
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\AbstractRowAction;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class AdditionalShipmentRowAction extends AbstractRowAction
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'additional_shipment_row_action';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver
+            ->setRequired([
+                'shipment_id_field',
+            ])
+            ->setAllowedTypes('shipment_id_field', 'string');
+    }
+}

--- a/src/Core/Grid/Data/Factory/ShipmentGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/ShipmentGridDataFactory.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
+
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Core\Context\CurrencyContext;
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
+
+class ShipmentGridDataFactory implements GridDataFactoryInterface
+{
+    public function __construct(
+        private readonly GridDataFactoryInterface $shipmentDataFactory,
+        private readonly LocaleInterface $locale,
+        private readonly CurrencyContext $currencyContext,
+        private readonly Configuration $configuration,
+    ) {
+    }
+
+    public function getData(SearchCriteriaInterface $searchCriteria): GridData
+    {
+        $data = $this->shipmentDataFactory->getData($searchCriteria);
+        $modifiedRecords = $this->applyModifications($data->getRecords());
+
+        return new GridData(
+            $modifiedRecords,
+            $data->getRecordsTotal(),
+            $data->getQuery()
+        );
+    }
+
+    private function applyModifications(RecordCollectionInterface $records): RecordCollectionInterface
+    {
+        $updated = [];
+
+        foreach ($records as $record) {
+            $record['price'] = $this->locale->formatPrice((float) $record['price'], $this->currencyContext->getIsoCode());
+            $record['weight'] = sprintf('%.3f %s', $record['weight'], $this->configuration->get('PS_WEIGHT_UNIT'));
+
+            $updated[] = $record;
+        }
+
+        return new RecordCollection($updated);
+    }
+}

--- a/src/Core/Grid/Definition/Factory/ShipmentGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ShipmentGridDefinitionFactory.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
+
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\Shipment\AdditionalShipmentRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\IdentifierColumn;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+
+final class ShipmentGridDefinitionFactory extends AbstractFilterableGridDefinitionFactory
+{
+    public const GRID_ID = 'shipment';
+
+    public function __construct(
+        HookDispatcherInterface $hookDispatcher,
+        private LanguageContext $languageContext
+    ) {
+        parent::__construct($hookDispatcher);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getId()
+    {
+        return self::GRID_ID;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getName()
+    {
+        return $this->trans('Shipments', [], 'Admin.Global');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getColumns()
+    {
+        $columns = (new ColumnCollection())
+            ->add((new DateTimeColumn('date'))
+                ->setName($this->trans('Date', [], 'Admin.Global'))
+                ->setOptions([
+                    'field' => 'date',
+                    'format' => $this->languageContext->getDateTimeFormat(),
+                    'clickable' => true,
+                ])
+            )
+            ->add(
+                (new IdentifierColumn('shipment_number'))
+                    ->setName($this->trans('Shipment number', [], 'Admin.Global'))
+                    ->setOptions([
+                        'identifier_field' => 'shipment_number',
+                        'bulk_field' => 'shipment_number',
+                        'with_bulk_field' => false,
+                        'clickable' => false,
+                    ])
+            )
+            ->add(
+                (new DataColumn('carrier'))
+                    ->setName($this->trans('Carrier', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'carrier',
+                        'sortable' => true,
+                        'alignment' => 'left',
+                    ])
+            )
+            ->add(
+                (new DataColumn('items'))
+                    ->setName($this->trans('Items', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'items',
+                        'sortable' => true,
+                        'alignment' => 'left',
+                    ])
+            )
+            ->add(
+                (new DataColumn('price'))
+                    ->setName($this->trans('Price', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'price',
+                        'sortable' => true,
+                        'alignment' => 'left',
+                    ])
+            )
+            ->add(
+                (new DataColumn('weight'))
+                    ->setName($this->trans('Weight', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'weight',
+                        'sortable' => true,
+                        'alignment' => 'left',
+                    ])
+            )
+            ->add(
+                (new DataColumn('tracking_number'))
+                    ->setName($this->trans('Tracking number', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'tracking_number',
+                        'sortable' => true,
+                        'alignment' => 'left',
+                    ])
+            )->add(
+                (new ActionColumn('actions'))
+                    ->setName($this->trans('Actions', [], 'Admin.Global'))
+                    ->setOptions([
+                        'actions' => $this->getRowActions(),
+                    ])
+            );
+
+        return $columns;
+    }
+
+    /**
+     * @return RowActionCollectionInterface
+     */
+    private function getRowActions()
+    {
+        return (new RowActionCollection())
+            ->add(
+                (new AdditionalShipmentRowAction('More'))
+                    ->setName($this->trans('More', [], 'Admin.Actions'))
+                    ->setIcon('more_vert')
+                    ->setOptions([
+                        'shipment_id_field' => 'shipment_number',
+                    ]));
+    }
+}

--- a/src/Core/Grid/Query/ShipmentQueryBuilder.php
+++ b/src/Core/Grid/Query/ShipmentQueryBuilder.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+
+/**
+ * Provides SQL for shipments listing.
+ */
+final class ShipmentQueryBuilder extends AbstractDoctrineQueryBuilder
+{
+    private const ALLOWED_FILTERS = [
+        'shipment_number',
+        'carrier',
+        'tracking_number',
+        'date',
+        'order_id',
+    ];
+
+    public function __construct(
+        Connection $connection,
+        string $dbPrefix,
+        private readonly DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
+    ) {
+        parent::__construct($connection, $dbPrefix);
+    }
+
+    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        $qb = $this->getBaseQueryBuilder($searchCriteria)
+            ->select([
+                's.id_shipment AS shipment_number',
+                's.date_add AS date',
+                'c.name AS carrier',
+                's.tracking_number',
+                'COUNT(sp.id_shipment_product) AS items',
+                's.shipping_cost_tax_incl AS price',
+                'SUM(od.product_weight * sp.quantity) AS weight',
+            ])
+            ->groupBy('s.id_shipment');
+
+        $this->searchCriteriaApplicator
+            ->applyPagination($searchCriteria, $qb)
+            ->applySorting($searchCriteria, $qb);
+
+        return $qb;
+    }
+
+    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        return $this->getBaseQueryBuilder($searchCriteria)
+            ->select('COUNT(DISTINCT s.id_shipment)');
+    }
+
+    private function getBaseQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        $qb = $this->connection->createQueryBuilder()
+            ->from($this->dbPrefix . 'shipment', 's')
+            ->leftJoin('s', $this->dbPrefix . 'carrier', 'c', 's.id_carrier = c.id_carrier')
+            ->leftJoin('s', $this->dbPrefix . 'shipment_product', 'sp', 's.id_shipment = sp.id_shipment')
+            ->leftJoin('sp', $this->dbPrefix . 'order_detail', 'od', 'sp.id_order_detail = od.id_order_detail');
+
+        $this->applyFilters($qb, $searchCriteria->getFilters());
+
+        return $qb;
+    }
+
+    private function applyFilters(QueryBuilder $qb, array $filters): void
+    {
+        foreach ($filters as $filterName => $filterValue) {
+            if (!in_array($filterName, self::ALLOWED_FILTERS)) {
+                continue;
+            }
+
+            if ($filterName === 'carrier') {
+                $qb->andWhere('c.name LIKE :carrier');
+                $qb->setParameter('carrier', '%' . $filterValue . '%');
+            } elseif ($filterName === 'date') {
+                $qb->andWhere('DATE(s.date_add) = :date');
+                $qb->setParameter('date', $filterValue);
+            } elseif ($filterName === 'shipment_number') {
+                $qb->andWhere('s.id_shipment = :shipment_number');
+                $qb->setParameter('shipment_number', $filterValue);
+            } elseif ($filterName === 'tracking_number') {
+                $qb->andWhere('s.tracking_number LIKE :tracking_number');
+                $qb->setParameter('tracking_number', '%' . $filterValue . '%');
+            } elseif ($filterName === 'order_id') {
+                $qb->andWhere('s.id_order = :order_id');
+                $qb->setParameter('order_id', (int) $filterValue);
+            }
+        }
+    }
+}

--- a/src/Core/Search/Filters/ShipmentFilters.php
+++ b/src/Core/Search/Filters/ShipmentFilters.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Search\Filters;
+
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ShipmentGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Search\Filters;
+
+class ShipmentFilters extends Filters
+{
+    /** @var string */
+    protected $filterId = ShipmentGridDefinitionFactory::GRID_ID;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getDefaults(): array
+    {
+        return [
+            'limit' => self::LIST_LIMIT,
+            'offset' => 0,
+            'orderBy' => 'shipment_number',
+            'sortOrder' => 'asc',
+            'filters' => [],
+        ];
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -563,3 +563,9 @@ services:
     autowire: true
     arguments:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
+
+  PrestaShop\PrestaShop\Core\Grid\Query\ShipmentQueryBuilder:
+    parent: 'prestashop.core.grid.abstract_query_builder'
+    public: false
+    arguments:
+      $searchCriteriaApplicator: '@prestashop.core.query.doctrine_search_criteria_applicator'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -705,3 +705,20 @@ services:
       - '@prestashop.core.hook.dispatcher'
       - '@prestashop.core.grid.query.doctrine_query_parser'
       - 'image_type'
+
+  PrestaShop\PrestaShop\Core\Grid\Data\Factory\Shipment:
+    class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
+    arguments:
+      - '@PrestaShop\PrestaShop\Core\Grid\Query\ShipmentQueryBuilder'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.core.grid.query.doctrine_query_parser'
+      - 'shipment'
+
+
+  PrestaShop\PrestaShop\Core\Grid\Data\Factory\ShipmentGridDataFactory:
+    autowire: true
+    arguments:
+      - '@PrestaShop\PrestaShop\Core\Grid\Data\Factory\Shipment'
+      - '@prestashop.core.localization.locale.context_locale'
+      - '@PrestaShop\PrestaShop\Core\Context\CurrencyContext'
+      - '@prestashop.adapter.legacy.configuration'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -487,6 +487,11 @@ services:
     autowire: true
     public: true
 
+  PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ShipmentGridDefinitionFactory:
+    parent: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory
+    autowire: true
+    public: true
+
   # deprecated services
   # Alias for this abstract definition causes tests in vendor fail for some reason, so we stick to full definition instead
   prestashop.core.grid.definition.factory.abstract_grid_definition:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
@@ -550,3 +550,11 @@ services:
       - '@prestashop.core.grid.data_factory.image_type'
       - '@prestashop.core.grid.filter.form_factory'
       - '@prestashop.core.hook.dispatcher'
+
+  PrestaShop\PrestaShop\Core\Grid\Factory\ShipmentFactory:
+    class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
+    arguments:
+      - '@PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ShipmentGridDefinitionFactory'
+      - '@PrestaShop\PrestaShop\Core\Grid\Data\Factory\ShipmentGridDataFactory'
+      - '@prestashop.core.grid.filter.form_factory'
+      - '@prestashop.core.hook.dispatcher'

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/additional_shipment_row_action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/additional_shipment_row_action.html.twig
@@ -1,0 +1,49 @@
+{# **
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * #}
+
+<div class="dropdown">
+  <span
+    class="grid-{{ action.name|lower }}-row-link"
+    data-toggle="dropdown"
+    role="button"
+    aria-haspopup="true"
+    aria-expanded="false"
+    title="More"
+    style="cursor: pointer;"
+  >
+    <i class="material-icons">{{ action.icon }}</i>
+  </span>
+
+  <div class="dropdown-menu dropdown-menu-right">
+    <a class="js-split-shipment-btn dropdown-item"
+      href="#"
+      data-toggle="modal"
+      data-target="#splitShipmentModal"
+      data-shipment-id="{{ record[action.options.shipment_id_field] }}">
+      Split
+    </a>
+    <a class="dropdown-item" href="#" data-action="merge">Merge</a>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
@@ -31,10 +31,6 @@
   {{ 'Documents'|trans({}, 'Admin.Orderscustomers.Feature') }} (<span class="count">{{ orderForViewing.documents.documents|length }}</span>)
 {% endset %}
 
-{% set carriersTitle %}
-  {{ 'Carriers'|trans({}, 'Admin.Shipping.Feature') }} (<span class="count">{{ orderForViewing.shipping.carriers|length }}</span>)
-{% endset %}
-
 {% set merchantReturnsTitle %}
   {{ 'Merchandise returns'|trans({}, 'Admin.Orderscustomers.Feature') }} (<span data-role="count">{{ orderForViewing.returns.orderReturns|length }}</span>)
 {% endset %}
@@ -53,12 +49,22 @@
         {{ documentsTitle }}
       </a>
     </li>
-    <li class="nav-item">
-      <a class="nav-link" id="orderShippingTab" data-toggle="tab" href="#orderShippingTabContent" role="tab" aria-controls="orderShippingTabContent" aria-expanded="true" aria-selected="false">
-        <i class="material-icons">local_shipping</i>
-        {{ carriersTitle }}
-      </a>
-    </li>
+    {% if isImprovedShipmentFeatureFlagEnabled %}
+      <li class="nav-item">
+        <a class="nav-link" id="orderShipmentsTab" data-toggle="tab" href="#orderShipmentsTabContent" role="tab" aria-controls="orderShipmentsTabContent" aria-expanded="true" aria-selected="false">
+          <i class="material-icons">local_shipping</i>
+          {{ shipmentsLabel|raw }}
+        </a>
+      </li>
+    {% else %}
+      <li class="nav-item">
+        <a class="nav-link" id="orderShippingTab" data-toggle="tab" href="#orderShippingTabContent" role="tab" aria-controls="orderShippingTabContent" aria-expanded="true" aria-selected="false">
+          <i class="material-icons">local_shipping</i>
+          {{ carriersLabel|raw }}
+        </a>
+      </li>
+    {% endif %}
+
     {% if merchandiseReturnEnabled %}
       <li class="nav-item">
         <a class="nav-link" id="orderReturnsTab" data-toggle="tab" href="#orderReturnsTabContent" role="tab" aria-controls="orderReturnsTabContent" aria-expanded="true" aria-selected="false">
@@ -90,16 +96,29 @@
         {% endblock %}
       {% endembed %}
     </div>
-    <div class="tab-pane d-print-block fade" id="orderShippingTabContent" role="tabpanel" aria-labelledby="orderShippingTab">
-      {% embed '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/details_card.html.twig' %}
-        {% block header %}
-          {{ carriersTitle }}
-        {% endblock %}
-        {% block body %}
-          {{ include('@PrestaShop/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig') }}
-        {% endblock %}
-      {% endembed %}
-    </div>
+    {% if isImprovedShipmentFeatureFlagEnabled %}
+      <div class="tab-pane d-print-block fade" id="orderShipmentsTabContent" role="tabpanel" aria-labelledby="orderShipmentsTab">
+        {% embed '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/details_card.html.twig' %}
+          {% block header %}
+            {{ shipmentsLabel|raw }}
+          {% endblock %}
+          {% block body %}
+            {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {grid: shipmentsGrid}) }}
+          {% endblock %}
+        {% endembed %}
+      </div>
+    {% else %}
+      <div class="tab-pane d-print-block fade" id="orderShippingTabContent" role="tabpanel" aria-labelledby="orderShippingTab">
+        {% embed '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/details_card.html.twig' %}
+          {% block header %}
+            {{ carriersLabel|raw }}
+          {% endblock %}
+          {% block body %}
+            {{ include('@PrestaShop/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig') }}
+          {% endblock %}
+        {% endembed %}
+      </div>
+    {% endif %}
     {% if merchandiseReturnEnabled %}
       <div class="tab-pane d-print-block fade" id="orderReturnsTabContent" role="tabpanel" aria-labelledby="orderReturnsTab">
         {% embed '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/details_card.html.twig' %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Creating a dedicated "Shipments" tab and an associated grid within the existing Order Detail page in the Back-Office. This new interface will provide a clear and structured view of individual shipments associated with an order, moving away from the current carrier-centric order management. This is part of our broader effort to implement multishipping, allowing merchants to manually split and merge fulfillments
| Type?             | new feature 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable "Improved shipment" feature flag, create order and see order details page
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/16222198348
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   |-