### PR TITLE
Fix API documentation page when multistore is enabled

### DIFF
--- a/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
@@ -364,18 +364,22 @@ class ShopContextSubscriber implements EventSubscriberInterface
         try {
             $routeInfo = $this->router->match($request->getPathInfo());
             $controller = $routeInfo['_controller'];
-            [$className, $methodName] = explode('::', $controller);
+            if (str_contains($controller, '::')) {
+                $controllerAttributes = explode('::', $controller);
+                if (isset($controllerAttributes[0], $controllerAttributes[1])) {
+                    [$className, $methodName] = $controllerAttributes;
 
-            $reflectionClass = new ReflectionClass($className);
-            $classAttributes = $reflectionClass->getAttributes(AllShopContext::class);
-            $methodAttributes = $reflectionClass->getMethod($methodName)->getAttributes(AllShopContext::class);
+                    $reflectionClass = new ReflectionClass($className);
+                    $classAttributes = $reflectionClass->getAttributes(AllShopContext::class);
+                    $methodAttributes = $reflectionClass->getMethod($methodName)->getAttributes(AllShopContext::class);
 
-            $attributes = array_merge($classAttributes, $methodAttributes);
-            if (!empty($attributes)) {
-                return ShopConstraint::allShops();
-            } else {
-                return null;
+                    if (!empty($classAttributes) || !empty($methodAttributes)) {
+                        return ShopConstraint::allShops();
+                    }
+                }
             }
+
+            return null;
         } catch (NoConfigurationException|ReflectionException) {
             return null;
         }

--- a/tests/Resources/Controller/TestAllShopContextAttributeController.php
+++ b/tests/Resources/Controller/TestAllShopContextAttributeController.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Resources\Controller;
+
+use PrestaShopBundle\Controller\Attribute\AllShopContext;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Class used to test #[AllShopContext()] attribute usage
+ */
+#[AllShopContext]
+class TestAllShopContextAttributeController extends AbstractController
+{
+    #[AllShopContext]
+    public function indexAction()
+    {
+        return new Response();
+    }
+}

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShopBundle\EventListener\Admin\Context\ShopContextSubscriber;
 use PrestaShopBundle\Routing\LegacyControllerConstants;
 use PrestaShopBundle\Security\Admin\TokenAttributes;
+use ReflectionClass;
 use Shop;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -51,6 +52,112 @@ use Tests\Unit\PrestaShopBundle\EventListener\ContextEventListenerTestCase;
 
 class ShopContextSubscriberTest extends ContextEventListenerTestCase
 {
+    /**
+     * Tests that `getShopConstraintFromRouteAttribute` returns an all-shop constraint
+     * when the `AllShopContext` attribute is present in the matched controller class/method.
+     */
+    public function testGetShopConstraintFromRouteAttribute(): void
+    {
+        $request = $this->mockRequest('/test-path', [
+            '_controller' => 'Tests\\Resources\\Controller\\TestAllShopContextAttributeController::indexAction',
+        ]);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->method('match')->willReturn($request->attributes->all());
+
+        $subscriber = new ShopContextSubscriber(
+            $this->mockShopContextBuilder(),
+            $this->mockEmployeeContext(),
+            $this->mockConfiguration(),
+            $this->mockMultistoreFeature(false),
+            $router,
+            $this->mockSecurity(),
+            $this->mockLegacyContext(),
+            $this->createMock(TranslatorInterface::class)
+        );
+
+        $class = new ReflectionClass($subscriber);
+        $method = $class->getMethod('getShopConstraintFromRouteAttribute');
+        $shopConstraint = $method->invokeArgs($subscriber, [$request]);
+
+        $this->assertInstanceOf(ShopConstraint::class, $shopConstraint);
+        $this->assertTrue($shopConstraint->forAllShops());
+    }
+
+    /**
+     * Tests that `getShopConstraintFromRouteAttribute` returns null
+     * when no relevant attributes (`AllShopContext`) are on the controller class or methods.
+     */
+    public function testGetShopConstraintFromRouteAttributeWithNonExistentController(): void
+    {
+        $request = $this->mockRequest('/non-existent-path', [
+            '_controller' => 'PrestaShopBundle\\Controller\\Admin\\NonExistentController::anyMethod',
+        ]);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->method('match')->willReturn($request->attributes->all());
+
+        $subscriber = new ShopContextSubscriber(
+            $this->mockShopContextBuilder(),
+            $this->mockEmployeeContext(),
+            $this->mockConfiguration(),
+            $this->mockMultistoreFeature(false),
+            $router,
+            $this->mockSecurity(),
+            $this->mockLegacyContext(),
+            $this->createMock(TranslatorInterface::class)
+        );
+
+        $class = new ReflectionClass($subscriber);
+        $method = $class->getMethod('getShopConstraintFromRouteAttribute');
+        $shopConstraint = $method->invokeArgs($subscriber, [$request]);
+
+        $this->assertNull($shopConstraint);
+    }
+
+    /**
+     * Tests that `getShopConstraintFromRouteAttribute` returns null
+     * when "_controller" value is not class::method notation
+     */
+    public function testGetShopConstraintFromRouteAttributeWithInvalidController(): void
+    {
+        $request = $this->mockRequest('/non-existent-path', [
+            '_controller' => 'this_is_not_a_controller_method_notation_using_double_colon',
+        ]);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->method('match')->willReturn($request->attributes->all());
+
+        $subscriber = new ShopContextSubscriber(
+            $this->mockShopContextBuilder(),
+            $this->mockEmployeeContext(),
+            $this->mockConfiguration(),
+            $this->mockMultistoreFeature(false),
+            $router,
+            $this->mockSecurity(),
+            $this->mockLegacyContext(),
+            $this->createMock(TranslatorInterface::class)
+        );
+
+        $class = new ReflectionClass($subscriber);
+        $method = $class->getMethod('getShopConstraintFromRouteAttribute');
+        $shopConstraint = $method->invokeArgs($subscriber, [$request]);
+
+        $this->assertNull($shopConstraint);
+    }
+
+    /**
+     * Helper to mock an HTTP request with the given attributes and path.
+     */
+    private function mockRequest(string $path, array $attributes): Request
+    {
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
+        foreach ($attributes as $key => $value) {
+            $request->attributes->set($key, $value);
+        }
+
+        return $request;
+    }
     private const PS_SSL_ENABLED = 1;
     private const DEFAULT_SHOP_ID = 42;
     private const EMPLOYEE_DEFAULT_SHOP_ID = 51;
@@ -59,14 +166,9 @@ class ShopContextSubscriberTest extends ContextEventListenerTestCase
     {
         $event = $this->createRequestEvent(new Request());
 
-        $shopContextBuilder = new ShopContextBuilder(
-            $this->mockShopRepository(self::DEFAULT_SHOP_ID),
-            $this->mockContextStateManager(),
-            $this->mockMultistoreFeature(false),
-        );
-
+        $shopContextBuilderMock = $this->mockShopContextBuilder();
         $listener = new ShopContextSubscriber(
-            $shopContextBuilder,
+            $shopContextBuilderMock,
             $this->mockEmployeeContext(),
             $this->mockConfiguration(['PS_SHOP_DEFAULT' => self::DEFAULT_SHOP_ID, 'PS_SSL_ENABLED' => self::PS_SSL_ENABLED]),
             $this->mockMultistoreFeature(false),
@@ -78,8 +180,8 @@ class ShopContextSubscriberTest extends ContextEventListenerTestCase
         $listener->initShopContext($event);
 
         $expectedShopConstraint = ShopConstraint::shop(self::DEFAULT_SHOP_ID);
-        $this->assertEquals(self::DEFAULT_SHOP_ID, $this->getPrivateField($shopContextBuilder, 'shopId'));
-        $this->assertEquals($expectedShopConstraint, $this->getPrivateField($shopContextBuilder, 'shopConstraint'));
+        $this->assertEquals(self::DEFAULT_SHOP_ID, $this->getPrivateField($shopContextBuilderMock, 'shopId'));
+        $this->assertEquals($expectedShopConstraint, $this->getPrivateField($shopContextBuilderMock, 'shopConstraint'));
         $this->assertEquals($expectedShopConstraint, $event->getRequest()->attributes->get('shopConstraint'));
     }
 
@@ -553,6 +655,15 @@ class ShopContextSubscriberTest extends ContextEventListenerTestCase
         ;
 
         return $router;
+    }
+
+    private function mockShopContextBuilder(): ShopContextBuilder|MockObject
+    {
+        return new ShopContextBuilder(
+            $this->mockShopRepository(self::DEFAULT_SHOP_ID),
+            $this->mockContextStateManager(),
+            $this->mockMultistoreFeature(false),
+        );
     }
 
     private function mockMultistoreFeature(bool $multiShopEnabled): MultistoreFeature|MockObject


### PR DESCRIPTION
Hello there

Here is a little fix for the administration api documentation endpoint when multishop is enabled.

Happy review !


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | When multistore is activated, accessing the API documentation (Swagger/ReDoc) display an error due to improper handling of Action Controllers using the `__invoke()` pattern. These controllers use a different naming convention (e.g., "api_platform.action.documentation") instead of the expected "Controller::method" format, causing an "Undefined array key 1" warning in `ShopContextSubscriber->getShopConstraintFromRouteAttribute()`.<br> This fix adds proper validation to handle both controller formats gracefully.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install fresh database<br>2. Enable multistore feature<br>3. Add a second shop<br>4. Navigate to `/admin-dev/configure/advanced/admin-api/docs.html`<br>5. Verify that Swagger/ReDoc/JSON documentation displays without errors
| UI Tests          | https://github.com/iNem0o/ga.tests.ui.pr/actions/runs/17324901693
| Fixed issue or discussion?     |  Fixes #39468
| Related PRs       | 
| Sponsor company   | e-frogg