### PR TITLE
Fix symlink issues on install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,8 @@ tests-legacy/.phpunit.result.cache
 !/admin-dev/export/.htaccess
 !/admin-dev/export/index.php
 
+/admin-dev/bundles/*
+
 # Downloaded RTL files
 /admin-dev/themes/default/css/bundle/default_rtl.css
 /admin-dev/themes/default/css/bundle/shared_rtl.css

--- a/admin-dev/bundles/apiplatform
+++ b/admin-dev/bundles/apiplatform
@@ -1,1 +1,0 @@
-../../vendor/api-platform/core/src/Symfony/Bundle/Resources/public/

--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -339,11 +339,6 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
     {
         $this->initializeContext();
 
-        // if admin folder doesn't exist, then there's nothing to do here
-        if (!file_exists(_PS_ROOT_DIR_ . '/admin/')) {
-            return true;
-        }
-
         $result = $this->model_install->finalize();
 
         if (!$result) {

--- a/src/Adapter/Bundle/AssetsInstaller.php
+++ b/src/Adapter/Bundle/AssetsInstaller.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Bundle;
+
+use PrestaShopBundle\Console\PrestaShopApplication;
+use PrestaShopException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Class AssetsInstaller aim to install bundle assets into filesystem.
+ *
+ * @internal
+ */
+final class AssetsInstaller
+{
+    public function installAssets(string $adminFolder): void
+    {
+        // We retrieve the kernel from the global scope
+        global $kernel;
+        if (!$kernel instanceof KernelInterface) {
+            throw new PrestaShopException('Kernel is not initialized. Cannot install assets.');
+        }
+
+        // We need to use the PrestaShopApplication to run the command
+        $application = new PrestaShopApplication($kernel);
+        $application->setAutoExit(false);
+
+        // Run the command to install bundles assets
+        // (for now! maybe we should use another way to install assets in the future)
+        $output = new BufferedOutput();
+        $errorCode = $application->run(new ArrayInput([
+            'command' => 'assets:install',
+            'target' => $adminFolder,
+        ]), $output);
+
+        // If the command failed (!= 0), we throw an exception with the output of the command
+        if (0 !== $errorCode) {
+            throw new PrestaShopException(sprintf(
+                'Failed to install bundle assets: %s',
+                $output->fetch()
+            ));
+        }
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
@@ -48,3 +48,6 @@ services:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
       - '@=service("prestashop.adapter.legacy.configuration").get("PS_LANG_DEFAULT")'
+
+  PrestaShop\PrestaShop\Adapter\Bundle\AssetsInstaller:
+    class: PrestaShop\PrestaShop\Adapter\Bundle\AssetsInstaller


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | With this PR, we create symlink (or hard copy if the hosting env doesn't have symlink enabled) on the "finalize" installation step.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install this PR, and verify the folder `admin-dev/bundles` are empty or not present.<br>2. Install PrestaShop with cli or web installer.<br>3. After installation, `admin-dev/bundles` must have `apiplateform` folder!
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/16806935930
| Fixed issue or discussion?     | Fixes #39104, and maybe #38960 too (after some work on autoupgrade module too! cc @Quetzacoalt91)
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
