### PR TITLE
Remove property from documentation that are not in the ressources

### DIFF
--- a/src/PrestaShopBundle/ApiPlatform/OpenApi/Factory/CQRSOpenApiFactory.php
+++ b/src/PrestaShopBundle/ApiPlatform/OpenApi/Factory/CQRSOpenApiFactory.php
@@ -41,14 +41,17 @@ use ApiPlatform\OpenApi\Model\Server;
 use ApiPlatform\OpenApi\OpenApi;
 use ArrayObject;
 use DateTimeInterface;
+use Exception;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShopBundle\ApiPlatform\DomainObjectDetector;
 use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
+use ReflectionProperty;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 
 /**
@@ -61,6 +64,7 @@ use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
  *   - it adapts some custom types like DecimalNumber and document them as numbers
  *   - it handles multi parameters setters and split the parameters into a sub object like the Admin API expects
  *   - it detects LocalizedValue fields and adapt their format and example
+ *   - it synchronizes the documentation with actual resource properties (removes undocumented fields)
  */
 class CQRSOpenApiFactory implements OpenApiFactoryInterface
 {
@@ -74,6 +78,7 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
         protected readonly DefinitionNameFactoryInterface $definitionNameFactory,
         protected readonly ClassMetadataFactoryInterface $classMetadataFactory,
         protected readonly DomainObjectDetector $domainObjectDetector,
+        protected readonly PropertyInfoExtractorInterface $propertyInfoExtractor,
         // No property promotion for this one since it's already defined in the ResourceMetadataTrait
         ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory,
     ) {
@@ -88,19 +93,21 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
     public function __invoke(array $context = []): OpenApi
     {
         $parentOpenApi = $this->decorated->__invoke($context);
-
         $domainsByUri = [];
         $scopesByUri = [];
+
         foreach ($this->resourceNameCollectionFactory->create() as $resourceClass) {
             $resourceMetadataCollection = $this->resourceMetadataFactory->create($resourceClass);
-
             foreach ($resourceMetadataCollection as $resourceMetadata) {
                 $resourceDefinitionName = $this->definitionNameFactory->create($resourceMetadata->getClass());
 
                 // Adapt localized value schema for API resource schema (mostly for read schema)
                 if ($parentOpenApi->getComponents()->getSchemas()->offsetExists($resourceDefinitionName)) {
-                    $this->adaptLocalizedValues($resourceMetadata->getClass(), $parentOpenApi->getComponents()->getSchemas()->offsetGet($resourceDefinitionName));
-                    $this->adaptDecimalNumbers($resourceMetadata->getClass(), $parentOpenApi->getComponents()->getSchemas()->offsetGet($resourceDefinitionName));
+                    $resourceSchema = $parentOpenApi->getComponents()->getSchemas()->offsetGet($resourceDefinitionName);
+                    $this->adaptLocalizedValues($resourceMetadata->getClass(), $resourceSchema);
+                    $this->adaptDecimalNumbers($resourceMetadata->getClass(), $resourceSchema);
+                    // NEW: Synchronize schema with actual resource properties
+                    $this->synchronizeSchemaWithResource($resourceMetadata->getClass(), $resourceSchema);
                 }
 
                 /** @var Operation $operation */
@@ -112,7 +119,6 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
                             $domainsByUri[$operation->getUriTemplate()] = $this->getOperationDomain($operation);
                         }
                     }
-
                     if ($operation instanceof HttpOperation && !empty($operation->getExtraProperties()['scopes'])) {
                         $scopesByUri[$operation->getUriTemplate()][strtolower($operation->getMethod())] = $operation->getExtraProperties()['scopes'];
                     }
@@ -124,10 +130,10 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
 
                     $this->adaptMultiParametersSetters($operation, $definition);
                     $this->applyCommandMapping($operation, $definition);
-
                     // Adapt localized value schema for operation definition (for valid input example)
                     $this->adaptLocalizedValues($operation->getClass(), $definition);
                     $this->adaptDecimalNumbers($operation->getClass(), $definition);
+                    $this->synchronizeSchemaWithResource($operation->getClass(), $definition);
                 }
             }
         }
