### PR TITLE
Fix carrier grade validation and prevent fatal error

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/CarrierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/CarrierController.php
@@ -130,8 +130,9 @@ class CarrierController extends PrestaShopAdminController
         #[Autowire(service: 'prestashop.core.form.identifiable_object.handler.carrier_form_handler')]
         FormHandlerInterface $formHandler,
     ): Response {
+        $form = $formBuilder->getForm();
+
         try {
-            $form = $formBuilder->getForm();
             $form->handleRequest($request);
             $result = $formHandler->handle($form);
 
@@ -159,8 +160,9 @@ class CarrierController extends PrestaShopAdminController
         #[Autowire(service: 'prestashop.core.form.identifiable_object.handler.carrier_form_handler')]
         FormHandlerInterface $formHandler,
     ): Response {
+        $form = $formBuilder->getFormFor($carrierId);
+
         try {
-            $form = $formBuilder->getFormFor($carrierId);
             $form->handleRequest($request);
             $result = $formHandler->handleFor($carrierId, $form);
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/CarrierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/CarrierController.php
@@ -130,14 +130,18 @@ class CarrierController extends PrestaShopAdminController
         #[Autowire(service: 'prestashop.core.form.identifiable_object.handler.carrier_form_handler')]
         FormHandlerInterface $formHandler,
     ): Response {
-        $form = $formBuilder->getForm();
-        $form->handleRequest($request);
-        $result = $formHandler->handle($form);
+        try {
+            $form = $formBuilder->getForm();
+            $form->handleRequest($request);
+            $result = $formHandler->handle($form);
 
-        if ($result->isSubmitted() && $result->isValid()) {
-            $this->addFlash('success', $this->trans('Successful creation', [], 'Admin.Notifications.Success'));
+            if ($result->isSubmitted() && $result->isValid()) {
+                $this->addFlash('success', $this->trans('Successful creation', [], 'Admin.Notifications.Success'));
 
-            return $this->redirectToRoute('admin_carriers_edit', ['carrierId' => $result->getIdentifiableObjectId()]);
+                return $this->redirectToRoute('admin_carriers_edit', ['carrierId' => $result->getIdentifiableObjectId()]);
+            }
+        } catch (CarrierException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
         return $this->render('@PrestaShop/Admin/Improve/Shipping/Carriers/form.html.twig', [
@@ -155,14 +159,18 @@ class CarrierController extends PrestaShopAdminController
         #[Autowire(service: 'prestashop.core.form.identifiable_object.handler.carrier_form_handler')]
         FormHandlerInterface $formHandler,
     ): Response {
-        $form = $formBuilder->getFormFor($carrierId);
-        $form->handleRequest($request);
-        $result = $formHandler->handleFor($carrierId, $form);
+        try {
+            $form = $formBuilder->getFormFor($carrierId);
+            $form->handleRequest($request);
+            $result = $formHandler->handleFor($carrierId, $form);
 
-        if ($result->isSubmitted() && $result->isValid()) {
-            $this->addFlash('success', $this->trans('Successful update', [], 'Admin.Notifications.Success'));
+            if ($result->isSubmitted() && $result->isValid()) {
+                $this->addFlash('success', $this->trans('Successful update', [], 'Admin.Notifications.Success'));
 
-            return $this->redirectToRoute('admin_carriers_edit', ['carrierId' => $result->getIdentifiableObjectId()]);
+                return $this->redirectToRoute('admin_carriers_edit', ['carrierId' => $result->getIdentifiableObjectId()]);
+            }
+        } catch (CarrierException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
 
         try {

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
@@ -39,8 +39,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Url;
 use Symfony\Component\Validator\Constraints\Range;
+use Symfony\Component\Validator\Constraints\Url;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class GeneralSettings extends TranslatorAwareType

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
@@ -40,6 +40,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Url;
+use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class GeneralSettings extends TranslatorAwareType
@@ -88,6 +89,13 @@ class GeneralSettings extends TranslatorAwareType
                 'attr' => [
                     'min' => 0,
                     'max' => 9,
+                ],
+                'constraints' => [
+                    new Range([
+                        'min' => 0,
+                        'max' => 9,
+                        'notInRangeMessage' => $this->trans('The grade must be between 0 and 9.', 'Admin.Shipping.Notification'),
+                    ]),
                 ],
             ])
             ->add('logo_preview', ImagePreviewType::class, [

--- a/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_management.feature
@@ -776,6 +776,26 @@ Feature: Carrier management
       | rangeBehavior    | disabled                           |
     Then carrier should throw an error with error code "INVALID_ZONE_MISSING"
 
+  Scenario: Add a new carrier with a wrong grade
+    When I create carrier "carrier1" with specified properties:
+      | name             | Carrier 1                          |
+      | grade            | 10                                 |
+      | trackingUrl      | http://example.com/track.php?num=@ |
+      | active           | true                               |
+      | max_width        | 1454                               |
+      | max_height       | 1234                               |
+      | max_depth        | 1111                               |
+      | max_weight       | 3864                               |
+      | group_access     | visitor, guest                     |
+      | delay[en-US]     | Shipping delay                     |
+      | delay[fr-FR]     | Délai de livraison                 |
+      | shippingHandling | false                              |
+      | isFree           | false                              |
+      | shippingMethod   | weight                             |
+      | zones            | zone1                              |
+      | rangeBehavior    | disabled                           |
+    Then carrier should throw an error with error code "INVALID_GRADE"
+
   Scenario: Edit a new carrier and delete all zone
     When I create carrier "carrier1" with specified properties:
       | name             | Carrier 1                          |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| UI Tests          | :green_circle:  https://github.com/MattKelvin/ga.tests.ui.pr/actions/runs/17269158178
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/issues/39457
| Related PRs       | /
| Sponsor company   | Mademoiselle bio

Today if you create or edit a carrier and set a grade not in the range 0-9, the page will break (fatal error: Invalid Carrier grade. Got "XX").

This PR does 2 things:

- Prevents unexpected errors from breaking the page (9e1b82a)
- Adds a range constraint to display a message if the grade is not between 0 and 9 (8b2b0fb)

I also added a test, not sure if it's the best way to check that. Tell me if I can do a better test :)

**How to test**

- Go on develop, try to add a carrier with a grade 12
- You should get a fatal error: Invalid Carrier grade. Got "12"
- Switch to this branch
- Refresh the page
- You should see the message "The grade must be between 0 and 9." below the grade field

If you want to test the fix 1), you can go on the linked commit, the page will not break and the error will appear like a standard notification warning

Thank you