### PR TITLE
Improve performance of admin notifications

### DIFF
--- a/admin-dev/themes/new-theme/js/notifications.ts
+++ b/admin-dev/themes/new-theme/js/notifications.ts
@@ -27,6 +27,9 @@ import GlobalMap from './global-map';
 
 const refreshNotifications = function (): void {
   let timer = null;
+  let nbOrders = 0;
+  let nbCustomers = 0;
+  let nbCustomerMessages = 0;
   const router = new Router();
 
   $.ajax({
@@ -38,11 +41,7 @@ const refreshNotifications = function (): void {
     dataType: 'json',
     success(json) {
       if (json && Object.keys(json).length > 0) {
-        var nbOrders = 0;
-        var nbCustomers = 0;
-        var nbCustomerMessages = 0;
-
-        if (json.hasOwnProperty('order')) {
+        if (Object.prototype.hasOwnProperty.call(json, 'order')) {
           nbOrders = parseInt(json.order.total, 10);
 
           fillTpl(
@@ -54,7 +53,7 @@ const refreshNotifications = function (): void {
           setNotificationsNumber('_nb_new_orders_', nbOrders);
         }
 
-        if (json.hasOwnProperty('customer')) {
+        if (Object.prototype.hasOwnProperty.call(json, 'customer')) {
           nbCustomers = parseInt(json.customer.total, 10);
 
           fillTpl(
@@ -66,7 +65,7 @@ const refreshNotifications = function (): void {
           setNotificationsNumber('_nb_new_customers_', nbCustomers);
         }
 
-        if (json.hasOwnProperty('customer_message')) {
+        if (Object.prototype.hasOwnProperty.call(json, 'customer_message')) {
           nbCustomerMessages = parseInt(json.customer_message.total, 10);
 
           fillTpl(

--- a/admin-dev/themes/new-theme/js/notifications.ts
+++ b/admin-dev/themes/new-theme/js/notifications.ts
@@ -37,31 +37,48 @@ const refreshNotifications = function (): void {
     cache: false,
     dataType: 'json',
     success(json) {
-      if (json) {
-        const nbOrders = parseInt(json.order.total, 10);
-        const nbCustomers = parseInt(json.customer.total, 10);
-        const nbCustomerMessages = parseInt(json.customer_message.total, 10);
+      if (json && Object.keys(json).length > 0) {
+        var nbOrders = 0;
+        var nbCustomers = 0;
+        var nbCustomerMessages = 0;
+
+        if (json.hasOwnProperty('order')) {
+          nbOrders = parseInt(json.order.total, 10);
+
+          fillTpl(
+            json.order.results,
+            $(GlobalMap.notifications.ordersNotifications),
+            $(GlobalMap.notifications.orderNotificationTemplate).html(),
+          );
+
+          setNotificationsNumber('_nb_new_orders_', nbOrders);
+        }
+
+        if (json.hasOwnProperty('customer')) {
+          nbCustomers = parseInt(json.customer.total, 10);
+
+          fillTpl(
+            json.customer.results,
+            $(GlobalMap.notifications.customersNotifications),
+            $(GlobalMap.notifications.customerNotificationTemplate).html(),
+          );
+
+          setNotificationsNumber('_nb_new_customers_', nbCustomers);
+        }
+
+        if (json.hasOwnProperty('customer_message')) {
+          nbCustomerMessages = parseInt(json.customer_message.total, 10);
+
+          fillTpl(
+            json.customer_message.results,
+            $(GlobalMap.notifications.messagesNotifications),
+            $(GlobalMap.notifications.messageNotificationTemplate).html(),
+          );
+          setNotificationsNumber('_nb_new_messages_', nbCustomerMessages);
+        }
+
         const notificationsTotal = nbOrders + nbCustomers + nbCustomerMessages;
 
-        fillTpl(
-          json.order.results,
-          $(GlobalMap.notifications.ordersNotifications),
-          $(GlobalMap.notifications.orderNotificationTemplate).html(),
-        );
-        fillTpl(
-          json.customer.results,
-          $(GlobalMap.notifications.customersNotifications),
-          $(GlobalMap.notifications.customerNotificationTemplate).html(),
-        );
-        fillTpl(
-          json.customer_message.results,
-          $(GlobalMap.notifications.messagesNotifications),
-          $(GlobalMap.notifications.messageNotificationTemplate).html(),
-        );
-
-        setNotificationsNumber('_nb_new_orders_', nbOrders);
-        setNotificationsNumber('_nb_new_customers_', nbCustomers);
-        setNotificationsNumber('_nb_new_messages_', nbCustomerMessages);
         if (notificationsTotal) {
           $(GlobalMap.notifications.total)
             .removeClass('hide')

--- a/classes/Notification.php
+++ b/classes/Notification.php
@@ -60,6 +60,39 @@ class NotificationCore
         return $notifications;
     }
 
+    public function getActiveLastElements(): array
+    {
+        $types = array_flip($this->types);
+
+        if (!(bool) Configuration::get('PS_SHOW_NEW_ORDERS')) {
+            unset($types['order']);
+        }
+        if (!(bool) Configuration::get('PS_SHOW_NEW_CUSTOMERS')) {
+            unset($types['customer']);
+        }
+        if (!(bool) Configuration::get('PS_SHOW_NEW_MESSAGES')) {
+            unset($types['customer_message']);
+        }
+
+        if (0 == count($types)) {
+            return [];
+        }
+
+        $notifications = [];
+        $employeeInfos = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow('
+        SELECT id_last_order, id_last_customer_message, id_last_customer
+        FROM `' . _DB_PREFIX_ . 'employee`
+        WHERE `id_employee` = ' . (int) Context::getContext()->employee->id);
+
+        $types = array_flip($types);
+
+        foreach ($types as $type) {
+            $notifications[$type] = Notification::getLastElementsIdsByType($type, $employeeInfos['id_last_' . $type]);
+        }
+
+        return $notifications;
+    }
+
     /**
      * getLastElementsIdsByType return all the element ids to show (order, customer registration, and customer message)
      * Get all the element ids.

--- a/classes/Notification.php
+++ b/classes/Notification.php
@@ -39,27 +39,6 @@ class NotificationCore
         $this->types = ['order', 'customer_message', 'customer'];
     }
 
-    /**
-     * getLastElements return all the notifications (new order, new customer registration, and new customer message)
-     * Get all the notifications.
-     *
-     * @return array containing the notifications
-     */
-    public function getLastElements()
-    {
-        $notifications = [];
-        $employeeInfos = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow('
-		SELECT id_last_order, id_last_customer_message, id_last_customer
-		FROM `' . _DB_PREFIX_ . 'employee`
-		WHERE `id_employee` = ' . (int) Context::getContext()->employee->id);
-
-        foreach ($this->types as $type) {
-            $notifications[$type] = Notification::getLastElementsIdsByType($type, $employeeInfos['id_last_' . $type]);
-        }
-
-        return $notifications;
-    }
-
     public function getActiveLastElements(): array
     {
         $types = array_flip($this->types);

--- a/classes/Notification.php
+++ b/classes/Notification.php
@@ -60,6 +60,12 @@ class NotificationCore
         return $notifications;
     }
 
+    /**
+     * getActiveLastElements returns all allowed notifications in the backoffice
+     * Get allowed notifications.
+     *
+     * @return array containing the notifications
+     */
     public function getActiveLastElements(): array
     {
         $types = array_flip($this->types);

--- a/classes/Notification.php
+++ b/classes/Notification.php
@@ -39,6 +39,27 @@ class NotificationCore
         $this->types = ['order', 'customer_message', 'customer'];
     }
 
+    /**
+     * getLastElements return all the notifications (new order, new customer registration, and new customer message)
+     * Get all the notifications.
+     *
+     * @return array containing the notifications
+     */
+    public function getLastElements()
+    {
+        $notifications = [];
+        $employeeInfos = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow('
+        SELECT id_last_order, id_last_customer_message, id_last_customer
+        FROM `' . _DB_PREFIX_ . 'employee`
+        WHERE `id_employee` = ' . (int) Context::getContext()->employee->id);
+
+        foreach ($this->types as $type) {
+            $notifications[$type] = Notification::getLastElementsIdsByType($type, $employeeInfos['id_last_' . $type]);
+        }
+
+        return $notifications;
+    }
+
     public function getActiveLastElements(): array
     {
         $types = array_flip($this->types);

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2691,7 +2691,12 @@ class AdminControllerCore extends Controller
                 $this->addJS(__PS_BASE_URI__ . $this->admin_webpath . '/themes/' . $this->bo_theme . '/js/help.js?v=' . _PS_VERSION_);
             }
 
-            if (!Tools::getValue('submitFormAjax')) {
+            if (!Tools::getValue('submitFormAjax')
+                && ((bool) Configuration::get('PS_SHOW_NEW_ORDERS') == true
+                    || (bool) Configuration::get('PS_SHOW_NEW_CUSTOMERS') == true
+                    || (bool) Configuration::get('PS_SHOW_NEW_MESSAGES') == true
+                )
+            ) {
                 $this->addJS(_PS_JS_DIR_ . 'admin/notifications.js?v=' . _PS_VERSION_);
             }
 

--- a/js/admin/notifications.js
+++ b/js/admin/notifications.js
@@ -116,16 +116,26 @@ function getPush() {
         return;
       }
 
-      // Add orders notifications to the list
-      renderNotifications('orders-notifications', json.order, renderOrderNotification);
+      var notifCount = 0;
 
-      // Add customers notifications to the list
-      renderNotifications('customers-notifications', json.customer, renderCustomerNotification);
+      if (json.hasOwnProperty('order')) {
+        // Add orders notifications to the list
+        renderNotifications('orders-notifications', json.order, renderOrderNotification);
+        notifCount += parseInt(json.order.total)
+      }
 
-      // Add messages notifications to the list
-      renderNotifications('messages-notifications', json.customer_message, renderMessageNotification);
+      if (json.hasOwnProperty('customer')) {
+        // Add customers notifications to the list
+        renderNotifications('customers-notifications', json.customer, renderCustomerNotification);
+        notifCount += parseInt(json.customer.total)
+      }
 
-      var notifCount = parseInt(json.order.total) + parseInt(json.customer.total) + parseInt(json.customer_message.total);
+      if (json.hasOwnProperty('customer_message')) {
+        // Add messages notifications to the list
+        renderNotifications('messages-notifications', json.customer_message, renderMessageNotification);
+        notifCount += parseInt(json.customer_message.total)
+      }
+
       if (notifCount > 0) {
         $("#total_notif_number_wrapper").removeClass('hide');
         $('#total_notif_value').text(notifCount);

--- a/src/Adapter/Notification/QueryHandler/GetNotificationLastElementsHandler.php
+++ b/src/Adapter/Notification/QueryHandler/GetNotificationLastElementsHandler.php
@@ -44,20 +44,6 @@ use PrestaShop\PrestaShop\Core\Domain\Notification\QueryResult\NotificationsResu
 final class GetNotificationLastElementsHandler implements GetNotificationLastElementsHandlerInterface
 {
     /**
-     * @var array
-     */
-    protected $configuration;
-
-    /**
-     * @param NotificationsConfiguration $notificationsConfiguration
-     */
-    public function __construct(
-        NotificationsConfiguration $notificationsConfiguration
-    ) {
-        $this->configuration = $notificationsConfiguration->getConfiguration();
-    }
-
-    /**
      * @param GetNotificationLastElements $query
      *
      * @return NotificationsResults
@@ -66,54 +52,32 @@ final class GetNotificationLastElementsHandler implements GetNotificationLastEle
      */
     public function handle(GetNotificationLastElements $query): NotificationsResults
     {
-        $elements = (new Notification())->getLastElements();
+        $elements = (new Notification())->getActiveLastElements();
         $results = [];
         foreach ($elements as $type => $notifications) {
             $notificationsResult = [];
-            $totalNotifications = 0;
-            if ($this->isDisplayed($type)) {
-                $totalNotifications = $notifications['total'];
-                foreach ($notifications['results'] as $notification) {
-                    $notificationsResult[] = new NotificationResult(
-                        $notification['id_order'],
-                        $notification['id_customer'],
-                        $notification['customer_name'],
-                        $notification['id_customer_message'],
-                        $notification['id_customer_thread'],
-                        $notification['customer_view_url'],
-                        $notification['total_paid'],
-                        $notification['carrier'],
-                        $notification['iso_code'],
-                        $notification['company'],
-                        $notification['status'],
-                        $notification['date_add'],
-                        $notification['customer_thread_view_url'],
-                        $notification['order_view_url']
-                    );
-                }
+            $totalNotifications = $notifications['total'];
+            foreach ($notifications['results'] as $notification) {
+                $notificationsResult[] = new NotificationResult(
+                    $notification['id_order'],
+                    $notification['id_customer'],
+                    $notification['customer_name'],
+                    $notification['id_customer_message'],
+                    $notification['id_customer_thread'],
+                    $notification['customer_view_url'],
+                    $notification['total_paid'],
+                    $notification['carrier'],
+                    $notification['iso_code'],
+                    $notification['company'],
+                    $notification['status'],
+                    $notification['date_add'],
+                    $notification['customer_thread_view_url'],
+                    $notification['order_view_url']
+                );
             }
             $results[] = new NotificationsResult($type, $totalNotifications, $notificationsResult);
         }
 
         return new NotificationsResults($results);
-    }
-
-    /**
-     * @param string $type
-     *
-     * @return bool
-     */
-    protected function isDisplayed(string $type): bool
-    {
-        switch ($type) {
-            case 'customer':
-                return $this->configuration['show_notifs_new_customers'] ?: false;
-            case 'customer_message':
-                return $this->configuration['show_notifs_new_messages'] ?: false;
-            case 'order':
-                return $this->configuration['show_notifs_new_orders'] ?: false;
-        }
-
-        return false;
     }
 }

--- a/src/Adapter/Notification/QueryHandler/GetNotificationLastElementsHandler.php
+++ b/src/Adapter/Notification/QueryHandler/GetNotificationLastElementsHandler.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Adapter\Notification\QueryHandler;
 
 use Notification;
-use PrestaShop\PrestaShop\Adapter\Admin\NotificationsConfiguration;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
 use PrestaShop\PrestaShop\Core\Domain\Notification\Query\GetNotificationLastElements;
 use PrestaShop\PrestaShop\Core\Domain\Notification\QueryHandler\GetNotificationLastElementsHandlerInterface;

--- a/src/PrestaShopBundle/Resources/config/services/adapter/notification.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/notification.yml
@@ -10,5 +10,3 @@ services:
   prestashop.adapter.notification.query_handler.get_notification_last_elements_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Notification\QueryHandler\GetNotificationLastElementsHandler'
     autoconfigure: true
-    arguments:
-      - '@prestashop.adapter.notifications.configuration'


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch           | develop
| Description | See below
| How to test | See below
| Type             | Improvement
| Category         | BO
| BC breaks        | No
| Deprecations     | No
| UI Tests              | 🟢  https://github.com/MattKelvin/ga.tests.ui.pr/actions/runs/17244695695
| Fixed issue or discussion?     | /
| Related PRs       | /
| Sponsor company   | Mademoiselle bio

**Description**

The issue

Currently, if you choose to disable admin notifications (new orders, customers, etc.), the related queries are still executed. On some shops, these queries can be time-consuming, so it’s better not to run them at all if notifications are disabled.

The improvements

- On legacy controllers, stop loading notification.js when no notifications are enabled
- Retrieve only the notifications that arae enabled in the configuration

**How to test**

- Recompile the admin assets
- In Notification.php, you can override `$employeeInfos` if needed:

```
$employeeInfos = [
  "id_last_order" => 0,
  "id_last_customer_message" => 0,
  "id_last_customer" => 0,
];
```

- In Administration, toggle the notification settings. Inspect the page and refresh: the /notifications request will only return the notifications that are enabled.
- On legacy controllers such as the dashboard, notification.js should not be loaded if no notifications are enabled.

Let me know what you think :)