### PR TITLE
Fix "get available carriers" query

### DIFF
--- a/src/Adapter/Carrier/QueryHandler/GetAvailableCarriersHandler.php
+++ b/src/Adapter/Carrier/QueryHandler/GetAvailableCarriersHandler.php
@@ -164,23 +164,28 @@ class GetAvailableCarriersHandler implements GetAvailableCarriersHandlerInterfac
      */
     private function getProductName(Product $product): string
     {
-        if (is_array($product->name)) {
-            $languageId = $this->languageContext->getId();
-            $defaultLanguageId = $this->defaultLanguageContext->getId();
+        $name = $product->name;
 
-            if (!isset($product->name[$languageId])) {
-                throw new RuntimeException(sprintf('Product name not found for product ID %d and language ID %d.', $product->id, $languageId));
-            }
-
-            $productName = $product->name[$languageId];
-
-            if (empty($productName)) {
-                $productName = $product->name[$defaultLanguageId];
-            }
-
-            return $productName;
+        if (!is_array($name)) {
+            return $name;
         }
 
-        return $product->name;
+        $languageId = $this->languageContext->getId();
+        $defaultLanguageId = $this->defaultLanguageContext->getId();
+
+        if (isset($name[$languageId])) {
+            return $name[$languageId];
+        }
+
+        if (isset($name[$defaultLanguageId])) {
+            return $name[$defaultLanguageId];
+        }
+
+        throw new RuntimeException(sprintf(
+            'Product name not found for product ID %d in current (%d) or default (%d) language.',
+            $product->id,
+            $languageId,
+            $defaultLanguageId
+        ));
     }
 }

--- a/src/Adapter/Carrier/QueryHandler/GetAvailableCarriersHandler.php
+++ b/src/Adapter/Carrier/QueryHandler/GetAvailableCarriersHandler.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use Product;
 use RuntimeException;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 #[AsQueryHandler]
 class GetAvailableCarriersHandler implements GetAvailableCarriersHandlerInterface
@@ -49,6 +50,8 @@ class GetAvailableCarriersHandler implements GetAvailableCarriersHandlerInterfac
         private readonly CarrierRepository $carrierRepository,
         private readonly ProductRepository $productRepository,
         private readonly LanguageContext $languageContext,
+        #[Autowire(service: 'prestashop.default.language.context')]
+        private readonly LanguageContext $defaultLanguageContext,
         private readonly ShopContext $shopContext,
     ) {
     }
