### PR TITLE
Add new hooks actionCategoryProductsTotalBefore and actionCategoryProductsBefore

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -979,16 +979,40 @@ class CategoryCore extends ObjectModel
 
         /* Return only the number of products */
         if ($getTotal) {
-            $sql = 'SELECT COUNT(cp.`id_product`) AS total
-					FROM `' . _DB_PREFIX_ . 'product` p
-					' . Shop::addSqlAssociation('product', 'p') . '
-					LEFT JOIN `' . _DB_PREFIX_ . 'category_product` cp ON p.`id_product` = cp.`id_product`
-					WHERE cp.`id_category` = ' . (int) $this->id .
-                ($front ? ' AND product_shop.`visibility` IN ("both", "catalog")' : '') .
-                ($active ? ' AND product_shop.`active` = 1' : '') .
-                ($idSupplier ? ' AND p.id_supplier = ' . (int) $idSupplier : '');
+            $query = new DbQuery();
+            $query->select('COUNT(cp.`id_product`) AS total');
+            $query->from('product', 'p');
+            $query->join(
+                Shop::addSqlAssociation('product', 'p')
+            );
+            $query->leftJoin('category_product', 'cp', 'p.`id_product` = cp.`id_product`');
+            $query->where('cp.`id_category` = ' . (int) $this->id);
 
-            return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+            if ($front) {
+                $query->where('product_shop.`visibility` IN ("both", "catalog")');
+            }
+            if ($active) {
+                $query->where('product_shop.`active` = 1');
+            }
+            if ($idSupplier) {
+                $query->where('p.id_supplier = ' . (int) $idSupplier);
+            }
+
+            Hook::exec('actionCategoryProductsTotalBefore', [
+                'query' => $query,
+                'category' => $this,
+                'idLang' => $idLang,
+                'pageNumber' => $pageNumber,
+                'productPerPage' => $productPerPage,
+                'orderBy' => $orderBy,
+                'orderWay' => $orderWay,
+                'getTotal' => $getTotal,
+                'active' => $active,
+                'random' => $random,
+                'randomNumberProducts' => $randomNumberProducts
+            ]);
+
+            return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
         }
 
         if ($pageNumber < 1) {
@@ -1020,48 +1044,89 @@ class CategoryCore extends ObjectModel
             $nbDaysNewProduct = 20;
         }
 
