### PR TITLE
Core: add type hints to GetCategoryForEditing query

### DIFF
--- a/src/Core/Domain/Category/Query/GetCategoryForEditing.php
+++ b/src/Core/Domain/Category/Query/GetCategoryForEditing.php
@@ -41,7 +41,7 @@ class GetCategoryForEditing
     /**
      * @param int $categoryId
      */
-    public function __construct($categoryId)
+    public function __construct(int $categoryId)
     {
         $this->categoryId = new CategoryId($categoryId);
     }
@@ -49,7 +49,7 @@ class GetCategoryForEditing
     /**
      * @return CategoryId
      */
-    public function getCategoryId()
+    public function getCategoryId(): CategoryId
     {
         return $this->categoryId;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR adds the missing type hints in the `GetCategoryForEditing` Domain class.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | @Codencode 