@@ -151,12 +157,10 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
                 /** @var OpenApiOperation $operation */
                 foreach ($operations as $httpMethod => $operation) {
                     $updatedOperation = $operation;
-
                     // Update tag to group by domain
                     if (!empty($domainsByUri[$path])) {
                         $updatedOperation = $operation->withTags([$domainsByUri[$path]]);
                     }
-
                     // Add security scopes
                     if (!empty($scopesByUri[$path][$httpMethod])) {
                         $updatedOperation = $updatedOperation->withSecurity([['oauth' => $scopesByUri[$path][$httpMethod]]]);
@@ -169,7 +173,7 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
             $updatedPaths->addPath($path, $updatedPathItem);
         }
 
-        $updatedOpenApi = new OpenApi(
+        return new OpenApi(
             $parentOpenApi->getInfo(),
             [
                 new Server('/admin-api'),
@@ -182,8 +186,101 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
             $parentOpenApi->getJsonSchemaDialect(),
             $parentOpenApi->getWebhooks(),
         );
+    }
 
-        return $updatedOpenApi;
+    /**
+     * Synchronizes the OpenAPI schema with the actual properties available in the resource
+     * This removes fields that are documented but don't exist in the actual resource
+     */
+    protected function synchronizeSchemaWithResource(string $resourceClass, ArrayObject $definition): void
+    {
+        if (empty($definition['properties']) || !class_exists($resourceClass)) {
+            return;
+        }
+
+        $actualProperties = $this->getResourceProperties($resourceClass);
+        if (empty($actualProperties)) {
+            return;
+        }
+
+        $currentProperties = $definition['properties'];
+        $synchronizedProperties = [];
+
+        foreach ($currentProperties as $propertyName => $propertySchema) {
+            if (in_array($propertyName, $actualProperties)) {
+                $synchronizedProperties[$propertyName] = $propertySchema;
+            }
+        }
+
+        $definition['properties'] = $synchronizedProperties;
+
+        if (!empty($definition['required'])) {
+            $definition['required'] = array_values(array_intersect($definition['required'], $actualProperties));
+        }
+    }
+
+    protected function getResourceProperties(string $resourceClass): array
+    {
+        try {
+            $properties = $this->propertyInfoExtractor->getProperties($resourceClass) ?? [];
+
+            if (!empty($properties)) {
+                return array_filter($properties, function ($property) {
+                    return !in_array($property, ['@context', '@id', '@type']);
+                });
+            }
+        } catch (Exception $e) {
+            // Fallback to reflection if PropertyInfoExtractor fails
+        }
+
+        return $this->getPropertiesUsingReflection($resourceClass);
+    }
+
+    protected function getPropertiesUsingReflection(string $resourceClass): array
+    {
+        try {
+            $reflection = new ReflectionClass($resourceClass);
+            $properties = [];
+
+            foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+                if (!$property->isStatic()) {
+                    $properties[] = $property->getName();
+                }
+            }
+
+            foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+                $methodName = $method->getName();
+
+                if ($method->isStatic() || $method->isConstructor() || $method->getNumberOfParameters() > 0) {
+                    continue;
+                }
+
+                if (str_starts_with($methodName, 'get') && strlen($methodName) > 3) {
+                    $propertyName = lcfirst(substr($methodName, 3));
+                    if (!in_array($propertyName, $properties)) {
+                        $properties[] = $propertyName;
+                    }
+                }
+
+                if (str_starts_with($methodName, 'is') && strlen($methodName) > 2) {
+                    $propertyName = lcfirst(substr($methodName, 2));
+                    if (!in_array($propertyName, $properties)) {
+                        $properties[] = $propertyName;
+                    }
+                }
+
+                if (str_starts_with($methodName, 'has') && strlen($methodName) > 3) {
+                    $propertyName = lcfirst(substr($methodName, 3));
+                    if (!in_array($propertyName, $properties)) {
+                        $properties[] = $propertyName;
+                    }
+                }
+            }
+
+            return array_unique($properties);
+        } catch (Exception $e) {
+            return [];
+        }
     }
 
     protected function getSchemaDefinition(OpenApi $openApi, Operation $operation): ?ArrayObject
@@ -468,7 +565,6 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
                 if (!str_starts_with($apiPath, '[_context]') && $this->propertyAccessor->isWritable($definition['properties'], $apiPath)) {
                     $this->propertyAccessor->setValue($definition['properties'], $apiPath, $this->propertyAccessor->getValue($definition['properties'], $cqrsPath));
                 }
-
                 // Use property path to set null, the null values will then be cleaned in a second loop (because unset cannot use property path as an input)
                 if ($this->propertyAccessor->isWritable($definition['properties'], $cqrsPath)) {
                     $this->propertyAccessor->setValue($definition['properties'], $cqrsPath, null);

--- a/tests/Integration/PrestaShopBundle/ApiPlatform/CQRSOpenApiFactoryTest.php
+++ b/tests/Integration/PrestaShopBundle/ApiPlatform/CQRSOpenApiFactoryTest.php
@@ -552,18 +552,6 @@ class CQRSOpenApiFactoryTest extends KernelTestCase
                         'type' => 'number',
                         'example' => 42.99,
                     ]),
-                    // Multi-parameters setter
-                    'redirectOption' => new ArrayObject([
-                        'type' => 'object',
-                        'properties' => [
-                            'redirectType' => new ArrayObject([
-                                'type' => 'string',
-                            ]),
-                            'redirectTarget' => new ArrayObject([
-                                'type' => 'integer',
-                            ]),
-                        ],
-                    ]),
                     'deliveryTimeNoteType' => new ArrayObject([
                         'type' => 'integer',
                     ]),
@@ -628,10 +616,6 @@ class CQRSOpenApiFactoryTest extends KernelTestCase
                     // Nullable DateTime
                     'availableDate' => new ArrayObject([
                         'format' => 'date-time',
-                        'type' => 'string',
-                    ]),
-                    // Deprecated setter still present for now
-                    'ean13' => new ArrayObject([
                         'type' => 'string',
                     ]),
                 ],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Added some logic to remove every field in the api schema that is not present in the ressources.
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        | yes 
| Deprecations?     | no
| How to test?      | On the api documentation the field ean13 should not be present anymore in the PATCH products
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/17609864565
| Fixed issue or discussion?     | Fixes #38788 
| Sponsor company   | PrestaShop SA
