### PR TITLE
Update api module and optimise API UI tests

### DIFF
--- a/.github/workflows/cron_nightly_tests_reusable.yml
+++ b/.github/workflows/cron_nightly_tests_reusable.yml
@@ -254,6 +254,8 @@ jobs:
       TEST_CAMPAIGN: ${{ matrix.CAMPAIGN }}  # Command to execute from the matrix
       INSTALL_AUTO: ${{ (matrix.CAMPAIGN == 'sanity') && 'false' || 'true' }}
       ENABLE_SSL: ${{ ((matrix.BRANCH == '8.0.x') || (matrix.BRANCH == '1.7.8.x')) && 'false' || 'true' }}
+      CLIENT_ID_API: ui-test-client
+      CLIENT_SECRET_API: 18c7b983c2eaa22a111609ce2b1c435e
 
     steps:
       - uses: actions/checkout@v4
@@ -280,6 +282,12 @@ jobs:
           INSTALL_AUTO: ${{ env.INSTALL_AUTO }}
         if: failure()
 
+      # Create API Client for API campaign
+      - name: Create API client
+        if: ${{ (env.GH_BRANCH == '9.0.x' || env.GH_BRANCH == 'develop') && env.TEST_CAMPAIGN == 'functional:API' }}
+        run: |
+          docker exec prestashop-prestashop-git-1 php ./bin/console prestashop:api-client create ${{ env.CLIENT_ID_API }} --all-scopes --name='Test client' --description='Test client with all scopes' --timeout=3600 --secret=${{ env.CLIENT_SECRET_API }}
+
       # Keycloak is only needed for API campaign
       - name: Setup Keycloak
         uses: ./.github/actions/setup-keycloak
@@ -293,6 +301,9 @@ jobs:
           TEST_CAMPAIGN: ${{ env.TEST_CAMPAIGN }}
           TESTS_DIR: ${{ inputs.TESTS_DIR }}
           DB_SERVER: ${{ inputs.DB_SERVER }}
+        env:
+          CLIENT_ID_API: ${{ env.CLIENT_ID_API }}
+          CLIENT_SECRET_API: ${{ env.CLIENT_SECRET_API }}
 
       # Rename and upload report as artifact
       - name: Rename file reports

--- a/src/PrestaShopBundle/ApiPlatform/Resources/ApiClient.php
+++ b/src/PrestaShopBundle/ApiPlatform/Resources/ApiClient.php
@@ -44,6 +44,7 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
             ],
         ),
     ],
