### PR TITLE
BO Theme import : Fixed bad display when filename is too long

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/_themes_import.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_themes_import.scss
@@ -1,0 +1,6 @@
+label.custom-file-label[for="import_theme_import_from_computer"] {
+  padding-right: 70px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/admin-dev/themes/new-theme/scss/theme.scss
+++ b/admin-dev/themes/new-theme/scss/theme.scss
@@ -80,6 +80,7 @@
 @import "pages/import_data";
 @import "pages/currency";
 @import "pages/themes_logo";
+@import "pages/themes_import";
 @import "pages/employee";
 @import "pages/error";
 @import "pages/order_states";


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | BO Theme import : Fixed bad display when filename is too long
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Cf #36596
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/16409793789
| Fixed issue or discussion?     | Fixes #36596
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

## Screenshots
* Before (from issue)
<img width="2464" height="814" alt="image" src="https://github.com/user-attachments/assets/0f6e4484-5077-42db-ab09-66e028dea3ab" />

* After
<img width="1335" height="305" alt="image" src="https://github.com/user-attachments/assets/43deee76-fb83-4768-a658-8f878bfbbf8b" />
