### PR TITLE
Improve perfs : Add static cache for  `Product::getTaxRulesGroupMostUsed`

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7599,11 +7599,11 @@ class ProductCore extends ObjectModel
     public static function getIdTaxRulesGroupMostUsed()
     {
         static $idTaxRulesGroupMostUsed = null;
-    
+
         if ($idTaxRulesGroupMostUsed !== null) {
             return $idTaxRulesGroupMostUsed;
         }
-    
+
         $idTaxRulesGroupMostUsed = Db::getInstance()->getValue(
             'SELECT product_shop.id_tax_rules_group
             FROM ' . _DB_PREFIX_ . 'product_shop product_shop
@@ -7612,7 +7612,7 @@ class ProductCore extends ObjectModel
             GROUP BY product_shop.id_tax_rules_group
             ORDER BY COUNT(*) DESC'
         );
-    
+
         return $idTaxRulesGroupMostUsed;
     }
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7598,14 +7598,29 @@ class ProductCore extends ObjectModel
      */
     public static function getIdTaxRulesGroupMostUsed()
     {
-        return Db::getInstance()->getValue(
-            'SELECT product_shop.id_tax_rules_group
-            FROM ' . _DB_PREFIX_ . 'product_shop product_shop
-            INNER JOIN ' . _DB_PREFIX_ . 'tax_rules_group trg ON product_shop.id_tax_rules_group = trg.id_tax_rules_group
-            WHERE trg.active = 1 AND trg.deleted = 0 AND product_shop.id_shop IN (' . implode(', ', Shop::getContextListShopID()) . ')
-            GROUP BY product_shop.id_tax_rules_group
-            ORDER BY COUNT(*) DESC'
+        static $idTaxRulesGroupMostUsed = null;
+    
+        if ($idTaxRulesGroupMostUsed !== null) {
+            return $idTaxRulesGroupMostUsed;
+        }
+    
+        $idTaxRulesGroupMostUsed = Db::getInstance()->getValue(
+            '
+            SELECT id_tax_rules_group
+            FROM (
+                SELECT COUNT(*) n, product_shop.id_tax_rules_group
+                FROM ' . _DB_PREFIX_ . 'product p
+                ' . Shop::addSqlAssociation('product', 'p') . '
+                JOIN ' . _DB_PREFIX_ . 'tax_rules_group trg 
+                    ON (product_shop.id_tax_rules_group = trg.id_tax_rules_group)
+                WHERE trg.active = 1 AND trg.deleted = 0
+                GROUP BY product_shop.id_tax_rules_group
+                ORDER BY n DESC
+                LIMIT 1
+            ) most_used'
         );
+    
+        return $idTaxRulesGroupMostUsed;
     }
 
     public static function getIdByEan13($ean13)

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7605,19 +7605,12 @@ class ProductCore extends ObjectModel
         }
     
         $idTaxRulesGroupMostUsed = Db::getInstance()->getValue(
-            '
-            SELECT id_tax_rules_group
-            FROM (
-                SELECT COUNT(*) n, product_shop.id_tax_rules_group
-                FROM ' . _DB_PREFIX_ . 'product p
-                ' . Shop::addSqlAssociation('product', 'p') . '
-                JOIN ' . _DB_PREFIX_ . 'tax_rules_group trg 
-                    ON (product_shop.id_tax_rules_group = trg.id_tax_rules_group)
-                WHERE trg.active = 1 AND trg.deleted = 0
-                GROUP BY product_shop.id_tax_rules_group
-                ORDER BY n DESC
-                LIMIT 1
-            ) most_used'
+            'SELECT product_shop.id_tax_rules_group
+            FROM ' . _DB_PREFIX_ . 'product_shop product_shop
+            INNER JOIN ' . _DB_PREFIX_ . 'tax_rules_group trg ON product_shop.id_tax_rules_group = trg.id_tax_rules_group
+            WHERE trg.active = 1 AND trg.deleted = 0 AND product_shop.id_shop IN (' . implode(', ', Shop::getContextListShopID()) . ')
+            GROUP BY product_shop.id_tax_rules_group
+            ORDER BY COUNT(*) DESC'
         );
     
         return $idTaxRulesGroupMostUsed;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add static cache for  `Product::getTaxRulesGroupMostUsed`.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable profiling and see the sql requests (make sure the page contains products).
| UI Tests          | N/A.
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | Evolutive
