### PR TITLE
Fix: recoverCart link does not log the user. Stuck to process checkout step 1

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1341,19 +1341,11 @@ class FrontControllerCore extends Controller
             return false;
         }
 
-        // Initialize this data into cookie, FrontController will use it later
-        $customer->logged = true;
-        $this->context->customer = $customer;
-        $this->context->cookie->id_customer = (int) $customer->id;
-        $this->context->cookie->customer_lastname = $customer->lastname;
-        $this->context->cookie->customer_firstname = $customer->firstname;
-        $this->context->cookie->logged = true;
         $this->context->cookie->check_cgv = 1;
-        $this->context->cookie->is_guest = $customer->isGuest();
-        $this->context->cookie->passwd = $customer->passwd;
-        $this->context->cookie->email = $customer->email;
-        $this->context->cookie->id_guest = (int) $cart->id_guest;
         $this->context->cookie->id_cart = $id_cart;
+
+        // Restore customer session and authentication state (cookie + CustomerSession)
+        $this->context->updateCustomer($customer);
 
         // Return the value for backward compatibility
         return $id_cart;


### PR DESCRIPTION
Refactor cart recovery: use updateCustomer for restoring customer session

During cart recovery, replaced manual cookie assignments with Context::updateCustomer(),
which restores the customer session and updates CustomerSession properly.

Left `check_cgv` and `id_cart` assignments intact, as they are not managed by updateCustomer.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | When trying to recover a cart from the admin panel, the user does not appear to be "actually" logged in. See #20977, #39188 
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | From the back office, when recovering a user's cart, the user must then appear as properly logged in on the front office. See: #20977
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16710153484
| Fixed issue or discussion?     | Fixes #20977, #39188
| Related PRs       | 
| Sponsor company   | Codencode
