### PR TITLE
BO : Titles : When editing, fetch dimensions of the image

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/title/title-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/title/title-map.ts
@@ -23,29 +23,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import TitleMap from './title-map';
-
-$(() => {
-  window.prestashop.component.initComponents(
-    [
-      'TranslatableInput',
-    ],
-  );
-
-  function onChangeImageInput() {
-    $(TitleMap.supplierImageHeight).prop('disabled', true);
-    $(TitleMap.supplierImageWidth).prop('disabled', true);
-    const inputfiles = $(TitleMap.supplierImage).prop('files');
-
-    if (inputfiles && inputfiles[0]) {
-      $(TitleMap.supplierImageHeight).prop('disabled', false);
-      $(TitleMap.supplierImageWidth).prop('disabled', false);
-    }
-  }
-
-  // On loading
-  onChangeImageInput();
-
-  // On events
-  $(TitleMap.supplierImage).on('change', () => onChangeImageInput());
-});
+export default {
+  supplierImage: '#title_image',
+  supplierImageWidth: '#title_img_width',
+  supplierImageHeight: '#title_img_height',
+};

--- a/src/Adapter/Title/QueryHandler/GetTitleForEditingHandler.php
+++ b/src/Adapter/Title/QueryHandler/GetTitleForEditingHandler.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
 use PrestaShop\PrestaShop\Core\Domain\Title\Query\GetTitleForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Title\QueryHandler\GetTitleForEditingHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Title\QueryResult\EditableTitle;
+use PrestaShop\PrestaShop\Core\Domain\Title\TitleSettings;
 
 /**
  * Handles command that gets title for editing
@@ -49,10 +50,18 @@ class GetTitleForEditingHandler extends AbstractTitleHandler implements GetTitle
     {
         $title = $this->titleRepository->get($query->getTitleId());
 
+        $titleImage = _PS_GENDERS_DIR_ . $query->getTitleId()->getValue() . '.jpg';
+        $titleWidth = $titleHeight = null;
+        if (file_exists($titleImage)) {
+            list($titleWidth, $titleHeight) = getimagesize($titleImage);
+        }
+
         return new EditableTitle(
             $query->getTitleId()->getValue(),
             $title->name,
-            (int) $title->type
+            (int) $title->type,
+            $titleWidth ?: TitleSettings::DEFAULT_IMAGE_WIDTH,
+            $titleHeight ?: TitleSettings::DEFAULT_IMAGE_HEIGHT
         );
     }
 }

--- a/src/Core/Domain/Title/QueryResult/EditableTitle.php
+++ b/src/Core/Domain/Title/QueryResult/EditableTitle.php
@@ -47,6 +47,10 @@ class EditableTitle
      */
     protected $gender;
 
+    protected int $width;
+
+    protected int $height;
+
     /**
      * @param int $titleId
      * @param array<string> $localizedNames
@@ -55,11 +59,15 @@ class EditableTitle
     public function __construct(
         int $titleId,
         array $localizedNames,
-        int $gender
+        int $gender,
+        int $width,
+        int $height
     ) {
         $this->titleId = $titleId;
         $this->localizedNames = $localizedNames;
         $this->gender = $gender;
+        $this->width = $width;
+        $this->height = $height;
     }
 
     /**
@@ -84,5 +92,15 @@ class EditableTitle
     public function getGender(): int
     {
         return $this->gender;
+    }
+
+    public function getHeight(): int
+    {
+        return $this->height;
+    }
+
+    public function getWidth(): int
+    {
+        return $this->width;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/TitleFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/TitleFormDataProvider.php
@@ -64,8 +64,8 @@ class TitleFormDataProvider implements FormDataProviderInterface
             'id' => $id,
             'name' => $result->getLocalizedNames(),
             'gender_type' => $result->getGender(),
-            'img_height' => TitleSettings::DEFAULT_IMAGE_HEIGHT,
-            'img_width' => TitleSettings::DEFAULT_IMAGE_WIDTH,
+            'img_height' => $result->getHeight(),
+            'img_width' => $result->getWidth(),
         ];
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | BO : Titles : When editing, fetch dimensions of the image & Disable dimensions input it there is no file in input file
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: & :arrow_down: 
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/16822894416
| Fixed issue or discussion?     | Fixes #30423
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

# How to test ?
* Open the BO
* Go to Shop Parameters > Customer Settings > Titles Page
* Add a title
* The width & height are disabled (and fill the default configuration value)
* Add a file
* The width & height are enabled
* You can change values
* Save
* Edit the title
* The width & height are your changed values but they are disabled
* Add a file
* You can change values