### PR TITLE
Fix RouteValidator by checking unknown keywords in schema URL

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -24,7 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class DispatcherCore
@@ -372,7 +370,7 @@ class DispatcherCore
 
                 break;
 
-                // Dispatch module controller for front office
+            // Dispatch module controller for front office
             case self::FC_MODULE:
                 $module_name = Validate::isModuleName(Tools::getValue('module')) ? Tools::getValue('module') : '';
                 $module = Module::getInstanceByName($module_name);
@@ -399,7 +397,7 @@ class DispatcherCore
 
                 break;
 
-                // Dispatch back office controller + module back office controller
+            // Dispatch back office controller + module back office controller
             case self::FC_ADMIN:
                 if (
                     $this->use_default_controller
@@ -541,7 +539,7 @@ class DispatcherCore
             if (preg_match('#^/([a-z]{2})(?:/.*)?$#', $requestUri, $matches)) {
                 $_GET['isolang'] = $matches[1];
                 $requestUri = substr($requestUri, 3);
-            // Otherwise, we use the default language
+                // Otherwise, we use the default language
             } else {
                 $defaultLanguage = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
                 $_GET['isolang'] = $defaultLanguage->iso_code;
@@ -708,7 +706,7 @@ class DispatcherCore
             $transform_keywords = [];
             preg_match_all(
                 '#\\\{(([^{}]*)\\\:)?(' .
-                    implode('|', array_keys($keywords)) . ')(\\\:([^{}]*))?\\\}#',
+                implode('|', array_keys($keywords)) . ')(\\\:([^{}]*))?\\\}#',
                 $regexp,
                 $m
             );
@@ -732,16 +730,16 @@ class DispatcherCore
                     $regexp = str_replace(
                         $m[0][$i],
                         $prepend_regexp .
-                            '(?P<' . $keywords[$keyword]['param'] . '>' . $keywords[$keyword]['regexp'] . ')' .
-                            $append_regexp,
+                        '(?P<' . $keywords[$keyword]['param'] . '>' . $keywords[$keyword]['regexp'] . ')' .
+                        $append_regexp,
                         $regexp
                     );
                 } else {
                     $regexp = str_replace(
                         $m[0][$i],
                         $prepend_regexp .
-                            '(' . $keywords[$keyword]['regexp'] . ')' .
-                            $append_regexp,
+                        '(' . $keywords[$keyword]['regexp'] . ')' .
+                        $append_regexp,
                         $regexp
                     );
                 }
@@ -897,8 +895,7 @@ class DispatcherCore
 
         if (
             !isset($this->routes[$id_shop]) || !isset($this->routes[$id_shop][$id_lang])
-            || !isset($this->routes[$id_shop][$id_lang][$route_id])
-        ) {
+            || !isset($this->routes[$id_shop][$id_lang][$route_id])) {
             return false;
         }
 
@@ -982,7 +979,8 @@ class DispatcherCore
             $query = http_build_query($params, '', '&');
             $index_link = $this->use_routes ? '' : 'index.php';
 
-            return ($route_id == 'index') ? $index_link . (($query) ? '?' . $query : '') : ((trim($route_id) == '') ? '' : $index_link . '?controller=' . $route_id) . (($query) ? '&' . $query : '') . $anchor;
+            return ($route_id == 'index') ? $index_link . (($query) ? '?' . $query : '') : 
+                ((trim($route_id) == '') ? '' : $index_link . '?controller=' . $route_id) . (($query) ? '&' . $query : '') . $anchor;
         }
         $route = $this->routes[$id_shop][$id_lang][$route_id];
         // Check required fields
@@ -1086,8 +1084,7 @@ class DispatcherCore
 
         $controller = Tools::getValue('controller');
 
