### PR TITLE
Allow specials characters in search

### DIFF
--- a/tests/Integration/Classes/SearchTest.php
+++ b/tests/Integration/Classes/SearchTest.php
@@ -52,6 +52,16 @@ class SearchTest extends TestCase
                 'langId' => 1,
                 'expected' => ['test'],
             ],
+            'with special characters' => [
+                'input' => '&&',
+                'langId' => 1,
+                'expected' => [''],
+            ],
+            'with special characters (allowed)' => [
+                'input' => 'test t&t',
+                'langId' => 1,
+                'expected' => ['test', 't&t'],
+            ],
             'with hyphen' => [
                 'input' => 'test1-test2',
                 'langId' => 1,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| UI Tests          | https://github.com/MattKelvin/ga.tests.ui.pr/actions/runs/17260529824
| Fixed issue or discussion?     | Fixes #26020, Fixes #36044 
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/28444/files
| Sponsor company   | Mademoiselle bio

I think currently we are too restrictive with special chars in search.

Currently: we remove all special chars.
In this PR: we remove only terms made of special chars.

This allows us to keep query words such as "B&W" or "C'est"

There is another PR on this topic (#28444). Mine is a bit different, so I’ll let you judge :)

How to test : 

- On _develop_ edit a product and add "B&W" in the name
- Reindex the catalog
- Search "B&W" => Nothing
- Switch on this branch
- Search "B&W" => The product should be found