### PR TITLE
Update hummingbird to v1.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "prestashop/graphnvd3": "^2",
         "prestashop/gridhtml": "^2",
         "prestashop/gsitemap": "^4",
-        "prestashop/hummingbird": "^1.0.0",
+        "prestashop/hummingbird": "^1.0.1",
         "prestashop/pagesnotfound": "^2",
         "prestashop/productcomments": "^7.0",
         "prestashop/ps_apiresources": "^0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77dc9701482239a7ad03b34cc1134026",
+    "content-hash": "63e461842cac5f5cbb9b0debeeb9bd8d",
     "packages": [
         {
             "name": "api-platform/core",
@@ -5136,16 +5136,16 @@
         },
         {
             "name": "prestashop/hummingbird",
-            "version": "v1.0.0",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/hummingbird.git",
-                "reference": "fbb97bcfb0184b1620a959cf32fb9f0e428ae474"
+                "reference": "d1b73eee052a206ff9a9bf472c2ca9e647392c11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/hummingbird/zipball/fbb97bcfb0184b1620a959cf32fb9f0e428ae474",
-                "reference": "fbb97bcfb0184b1620a959cf32fb9f0e428ae474",
+                "url": "https://api.github.com/repos/PrestaShop/hummingbird/zipball/d1b73eee052a206ff9a9bf472c2ca9e647392c11",
+                "reference": "d1b73eee052a206ff9a9bf472c2ca9e647392c11",
                 "shasum": ""
             },
             "require-dev": {
@@ -5170,9 +5170,9 @@
             "description": "Hummingbird theme for develop PrestaShop version",
             "support": {
                 "issues": "https://github.com/PrestaShop/hummingbird/issues",
-                "source": "https://github.com/PrestaShop/hummingbird/tree/v1.0.0"
+                "source": "https://github.com/PrestaShop/hummingbird/tree/v1.0.1"
             },
-            "time": "2024-11-29T13:23:35+00:00"
+            "time": "2025-06-16T12:52:34+00:00"
         },
         {
             "name": "prestashop/pagesnotfound",
@@ -18079,7 +18079,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -18096,9 +18096,9 @@
         "ext-simplexml": "*",
         "ext-zip": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Update Hummingbird to v1.0.1 through Composer
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | When installing PrestaShop, Hummingbird theme should be at version 1.0.1.
| UI Tests          | https://github.com/tblivet/ga.tests.ui.pr/actions/runs/16367233125
| Fixed issue or discussion?     | --
| Related PRs       | --
| Sponsor company   | @PrestaShopCorp
