### PR TITLE
Fix OrderStateType form to show all languages, including disabled ones

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -8,7 +8,7 @@ services:
       # Symfony will throw an error when an argument is no more used in all services definitions so we can safely remove them.
       # Before adding your own, please check it does not already exist in the list.
       # There could be some duplicates.
-      $locales: "@=service('prestashop.adapter.legacy.context').getLanguages()"
+      $locales: "@=service('prestashop.adapter.legacy.context').getLanguages(false)"
       $isMultiShopEnabled: '@=service("prestashop.adapter.multistore_feature").isUsed()'
       $isShopFeatureEnabled: '@=service("prestashop.adapter.multistore_feature").isUsed()'
       $isMultistoreEnabled: '@=service("prestashop.adapter.multistore_feature").isActive()'


### PR DESCRIPTION
The $locales variable injected into the OrderStateType form only includes active languages, due to the default behavior of getLanguages().

As a result, the "template" field — which depends on $locales — is built only for active languages, making it impossible to set template values for disabled languages.

This commit updates the service definition in form_type.yml to use getLanguages(false), ensuring that all languages (active and inactive) are passed to the form.

This change has an impact on all admin forms using this shared $locales definition. However, this behavior is intentional and correct, as admin forms should always display fields for all configured languages — including disabled ones — to allow administrators to prepare translations in advance. This is consistent with how product forms behave in the back office.


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | See #39059
| Type?             | bug fix
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #39059
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16709936464
| Fixed issue or discussion?     | Fixes #39059
| Related PRs       | 
| Sponsor company   | Codencode
