### PR TITLE
Fix 38139 cache clearing doesn't work properly on 9.0.0, doesn't rebuild some things, like a container

### DIFF
--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -129,7 +129,13 @@ class ContainerBuilder
     {
         $this->containerName = $containerName;
         $this->containerClassName = ucfirst($this->containerName) . 'Container';
-        $this->dumpFile = $this->environment->getCacheDir() . DIRECTORY_SEPARATOR . $this->containerClassName . '.php';
+
+        $this->dumpFile = $this->environment->getCacheDir() . DIRECTORY_SEPARATOR;
+        if ($containerName === 'front') {
+            $this->dumpFile .= 'front' . DIRECTORY_SEPARATOR;
+        }
+        $this->dumpFile .= $this->containerClassName . '.php';
+
         $this->containerConfigCache = new ConfigCache($this->dumpFile, $this->environment->isDebug());
 
         // These methods load required files like autoload or annotation metadata so we need to load


### PR DESCRIPTION
Updated the buildContainer() method to store the compiled front office container (FrontContainer.php) inside the front/ subdirectory of the cache directory.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This commit attempts to resolve the issue related to the front-office container by creating the container in the "front" folder.
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. If the [productcomments](https://github.com/PrestaShop/productcomments/releases/tag/v7.0.0) module is installed, uninstall it. 2. Manually delete the cache folder (var/cache/dev, var/cache/prod). 3. Install the productcomments module. 4. Clear the cache from the admin panel. 5. Access a product in the front office and verify that the error `You have requested a non-existent service "product_comment_repository"` no longer appears
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #38124, #38139
| Related PRs       | 
| Sponsor company   | Codencode
