### PR TITLE
Add hook on rendertemplate in CheckoutStep

### DIFF
--- a/classes/checkout/AbstractCheckoutStep.php
+++ b/classes/checkout/AbstractCheckoutStep.php
@@ -86,6 +86,13 @@ abstract class AbstractCheckoutStepCore implements CheckoutStepInterface
             'step_is_current' => (int) $this->isCurrent(),
         ];
 
+        Hook::exec('actionCheckoutStepRenderTemplate', [
+            'template' => &$template,
+            'params' => &$params,
+            'extraParams' => &$extraParams,
+            'defaultParams' => &$defaultParams,
+        ]);
+
         $scope = $this->smarty->createData(
             $this->smarty
         );

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -2873,6 +2873,11 @@
       <title>Modify checkout process</title>
       <description>This hook is called when constructing the checkout process</description>
     </hook>
+    <hook id="actionCheckoutStepRenderTemplate">
+      <name>actionCheckoutStepRenderTemplate</name>
+      <title>Modify the parameters of the checkout step template rendering</title>
+      <description>This hook is called when rendering every checkout step template</description>
+    </hook>
     <hook id="actionPresentProductListing">
       <name>actionPresentProductListing</name>
       <title>Product Listing Presenter</title>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Add the actionCheckoutStepRenderTemplate hook to allow modification of params used to render template in checkout step, e.g. in DeliveryStep we can remove the delivery_option if no carrier selected to force the user to select an option and before that we can display the message "Shipping calculated at delivery step" in the theme files.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Register a new hook in your module, and modify some params.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       |  https://github.com/PrestaShop/PrestaShop/pull/39360 (Before Rebase)
| Autoupgrade PR | https://github.com/PrestaShop/autoupgrade/pull/1444
| Sponsor company   | Beyonds
