### PR TITLE
Fix: Call to a member function getClassName() on null when the Employee default tab does not exist anymore

### DIFF
--- a/src/PrestaShopBundle/Twig/Component/NavBar.php
+++ b/src/PrestaShopBundle/Twig/Component/NavBar.php
@@ -50,7 +50,13 @@ class NavBar
 
     public function getDefaultTab(): string
     {
-        return Tab::getClassNameById((int) $this->context->getContext()->employee->default_tab);
+        $className = Tab::getClassNameById((int) $this->context->getContext()->employee->default_tab);
+
+        if (!$className) {
+            $className = 'AdminDashboard';
+        }
+
+        return $className;
     }
 
     public function getPsVersion(): string

--- a/src/PrestaShopBundle/Twig/Layout/TemplateVariablesBuilder.php
+++ b/src/PrestaShopBundle/Twig/Layout/TemplateVariablesBuilder.php
@@ -114,6 +114,10 @@ class TemplateVariablesBuilder
             /** @var Tab|null $tab */
             $tab = $this->tabRepository->findOneBy(['id' => $this->employeeContext->getEmployee()->getDefaultTabId()]);
 
+            if (!$tab) {
+                $tab = $this->tabRepository->findOneByClassName('AdminDashboard');
+            }
+
             return $this->context->getAdminLink($tab->getClassName());
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x 
| Description?      | See: #39081
| Type?             | bug fix
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | 1. Install the module: https://github.com/user-attachments/files/21465603/pr_39216.zip - 2. Set the employee’s default page to: "Legacy admin controller for PR 39216" - 3. Uninstall the module - 4. Log in to the admin panel - 5. Expected result: The system should redirect to the dashboard.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16621238066
| Fixed issue or discussion?     | Fixes #39081
| Related PRs       | 
| Sponsor company   | @Codencode 
