### PR TITLE
Add the parameter `--symlink` to the command `assets:install` of Symfony

### DIFF
--- a/src/Adapter/Bundle/AssetsInstaller.php
+++ b/src/Adapter/Bundle/AssetsInstaller.php
@@ -57,6 +57,7 @@ final class AssetsInstaller
         $errorCode = $application->run(new ArrayInput([
             'command' => 'assets:install',
             'target' => $adminFolder,
+            '--symlink' => true,
         ]), $output);
 
         // If the command failed (!= 0), we throw an exception with the output of the command


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      |When installing the assets via Symfony, we want the command to do it with a symbolic link when possible. This is only possible if providing the `--symlink` attribute, otherwise it always copy the whole directory contents.
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | After installing PrestaShop, the assets must be accessible via a symlink. If the method `symlink` is disabled on the PHP configuration with `disabled_functions`, then the directory contents will be copied.
| UI Tests          | /
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39104, and maybe https://github.com/PrestaShop/PrestaShop/issues/38960 too
| Related PRs       | Related to https://github.com/PrestaShop/PrestaShop/pull/39327 (Follow up changes) and https://github.com/PrestaShop/autoupgrade/pull/1454
| Sponsor company   | @PrestaShopCorp

## Expected result with a server allowing the use of Symbolic links

```
root@a8b5ac156df8:/var/www/html# ls -l /var/www/html/admin-dev/bundles
total 8
lrwxrwxrwx 1 www-data www-data 74 Sep  4 10:22 apiplatform -> /var/www/html/vendor/api-platform/core/src/Symfony/Bundle/Resources/public
lrwxrwxrwx 1 www-data www-data 71 Sep  4 10:22 fosjsrouting -> /var/www/html/vendor/friendsofsymfony/jsrouting-bundle/Resources/public
```

## Expected result with a server forbidding the use of Symbolic links

```
root@9a5de18b7bf7:/var/www/html/admin-dev# php -i | grep symlink
disable_functions => symlink => symlink     <-- symlink function is forbidden

root@9a5de18b7bf7:/var/www/html/admin-dev# ls -l bundles
total 8
drwxr-xr-x 10 www-data www-data 4096 Sep  4 11:28 apiplatform
drwxr-xr-x  3 www-data www-data 4096 Sep  4 11:28 fosjsrouting

```

## Description of the command `assets:install`

```
  The assets:install command installs bundle assets into a given
  directory (e.g. the public directory).
  
    php ../../bin/console assets:install public
  
  A "bundles" directory will be created inside the target directory and the
  "Resources/public" directory of each bundle will be copied into it.
  
  To create a symlink to each bundle instead of copying its assets, use the
  --symlink option (will fall back to hard copies when symbolic links aren't possible:
  
    php ../../bin/console assets:install public --symlink
```