### PR TITLE
Docker 7.2-apache : Fixed use of archive Debian repo 

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,7 +1,11 @@
 # To run files with the same group as your primary user
-ARG VERSION
+ARG VERSION="8.1-apache"
 
 FROM prestashop/base:$VERSION
+
+# Declare a new time the ARG VERSION
+## Because "An ARG declared before a FROM is outside of a build stage, so it can't be used in any instruction after a FROM."
+ARG VERSION
 
 EXPOSE 443
 
@@ -20,7 +24,7 @@ RUN chown -R www-data:www-data /var/www/.npm
 RUN mkdir -p /var/www/.composer
 RUN chown -R www-data:www-data /var/www/.composer
 
-ENV NVM_DIR       /usr/local/nvm
+ENV NVM_DIR=/usr/local/nvm
 RUN mkdir -p $NVM_DIR \
     && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash \
     && . $NVM_DIR/nvm.sh \
@@ -28,9 +32,15 @@ RUN mkdir -p $NVM_DIR \
     && nvm alias default $NODE_VERSION \
     && nvm use default
 
-ENV NODE_PATH     $NVM_DIR/versions/node/v$NODE_VERSION/bin
-ENV PATH          $PATH:$NODE_PATH
+ENV NODE_PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin
+ENV PATH=$PATH:$NODE_PATH
 
+# Old version of base image use Archived repository of Debian (Buster)
+RUN if [ "$VERSION" = "7.2-apache" ]; then \
+    sed -ie "s/deb.debian.org/archive.debian.org/g" /etc/apt/sources.list \
+    && sed -ie "s/security.debian.org/archive.debian.org/g" /etc/apt/sources.list \
+    && echo 'Sources list updated'; \
+  fi
 # Install mailutils to make sendmail work
 RUN apt update && apt install -y mailutils
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | 8.2.x : Fixed Docker (Thanks @qmacro for your article : https://qmacro.org/blog/posts/2024/05/13/using-arg-in-a-dockerfile-beware-the-gotcha/)
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: 
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp