### PR TITLE
BO: Fix texture field not displaying for new color attribute groups

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/attribute/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/attribute/form/index.ts
@@ -44,9 +44,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const attributeTextureRow = document.querySelector(AttributeFormMap.attributeTextureFormRow) as HTMLElement | null;
   const attributeGroupSelectValue = (attributeGroupSelect as HTMLInputElement | null)?.value;
 
+  // Get color group IDs from data attribute
+  const colorGroupIds = getColorGroupIds(attributeGroupSelect);
+
   const toggleDisplay = (value: string | null) => {
     if (attributeColorRow && attributeTextureRow) {
-      const displayValue = value === '2' ? 'flex' : 'none';
+      const isColorGroup = value !== null && colorGroupIds.includes(value);
+      const displayValue = isColorGroup ? 'flex' : 'none';
       attributeColorRow.style.display = displayValue;
       attributeTextureRow.style.display = displayValue;
     }
@@ -64,3 +68,24 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 });
+
+/**
+ * Get array of color group IDs from the select element's data attribute
+ */
+function getColorGroupIds(selectElement: HTMLInputElement | null): string[] {
+  if (!selectElement) {
+    return [];
+  }
+  
+  const dataColorGroups = selectElement.dataset.colorGroups;
+  if (!dataColorGroups) {
+    return [];
+  }
+  
+  try {
+    return JSON.parse(dataColorGroups);
+  } catch (e) {
+    console.error('Error parsing color groups data:', e);
+    return [];
+  }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/Catalog/AttributeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Catalog/AttributeType.php
@@ -74,8 +74,9 @@ class AttributeType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $attributeGroupId = $options['attribute_group'];
-
+        $attributeGroup = null;
         $hasAttributeGroupId = false;
+
         if (0 < $attributeGroupId) {
             $attributeGroup = $this->attributeGroupRepository->get(
                 new AttributeGroupId($attributeGroupId)
@@ -92,6 +93,9 @@ class AttributeType extends TranslatorAwareType
                     new LanguageId($this->languageContext->getId())
                 ),
                 'data' => ($hasAttributeGroupId ? $attributeGroupId : ''),
+                'attr' => [
+                    'data-color-groups' => json_encode($this->getColorGroupIds())
+                ],
             ])
             ->add('name', TranslatableType::class, [
                 'type' => TextType::class,
@@ -106,21 +110,19 @@ class AttributeType extends TranslatorAwareType
                 'help' => $this->trans('Your internal name for this attribute.', 'Admin.Catalog.Help')
                     . '&nbsp;' . $this->trans('Invalid characters:', 'Admin.Notifications.Info')
                     . ' ' . TypedRegexValidator::CATALOG_CHARS,
-            ])
-            ->add('color', ColorType::class, [
-                'label' => $this->trans('Color', 'Admin.Global'),
-                'row_attr' => [
-                    'class' => 'js-attribute-type-color-form-row',
-                ],
-                'required' => false,
-            ])
-            ->add('texture', FileType::class, [
-                'label' => $this->trans('Texture', 'Admin.Global'),
-                'row_attr' => [
-                    'class' => 'js-attribute-type-texture-form-row',
-                ],
-                'required' => false,
             ]);
+
+        if ($hasAttributeGroupId && $attributeGroup !== null && $attributeGroup->group_type === 'color') {
+            $builder
+                ->add('color', ColorType::class, [
+                    'label' => $this->trans('Color', 'Admin.Global'),
+                    'required' => false,
+                ])
+                ->add('texture', FileType::class, [
+                    'label' => $this->trans('Texture', 'Admin.Global'),
+                    'required' => false,
+                ]);
+        }
 
         if ($this->multistoreFeature->isUsed()) {
             $builder->add('shop_association', ShopChoiceTreeType::class, [
@@ -165,5 +167,23 @@ class AttributeType extends TranslatorAwareType
         }
 
         return $return;
+    }
+
+    /**
+     * Get array of attribute group IDs that are of type 'color'
+     */
+    private function getColorGroupIds(): array
+    {
+        $shopConstraint = ShopConstraint::shop($this->shopContext->getId());
+        $groups = $this->attributeGroupRepository->getAttributeGroups($shopConstraint);
+        
+        $colorGroupIds = [];
+        foreach ($groups as $group) {
+            if ($group->group_type === 'color') {
+                $colorGroupIds[] = (string) $group->id;
+            }
+        }
+        
+        return $colorGroupIds;
     }
 }


### PR DESCRIPTION
| Questions | Answers |
| :--- | :--- |
| **Branch?** | `9.0.x` |
| **Description?** | This PR fixes a bug in the Back Office where the "Texture" file upload field was not displayed when creating an attribute value for a newly created group of type "Color or Texture". <br><br> The root cause is a client-side JavaScript issue that incorrectly hides the form fields. This fix addresses the problem on the server-side by conditionally adding the `color` and `texture` fields in the `AttributeType.php` form builder **only** when the parent attribute group's type is `color`. This bypasses the faulty JavaScript and ensures the expected behavior. |
| **Type?** | `bug fix` |
| **Category?** | `BO` (Back Office) |
| **BC breaks?** | `no` |
| **Deprecations?** | `no` |
| **How to test?** | 1. Go to **Sell > Catalog > Attributes & Features**. <br> 2. Create a new **Attribute Group**. <br> 3. Name it (e.g., "Custom Logos") and select the type **"Color or Texture"**. Save it. <br> 4. Enter the newly created group and click **"Add new value"**. <br> 5. **Verify the bug:** Before this PR, the "Color" and "Texture" fields are missing. <br> 6. **Apply this PR.** <br> 7. Repeat step 4. <br> 8. **Verify the fix:** The form now correctly displays the "Color" and "Texture" fields. |
| **UI Tests** | |
| **Fixed issue or discussion?** | None. This PR includes the full description and steps to reproduce the bug. |
| **Related PRs** | None. |
| **Sponsor company** |  |