+    normalizationContext: ['skip_null_values' => false],
 )]
 class ApiClient
 {
@@ -55,6 +56,8 @@ class ApiClient
     public string $clientName;
 
     public string $description;
+
+    public ?string $externalIssuer;
 
     public bool $enabled;
 

--- a/tests/Integration/ApiPlatform/EndPoint/ApiClientEndpointTest.php
+++ b/tests/Integration/ApiPlatform/EndPoint/ApiClientEndpointTest.php
@@ -65,6 +65,7 @@ class ApiClientEndpointTest extends ApiTestCase
                 'clientId' => self::CLIENT_ID,
                 'clientName' => self::CLIENT_NAME,
                 'description' => '',
+                'externalIssuer' => null,
                 'enabled' => true,
                 'lifetime' => 10000,
                 'scopes' => [],

--- a/tests/UI/.env.ci
+++ b/tests/UI/.env.ci
@@ -48,3 +48,7 @@ KEYCLOAK_ADMIN_USER="admin"
 KEYCLOAK_ADMIN_PASS="admin"
 KEYCLOAK_CLIENT_ID="prestashop-keycloak"
 KEYCLOAK_CLIENT_SECRET="O2kKN0fprCK2HWP6PS6reVbZThWf5LFw"
+
+# API Client credentials
+CLIENT_ID_API="ui-test-client"
+CLIENT_SECRET_API="client-secret"

--- a/tests/UI/.env.local
+++ b/tests/UI/.env.local
@@ -49,3 +49,7 @@ KEYCLOAK_ADMIN_USER="admin"
 KEYCLOAK_ADMIN_PASS="admin"
 KEYCLOAK_CLIENT_ID="prestashop-keycloak"
 KEYCLOAK_CLIENT_SECRET="O2kKN0fprCK2HWP6PS6reVbZThWf5LFw"
+
+# API Client credentials
+CLIENT_ID_API="ui-test-client"
+CLIENT_SECRET_API="client-secret"

--- a/tests/UI/README.md
+++ b/tests/UI/README.md
@@ -78,6 +78,22 @@ npm run test:functional:BO:orders
 | SMTP_SERVER | The smtp server address for maildev (default to **`172.20.0.4`**) |
 | SMTP_PORT   | The smtp port for maildev (default to **`1026`**)                 |
 
+### Admin API parameters
+
+| Parameter         | Description                                                   |
+|-------------------|---------------------------------------------------------------|
+| URL_API           | The Admin API base URL (default to **`URL_FO + admin-api/`**) |
+| CLIENT_ID_API     | The API Client client ID                                      |
+| CLIENT_SECRET_API | The API Client client secret                                  |
+
+To run the API tests you need to create an API Client before you run the related tests, and the env variables should be adpted to use the appropriate Client ID and secret.
+
+You can create an API Client with this command at the root of your project (where `{clientId}` and `{secret}` are placeholders to fill):
+
+```bash
+php ./bin/console prestashop:api-client create {clientId} --all-scopes --name='Test client' --description='Test client with all scopes' --timeout=3600 --secret={secret}
+```
+
 ### Keycloak parameters
 
 | Parameter               | Description                                                                                              |

--- a/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/01_internalAuthServer/01_authorizationEndpoint.ts
+++ b/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/01_internalAuthServer/01_authorizationEndpoint.ts
@@ -25,7 +25,7 @@ describe('API : Internal Auth Server - Authorization Endpoint', async () => {
   let apiContext: APIRequestContext;
   let clientSecret: string;
 
-  const clientClient: FakerAPIClient = new FakerAPIClient({
+  const apiClient: FakerAPIClient = new FakerAPIClient({
     scopes: [
       'hook_read',
     ],
@@ -66,11 +66,11 @@ describe('API : Internal Auth Server - Authorization Endpoint', async () => {
       expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
     });
 
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
+    it('should check that at least one API client is present', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkThatOneAPIClientExists', baseContext);
 
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
+      const apiClientsNumber = await boApiClientsPage.getNumberOfElementInGrid(page);
+      expect(apiClientsNumber).to.be.greaterThanOrEqual(1);
     });
 
     it('should go to add New API Client page', async function () {
@@ -85,7 +85,7 @@ describe('API : Internal Auth Server - Authorization Endpoint', async () => {
     it('should create API Client', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
 
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientClient);
+      const textResult = await boApiClientsCreatePage.addAPIClient(page, apiClient);
       expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
 
       const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
@@ -146,7 +146,7 @@ describe('API : Internal Auth Server - Authorization Endpoint', async () => {
 
       const apiResponse = await apiContext.post('access_token', {
         form: {
-          client_id: clientClient.clientId,
+          client_id: apiClient.clientId,
           client_secret: clientSecret,
           grant_type: 'client_credentials',
           notUsed: 'notUsed',
@@ -160,7 +160,7 @@ describe('API : Internal Auth Server - Authorization Endpoint', async () => {
 
       const apiResponse = await apiContext.post('access_token', {
         form: {
-          client_id: clientClient.clientId,
+          client_id: apiClient.clientId,
           client_secret: clientSecret,
           grant_type: 'client_credentials',
         },
@@ -173,11 +173,11 @@ describe('API : Internal Auth Server - Authorization Endpoint', async () => {
       expect(jsonResponse).to.have.property('token_type');
       expect(jsonResponse.token_type).to.be.eq('Bearer');
       expect(jsonResponse).to.have.property('expires_in');
-      expect(jsonResponse.expires_in).to.be.eq(clientClient.tokenLifetime);
+      expect(jsonResponse.expires_in).to.be.eq(apiClient.tokenLifetime);
       expect(jsonResponse).to.have.property('access_token');
       expect(jsonResponse.token_type).to.be.a('string');
     });
   });
 
-  deleteAPIClientTest(`${baseContext}_postTest_0`);
+  deleteAPIClientTest(`${baseContext}_postTest_0`, apiClient.clientId);
 });

--- a/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/01_internalAuthServer/02_resourceEndpoint.ts
+++ b/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/01_internalAuthServer/02_resourceEndpoint.ts
@@ -27,7 +27,7 @@ describe('API : Internal Auth Server - Resource Endpoint', async () => {
   let accessTokenExpired: string;
   let clientSecret: string;
 
-  const clientClient: FakerAPIClient = new FakerAPIClient({
+  const apiClient: FakerAPIClient = new FakerAPIClient({
     enabled: true,
     scopes: [
       'hook_read',
@@ -69,11 +69,11 @@ describe('API : Internal Auth Server - Resource Endpoint', async () => {
       expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
     });
 
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
+    it('should check that at least one API client is present', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkThatOneAPIClientExists', baseContext);
 
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
+      const apiClientsNumber = await boApiClientsPage.getNumberOfElementInGrid(page);
+      expect(apiClientsNumber).to.be.greaterThanOrEqual(1);
     });
 
     it('should go to add New API Client page', async function () {
@@ -88,7 +88,7 @@ describe('API : Internal Auth Server - Resource Endpoint', async () => {
     it('should create API Client', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
 
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientClient);
+      const textResult = await boApiClientsCreatePage.addAPIClient(page, apiClient);
       expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
 
       const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
@@ -111,7 +111,7 @@ describe('API : Internal Auth Server - Resource Endpoint', async () => {
 
       const apiResponse = await apiContext.post('access_token', {
         form: {
-          client_id: clientClient.clientId,
+          client_id: apiClient.clientId,
           client_secret: clientSecret,
           grant_type: 'client_credentials',
           scope: 'hook_read',
@@ -181,5 +181,5 @@ describe('API : Internal Auth Server - Resource Endpoint', async () => {
     });
   });
 
-  deleteAPIClientTest(`${baseContext}_postTest_0`);
+  deleteAPIClientTest(`${baseContext}_postTest_0`, apiClient.clientId);
 });

--- a/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/02_externalAuthServer/02_resourceEndpoint.ts
+++ b/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/02_externalAuthServer/02_resourceEndpoint.ts
@@ -28,8 +28,8 @@ describe('API : External Auth Server - Resource Endpoint', async () => {
   let apiContext: APIRequestContext;
   let accessTokenKeycloak: string;
   let accessTokenExpiredKeycloak: string;
-  let dynamicApiClientId: number;
-  let createdApiClientId;
+  // Contains the DB dynamic integer ID
+  let databaseDynamicID: number;
   const allowedIssuers = [
     `${global.keycloakConfig.keycloakExternalUrl}/realms/prestashop`,
     `${global.keycloakConfig.keycloakInternalUrl}/realms/prestashop`,
@@ -200,14 +200,13 @@ describe('API : External Auth Server - Resource Endpoint', async () => {
       expect(allowedIssuers).to.include(apiClient.externalIssuer);
 
       // Use dynamic ID because some other data may have been created before and the ID incremented already
-      dynamicApiClientId = apiClient.apiClientId;
-      createdApiClientId = apiClient.clientId;
+      databaseDynamicID = apiClient.apiClientId;
     });
 
     it('should request the endpoint /api-client/{apiClientId} with valid access token', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestSingleEndpointWithValidAccessToken', baseContext);
 
-      const apiResponse = await apiContext.get(`api-client/${dynamicApiClientId}`, {
+      const apiResponse = await apiContext.get(`api-client/${databaseDynamicID}`, {
         headers: {
           Authorization: `Bearer ${accessTokenKeycloak}`,
         },
@@ -220,7 +219,7 @@ describe('API : External Auth Server - Resource Endpoint', async () => {
       const jsonResponse = await apiResponse.json();
       expect(jsonResponse).to.have.property('apiClientId');
       expect(jsonResponse.apiClientId).to.be.a('number');
-      expect(jsonResponse.apiClientId).to.eq(dynamicApiClientId);
+      expect(jsonResponse.apiClientId).to.eq(databaseDynamicID);
       expect(jsonResponse).to.have.property('clientId');
       expect(jsonResponse.clientId).to.be.a('string');
       expect(jsonResponse.clientId).to.eq('prestashop-keycloak');
@@ -245,6 +244,6 @@ describe('API : External Auth Server - Resource Endpoint', async () => {
     });
   });
 
-  deleteAPIClientTest(`${baseContext}_postTest_0`, createdApiClientId);
+  deleteAPIClientTest(`${baseContext}_postTest_0`, global.keycloakConfig.keycloakClientId);
   uninstallModule(dataModules.keycloak, `${baseContext}_postTest_1`);
 });

--- a/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/02_externalAuthServer/02_resourceEndpoint.ts
+++ b/tests/UI/campaigns/functional/API/01_clientCredentialGrantFlow/02_externalAuthServer/02_resourceEndpoint.ts
@@ -29,6 +29,7 @@ describe('API : External Auth Server - Resource Endpoint', async () => {
   let accessTokenKeycloak: string;
   let accessTokenExpiredKeycloak: string;
   let dynamicApiClientId: number;
+  let createdApiClientId;
   const allowedIssuers = [
     `${global.keycloakConfig.keycloakExternalUrl}/realms/prestashop`,
     `${global.keycloakConfig.keycloakInternalUrl}/realms/prestashop`,
@@ -176,7 +177,8 @@ describe('API : External Auth Server - Resource Endpoint', async () => {
       expect(jsonResponse).to.have.property('totalItems');
       expect(jsonResponse.totalItems).to.be.a('number');
       expect(jsonResponse.items).to.be.a('array');
-      const apiClient = jsonResponse.items[0];
+      // Get the last element (the first one is the initial API client)
+      const apiClient = jsonResponse.items[jsonResponse.items.length - 1];
       expect(apiClient).to.have.property('apiClientId');
       expect(apiClient.apiClientId).to.be.a('number');
       expect(apiClient).to.have.property('clientId');
@@ -199,6 +201,7 @@ describe('API : External Auth Server - Resource Endpoint', async () => {
 
       // Use dynamic ID because some other data may have been created before and the ID incremented already
       dynamicApiClientId = apiClient.apiClientId;
+      createdApiClientId = apiClient.clientId;
     });
 
     it('should request the endpoint /api-client/{apiClientId} with valid access token', async function () {
@@ -242,6 +245,6 @@ describe('API : External Auth Server - Resource Endpoint', async () => {
     });
   });
 
-  deleteAPIClientTest(`${baseContext}_postTest_0`);
+  deleteAPIClientTest(`${baseContext}_postTest_0`, createdApiClientId);
   uninstallModule(dataModules.keycloak, `${baseContext}_postTest_1`);
 });

--- a/tests/UI/campaigns/functional/API/02_checkEndpoints.ts
+++ b/tests/UI/campaigns/functional/API/02_checkEndpoints.ts
@@ -149,9 +149,9 @@ describe('API : Check endpoints', async () => {
         '/modules/uninstall: PUT',
         // tests/UI/campaigns/functional/API/02_endpoints/05_module/11_getModules.ts
         '/modules: GET',
-        // tests/UI/campaigns/functional/API/02_endpoints/06_product/01_getProductImageId.ts
         // todo: add tests for delete and shopIds
         '/product/image/{imageId}: DELETE',
+        // tests/UI/campaigns/functional/API/02_endpoints/06_product/01_getProductImageId.ts
         '/product/image/{imageId}: GET',
         // tests/UI/campaigns/functional/API/02_endpoints/06_product/02_postProductImageId.ts
         '/product/image/{imageId}: POST',

--- a/tests/UI/campaigns/functional/API/02_checkEndpoints.ts
+++ b/tests/UI/campaigns/functional/API/02_checkEndpoints.ts
@@ -50,11 +50,11 @@ describe('API : Check endpoints', async () => {
       expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
     });
 
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
+    it('should check that at least one API client is present', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkThatOneAPIClientExists', baseContext);
 
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
+      const apiClientsNumber = await boApiClientsPage.getNumberOfElementInGrid(page);
+      expect(apiClientsNumber).to.be.greaterThanOrEqual(1);
     });
 
     it('should fetch the documentation in JSON', async function () {

--- a/tests/UI/campaigns/functional/API/02_endpoints/01_apiClient/01_getApiClientInfos.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/01_apiClient/01_getApiClientInfos.ts
@@ -72,11 +72,11 @@ describe('API : GET /api-client/infos', async () => {
       expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
     });
 
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
+    it('should check that at least one API client is present', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkThatOneAPIClientExists', baseContext);
 
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
+      const apiClientsNumber = await boApiClientsPage.getNumberOfElementInGrid(page);
+      expect(apiClientsNumber).to.be.greaterThanOrEqual(1);
     });
 
     it('should go to add New API Client page', async function () {
@@ -147,16 +147,18 @@ describe('API : GET /api-client/infos', async () => {
     it('should get informations', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'getInformations', baseContext);
 
-      idApiClient = parseInt(await boApiClientsPage.getTextColumn(page, 'id_api_client', 1), 10);
+      // Get ID from last created API Client
+      const apiClientsNumber = await boApiClientsPage.getNumberOfElementInGrid(page);
+      idApiClient = parseInt(await boApiClientsPage.getTextColumn(page, 'id_api_client', apiClientsNumber), 10);
       expect(idApiClient).to.be.gt(0);
     });
   });
 
   describe('API : Check Data', async () => {
-    it('should request the endpoint /api-client/{apiClientId}', async function () {
+    it('should request the endpoint /api-client/infos', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestEndpoint', baseContext);
 
-      const apiResponse = await apiContext.get(`api-client/${idApiClient}`, {
+      const apiResponse = await apiContext.get('api-client/infos', {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
@@ -241,5 +243,5 @@ describe('API : GET /api-client/infos', async () => {
   });
 
   // Pre-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest`);
+  deleteAPIClientTest(`${baseContext}_postTest`, clientData.clientId);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/01_apiClient/02_deleteApiClientId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/01_apiClient/02_deleteApiClientId.ts
@@ -24,6 +24,7 @@ describe('API : DELETE /api-client/{apiClientId}', async () => {
   let accessToken: string;
   let clientSecret: string;
   let idApiClient: number;
+  let initialNumberOfApiClients: number;
 
   const clientScope: string = 'api_client_write';
   const clientData: FakerAPIClient = new FakerAPIClient({
@@ -68,11 +69,11 @@ describe('API : DELETE /api-client/{apiClientId}', async () => {
       expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
     });
 
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
+    it('should check that at least one API client is present', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkThatOneAPIClientExists', baseContext);
 
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
+      initialNumberOfApiClients = await boApiClientsPage.getNumberOfElementInGrid(page);
+      expect(initialNumberOfApiClients).to.be.greaterThanOrEqual(1);
     });
 
     it('should go to add New API Client page', async function () {
@@ -143,7 +144,11 @@ describe('API : DELETE /api-client/{apiClientId}', async () => {
     it('should get informations', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'getInformations', baseContext);
 
-      idApiClient = parseInt(await boApiClientsPage.getTextColumn(page, 'id_api_client', 1), 10);
+      const apiClientsNumber = await boApiClientsPage.getNumberOfElementInGrid(page);
+      expect(apiClientsNumber).to.be.equal(initialNumberOfApiClients + 1);
+
+      // Get ID from last created API Client
+      idApiClient = parseInt(await boApiClientsPage.getTextColumn(page, 'id_api_client', apiClientsNumber), 10);
       expect(idApiClient).to.be.gt(0);
     });
   });
@@ -167,8 +172,8 @@ describe('API : DELETE /api-client/{apiClientId}', async () => {
 
       await boApiClientsPage.reloadPage(page);
 
-      const numberOfGroupsAfterCreation = await boApiClientsPage.getNumberOfElementInGrid(page);
-      expect(numberOfGroupsAfterCreation).to.be.equal(0);
+      const numberOfGroupsAfterDeletion = await boApiClientsPage.getNumberOfElementInGrid(page);
+      expect(numberOfGroupsAfterDeletion).to.be.equal(initialNumberOfApiClients);
     });
   });
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/01_apiClient/03_getApiClientId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/01_apiClient/03_getApiClientId.ts
@@ -72,11 +72,11 @@ describe('API : GET /api-client/{apiClientId}', async () => {
       expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
     });
 
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
+    it('should check that at least one API client is present', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkThatOneAPIClientExists', baseContext);
 
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
+      const apiClientsNumber = await boApiClientsPage.getNumberOfElementInGrid(page);
+      expect(apiClientsNumber).to.be.greaterThanOrEqual(1);
     });
 
     it('should go to add New API Client page', async function () {
@@ -147,7 +147,9 @@ describe('API : GET /api-client/{apiClientId}', async () => {
     it('should get informations', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'getInformations', baseContext);
 
-      idApiClient = parseInt(await boApiClientsPage.getTextColumn(page, 'id_api_client', 1), 10);
+      // Get ID from last created API Client
+      const apiClientsNumber = await boApiClientsPage.getNumberOfElementInGrid(page);
+      idApiClient = parseInt(await boApiClientsPage.getTextColumn(page, 'id_api_client', apiClientsNumber), 10);
       expect(idApiClient).to.be.gt(0);
     });
   });
@@ -248,5 +250,5 @@ describe('API : GET /api-client/{apiClientId}', async () => {
   });
 
   // Post-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest`);
+  deleteAPIClientTest(`${baseContext}_postTest`, clientData.clientId);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/01_apiClient/05_postApiClient.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/01_apiClient/05_postApiClient.ts
@@ -2,7 +2,7 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 
 import {expect} from 'chai';
 import {
@@ -25,16 +25,9 @@ describe('API : POST /api-client', async () => {
   let browserContext: BrowserContext;
   let page: Page;
   let accessToken: string;
-  let clientSecret: string;
   let jsonResponse: any;
 
   const clientScope: string = 'api_client_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
   const createClient: FakerAPIClient = new FakerAPIClient({
     scopes: [
       'api_client_read',
@@ -54,84 +47,9 @@ describe('API : POST /api-client', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
-    it('should login in BO', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
-
-      await boLoginPage.goTo(page, global.BO.URL);
-      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
-
-      const pageTitle = await boDashboardPage.getPageTitle(page);
-      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
-    });
-
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
+      accessToken = await requestAccessToken(clientScope);
     });
   });
 
@@ -177,6 +95,16 @@ describe('API : POST /api-client', async () => {
   });
 
   describe('BackOffice : Check the API Access is created', async () => {
+    it('should login in BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+      await boLoginPage.goTo(page, global.BO.URL);
+      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+      const pageTitle = await boDashboardPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+    });
+
     it('should go to \'Advanced Parameters > API Client\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'returnToAdminAPIPage', baseContext);
 
@@ -200,21 +128,27 @@ describe('API : POST /api-client', async () => {
     it('should check the JSON Response : `apiClientId`', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkResponseApiClientId', baseContext);
 
-      const value = parseInt(await boApiClientsPage.getTextColumn(page, 'id_api_client', 2), 10);
+      // Get ID from last created API Client
+      const apiClientsNumber = await boApiClientsPage.getNumberOfElementInGrid(page);
+      const value = parseInt(await boApiClientsPage.getTextColumn(page, 'id_api_client', apiClientsNumber), 10);
       expect(value).to.equal(jsonResponse.apiClientId);
     });
 
     it('should check the JSON Response : `clientId`', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkResponseClientId', baseContext);
 
-      const value = await boApiClientsPage.getTextColumn(page, 'client_id', 2);
+      // Get ID from last created API Client
+      const apiClientsNumber = await boApiClientsPage.getNumberOfElementInGrid(page);
+      const value = await boApiClientsPage.getTextColumn(page, 'client_id', apiClientsNumber);
       expect(value).to.equal(createClient.clientId);
     });
 
     it('should check the JSON Response : `clientName`', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkResponseClientName', baseContext);
 
-      const value = await boApiClientsPage.getTextColumn(page, 'client_name', 2);
+      // Get ID from last created API Client
+      const apiClientsNumber = await boApiClientsPage.getNumberOfElementInGrid(page);
+      const value = await boApiClientsPage.getTextColumn(page, 'client_name', apiClientsNumber);
       expect(value).to.equal(createClient.clientName);
     });
 
@@ -282,7 +216,4 @@ describe('API : POST /api-client', async () => {
       expect(numElements).to.equal(1);
     });
   });
-
-  // Pre-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/02_customerGroup/01_deleteCustomerGroupsId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/02_customerGroup/01_deleteCustomerGroupsId.ts
@@ -2,23 +2,18 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boCustomerGroupsPage,
   boCustomerGroupsCreatePage,
   boCustomerSettingsPage,
   boDashboardPage,
-  boLoginPage,
   type BrowserContext,
-  FakerAPIClient,
   FakerGroup,
   type Page,
-  utilsAPI,
-  utilsPlaywright,
+  utilsPlaywright, boLoginPage,
 } from '@prestashop-core/ui-testing';
 
 import {expect} from 'chai';
@@ -31,16 +26,9 @@ describe('API : DELETE /customers/group/{customerGroupId}', async () => {
   let page: Page;
   let numberOfGroups: number;
   let idCustomerGroup: number;
-  let clientSecret: string;
   let accessToken: string;
 
   const clientScope: string = 'customer_group_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
   const createGroupData: FakerGroup = new FakerGroup();
 
   before(async function () {
@@ -55,6 +43,13 @@ describe('API : DELETE /customers/group/{customerGroupId}', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+      accessToken = await requestAccessToken(clientScope);
+    });
+  });
+
+  describe('BackOffice : Create a Customer Group', async () => {
     it('should login in BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -65,78 +60,6 @@ describe('API : DELETE /customers/group/{customerGroupId}', async () => {
       expect(pageTitle).to.contains(boDashboardPage.pageTitle);
     });
 
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
-    });
-  });
-
-  describe('BackOffice : Create a Customer Group', async () => {
     it('should go to \'Shop Parameters > Customer Settings\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToCustomerSettingsPage', baseContext);
 
@@ -227,7 +150,4 @@ describe('API : DELETE /customers/group/{customerGroupId}', async () => {
       expect(numberOfGroupsAfterCreation).to.be.equal(0);
     });
   });
-
-  // Pre-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/02_customerGroup/02_getCustomerGroupsId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/02_customerGroup/02_getCustomerGroupsId.ts
@@ -2,24 +2,20 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 
 import {expect} from 'chai';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boCustomerGroupsPage,
   boCustomerGroupsCreatePage,
   boCustomerSettingsPage,
   boDashboardPage,
-  boLoginPage,
   type BrowserContext,
   dataLanguages,
-  FakerAPIClient,
   type Page,
   utilsAPI,
-  utilsPlaywright,
+  utilsPlaywright, boLoginPage,
 } from '@prestashop-core/ui-testing';
 
 const baseContext: string = 'functional_API_endpoints_customerGroup_getCustomerGroupsId';
@@ -30,7 +26,6 @@ describe('API : GET /customers/group/{customerGroupId}', async () => {
   let page: Page;
   let accessToken: string;
   let jsonResponse: any;
-  let clientSecret: string;
   let idCustomerGroup: number;
   let reductionPercent: number;
   let displayPriceTaxExcluded: boolean;
@@ -39,12 +34,6 @@ describe('API : GET /customers/group/{customerGroupId}', async () => {
   let nameEn: string;
 
   const clientScope: string = 'customer_group_read';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
 
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
@@ -58,6 +47,13 @@ describe('API : GET /customers/group/{customerGroupId}', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+      accessToken = await requestAccessToken(clientScope);
+    });
+  });
+
+  describe('BackOffice : Expected data', async () => {
     it('should login in BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -68,78 +64,6 @@ describe('API : GET /customers/group/{customerGroupId}', async () => {
       expect(pageTitle).to.contains(boDashboardPage.pageTitle);
     });
 
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
-    });
-  });
-
-  describe('BackOffice : Expected data', async () => {
     it('should go to \'Shop Parameters > Customer Settings\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToCustomerSettingsPage', baseContext);
 
@@ -280,7 +204,4 @@ describe('API : GET /customers/group/{customerGroupId}', async () => {
       expect(jsonResponse.shopIds).to.deep.equal([1]);
     });
   });
-
-  // Post-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/02_customerGroup/03_putCustomerGroupsId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/02_customerGroup/03_putCustomerGroupsId.ts
@@ -2,24 +2,20 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boCustomerGroupsPage,
   boCustomerGroupsCreatePage,
   boCustomerSettingsPage,
   boDashboardPage,
-  boLoginPage,
   type BrowserContext,
   dataLanguages,
-  FakerAPIClient,
   FakerGroup,
   type Page,
   utilsAPI,
-  utilsPlaywright,
+  utilsPlaywright, boLoginPage,
 } from '@prestashop-core/ui-testing';
 
 import {expect} from 'chai';
@@ -33,16 +29,9 @@ describe('API : PUT /customers/group/{customerGroupId}', async () => {
   let numberOfGroups: number;
   let idCustomerGroup: number;
   let jsonResponse: any;
-  let clientSecret: string;
   let accessToken: string;
 
   const clientScope: string = 'customer_group_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
   const createGroupData: FakerGroup = new FakerGroup({
     priceDisplayMethod: 'Tax included',
   });
@@ -66,6 +55,13 @@ describe('API : PUT /customers/group/{customerGroupId}', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+      accessToken = await requestAccessToken(clientScope);
+    });
+  });
+
+  describe('BackOffice : Create a Customer Group', async () => {
     it('should login in BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -76,78 +72,6 @@ describe('API : PUT /customers/group/{customerGroupId}', async () => {
       expect(pageTitle).to.contains(boDashboardPage.pageTitle);
     });
 
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
-    });
-  });
-
-  describe('BackOffice : Create a Customer Group', async () => {
     it('should go to \'Shop Parameters > Customer Settings\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToCustomerSettingsPage', baseContext);
 
@@ -364,7 +288,4 @@ describe('API : PUT /customers/group/{customerGroupId}', async () => {
       expect(numberOfGroupsAfterDelete).to.be.equal(numberOfGroups);
     });
   });
-
-  // Pre-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/03_hook/03_getHooksId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/03_hook/03_getHooksId.ts
@@ -2,18 +2,15 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 
 import {expect} from 'chai';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boDesignPositionsPage,
   boLoginPage,
   type BrowserContext,
-  FakerAPIClient,
   type Page,
   utilsAPI,
   utilsPlaywright,
@@ -25,7 +22,6 @@ describe('API : GET /hook/{hookId}', async () => {
   let apiContext: APIRequestContext;
   let browserContext: BrowserContext;
   let page: Page;
-  let clientSecret: string;
   let accessToken: string;
   let jsonResponse: any;
   let hookId: number;
@@ -35,12 +31,6 @@ describe('API : GET /hook/{hookId}', async () => {
   let descriptionHook: string;
 
   const clientScope: string = 'hook_read';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
 
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
@@ -54,6 +44,13 @@ describe('API : GET /hook/{hookId}', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+      accessToken = await requestAccessToken(clientScope);
+    });
+  });
+
+  describe('BackOffice : Expected data', async () => {
     it('should login in BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -64,78 +61,6 @@ describe('API : GET /hook/{hookId}', async () => {
       expect(pageTitle).to.contains(boDashboardPage.pageTitle);
     });
 
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
-    });
-  });
-
-  describe('BackOffice : Expected data', async () => {
     it('should go to \'Design > Positions\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToPositionsPage', baseContext);
 
@@ -238,7 +163,4 @@ describe('API : GET /hook/{hookId}', async () => {
       expect(jsonResponse.description).to.be.equal(descriptionHook);
     });
   });
-
-  // Pre-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/04_language/01_getLanguages.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/04_language/01_getLanguages.ts
@@ -2,20 +2,17 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 
 import {expect} from 'chai';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boLocalizationPage,
   boLanguagesPage,
   boLanguagesCreatePage,
   boLoginPage,
   type BrowserContext,
-  FakerAPIClient,
   type Page,
   utilsAPI,
   utilsPlaywright,
@@ -27,14 +24,8 @@ describe('API : GET /languages', async () => {
   let apiContext: APIRequestContext;
   let browserContext: BrowserContext;
   let page: Page;
-  let clientSecret: string;
   let accessToken: string;
   let jsonResponse: any;
-
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [],
-  });
 
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
@@ -48,83 +39,9 @@ describe('API : GET /languages', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
-    it('should login in BO', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
-
-      await boLoginPage.goTo(page, global.BO.URL);
-      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
-
-      const pageTitle = await boDashboardPage.getPageTitle(page);
-      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
-    });
-
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
     it('should request the endpoint /access_token', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
+      accessToken = await requestAccessToken('');
     });
   });
 
@@ -174,6 +91,16 @@ describe('API : GET /languages', async () => {
   });
 
   describe('BackOffice : Expected data', async () => {
+    it('should login in BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+      await boLoginPage.goTo(page, global.BO.URL);
+      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+      const pageTitle = await boDashboardPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+    });
+
     it('should go to \'International > Localization\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToLocalizationPage', baseContext);
 
@@ -264,7 +191,4 @@ describe('API : GET /languages', async () => {
       expect(numberOfLanguages).to.be.above(0);
     });
   });
-
-  // Post-condition: Delete the API Client
-  deleteAPIClientTest(`${baseContext}_postTest`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/05_module/01_postModuleUploadArchive.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/05_module/01_postModuleUploadArchive.ts
@@ -2,21 +2,18 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 import {deleteModule} from '@commonTests/BO/modules/moduleManager';
 
 import {expect} from 'chai';
 import fs from 'fs';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boModuleManagerPage,
   boLoginPage,
   type BrowserContext,
   dataModules,
-  FakerAPIClient,
   type Page,
   utilsAPI,
   utilsPlaywright,
@@ -29,18 +26,11 @@ describe('API : POST /module/upload-archive', async () => {
   let apiContext: APIRequestContext;
   let browserContext: BrowserContext;
   let page: Page;
-  let clientSecret: string;
   let accessToken: string;
   let jsonResponse: any;
 
   const module: string = 'module.zip';
   const clientScope: string = 'module_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
 
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
@@ -54,6 +44,13 @@ describe('API : POST /module/upload-archive', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+      accessToken = await requestAccessToken(clientScope);
+    });
+  });
+
+  describe('BackOffice : Check the module is not present', async () => {
     it('should login in BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -64,78 +61,6 @@ describe('API : POST /module/upload-archive', async () => {
       expect(pageTitle).to.contains(boDashboardPage.pageTitle);
     });
 
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
-    });
-  });
-
-  describe('BackOffice : Check the module is not present', async () => {
     it('should go to \'Modules > Module Manager\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToModulesPage', baseContext);
 
@@ -263,7 +188,4 @@ describe('API : POST /module/upload-archive', async () => {
 
   // Pre-condition: Uninstall the module
   deleteModule(dataModules.keycloak, `${baseContext}_postTest_0`);
-
-  // Pre-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest_1`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/05_module/02_postModuleUploadSource.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/05_module/02_postModuleUploadSource.ts
@@ -2,20 +2,17 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 import {deleteModule} from '@commonTests/BO/modules/moduleManager';
 
 import {expect} from 'chai';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boModuleManagerPage,
   boLoginPage,
   type BrowserContext,
   dataModules,
-  FakerAPIClient,
   type Page,
   utilsAPI,
   utilsPlaywright,
@@ -27,17 +24,10 @@ describe('API : POST /module/upload-source', async () => {
   let apiContext: APIRequestContext;
   let browserContext: BrowserContext;
   let page: Page;
-  let clientSecret: string;
   let accessToken: string;
   let jsonResponse: any;
 
   const clientScope: string = 'module_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
 
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
@@ -51,6 +41,13 @@ describe('API : POST /module/upload-source', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+      accessToken = await requestAccessToken(clientScope);
+    });
+  });
+
+  describe('BackOffice : Check the module is not present', async () => {
     it('should login in BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -61,78 +58,6 @@ describe('API : POST /module/upload-source', async () => {
       expect(pageTitle).to.contains(boDashboardPage.pageTitle);
     });
 
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
-    });
-  });
-
-  describe('BackOffice : Check the module is not present', async () => {
     it('should go to \'Modules > Module Manager\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToModulesPage', baseContext);
 
@@ -246,7 +171,4 @@ describe('API : POST /module/upload-source', async () => {
 
   // Pre-condition: Uninstall the module
   deleteModule(dataModules.keycloak, `${baseContext}_postTest_0`);
-
-  // Pre-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest_1`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/05_module/03_putModuleTechnicalNameInstall.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/05_module/03_putModuleTechnicalNameInstall.ts
@@ -2,20 +2,17 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 import {uninstallModule} from '@commonTests/BO/modules/moduleManager';
 
 import {expect} from 'chai';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boModuleManagerPage,
   boLoginPage,
   type BrowserContext,
   dataModules,
-  FakerAPIClient,
   type Page,
   utilsAPI,
   utilsPlaywright,
@@ -27,17 +24,10 @@ describe('API : PUT /module/{technicalName}/install', async () => {
   let apiContext: APIRequestContext;
   let browserContext: BrowserContext;
   let page: Page;
-  let clientSecret: string;
   let accessToken: string;
   let jsonResponse: any;
 
   const clientScope: string = 'module_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
 
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
@@ -51,6 +41,13 @@ describe('API : PUT /module/{technicalName}/install', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+      accessToken = await requestAccessToken(clientScope);
+    });
+  });
+
+  describe('BackOffice : Check the module is not present', async () => {
     it('should login in BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -61,78 +58,6 @@ describe('API : PUT /module/{technicalName}/install', async () => {
       expect(pageTitle).to.contains(boDashboardPage.pageTitle);
     });
 
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
-    });
-  });
-
-  describe('BackOffice : Check the module is not present', async () => {
     it('should go to \'Modules > Module Manager\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToModulesPage', baseContext);
 
@@ -263,7 +188,4 @@ describe('API : PUT /module/{technicalName}/install', async () => {
 
   // Pre-condition: Uninstall the module
   uninstallModule(dataModules.keycloak, `${baseContext}_postTest_0`);
-
-  // Pre-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest_1`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/05_module/04_patchModuleTechnicalNameReset.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/05_module/04_patchModuleTechnicalNameReset.ts
@@ -2,19 +2,16 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 
 import {expect} from 'chai';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boModuleManagerPage,
   boLoginPage,
   type BrowserContext,
   dataModules,
-  FakerAPIClient,
   modBlockwishlistBoMain,
   type ModuleInfo,
   type Page,
@@ -28,18 +25,11 @@ describe('API : PATCH /module/{technicalName}/reset', async () => {
   let apiContext: APIRequestContext;
   let browserContext: BrowserContext;
   let page: Page;
-  let clientSecret: string;
   let accessToken: string;
   let jsonResponse: any;
   let moduleInfo: ModuleInfo;
 
   const clientScope: string = 'module_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
 
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
@@ -53,6 +43,13 @@ describe('API : PATCH /module/{technicalName}/reset', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+      accessToken = await requestAccessToken(clientScope);
+    });
+  });
+
+  describe('BackOffice : Expected data', async () => {
     it('should login in BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -63,78 +60,6 @@ describe('API : PATCH /module/{technicalName}/reset', async () => {
       expect(pageTitle).to.contains(boDashboardPage.pageTitle);
     });
 
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
-    });
-  });
-
-  describe('BackOffice : Expected data', async () => {
     it('should go to \'Modules > Module Manager\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToModulesPage', baseContext);
 
@@ -295,7 +220,4 @@ describe('API : PATCH /module/{technicalName}/reset', async () => {
       }
     });
   });
-
-  // Pre-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/05_module/05_putModuleTechnicalNameStatus.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/05_module/05_putModuleTechnicalNameStatus.ts
@@ -2,19 +2,16 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 
 import {expect} from 'chai';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boModuleManagerPage,
   boLoginPage,
   type BrowserContext,
   dataModules,
-  FakerAPIClient,
   type ModuleInfo,
   type Page,
   utilsAPI,
@@ -27,18 +24,11 @@ describe('API : PUT /module/{technicalName}/status', async () => {
   let apiContext: APIRequestContext;
   let browserContext: BrowserContext;
   let page: Page;
-  let clientSecret: string;
   let accessToken: string;
   let jsonResponse: any;
   let moduleInfo: ModuleInfo;
 
   const clientScope: string = 'module_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
 
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
@@ -52,6 +42,13 @@ describe('API : PUT /module/{technicalName}/status', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+      accessToken = await requestAccessToken(clientScope);
+    });
+  });
+
+  describe('BackOffice : Expected data', async () => {
     it('should login in BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -62,78 +59,6 @@ describe('API : PUT /module/{technicalName}/status', async () => {
       expect(pageTitle).to.contains(boDashboardPage.pageTitle);
     });
 
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
-    });
-  });
-
-  describe('BackOffice : Expected data', async () => {
     it('should go to \'Modules > Module Manager\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToModulesPage', baseContext);
 
@@ -262,7 +187,4 @@ describe('API : PUT /module/{technicalName}/status', async () => {
       });
     });
   });
-
-  // Pre-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/05_module/06_putModuleTechnicalNameUninstall.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/05_module/06_putModuleTechnicalNameUninstall.ts
@@ -1,21 +1,17 @@
 import testContext from '@utils/testContext';
 
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 import {installModule} from '@commonTests/BO/modules/moduleManager';
 
 import {expect} from 'chai';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boModuleManagerPage,
   boLoginPage,
   type BrowserContext,
   dataModules,
-  FakerAPIClient,
   type Page,
-  utilsAPI,
   utilsPlaywright,
 } from '@prestashop-core/ui-testing';
 
@@ -25,16 +21,9 @@ describe('API : PUT /module/{technicalName}/uninstall', async () => {
   let apiContext: APIRequestContext;
   let browserContext: BrowserContext;
   let page: Page;
-  let clientSecret: string;
   let accessToken: string;
 
   const clientScope: string = 'module_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
 
   // PRE-CONDITION : Install module
   installModule(dataModules.keycloak, true, `${baseContext}_preTest_1`);
@@ -51,6 +40,13 @@ describe('API : PUT /module/{technicalName}/uninstall', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+      accessToken = await requestAccessToken(clientScope);
+    });
+  });
+
+  describe('BackOffice : Check the module is installed', async () => {
     it('should login in BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -61,78 +57,6 @@ describe('API : PUT /module/{technicalName}/uninstall', async () => {
       expect(pageTitle).to.contains(boDashboardPage.pageTitle);
     });
 
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
-    });
-  });
-
-  describe('BackOffice : Check the module is installed', async () => {
     it('should go to \'Modules > Module Manager\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToModulesPage', baseContext);
 
@@ -223,7 +147,4 @@ describe('API : PUT /module/{technicalName}/uninstall', async () => {
       expect(isModuleVisible).to.be.equal(false);
     });
   });
-
-  // POST-CONDITION: Delete an API Client
-  deleteAPIClientTest(`${baseContext}_postTest_0`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/05_module/07_putModuleTechnicalNameUpgrade.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/05_module/07_putModuleTechnicalNameUpgrade.ts
@@ -1,18 +1,15 @@
 import {expect} from 'chai';
 import testContext from '@utils/testContext';
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 import {installModule, uninstallModule} from '@commonTests/BO/modules/moduleManager';
 
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boModuleManagerPage,
   boLoginPage,
   type BrowserContext,
   dataModules,
-  FakerAPIClient,
   type Page,
   utilsAPI,
   utilsPlaywright,
@@ -24,17 +21,10 @@ describe('API : PUT /module/{technicalName}/upgrade', async () => {
   let apiContext: APIRequestContext;
   let browserContext: BrowserContext;
   let page: Page;
-  let clientSecret: string;
   let accessToken: string;
   let jsonResponse: any;
 
   const clientScope: string = 'module_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
 
   // PRE-TEST : Uninstall ps_cashondelivery
   uninstallModule(dataModules.psCashOnDelivery, `${baseContext}_preTest_0`);
@@ -53,6 +43,13 @@ describe('API : PUT /module/{technicalName}/upgrade', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+      accessToken = await requestAccessToken(clientScope);
+    });
+  });
+
+  describe('BackOffice : Check the module is installed', async () => {
     it('should login in BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -63,78 +60,6 @@ describe('API : PUT /module/{technicalName}/upgrade', async () => {
       expect(pageTitle).to.contains(boDashboardPage.pageTitle);
     });
 
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
-    });
-  });
-
-  describe('BackOffice : Check the module is installed', async () => {
     it('should go to \'Modules > Module Manager\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToModulesPage', baseContext);
 
@@ -270,7 +195,4 @@ describe('API : PUT /module/{technicalName}/upgrade', async () => {
       expect(moduleInfo.installed).to.equal(true);
     });
   });
-
-  // POST-CONDITION: Delete an API Client
-  deleteAPIClientTest(`${baseContext}_postTest_0`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/05_module/08_getModuleTechnicalName.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/05_module/08_getModuleTechnicalName.ts
@@ -2,19 +2,16 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 
 import {expect} from 'chai';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boModuleManagerPage,
   boLoginPage,
   type BrowserContext,
   dataModules,
-  FakerAPIClient,
   type ModuleInfo,
   type Page,
   utilsAPI,
@@ -27,18 +24,11 @@ describe('API : GET /module/{technicalName}', async () => {
   let apiContext: APIRequestContext;
   let browserContext: BrowserContext;
   let page: Page;
-  let clientSecret: string;
   let accessToken: string;
   let jsonResponse: any;
   let moduleInfo: ModuleInfo;
 
   const clientScope: string = 'module_read';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
 
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
@@ -52,6 +42,13 @@ describe('API : GET /module/{technicalName}', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+      accessToken = await requestAccessToken(clientScope);
+    });
+  });
+
+  describe('BackOffice : Expected data', async () => {
     it('should login in BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -62,78 +59,6 @@ describe('API : GET /module/{technicalName}', async () => {
       expect(pageTitle).to.contains(boDashboardPage.pageTitle);
     });
 
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
-    });
-  });
-
-  describe('BackOffice : Expected data', async () => {
     it('should go to \'Modules > Module Manager\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToModulesPage', baseContext);
 
@@ -230,7 +155,4 @@ describe('API : GET /module/{technicalName}', async () => {
       expect(jsonResponse.installed).to.be.equal(moduleInfo.installed);
     });
   });
-
-  // Pre-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/05_module/09_putModulesToggleStatus.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/05_module/09_putModulesToggleStatus.ts
@@ -2,21 +2,17 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
-  boLoginPage,
   boModuleManagerPage,
+  boLoginPage,
   type BrowserContext,
-  FakerAPIClient,
   FakerModule,
   type ModuleInfo,
   type Page,
-  utilsAPI,
   utilsCore,
   utilsPlaywright,
 } from '@prestashop-core/ui-testing';
@@ -29,18 +25,11 @@ describe('API : PUT /modules/toggle-status', async () => {
   let apiContext: APIRequestContext;
   let browserContext: BrowserContext;
   let page: Page;
-  let clientSecret: string;
   let accessToken: string;
   let moduleInfo1: ModuleInfo;
   let moduleInfo2: ModuleInfo;
 
   const clientScope: string = 'module_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
 
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
@@ -54,6 +43,13 @@ describe('API : PUT /modules/toggle-status', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+      accessToken = await requestAccessToken(clientScope);
+    });
+  });
+
+  describe('BackOffice : Fetch two modules', async () => {
     it('should login in BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -64,78 +60,6 @@ describe('API : PUT /modules/toggle-status', async () => {
       expect(pageTitle).to.contains(boDashboardPage.pageTitle);
     });
 
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
-    });
-  });
-
-  describe('BackOffice : Fetch two modules', async () => {
     it('should go to \'Modules > Module Manager\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToModulesPage', baseContext);
 
@@ -216,7 +140,4 @@ describe('API : PUT /modules/toggle-status', async () => {
       });
     });
   });
-
-  // Pre-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/05_module/10_putModulesUninstall.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/05_module/10_putModulesUninstall.ts
@@ -1,21 +1,17 @@
 import testContext from '@utils/testContext';
 
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 import {installModule} from '@commonTests/BO/modules/moduleManager';
 
 import {expect} from 'chai';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boModuleManagerPage,
   boLoginPage,
   type BrowserContext,
   dataModules,
-  FakerAPIClient,
   type Page,
-  utilsAPI,
   utilsPlaywright,
   FakerModule,
 } from '@prestashop-core/ui-testing';
@@ -26,16 +22,9 @@ describe('API : PUT /modules/uninstall', async () => {
   let apiContext: APIRequestContext;
   let browserContext: BrowserContext;
   let page: Page;
-  let clientSecret: string;
   let accessToken: string;
 
   const clientScope: string = 'module_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
   const modules: FakerModule[] = [
     dataModules.keycloak,
     dataModules.psCashOnDelivery,
@@ -60,6 +49,13 @@ describe('API : PUT /modules/uninstall', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+      accessToken = await requestAccessToken(clientScope);
+    });
+  });
+
+  describe('BackOffice : Check the module is installed', async () => {
     it('should login in BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -70,78 +66,6 @@ describe('API : PUT /modules/uninstall', async () => {
       expect(pageTitle).to.contains(boDashboardPage.pageTitle);
     });
 
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
-    });
-  });
-
-  describe('BackOffice : Check the module is installed', async () => {
     it('should go to \'Modules > Module Manager\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToModulesPage', baseContext);
 
@@ -256,7 +180,4 @@ describe('API : PUT /modules/uninstall', async () => {
 
   // POST-CONDITION: Reinstall module
   installModule(dataModules.psCashOnDelivery, true, `${baseContext}_postTest_0`);
-
-  // POST-CONDITION: Delete an API Client
-  deleteAPIClientTest(`${baseContext}_postTest_0`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/05_module/11_getModules.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/05_module/11_getModules.ts
@@ -1,17 +1,14 @@
 import testContext from '@utils/testContext';
 import {expect} from 'chai';
 
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
-  boLoginPage,
   boModuleManagerPage,
+  boLoginPage,
   type BrowserContext,
-  FakerAPIClient,
   FakerModule,
   type ModuleApiInfo,
   type Page,
@@ -25,18 +22,11 @@ describe('API : GET /modules', async () => {
   let apiContext: APIRequestContext;
   let browserContext: BrowserContext;
   let page: Page;
-  let clientSecret: string;
   let accessToken: string;
   let jsonResponse: any;
   const jsonResponseItems: ModuleApiInfo[] = [];
 
   const clientScope: string = 'module_read';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
 
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
@@ -50,84 +40,9 @@ describe('API : GET /modules', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
-    it('should login in BO', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
-
-      await boLoginPage.goTo(page, global.BO.URL);
-      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
-
-      const pageTitle = await boDashboardPage.getPageTitle(page);
-      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
-    });
-
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
+      accessToken = await requestAccessToken(clientScope);
     });
   });
 
@@ -195,6 +110,16 @@ describe('API : GET /modules', async () => {
   });
 
   describe('BackOffice : Expected data', async () => {
+    it('should login in BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+      await boLoginPage.goTo(page, global.BO.URL);
+      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+      const pageTitle = await boDashboardPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+    });
+
     it('should go to \'Modules > Module Manager\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToModulesPage', baseContext);
 
@@ -229,7 +154,4 @@ describe('API : GET /modules', async () => {
       }
     });
   });
-
-  // Pre-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/06_product/01_getProductImageId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/06_product/01_getProductImageId.ts
@@ -2,13 +2,11 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 
 import {expect} from 'chai';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boLoginPage,
   boProductsPage,
@@ -17,7 +15,6 @@ import {
   type BrowserContext,
   dataLanguages,
   dataProducts,
-  FakerAPIClient,
   type Page,
   utilsAPI,
   utilsPlaywright,
@@ -30,17 +27,10 @@ describe('API : GET /product/image/{imageId}', async () => {
   let browserContext: BrowserContext;
   let page: Page;
   let accessToken: string;
-  let clientSecret: string;
   let jsonResponse: any;
 
   const imageId: number = 1;
   const clientScope: string = 'product_read';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
 
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
@@ -54,84 +44,9 @@ describe('API : GET /product/image/{imageId}', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
-    it('should login in BO', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
-
-      await boLoginPage.goTo(page, global.BO.URL);
-      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
-
-      const pageTitle = await boDashboardPage.getPageTitle(page);
-      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
-    });
-
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
+      accessToken = await requestAccessToken(clientScope);
     });
   });
 
