### PR TITLE
Allow to use static db prefix during installation

### DIFF
--- a/install-dev/controllers/http/database.php
+++ b/install-dev/controllers/http/database.php
@@ -226,6 +226,11 @@ class InstallControllerHttpDatabase extends InstallControllerHttp implements Htt
             $this->smtp_port = $this->session->smtp_port;
         }
 
+        $staticPrefix = defined('_PS_INSTALLER_STATIC_DB_PREFIX_') ? _PS_INSTALLER_STATIC_DB_PREFIX_ : null;
+        if (is_string($staticPrefix) && $staticPrefix !== '') {
+            $this->database_prefix = rtrim($staticPrefix, '_') . '_';
+        }
+
         $this->displayContent('database');
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | It's just for devs. Allow the use of a static (but still custom) prefix during the web-based installation. It is useful for the local environment when I do not want to use the CLI command to install PrestaShop, yet I still need to keep a database for test purposes. W/o this option, clearing previously populated database tables during the installation is impossible.
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Indicate how to verify that this change works as expected.
| UI Tests          | not needed
| Fixed issue or discussion?     | n/a
| Related PRs       | n/a
| Sponsor company   | impSolutions
