### PR TITLE
Fix shipments "items"

### DIFF
--- a/src/Core/Grid/Query/ShipmentQueryBuilder.php
+++ b/src/Core/Grid/Query/ShipmentQueryBuilder.php
@@ -62,7 +62,7 @@ final class ShipmentQueryBuilder extends AbstractDoctrineQueryBuilder
                 's.id_order AS order_id',
                 'c.name AS carrier',
                 's.tracking_number',
-                'COUNT(sp.id_shipment_product) AS items',
+                'SUM(sp.quantity) AS items',
                 's.shipping_cost_tax_incl AS shipping_cost',
                 'SUM(od.product_weight * sp.quantity) AS weight',
             ])


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The "items" column of shipments does not behave correctly. It should return the total number of items, not the number of different products. The condition for the "split" tooltip to appear is also impacted.
| Type?             | bug fix 
| Category?         |  BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | -
| UI Tests          | -
| Fixed issue or discussion?     | fixes https://github.com/PrestaShop/PrestaShop/issues/39342
| Related PRs       | -
| Sponsor company   | -
