### PR TITLE
Added closure of the 'deleteCategoriesForm' form

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig
@@ -37,7 +37,6 @@
   {% block content %}
     <div class="modal-body">
       {{ form_start(deleteCategoriesForm, {'action': path('admin_categories_delete')}) }}
-
       <div class="form-group mb-0">
         {{ form_widget(deleteCategoriesForm.delete_mode) }}
       </div>
@@ -50,6 +49,7 @@
       <div class="d-none">
         {{ form_widget(deleteCategoriesForm.categories_to_delete_parent) }}
       </div>
+      {{ form_end(deleteCategoriesForm) }}
     </div>
   {% endblock %}
 {% endembed %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | In the file `src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig`, the form closing tag is missing - see: https://github.com/PrestaShop/PrestaShop/issues/39270
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | [see: https://github.com/PrestaShop/PrestaShop/issues/39270
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #39270
| Related PRs       | 
| Sponsor company   | @Codencode 
