### PR TITLE
Command `prestashop:list:commands-and-queries` : Filter CQRS with (1) or without (0) an endpoint

### DIFF
--- a/src/PrestaShopBundle/Command/ListCommandsAndQueriesCommand.php
+++ b/src/PrestaShopBundle/Command/ListCommandsAndQueriesCommand.php
@@ -81,6 +81,12 @@ class ListCommandsAndQueriesCommand extends Command
                 'Outputs either a regular or simplified format.',
                 'regular'
             )
+            ->addOption(
+                'hasApiEndpoint',
+                '',
+                InputOption::VALUE_OPTIONAL,
+                'Filter CQRS with (1) or without (0) an endpoint'
+            )
         ;
     }
 
@@ -95,9 +101,17 @@ class ListCommandsAndQueriesCommand extends Command
         $outputStyle = new OutputFormatterStyle('blue', null);
         $output->getFormatter()->setStyle('blue', $outputStyle);
 
+        $optionHasApiEndpoint = $input->getOption('hasApiEndpoint') !== null ? (bool) $input->getOption('hasApiEndpoint') : null;
+
         foreach ($this->commandAndQueries as $key => $commandName) {
             $commandDefinition = $this->commandDefinitionParser->parseDefinition($commandName);
             $cqrsEndpointURI = $this->getCQRSEndpointURI($commandDefinition);
+
+            if ($optionHasApiEndpoint !== null) {
+                if (($optionHasApiEndpoint && empty($cqrsEndpointURI)) || (!$optionHasApiEndpoint && !empty($cqrsEndpointURI))) {
+                    continue;
+                }
+            }
 
             if ($this->isFormatSimple) {
                 $output->writeln('<info>' . $commandDefinition->getClassName() . (!empty($cqrsEndpointURI) ? ' OK' : ' NOT OK') . '</info>');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Command `prestashop:list:commands-and-queries` : Filter CQRS with (1) or without (0) an endpoint
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: & Process :arrow_double_down: 
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/16715384163
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

## How to test?
* Execute `php bin/console prestashop:list:commands-and-queries`
<img width="847" height="528" alt="image" src="https://github.com/user-attachments/assets/4812f31d-8ade-4ba9-85b1-524bf0fbd0dc" />

* Execute `php bin/console prestashop:list:commands-and-queries --hasApiEndpoint=0`
<img width="934" height="424" alt="image" src="https://github.com/user-attachments/assets/524d01ed-3c6d-42ef-a7f6-7ada25a6bc72" />

* Execute `php bin/console prestashop:list:commands-and-queries --hasApiEndpoint=1`
<img width="841" height="81" alt="image" src="https://github.com/user-attachments/assets/831550e5-ea34-4f2e-9dc1-62e6af4515a1" />
