### PR TITLE
Update CancelProductType to display only refundable quantities as available quantity to refund

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CancelProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CancelProductType.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Sell\Order;
 
 use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderProductForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\VoucherRefundType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -44,6 +45,7 @@ class CancelProductType extends TranslatorAwareType
         $taxMethod = $options['data']['taxMethod'];
         $precision = $options['data']['precision'];
 
+        /** @var OrderProductForViewing $product */
         foreach ($products as $product) {
             $builder
                 ->add('selected_' . $product->getOrderDetailId(), CheckboxType::class,
@@ -62,7 +64,7 @@ class CancelProductType extends TranslatorAwareType
                     'required' => false,
                     'data' => 0,
                     'scale' => 0,
-                    'unit' => '/ ' . $product->getQuantity(),
+                    'unit' => '/ ' . $product->getQuantityRefundable(),
                 ])
                 ->add('amount_' . $product->getOrderDetailId(), TextType::class, [
                     'attr' => ['max' => $product->getTotalPrice(), 'class' => 'refund-amount'],


### PR DESCRIPTION
Hello!

This PR is same as https://github.com/PrestaShop/PrestaShop/pull/39387 recreated with the 9.0.x target.



| Questions         | Answers
| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | In the partial refund form, the label for the available quantity to refund was incorrectly displaying the total ordered quantity instead of the remaining refundable quantity. This PR corrects the displayed value to only show the quantity that is actually available for refund (ordered quantity minus already refunded quantity).
| Type?             | Bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create an order with a product that has a quantity of 3. <br> 2. Go to the order page in the Back Office. <br> 3. Perform a partial refund for 1 unit of that product. <br> 4. Go back to the order page and attempt another partial refund. <br> 5. **Before this fix:** The form would incorrectly show that 3 units are available for refund. <br> 6. **After this fix:** The form now correctly shows that only 2 units are available for refund. <br> *Note: This was a display issue only. The backend validation already correctly prevented refunding more than the available quantity [here](https://github.com/PrestaShop/PrestaShop/blob/develop/src/Adapter/Order/CommandHandler/CancelOrderProductHandler.php#L184).*
| UI Tests          | :green_circle:  https://github.com/Touxten/ga.tests.ui.pr/actions/runs/17125528087
| Fixed issue or discussion?     | n/a
| Related PRs       | n/a
| Sponsor company   | e-frogg




Thank you for your review!
