### PR TITLE
add product rules cache to CartRule.php

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -103,7 +103,7 @@ class CartRuleCore extends ObjectModel
     public $active = true;
     public $date_add;
     public $date_upd;
-
+    protected static $productRulesCache = [];
     protected static $cartAmountCache = [];
 
     /**
@@ -673,22 +673,25 @@ class CartRuleCore extends ObjectModel
             return [];
         }
 
-        $productRules = [];
-        $results = Db::getInstance()->executeS('
-		SELECT *
-		FROM ' . _DB_PREFIX_ . 'cart_rule_product_rule pr
-		LEFT JOIN ' . _DB_PREFIX_ . 'cart_rule_product_rule_value prv ON pr.id_product_rule = prv.id_product_rule
-		WHERE pr.id_product_rule_group = ' . (int) $id_product_rule_group);
-        foreach ($results as $row) {
-            if (!isset($productRules[$row['id_product_rule']])) {
-                $productRules[$row['id_product_rule']] = ['type' => $row['type'], 'values' => []];
-            }
-            $productRules[$row['id_product_rule']]['values'][] = $row['id_item'];
+        if(!isset($productRulesCache[$id_product_rule_group])){
+            $productRules = [];
+            $results = Db::getInstance()->executeS('
+    		SELECT *
+    		FROM ' . _DB_PREFIX_ . 'cart_rule_product_rule pr
+    		LEFT JOIN ' . _DB_PREFIX_ . 'cart_rule_product_rule_value prv ON pr.id_product_rule = prv.id_product_rule
+    		WHERE pr.id_product_rule_group = ' . (int) $id_product_rule_group);
+            foreach ($results as $row) {
+                if (!isset($productRules[$row['id_product_rule']])) {
+                    $productRules[$row['id_product_rule']] = ['type' => $row['type'], 'values' => []];
+                }
+                $productRules[$row['id_product_rule']]['values'][] = $row['id_item'];
+            }    
+            static::$productRulesCache[$id_product_rule_group] = $productRules;
         }
 
-        return $productRules;
+        return static::$productRulesCache[$id_product_rule_group];
     }
-
+    
     /**
      * Check if this CartRule can be applied.
      *

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -673,7 +673,7 @@ class CartRuleCore extends ObjectModel
             return [];
         }
 
-        if(!isset($productRulesCache[$id_product_rule_group])){
+        if(!isset(static::$productRulesCache[$id_product_rule_group])){
             $productRules = [];
             $results = Db::getInstance()->executeS('
     		SELECT *


### PR DESCRIPTION
Keep already fetched product rules in static variable. Improves loading when product rule has a lot of selected variables like product or categories.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop, 9.0.x, 8.2.x
| Description?      |  Reduces SQL query doubles with static variable for product rules. Improves loading speed when there are a lot of products selected inside cart rule restriction.
| Type?             | improvement
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | make cart rule with 10k products selected out of 20k, load cart with matching product and compare loading speed. Small improvements even with lower amount of product rule in cart rule restriction.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

with static:
<img width="2553" height="421" alt="image" src="https://github.com/user-attachments/assets/adc9f158-c16b-44b1-8b02-0a9e2b1e77ff" />
without static:
<img width="2514" height="416" alt="image" src="https://github.com/user-attachments/assets/6c3b5e7f-77ba-41db-a8ec-7ca5915b4d37" />

<img width="2270" height="288" alt="image" src="https://github.com/user-attachments/assets/87248f8b-c314-4e8a-b6df-f29631bd01ed" />


