### PR TITLE
Admin API CQRSDelete can use CQRSCommand and empty bodies can be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "prestashop/hummingbird": "^1.0.1",
         "prestashop/pagesnotfound": "^2",
         "prestashop/productcomments": "^7.0",
-        "prestashop/ps_apiresources": "^0.1",
+        "prestashop/ps_apiresources": "dev-delete-endpoints-command",
         "prestashop/ps_banner": "^2",
         "prestashop/ps_bestsellers": "^1.0",
         "prestashop/ps_brandlist": "^1.0",
@@ -209,6 +209,10 @@
         "php-sql-parser": {
             "type": "vcs",
             "url": "https://github.com/PrestaShop/PHP-SQL-Parser"
+        },
+        "ps_apiresources": {
+            "type": "vcs",
+            "url": "https://github.com/jolelievre/ps_apiresources"
         }
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "63e461842cac5f5cbb9b0debeeb9bd8d",
+    "content-hash": "0cfe14a7cd72fd747df24fce71e32a75",
     "packages": [
         {
             "name": "api-platform/core",
@@ -5261,16 +5261,16 @@
         },
         {
             "name": "prestashop/ps_apiresources",
-            "version": "v0.1.0",
+            "version": "dev-delete-endpoints-command",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PrestaShop/ps_apiresources.git",
-                "reference": "6aebe14f12e4951285a1946ae9f75a3390aa1803"
+                "url": "https://github.com/jolelievre/ps_apiresources.git",
+                "reference": "0387b2fb74801c2e6011fa84fb207d881b546afa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_apiresources/zipball/6aebe14f12e4951285a1946ae9f75a3390aa1803",
-                "reference": "6aebe14f12e4951285a1946ae9f75a3390aa1803",
+                "url": "https://api.github.com/repos/jolelievre/ps_apiresources/zipball/0387b2fb74801c2e6011fa84fb207d881b546afa",
+                "reference": "0387b2fb74801c2e6011fa84fb207d881b546afa",
                 "shasum": ""
             },
             "require": {
@@ -5291,7 +5291,26 @@
                     "ps_apiresources.php"
                 ]
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "PsApiResourcesTest\\": "tests/"
+                }
+            },
+            "scripts": {
+                "clear-test-cache": [
+                    "PsApiResourcesTest\\EnvironmentBuilder::clearCache"
+                ],
+                "create-test-db": [
+                    "@composer clear-test-cache",
+                    "@composer setup-local-tests -- --build-db"
+                ],
+                "run-module-tests": [
+                    "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/Integration/phpunit-local.xml"
+                ],
+                "setup-local-tests": [
+                    "PsApiResourcesTest\\EnvironmentBuilder::setupLocalTests"
+                ]
+            },
             "license": [
                 "AFL-3.0"
             ],
@@ -5304,9 +5323,9 @@
             "description": "PrestaShop - API Resources",
             "homepage": "https://github.com/PrestaShop/ps_apiresources",
             "support": {
-                "source": "https://github.com/PrestaShop/ps_apiresources/tree/v0.1.0"
+                "source": "https://github.com/jolelievre/ps_apiresources/tree/delete-endpoints-command"
             },
-            "time": "2025-06-05T16:18:02+00:00"
+            "time": "2025-08-05T07:33:05+00:00"
         },
         {
             "name": "prestashop/ps_banner",
@@ -18078,7 +18097,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "prestashop/ps_apiresources": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSCommand.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSCommand.php
@@ -129,6 +129,7 @@ class CQRSCommand extends AbstractCQRSOperation
         ?array $ApiResourceMapping = null,
         ?array $CQRSCommandMapping = null,
         ?bool $experimentalOperation = null,
+        ?bool $allowEmptyBody = null,
     ) {
         $passedArguments = \get_defined_vars();
 
@@ -144,9 +145,15 @@ class CQRSCommand extends AbstractCQRSOperation
             $passedArguments['extraProperties']['CQRSCommandMapping'] = $CQRSCommandMapping;
         }
 
+        if ($allowEmptyBody !== null) {
+            $this->checkArgumentAndExtraParameterValidity('allowEmptyBody', $allowEmptyBody, $passedArguments['extraProperties']);
+            $passedArguments['extraProperties']['allowEmptyBody'] = $allowEmptyBody;
+        }
+
         // Remove custom arguments
         unset($passedArguments['CQRSCommand']);
         unset($passedArguments['CQRSCommandMapping']);
+        unset($passedArguments['allowEmptyBody']);
 
         // By default, the CQRS command is used as the input base class as it contains the exact available parameters for this operation
         // Exception in case the class doesn't exist we don't force the input because InputOutputResourceMetadataCollectionFactory will raise an exception when the resources are parsed
