### PR TITLE
Fix: Cannot use newline in textarea on product page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
@@ -76,7 +76,16 @@ export default class ProductPartialUpdater {
    */
   private watch(): void {
     // Avoid submitting form when pressing Enter
-    this.$productForm.keypress((e) => e.which !== 13);
+    this.$productForm.keypress((event) => {
+      if (event.which === 13) {
+        const target = (event.target as HTMLElement);
+
+        // Allow Enter in textareas and contenteditable elements
+        if (target.tagName.toLocaleLowerCase() !== 'textarea' && !target.isContentEditable) {
+          event.preventDefault(); // Prevent form submit
+        }
+      }
+    });
     this.$productFormSubmitButton.prop('disabled', true);
     this.initialData = this.getFormDataAsObject();
     this.$productForm.submit(() => this.updatePartialForm());


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.2.x
| Description?      | See https://github.com/PrestaShop/PrestaShop/issues/39319
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install [issue39319.zip](https://github.com/user-attachments/files/21682077/issue39319.zip) - 2. Go to a product - 3. Scroll to the newly added textarea **Category diagram positions** - 4. Press Enter — this should create a new line.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/16886374966
| Fixed issue or discussion?     | Fixes #39319
| Related PRs       | 
| Sponsor company   | @Codencode 