### PR TITLE
Fix total_price_tax_incl calculation in OrderDetailUpdater

### DIFF
--- a/src/Adapter/Order/OrderDetailUpdater.php
+++ b/src/Adapter/Order/OrderDetailUpdater.php
@@ -201,7 +201,7 @@ class OrderDetailUpdater
                             'total_amount' => (float) $totalAmount,
                         ];
                         $orderDetail->unit_price_tax_incl = (float) $orderDetail->unit_price_tax_excl + $unitAmount;
-                        $orderDetail->total_price_tax_incl = (float) $orderDetail->total_price_tax_incl + $totalAmount;
+                        $orderDetail->total_price_tax_incl = (float) $orderDetail->total_price_tax_excl + $totalAmount;
                     }
 
                     Db::getInstance()->insert('order_detail_tax', $orderDetailTaxes, false);
@@ -209,7 +209,7 @@ class OrderDetailUpdater
 
                 // Update OrderDetail values
                 $orderDetail->unit_price_tax_incl = (float) $orderDetail->unit_price_tax_excl + $unitAmount;
-                $orderDetail->total_price_tax_incl = (float) $orderDetail->total_price_tax_incl + $totalAmount;
+                $orderDetail->total_price_tax_incl = (float) $orderDetail->total_price_tax_excl + $totalAmount;
                 if (!$orderDetail->update()) {
                     throw new OrderException('An error occurred while editing the product line.');
                 }


### PR DESCRIPTION
Corrects the calculation of total_price_tax_incl by using total_price_tax_excl as the base instead of total_price_tax_incl, preventing compounding errors when updating order details.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | In OrderDetailUpdater::updateOrderDetailsTaxes() the base for the calculation of the order detail is wrong. Please see committed file to recognize the error.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Please see committed file to recognize the error.
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | Fixes #{issue number here}, Fixes #{another issue number here}, Fixes https://github.com/PrestaShop/PrestaShop/discussions/ {discussion number here}
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Gurkcity.de
