### PR TITLE
BO : Fixed HTML in informations & warnings block

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/session_alert.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/session_alert.html.twig
@@ -66,7 +66,7 @@
     <button type="button" class="close" data-dismiss="alert">&times;</button>
     <ul id="infos_block" class="list-unstyled">
       {% for info in this.informations %}
-      <li>{{ info }}</li>
+      <li>{{ info|raw }}</li>
       {% endfor %}
     </ul>
   </div>
@@ -92,7 +92,7 @@
     {% endif %}
     <ul class="list-unstyled">
       {% for warning in this.warnings %}
-      <li>{{ warning }}</li>
+      <li>{{ warning|raw }}</li>
       {% endfor %}
     </ul>
   </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | BO : Fixed HTML in informations & warnings block
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle:  / "How to test" is in the issue
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/16560371824
| Fixed issue or discussion?     | Fixes #36635 & Fixes #36489
| Related PRs       | N/A
| Sponsor company   | lefevre.dev