### PR TITLE
Update PaymentModule.php: replace unset($voucher->id) with $voucher->id = 0 to satisfy PHPStan

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1244,7 +1244,7 @@ abstract class PaymentModuleCore extends Module
             if (count($order_list) == 1 && $remainingValue > 0 && $cartRule->partial_use == 1 && $cartRuleReductionAmountConverted > 0) {
                 // Create a new voucher from the original
                 $voucher = new CartRule((int) $cartRule->id); // We need to instantiate the CartRule without lang parameter to allow saving it
-                unset($voucher->id);
+                $voucher->id = 0;
 
                 // Set a new voucher code
                 $voucher->code = empty($voucher->code) ? substr(md5($order->id . '-' . $order->id_customer . '-' . $cartRule->id), 0, 16) : $voucher->code . '-2';

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1244,7 +1244,7 @@ abstract class PaymentModuleCore extends Module
             if (count($order_list) == 1 && $remainingValue > 0 && $cartRule->partial_use == 1 && $cartRuleReductionAmountConverted > 0) {
                 // Create a new voucher from the original
                 $voucher = new CartRule((int) $cartRule->id); // We need to instantiate the CartRule without lang parameter to allow saving it
-                $voucher->id = 0;
+                $voucher->id = null;
 
                 // Set a new voucher code
                 $voucher->code = empty($voucher->code) ? substr(md5($order->id . '-' . $order->id_customer . '-' . $cartRule->id), 0, 16) : $voucher->code . '-2';


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | PHPStan reports the following issue when using unset($voucher->id): "Cannot unset property CartRuleCore::$id because it might have hooks in a subclass. 🪪 unset.possiblyHookedProperty" - In PHP 8, unsetting properties that may have hooks is unsafe. To address this, we now assign 0 to $voucher->id instead of unsetting it. This approach is safe and ensures that the object can be saved correctly as a new record.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/
