### PR TITLE
chore: Introduce ECS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -203,6 +203,7 @@
         "symfony/css-selector": "~6.4.0",
         "symfony/phpunit-bridge": "~6.4.0",
         "symfony/stopwatch": "~6.4.0",
+        "symplify/easy-coding-standard": "^12.5",
         "vincentlanglet/twig-cs-fixer": "^3.1"
     },
     "repositories": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "458b542e1b1c61f4b18ab656c7b483e5",
+    "content-hash": "17f476299d820e001c2ad020f3eff1c3",
     "packages": [
         {
             "name": "api-platform/core",
@@ -17906,6 +17906,67 @@
                 }
             ],
             "time": "2025-02-21T10:06:30+00:00"
+        },
+        {
+            "name": "symplify/easy-coding-standard",
+            "version": "12.5.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/easy-coding-standard/easy-coding-standard.git",
+                "reference": "4b90f2b6efed9508000968eac2397ac7aff34354"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/easy-coding-standard/easy-coding-standard/zipball/4b90f2b6efed9508000968eac2397ac7aff34354",
+                "reference": "4b90f2b6efed9508000968eac2397ac7aff34354",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "conflict": {
+                "friendsofphp/php-cs-fixer": "<3.46",
+                "phpcsstandards/php_codesniffer": "<3.8",
+                "symplify/coding-standard": "<12.1"
+            },
+            "suggest": {
+                "ext-dom": "Needed to support checkstyle output format in class CheckstyleOutputFormatter"
+            },
+            "bin": [
+                "bin/ecs"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Use Coding Standard with 0-knowledge of PHP-CS-Fixer and PHP_CodeSniffer",
+            "keywords": [
+                "Code style",
+                "automation",
+                "fixer",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/easy-coding-standard/easy-coding-standard/issues",
+                "source": "https://github.com/easy-coding-standard/easy-coding-standard/tree/12.5.24"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/rectorphp",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-21T06:57:14+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+
+return ECSConfig::configure()
+    ->withPaths([
+        // __DIR__ . '/admin-dev',
+        // __DIR__ . '/app',
+        // __DIR__ . '/classes',
+        // __DIR__ . '/config',
+        // __DIR__ . '/controllers',
+        // __DIR__ . '/install-dev',
+        __DIR__ . '/src',
+        // __DIR__ . '/tests',
+        // __DIR__ . '/tools',
+        // __DIR__ . '/webservice',
+    ])
+
+    ->withRules([
+        NoUnusedImportsFixer::class,
+    ])
+
+    // add sets - group of rules, from easiest to more complex ones
+    // uncomment one, apply one, commit, PR, merge and repeat
+    //->withPreparedSets(
+    //      spaces: true,
+    //      namespaces: true,
+    //      docblocks: true,
+    //      arrays: true,
+    //      comments: true,
+    //)
+;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR introduce ECS as a new Coding Standard. ECS combines PHP-CS-Fixer & PHP_CodeSniffer rules in one configuration and it a lot extensible.<br>The last ECS version 12 introduced incremental changes opening a room to improve code little by little with the PHP 8.1-level upgrades, and others in combinaison with Rector.<br>By the way, ECS is a lot faster and it could help CI / DX.<br>See https://tomasvotruba.com/blog/zen-config-in-ecs
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Update dependencies using composer install and run `vendor/bin/ecs`
| UI Tests          | https://github.com/tyloo/ga.tests.ui.pr/actions/runs/17101983883
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
