### PR TITLE
Removes outdated config_XX.xml to force module version update

### DIFF
--- a/src/Core/Module/ModuleManager.php
+++ b/src/Core/Module/ModuleManager.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Module;
 
-use Context;
 use Exception;
 use Language as LegacyLanguage;
 use Module as LegacyModule;
@@ -396,10 +395,11 @@ class ModuleManager implements ModuleManagerInterface
 
     protected function upgradeMigration(string $name): bool
     {
-        // Removes outdated config_XX.xml to force module version update
-        $iso = substr(Context::getContext()->language->iso_code, 0, 2);
-        if (file_exists(_PS_MODULE_DIR_ . $name . '/config_' . $iso . '.xml')) {
-            unlink(_PS_MODULE_DIR_ . $name . '/config_' . $iso . '.xml');
+        // Removes all config_*.xml files to force module version update
+        foreach (glob(_PS_MODULE_DIR_ . $name . '/config_*.xml') as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
         }
 
         $module_list = LegacyModule::getModulesOnDisk();

--- a/src/Core/Module/ModuleManager.php
+++ b/src/Core/Module/ModuleManager.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Module;
 
+use Context;
 use Exception;
 use Language as LegacyLanguage;
 use Module as LegacyModule;
@@ -395,6 +396,12 @@ class ModuleManager implements ModuleManagerInterface
 
     protected function upgradeMigration(string $name): bool
     {
+        // Removes outdated config_XX.xml to force module version update
+        $iso = substr(Context::getContext()->language->iso_code, 0, 2);
+        if (file_exists(_PS_MODULE_DIR_ . $name . '/config_' . $iso . '.xml')) {
+            unlink(_PS_MODULE_DIR_ . $name . '/config_' . $iso . '.xml');
+        }
+
         $module_list = LegacyModule::getModulesOnDisk();
 
         foreach ($module_list as $module) {


### PR DESCRIPTION
This change forces the deletion of the localized configuration file (config_XX.xml, where XX is the ISO code of the current language, e.g., it for Italian), if it exists, during the module migration.

It was introduced to solve an issue encountered in specific cases: when the config_it.xml file (or the equivalent for other languages) exists and is more recent than the module's main PHP file ($name.php), the system considers the XML file up to date and does not regenerate it, thus preventing the related database record from being updated.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | see #39151
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see #39151
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #39151
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/38973
| Sponsor company   | Codencode
