### PR TITLE
Make the TinyMCEEditor more flexible and extensible via module

### DIFF
--- a/admin-dev/themes/new-theme/js/components/tinymce-editor.js
+++ b/admin-dev/themes/new-theme/js/components/tinymce-editor.js
@@ -130,6 +130,10 @@ class TinyMCEEditor {
       cfg.selector = `.${cfg.editor_selector}`;
     }
 
+    EventEmitter.emit('initTinyMCE', {
+      config: cfg,
+    });
+
     // Change icons in popups
     $('body').on('click', '.mce-btn, .mce-open, .mce-menu-item', () => {
       this.changeToMaterial();

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3682,6 +3682,9 @@ exit;
                     if ($allow_style) {
                         $def->addElement('style', 'Block', 'Flow', 'Common', ['type' => 'Text']);
                     }
+                    Hook::exec('actionModifyHtmlPurifierConfig', [
+                        'config' => &$config,
+                    ]);
                 }
 
                 $purifier = new HTMLPurifier($config);

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -5473,5 +5473,10 @@
         <title>Called when checking if an order has been delivered</title>
         <description>Allows modules to override or react to the hasBeenDelivered() method of the Order class.</description>
     </hook>
+    <hook id="actionModifyHtmlPurifierConfig">
+        <name>actionModifyHtmlPurifierConfig</name>
+        <title>Called when configuring HTMLPurifier</title>
+        <description>Allows modules to modify the HTMLPurifier definition by adding custom allowed HTML elements or attributes during Tools::purifyHTML().</description>
+    </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Make the TinyMCEEditor more flexible and extensible via module see: https://github.com/PrestaShop/PrestaShop/discussions/39259
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install the module I posted [idea_39259.zip](https://github.com/user-attachments/files/21551471/idea_39259.zip) - 2. Access an admin page containing the editor (e.g., a product page) - 3. Click the new button added by the module - 4. Save - 5. After saving, verify that the editor's source code contains the following tag: `<span data-specific-value="1">Text previously inserted via popup</span>`
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16883551915
| Fixed issue or discussion?     | Idea https://github.com/PrestaShop/PrestaShop/discussions/39259
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/1439
| Sponsor company   | @Codencode 
