### PR TITLE
Fix: Back Office becomes inaccessible if the employee's assigned language is deleted

### DIFF
--- a/src/Adapter/Employee/EmployeeLanguageUpdater.php
+++ b/src/Adapter/Employee/EmployeeLanguageUpdater.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Employee;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Class EmployeeLanguageUpdater updates the `id_lang` field in the `employee` table for all employees
+ * using a deleted language, assigning them the default language instead.
+ */
+final class EmployeeLanguageUpdater
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var string
+     */
+    private $dbPrefix;
+
+    private $langDefaultId;
+
+    /**
+     * @param Connection $connection
+     * @param string $dbPrefix
+     * @param int $langDefaultId
+     */
+    public function __construct(
+        Connection $connection,
+        string $dbPrefix,
+        int $langDefaultId
+    ) {
+        $this->connection = $connection;
+        $this->dbPrefix = $dbPrefix;
+        $this->langDefaultId = $langDefaultId;
+    }
+
+    public function replaceDeletedLanguage(int $deletedLangId)
+    {
+        $this->connection->update(
+            $this->dbPrefix . 'employee',
+            ['id_lang' => $this->langDefaultId],
+            ['id_lang' => $deletedLangId]
+        );
+    }
+}

--- a/src/Adapter/Language/CommandHandler/DeleteLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/DeleteLanguageHandler.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Language\CommandHandler;
 
+use PrestaShop\PrestaShop\Adapter\Employee\EmployeeLanguageUpdater;
 use PrestaShop\PrestaShop\Adapter\File\RobotsTextFileGenerator;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\Language\Command\DeleteLanguageCommand;
@@ -48,11 +49,17 @@ final class DeleteLanguageHandler extends AbstractLanguageHandler implements Del
     private $robotsTextFileGenerator;
 
     /**
+     * @var EmployeeLanguageUpdater
+     */
+    private $employeeLanguageUpdater;
+
+    /**
      * @param RobotsTextFileGenerator $robotsTextFileGenerator
      */
-    public function __construct(RobotsTextFileGenerator $robotsTextFileGenerator)
+    public function __construct(RobotsTextFileGenerator $robotsTextFileGenerator, EmployeeLanguageUpdater $employeeLanguageUpdater)
     {
         $this->robotsTextFileGenerator = $robotsTextFileGenerator;
+        $this->employeeLanguageUpdater = $employeeLanguageUpdater;
     }
 
     /**
@@ -82,6 +89,9 @@ final class DeleteLanguageHandler extends AbstractLanguageHandler implements Del
         if (false === $language->delete()) {
             throw new LanguageException(sprintf('Failed to delete language "%s"', $language->iso_code));
         }
+
         $this->robotsTextFileGenerator->generateFile();
+
+        $this->employeeLanguageUpdater->replaceDeletedLanguage($language->id);
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
@@ -41,3 +41,10 @@ services:
     alias: PrestaShop\PrestaShop\Adapter\ContextStateManager
 
   PrestaShop\PrestaShop\Adapter\Employee\EmployeeRepository: ~
+
+  prestashop.adapter.employee_language_updater:
+    class: PrestaShop\PrestaShop\Adapter\Employee\EmployeeLanguageUpdater
+    arguments:
+      - '@doctrine.dbal.default_connection'
+      - '%database_prefix%'
+      - '@=service("prestashop.adapter.legacy.configuration").get("PS_LANG_DEFAULT")'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/language.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/language.yml
@@ -66,6 +66,7 @@ services:
     autoconfigure: true
     arguments:
       - '@prestashop.adapter.file.robots_text_file_generator'
+      - '@prestashop.adapter.employee_language_updater'
 
   PrestaShop\PrestaShop\Adapter\Language\ContextLanguageProvider:
     autowire: true


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | The issue occurs when an employee is assigned a language (e.g., French) and that language is later deleted from the system. In this case, the employee can no longer access the Back Office. See #39244
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Assign the French language to an employee via their profile - 2. Delete the French language from the system (Localization > Languages). 3. Attempt to log in to the Back Office with that employee's account.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16887502406
| Fixed issue or discussion?     | Fixes #39244
| Related PRs       |
| Sponsor company   | @Codencode 
