### PR TITLE
Add option to define admin folder name during install

### DIFF
--- a/install-dev/classes/datas.php
+++ b/install-dev/classes/datas.php
@@ -45,6 +45,7 @@
  * @property string $admin_lastname
  * @property string $admin_password
  * @property string $admin_email
+ * @property string $admin_folder
  * @property int $show_license
  * @property string $theme
  * @property int $enable_ssl
@@ -163,6 +164,11 @@ class Datas
             'name' => 'email',
             'validate' => 'isEmail',
             'default' => 'pub@prestashop.com',
+        ],
+        'admin_folder' => [
+            'validate' => 'isDirName',
+            'default' => '',
+            'help' => 'the name for the admin folder, useful for provisioning systems, defaults to a randomly generated name',
         ],
         'show_license' => [
             'name' => 'license',

--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -344,7 +344,7 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
             return true;
         }
 
-        $result = $this->model_install->finalize();
+        $result = $this->model_install->finalize($this->datas->admin_folder);
 
         if (!$result) {
             $this->printErrors();

--- a/install-dev/controllers/http/configure.php
+++ b/install-dev/controllers/http/configure.php
@@ -67,18 +67,6 @@ class InstallControllerHttpConfigure extends InstallControllerHttp implements Ht
             if (!$this->session->admin_password_confirm || trim(Tools::getValue('admin_password_confirm'))) {
                 $this->session->admin_password_confirm = trim(Tools::getValue('admin_password_confirm'));
             }
-
-            if (!$this->session->adminFolderName) {
-                if (file_exists(_PS_ROOT_DIR_ . '/admin-dev')) {
-                    $this->session->adminFolderName = 'admin-dev';
-                } else {
-                    $this->session->adminFolderName = sprintf(
-                        'admin%03d%s/',
-                        mt_rand(0, 999),
-                        Tools::strtolower(Tools::passwdGen(16))
-                    );
-                }
-            }
         }
     }
 

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -1210,11 +1210,16 @@ class Install extends AbstractInstall
     {
         $adminFolder = 'admin-dev';
         if (file_exists(_PS_ROOT_DIR_ . '/admin/')) {
-            $randomizedAdminFolderName = $randomizedAdminFolderName ?? sprintf(
-                'admin%03d%s/',
-                mt_rand(0, 999),
-                Tools::strtolower(Tools::passwdGen(16))
-            );
+            if (null === $randomizedAdminFolderName) {
+                $randomizedAdminFolderName = trim(Tools::getValue('admin_folder', null));
+                if (in_array($randomizedAdminFolderName, [null, ''], true)) {
+                    $randomizedAdminFolderName = sprintf(
+                        'admin%03d%s/',
+                        mt_rand(0, 999),
+                        Tools::strtolower(Tools::passwdGen(16))
+                    );
+                }
+            }
             $adminFolder = $randomizedAdminFolderName;
 
             // rename folder


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allow the CLI based installer to define the admin folder name. A randomly generated admin folder name is fatal for automated provisioning. Resorting to regex to find this folder is brittle.
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Perform a CLI based installation using the new `--admin_folder` set to a desired admin folder name.<br>Assert this name is used for the admin folder after the installation is finished.<br>Assert the HTTP based installer still works and generates a random admin folder name.
| UI Tests          | Not executed since this only touches backend processes.
| Fixed issue or discussion?     | n/a
| Related PRs       | n/a
| Sponsor company   | DeltaBlue
