### PR TITLE
Change 404 admin template

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Error/error404.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Error/error404.html.twig
@@ -46,6 +46,10 @@
               {{ 'Page not found'|trans({}, 'Admin.Notifications.Error') }}
             </p>
 
+            <div class="mx-auto">
+              <p class="mb-0">The page you're looking for could not be found. This might be due to a typo in the URL, an outdated link, or because the page was part of a module that is no longer installed.</p>
+            </div>
+
             {% if exception is defined and exception %}
               <div class="mx-auto">
                 <p class="mb-0">{{ exception.message }}</p>
@@ -59,24 +63,10 @@
             {% endif %}
 
             <div class="mt-4">
-              <form action="{{ path('admin_errors_enable_debug_mode') }}" method="post" class="d-inline">
-                <input type="hidden" name="_redirect_url" value="{{ app.request.requestUri }}">
-
-                <button class="btn btn-outline-secondary" type="submit">
-                  {{ 'Enable debug mode'|trans({}, 'Admin.Actions') }}
-                </button>
-              </form>
-              <button class="btn btn-primary js-go-back-btn ml-3" type="button">
-                {{ 'Back to previous page'|trans({}, 'Admin.Actions') }}
+              <button class="btn btn-primary js-go-back-btn" type="button">
+                <i class="material-icons">arrow_back</i> {{ 'Back to previous page'|trans({}, 'Admin.Actions') }}
               </button>
             </div>
-
-            <p class="mt-3">
-              <a href="{{ documentation_link('debug_mode') }}" target="_blank">
-                {{ 'Learn more about debug mode'|trans({}, 'Admin.Actions') }}
-                <i class="material-icons rtl-flip">arrow_right_alt</i>
-              </a>
-            </p>
           </div>
         </div>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Error/error404.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Error/error404.html.twig
@@ -47,7 +47,7 @@
             </p>
 
             <div class="mx-auto">
-              <p class="mb-0">The page you're looking for could not be found. This might be due to a typo in the URL, an outdated link, or because the page was part of a module that is no longer installed.</p>
+              <p class="mb-0">{{ 'The page you\'re looking for could not be found. This might be due to a typo in the URL, an outdated link, or because the page was part of a module that is no longer installed.'|trans({}, 'Admin.Notifications.Error') }}</p>
             </div>
 
             {% if exception is defined and exception %}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Changes 404 page template in the admin. Removes debug mode link and adds a paragraph of what could be wrong.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to nonsense page in admin
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16830725052
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39195
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### Before
![Snímek obrazovky 2025-07-24 160520](https://github.com/user-attachments/assets/42b4b9cd-5317-4840-b8e9-736904435d71)

### After
![after](https://github.com/user-attachments/assets/e73d452f-af9d-45d6-b22c-70255d9c14b0)

cc @kpodemski @ibahloul-ps @Codencode 