### PR TITLE
fix(checkout): Do not send email to customer if order state is not emailable

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -655,9 +655,9 @@ abstract class PaymentModuleCore extends Module
             $orderState = new OrderState((int) $id_order_state);
 
             if ($orderState->send_email
-+                && $this->context->customer->id
-+                && $orderState->id !== (int) Configuration::get('PS_OS_ERROR')
-+                && $orderState->id !== (int) Configuration::get('PS_OS_CANCELED')
+                && $this->context->customer->id
+                && $orderState->id !== (int) Configuration::get('PS_OS_ERROR')
+                && $orderState->id !== (int) Configuration::get('PS_OS_CANCELED')
              ) {
                 $invoice = new Address((int) $order->id_address_invoice);
                 $delivery = new Address((int) $order->id_address_delivery);

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -654,11 +654,11 @@ abstract class PaymentModuleCore extends Module
             // Send an e-mail to customer (one order = one email)
             $orderState = new OrderState((int) $id_order_state);
 
-            if ($orderState->send_email &&
-                $this->context->customer->id &&
-                $orderState->id !== (int) Configuration::get('PS_OS_ERROR') &&
-                $orderState->id !== (int) Configuration::get('PS_OS_CANCELED')
-            ) {
+            if ($orderState->send_email
++                && $this->context->customer->id
++                && $orderState->id !== (int) Configuration::get('PS_OS_ERROR')
++                && $orderState->id !== (int) Configuration::get('PS_OS_CANCELED')
+             ) {
                 $invoice = new Address((int) $order->id_address_invoice);
                 $delivery = new Address((int) $order->id_address_delivery);
                 $delivery_state = $delivery->id_state ? new State((int) $delivery->id_state) : false;

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -652,7 +652,13 @@ abstract class PaymentModuleCore extends Module
             $order = new Order((int) $order->id);
 
             // Send an e-mail to customer (one order = one email)
-            if ($id_order_state != Configuration::get('PS_OS_ERROR') && $id_order_state != Configuration::get('PS_OS_CANCELED') && $this->context->customer->id) {
+            $orderState = new OrderState((int) $id_order_state);
+
+            if ($orderState->send_email &&
+                $this->context->customer->id &&
+                $orderState->id !== (int) Configuration::get('PS_OS_ERROR') &&
+                $orderState->id !== (int) Configuration::get('PS_OS_CANCELED')
+            ) {
                 $invoice = new Address((int) $order->id_address_invoice);
                 $delivery = new Address((int) $order->id_address_delivery);
                 $delivery_state = $delivery->id_state ? new State((int) $delivery->id_state) : false;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Order States have a send_email property that can be edited for any order state. It allows, or not, to send an email. PaymentModule was not taking in account the value of this property before sending the order_conf email.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set "Send email" to NO for the order state configured as a successful payment (PS_OS_PAYMENT). Complete a successful order and check that no email has been sent. Set the option back yo YES, complete a successful payment, and confirm an email has been sent.
| UI Tests          | NA
| Fixed issue or discussion?     | NA
| Related PRs       | NA
| Sponsor company   | Evolutive
