### PR TITLE
Update CSSJanus to wikimedia/cssjanus

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         "bjeavons/zxcvbn-php": "^1.4",
         "composer/ca-bundle": "^1.0",
         "composer/installers": "^2.2.0",
-        "cssjanus/cssjanus": "^2.0",
         "curl/curl": "^2.3.2",
         "defuse/php-encryption": "^2.3.1",
         "doctrine/cache": "^2.0",
@@ -186,7 +185,8 @@
         "tijsverkoyen/css-to-inline-styles": "^2.2",
         "twig/extra-bundle": "^3.6",
         "twig/string-extra": "^3.6",
-        "twig/twig": "^3.0"
+        "twig/twig": "^3.0",
+        "wikimedia/cssjanus": "^2.0"
     },
     "require-dev": {
         "behat/behat": "^3.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "01030ac3c9fe67217e8b7682a6d3b099",
+    "content-hash": "458b542e1b1c61f4b18ab656c7b483e5",
     "packages": [
         {
             "name": "api-platform/core",
@@ -631,57 +631,6 @@
                 }
             ],
             "time": "2024-05-27T13:40:54+00:00"
-        },
-        {
-            "name": "cssjanus/cssjanus",
-            "version": "v2.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wikimedia/php-cssjanus.git",
-                "reference": "befd1eb7b1e70ee2cd71cd5b9a86ff250d2e8423"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/php-cssjanus/zipball/befd1eb7b1e70ee2cd71cd5b9a86ff250d2e8423",
-                "reference": "befd1eb7b1e70ee2cd71cd5b9a86ff250d2e8423",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4.0"
-            },
-            "require-dev": {
-                "mediawiki/mediawiki-phan-config": "0.12.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.0",
-                "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "^3.6.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Roan Kattouw"
-                },
-                {
-                    "name": "Trevor Parscal"
-                },
-                {
-                    "name": "Timo Tijhof"
-                }
-            ],
-            "description": "Convert CSS stylesheets between left-to-right and right-to-left.",
-            "homepage": "https://www.mediawiki.org/wiki/CSSJanus",
-            "support": {
-                "source": "https://github.com/wikimedia/php-cssjanus/tree/v2.1.1"
-            },
-            "time": "2023-01-08T17:45:35+00:00"
         },
         {
             "name": "curl/curl",
@@ -14447,6 +14396,57 @@
                 }
             ],
             "time": "2025-02-13T08:34:43+00:00"
+        },
+        {
+            "name": "wikimedia/cssjanus",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/php-cssjanus.git",
+                "reference": "c5868a543c466c994ba5bf9b3297e150105ab803"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/php-cssjanus/zipball/c5868a543c466c994ba5bf9b3297e150105ab803",
+                "reference": "c5868a543c466c994ba5bf9b3297e150105ab803",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "require-dev": {
+                "mediawiki/mediawiki-codesniffer": "43.0.0",
+                "mediawiki/mediawiki-phan-config": "0.14.0",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpunit/phpunit": "9.6.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Roan Kattouw"
+                },
+                {
+                    "name": "Trevor Parscal"
+                },
+                {
+                    "name": "Timo Tijhof"
+                }
+            ],
+            "description": "Convert CSS stylesheets between left-to-right and right-to-left.",
+            "homepage": "https://www.mediawiki.org/wiki/CSSJanus",
+            "support": {
+                "source": "https://github.com/wikimedia/php-cssjanus/tree/v2.3.0"
+            },
+            "time": "2024-08-06T19:37:16+00:00"
         },
         {
             "name": "willdurand/jsonp-callback-validator",


### PR DESCRIPTION
Ref https://packagist.org/packages/cssjanus/cssjanus
Ref https://packagist.org/packages/wikimedia/cssjanus

Same repo, same project, same versions and complete history available. I've ran `composer install` which updates the lock file to 2.3.0, which contains minor improvements. See also https://github.com/wikimedia/php-cssjanus/blob/master/CHANGELOG.md and https://github.com/PrestaShop/PrestaShop/pull/32873.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Update from deprecated `cssjanus/cssjanus` package, to the renamed `wikimedia/cssjanus`.
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Ui Tests    | https://github.com/Touxten/ga.tests.ui.pr/actions/runs/17207672870
| How to test?      | Existing CI coverage.