@@ -163,12 +166,19 @@ class GetAvailableCarriersHandler implements GetAvailableCarriersHandlerInterfac
     {
         if (is_array($product->name)) {
             $languageId = $this->languageContext->getId();
+            $defaultLanguageId = $this->defaultLanguageContext->getId();
 
             if (!isset($product->name[$languageId])) {
                 throw new RuntimeException(sprintf('Product name not found for product ID %d and language ID %d.', $product->id, $languageId));
             }
 
-            return $product->name[$languageId];
+            $productName = $product->name[$languageId];
+
+            if (empty($productName)) {
+                $productName = $product->name[$defaultLanguageId];
+            }
+
+            return $productName;
         }
 
         return $product->name;

--- a/src/Adapter/Carrier/Repository/CarrierRepository.php
+++ b/src/Adapter/Carrier/Repository/CarrierRepository.php
@@ -376,19 +376,58 @@ class CarrierRepository extends AbstractMultiShopObjectModelRepository
      */
     public function findCarriersByProductIds(array $productIds, ShopId $shopId): array
     {
+        $productCarriers = $this->getProductCarriers($productIds, $shopId);
+        $mapping = $this->mapProductCarriers($productCarriers);
+
+        $foundProductIds = array_keys($mapping);
+        $missingProductIds = array_diff($productIds, $foundProductIds);
+
+        if (!empty($missingProductIds)) {
+            $allCarriers = $this->getAllActiveCarriers();
+
+            foreach ($missingProductIds as $productId) {
+                $mapping[$productId] = $allCarriers;
+            }
+        }
+
+        return $mapping;
+    }
+
+    private function getProductCarriers(array $productIds, ShopId $shopId): array
+    {
         $qb = $this->connection->createQueryBuilder();
-        $qb->select('pc.id_product as product_id, c.id_carrier AS id_carrier, c.name')
+
+        return $qb->select('pc.id_product as product_id', 'c.id_carrier', 'c.name')
             ->from($this->prefix . 'product_carrier', 'pc')
-            ->innerJoin('pc', $this->prefix . 'carrier', 'c', 'c.id_reference = pc.id_carrier_reference AND c.deleted = 0')
+            ->innerJoin(
+                'pc',
+                $this->prefix . 'carrier',
+                'c',
+                'c.id_reference = pc.id_carrier_reference AND c.deleted = 0'
+            )
             ->where($qb->expr()->in('pc.id_product', ':product_ids'))
             ->andWhere('pc.id_shop = :shop_id')
             ->setParameter('product_ids', $productIds, ArrayParameterType::INTEGER)
-            ->setParameter('shop_id', $shopId->getValue());
+            ->setParameter('shop_id', $shopId->getValue())
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
 
-        $results = $qb->executeQuery()->fetchAllAssociative();
+    private function getAllActiveCarriers(): array
+    {
+        return $this->connection->createQueryBuilder()
+            ->select('id_carrier', 'name')
+            ->from($this->prefix . 'carrier')
+            ->where('deleted = 0')
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
 
+    private function mapProductCarriers(array $rows): array
+    {
         $mapping = [];
-        foreach ($results as $row) {
+
+        foreach ($rows as $row) {
             $mapping[$row['product_id']][] = [
                 'id_carrier' => $row['id_carrier'],
                 'name' => $row['name'],

--- a/src/Adapter/Carrier/Repository/CarrierRepository.php
+++ b/src/Adapter/Carrier/Repository/CarrierRepository.php
@@ -376,18 +376,22 @@ class CarrierRepository extends AbstractMultiShopObjectModelRepository
      */
     public function findCarriersByProductIds(array $productIds, ShopId $shopId): array
     {
+        // Step 1: Get all active carriers once
+        $allCarriers = $this->getAllActiveCarriers();
+
+        // Step 2: Initialize mapping with all carriers for each product
+        $mapping = [];
+        foreach ($productIds as $productId) {
+            $mapping[$productId] = $allCarriers;
+        }
+
+        // Step 3: Get restricted carriers for certain products
         $productCarriers = $this->getProductCarriers($productIds, $shopId);
-        $mapping = $this->mapProductCarriers($productCarriers);
+        $restricted = $this->mapProductCarriers($productCarriers);
 
-        $foundProductIds = array_keys($mapping);
-        $missingProductIds = array_diff($productIds, $foundProductIds);
-
-        if (!empty($missingProductIds)) {
-            $allCarriers = $this->getAllActiveCarriers();
-
-            foreach ($missingProductIds as $productId) {
-                $mapping[$productId] = $allCarriers;
-            }
+        // Step 4: Override default mapping with restricted carriers where applicable
+        foreach ($restricted as $productId => $carriers) {
+            $mapping[$productId] = $carriers;
         }
 
         return $mapping;

--- a/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
@@ -29,6 +29,7 @@ namespace Tests\Integration\Behaviour\Features\Context;
 use Configuration;
 use Language;
 use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
 use RuntimeException;
 use Tests\Resources\Resetter\LanguageResetter;
 
@@ -77,6 +78,10 @@ class LanguageFeatureContext extends AbstractPrestaShopFeatureContext
         Configuration::updateValue('PS_LANG_DEFAULT', (string) $languageId);
 
         SharedStorage::getStorage()->set('default_language_id', $languageId);
+
+        /** @var LanguageContextBuilder $languageBuilder */
+        $languageBuilder = CommonFeatureContext::getContainer()->get('test_language_context_builder');
+        $languageBuilder->setDefaultLanguageId($languageId);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_available.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_available.feature
@@ -8,13 +8,19 @@ Feature: Carrier available
   Background:
     Given shop "shop1" with name "test_shop" exists
     And I set up shop context to single shop shop1
-    And language "language1" with locale "en-US" exists
-    And language "language2" with locale "fr-FR" exists
+    And language "fr" with locale "fr-FR" exists
+    And language "en" with locale "en-US" exists
+    And language with iso code "en" is the default one
     And I add product "product1" with following information:
-      | name[en-US] | bottle of beer |
-      | type        | standard       |
+      | name[fr-FR] | bouteille de bière |
+      | name[en-US] | bottle of beer     |
+      | type        | standard           |
     And I add product "product2" with following information:
       | name[fr-FR] | bouteille de rhum |
+      | name[en-US] | bottle of rhum    |
+      | type        | standard          |
+    And I add product "product3" with following information:
+      | name[en-US] | bottle of whiskey |
       | type        | standard       |
     And I create carrier "standard_carrier" with specified properties:
       | name | Standard |
@@ -31,8 +37,12 @@ Feature: Carrier available
     And I assign product "product2" with following carriers:
       | standard_carrier |
       | pickup_carrier |
-    Then the products "product1, product2" should have the following carriers:
-      | carrier  | state     | products       |
-      | Standard | available |                |
-      | Pickup   | available |                |
-      | Express  | filtered  | bottle of beer |
+    Then the products "product1, product2, product3" should have the following carriers:
+      | carrier           | state     | products                          |
+      | Standard          | available |                                   |
+      | Pickup            | available |                                   |
+      | Express           | filtered  | bottle of beer, bottle of whiskey |
+      | My cheap carrier  | filtered  | bottle of whiskey                 |
+      | My light carrier  | filtered  | bottle of whiskey                 |
+      | Click and collect | filtered  | bottle of whiskey                 |
+      | My carrier        | filtered  | bottle of whiskey                 |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixed the "get Available Carriers" query that retrieves common carriers for a list of products. This query did not take into account products configured on "allCarriers"
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See behat tests.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16935660959
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -