### PR TITLE
Fix installation of en-GB during install, improve installation error report

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1653,12 +1653,17 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     private static function updateMultilangFromClassForShop(DataLangCore $classObject, self $lang, Shop $shop)
     {
         $shopDefaultLangId = (int) Configuration::get('PS_LANG_DEFAULT', null, $shop->id_shop_group, $shop->id);
-        $shopDefaultLanguage = new Language($shopDefaultLangId);
+        // During install process the default language may not be available yet
+        if (!empty($shopDefaultLangId)) {
+            $shopDefaultLanguage = new Language($shopDefaultLangId);
+            self::loadAdminTranslatorLocale($shopDefaultLanguage->locale, false);
+        }
 
-        self::loadAdminTranslatorLocale($shopDefaultLanguage->locale, false);
+        // The provided locale should always be loaded though
         self::loadAdminTranslatorLocale($lang->locale, false);
 
         $sfContainer = SymfonyContainer::getInstance();
+        /** @var TranslatorInterface $translator */
         $translator = $sfContainer->get(TranslatorInterface::class);
         (new EntityTranslatorFactory($translator))
             ->build($classObject)

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -70,6 +70,7 @@ use PrestaShopLoggerInterface;
 use PSRLoggerAdapter;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
+use Throwable;
 
 class Install extends AbstractInstall
 {
@@ -454,7 +455,7 @@ class Install extends AbstractInstall
             } else {
                 $languages = $this->installLanguages();
             }
-        } catch (PrestashopInstallerException $e) {
+        } catch (Throwable $e) {
             $this->setError($e->getMessage());
 
             return false;
@@ -535,7 +536,7 @@ class Install extends AbstractInstall
                     return false;
                 }
             }
-        } catch (PrestashopInstallerException $e) {
+        } catch (Throwable $e) {
             $this->setError($e->getMessage());
 
             return false;
@@ -546,6 +547,8 @@ class Install extends AbstractInstall
 
     public function createShop($shop_name)
     {
+        $this->getLogger()->log('Creating shop');
+
         // Create default group shop
         $shop_group = new ShopGroup();
         $shop_group->name = 'Default';
@@ -602,6 +605,7 @@ class Install extends AbstractInstall
         if ($languages_list === null || (is_array($languages_list) && !count($languages_list))) {
             $languages_list = $this->language->getIsoList();
         }
+        $this->getLogger()->log('Installing languages: ' . implode(', ', $languages_list));
 
         $languages_list = array_unique($languages_list);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fix installation of en-GB during install: since the language is not present in available languages from `install-dev/langs` folder some additional `downloadAndInstallLanguagePack` method was called before the default language is initialized Also improve installation error report to get more accurate feedback
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green UI tests green Test manually (see issue)
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/16314613094
| Fixed issue or discussion?     | Fixes #38878
| Related PRs       | ~
| Sponsor company   | ~
