### PR TITLE
Propagate auth header

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2207,9 +2207,14 @@ class ToolsCore
             }
         }
 
-        if (Configuration::get('PS_WEBSERVICE_CGI_HOST')) {
-            fwrite($write_fd, "RewriteCond %{HTTP:Authorization} ^(.*)\nRewriteRule . - [E=HTTP_AUTHORIZATION:%1]\n\n");
-        }
+        /*
+         * Propagate authorization header to PHP that is normally removed by Apache.
+         * In the past, it was passed only if PS_WEBSERVICE_CGI_HOST was enabled,
+         * but today, there is no reason not to pass it.
+         */
+        fwrite($write_fd, "# Sets the HTTP_AUTHORIZATION header removed by apache\n");
+        fwrite($write_fd, "RewriteCond %{HTTP:Authorization} .\n");
+        fwrite($write_fd, "RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]\n\n");
 
         foreach ($domains as $domain => $list_uri) {
             // As we use regex in the htaccess, ipv6 surrounded by brackets must be escaped


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | I am building an endpoint with data export for our marketing company, secured by Authorization (Bearer, Basic auth etc.) and the header is not propagated into the code, so I can't validate it. This follows the .htaccess rules from `/admin-api` and `/admin` and sets the header.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No need to test. Just launch UI tests.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/17922798488
| Fixed issue or discussion?     |
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.