### PR TITLE
CORE : Fix Cart constructor initialization order to prevent null configuration errors

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -211,6 +211,9 @@ class CartCore extends ObjectModel
      */
     public function __construct($id = null, $idLang = null)
     {
+        $this->configuration = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Core\\ConfigurationInterface');
+        $this->addressFactory = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\AddressFactory');
+        
         parent::__construct($id);
 
         if (null !== $idLang) {
@@ -233,9 +236,6 @@ class CartCore extends ObjectModel
         }
 
         $this->setTaxCalculationMethod();
-
-        $this->configuration = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Core\\ConfigurationInterface');
-        $this->addressFactory = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\AddressFactory');
     }
 
     public static function resetStaticCache()

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -213,7 +213,7 @@ class CartCore extends ObjectModel
     {
         $this->configuration = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Core\\ConfigurationInterface');
         $this->addressFactory = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\AddressFactory');
-        
+
         parent::__construct($id);
 
         if (null !== $idLang) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR fixes a race condition in the Cart constructor that causes fatal errors when modules hooked to cart update events try to access cart methods during secure_key updates. <br><br>The issue occurs because `$this->save()` is called before `$this->configuration` and `$this->addressFactory` are initialized. When save() triggers cart update hooks, any module trying to use methods like `Cart->getProducts()` encounters null property errors.<br><br>This fix moves the initialization of configuration and addressFactory to the beginning of the constructor, ensuring they are available before any operations that might trigger hooks.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create a test module that hooks to `actionCartSave`<br>2. In the hook, call `$cart->getProducts()`<br>3. Create a cart for a logged-in customer with no secure_key or secure_key = '-1'<br>4. Without this fix: Fatal error when cart constructor tries to update secure_key<br>5. With this fix: Cart initializes properly and hook executes without errors
| UI Tests          | :green_circle:  https://github.com/friends-of-presta/ga.tests.ui.pr/actions/runs/17322783996
| Fixed issue or discussion?     | Fixes #39462
| Related PRs       | N/A
| Sponsor company   | Web Premiere