-        if (
-            isset($controller)
+        if (isset($controller)
             && is_string($controller)
             && preg_match('/^([0-9a-z_-]+)\?(.*)=(.*)$/Ui', $controller, $m)
         ) {
@@ -1116,8 +1113,7 @@ class DispatcherCore
             // "controller_not_found" (a static file should not go through the dispatcher)
             if (
                 !preg_match('/\.(gif|jpe?g|png|css|js|ico)$/i', parse_url($test_request_uri, PHP_URL_PATH))
-                || preg_match('/^\/upload/', parse_url($test_request_uri, PHP_URL_PATH))
-            ) {
+                || preg_match('/^\/upload/', parse_url($test_request_uri, PHP_URL_PATH))) {
                 // Add empty route as last route to prevent this greedy regexp to match request uri before right time
                 if ($this->empty_route) {
                     $this->addRoute(

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -344,7 +344,7 @@ class DispatcherCore
 
         // Dispatch with right front controller
         switch ($this->front_controller) {
-                // Dispatch front office controller
+            // Dispatch front office controller
             case self::FC_FRONT:
                 $controllers = Dispatcher::getControllers([
                     _PS_FRONT_CONTROLLER_DIR_,
@@ -397,7 +397,7 @@ class DispatcherCore
 
                 break;
 
-            // Dispatch back office controller + module back office controller
+                // Dispatch back office controller + module back office controller
             case self::FC_ADMIN:
                 if ($this->use_default_controller
                     && !Tools::getValue('token')
@@ -537,7 +537,7 @@ class DispatcherCore
             if (preg_match('#^/([a-z]{2})(?:/.*)?$#', $requestUri, $matches)) {
                 $_GET['isolang'] = $matches[1];
                 $requestUri = substr($requestUri, 3);
-                    // Otherwise, we use the default language
+            // Otherwise, we use the default language
             } else {
                 $defaultLanguage = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
                 $_GET['isolang'] = $defaultLanguage->iso_code;

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -372,7 +372,7 @@ class DispatcherCore
 
                 break;
 
-            // Dispatch module controller for front office
+                // Dispatch module controller for front office
             case self::FC_MODULE:
                 $module_name = Validate::isModuleName(Tools::getValue('module')) ? Tools::getValue('module') : '';
                 $module = Module::getInstanceByName($module_name);
@@ -399,7 +399,7 @@ class DispatcherCore
 
                 break;
 
-            // Dispatch back office controller + module back office controller
+                // Dispatch back office controller + module back office controller
             case self::FC_ADMIN:
                 if (
                     $this->use_default_controller
@@ -541,7 +541,7 @@ class DispatcherCore
             if (preg_match('#^/([a-z]{2})(?:/.*)?$#', $requestUri, $matches)) {
                 $_GET['isolang'] = $matches[1];
                 $requestUri = substr($requestUri, 3);
-                // Otherwise, we use the default language
+            // Otherwise, we use the default language
             } else {
                 $defaultLanguage = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
                 $_GET['isolang'] = $defaultLanguage->iso_code;
@@ -919,7 +919,7 @@ class DispatcherCore
     {
         $errors = [
             'missing' => [],
-            'unknown' => []
+            'unknown' => [],
         ];
         if (!isset($this->default_routes[$route_id])) {
             return false;

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -975,7 +975,7 @@ class DispatcherCore
             $query = http_build_query($params, '', '&');
             $index_link = $this->use_routes ? '' : 'index.php';
 
-            return ($route_id == 'index') ? $index_link . (($query) ? '?' . $query : '') : 
+            return ($route_id == 'index') ? $index_link . (($query) ? '?' . $query : '') :
                 ((trim($route_id) == '') ? '' : $index_link . '?controller=' . $route_id) . (($query) ? '&' . $query : '') . $anchor;
         }
         $route = $this->routes[$id_shop][$id_lang][$route_id];

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -344,7 +344,7 @@ class DispatcherCore
 
         // Dispatch with right front controller
         switch ($this->front_controller) {
-            // Dispatch front office controller
+                // Dispatch front office controller
             case self::FC_FRONT:
                 $controllers = Dispatcher::getControllers([
                     _PS_FRONT_CONTROLLER_DIR_,
@@ -370,7 +370,7 @@ class DispatcherCore
 
                 break;
 
-            // Dispatch module controller for front office
+                // Dispatch module controller for front office
             case self::FC_MODULE:
                 $module_name = Validate::isModuleName(Tools::getValue('module')) ? Tools::getValue('module') : '';
                 $module = Module::getInstanceByName($module_name);
@@ -399,8 +399,7 @@ class DispatcherCore
 
             // Dispatch back office controller + module back office controller
             case self::FC_ADMIN:
-                if (
-                    $this->use_default_controller
+                if ($this->use_default_controller
                     && !Tools::getValue('token')
                     && Validate::isLoadedObject(Context::getContext()->employee)
                     && Context::getContext()->employee->isLoggedBack()
@@ -449,8 +448,7 @@ class DispatcherCore
                     );
                     if (!isset($controllers[strtolower($this->controller)])) {
                         // If this is a parent tab, load the first child
-                        if (
-                            Validate::isLoadedObject($tab)
+                        if (Validate::isLoadedObject($tab)
                             && $tab->id_parent == 0
                             && ($tabs = Tab::getTabs(Context::getContext()->language->id, $tab->id))
                             && isset($tabs[0])
@@ -539,7 +537,7 @@ class DispatcherCore
             if (preg_match('#^/([a-z]{2})(?:/.*)?$#', $requestUri, $matches)) {
                 $_GET['isolang'] = $matches[1];
                 $requestUri = substr($requestUri, 3);
-                // Otherwise, we use the default language
+                    // Otherwise, we use the default language
             } else {
                 $defaultLanguage = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
                 $_GET['isolang'] = $defaultLanguage->iso_code;
@@ -588,8 +586,7 @@ class DispatcherCore
             foreach ($modules_routes as $module_route) {
                 if (is_array($module_route) && count($module_route)) {
                     foreach ($module_route as $route => $route_details) {
-                        if (
-                            array_key_exists('controller', $route_details)
+                        if (array_key_exists('controller', $route_details)
                             && array_key_exists('rule', $route_details)
                             && array_key_exists('keywords', $route_details)
                             && array_key_exists('params', $route_details)
@@ -893,8 +890,7 @@ class DispatcherCore
             $this->loadRoutes($id_shop);
         }
 
-        if (
-            !isset($this->routes[$id_shop]) || !isset($this->routes[$id_shop][$id_lang])
+        if (!isset($this->routes[$id_shop]) || !isset($this->routes[$id_shop][$id_lang])
             || !isset($this->routes[$id_shop][$id_lang][$route_id])) {
             return false;
         }

--- a/src/Adapter/Routes/RouteValidator.php
+++ b/src/Adapter/Routes/RouteValidator.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/src/Adapter/Routes/RouteValidator.php
+++ b/src/Adapter/Routes/RouteValidator.php
@@ -66,7 +66,7 @@ class RouteValidator
      *
      * @throws PrestaShopException
      */
-    public function isRouteValid($routeId, $rule)
+    public function isRouteValid(string $routeId, string $rule): array
     {
         $errors = [];
         $validationResult = Dispatcher::getInstance()->validateRoute($routeId, $rule, $errors);

--- a/src/Adapter/Routes/RouteValidator.php
+++ b/src/Adapter/Routes/RouteValidator.php
@@ -52,7 +52,9 @@ class RouteValidator
      */
     public function doesRouteContainsRequiredKeywords($routeId, $rule)
     {
-        return $this->isRouteValid($routeId, $rule);
+        $errors = $this->isRouteValid($routeId, $rule);
+
+        return $errors['missing'] ?? [];
     }
 
     /**

--- a/src/Adapter/Routes/RouteValidator.php
+++ b/src/Adapter/Routes/RouteValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -48,20 +49,28 @@ class RouteValidator
     }
 
     /**
-     * Check if a route rule contain all required keywords of default route definition.
+     * @deprecated since 9.0.1, use isRouteValid instead.
+     */
+    public function doesRouteContainsRequiredKeywords($routeId, $rule)
+    {
+        return $this->isRouteValid($routeId, $rule);
+    }
+
+    /**
+     * Check if a route rule is valid.
      *
      * @param string $routeId
      * @param string $rule Rule to verify
      *
-     * @return array - returns list of missing keywords
+     * @return array - returns list of missing or unknown keywords
      *
      * @throws PrestaShopException
      */
-    public function doesRouteContainsRequiredKeywords($routeId, $rule)
+    public function isRouteValid($routeId, $rule)
     {
-        $missingKeywords = [];
-        $validationResult = Dispatcher::getInstance()->validateRoute($routeId, $rule, $missingKeywords);
+        $errors = [];
+        $validationResult = Dispatcher::getInstance()->validateRoute($routeId, $rule, $errors);
 
-        return $validationResult ? [] : $missingKeywords;
+        return $validationResult ? [] : $errors;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsSetUpUrlsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsSetUpUrlsFormDataProvider.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -24,7 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
 declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta;

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsSetUpUrlsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsSetUpUrlsFormDataProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -23,6 +24,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta;

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsUrlSchemaFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsUrlSchemaFormDataProvider.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -24,7 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
 declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta;

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsUrlSchemaFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsUrlSchemaFormDataProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -23,6 +24,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta;
@@ -105,7 +107,7 @@ final class MetaSettingsUrlSchemaFormDataProvider implements FormDataProviderInt
     private function validateData(array $data)
     {
         $patternErrors = [];
-        $requiredFieldErrors = [];
+        $fieldErrors = [];
         foreach ($data as $routeId => $rule) {
             if (!$this->routeValidator->isRoutePattern($rule)) {
                 $patternErrors[] = $this->translator->trans(
@@ -117,19 +119,23 @@ final class MetaSettingsUrlSchemaFormDataProvider implements FormDataProviderInt
                 );
             }
 
-            $missingKeywords = $this->routeValidator->doesRouteContainsRequiredKeywords($routeId, $rule);
+            $errors = $this->routeValidator->isRouteValid($routeId, $rule);
 
-            if (!empty($missingKeywords)) {
-                foreach ($missingKeywords as $keyword) {
-                    $requiredFieldErrors[] = $this->translator->trans(
-                        'Keyword "{%keyword%}" required for route "%routeName%" (rule: "%routeRule%")',
-                        [
-                            '%keyword%' => $keyword,
-                            '%routeName%' => $routeId,
-                            '%routeRule%' => $rule,
-                        ],
-                        'Admin.Shopparameters.Feature'
-                    );
+            foreach (['missing', 'unknown'] as $type) {
+                if (!empty($errors[$type])) {
+                    foreach ($errors[$type] as $keyword) {
+                        $fieldErrors[] = $this->translator->trans(
+                            $type === 'missing'
+                                ? 'Keyword "{%keyword%}" required for route "%routeName%" (rule: "%routeRule%")'
+                                : 'Keyword "{%keyword%}" doesn\'t exist for route "%routeName%" (rule: "%routeRule%")',
+                            [
+                                '%keyword%' => $keyword,
+                                '%routeName%' => $routeId,
+                                '%routeRule%' => $rule,
+                            ],
+                            'Admin.Shopparameters.Feature'
+                        );
+                    }
                 }
             }
         }
@@ -138,6 +144,6 @@ final class MetaSettingsUrlSchemaFormDataProvider implements FormDataProviderInt
             return $patternErrors;
         }
 
-        return $requiredFieldErrors;
+        return $fieldErrors;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig
@@ -56,7 +56,7 @@
               <li>
                 {{ 'All mandatory keywords (*) must be included in the route'|trans({}, 'Admin.Shopparameters.Notification') }}
               </li>
-                            <li>
+              <li>
                 {{ 'All keywords must be defined in the route rules'|trans({}, 'Admin.Shopparameters.Notification') }}
               </li>
             </ul>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig
@@ -57,7 +57,7 @@
                 {{ 'All mandatory keywords (*) must be included in the route'|trans({}, 'Admin.Shopparameters.Notification') }}
               </li>
               <li>
-                {{ 'All keywords must be defined in the route rules'|trans({}, 'Admin.Shopparameters.Notification') }}
+                {{ 'Only available keywords for a given route can be used'|trans({}, 'Admin.Shopparameters.Notification') }}
               </li>
             </ul>
             {{ 'You should also comply with the syntax:'|trans({}, 'Admin.Shopparameters.Notification') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig
@@ -56,6 +56,9 @@
               <li>
                 {{ 'All mandatory keywords (*) must be included in the route'|trans({}, 'Admin.Shopparameters.Notification') }}
               </li>
+                            <li>
+                {{ 'All keywords must be defined in the route rules'|trans({}, 'Admin.Shopparameters.Notification') }}
+              </li>
             </ul>
             {{ 'You should also comply with the syntax:'|trans({}, 'Admin.Shopparameters.Notification') }}
             <ul>

--- a/tests/Unit/Adapter/Routes/RouteValidatorTest.php
+++ b/tests/Unit/Adapter/Routes/RouteValidatorTest.php
@@ -31,9 +31,6 @@ namespace Tests\Unit\Adapter\Routes;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\Routes\RouteValidator;
-use Dispatcher;
-use Validate;
-
 
 class RouteValidatorTest extends TestCase
 {

--- a/tests/Unit/Adapter/Routes/RouteValidatorTest.php
+++ b/tests/Unit/Adapter/Routes/RouteValidatorTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Routes;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Routes\RouteValidator;
+use Dispatcher;
+use Validate;
+
+
+class RouteValidatorTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        // Mock Validate static method
+        $validateMock = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['isRoutePattern'])
+            ->getMock();
+        $validateMock::staticExpects($this->any())
+            ->method('isRoutePattern')
+            ->willReturnCallback(function ($pattern) {
+                // Accept only patterns with {id} or {rewrite}
+                return preg_match('/\{[a-zA-Z0-9_]+\}/', $pattern) === 1;
+            });
+
+        // Replace Validate with our mock
+        Validate::$instance = $validateMock;
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        // Clean up static mock
+        Validate::$instance = null;
+    }
+
+    public function testIsRoutePatternReturnsTrueForValidPattern()
+    {
+        $validator = new RouteValidator();
+        $this->assertTrue($validator->isRoutePattern('category/{id}-{rewrite}'));
+    }
+
+    public function testIsRoutePatternReturnsFalseForInvalidPattern()
+    {
+        $validator = new RouteValidator();
+        $this->assertFalse($validator->isRoutePattern('category/id-rewrite'));
+    }
+
+    public function testDoesRouteContainsRequiredKeywordsCallsIsRouteValid()
+    {
+        $validator = $this->getMockBuilder(RouteValidator::class)
+            ->onlyMethods(['isRouteValid'])
+            ->getMock();
+
+        $validator->expects($this->once())
+            ->method('isRouteValid')
+            ->with('category_rule', 'category/{id}-{rewrite}')
+            ->willReturn([]);
+
+        $validator->doesRouteContainsRequiredKeywords('category_rule', 'category/{id}-{rewrite}');
+    }
+
+    /**
+     * @dataProvider routeValidationProvider
+     */
+    public function testIsRouteValid($routeId, $rule, $validateReturn, $expected)
+    {
+        $dispatcherMock = $this->getMockBuilder(Dispatcher::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['validateRoute'])
+            ->getMock();
+
+        $dispatcherMock->expects($this->once())
+            ->method('validateRoute')
+            ->with($routeId, $rule, $this->anything())
+            ->willReturnCallback(function ($routeId, $rule, &$errors) use ($validateReturn) {
+                $errors = $validateReturn['errors'];
+                return $validateReturn['result'];
+            });
+
+        // Replace Dispatcher::getInstance() with our mock
+        Dispatcher::setInstanceForTesting($dispatcherMock);
+
+        $validator = new RouteValidator();
+        $result = $validator->isRouteValid($routeId, $rule);
+
+        $this->assertEquals($expected, $result);
+
+        // Clean up static instance
+        Dispatcher::setInstanceForTesting(null);
+    }
+
+    public function routeValidationProvider()
+    {
+        return [
+            // Valid route
+            [
+                'category_rule',
+                'category/{id}-{rewrite}',
+                ['result' => true, 'errors' => []],
+                [],
+            ],
+            // Missing keyword
+            [
+                'category_rule',
+                'category/{id}',
+                ['result' => false, 'errors' => ['missing' => ['rewrite'], 'unknown' => []]],
+                ['missing' => ['rewrite'], 'unknown' => []],
+            ],
+            // Unknown keyword
+            [
+                'category_rule',
+                'category/{id}-{rewrite}-{foo}',
+                ['result' => false, 'errors' => ['missing' => [], 'unknown' => ['foo']]],
+                ['missing' => [], 'unknown' => ['foo']],
+            ],
+            // Both missing and unknown
+            [
+                'category_rule',
+                'category/{id}-{foo}',
+                ['result' => false, 'errors' => ['missing' => ['rewrite'], 'unknown' => ['foo']]],
+                ['missing' => ['rewrite'], 'unknown' => ['foo']],
+            ],
+            // Route id not found
+            [
+                'not_existing_rule',
+                'category/{id}-{rewrite}',
+                ['result' => false, 'errors' => ['missing' => [], 'unknown' => []]],
+                ['missing' => [], 'unknown' => []],
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Classes/DispatcherTest.php
+++ b/tests/Unit/Classes/DispatcherTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes;
+
+use DispatcherCore;
+use PHPUnit\Framework\TestCase;
+
+class DispatcherTest extends TestCase
+{
+    /**
+     * @dataProvider validateRouteProvider
+     */
+    public function testValidateRoute($routeId, $rule, $defaultRoutes, $expectedResult, $expectedErrors)
+    {
+        $dispatcher = $this->getMockBuilder(DispatcherCore::class)
+            ->disableOriginalConstructor()
+            ->setMethodsExcept(['validateRoute'])
+            ->getMock();
+
+        // Inject default_routes property
+        $reflection = new \ReflectionClass($dispatcher);
+        $property = $reflection->getProperty('default_routes');
+        $property->setAccessible(true);
+        $property->setValue($dispatcher, $defaultRoutes);
+
+        $errors = [];
+        $result = $dispatcher->validateRoute($routeId, $rule, $errors);
+
+        $this->assertSame($expectedResult, $result);
+        $this->assertEquals($expectedErrors, $errors);
+    }
+
+    public function validateRouteProvider()
+    {
+        return [
+            // Valid route: all keywords present, none unknown
+            [
+                'category_rule',
+                'category/{id}-{rewrite}',
+                [
+                    'category_rule' => [
+                        'controller' => 'category',
+                        'rule' => 'category/{id}-{rewrite}',
+                        'keywords' => [
+                            'id' => ['regexp' => '[0-9]+', 'param' => 'id_category'],
+                            'rewrite' => ['regexp' => '[_a-zA-Z0-9-]*'],
+                        ],
+                    ],
+                ],
+                true,
+                ['missing' => [], 'unknown' => []],
+            ],
+            // Missing keyword
+            [
+                'category_rule',
+                'category/{id}',
+                [
+                    'category_rule' => [
+                        'controller' => 'category',
+                        'rule' => 'category/{id}-{rewrite}',
+                        'keywords' => [
+                            'id' => ['regexp' => '[0-9]+', 'param' => 'id_category'],
+                            'rewrite' => ['regexp' => '[_a-zA-Z0-9-]*'],
+                        ],
+                    ],
+                ],
+                false,
+                ['missing' => ['rewrite'], 'unknown' => []],
+            ],
+            // Unknown keyword
+            [
+                'category_rule',
+                'category/{id}-{rewrite}-{foo}',
+                [
+                    'category_rule' => [
+                        'controller' => 'category',
+                        'rule' => 'category/{id}-{rewrite}',
+                        'keywords' => [
+                            'id' => ['regexp' => '[0-9]+', 'param' => 'id_category'],
+                            'rewrite' => ['regexp' => '[_a-zA-Z0-9-]*'],
+                        ],
+                    ],
+                ],
+                false,
+                ['missing' => [], 'unknown' => ['foo']],
+            ],
+            // Both missing and unknown
+            [
+                'category_rule',
+                'category/{id}-{foo}',
+                [
+                    'category_rule' => [
+                        'controller' => 'category',
+                        'rule' => 'category/{id}-{rewrite}',
+                        'keywords' => [
+                            'id' => ['regexp' => '[0-9]+', 'param' => 'id_category'],
+                            'rewrite' => ['regexp' => '[_a-zA-Z0-9-]*'],
+                        ],
+                    ],
+                ],
+                false,
+                ['missing' => ['rewrite'], 'unknown' => ['foo']],
+            ],
+            // Route id not found
+            [
+                'not_existing_rule',
+                'category/{id}-{rewrite}',
+                [
+                    'category_rule' => [
+                        'controller' => 'category',
+                        'rule' => 'category/{id}-{rewrite}',
+                        'keywords' => [
+                            'id' => ['regexp' => '[0-9]+', 'param' => 'id_category'],
+                            'rewrite' => ['regexp' => '[_a-zA-Z0-9-]*'],
+                        ],
+                    ],
+                ],
+                false,
+                ['missing' => [], 'unknown' => []],
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Classes/DispatcherTest.php
+++ b/tests/Unit/Classes/DispatcherTest.php
@@ -31,6 +31,7 @@ namespace Tests\Unit\Classes;
 
 use DispatcherCore;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 class DispatcherTest extends TestCase
 {
@@ -42,7 +43,7 @@ class DispatcherTest extends TestCase
         $dispatcher = DispatcherCore::getInstance();
 
         // Inject default_routes property
-        $reflection = new \ReflectionClass($dispatcher);
+        $reflection = new ReflectionClass($dispatcher);
         $property = $reflection->getProperty('default_routes');
         $property->setAccessible(true);
         $property->setValue($dispatcher, $defaultRoutes);

--- a/tests/Unit/Classes/DispatcherTest.php
+++ b/tests/Unit/Classes/DispatcherTest.php
@@ -39,10 +39,7 @@ class DispatcherTest extends TestCase
      */
     public function testValidateRoute($routeId, $rule, $defaultRoutes, $expectedResult, $expectedErrors)
     {
-        $dispatcher = $this->getMockBuilder(DispatcherCore::class)
-            ->disableOriginalConstructor()
-            ->setMethodsExcept(['validateRoute'])
-            ->getMock();
+        $dispatcher = DispatcherCore::getInstance();
 
         // Inject default_routes property
         $reflection = new \ReflectionClass($dispatcher);
@@ -80,7 +77,7 @@ class DispatcherTest extends TestCase
             // Missing keyword
             [
                 'category_rule',
-                'category/{id}',
+                'category/{rewrite}',
                 [
                     'category_rule' => [
                         'controller' => 'category',
@@ -92,7 +89,7 @@ class DispatcherTest extends TestCase
                     ],
                 ],
                 false,
-                ['missing' => ['rewrite'], 'unknown' => []],
+                ['missing' => ['id'], 'unknown' => []],
             ],
             // Unknown keyword
             [
@@ -114,7 +111,7 @@ class DispatcherTest extends TestCase
             // Both missing and unknown
             [
                 'category_rule',
-                'category/{id}-{foo}',
+                'category/{rewrite}-{foo}',
                 [
                     'category_rule' => [
                         'controller' => 'category',
@@ -126,7 +123,7 @@ class DispatcherTest extends TestCase
                     ],
                 ],
                 false,
-                ['missing' => ['rewrite'], 'unknown' => ['foo']],
+                ['missing' => ['id'], 'unknown' => ['foo']],
             ],
             // Route id not found
             [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x 
| Description?      | Validate routes by checking unknown keywords in schema URL. This fix will solve issue [404 page if you add unknown keyword in schema URL](https://github.com/PrestaShop/PrestaShop/issues/36392)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | Login in BO. Go to Shop parameters > Traffic & SEO> SEO & URLs. Add unknown keyword (eg. foo) in Schema of URLs fields. Save and see error "Keyword "{foo}" doesn't exist for route..."
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16521605267
| Fixed issue or discussion?     | Fixes #36392
| Related PRs       | 
| Sponsor company   | PrestaShop SA
