### PR TITLE
Allow filtering module list for translation export

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportCataloguesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportCataloguesType.php
@@ -119,6 +119,7 @@ class ExportCataloguesType extends TranslatorAwareType
                 'choices' => $this->moduleChoices,
                 'label' => false,
                 'multiple' => false,
+                'autocomplete' => true,
             ],
         ]);
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/RadioWithChoiceChildrenType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/RadioWithChoiceChildrenType.php
@@ -57,6 +57,7 @@ class RadioWithChoiceChildrenType extends AbstractType
                 'row_attr' => [
                     'class' => 'export-translations-child',
                 ],
+                'autocomplete' => $childChoice['autocomplete'] ?? false,
                 'choices' => $childChoice['choices'],
                 'choice_attr' => $childChoiceAttr,
                 'expanded' => $childChoice['multiple'], // same value as multiple. We can only have Select or Checkboxes


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x 
| Description?      | List of modules to export translations from is now searchable
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to International -> Translations, see that you can filter out the list of modules to export translations from
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/17109753810
| Fixed issue or discussion?     | n/a
| Related PRs       | n/a
| Sponsor company   | impSolutions
