### PR TITLE
Apply filters mapping on the orderBy query parameter in API listing

### DIFF
--- a/src/PrestaShopBundle/ApiPlatform/Provider/QueryListProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/QueryListProvider.php
@@ -148,10 +148,20 @@ class QueryListProvider implements ProviderInterface
             [NormalizationMapper::NORMALIZATION_MAPPING => $filtersMapping]
         );
 
+        $orderBy = $queryParameters['orderBy'] ?? null;
+        if (!empty($orderBy)) {
+            // The orderBy parameter also needs to be mapped (the APIResource field should be used but may not match the SQL query one)
+            foreach ($filtersMapping as $apiKey => $gridKey) {
+                if ('[' . $orderBy . ']' === $apiKey) {
+                    $orderBy = str_replace(['[', ']'], '', $gridKey);
+                }
+            }
+        }
+
         $paginationParameters = [
             'filters' => $paginationFilters,
-            'orderBy' => array_key_exists('orderBy', $queryParameters) ? $queryParameters['orderBy'] : null,
-            'sortOrder' => array_key_exists('sortOrder', $queryParameters) ? $queryParameters['sortOrder'] : 'asc',
+            'orderBy' => $orderBy,
+            'sortOrder' => $queryParameters['sortOrder'] ?? 'asc',
             'offset' => array_key_exists('offset', $queryParameters) ? (int) $queryParameters['offset'] : null,
             'limit' => array_key_exists('limit', $queryParameters)
                 ? (int) $queryParameters['limit']


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Apply filters mapping on the orderBy query parameter in listing, this allows using the APIResource fields name in the `orderBy` query parameter by specifying the correct mapping
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/16525845563
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
