### PR TITLE
Bottleneck due to non-optimized function cleanConnectionsPages

### DIFF
--- a/classes/Connection.php
+++ b/classes/Connection.php
@@ -147,9 +147,6 @@ class ConnectionCore extends ObjectModel
 				ORDER BY `date_add` DESC';
         $result = Db::getInstance()->getRow($sql, false);
         if (empty($result['id_guest']) && (int) $cookie->id_guest) {
-            // The old connections details are removed from the database in order to spare some memory
-            Connection::cleanConnectionsPages();
-
             $referer = isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '';
             $arrayUrl = parse_url($referer);
             if (!isset($arrayUrl['host']) || preg_replace('/^www./', '', $arrayUrl['host']) == preg_replace('/^www./', '', Tools::getHttpHost(false, false))) {
@@ -198,30 +195,5 @@ class ConnectionCore extends ObjectModel
 		WHERE `id_connections` = ' . (int) $idConnections . '
 		AND `id_page` = ' . (int) $idPage . '
 		AND `time_start` = \'' . pSQL($timeStart) . '\'');
-    }
-
-    /**
-     * Clean connections page.
-     */
-    public static function cleanConnectionsPages()
-    {
-        $period = Configuration::get('PS_STATS_OLD_CONNECT_AUTO_CLEAN');
-
-        if ($period === 'week') {
-            $interval = '1 WEEK';
-        } elseif ($period === 'month') {
-            $interval = '1 MONTH';
-        } elseif ($period === 'year') {
-            $interval = '1 YEAR';
-        } else {
-            return;
-        }
-
-        if ($interval != null) {
-            // Records of connections details older than the beginning of the  specified interval are deleted
-            Db::getInstance()->execute('
-			DELETE FROM `' . _DB_PREFIX_ . 'connections_page`
-			WHERE time_start < LAST_DAY(DATE_SUB(NOW(), INTERVAL ' . $interval . '))');
-        }
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Like I wrote here #39365, this should be removed and make via cron. This is only partially solution, and totally wrong! If anyone enable this option, it make crazy DELETE sql query and it's totally bottleneck. It totally crash whole website/server, because it's very timeconsuming this type of query. This should be make more complex and via cron! Not "on the fly"... This should be removed for now and for future we must do it better. And not only ps_connections_page, but other similar statistics tables as well..
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Prepare eshop with a lot of traffic. Enable PS_STATS_OLD_CONNECT_AUTO_CLEAN to **any** value. Then you will see there will be DELETE FROM statement nearly for every query in process list.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | #39365 
| Sponsor company   | https://www.openservis.cz/
