### PR TITLE
Set default level of prestashop.handler.log to WARNING instead of DEBUG to prevent ps_log population

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -73,6 +73,7 @@ services:
     class: PrestaShopBundle\Service\Log\LogHandler
     arguments:
       - "@service_container"
+      - !php/const Monolog\Logger::WARNING
 
   # CSRF/XSS additional protection middleware
   PrestaShopBundle\Service\DataProvider\UserProvider:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | In Monolog 2.10 the handler is pushed directly and this became visible so set default level of prestashop.handler.log to WARNING instead of DEBUG.
This PR sets `$level = Logger::WARNING` in the service definition so only meaningful records are stored.
Integrators can still override this via DI if needed.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Visit Performance->Logs and no DEBUG logs should appear.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/36446
| Related PRs       |
| Sponsor company   |
