### PR TITLE
Fix: using dev version of ps_apiresources

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "prestashop/hummingbird": "^1.0.1",
         "prestashop/pagesnotfound": "^2",
         "prestashop/productcomments": "^7.0",
-        "prestashop/ps_apiresources": "dev-delete-endpoints-command",
+        "prestashop/ps_apiresources": "dev-dev",
         "prestashop/ps_banner": "^2",
         "prestashop/ps_bestsellers": "^1.0",
         "prestashop/ps_brandlist": "^1.0",
@@ -212,7 +212,7 @@
         },
         "ps_apiresources": {
             "type": "vcs",
-            "url": "https://github.com/jolelievre/ps_apiresources"
+            "url": "https://github.com/PrestaShop/ps_apiresources"
         }
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cde67ab8b4884050caf8690edffac741",
+    "content-hash": "01030ac3c9fe67217e8b7682a6d3b099",
     "packages": [
         {
             "name": "api-platform/core",
@@ -5261,16 +5261,16 @@
         },
         {
             "name": "prestashop/ps_apiresources",
-            "version": "dev-delete-endpoints-command",
+            "version": "dev-dev",
             "source": {
                 "type": "git",
-                "url": "https://github.com/jolelievre/ps_apiresources.git",
-                "reference": "0387b2fb74801c2e6011fa84fb207d881b546afa"
+                "url": "https://github.com/PrestaShop/ps_apiresources.git",
+                "reference": "fbc3508fd0495dc16817a103afccb4d86186a819"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jolelievre/ps_apiresources/zipball/0387b2fb74801c2e6011fa84fb207d881b546afa",
-                "reference": "0387b2fb74801c2e6011fa84fb207d881b546afa",
+                "url": "https://api.github.com/repos/PrestaShop/ps_apiresources/zipball/fbc3508fd0495dc16817a103afccb4d86186a819",
+                "reference": "fbc3508fd0495dc16817a103afccb4d86186a819",
                 "shasum": ""
             },
             "require": {
@@ -5282,6 +5282,7 @@
                 "phpunit/phpunit": "^10",
                 "prestashop/php-dev-tools": "^4.3"
             },
+            "default-branch": true,
             "type": "prestashop-module",
             "autoload": {
                 "psr-4": {
@@ -5323,9 +5324,9 @@
             "description": "PrestaShop - API Resources",
             "homepage": "https://github.com/PrestaShop/ps_apiresources",
             "support": {
-                "source": "https://github.com/jolelievre/ps_apiresources/tree/delete-endpoints-command"
+                "source": "https://github.com/PrestaShop/ps_apiresources/tree/dev"
             },
-            "time": "2025-08-05T07:33:05+00:00"
+            "time": "2025-08-06T11:40:50+00:00"
         },
         {
             "name": "prestashop/ps_banner",

--- a/tests/UI/campaigns/functional/API/02_checkEndpoints.ts
+++ b/tests/UI/campaigns/functional/API/02_checkEndpoints.ts
@@ -97,6 +97,18 @@ describe('API : Check endpoints', async () => {
         '/api-client: POST',
         // tests/UI/campaigns/functional/API/02_endpoints/01_apiClient/06_getApiClients.ts
         '/api-clients: GET',
+        // todo: add tests
+        '/attributes/group/{attributeGroupId}: DELETE',
+        // todo: add tests
+        '/attributes/group/{attributeGroupId}: GET',
+        // todo: add tests
+        '/attributes/group/{attributeGroupId}: PATCH',
+        // todo: add tests
+        '/attributes/group: POST',
+        // todo: add tests
+        '/attributes/groups/delete: PUT',
+        // todo: add tests
+        '/attributes/groups: GET',
         // tests/UI/campaigns/functional/API/02_endpoints/02_customerGroup/01_deleteCustomerGroupsId.ts
         '/customers/group/{customerGroupId}: DELETE',
         // tests/UI/campaigns/functional/API/02_endpoints/02_customerGroup/02_getCustomerGroupsId.ts


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Since the merge of https://github.com/PrestaShop/ps_apiresources/pull/58, the branch is deleted on the VSC mention inside the composer.json. Composer install/update failed.
| Type?             | bug fix 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| UI tests | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/16808830667 |