### PR TITLE
When enriching the module data always keep most recent version

### DIFF
--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -358,6 +358,13 @@ class ModuleRepository implements ModuleRepositoryInterface
 
         foreach ($modulesFromHook as $moduleFromHook) {
             if ($module->get('name') === $moduleFromHook['name']) {
+                $moduleVersionAvailable = $module->getAttributes()->get('version_available');
+                $moduleHookVersionAvailable = $moduleFromHook['version_available'];
+                // We keep the more up-to-date information (in case multiple sources provide the same module)
+                if (!empty($moduleVersionAvailable) && !empty($moduleHookVersionAvailable) && version_compare($moduleVersionAvailable, $moduleHookVersionAvailable, '>')) {
+                    continue;
+                }
+
                 // Prevent data from hooks from overriding local translations on displayName and description
                 if ($module->attributes->has('displayName') && !empty($module->attributes->get('displayName'))) {
                     unset($moduleFromHook['displayName']);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | When enriching the module data always keep the more up to date version available, important when multiple sources handle the same module
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green (maybe QA by dev)
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/16502178720
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