@@ -166,7 +173,8 @@ class CQRSCommand extends AbstractCQRSOperation
     {
         $self = clone $this;
         $self->extraProperties['CQRSCommand'] = $CQRSCommand;
-        if ($this->input === $this->extraProperties['CQRSCommand']) {
+        // Test if the input was a copy of the CQRSCommand extra property, set in the constructor (if none was set then we can copy it as well)
+        if (empty($this->input) || empty($this->extraProperties['CQRSCommand']) || $this->input === $this->extraProperties['CQRSCommand']) {
             $self->input = $CQRSCommand;
         }
 
@@ -186,10 +194,23 @@ class CQRSCommand extends AbstractCQRSOperation
         return $this->extraProperties['CQRSCommandMapping'] ?? null;
     }
 
-    public function withCQRSCommandMapping(array $CQRSQuery): static
+    public function withCQRSCommandMapping(array $CQRSCommandMapping): static
     {
         $self = clone $this;
-        $self->extraProperties['CQRSCommandMapping'] = $CQRSQuery;
+        $self->extraProperties['CQRSCommandMapping'] = $CQRSCommandMapping;
+
+        return $self;
+    }
+
+    public function getAllowEmptyBody(): ?bool
+    {
+        return $this->extraProperties['allowEmptyBody'] ?? null;
+    }
+
+    public function withAllowEmptyBody(bool $allowEmptyBody): static
+    {
+        $self = clone $this;
+        $self->extraProperties['allowEmptyBody'] = $allowEmptyBody;
 
         return $self;
     }

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSCreate.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSCreate.php
@@ -126,6 +126,7 @@ class CQRSCreate extends CQRSCommand
         ?array $ApiResourceMapping = null,
         ?array $CQRSCommandMapping = null,
         ?bool $experimentalOperation = null,
+        ?bool $allowEmptyBody = null,
     ) {
         $passedArguments = \get_defined_vars();
         $passedArguments['method'] = self::METHOD_POST;

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSPartialUpdate.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSPartialUpdate.php
@@ -127,6 +127,7 @@ class CQRSPartialUpdate extends CQRSCommand
         ?array $ApiResourceMapping = null,
         ?array $CQRSCommandMapping = null,
         ?bool $experimentalOperation = null,
+        ?bool $allowEmptyBody = null,
     ) {
         $passedArguments = \get_defined_vars();
         $passedArguments['method'] = self::METHOD_PATCH;

--- a/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSUpdate.php
+++ b/src/PrestaShopBundle/ApiPlatform/Metadata/CQRSUpdate.php
@@ -128,6 +128,7 @@ class CQRSUpdate extends CQRSCommand
         ?array $ApiResourceMapping = null,
         ?array $CQRSCommandMapping = null,
         ?bool $experimentalOperation = null,
+        ?bool $allowEmptyBody = null,
     ) {
         $passedArguments = \get_defined_vars();
         // Disable read listener because it is forced when using PUT method, but we don't need it since we rely on CQRS commands/queries

--- a/src/PrestaShopBundle/ApiPlatform/Provider/EmptyBodyDeserializerProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/EmptyBodyDeserializerProvider.php
@@ -28,6 +28,8 @@ namespace PrestaShopBundle\ApiPlatform\Provider;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -35,9 +37,11 @@ use Symfony\Component\HttpFoundation\Request;
  * a content-type in this case but the DeserializerProvider forces it, so we decorate it and mimic the
  * expected behaviour.
  */
+#[AsDecorator(decorates: 'api_platform.state_provider.deserialize')]
 class EmptyBodyDeserializerProvider implements ProviderInterface
 {
     public function __construct(
+        #[AutowireDecorated]
         private readonly ProviderInterface $decorated,
     ) {
     }

--- a/src/PrestaShopBundle/ApiPlatform/Provider/EmptyBodyDeserializerProvider.php
+++ b/src/PrestaShopBundle/ApiPlatform/Provider/EmptyBodyDeserializerProvider.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\ApiPlatform\Provider;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * This decorator is used when we enabled our custom property allowEmptyBody We don't need to specify
+ * a content-type in this case but the DeserializerProvider forces it, so we decorate it and mimic the
+ * expected behaviour.
+ */
+class EmptyBodyDeserializerProvider implements ProviderInterface
+{
+    public function __construct(
+        private readonly ProviderInterface $decorated,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        if ($context['request'] instanceof Request) {
+            $request = $context['request'];
+            if (($operation->getExtraProperties()['allowEmptyBody'] ?? false) && empty((string) $request->getContent())) {
+                $requestFormat = $request->getRequestFormat() ?: 'json';
+                $mimeType = $request->getMimeType($requestFormat) ?: 'application/json';
+                $request->headers->set('Content-Type', $mimeType);
+                $request->attributes->set('input_format', $requestFormat);
+            }
+        }
+
+        return $this->decorated->provide($operation, $uriVariables, $context);
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
@@ -67,9 +67,8 @@ services:
 
   # Decorator of api_platform.state_provider.deserialize DeserializeProvider
   PrestaShopBundle\ApiPlatform\Provider\EmptyBodyDeserializerProvider:
-    decorates: 'api_platform.state_provider.deserialize'
-    arguments:
-      $decorated: '@.inner'
+    autowire: true
+    public: false
 
   # Customer provider for CQRS queries
   PrestaShopBundle\ApiPlatform\Provider\QueryProvider:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
@@ -64,6 +64,13 @@ services:
     arguments:
       $validatorMetadataFactory: '@validator.mapping.class_metadata_factory'
 
+
+  # Decorator of api_platform.state_provider.deserialize DeserializeProvider
+  PrestaShopBundle\ApiPlatform\Provider\EmptyBodyDeserializerProvider:
+    decorates: 'api_platform.state_provider.deserialize'
+    arguments:
+      $decorated: '@.inner'
+
   # Customer provider for CQRS queries
   PrestaShopBundle\ApiPlatform\Provider\QueryProvider:
     tags: [ 'api_platform.state_provider' ]

--- a/tests/Integration/ApiPlatform/Serializer/CQRSApiSerializerTest.php
+++ b/tests/Integration/ApiPlatform/Serializer/CQRSApiSerializerTest.php
@@ -426,7 +426,7 @@ class CQRSApiSerializerTest extends KernelTestCase
         ];
 
         $hook = new Hook();
-        $hook->id = 1;
+        $hook->hookId = 1;
         $hook->active = true;
         $hook->name = 'testHook';
         $hook->title = 'testHookTitle';
@@ -440,7 +440,7 @@ class CQRSApiSerializerTest extends KernelTestCase
                 'description' => '',
             ],
             $hook,
-            ['[id_hook]' => '[id]'],
+            ['[id_hook]' => '[hookId]'],
         ];
 
         $command = new AddProductCommand(

--- a/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/01_internalAuthServer/02_resourceEndpoint.ts
+++ b/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/01_internalAuthServer/02_resourceEndpoint.ts
@@ -174,8 +174,8 @@ describe('API : Internal Auth Server - Resource Endpoint', async () => {
       expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
 
       const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('id');
-      expect(jsonResponse.id).to.be.a('number');
+      expect(jsonResponse).to.have.property('hookId');
+      expect(jsonResponse.hookId).to.be.a('number');
       expect(jsonResponse).to.have.property('active');
       expect(jsonResponse.active).to.be.a('boolean');
     });

--- a/tests/UI/campaigns/functional/API/02_checkEndpoints.ts
+++ b/tests/UI/campaigns/functional/API/02_checkEndpoints.ts
@@ -105,10 +105,12 @@ describe('API : Check endpoints', async () => {
         '/customers/group/{customerGroupId}: PUT',
         // tests/UI/campaigns/functional/API/02_endpoints/02_customerGroup/04_postCustomersGroup.ts
         '/customers/group: POST',
+        // todo: add tests
+        '/customers/groups: GET',
         // tests/UI/campaigns/functional/API/02_endpoints/03_hook/01_putHookStatusId.ts
-        '/hook-status: PUT',
+        '/hook-status/{hookId}: PUT',
         // tests/UI/campaigns/functional/API/02_endpoints/03_hook/02_getHooksId.ts
-        '/hook/{id}: GET',
+        '/hook/{hookId}: GET',
         // tests/UI/campaigns/functional/API/02_endpoints/03_hook/03_getHooks.ts
         '/hooks: GET',
         // tests/UI/campaigns/functional/API/02_endpoints/04_language/01_getLanguages.ts
@@ -136,6 +138,8 @@ describe('API : Check endpoints', async () => {
         // tests/UI/campaigns/functional/API/02_endpoints/05_module/11_getModules.ts
         '/modules: GET',
         // tests/UI/campaigns/functional/API/02_endpoints/06_product/01_getProductImageId.ts
+        // todo: add tests for delete and shopIds
+        '/product/image/{imageId}: DELETE',
         '/product/image/{imageId}: GET',
         // tests/UI/campaigns/functional/API/02_endpoints/06_product/02_postProductImageId.ts
         '/product/image/{imageId}: POST',

--- a/tests/UI/campaigns/functional/API/02_endpoints/03_hook/03_getHooksId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/03_hook/03_getHooksId.ts
@@ -21,14 +21,14 @@ import {
 
 const baseContext: string = 'functional_API_endpoints_hook_getHooksId';
 
-describe('API : GET /hook/{id}', async () => {
+describe('API : GET /hook/{hookId}', async () => {
   let apiContext: APIRequestContext;
   let browserContext: BrowserContext;
   let page: Page;
   let clientSecret: string;
   let accessToken: string;
   let jsonResponse: any;
-  let idHook: number;
+  let hookId: number;
   let statusHook: boolean;
   let nameHook: string;
   let titleHook: string;
@@ -153,8 +153,8 @@ describe('API : GET /hook/{id}', async () => {
     it('should get the hook informations', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'getHookInformations', baseContext);
 
-      idHook = await boDesignPositionsPage.getHookId(page, 0);
-      expect(idHook).to.be.gt(0);
+      hookId = await boDesignPositionsPage.getHookId(page, 0);
+      expect(hookId).to.be.gt(0);
 
       statusHook = await boDesignPositionsPage.getHookStatus(page, 0);
       expect(statusHook).to.be.equal(true);
@@ -171,10 +171,10 @@ describe('API : GET /hook/{id}', async () => {
   });
 
   describe('API : Check Data', async () => {
-    it('should request the endpoint /hook/{id}', async function () {
+    it('should request the endpoint /hook/{hookId}', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestEndpoint', baseContext);
 
-      const apiResponse = await apiContext.get(`hook/${idHook}`, {
+      const apiResponse = await apiContext.get(`hook/${hookId}`, {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
@@ -190,7 +190,7 @@ describe('API : GET /hook/{id}', async () => {
       await testContext.addContextItem(this, 'testIdentifier', 'checkResponseKeys', baseContext);
 
       expect(jsonResponse).to.have.all.keys(
-        'id',
+        'hookId',
         'active',
         'name',
         'title',
@@ -198,12 +198,12 @@ describe('API : GET /hook/{id}', async () => {
       );
     });
 
-    it('should check the JSON Response : `id`', async function () {
+    it('should check the JSON Response : `hookId`', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkResponseId', baseContext);
 
-      expect(jsonResponse).to.have.property('id');
-      expect(jsonResponse.id).to.be.a('number');
-      expect(jsonResponse.id).to.be.equal(idHook);
+      expect(jsonResponse).to.have.property('hookId');
+      expect(jsonResponse.hookId).to.be.a('number');
+      expect(jsonResponse.hookId).to.be.equal(hookId);
     });
 
     it('should check the JSON Response : `active`', async function () {

--- a/tests/UI/campaigns/functional/API/02_endpoints/05_module/03_putModuleTechnicalNameInstall.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/05_module/03_putModuleTechnicalNameInstall.ts
@@ -176,7 +176,6 @@ describe('API : PUT /module/{technicalName}/install', async () => {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
-        data: {},
       });
       expect(apiResponse.status()).to.eq(200);
       expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);

--- a/tests/UI/campaigns/functional/API/02_endpoints/05_module/04_patchModuleTechnicalNameReset.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/05_module/04_patchModuleTechnicalNameReset.ts
@@ -180,21 +180,35 @@ describe('API : PATCH /module/{technicalName}/reset', async () => {
   [
     true,
     false,
-  ].forEach((argKeepData: boolean, index: number) => {
+    null,
+  ].forEach((argKeepData: boolean|null, index: number) => {
     describe(`API : Check Data with keepData = ${argKeepData}`, async () => {
       it('should request the endpoint /module/{technicalName}/reset', async function () {
         await testContext.addContextItem(this, 'testIdentifier', `requestEndpoint${index}`, baseContext);
 
         // keepData == true => trigger onReset method (if exists, else keepData == false)
         // keepData == false => trigger uninstall & install method
-        const apiResponse = await apiContext.patch(`module/${moduleInfo.technicalName}/reset`, {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
-          data: {
-            keepData: argKeepData,
-          },
-        });
+        // keepData === null => Provide no data (equivalent to keepData == true)
+        let apiData;
+
+        if (argKeepData !== null) {
+          apiData = {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+            data: {
+              keepData: argKeepData,
+            },
+          };
+        } else {
+          apiData = {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          };
+        }
+
+        const apiResponse = await apiContext.patch(`module/${moduleInfo.technicalName}/reset`, apiData);
         expect(apiResponse.status()).to.eq(200);
         expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
         expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');

--- a/tests/UI/campaigns/functional/API/02_endpoints/05_module/07_putModuleTechnicalNameUpgrade.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/05_module/07_putModuleTechnicalNameUpgrade.ts
@@ -184,7 +184,6 @@ describe('API : PUT /module/{technicalName}/upgrade', async () => {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
-        data: {},
       });
 
       expect(apiResponse.status()).to.eq(200);

--- a/tests/UI/campaigns/functional/API/02_endpoints/06_product/03_postProductIdImage.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/06_product/03_postProductIdImage.ts
@@ -208,6 +208,7 @@ describe('API : POST /product/{productId}/image', async () => {
           'legends',
           'cover',
           'position',
+          'shopIds',
         );
       });
 
@@ -230,6 +231,12 @@ describe('API : POST /product/{productId}/image', async () => {
 
         expect(jsonResponse.position).to.be.a('number');
         expect(jsonResponse.position).to.be.equals(1);
+
+        expect(jsonResponse).to.have.property('shopIds');
+        expect(jsonResponse.shopIds).to.be.a('array');
+        expect(jsonResponse.shopIds).to.be.deep.equal([1]);
+        expect(jsonResponse.shopIds[0]).to.be.a('number');
+        expect(jsonResponse.shopIds[0]).to.be.equal(1);
       });
     });
 

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSCommandTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSCommandTest.php
@@ -563,4 +563,58 @@ class CQRSCommandTest extends TestCase
         $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
         $this->assertEquals('Specifying an extra property experimentalOperation and a experimentalOperation argument that are different is invalid', $caughtException->getMessage());
     }
+
+    public function testAllowEmptyBody(): void
+    {
+        // Default value is false (no extra property added)
+        $operation = new CQRSCommand();
+        $this->assertEquals([], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getAllowEmptyBody());
+
+        // Scopes parameters in constructor
+        $operation = new CQRSCommand(
+            allowEmptyBody: true,
+        );
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // Extra properties parameters in constructor
+        $operation = new CQRSCommand(
+            extraProperties: ['allowEmptyBody' => false]
+        );
+        $this->assertEquals(['allowEmptyBody' => false], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getAllowEmptyBody());
+
+        // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
+        $operation = new CQRSCommand(
+            extraProperties: ['allowEmptyBody' => true],
+            allowEmptyBody: true,
+        );
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // Use with method, returned object is a clone All values are replaced
+        $operation2 = $operation->withallowEmptyBody(false);
+        $this->assertNotEquals($operation2, $operation);
+        $this->assertEquals(['allowEmptyBody' => false], $operation2->getExtraProperties());
+        $this->assertEquals(false, $operation2->getAllowEmptyBody());
+        // Initial operation not modified of course
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // When both values are specified, but they are different trigger an exception
+        $caughtException = null;
+        try {
+            new CQRSCommand(
+                extraProperties: ['allowEmptyBody' => true],
+                allowEmptyBody: false,
+            );
+        } catch (InvalidArgumentException $e) {
+            $caughtException = $e;
+        }
+
+        $this->assertNotNull($caughtException);
+        $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
+        $this->assertEquals('Specifying an extra property allowEmptyBody and a allowEmptyBody argument that are different is invalid', $caughtException->getMessage());
+    }
 }

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSCreateTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSCreateTest.php
@@ -417,4 +417,58 @@ class CQRSCreateTest extends TestCase
         $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
         $this->assertEquals('Specifying an extra property experimentalOperation and a experimentalOperation argument that are different is invalid', $caughtException->getMessage());
     }
+
+    public function testAllowEmptyBody(): void
+    {
+        // Default value is false (no extra property added)
+        $operation = new CQRSCreate();
+        $this->assertEquals([], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getAllowEmptyBody());
+
+        // Scopes parameters in constructor
+        $operation = new CQRSCreate(
+            allowEmptyBody: true,
+        );
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // Extra properties parameters in constructor
+        $operation = new CQRSCreate(
+            extraProperties: ['allowEmptyBody' => false]
+        );
+        $this->assertEquals(['allowEmptyBody' => false], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getAllowEmptyBody());
+
+        // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
+        $operation = new CQRSCreate(
+            extraProperties: ['allowEmptyBody' => true],
+            allowEmptyBody: true,
+        );
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // Use with method, returned object is a clone All values are replaced
+        $operation2 = $operation->withallowEmptyBody(false);
+        $this->assertNotEquals($operation2, $operation);
+        $this->assertEquals(['allowEmptyBody' => false], $operation2->getExtraProperties());
+        $this->assertEquals(false, $operation2->getAllowEmptyBody());
+        // Initial operation not modified of course
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // When both values are specified, but they are different trigger an exception
+        $caughtException = null;
+        try {
+            new CQRSCreate(
+                extraProperties: ['allowEmptyBody' => true],
+                allowEmptyBody: false,
+            );
+        } catch (InvalidArgumentException $e) {
+            $caughtException = $e;
+        }
+
+        $this->assertNotNull($caughtException);
+        $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
+        $this->assertEquals('Specifying an extra property allowEmptyBody and a allowEmptyBody argument that are different is invalid', $caughtException->getMessage());
+    }
 }

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSDeleteTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSDeleteTest.php
@@ -31,7 +31,7 @@ namespace Tests\Unit\PrestaShopBundle\ApiPlatform\Metadata;
 use ApiPlatform\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
-use PrestaShopBundle\ApiPlatform\Provider\QueryProvider;
+use PrestaShopBundle\ApiPlatform\Processor\CommandProcessor;
 
 class CQRSDeleteTest extends TestCase
 {
@@ -39,22 +39,31 @@ class CQRSDeleteTest extends TestCase
     {
         // Without any parameters
         $operation = new CQRSDelete();
-        $this->assertEquals(QueryProvider::class, $operation->getProvider());
-        $this->assertNull($operation->getProcessor());
+        $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
+        $this->assertNull($operation->getProvider());
         $this->assertEquals(CQRSDelete::METHOD_DELETE, $operation->getMethod());
-        $this->assertEquals([], $operation->getExtraProperties());
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertFalse($operation->getOutput());
         $this->assertEquals(['json'], $operation->getFormats());
+        // ReadListener disabled to avoid 404
+        $this->assertFalse($operation->canRead());
+        // DeserializeListener forced to tru (unlike POST, PUT and PATCH that are automatically deserialized)
+        $this->assertTrue($operation->canDeserialize());
+        // By default empty body is allowed
+        $this->assertTrue($operation->getAllowEmptyBody());
 
         // With positioned parameters
         $operation = new CQRSDelete('/uri');
-        $this->assertEquals(QueryProvider::class, $operation->getProvider());
-        $this->assertNull($operation->getProcessor());
+        $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
+        $this->assertNull($operation->getProvider());
         $this->assertEquals(CQRSDelete::METHOD_DELETE, $operation->getMethod());
         $this->assertEquals('/uri', $operation->getUriTemplate());
-        $this->assertEquals([], $operation->getExtraProperties());
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertFalse($operation->getOutput());
         $this->assertEquals(['json'], $operation->getFormats());
+        $this->assertFalse($operation->canRead());
+        $this->assertTrue($operation->canDeserialize());
+        $this->assertTrue($operation->getAllowEmptyBody());
 
         // With named parameters
         $operation = new CQRSDelete(
@@ -62,11 +71,14 @@ class CQRSDeleteTest extends TestCase
             output: 'test',
             extraProperties: ['scopes' => ['test']],
         );
-        $this->assertEquals(QueryProvider::class, $operation->getProvider());
-        $this->assertNull($operation->getProcessor());
-        $this->assertEquals(['scopes' => ['test']], $operation->getExtraProperties());
+        $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
+        $this->assertNull($operation->getProvider());
+        $this->assertEquals(['scopes' => ['test'], 'allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertEquals('test', $operation->getOutput());
         $this->assertEquals(['json', 'html'], $operation->getFormats());
+        $this->assertFalse($operation->canRead());
+        $this->assertTrue($operation->canDeserialize());
+        $this->assertTrue($operation->getAllowEmptyBody());
     }
 
     public function testScopes(): void
@@ -75,14 +87,14 @@ class CQRSDeleteTest extends TestCase
         $operation = new CQRSDelete(
             scopes: ['test', 'test2']
         );
-        $this->assertEquals(['scopes' => ['test', 'test2']], $operation->getExtraProperties());
+        $this->assertEquals(['scopes' => ['test', 'test2'], 'allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertEquals(['test', 'test2'], $operation->getScopes());
 
         // Extra properties parameters in constructor
         $operation = new CQRSDelete(
             extraProperties: ['scopes' => ['test']]
         );
-        $this->assertEquals(['scopes' => ['test']], $operation->getExtraProperties());
+        $this->assertEquals(['scopes' => ['test'], 'allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertEquals(['test'], $operation->getScopes());
 
         // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
@@ -90,82 +102,82 @@ class CQRSDeleteTest extends TestCase
             extraProperties: ['scopes' => ['test', 'test1']],
             scopes: ['test', 'test2'],
         );
-        $this->assertEquals(['scopes' => ['test', 'test1', 'test2']], $operation->getExtraProperties());
+        $this->assertEquals(['scopes' => ['test', 'test1', 'test2'], 'allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertEquals(['test', 'test1', 'test2'], $operation->getScopes());
 
         // Use with method, returned object is a clone All values are replaced
         $operation2 = $operation->withScopes(['test3']);
         $this->assertNotEquals($operation2, $operation);
-        $this->assertEquals(['scopes' => ['test3']], $operation2->getExtraProperties());
+        $this->assertEquals(['scopes' => ['test3'], 'allowEmptyBody' => true], $operation2->getExtraProperties());
         $this->assertEquals(['test3'], $operation2->getScopes());
         // Initial operation not modified of course
-        $this->assertEquals(['scopes' => ['test', 'test1', 'test2']], $operation->getExtraProperties());
+        $this->assertEquals(['scopes' => ['test', 'test1', 'test2'], 'allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertEquals(['test', 'test1', 'test2'], $operation->getScopes());
     }
 
-    public function testCQRSQuery(): void
+    public function testCQRSCommand(): void
     {
         // CQRS query parameters in constructor
         $operation = new CQRSDelete(
-            CQRSQuery: 'My\\Namespace\\MyQuery',
+            CQRSCommand: 'My\\Namespace\\MyQuery',
         );
-        $this->assertEquals(QueryProvider::class, $operation->getProvider());
-        $this->assertNull($operation->getProcessor());
-        $this->assertEquals(['CQRSQuery' => 'My\\Namespace\\MyQuery'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyQuery', $operation->getCQRSQuery());
+        $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
+        $this->assertEquals(null, $operation->getProvider());
+        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyQuery', 'allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals('My\\Namespace\\MyQuery', $operation->getCQRSCommand());
 
         // Extra properties parameters in constructor
         $operation = new CQRSDelete(
-            extraProperties: ['CQRSQuery' => 'My\\Namespace\\MyQuery'],
+            extraProperties: ['CQRSCommand' => 'My\\Namespace\\MyQuery'],
         );
-        $this->assertEquals(QueryProvider::class, $operation->getProvider());
-        $this->assertNull($operation->getProcessor());
-        $this->assertEquals(['CQRSQuery' => 'My\\Namespace\\MyQuery'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyQuery', $operation->getCQRSQuery());
+        $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
+        $this->assertEquals(null, $operation->getProvider());
+        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyQuery', 'allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals('My\\Namespace\\MyQuery', $operation->getCQRSCommand());
 
         // Extra properties AND CQRS query parameters in constructor, both values are equals no problem
         $operation = new CQRSDelete(
-            extraProperties: ['CQRSQuery' => 'My\\Namespace\\MyQuery'],
-            CQRSQuery: 'My\\Namespace\\MyQuery',
+            extraProperties: ['CQRSCommand' => 'My\\Namespace\\MyQuery'],
+            CQRSCommand: 'My\\Namespace\\MyQuery',
         );
-        $this->assertEquals(QueryProvider::class, $operation->getProvider());
-        $this->assertNull($operation->getProcessor());
-        $this->assertEquals(['CQRSQuery' => 'My\\Namespace\\MyQuery'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyQuery', $operation->getCQRSQuery());
+        $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
+        $this->assertEquals(null, $operation->getProvider());
+        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyQuery', 'allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals('My\\Namespace\\MyQuery', $operation->getCQRSCommand());
 
         // Use with method, returned object is a clone All values are replaced
-        $operation2 = $operation->withCQRSQuery('My\\Namespace\\MyOtherQuery');
+        $operation2 = $operation->withCQRSCommand('My\\Namespace\\MyOtherQuery');
         $this->assertNotEquals($operation2, $operation);
-        $this->assertEquals(['CQRSQuery' => 'My\\Namespace\\MyOtherQuery'], $operation2->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyOtherQuery', $operation2->getCQRSQuery());
+        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyOtherQuery', 'allowEmptyBody' => true], $operation2->getExtraProperties());
+        $this->assertEquals('My\\Namespace\\MyOtherQuery', $operation2->getCQRSCommand());
         // Initial operation not modified of course
-        $this->assertEquals(['CQRSQuery' => 'My\\Namespace\\MyQuery'], $operation->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyQuery', $operation->getCQRSQuery());
+        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyQuery', 'allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals('My\\Namespace\\MyQuery', $operation->getCQRSCommand());
 
         // New operation without query, the provider is forced when it is set
         $operation = new CQRSDelete();
-        $this->assertEquals(QueryProvider::class, $operation->getProvider());
-        $this->assertNull($operation->getProcessor());
-        $this->assertArrayNotHasKey('CQRSQuery', $operation->getExtraProperties());
-        $this->assertNull($operation->getCQRSQuery());
+        $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
+        $this->assertEquals(null, $operation->getProvider());
+        $this->assertArrayNotHasKey('CQRSCommand', $operation->getExtraProperties());
+        $this->assertNull($operation->getCQRSCommand());
 
-        $operation3 = $operation->withCQRSQuery('My\\Namespace\\MyQuery');
-        $this->assertEquals(QueryProvider::class, $operation3->getProvider());
-        $this->assertNull($operation3->getProcessor());
-        $this->assertEquals(['CQRSQuery' => 'My\\Namespace\\MyQuery'], $operation3->getExtraProperties());
-        $this->assertEquals('My\\Namespace\\MyQuery', $operation3->getCQRSQuery());
+        $operation3 = $operation->withCQRSCommand('My\\Namespace\\MyQuery');
+        $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
+        $this->assertEquals(null, $operation->getProvider());
+        $this->assertEquals(['CQRSCommand' => 'My\\Namespace\\MyQuery', 'allowEmptyBody' => true], $operation3->getExtraProperties());
+        $this->assertEquals('My\\Namespace\\MyQuery', $operation3->getCQRSCommand());
         // And initial operation as not modified of course
-        $this->assertEquals(QueryProvider::class, $operation->getProvider());
-        $this->assertNull($operation->getProcessor());
-        $this->assertArrayNotHasKey('CQRSQuery', $operation->getExtraProperties());
-        $this->assertNull($operation->getCQRSQuery());
+        $this->assertEquals(CommandProcessor::class, $operation->getProcessor());
+        $this->assertEquals(null, $operation->getProvider());
+        $this->assertArrayNotHasKey('CQRSCommand', $operation->getExtraProperties());
+        $this->assertNull($operation->getCQRSCommand());
 
         // When both values are specified, but they are different trigger an exception
         $caughtException = null;
         try {
             new CQRSDelete(
-                extraProperties: ['CQRSQuery' => 'My\\Namespace\\MyQuery'],
-                CQRSQuery: 'My\\Namespace\\MyOtherQuery',
+                extraProperties: ['CQRSCommand' => 'My\\Namespace\\MyQuery'],
+                CQRSCommand: 'My\\Namespace\\MyOtherQuery',
             );
         } catch (InvalidArgumentException $e) {
             $caughtException = $e;
@@ -173,51 +185,51 @@ class CQRSDeleteTest extends TestCase
 
         $this->assertNotNull($caughtException);
         $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
-        $this->assertEquals('Specifying an extra property CQRSQuery and a CQRSQuery argument that are different is invalid', $caughtException->getMessage());
+        $this->assertEquals('Specifying an extra property CQRSCommand and a CQRSCommand argument that are different is invalid', $caughtException->getMessage());
     }
 
-    public function testCQRSQueryMapping(): void
+    public function testCQRSCommandMapping(): void
     {
         // CQRS query mapping parameters in constructor
         $queryMapping = ['[id]' => '[queryId]'];
         $operation = new CQRSDelete(
-            CQRSQueryMapping: $queryMapping,
+            CQRSCommandMapping: $queryMapping,
         );
 
-        $this->assertEquals(['CQRSQueryMapping' => $queryMapping], $operation->getExtraProperties());
-        $this->assertEquals($queryMapping, $operation->getCQRSQueryMapping());
+        $this->assertEquals(['CQRSCommandMapping' => $queryMapping, 'allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals($queryMapping, $operation->getCQRSCommandMapping());
 
         // Extra properties parameters in constructor
         $operation = new CQRSDelete(
-            extraProperties: ['CQRSQueryMapping' => $queryMapping],
+            extraProperties: ['CQRSCommandMapping' => $queryMapping],
         );
-        $this->assertEquals(['CQRSQueryMapping' => $queryMapping], $operation->getExtraProperties());
-        $this->assertEquals($queryMapping, $operation->getCQRSQueryMapping());
+        $this->assertEquals(['CQRSCommandMapping' => $queryMapping, 'allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals($queryMapping, $operation->getCQRSCommandMapping());
 
         // Extra properties AND CQRS query mapping parameters in constructor, both values are equals no problem
         $operation = new CQRSDelete(
-            extraProperties: ['CQRSQueryMapping' => $queryMapping],
-            CQRSQueryMapping: $queryMapping,
+            extraProperties: ['CQRSCommandMapping' => $queryMapping],
+            CQRSCommandMapping: $queryMapping,
         );
-        $this->assertEquals(['CQRSQueryMapping' => $queryMapping], $operation->getExtraProperties());
-        $this->assertEquals($queryMapping, $operation->getCQRSQueryMapping());
+        $this->assertEquals(['CQRSCommandMapping' => $queryMapping, 'allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals($queryMapping, $operation->getCQRSCommandMapping());
 
         // Use with method, returned object is a clone All values are replaced
         $newMapping = ['[queryId' => '[valueObjectId]'];
-        $operation2 = $operation->withCQRSQueryMapping($newMapping);
+        $operation2 = $operation->withCQRSCommandMapping($newMapping);
         $this->assertNotEquals($operation2, $operation);
-        $this->assertEquals(['CQRSQueryMapping' => $newMapping], $operation2->getExtraProperties());
-        $this->assertEquals($newMapping, $operation2->getCQRSQueryMapping());
+        $this->assertEquals(['CQRSCommandMapping' => $newMapping, 'allowEmptyBody' => true], $operation2->getExtraProperties());
+        $this->assertEquals($newMapping, $operation2->getCQRSCommandMapping());
         // Initial operation not modified of course
-        $this->assertEquals(['CQRSQueryMapping' => $queryMapping], $operation->getExtraProperties());
-        $this->assertEquals($queryMapping, $operation->getCQRSQueryMapping());
+        $this->assertEquals(['CQRSCommandMapping' => $queryMapping, 'allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals($queryMapping, $operation->getCQRSCommandMapping());
 
         // When both values are specified, but they are different trigger an exception
         $caughtException = null;
         try {
             new CQRSDelete(
-                extraProperties: ['CQRSQueryMapping' => $queryMapping],
-                CQRSQueryMapping: $newMapping,
+                extraProperties: ['CQRSCommandMapping' => $queryMapping],
+                CQRSCommandMapping: $newMapping,
             );
         } catch (InvalidArgumentException $e) {
             $caughtException = $e;
@@ -225,7 +237,7 @@ class CQRSDeleteTest extends TestCase
 
         $this->assertNotNull($caughtException);
         $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
-        $this->assertEquals('Specifying an extra property CQRSQueryMapping and a CQRSQueryMapping argument that are different is invalid', $caughtException->getMessage());
+        $this->assertEquals('Specifying an extra property CQRSCommandMapping and a CQRSCommandMapping argument that are different is invalid', $caughtException->getMessage());
     }
 
     public function testApiResourceMapping(): void
@@ -236,14 +248,14 @@ class CQRSDeleteTest extends TestCase
             ApiResourceMapping: $resourceMapping,
         );
 
-        $this->assertEquals(['ApiResourceMapping' => $resourceMapping], $operation->getExtraProperties());
+        $this->assertEquals(['ApiResourceMapping' => $resourceMapping, 'allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertEquals($resourceMapping, $operation->getApiResourceMapping());
 
         // Extra properties parameters in constructor
         $operation = new CQRSDelete(
             extraProperties: ['ApiResourceMapping' => $resourceMapping],
         );
-        $this->assertEquals(['ApiResourceMapping' => $resourceMapping], $operation->getExtraProperties());
+        $this->assertEquals(['ApiResourceMapping' => $resourceMapping, 'allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertEquals($resourceMapping, $operation->getApiResourceMapping());
 
         // Extra properties AND Api resource mapping parameters in constructor, both values are equals no problem
@@ -251,17 +263,17 @@ class CQRSDeleteTest extends TestCase
             extraProperties: ['ApiResourceMapping' => $resourceMapping],
             ApiResourceMapping: $resourceMapping,
         );
-        $this->assertEquals(['ApiResourceMapping' => $resourceMapping], $operation->getExtraProperties());
+        $this->assertEquals(['ApiResourceMapping' => $resourceMapping, 'allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertEquals($resourceMapping, $operation->getApiResourceMapping());
 
         // Use with method, returned object is a clone All values are replaced
         $newMapping = ['[queryId' => '[valueObjectId]'];
         $operation2 = $operation->withApiResourceMapping($newMapping);
         $this->assertNotEquals($operation2, $operation);
-        $this->assertEquals(['ApiResourceMapping' => $newMapping], $operation2->getExtraProperties());
+        $this->assertEquals(['ApiResourceMapping' => $newMapping, 'allowEmptyBody' => true], $operation2->getExtraProperties());
         $this->assertEquals($newMapping, $operation2->getApiResourceMapping());
         // Initial operation not modified of course
-        $this->assertEquals(['ApiResourceMapping' => $resourceMapping], $operation->getExtraProperties());
+        $this->assertEquals(['ApiResourceMapping' => $resourceMapping, 'allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertEquals($resourceMapping, $operation->getApiResourceMapping());
 
         // When both values are specified, but they are different trigger an exception
@@ -284,21 +296,21 @@ class CQRSDeleteTest extends TestCase
     {
         // Default value is false (no extra property added)
         $operation = new CQRSDelete();
-        $this->assertEquals([], $operation->getExtraProperties());
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertEquals(false, $operation->getExperimentalOperation());
 
         // Scopes parameters in constructor
         $operation = new CQRSDelete(
             experimentalOperation: true,
         );
-        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(['experimentalOperation' => true, 'allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertEquals(true, $operation->getExperimentalOperation());
 
         // Extra properties parameters in constructor
         $operation = new CQRSDelete(
             extraProperties: ['experimentalOperation' => false]
         );
-        $this->assertEquals(['experimentalOperation' => false], $operation->getExtraProperties());
+        $this->assertEquals(['experimentalOperation' => false, 'allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertEquals(false, $operation->getExperimentalOperation());
 
         // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
@@ -306,16 +318,16 @@ class CQRSDeleteTest extends TestCase
             extraProperties: ['experimentalOperation' => true],
             experimentalOperation: true,
         );
-        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(['experimentalOperation' => true, 'allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertEquals(true, $operation->getExperimentalOperation());
 
         // Use with method, returned object is a clone All values are replaced
         $operation2 = $operation->withExperimentalOperation(false);
         $this->assertNotEquals($operation2, $operation);
-        $this->assertEquals(['experimentalOperation' => false], $operation2->getExtraProperties());
+        $this->assertEquals(['experimentalOperation' => false, 'allowEmptyBody' => true], $operation2->getExtraProperties());
         $this->assertEquals(false, $operation2->getExperimentalOperation());
         // Initial operation not modified of course
-        $this->assertEquals(['experimentalOperation' => true], $operation->getExtraProperties());
+        $this->assertEquals(['experimentalOperation' => true, 'allowEmptyBody' => true], $operation->getExtraProperties());
         $this->assertEquals(true, $operation->getExperimentalOperation());
 
         // When both values are specified, but they are different trigger an exception
@@ -332,5 +344,59 @@ class CQRSDeleteTest extends TestCase
         $this->assertNotNull($caughtException);
         $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
         $this->assertEquals('Specifying an extra property experimentalOperation and a experimentalOperation argument that are different is invalid', $caughtException->getMessage());
+    }
+
+    public function testAllowEmptyBody(): void
+    {
+        // Default value is true (special case for CQRSDelete)
+        $operation = new CQRSDelete();
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // Scopes parameters in constructor
+        $operation = new CQRSDelete(
+            allowEmptyBody: true,
+        );
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // Extra properties parameters in constructor
+        $operation = new CQRSDelete(
+            extraProperties: ['allowEmptyBody' => false]
+        );
+        $this->assertEquals(['allowEmptyBody' => false], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getAllowEmptyBody());
+
+        // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
+        $operation = new CQRSDelete(
+            extraProperties: ['allowEmptyBody' => true],
+            allowEmptyBody: true,
+        );
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // Use with method, returned object is a clone All values are replaced
+        $operation2 = $operation->withallowEmptyBody(false);
+        $this->assertNotEquals($operation2, $operation);
+        $this->assertEquals(['allowEmptyBody' => false], $operation2->getExtraProperties());
+        $this->assertEquals(false, $operation2->getAllowEmptyBody());
+        // Initial operation not modified of course
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // When both values are specified, but they are different trigger an exception
+        $caughtException = null;
+        try {
+            new CQRSDelete(
+                extraProperties: ['allowEmptyBody' => true],
+                allowEmptyBody: false,
+            );
+        } catch (InvalidArgumentException $e) {
+            $caughtException = $e;
+        }
+
+        $this->assertNotNull($caughtException);
+        $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
+        $this->assertEquals('Specifying an extra property allowEmptyBody and a allowEmptyBody argument that are different is invalid', $caughtException->getMessage());
     }
 }

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSPartialUpdateTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSPartialUpdateTest.php
@@ -424,4 +424,58 @@ class CQRSPartialUpdateTest extends TestCase
         $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
         $this->assertEquals('Specifying an extra property experimentalOperation and a experimentalOperation argument that are different is invalid', $caughtException->getMessage());
     }
+
+    public function testAllowEmptyBody(): void
+    {
+        // Default value is false (no extra property added)
+        $operation = new CQRSPartialUpdate();
+        $this->assertEquals([], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getAllowEmptyBody());
+
+        // Scopes parameters in constructor
+        $operation = new CQRSPartialUpdate(
+            allowEmptyBody: true,
+        );
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // Extra properties parameters in constructor
+        $operation = new CQRSPartialUpdate(
+            extraProperties: ['allowEmptyBody' => false]
+        );
+        $this->assertEquals(['allowEmptyBody' => false], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getAllowEmptyBody());
+
+        // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
+        $operation = new CQRSPartialUpdate(
+            extraProperties: ['allowEmptyBody' => true],
+            allowEmptyBody: true,
+        );
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // Use with method, returned object is a clone All values are replaced
+        $operation2 = $operation->withallowEmptyBody(false);
+        $this->assertNotEquals($operation2, $operation);
+        $this->assertEquals(['allowEmptyBody' => false], $operation2->getExtraProperties());
+        $this->assertEquals(false, $operation2->getAllowEmptyBody());
+        // Initial operation not modified of course
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // When both values are specified, but they are different trigger an exception
+        $caughtException = null;
+        try {
+            new CQRSPartialUpdate(
+                extraProperties: ['allowEmptyBody' => true],
+                allowEmptyBody: false,
+            );
+        } catch (InvalidArgumentException $e) {
+            $caughtException = $e;
+        }
+
+        $this->assertNotNull($caughtException);
+        $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
+        $this->assertEquals('Specifying an extra property allowEmptyBody and a allowEmptyBody argument that are different is invalid', $caughtException->getMessage());
+    }
 }

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSUpdateTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Metadata/CQRSUpdateTest.php
@@ -420,4 +420,58 @@ class CQRSUpdateTest extends TestCase
         $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
         $this->assertEquals('Specifying an extra property experimentalOperation and a experimentalOperation argument that are different is invalid', $caughtException->getMessage());
     }
+
+    public function testAllowEmptyBody(): void
+    {
+        // Default value is false (no extra property added)
+        $operation = new CQRSUpdate();
+        $this->assertEquals([], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getAllowEmptyBody());
+
+        // Scopes parameters in constructor
+        $operation = new CQRSUpdate(
+            allowEmptyBody: true,
+        );
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // Extra properties parameters in constructor
+        $operation = new CQRSUpdate(
+            extraProperties: ['allowEmptyBody' => false]
+        );
+        $this->assertEquals(['allowEmptyBody' => false], $operation->getExtraProperties());
+        $this->assertEquals(false, $operation->getAllowEmptyBody());
+
+        // Extra properties AND scopes parameters in constructor, both values get merged but remain unique
+        $operation = new CQRSUpdate(
+            extraProperties: ['allowEmptyBody' => true],
+            allowEmptyBody: true,
+        );
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // Use with method, returned object is a clone All values are replaced
+        $operation2 = $operation->withallowEmptyBody(false);
+        $this->assertNotEquals($operation2, $operation);
+        $this->assertEquals(['allowEmptyBody' => false], $operation2->getExtraProperties());
+        $this->assertEquals(false, $operation2->getAllowEmptyBody());
+        // Initial operation not modified of course
+        $this->assertEquals(['allowEmptyBody' => true], $operation->getExtraProperties());
+        $this->assertEquals(true, $operation->getAllowEmptyBody());
+
+        // When both values are specified, but they are different trigger an exception
+        $caughtException = null;
+        try {
+            new CQRSUpdate(
+                extraProperties: ['allowEmptyBody' => true],
+                allowEmptyBody: false,
+            );
+        } catch (InvalidArgumentException $e) {
+            $caughtException = $e;
+        }
+
+        $this->assertNotNull($caughtException);
+        $this->assertInstanceOf(InvalidArgumentException::class, $caughtException);
+        $this->assertEquals('Specifying an extra property allowEmptyBody and a allowEmptyBody argument that are different is invalid', $caughtException->getMessage());
+    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Improve Admin API internals so that CQRSDelete can be used like other write operations and with a CQRSCommand, also add an emptyBody extra property that allows empty body when specified
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | ~
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/16748843744
| Fixed issue or discussion?     | ~
| Related PRs       | https://github.com/PrestaShop/ps_apiresources/pull/58
| Sponsor company   | ~

### Breaking change

When you use the `CQRSDelete` operation you can no longer specify the `CQRSQuery` and `CQRSQueryMapping` parameters, this was an error in the first place to rely on read elements for a write operation as it creates confusion We did so in the early phase of development because it didn't work well with API Platform expect conventio

This PR fixes this problem allowing us to fix this architectural flaw, so yes breaking change should never happen in minor versions and even less in patch versions But this flaw was forgotten and the new Admin API has not been widely used yet so we think it's better to fix this for the `9.0.1` and guaranty consistency and stability for all future versions

TLDR; When using the `CQRSDelete` operation:
- use `CQRSCommand` instead of `CQRSQuery`
- use `CQRSCommandMapping` instead of `CQRSQueryMapping`

You can now have empty bodies in your write requests (POST, PUT, PATCH, DELETE) It is automatic for `CQRSDelete` operations, for other you can use the `allowEmptyBody` custom option on our CQRS write operations.