### PR TITLE
Do not show debug toolbar for login page in BO

### DIFF
--- a/src/PrestaShopBundle/EventListener/Admin/DisableDebugToolbarListener.php
+++ b/src/PrestaShopBundle/EventListener/Admin/DisableDebugToolbarListener.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\EventListener\Admin;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+
+class DisableDebugToolbarListener implements EventSubscriberInterface
+{
+    public function __construct(private ?Profiler $profiler = null, private array $routes = ['admin_login'])
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 0],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        $route = $event->getRequest()->attributes->get('_route');
+        if ($route && \in_array($route, $this->routes, true)) {
+            $this->profiler?->disable();
+            $event->getRequest()->attributes->set('_disable_wdt', true);
+        }
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
@@ -30,3 +30,10 @@ services:
       - '@logger'
     tags:
       - { name: kernel.event_subscriber }
+
+  PrestaShopBundle\EventListener\Admin\DisableDebugToolbarListener:
+    arguments:
+      $profiler: '@?profiler'
+      $routes: ['admin_login']
+    tags:
+      - { name: kernel.event_subscriber }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
@@ -34,6 +34,6 @@ services:
   PrestaShopBundle\EventListener\Admin\DisableDebugToolbarListener:
     arguments:
       $profiler: '@?profiler'
-      $routes: ['admin_login']
+      $routes: [ 'admin_login' ]
     tags:
       - { name: kernel.event_subscriber }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | My proposal for https://github.com/PrestaShop/PrestaShop/discussions/39042
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable dev mode, see that toolbar is not enabled when visiting BO login page
| UI Tests          | n/a
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/39042
| Related PRs       | n/a
| Sponsor company   | PrestaShop
