### PR TITLE
Fix comparison of AmountImmutable objects when applying discounts

### DIFF
--- a/src/Core/Cart/AmountImmutable.php
+++ b/src/Core/Cart/AmountImmutable.php
@@ -119,4 +119,10 @@ class AmountImmutable
             $this->getTaxExcluded() - $amount->getTaxExcluded()
         );
     }
+
+    public function isGreaterThan(AmountImmutable $allowedMaxDiscount): bool
+    {
+        return $this->getTaxIncluded() > $allowedMaxDiscount->getTaxIncluded()
+            || $this->getTaxExcluded() > $allowedMaxDiscount->getTaxExcluded();
+    }
 }

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -249,7 +249,7 @@ class Calculator
             $allowedMaxDiscount = $allowedMaxDiscount->add($shippingDiscount);
         }
         // discount cannot be above total cart price
-        if ($amount > $allowedMaxDiscount) {
+        if ($amount->isGreaterThan($allowedMaxDiscount)) {
             $amount = $allowedMaxDiscount;
         }
 

--- a/tests/Unit/Core/Cart/AmountImmutableTest.php
+++ b/tests/Unit/Core/Cart/AmountImmutableTest.php
@@ -75,4 +75,68 @@ class AmountImmutableTest extends TestCase
         $this->assertEquals(2.5, $amount2->getTaxIncluded());
         $this->assertEquals(3.7, $amount2->getTaxExcluded());
     }
+
+    public function testIsGreaterThanWhenBothValuesAreGreater(): void
+    {
+        $amount1 = new AmountImmutable(10.0, 8.0);
+        $amount2 = new AmountImmutable(5.0, 4.0);
+
+        $this->assertTrue($amount1->isGreaterThan($amount2));
+    }
+
+    public function testIsGreaterThanWhenOnlyTaxIncludedIsGreater(): void
+    {
+        $amount1 = new AmountImmutable(10.0, 3.0);
+        $amount2 = new AmountImmutable(5.0, 8.0);
+
+        $this->assertTrue($amount1->isGreaterThan($amount2));
+    }
+
+    public function testIsGreaterThanWhenOnlyTaxExcludedIsGreater(): void
+    {
+        $amount1 = new AmountImmutable(3.0, 10.0);
+        $amount2 = new AmountImmutable(5.0, 4.0);
+
+        $this->assertTrue($amount1->isGreaterThan($amount2));
+    }
+
+    public function testIsGreaterThanWhenBothValuesAreLess(): void
+    {
+        $amount1 = new AmountImmutable(3.0, 2.0);
+        $amount2 = new AmountImmutable(5.0, 4.0);
+
+        $this->assertFalse($amount1->isGreaterThan($amount2));
+    }
+
+    public function testIsGreaterThanWhenBothValuesAreEqual(): void
+    {
+        $amount1 = new AmountImmutable(5.0, 4.0);
+        $amount2 = new AmountImmutable(5.0, 4.0);
+
+        $this->assertFalse($amount1->isGreaterThan($amount2));
+    }
+
+    public function testIsGreaterThanWithZeroValues(): void
+    {
+        $amount1 = new AmountImmutable(0.0, 0.0);
+        $amount2 = new AmountImmutable(0.0, 0.0);
+
+        $this->assertFalse($amount1->isGreaterThan($amount2));
+    }
+
+    public function testIsGreaterThanWithNegativeValues(): void
+    {
+        $amount1 = new AmountImmutable(-5.0, -3.0);
+        $amount2 = new AmountImmutable(-10.0, -8.0);
+
+        $this->assertTrue($amount1->isGreaterThan($amount2));
+    }
+
+    public function testIsGreaterThanWithMixedPositiveNegative(): void
+    {
+        $amount1 = new AmountImmutable(5.0, -3.0);
+        $amount2 = new AmountImmutable(-2.0, 4.0);
+
+        $this->assertTrue($amount1->isGreaterThan($amount2));
+    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This bug causes the total amount to potentially become negative when applying a discount.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Steps to reproduce below
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | Fixes #{issue number here}, Fixes #{another issue number here}, Fixes https://github.com/PrestaShop/PrestaShop/discussions/ {discussion number here}
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | COFIS CZ, s.r.o.

We cannot directly compare two AmountImmutable objects.
This bug causes the total amount to potentially become negative when applying a discount.

Specifically, the issue occurs when applying a 100% discount:

The check fails (comparison always returns false)
As a result, order completion ends with a 500 error because a negative value is written into $order->total_paid_tax_excl.
This PR fixes the comparison so that discounts are applied correctly without resulting in negative totals.

**Expected behavior**
When applying a discount, including a 100% discount:

- The comparison between AmountImmutable objects works correctly
- The order total never becomes negative
- The checkout process completes successfully without triggering a 500 error
- $order->total_paid_tax_excl contains 0 (for 100% discount) or the correct non-negative amount

**Steps to reproduce**

1. Add a product with a price including decimals in the tax-excluded price (e.g. 10.50 without tax)
2. Add this product to the cart
3. Create and apply a 100% discount voucher to the cart
4. Proceed to checkout and try to complete the order