### PR TITLE
Don't allow  delete default country

### DIFF
--- a/classes/Country.php
+++ b/classes/Country.php
@@ -120,6 +120,10 @@ class CountryCore extends ObjectModel
      */
     public function delete()
     {
+        if ((int) $this->id === (int) Configuration::get('PS_COUNTRY_DEFAULT')){
+            throw new PrestaShopException(sprintf('Default country "%s" cannot be deleted.', $this->iso_code));
+        }
+
         if (!parent::delete()) {
             return false;
         }

--- a/classes/Country.php
+++ b/classes/Country.php
@@ -120,7 +120,7 @@ class CountryCore extends ObjectModel
      */
     public function delete()
     {
-        if ((int) $this->id === (int) Configuration::get('PS_COUNTRY_DEFAULT')){
+        if ((int) $this->id === (int) Configuration::get('PS_COUNTRY_DEFAULT')) {
             throw new PrestaShopException(sprintf('Default country "%s" cannot be deleted.', $this->iso_code));
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | It is possible to delete the default country, but this generates an error.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See issue
| UI Tests          | https://github.com/Touxten/ga.tests.ui.pr/actions/runs/17036657515
| Fixed issue or discussion?     | Fixes [#38978](https://github.com/PrestaShop/PrestaShop/issues/38978)
| Related PRs       | 
| Sponsor company   | FOP
