### PR TITLE
Method getIdFromClassName incorrect phpdoc - phpstan is complaining

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -344,7 +344,7 @@ class TabCore extends ObjectModel
      *
      * @param string $className
      *
-     * @return int Tab ID
+     * @return int|false Tab ID
      */
     public static function getIdFromClassName($className)
     {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | I’m using PHPStan in my projects, and the getIdFromClassName function in the Tab class has an incorrect return type in its PHPDoc. Because of that, PHPStan raises a complaint about the return value.
| Type?             | refacto
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | no test needed, just phpdoc
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
