### PR TITLE
Improve warning on languages page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/index.html.twig
@@ -34,10 +34,6 @@
 {% block content %}
   {{ include('@PrestaShop/Admin/Common/multistore-infotip.html.twig') }}
 
-  <div class="alert alert-warning" role="alert">
-    <p class="alert-text">{{ 'When you delete a language, all related translations in the database will be deleted.'|trans({}, 'Admin.International.Notification') }}</p>
-  </div>
-
   {% if not isHtaccessFileWriter %}
     <div class="alert alert-info" role="alert">
       <p class="alert-text">{{ 'Your .htaccess file must be writable.'|trans({}, 'Admin.International.Notification') }}</p>
@@ -47,6 +43,15 @@
   {% block language_listing %}
     {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {grid: languageGrid}) }}
   {% endblock %}
+
+  <div class="alert alert-warning" role="alert">
+    <p><strong>{{ 'Important information regarding languages:'|trans({}, 'Admin.International.Notification') }}</strong></p>
+    <ul>
+      <li>{{ 'Only active languages are available to customers in the front office. You can still edit content in disabled languages in the back office - it just won\'t be visible to customers until the language is activated.'|trans({}, 'Admin.International.Notification') }}</li>
+      <li>{{ 'If you switch from a single-language shop to a multi-language setup, be aware that URLs may change depending on your URL settings.'|trans({}, 'Admin.International.Notification') }}</li>
+      <li>{{ 'When you delete a language, all content for all objects related to that language will be permanently removed from the database.'|trans({}, 'Admin.International.Notification') }}</li>
+    </ul>
+  </div>
 {% endblock %}
 
 {% block javascripts %}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Improves warning on languages page. Moves it under the list and expands the most important info.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open languages page.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16709992013
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.


### Screenshot
![after](https://github.com/user-attachments/assets/30006ba5-7738-4410-8556-a194b785180b)

cc @ibahloul-ps @kpodemski @jf-viguier 