### PR TITLE
Adding taxes for shipping cost if needed

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3590,6 +3590,21 @@ class CartCore extends ObjectModel
         if ($orderTotalwithDiscounts >= (float) $free_fees_price && (float) $free_fees_price > 0) {
             // Allow module to override the shipping cost and return their custom value
             $shipping_cost = $this->getPackageShippingCostFromModule($carrier, $shipping_cost, $products);
+
+            if (Configuration::get('PS_ATCP_SHIPWRAP')) {
+                if (!$use_tax) {
+                    // With PS_ATCP_SHIPWRAP, we deduce the pre-tax price from the post-tax
+                    // price. This is on purpose and required in Germany.
+                    $shipping_cost /= (1 + $this->getAverageProductsTaxRate());
+                }
+            } else {
+                // Apply tax
+                if ($use_tax && isset($carrier_tax)) {
+                    $shipping_cost *= 1 + ($carrier_tax / 100);
+                }
+            }
+
+            $shipping_cost = (float) Tools::ps_round((float) $shipping_cost, Context::getContext()->getComputingPrecision());
             Cache::store($cache_id, $shipping_cost);
 
             return $shipping_cost;
@@ -3605,6 +3620,21 @@ class CartCore extends ObjectModel
             && (float) $configuration['PS_SHIPPING_FREE_WEIGHT'] > 0) {
             // Allow module to override the shipping cost and return their custom value
             $shipping_cost = $this->getPackageShippingCostFromModule($carrier, $shipping_cost, $products);
+
+            if (Configuration::get('PS_ATCP_SHIPWRAP')) {
+                if (!$use_tax) {
+                    // With PS_ATCP_SHIPWRAP, we deduce the pre-tax price from the post-tax
+                    // price. This is on purpose and required in Germany.
+                    $shipping_cost /= (1 + $this->getAverageProductsTaxRate());
+                }
+            } else {
+                // Apply tax
+                if ($use_tax && isset($carrier_tax)) {
+                    $shipping_cost *= 1 + ($carrier_tax / 100);
+                }
+            }
+
+            $shipping_cost = (float) Tools::ps_round((float) $shipping_cost, Context::getContext()->getComputingPrecision());
             Cache::store($cache_id, $shipping_cost);
 
             return $shipping_cost;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fixes shipping price calculation. Modules should return the custom price without tax and core logic adds it automatically. But, it's not the case when the module method is called from the two "free shipping" ifs in the code.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Steps how to test were written in Github Issue. A developer must test it.
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39243
| Related PRs       | 