-        $sql = 'SELECT p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) AS quantity' . (Combination::isFeatureActive() ? ', IFNULL(product_attribute_shop.id_product_attribute, 0) AS id_product_attribute,
-					product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity' : '') . ', pl.`description`, pl.`description_short`, pl.`available_now`,
-					pl.`available_later`, pl.`link_rewrite`, pl.`meta_description`, pl.`meta_title`, pl.`name`, image_shop.`id_image` id_image,
-					il.`legend` as legend, m.`name` AS manufacturer_name, cl.`name` AS category_default,
-					DATEDIFF(product_shop.`date_add`, DATE_SUB("' . date('Y-m-d') . ' 00:00:00",
-					INTERVAL ' . (int) $nbDaysNewProduct . ' DAY)) > 0 AS new, product_shop.price AS orderprice, psales.`quantity` as sales
-				FROM `' . _DB_PREFIX_ . 'category_product` cp
-				LEFT JOIN `' . _DB_PREFIX_ . 'product` p
-					ON p.`id_product` = cp.`id_product`
-				' . Shop::addSqlAssociation('product', 'p') .
-                (Combination::isFeatureActive() ? ' LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_shop` product_attribute_shop
-				ON (p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id . ')' : '') . '
-				' . Product::sqlStock('p', 0) . '
-				LEFT JOIN `' . _DB_PREFIX_ . 'category_lang` cl
-					ON (product_shop.`id_category_default` = cl.`id_category`
-					AND cl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('cl') . ')
-				LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl
-					ON (p.`id_product` = pl.`id_product`
-					AND pl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('pl') . ')
-				LEFT JOIN `' . _DB_PREFIX_ . 'image_shop` image_shop
-					ON (image_shop.`id_product` = p.`id_product` AND image_shop.cover=1 AND image_shop.id_shop=' . (int) $context->shop->id . ')
-				LEFT JOIN `' . _DB_PREFIX_ . 'image_lang` il
-					ON (image_shop.`id_image` = il.`id_image`
-					AND il.`id_lang` = ' . (int) $idLang . ')
-				LEFT JOIN `' . _DB_PREFIX_ . 'manufacturer` m
-					ON m.`id_manufacturer` = p.`id_manufacturer`
-                LEFT JOIN `' . _DB_PREFIX_ . 'product_sale` psales
-					ON psales.`id_product` = p.`id_product`
-				WHERE product_shop.`id_shop` = ' . (int) $context->shop->id . '
-					AND cp.`id_category` = ' . (int) $this->id
-                    . ($active ? ' AND product_shop.`active` = 1' : '')
-                    . ($front ? ' AND product_shop.`visibility` IN ("both", "catalog")' : '')
-                    . ($idSupplier ? ' AND p.id_supplier = ' . (int) $idSupplier : '');
-
+        $query = new DbQuery();
+        
+        // Build SELECT clause
+        $selectFields = 'p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) AS quantity';
+        if (Combination::isFeatureActive()) {
+            $selectFields .= ', IFNULL(product_attribute_shop.id_product_attribute, 0) AS id_product_attribute, product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity';
+        }
+        $selectFields .= ', pl.`description`, pl.`description_short`, pl.`available_now`, pl.`available_later`, pl.`link_rewrite`, pl.`meta_description`, pl.`meta_title`, pl.`name`, image_shop.`id_image` id_image, il.`legend` as legend, m.`name` AS manufacturer_name, cl.`name` AS category_default, DATEDIFF(product_shop.`date_add`, DATE_SUB("' . date('Y-m-d') . ' 00:00:00", INTERVAL ' . (int) $nbDaysNewProduct . ' DAY)) > 0 AS new, product_shop.price AS orderprice, psales.`quantity` as sales';
+        
+        $query->select($selectFields);
+        $query->from('category_product', 'cp');
+        $query->leftJoin('product', 'p', 'p.`id_product` = cp.`id_product`');
+        
+        // Add shop association
+        $query->join(Shop::addSqlAssociation('product', 'p'));
+        
+        // Add product attribute shop join if combinations are active
+        if (Combination::isFeatureActive()) {
+            $query->leftJoin('product_attribute_shop', 'product_attribute_shop', 'p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id);
+        }
+        
+        // Add stock join
+        $query->join(Product::sqlStock('p', 0));
+        
+        // Add category lang join
+        $query->leftJoin('category_lang', 'cl', 'product_shop.`id_category_default` = cl.`id_category` AND cl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('cl'));
+        
+        // Add product lang join
+        $query->leftJoin('product_lang', 'pl', 'p.`id_product` = pl.`id_product` AND pl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('pl'));
+        
+        // Add image shop join
+        $query->leftJoin('image_shop', 'image_shop', 'image_shop.`id_product` = p.`id_product` AND image_shop.cover=1 AND image_shop.id_shop=' . (int) $context->shop->id);
+        
+        // Add image lang join
+        $query->leftJoin('image_lang', 'il', 'image_shop.`id_image` = il.`id_image` AND il.`id_lang` = ' . (int) $idLang);
+        
+        // Add manufacturer join
+        $query->leftJoin('manufacturer', 'm', 'm.`id_manufacturer` = p.`id_manufacturer`');
+        
+        // Add product sale join
+        $query->leftJoin('product_sale', 'psales', 'psales.`id_product` = p.`id_product`');
+        
+        // Add WHERE conditions
+        $query->where('product_shop.`id_shop` = ' . (int) $context->shop->id);
+        $query->where('cp.`id_category` = ' . (int) $this->id);
+        
+        if ($active) {
+            $query->where('product_shop.`active` = 1');
+        }
+        
+        if ($front) {
+            $query->where('product_shop.`visibility` IN ("both", "catalog")');
+        }
+        
+        if ($idSupplier) {
+            $query->where('p.id_supplier = ' . (int) $idSupplier);
+        }
+        
+        // Add ORDER BY and LIMIT
         if ($random === true) {
-            $sql .= ' ORDER BY RAND() LIMIT ' . (int) $randomNumberProducts;
+            $query->orderBy('RAND()');
+            $query->limit((int) $randomNumberProducts);
         } elseif ($orderBy !== 'orderprice') {
-            $sql .= ' ORDER BY ' . (!empty($orderByPrefix) ? $orderByPrefix . '.' : '') . '`' . bqSQL($orderBy) . '` ' . pSQL($orderWay) . '
-			LIMIT ' . (((int) $pageNumber - 1) * (int) $productPerPage) . ',' . (int) $productPerPage;
+            $orderByField = (!empty($orderByPrefix) ? $orderByPrefix . '.' : '') . '`' . bqSQL($orderBy) . '`';
+            $query->orderBy($orderByField . ' ' . pSQL($orderWay));
+            $query->limit((int) $productPerPage, (((int) $pageNumber - 1) * (int) $productPerPage));
         }
 
-        $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql, true, false);
+        Hook::exec('actionCategoryProductsBefore', [
+            'query' => $query,
+            'category' => $this,
+            'idLang' => $idLang,
+            'pageNumber' => $pageNumber,
+            'productPerPage' => $productPerPage,
+            'orderBy' => $orderBy,
+            'orderWay' => $orderWay,
+            'getTotal' => $getTotal,
+            'active' => $active,
+            'random' => $random,
+            'randomNumberProducts' => $randomNumberProducts
+        ]);
+
+        $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query, true, false);
 
         if (!$result) {
             return [];

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1009,7 +1009,7 @@ class CategoryCore extends ObjectModel
                 'getTotal' => $getTotal,
                 'active' => $active,
                 'random' => $random,
-                'randomNumberProducts' => $randomNumberProducts
+                'randomNumberProducts' => $randomNumberProducts,
             ]);
 
             return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
@@ -1045,63 +1045,63 @@ class CategoryCore extends ObjectModel
         }
 
         $query = new DbQuery();
-        
+
         // Build SELECT clause
         $selectFields = 'p.*, product_shop.*, stock.out_of_stock, IFNULL(stock.quantity, 0) AS quantity';
         if (Combination::isFeatureActive()) {
             $selectFields .= ', IFNULL(product_attribute_shop.id_product_attribute, 0) AS id_product_attribute, product_attribute_shop.minimal_quantity AS product_attribute_minimal_quantity';
         }
         $selectFields .= ', pl.`description`, pl.`description_short`, pl.`available_now`, pl.`available_later`, pl.`link_rewrite`, pl.`meta_description`, pl.`meta_title`, pl.`name`, image_shop.`id_image` id_image, il.`legend` as legend, m.`name` AS manufacturer_name, cl.`name` AS category_default, DATEDIFF(product_shop.`date_add`, DATE_SUB("' . date('Y-m-d') . ' 00:00:00", INTERVAL ' . (int) $nbDaysNewProduct . ' DAY)) > 0 AS new, product_shop.price AS orderprice, psales.`quantity` as sales';
-        
+
         $query->select($selectFields);
         $query->from('category_product', 'cp');
         $query->leftJoin('product', 'p', 'p.`id_product` = cp.`id_product`');
-        
+
         // Add shop association
         $query->join(Shop::addSqlAssociation('product', 'p'));
-        
+
         // Add product attribute shop join if combinations are active
         if (Combination::isFeatureActive()) {
             $query->leftJoin('product_attribute_shop', 'product_attribute_shop', 'p.`id_product` = product_attribute_shop.`id_product` AND product_attribute_shop.`default_on` = 1 AND product_attribute_shop.id_shop=' . (int) $context->shop->id);
         }
-        
+
         // Add stock join
         $query->join(Product::sqlStock('p', 0));
-        
+
         // Add category lang join
         $query->leftJoin('category_lang', 'cl', 'product_shop.`id_category_default` = cl.`id_category` AND cl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('cl'));
-        
+
         // Add product lang join
         $query->leftJoin('product_lang', 'pl', 'p.`id_product` = pl.`id_product` AND pl.`id_lang` = ' . (int) $idLang . Shop::addSqlRestrictionOnLang('pl'));
-        
+
         // Add image shop join
         $query->leftJoin('image_shop', 'image_shop', 'image_shop.`id_product` = p.`id_product` AND image_shop.cover=1 AND image_shop.id_shop=' . (int) $context->shop->id);
-        
+
         // Add image lang join
         $query->leftJoin('image_lang', 'il', 'image_shop.`id_image` = il.`id_image` AND il.`id_lang` = ' . (int) $idLang);
-        
+
         // Add manufacturer join
         $query->leftJoin('manufacturer', 'm', 'm.`id_manufacturer` = p.`id_manufacturer`');
-        
+
         // Add product sale join
         $query->leftJoin('product_sale', 'psales', 'psales.`id_product` = p.`id_product`');
-        
+
         // Add WHERE conditions
         $query->where('product_shop.`id_shop` = ' . (int) $context->shop->id);
         $query->where('cp.`id_category` = ' . (int) $this->id);
-        
+
         if ($active) {
             $query->where('product_shop.`active` = 1');
         }
-        
+
         if ($front) {
             $query->where('product_shop.`visibility` IN ("both", "catalog")');
         }
-        
+
         if ($idSupplier) {
             $query->where('p.id_supplier = ' . (int) $idSupplier);
         }
-        
+
         // Add ORDER BY and LIMIT
         if ($random === true) {
             $query->orderBy('RAND()');
@@ -1109,7 +1109,7 @@ class CategoryCore extends ObjectModel
         } elseif ($orderBy !== 'orderprice') {
             $orderByField = (!empty($orderByPrefix) ? $orderByPrefix . '.' : '') . '`' . bqSQL($orderBy) . '`';
             $query->orderBy($orderByField . ' ' . pSQL($orderWay));
-            $query->limit((int) $productPerPage, (((int) $pageNumber - 1) * (int) $productPerPage));
+            $query->limit((int) $productPerPage, ((int) $pageNumber - 1) * (int) $productPerPage);
         }
 
         Hook::exec('actionCategoryProductsBefore', [
@@ -1123,7 +1123,7 @@ class CategoryCore extends ObjectModel
             'getTotal' => $getTotal,
             'active' => $active,
             'random' => $random,
-            'randomNumberProducts' => $randomNumberProducts
+            'randomNumberProducts' => $randomNumberProducts,
         ]);
 
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query, true, false);

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -5481,7 +5481,7 @@
     <hook id="actionCategoryProductsTotalBefore">
       <name>actionCategoryProductsTotalBefore</name>
       <title>Called before getting the total number of products in a category</title>
-      <description>Allows modules to modify the SQL query used to get the total number of products in a category.</description>
+      <description>Allows modules to modify the SQL query used to get the total number of products in a category. This hook works exclusively with the default product provider; if you are using ps_facetedsearch or another custom provider, this hook will not be triggered.</description>
     </hook>
     <hook id="actionCategoryProductsBefore">
       <name>actionCategoryProductsBefore</name>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -5478,5 +5478,15 @@
         <title>Called when configuring HTMLPurifier</title>
         <description>Allows modules to modify the HTMLPurifier definition by adding custom allowed HTML elements or attributes during Tools::purifyHTML().</description>
     </hook>
+    <hook id="actionCategoryProductsTotalBefore">
+      <name>actionCategoryProductsTotalBefore</name>
+      <title>Called before getting the total number of products in a category</title>
+      <description>Allows modules to modify the SQL query used to get the total number of products in a category.</description>
+    </hook>
+    <hook id="actionCategoryProductsBefore">
+      <name>actionCategoryProductsBefore</name>
+      <title>Called before getting the products in a category</title>
+      <description>Allows modules to modify the SQL query used to get the products in a category.</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -5486,7 +5486,7 @@
     <hook id="actionCategoryProductsBefore">
       <name>actionCategoryProductsBefore</name>
       <title>Called before getting the products in a category</title>
-      <description>Allows modules to modify the SQL query used to get the products in a category.</description>
+      <description>Allows modules to modify the SQL query used to get the products in a category. This hook works exclusively with the default product provider; if you are using ps_facetedsearch or another custom provider, this hook will not be triggered.</description>
     </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | **actionCategoryProductsTotalBefore**: Allows modules to modify the SQL query used to get the total number of products in a category. <br>**actionCategoryProductsBefore**: Allows modules to modify the SQL query used to get the products in a category. <br><br>In many customer stores, I had to override the Category::getProducts method to prevent products that are out of stock from being displayed. With these hooks, it will be possible to add a condition for quantity. I also rewrote the SQL to DbQuery so that modifications using Hook could be implemented in a safer way.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Register hooks in the module. <br>2. Make a modification in the query object (e.g., add "where" for products with quantity < 0 that should not be queried).<br>3. You must add this modification in both hooks so that the query from the number of products does not diverge from the query from the products themselves.<br>4. Reset the stock of one of the selected products. <br>5. Check if the product shows on its category.
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     |
| Related PRs       | 
| Sponsor company   | Arkonsoft
