### PR TITLE
Fix: Carrier search not working when editing order's carrier

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/OrderViewPageMap.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/OrderViewPageMap.ts
@@ -52,6 +52,7 @@ export default {
   showOrderShippingUpdateModalBtn: '.js-update-shipping-btn',
   updateOrderShippingTrackingNumberInput: '#update_order_shipping_tracking_number',
   updateOrderShippingCurrentOrderCarrierIdInput: '#update_order_shipping_current_order_carrier_id',
+  updateOrderShippingNewCarrierIdSelect: '#update_order_shipping_new_carrier_id',
   updateCustomerAddressModal: '#updateCustomerAddressModal',
   openOrderAddressUpdateModalBtn: '.js-update-customer-address-modal-btn',
   updateOrderAddressTypeInput: '#change_order_address_address_type',

--- a/admin-dev/themes/new-theme/js/pages/order/order-shipping-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/order-shipping-manager.ts
@@ -29,6 +29,7 @@ const {$} = window;
 export default class OrderShippingManager {
   constructor() {
     this.initOrderShippingUpdateEventHandler();
+    this.overrideNewCarrierSelect2();
   }
 
   initOrderShippingUpdateEventHandler(): void {
@@ -37,6 +38,17 @@ export default class OrderShippingManager {
 
       $(OrderViewPageMap.updateOrderShippingTrackingNumberInput).val($btn.data('order-tracking-number'));
       $(OrderViewPageMap.updateOrderShippingCurrentOrderCarrierIdInput).val($btn.data('order-carrier-id'));
+    });
+  }
+
+  overrideNewCarrierSelect2(): void {
+    // Reinitialize Select2 to specify the dropdown container.
+    // Required to avoid display issues inside the modal.
+    const $select = $(OrderViewPageMap.updateOrderShippingNewCarrierIdSelect);
+    const $modal = $select.closest('.modal');
+
+    $select.select2('destroy').select2({
+      dropdownParent: $modal,
     });
   }
 }


### PR DESCRIPTION
Reinitialize the Select2 component on the new carrier select element, specifying the modal as the dropdown parent to prevent display and positioning issues within Bootstrap modals.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | See #38961
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Have a store with at least 8 universal carriers - 2.Go to an order in back office, that is eligible for carrier change - 3. Try to change the carrier by clicking "Edit" in the "Carriers" tab - 4. Check that the search field in the couriers' select works..
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16711041512
| Fixed issue or discussion?     | Fixes #38961
| Related PRs       | 
| Sponsor company   | Codencode
