### PR TITLE
BO : Orders : Modal Discount reset when it's hidden

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/view.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/view.ts
@@ -159,6 +159,11 @@ $(() => {
     $modal.on('shown.bs.modal', () => {
       $(OrderViewPageMap.addCartRuleSubmit).prop('disabled', true);
     });
+    $modal.on('hidden.bs.modal', () => {
+      $(OrderViewPageMap.addCartRuleNameInput).val('');
+      $(OrderViewPageMap.addCartRuleTypeSelect).val(DISCOUNT_TYPE_PERCENT).trigger('change');
+      $(OrderViewPageMap.addCartRuleValueInput).val('');
+    });
 
     $form.find(OrderViewPageMap.addCartRuleNameInput).on('keyup', (event) => {
       const cartRuleName = <string>$(event.currentTarget).val();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | BO : Orders : Modal Discount reset when it's hidden
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: / "How to test ?" is in the issue
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/16774285142
| Fixed issue or discussion?     | Fixes #26860
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp