### PR TITLE
Fix: Help is displayed two times

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
@@ -148,7 +148,6 @@
     <div class="w-100">{{- block('form_widget_simple') -}}</div>
     {{- block('form_unit') -}}
   </div>
-  {{ block('form_help') }}
 {%- endblock number_widget -%}
 
 {%- block integer_widget -%}
@@ -158,7 +157,6 @@
     {{- block('form_widget_simple') -}}
     {{- block('form_unit') -}}
   </div>
-  {{ block('form_help') }}
 {%- endblock integer_widget -%}
 
 {% block form_unit %}


### PR DESCRIPTION
Removed `{{ block('form_help') }}` from `number_widget` and `integer_widget`

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x 
| Description?      | When using symfony forms in a module, the help attribute is displayed two times for IntegerType and NumberType
| Type?             | bug fix
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install the module I posted [pr_39400.zip](https://github.com/user-attachments/files/21901013/pr_39400.zip) - 2. Go to the module configuration page - 3. Check the field description → it should be displayed only once, but it appears twice
| UI Tests          |https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/17127039189
| Fixed issue or discussion?     | Fixes #39392
| Related PRs       | 
| Sponsor company   | @Codencode 



### Without fix
<img width="634" height="327" alt="without-fix" src="https://github.com/user-attachments/assets/d2439db5-2b5c-41b5-ac42-a78700563283" />

---

### With fix
<img width="634" height="283" alt="wit-fix" src="https://github.com/user-attachments/assets/e5403630-314c-4c31-ab17-fd211ebf3800" />