@@ -177,6 +92,16 @@ describe('API : GET /product/image/{imageId}', async () => {
   });
 
   describe('BackOffice : Check the Product Images', async () => {
+    it('should login in BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+      await boLoginPage.goTo(page, global.BO.URL);
+      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+      const pageTitle = await boDashboardPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+    });
+
     it('should go to \'Catalog > Products\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToProductsPage', baseContext);
 
@@ -224,7 +149,4 @@ describe('API : GET /product/image/{imageId}', async () => {
       expect(productImageInformation.position).to.equal(jsonResponse.position);
     });
   });
-
-  // Post-condition: Delete an API Client
-  deleteAPIClientTest(`${baseContext}_postTest_0`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/06_product/02_postProductImageId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/06_product/02_postProductImageId.ts
@@ -2,15 +2,13 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 import {createProductTest, deleteProductTest} from '@commonTests/BO/catalog/product';
 
 import {expect} from 'chai';
 import fs from 'fs';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boLoginPage,
   boProductsPage,
@@ -18,7 +16,6 @@ import {
   boProductsCreateTabDescriptionPage,
   type BrowserContext,
   dataLanguages,
-  FakerAPIClient,
   FakerProduct,
   type Page,
   type ProductImageInformation,
@@ -34,18 +31,11 @@ describe('API : POST /product/image/{imageId}', async () => {
   let browserContext: BrowserContext;
   let page: Page;
   let accessToken: string;
-  let clientSecret: string;
   let jsonResponse: any;
   let idProduct: number;
   let productImageInformation: ProductImageInformation;
 
   const clientScope: string = 'product_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
   const productImageCreated: string = 'coverCreated.jpg';
   const productImageUpdated: string = 'coverUpdated.jpg';
   const productCaptionEN: string = 'Caption EN';
@@ -78,6 +68,13 @@ describe('API : POST /product/image/{imageId}', async () => {
     });
 
     describe('BackOffice : Fetch the access token', async () => {
+      it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+        await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+        accessToken = await requestAccessToken(clientScope);
+      });
+    });
+
+    describe('BackOffice : Fetch the ID of the Product', async () => {
       it('should login in BO', async function () {
         await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -88,78 +85,6 @@ describe('API : POST /product/image/{imageId}', async () => {
         expect(pageTitle).to.contains(boDashboardPage.pageTitle);
       });
 
-      it('should go to \'Advanced Parameters > API Client\' page', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-        await boDashboardPage.goToSubMenu(
-          page,
-          boDashboardPage.advancedParametersLink,
-          boDashboardPage.adminAPILink,
-        );
-
-        const pageTitle = await boApiClientsPage.getPageTitle(page);
-        expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-      });
-
-      it('should check that no records found', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-        const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-        expect(noRecordsFoundText).to.contains('warning No records found');
-      });
-
-      it('should go to add New API Client page', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-        await boApiClientsPage.goToNewAPIClientPage(page);
-
-        const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-        expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-      });
-
-      it('should create API Client', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-        const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-        expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-        const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-        expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-      });
-
-      it('should copy client secret', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-        await boApiClientsCreatePage.copyClientSecret(page);
-
-        clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-        expect(clientSecret.length).to.be.gt(0);
-      });
-
-      it('should request the endpoint /access_token', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-        const apiResponse = await apiContext.post('access_token', {
-          form: {
-            client_id: clientData.clientId,
-            client_secret: clientSecret,
-            grant_type: 'client_credentials',
-            scope: clientScope,
-          },
-        });
-        expect(apiResponse.status()).to.eq(200);
-        expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-        expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-        const jsonResponse = await apiResponse.json();
-        expect(jsonResponse).to.have.property('access_token');
-        expect(jsonResponse.token_type).to.be.a('string');
-
-        accessToken = jsonResponse.access_token;
-      });
-    });
-
-    describe('BackOffice : Fetch the ID of the Product', async () => {
       it('should go to \'Catalog > Products\' page', async function () {
         await testContext.addContextItem(this, 'testIdentifier', 'goToProductsPage', baseContext);
 
@@ -335,7 +260,4 @@ describe('API : POST /product/image/{imageId}', async () => {
 
   // Post-condition: Delete a Product
   deleteProductTest(createProduct, `${baseContext}_postTest_0`);
-
-  // Post-condition: Delete an API Client
-  deleteAPIClientTest(`${baseContext}_postTest_1`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/06_product/03_postProductIdImage.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/06_product/03_postProductIdImage.ts
@@ -1,13 +1,11 @@
 import testContext from '@utils/testContext';
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 import {createProductTest, deleteProductTest} from '@commonTests/BO/catalog/product';
 import {expect} from 'chai';
 import fs from 'fs';
 
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boLoginPage,
   boProductsPage,
@@ -15,7 +13,6 @@ import {
   boProductsCreateTabDescriptionPage,
   type BrowserContext,
   dataLanguages,
-  FakerAPIClient,
   FakerProduct,
   type Page,
   type ProductImageInformation,
@@ -31,18 +28,11 @@ describe('API : POST /product/{productId}/image', async () => {
   let browserContext: BrowserContext;
   let page: Page;
   let accessToken: string;
-  let clientSecret: string;
   let jsonResponse: any;
   let idProduct: number;
   let productImageInformation: ProductImageInformation;
 
   const clientScope: string = 'product_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
   const createProduct: FakerProduct = new FakerProduct({});
 
   createProductTest(createProduct, `${baseContext}_preTest`);
@@ -64,6 +54,13 @@ describe('API : POST /product/{productId}/image', async () => {
     });
 
     describe('BackOffice : Fetch the access token', async () => {
+      it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+        await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+        accessToken = await requestAccessToken(clientScope);
+      });
+    });
+
+    describe('BackOffice : Fetch the ID of the Product', async () => {
       it('should login in BO', async function () {
         await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -74,78 +71,6 @@ describe('API : POST /product/{productId}/image', async () => {
         expect(pageTitle).to.contains(boDashboardPage.pageTitle);
       });
 
-      it('should go to \'Advanced Parameters > API Client\' page', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-        await boDashboardPage.goToSubMenu(
-          page,
-          boDashboardPage.advancedParametersLink,
-          boDashboardPage.adminAPILink,
-        );
-
-        const pageTitle = await boApiClientsPage.getPageTitle(page);
-        expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-      });
-
-      it('should check that no records found', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-        const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-        expect(noRecordsFoundText).to.contains('warning No records found');
-      });
-
-      it('should go to add New API Client page', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-        await boApiClientsPage.goToNewAPIClientPage(page);
-
-        const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-        expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-      });
-
-      it('should create API Client', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-        const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-        expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-        const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-        expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-      });
-
-      it('should copy client secret', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-        await boApiClientsCreatePage.copyClientSecret(page);
-
-        clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-        expect(clientSecret.length).to.be.gt(0);
-      });
-
-      it('should request the endpoint /access_token', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-        const apiResponse = await apiContext.post('access_token', {
-          form: {
-            client_id: clientData.clientId,
-            client_secret: clientSecret,
-            grant_type: 'client_credentials',
-            scope: clientScope,
-          },
-        });
-        expect(apiResponse.status()).to.eq(200);
-        expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-        expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-        const jsonResponse = await apiResponse.json();
-        expect(jsonResponse).to.have.property('access_token');
-        expect(jsonResponse.token_type).to.be.a('string');
-
-        accessToken = jsonResponse.access_token;
-      });
-    });
-
-    describe('BackOffice : Fetch the ID of the Product', async () => {
       it('should go to \'Catalog > Products\' page', async function () {
         await testContext.addContextItem(this, 'testIdentifier', 'goToProductsPage', baseContext);
 
@@ -284,7 +209,4 @@ describe('API : POST /product/{productId}/image', async () => {
 
   // Post-condition: Delete a Product
   deleteProductTest(createProduct, `${baseContext}_postTest_0`);
-
-  // Post-condition: Delete an API Client
-  deleteAPIClientTest(`${baseContext}_postTest_1`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/06_product/04_getProductIdImages.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/06_product/04_getProductIdImages.ts
@@ -2,13 +2,11 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 
 import {expect} from 'chai';
 import {
-  boApiClientsPage,
   type APIRequestContext,
-  boApiClientsCreatePage,
   boDashboardPage,
   boLoginPage,
   boProductsPage,
@@ -17,7 +15,6 @@ import {
   type BrowserContext,
   dataLanguages,
   dataProducts,
-  FakerAPIClient,
   type Page,
   utilsAPI,
   utilsPlaywright,
@@ -30,16 +27,9 @@ describe('API : GET /product/{productId}/images', async () => {
   let browserContext: BrowserContext;
   let page: Page;
   let accessToken: string;
-  let clientSecret: string;
   let jsonResponse: any;
 
   const clientScope: string = 'product_read';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
 
   describe('GET /product/{productId}/images', async () => {
     before(async function () {
@@ -54,84 +44,9 @@ describe('API : GET /product/{productId}/images', async () => {
     });
 
     describe('BackOffice : Fetch the access token', async () => {
-      it('should login in BO', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
-
-        await boLoginPage.goTo(page, global.BO.URL);
-        await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
-
-        const pageTitle = await boDashboardPage.getPageTitle(page);
-        expect(pageTitle).to.contains(boDashboardPage.pageTitle);
-      });
-
-      it('should go to \'Advanced Parameters > API Client\' page', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-        await boDashboardPage.goToSubMenu(
-          page,
-          boDashboardPage.advancedParametersLink,
-          boDashboardPage.adminAPILink,
-        );
-
-        const pageTitle = await boApiClientsPage.getPageTitle(page);
-        expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-      });
-
-      it('should check that no records found', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-        const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-        expect(noRecordsFoundText).to.contains('warning No records found');
-      });
-
-      it('should go to add New API Client page', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-        await boApiClientsPage.goToNewAPIClientPage(page);
-
-        const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-        expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-      });
-
-      it('should create API Client', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-        const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-        expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-        const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-        expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-      });
-
-      it('should copy client secret', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-        await boApiClientsCreatePage.copyClientSecret(page);
-
-        clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-        expect(clientSecret.length).to.be.gt(0);
-      });
-
-      it('should request the endpoint /access_token', async function () {
+      it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
         await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-        const apiResponse = await apiContext.post('access_token', {
-          form: {
-            client_id: clientData.clientId,
-            client_secret: clientSecret,
-            grant_type: 'client_credentials',
-            scope: clientScope,
-          },
-        });
-        expect(apiResponse.status()).to.eq(200);
-        expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-        expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-        const jsonResponse = await apiResponse.json();
-        expect(jsonResponse).to.have.property('access_token');
-        expect(jsonResponse.token_type).to.be.a('string');
-
-        accessToken = jsonResponse.access_token;
+        accessToken = await requestAccessToken(clientScope);
       });
     });
 
@@ -181,6 +96,16 @@ describe('API : GET /product/{productId}/images', async () => {
     });
 
     describe('BackOffice : Check the Product Images', async () => {
+      it('should login in BO', async function () {
+        await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+        await boLoginPage.goTo(page, global.BO.URL);
+        await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+        const pageTitle = await boDashboardPage.getPageTitle(page);
+        expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+      });
+
       it('should go to \'Catalog > Products\' page', async function () {
         await testContext.addContextItem(this, 'testIdentifier', 'goToProductsPage', baseContext);
 
@@ -234,7 +159,4 @@ describe('API : GET /product/{productId}/images', async () => {
       });
     });
   });
-
-  // Post-condition: Delete an API Client
-  deleteAPIClientTest(`${baseContext}_postTest_0`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/06_product/06_deleteProductId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/06_product/06_deleteProductId.ts
@@ -2,22 +2,18 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 import {createProductTest} from '@commonTests/BO/catalog/product';
 
 import {expect} from 'chai';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boProductsPage,
   boDashboardPage,
   boLoginPage,
   type BrowserContext,
-  FakerAPIClient,
   FakerProduct,
   type Page,
-  utilsAPI,
   utilsPlaywright,
 } from '@prestashop-core/ui-testing';
 
@@ -28,16 +24,9 @@ describe('API : DELETE /product/{productId}', async () => {
   let browserContext: BrowserContext;
   let page: Page;
   let idProduct: number;
-  let clientSecret: string;
   let accessToken: string;
 
   const clientScope: string = 'product_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
   const productData: FakerProduct = new FakerProduct({type: 'standard', status: true});
 
   before(async function () {
@@ -55,6 +44,13 @@ describe('API : DELETE /product/{productId}', async () => {
   createProductTest(productData, `${baseContext}_preTest_0`);
 
   describe('BackOffice : Fetch the access token', async () => {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+      accessToken = await requestAccessToken(clientScope);
+    });
+  });
+
+  describe('BackOffice : Fetch the ID of the product', async () => {
     it('should login in BO', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -65,78 +61,6 @@ describe('API : DELETE /product/{productId}', async () => {
       expect(pageTitle).to.contains(boDashboardPage.pageTitle);
     });
 
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
-    });
-  });
-
-  describe('BackOffice : Fetch the ID of the product', async () => {
     it('should go to \'Catalog > Products\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToProductsPage', baseContext);
 
@@ -188,7 +112,4 @@ describe('API : DELETE /product/{productId}', async () => {
       expect(numProducts).to.be.equal(0);
     });
   });
-
-  // Pre-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/06_product/08_patchProductId.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/06_product/08_patchProductId.ts
@@ -1,5 +1,5 @@
 import testContext from '@utils/testContext';
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 import {createProductTest, deleteProductTest} from '@commonTests/BO/catalog/product';
 import {disableEcoTaxTest, enableEcoTaxTest} from '@commonTests/BO/international/ecoTax';
 import {expect} from 'chai';
@@ -7,8 +7,6 @@ import {expect} from 'chai';
 import {faker} from '@faker-js/faker';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boLoginPage,
   boProductsPage,
@@ -25,7 +23,6 @@ import {
   dataCategories,
   dataLanguages,
   dataTaxRules,
-  FakerAPIClient,
   FakerProduct,
   type Page,
   utilsAPI,
@@ -39,17 +36,10 @@ describe('API : PATCH /product/{productId}', async () => {
   let browserContext: BrowserContext;
   let page: Page;
   let accessToken: string;
-  let clientSecret: string;
   let idProduct: number;
   let jsonResponse: any;
 
   const clientScope: string = 'product_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
   const createProduct: FakerProduct = new FakerProduct({
     type: 'standard',
     status: true,
@@ -74,6 +64,13 @@ describe('API : PATCH /product/{productId}', async () => {
     });
 
     describe('BackOffice : Fetch the access token', async () => {
+      it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
+        await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
+        accessToken = await requestAccessToken(clientScope);
+      });
+    });
+
+    describe('BackOffice : Fetch the ID product', async () => {
       it('should login in BO', async function () {
         await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
 
@@ -84,78 +81,6 @@ describe('API : PATCH /product/{productId}', async () => {
         expect(pageTitle).to.contains(boDashboardPage.pageTitle);
       });
 
-      it('should go to \'Advanced Parameters > API Client\' page', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-        await boDashboardPage.goToSubMenu(
-          page,
-          boDashboardPage.advancedParametersLink,
-          boDashboardPage.adminAPILink,
-        );
-
-        const pageTitle = await boApiClientsPage.getPageTitle(page);
-        expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-      });
-
-      it('should check that no records found', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-        const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-        expect(noRecordsFoundText).to.contains('warning No records found');
-      });
-
-      it('should go to add New API Client page', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-        await boApiClientsPage.goToNewAPIClientPage(page);
-
-        const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-        expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-      });
-
-      it('should create API Client', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-        const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-        expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-        const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-        expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-      });
-
-      it('should copy client secret', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-        await boApiClientsCreatePage.copyClientSecret(page);
-
-        clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-        expect(clientSecret.length).to.be.gt(0);
-      });
-
-      it('should request the endpoint /access_token', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-        const apiResponse = await apiContext.post('access_token', {
-          form: {
-            client_id: clientData.clientId,
-            client_secret: clientSecret,
-            grant_type: 'client_credentials',
-            scope: clientScope,
-          },
-        });
-        expect(apiResponse.status()).to.eq(200);
-        expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-        expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-        const jsonResponse = await apiResponse.json();
-        expect(jsonResponse).to.have.property('access_token');
-        expect(jsonResponse.token_type).to.be.a('string');
-
-        accessToken = jsonResponse.access_token;
-      });
-    });
-
-    describe('BackOffice : Fetch the ID product', async () => {
       it('should go to \'Catalog > Products\' page', async function () {
         await testContext.addContextItem(this, 'testIdentifier', 'goToProductsPage', baseContext);
 
@@ -827,7 +752,4 @@ describe('API : PATCH /product/{productId}', async () => {
 
   // Pre-condition: Delete a product
   disableEcoTaxTest(`${baseContext}_postTest_1`);
-
-  // Pre-condition: Delete an API Client
-  deleteAPIClientTest(`${baseContext}_postTest_2`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/06_product/09_postProduct.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/06_product/09_postProduct.ts
@@ -2,14 +2,12 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 import {deleteProductTest} from '@commonTests/BO/catalog/product';
 
 import {expect} from 'chai';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boProductsPage,
   boProductsCreatePage,
   boProductsCreateTabDescriptionPage,
@@ -17,7 +15,6 @@ import {
   boLoginPage,
   type BrowserContext,
   dataLanguages,
-  FakerAPIClient,
   FakerProduct,
   type Page,
   utilsAPI,
@@ -31,16 +28,9 @@ describe('API : POST /product', async () => {
   let browserContext: BrowserContext;
   let page: Page;
   let accessToken: string;
-  let clientSecret: string;
   let jsonResponse: any;
 
   const clientScope: string = 'product_write';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
   const createProduct: FakerProduct = new FakerProduct({});
 
   before(async function () {
@@ -55,84 +45,9 @@ describe('API : POST /product', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
-    it('should login in BO', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
-
-      await boLoginPage.goTo(page, global.BO.URL);
-      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
-
-      const pageTitle = await boDashboardPage.getPageTitle(page);
-      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
-    });
-
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
+      accessToken = await requestAccessToken(clientScope);
     });
   });
 
@@ -235,6 +150,16 @@ describe('API : POST /product', async () => {
   });
 
   describe('BackOffice : Check the Product is created', async () => {
+    it('should login in BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+      await boLoginPage.goTo(page, global.BO.URL);
+      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+      const pageTitle = await boDashboardPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+    });
+
     it('should go to \'Catalog > Products\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToProductsPage', baseContext);
 
@@ -316,7 +241,4 @@ describe('API : POST /product', async () => {
 
   // Post-condition: Delete a Product
   deleteProductTest(createProduct, `${baseContext}_postTest_0`);
-
-  // Post-condition: Delete an API Client
-  deleteAPIClientTest(`${baseContext}_postTest_1`);
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/06_product/11_getProducts.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/06_product/11_getProducts.ts
@@ -2,18 +2,15 @@
 import testContext from '@utils/testContext';
 
 // Import commonTests
-import {deleteAPIClientTest} from '@commonTests/BO/advancedParameters/authServer';
+import {requestAccessToken} from '@commonTests/BO/advancedParameters/authServer';
 
 import {expect} from 'chai';
 import {
   type APIRequestContext,
-  boApiClientsPage,
-  boApiClientsCreatePage,
   boDashboardPage,
   boLoginPage,
   boProductsPage,
   type BrowserContext,
-  FakerAPIClient,
   type Page,
   utilsAPI,
   utilsPlaywright,
@@ -25,17 +22,10 @@ describe('API : GET /products', async () => {
   let apiContext: APIRequestContext;
   let browserContext: BrowserContext;
   let page: Page;
-  let clientSecret: string;
   let accessToken: string;
   let jsonResponse: any;
 
   const clientScope: string = 'product_read';
-  const clientData: FakerAPIClient = new FakerAPIClient({
-    enabled: true,
-    scopes: [
-      clientScope,
-    ],
-  });
 
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
@@ -49,84 +39,9 @@ describe('API : GET /products', async () => {
   });
 
   describe('BackOffice : Fetch the access token', async () => {
-    it('should login in BO', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
-
-      await boLoginPage.goTo(page, global.BO.URL);
-      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
-
-      const pageTitle = await boDashboardPage.getPageTitle(page);
-      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
-    });
-
-    it('should go to \'Advanced Parameters > API Client\' page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToAdminAPIPage', baseContext);
-
-      await boDashboardPage.goToSubMenu(
-        page,
-        boDashboardPage.advancedParametersLink,
-        boDashboardPage.adminAPILink,
-      );
-
-      const pageTitle = await boApiClientsPage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
-    });
-
-    it('should check that no records found', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkThatNoRecordFound', baseContext);
-
-      const noRecordsFoundText = await boApiClientsPage.getTextForEmptyTable(page);
-      expect(noRecordsFoundText).to.contains('warning No records found');
-    });
-
-    it('should go to add New API Client page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAPIClientPage', baseContext);
-
-      await boApiClientsPage.goToNewAPIClientPage(page);
-
-      const pageTitle = await boApiClientsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.eq(boApiClientsCreatePage.pageTitleCreate);
-    });
-
-    it('should create API Client', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'createAPIClient', baseContext);
-
-      const textResult = await boApiClientsCreatePage.addAPIClient(page, clientData);
-      expect(textResult).to.contains(boApiClientsCreatePage.successfulCreationMessage);
-
-      const textMessage = await boApiClientsCreatePage.getAlertInfoBlockParagraphContent(page);
-      expect(textMessage).to.contains(boApiClientsCreatePage.apiClientGeneratedMessage);
-    });
-
-    it('should copy client secret', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'copyClientSecret', baseContext);
-
-      await boApiClientsCreatePage.copyClientSecret(page);
-
-      clientSecret = await boApiClientsCreatePage.getClipboardText(page);
-      expect(clientSecret.length).to.be.gt(0);
-    });
-
-    it('should request the endpoint /access_token', async function () {
+    it(`should request the endpoint /access_token with scope ${clientScope}`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'requestOauth2Token', baseContext);
-
-      const apiResponse = await apiContext.post('access_token', {
-        form: {
-          client_id: clientData.clientId,
-          client_secret: clientSecret,
-          grant_type: 'client_credentials',
-          scope: clientScope,
-        },
-      });
-      expect(apiResponse.status()).to.eq(200);
-      expect(utilsAPI.hasResponseHeader(apiResponse, 'Content-Type')).to.eq(true);
-      expect(utilsAPI.getResponseHeader(apiResponse, 'Content-Type')).to.contains('application/json');
-
-      const jsonResponse = await apiResponse.json();
-      expect(jsonResponse).to.have.property('access_token');
-      expect(jsonResponse.token_type).to.be.a('string');
-
-      accessToken = jsonResponse.access_token;
+      accessToken = await requestAccessToken(clientScope);
     });
   });
 
@@ -174,6 +89,16 @@ describe('API : GET /products', async () => {
   });
 
   describe('BackOffice : Expected data', async () => {
+    it('should login in BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+      await boLoginPage.goTo(page, global.BO.URL);
+      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+      const pageTitle = await boDashboardPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+    });
+
     it('should go to \'Catalog > Products\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToProductsPage', baseContext);
 
@@ -231,7 +156,4 @@ describe('API : GET /products', async () => {
       expect(numberOfProducts).to.be.above(0);
     });
   });
-
-  // Pre-condition: Create an API Client
-  deleteAPIClientTest(`${baseContext}_postTest`);
 });

--- a/tests/UI/commonTests/BO/advancedParameters/authServer.ts
+++ b/tests/UI/commonTests/BO/advancedParameters/authServer.ts
@@ -140,12 +140,12 @@ function deleteAPIClientTest(baseContext: string = 'commonTests-deleteAPIClientT
       expect(numberOfAPIClient).to.greaterThanOrEqual(0);
     });
 
-    it('should delete API Client', async function () {
+    it(`should delete API Client by clientId ${clientId}`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'deleteAPIClient', baseContext);
 
       const row = await boApiClientsPage.getNthRowByClientId(page, clientId);
-      expect(row).to.be.a('number');
-      expect(row).to.be.greaterThan(0, `Coudl not find API client with client ID "${clientId}"`);
+      expect(row).to.be.a('number', `Could not find API client with client ID "${clientId}"`);
+      expect(row).to.be.greaterThan(0, `Could not find API client with client ID "${clientId}"`);
 
       // @ts-ignore
       const textResult = await boApiClientsPage.deleteAPIClient(page, row);

--- a/tests/UI/commonTests/BO/advancedParameters/authServer.ts
+++ b/tests/UI/commonTests/BO/advancedParameters/authServer.ts
@@ -96,8 +96,9 @@ function createAPIClientTest(apiClient: FakerAPIClient, baseContext: string = 'c
 /**
  * Function to delete API Client
  * @param baseContext {string} String to identify the test
+ * @param clientId {string|null} Client ID of the APi client we want to remove, if empty the first row is used
  */
-function deleteAPIClientTest(baseContext: string = 'commonTests-deleteAPIClientTest'): void {
+function deleteAPIClientTest(baseContext: string = 'commonTests-deleteAPIClientTest', clientId: string|null = null): void {
   let browserContext: BrowserContext;
   let page: Page;
   let numberOfAPIClient: number = 0;
@@ -136,17 +137,28 @@ function deleteAPIClientTest(baseContext: string = 'commonTests-deleteAPIClientT
       expect(pageTitle).to.eq(boApiClientsPage.pageTitle);
 
       numberOfAPIClient = await boApiClientsPage.getNumberOfElementInGrid(page);
-      expect(numberOfAPIClient).to.gte(0);
+      expect(numberOfAPIClient).to.greaterThanOrEqual(0);
     });
 
     it('should delete API Client', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'deleteAPIClient', baseContext);
 
-      const textResult = await boApiClientsPage.deleteAPIClient(page, 1);
+      let row;
+
+      if (clientId) {
+        row = await boApiClientsPage.getNthRowByClientId(page, clientId);
+        expect(row).to.be.a('number');
+        expect(row).to.be.greaterThan(0, `Coudl not find API client with client ID "${clientId}"`);
+      } else {
+        row = 1;
+      }
+
+      // @ts-ignore
+      const textResult = await boApiClientsPage.deleteAPIClient(page, row);
       expect(textResult).to.equal(boApiClientsCreatePage.successfulDeleteMessage);
 
       const numElements = await boApiClientsPage.getNumberOfElementInGrid(page);
-      expect(numElements).to.equal(0);
+      expect(numElements).to.equal(numberOfAPIClient - 1);
     });
   });
 }

--- a/tests/UI/commonTests/BO/advancedParameters/authServer.ts
+++ b/tests/UI/commonTests/BO/advancedParameters/authServer.ts
@@ -96,9 +96,9 @@ function createAPIClientTest(apiClient: FakerAPIClient, baseContext: string = 'c
 /**
  * Function to delete API Client
  * @param baseContext {string} String to identify the test
- * @param clientId {string|null} Client ID of the APi client we want to remove, if empty the first row is used
+ * @param clientId {string} Client ID of the APi client we want to remove, if empty the first row is used
  */
-function deleteAPIClientTest(baseContext: string = 'commonTests-deleteAPIClientTest', clientId: string|null = null): void {
+function deleteAPIClientTest(baseContext: string = 'commonTests-deleteAPIClientTest', clientId: string = 'client-id'): void {
   let browserContext: BrowserContext;
   let page: Page;
   let numberOfAPIClient: number = 0;
@@ -143,15 +143,9 @@ function deleteAPIClientTest(baseContext: string = 'commonTests-deleteAPIClientT
     it('should delete API Client', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'deleteAPIClient', baseContext);
 
-      let row;
-
-      if (clientId) {
-        row = await boApiClientsPage.getNthRowByClientId(page, clientId);
-        expect(row).to.be.a('number');
-        expect(row).to.be.greaterThan(0, `Coudl not find API client with client ID "${clientId}"`);
-      } else {
-        row = 1;
-      }
+      const row = await boApiClientsPage.getNthRowByClientId(page, clientId);
+      expect(row).to.be.a('number');
+      expect(row).to.be.greaterThan(0, `Coudl not find API client with client ID "${clientId}"`);
 
       // @ts-ignore
       const textResult = await boApiClientsPage.deleteAPIClient(page, row);

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -418,7 +418,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#9da6b9dd560585ed62bf80c3c66eb1c66f91ed60",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#ecfcc4d5375299f55257be6d62aadfde02563d92",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^9.0.3",
@@ -7751,7 +7751,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#9da6b9dd560585ed62bf80c3c66eb1c66f91ed60",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#ecfcc4d5375299f55257be6d62aadfde02563d92",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^9.0.3",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Update api module and optimise API UI tests, the API client is created before the tests are run, its client ID and secret are passed by env variables so the campaign no longer need to create and delete an API client in each scenario
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/16886442201
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/ui-testing-library/pull/656 + https://github.com/PrestaShop/ui-testing-library/pull/657 + https://github.com/PrestaShop/ga.tests.ui.pr/pull/92
| Sponsor company   | ~


### Validation by UI tests

This PR requires some updates on the GA tests ui PR tool, done in this PR https://github.com/PrestaShop/ga.tests.ui.pr/pull/92

- here is an example of a full campaign (without cache) https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/16877343521
- here is an exemple with the alternative workflow with cache (less used these days but at least it won't be too late regarding this when we fix it) https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/16878789130

We need to validate and merge the PR on the GA tool, then we'll relaunch a full campaign just to be sure and validate this PR