### PR TITLE
Add console command "prestashop:thumbnails:regenerate"

### DIFF
--- a/src/Core/Domain/ImageSettings/ImageDomain.php
+++ b/src/Core/Domain/ImageSettings/ImageDomain.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core\Domain\ImageSettings;
+
+use RuntimeException;
+
+enum ImageDomain: string
+{
+    case ALL = 'all';
+    case CATEGORIES = 'categories';
+    case MANUFACTURERS = 'manufacturers';
+    case SUPPLIERS = 'suppliers';
+    case PRODUCTS = 'products';
+    case STORES = 'stores';
+
+    /**
+     * Get the directory path for the image type
+     */
+    public function getDirectory(): string
+    {
+        return match ($this) {
+            self::CATEGORIES => _PS_CAT_IMG_DIR_,
+            self::MANUFACTURERS => _PS_MANU_IMG_DIR_,
+            self::SUPPLIERS => _PS_SUPP_IMG_DIR_,
+            self::PRODUCTS => _PS_PRODUCT_IMG_DIR_,
+            self::STORES => _PS_STORE_IMG_DIR_,
+            self::ALL => throw new RuntimeException("getDirectory() is not usable for 'ALL' image domain"),
+        };
+    }
+
+    public function isProduct(): bool
+    {
+        return $this === self::PRODUCTS;
+    }
+
+    /**
+     * Get all image types with thumbnails
+     *
+     * @return array<self>
+     */
+    public static function getDomainsWithThumbnails(): array
+    {
+        return array_filter(self::cases(), static fn (self $imageType) => $imageType !== self::ALL);
+    }
+
+    public static function getAllowedValues(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/src/Core/Domain/Product/Image/QueryResult/ProductImageForThumbnailGeneration.php
+++ b/src/Core/Domain/Product/Image/QueryResult/ProductImageForThumbnailGeneration.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Image\QueryResult;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+
+/**
+ * Represents product image data with only the essential information needed for bulk thumbnail operations.
+ */
+class ProductImageForThumbnailGeneration
+{
+    public function __construct(
+        private readonly ImageId $imageId,
+        private readonly ProductId $productId
+    ) {
+    }
+
+    public function getImageId(): ImageId
+    {
+        return $this->imageId;
+    }
+
+    public function getProductId(): ProductId
+    {
+        return $this->productId;
+    }
+}

--- a/src/PrestaShopBundle/Command/RegenerateThumbnailsCommand.php
+++ b/src/PrestaShopBundle/Command/RegenerateThumbnailsCommand.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Command;
+
+use Exception;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\RegenerateThumbnailsCommand as RegenerateThumbnailsCommandBus;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ImageDomain;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject\ImageTypeId;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use ValueError;
+
+/**
+ * Console command to regenerate thumbnails
+ */
+#[AsCommand(
+    name: 'prestashop:thumbnails:regenerate',
+    description: 'Regenerate thumbnails')
+]
+class RegenerateThumbnailsCommand extends Command
+{
+    public function __construct(
+        private readonly CommandBusInterface $commandBus,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->addArgument(
+                'image',
+                InputArgument::REQUIRED,
+                sprintf('Allowed images (%s)', implode(', ', ImageDomain::getAllowedValues()))
+            )
+            ->addArgument('image-type', InputArgument::OPTIONAL, 'Image format ID (0 for all)', null)
+            ->addOption('delete', 'd', InputOption::VALUE_NONE, 'Erase previous images before regenerating');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $image = $input->getArgument('image');
+        $imageTypeId = $input->getArgument('image-type');
+        $erase = (bool) $input->getOption('delete');
+
+        try {
+            $image = ImageDomain::from($image);
+        } catch (ValueError) {
+            $io->error(
+                sprintf(
+                    'Unknown image type "%s". Allowed types are: %s',
+                    $image,
+                    implode(', ', ImageDomain::getAllowedValues())
+                )
+            );
+
+            return self::FAILURE;
+        }
+
+        $imageTypeValue = 0;
+
+        if (null !== $imageTypeId) {
+            if (!is_numeric($imageTypeId)) {
+                $io->error(sprintf('Image format ID "%s" is invalid. It must be a numeric value.', $imageTypeId));
+
+                return self::FAILURE;
+            }
+
+            $imageTypeId = (int) $imageTypeId;
+
+            if (0 === $imageTypeId) {
+                $imageTypeValue = 0;
+            } else {
+                try {
+                    $imageTypeValueObject = new ImageTypeId($imageTypeId);
+                    $imageTypeValue = $imageTypeValueObject->getValue();
+                } catch (ImageTypeException $e) {
+                    $io->error($e->getMessage());
+
+                    return self::FAILURE;
+                }
+            }
+        }
+
+        try {
+            $this->commandBus->handle(new RegenerateThumbnailsCommandBus($image->value, $imageTypeValue, $erase));
+            $io->info('The thumbnails were successfully regenerated.');
+        } catch (Exception $e) {
+            $io->error('Unable to regenerate thumbnails : ' . $e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ImageSettingsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ImageSettingsController.php
@@ -34,8 +34,10 @@ use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\DeleteImagesFromType
 use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\DeleteImageTypeCommand;
 use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\RegenerateThumbnailsCommand;
 use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ImageDomain;
 use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Query\GetImageTypeForEditing;
 use PrestaShop\PrestaShop\Core\Domain\ImageSettings\QueryResult\EditableImageType;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ValueObject\ImageTypeId;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface as ConfigurationFormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
@@ -294,10 +296,12 @@ class ImageSettingsController extends PrestaShopAdminController
         try {
             $regenThumbnailsForm = $this->createForm(RegenerateThumbnailsType::class);
             $regenThumbnailsForm->handleRequest($request);
-
+            $rawImageTypeId = (int) $regenThumbnailsForm->get('image-type')->getData();
+            $imageTypeId = 0 !== $rawImageTypeId ? (new ImageTypeId($rawImageTypeId))->getValue() : 0;
+            $imageDomain = ImageDomain::from((string) $regenThumbnailsForm->get('image')->getData());
             $this->dispatchCommand(new RegenerateThumbnailsCommand(
-                $regenThumbnailsForm->get('image')->getData(),
-                $regenThumbnailsForm->get('image-type')->getData(),
+                $imageDomain->value,
+                $imageTypeId,
                 $regenThumbnailsForm->get('erase-previous-images')->getData()
             ));
             $this->addFlash('success', $this->trans('The thumbnails were successfully regenerated.', [], 'Admin.Notifications.Success'));

--- a/src/PrestaShopBundle/Resources/config/services/bundle/command.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/command.yml
@@ -92,3 +92,9 @@ services:
       - '@prestashop.core.command_bus'
     tags:
       - 'console.command'
+
+  PrestaShopBundle\Command\RegenerateThumbnailsCommand:
+    arguments:
+      - '@prestashop.core.command_bus'
+    tags:
+      - 'console.command'

--- a/tests/Unit/Core/Domain/ImageSettings/CommandHandler/RegenerateThumbnailsHandlerTest.php
+++ b/tests/Unit/Core/Domain/ImageSettings/CommandHandler/RegenerateThumbnailsHandlerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Core\Domain\ImageSettings\CommandHandler;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\ImageThumbnailsRegenerator;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\RegenerateThumbnailsCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\CommandHandler\RegenerateThumbnailsHandler;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\RegenerateThumbnailsTimeoutException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\RegenerateThumbnailsWriteException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ImageDomain;
+use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
+use PrestaShopBundle\Entity\Repository\ImageTypeRepository;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class RegenerateThumbnailsHandlerTest extends TestCase
+{
+    private TranslatorInterface&MockObject $translator;
+    private ImageTypeRepository&MockObject $imageTypeRepository;
+    private LanguageRepositoryInterface&MockObject $languageRepository;
+    private ImageThumbnailsRegenerator&MockObject $imageThumbnailsRegenerator;
+    private RegenerateThumbnailsHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->translator = $this->createMock(TranslatorInterface::class);
+        $this->imageTypeRepository = $this->createMock(ImageTypeRepository::class);
+        $this->languageRepository = $this->createMock(LanguageRepositoryInterface::class);
+        $this->imageThumbnailsRegenerator = $this->createMock(ImageThumbnailsRegenerator::class);
+
+        $this->handler = new RegenerateThumbnailsHandler(
+            $this->translator,
+            $this->imageTypeRepository,
+            $this->languageRepository,
+            $this->imageThumbnailsRegenerator
+        );
+    }
+
+    public function testHandleThrowsRegenerateThumbnailsTimeoutException(): void
+    {
+        $this->languageRepository->expects($this->once())
+            ->method('findAll')
+            ->willReturn([]);
+
+        $this->imageTypeRepository->expects($this->once())
+            ->method('findBy')
+            ->willReturn(['dummy_format']);
+
+        $this->imageThumbnailsRegenerator->expects($this->once())
+            ->method('regenerateNewImages')
+            ->willReturn(['timeout']);
+
+        $command = new RegenerateThumbnailsCommand(ImageDomain::CATEGORIES->value, 0, false);
+
+        $this->expectException(RegenerateThumbnailsTimeoutException::class);
+
+        $this->handler->handle($command);
+    }
+
+    public function testHandleThrowsRegenerateThumbnailsWriteException(): void
+    {
+        $this->languageRepository->expects($this->once())
+            ->method('findAll')
+            ->willReturn([]);
+
+        $this->imageTypeRepository->expects($this->once())
+            ->method('findBy')
+            ->willReturn(['dummy_format']);
+
+        $this->imageThumbnailsRegenerator->expects($this->once())
+            ->method('regenerateNewImages')
+            ->willReturn(['write_error']);
+
+        $command = new RegenerateThumbnailsCommand(ImageDomain::CATEGORIES->value, 0, false);
+
+        $this->expectException(RegenerateThumbnailsWriteException::class);
+
+        $this->handler->handle($command);
+    }
+
+    public function testHandleSuccessfulRegeneration(): void
+    {
+        $languages = [['id_lang' => 1, 'name' => 'English']];
+
+        $this->languageRepository->expects($this->once())
+            ->method('findAll')
+            ->willReturn($languages);
+
+        $this->imageTypeRepository->expects($this->once())
+            ->method('findBy')
+            ->willReturn(['dummy_format']);
+
+        $this->imageThumbnailsRegenerator->expects($this->once())
+            ->method('regenerateNewImages')
+            ->willReturn([]);
+
+        $this->imageThumbnailsRegenerator->expects($this->once())
+            ->method('regenerateNoPictureImages')
+            ->with(_PS_CAT_IMG_DIR_, ['dummy_format'], $languages)
+            ->willReturn(false);
+
+        $command = new RegenerateThumbnailsCommand(ImageDomain::CATEGORIES->value, 0, false);
+
+        $this->handler->handle($command);
+
+        $this->addToAssertionCount(1); // Assert no exceptions were thrown
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Command/RegenerateThumbnailsCommandTest.php
+++ b/tests/Unit/PrestaShopBundle/Command/RegenerateThumbnailsCommandTest.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Command;
+
+use Generator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\RegenerateThumbnailsCommand as DomainRegenerateThumbnailsCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\ImageDomain;
+use PrestaShopBundle\Command\RegenerateThumbnailsCommand;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class RegenerateThumbnailsCommandTest extends TestCase
+{
+    private CommandBusInterface&MockObject $commandBus;
+    private RegenerateThumbnailsCommand $command;
+    private CommandTester $tester;
+
+    protected function setUp(): void
+    {
+        $this->commandBus = $this->createMock(CommandBusInterface::class);
+        $this->command = new RegenerateThumbnailsCommand($this->commandBus);
+        $this->tester = new CommandTester($this->command);
+    }
+
+    public function testItDispatchesDomainCommand(): void
+    {
+        $imageType = 5;
+        $this->commandBus->expects($this->once())
+            ->method('handle')
+            ->with(
+                $this->callback(function (DomainRegenerateThumbnailsCommand $command) use ($imageType) {
+                    return $command->getImage() === ImageDomain::PRODUCTS->value
+                        && $command->getImageTypeId() === $imageType
+                        && $command->erasePreviousImages() === true;
+                }));
+
+        $exitCode = $this->tester->execute([
+            'image' => 'products',
+            'image-type' => $imageType,
+            '--delete' => true,
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+    }
+
+    public function testItDispatchesDomainCommandWithShortcutErase(): void
+    {
+        $imageType = 5;
+        $this->commandBus->expects($this->once())
+            ->method('handle')
+            ->with(
+                $this->callback(function (DomainRegenerateThumbnailsCommand $command) use ($imageType) {
+                    return $command->getImage() === ImageDomain::PRODUCTS->value
+                        && $command->getImageTypeId() === $imageType
+                        && $command->erasePreviousImages() === true;
+                }));
+
+        $exitCode = $this->tester->execute([
+            'image' => 'products',
+            'image-type' => $imageType,
+            '-d' => true,
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+    }
+
+    /**
+     * @dataProvider validImageDomainsProvider
+     */
+    public function testAllValidImageDomains(ImageDomain $imageCategory): void
+    {
+        $this->commandBus->expects($this->once())->method('handle');
+
+        $exitCode = $this->tester->execute([
+            'image' => $imageCategory->value,
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+    }
+
+    public function testInvalidImageDomain(): void
+    {
+        $this->commandBus->expects($this->never())->method('handle');
+
+        $exitCode = $this->tester->execute([
+            'image' => 'invalid',
+        ]);
+
+        $this->assertSame(Command::FAILURE, $exitCode);
+    }
+
+    /**
+     * @dataProvider invalidImageDomainsProvider
+     */
+    public function testInvalidImageTypes($imageType): void
+    {
+        $this->commandBus->expects($this->never())->method('handle');
+
+        $exitCode = $this->tester->execute([
+            'image' => 'products',
+            'image-type' => $imageType,
+        ]);
+
+        $this->assertSame(Command::FAILURE, $exitCode);
+    }
+
+    public function testWithoutEraseOption(): void
+    {
+        $this->commandBus->expects($this->once())
+            ->method('handle')
+            ->with($this->callback(function (DomainRegenerateThumbnailsCommand $command) {
+                return $command->erasePreviousImages() === false;
+            }));
+
+        $exitCode = $this->tester->execute([
+            'image' => 'products',
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+    }
+
+    /**
+     * @dataProvider invalidImageCasingProvider
+     */
+    public function testInvalidCasingOrWhitespaceForImage(string $image): void
+    {
+        $this->commandBus->expects($this->never())->method('handle');
+
+        $exitCode = $this->tester->execute(['image' => $image]);
+
+        $this->assertSame(Command::FAILURE, $exitCode);
+    }
+
+    public function testBusFailureIsReported(): void
+    {
+        $this->commandBus->method('handle')->willThrowException(new RuntimeException('boom'));
+
+        $exitCode = $this->tester->execute(['image' => 'products']);
+        $this->assertSame(Command::FAILURE, $exitCode);
+    }
+
+    public static function numericStringImageTypesProvider(): array
+    {
+        return [
+            ['5', 5],
+            ['05', 5],
+            ['000', 0],
+        ];
+    }
+
+    public static function validImageDomainsProvider(): Generator
+    {
+        yield from array_map(static fn (ImageDomain $imageCategory) => [$imageCategory->name => $imageCategory], ImageDomain::cases());
+    }
+
+    public static function invalidImageDomainsProvider(): array
+    {
+        return [
+            'non-numeric string' => ['foo'],
+            'negative integer' => [-1],
+            'empty string' => [''],
+        ];
+    }
+
+    public static function invalidImageCasingProvider(): array
+    {
+        return [
+            ['Products'],
+            [' products '],
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add console command `prestashop:thumbnails:regenerate` to allow thumbnail regeneration from command line. This command accepts image type (categories, manufacturers, suppliers, products, stores, or all), optional image format ID, and an erase flag.<br> Refactor `ImageThumbnailsRegenerator` with modern components and improve memory management and database operations for better handling large product image datasets.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Run `bin/console prestashop:thumbnails:regenerate products` to regenerate all product thumbnails<br>2. Run `bin/console prestashop:thumbnails:regenerate categories 5` to regenerate category thumbnails for image type ID 5<br>3. Run `bin/console prestashop:thumbnails:regenerate all --erase` to regenerate all image types and erase previous thumbnails<br>4. Verify thumbnails are properly generated in their respective directories<br>5. Execute similar tests with back office "Design > Image Settings > Regenerate thumbnails"
| UI Tests          | [here](https://github.com/iNem0o/ga.tests.ui.pr/actions/runs/17429044386)
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | e-frogg


## Console command
```
www-data@localhost:~/html$ ./bin/console prestashop:thumbnails:regenerate --help
Description:
  Regenerate thumbnails

Usage:
  prestashop:thumbnails:regenerate [options] [--] <image> [<image-type>]

Arguments:
  image                 Allowed images (all, categories, manufacturers, suppliers, products, stores)
  image-type            Image format ID (0 for all) [default: 0]

Options:
      --erase           Erase previous images before regenerating
  -h, --help            Display help for the given command. When no command is given display help for the list command
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
  -n, --no-interaction  Do not ask any interactive question
      --app-id=APP-ID   Specify a PrestaShop Application ID. [default: "admin"]
  -e, --env=ENV         The Environment name. [default: "dev"]
      --no-debug        Switch off debug mode.
      --profile         Enables profiling (requires debug).
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

## Modernization of `ImageThumbnailsRegenerator`

| Component                 | Old Approach                                                                          | New Approach                                                                                                                               |
| ------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
| **Image Data Loading**    | `$this->productImageRepository->getAllImages()` with full `Image` objects             | `$this->productImageRepository->iterateImagesForThumbnailGeneration()` with lightweight data objects                                       |
| **Path Resolution**       | `$imageObj->getImgFolder()` and `$imageObj->getExistingImgPath()` using Image methods | modern components to handle images path `$this->productImagePathFactory->getImageFolder()` and `$this->productImagePathFactory->getPath()` |
| **Image Type Management** | Hard-coded array with directory mappings                                              | `ImageCategory` enum with structured type definitions                                                                                       |
| **Memory Pattern**        | Load all images at once in memory                                                     | PHP Generator for iterator pattern                                                                                                         |
| **Data Structure**        | Full `Image` ObjectModel with all database rows                                       | `ProductImageForThumbnailGeneration` with only essential fields                                                                            |

Introduced `ProductImageForThumbnailGeneration` data class that contains only `ImageId` and `ProductId`, reducing memory footprint compared to full `Image` objects loaded.  This refactor eliminates the N+1 query by replacing individual `new Image($id)` instantiations (which trigger `ObjectModel::__construct()` database loads) with a single optimized query using `iterateImagesForThumbnailGeneration()`. This reduces database calls from **1 + N queries** to **1 single query** for N images.


### Fetch all vs iterator comparision

Here is a performance comparision between the two methods executed using [this benchmark](https://gist.github.com/iNem0o/3fe486b85c4d9c9e90e5afcf497960a6).


#### Prestashop github default database

|                      | fetchAllMethod | iteratorMethod |
| -------------------- | -------------- | -------------- |
| duration             | 12.48ms        | 2.90ms         |
| memory               | 379.74 KB      | 269.30 KB      |
| peak_memory          | 367.32 KB      | 222.60 KB      |
| sql_queries          | 46             | 0              |
| processed            | 23             | 23             |
| items_per_second     | 1843.54        | 7928.09        |
| memory_per_item      | 16906.78       | 11989.91       |
| sql_queries_per_item | 2              | 0              |

 [full results](https://gist.github.com/iNem0o/185472b6c79d507e32253e4135940796)


#### Real world catalog with 412296 products images

|                      | fetchAllMethod | iteratorMethod |
| -------------------- | -------------- | -------------- |
| duration             | 1min 1.00s     | 172.82ms       |
| memory               | 3.75 GB        | 269.73 KB      |
| peak_memory          | 4.53 GB        | 12.96 MB       |
| sql_queries          | 824592         | 0              |
| processed            | 412296         | 412296         |
| items_per_second     | 6681           | 2385668.51     |
| memory_per_item      | 9776.96        | 0.67           |
| sql_queries_per_item | 2              | 0              |

 [full results](https://gist.github.com/iNem0o/b47e8ad269206ec27b8168936b4ca670)
