### PR TITLE
Display full history time

### DIFF
--- a/src/Adapter/Presenter/Order/OrderLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderLazyArray.php
@@ -299,7 +299,7 @@ class OrderLazyArray extends AbstractLazyArray
                 $historyId = 'current';
             }
             $orderHistory[$historyId] = $history;
-            $orderHistory[$historyId]['history_date'] = Tools::displayDate($history['date_add'], false);
+            $orderHistory[$historyId]['history_date'] = Tools::displayDate($history['date_add'], true);
             $orderHistory[$historyId]['contrast'] = (new ColorBrightnessCalculator())->isBright($history['color']) ? 'dark' : 'bright';
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | I had my clients request this and it's actually a nice point. The timestamps on order tracking should include the times of history. When you have several history changes on a single day, date is not enough.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No need
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/17124360759
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### Before
![before](https://github.com/user-attachments/assets/f696fd27-9056-4611-afaf-f952b4f8ff94)

### After
![after](https://github.com/user-attachments/assets/dd5d29ca-f1f0-49e7-b876-f2e25c470d45)

