### PR TITLE
Add customer_service to contact query selection

### DIFF
--- a/src/Core/Grid/Query/ContactQueryBuilder.php
+++ b/src/Core/Grid/Query/ContactQueryBuilder.php
@@ -78,7 +78,7 @@ final class ContactQueryBuilder extends AbstractDoctrineQueryBuilder
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
         $qb
-            ->select('c.id_contact, c.email, cl.name, cl.description')
+            ->select('c.id_contact, c.email, cl.name, cl.description, c.customer_service')
             ->groupBy('c.id_contact');
 
         $this->searchCriteriaApplicator
@@ -113,6 +113,7 @@ final class ContactQueryBuilder extends AbstractDoctrineQueryBuilder
             'name',
             'email',
             'description',
+            'customer_service',
         ];
 
         $qb = $this->connection


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Add customer_service in query build ; allow to have it on Admin Api listing.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| UI tests               | :green_circle: https://github.com/Touxten/ga.tests.ui.pr/actions/runs/17315123799
| How to test?      | You can't really tests ; just see that the "Contacts" page is not broken, for the moment.
