### PR TITLE
Add refresh option for Customer::getAddresses()

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -638,10 +638,13 @@ class CustomerCore extends ObjectModel
      * Return customer addresses.
      *
      * @param int $idLang Language ID
+     * @param bool $refresh Refresh cached entries
      *
      * @return array Addresses
+     *
+     * @throws PrestaShopDatabaseException
      */
-    public function getAddresses($idLang)
+    public function getAddresses($idLang, bool $refresh = false)
     {
         $group = Context::getContext()->shop->getGroup();
         $shareOrder = isset($group->share_order) ? (bool) $group->share_order : false;
@@ -649,7 +652,7 @@ class CustomerCore extends ObjectModel
             . '-' . (int) $this->id
             . '-' . (int) $idLang
             . '-' . ($shareOrder ? 1 : 0);
-        if (!Cache::isStored($cacheId)) {
+        if (true === $refresh || !Cache::isStored($cacheId)) {
             $sql = 'SELECT DISTINCT a.*, cl.`name` AS country, s.name AS state, s.iso_code AS state_iso
                     FROM `' . _DB_PREFIX_ . 'address` a
                     LEFT JOIN `' . _DB_PREFIX_ . 'country` c ON (a.`id_country` = c.`id_country`)


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In some cases, after adding a new address to a customer and calling this function, we would not get the new address. It is then useful to add a refresh option (as used in many other methods) to not use the actual cached entries.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a script that creates a customer address, call this function on the customer, it should return an empty array. Call the function with refresh = true, you should get 1 entry in the array.
| UI Tests          | NA
| Fixed issue or discussion?     | NA
| Related PRs       | NA
| Sponsor company   | Evolutive