### PR TITLE
Add possibility to get multiple shipment id for one product

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -184,15 +184,14 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
 
             $orderInvoice = new OrderInvoice($product['id_order_invoice']);
             $shipments = $this->shipmentRepository->findByOrderId($order->id);
-            $shipmentId = null;
+            $shipmentIds = [];
 
             if ($shipments) {
                 foreach ($shipments as $shipment) {
                     $shipmentProducts = $shipment->getProducts();
                     foreach ($shipmentProducts as $shipmentProduct) {
                         if ($shipmentProduct->getOrderDetailId() == $product['id_order_detail']) {
-                            $shipmentId = $shipment->getId();
-                            break 2;
+                            $shipmentIds[] = $shipment->getId();
                         }
                     }
                 }
@@ -264,7 +263,7 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                 $packItems,
                 $product['customizations'],
                 $product['product_mpn'],
-                $shipmentId
+                $shipmentIds
             );
         }
 

--- a/src/Adapter/Shipment/QueryHandler/GetShipmentForEditingHandler.php
+++ b/src/Adapter/Shipment/QueryHandler/GetShipmentForEditingHandler.php
@@ -60,7 +60,7 @@ class GetShipmentForEditingHandler implements GetShipmentForEditingHandlerInterf
             $shipmentDetails['tracking_number'] = $result->getTrackingNumber();
             $shipmentDetails['carrier'] = $result->getCarrierId();
             foreach ($shipmentProducts as $shipmentProduct) {
-                $shipmentDetails['selectedProducts'][] = (new OrderDetail($shipmentProduct->getOrderDetailId()))->product_id;
+                $shipmentDetails['selectedProducts'][(new OrderDetail($shipmentProduct->getOrderDetailId()))->product_id] = 0;
             }
         } catch (Throwable $e) {
             throw new ShipmentNotFoundException(sprintf('Could not find shipment for order with id "%s"', $orderId), 0, $e);

--- a/src/Core/Domain/Order/QueryResult/OrderProductForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderProductForViewing.php
@@ -225,7 +225,7 @@ class OrderProductForViewing implements JsonSerializable
         array $packItems = [],
         ?OrderProductCustomizationsForViewing $customizations = null,
         string $mpn = '',
-        ?array $shipmentIds = []
+        array $shipmentIds = []
     ) {
         $this->id = $id;
         $this->combinationId = $combinationId;

--- a/src/Core/Domain/Order/QueryResult/OrderProductForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderProductForViewing.php
@@ -165,9 +165,9 @@ class OrderProductForViewing implements JsonSerializable
     private $mpn;
 
     /**
-     * @var int
+     * @var int[]
      */
-    private $shipmentId;
+    private $shipmentIds;
 
     /**
      * @param int $orderDetailId
@@ -196,7 +196,7 @@ class OrderProductForViewing implements JsonSerializable
      * @param array $packItems
      * @param OrderProductCustomizationsForViewing|null $customizations
      * @param string $mpn
-     * @param int|null $shipmentId
+     * @param int[] $shipmentIdss
      */
     public function __construct(
         ?int $orderDetailId,
@@ -225,7 +225,7 @@ class OrderProductForViewing implements JsonSerializable
         array $packItems = [],
         ?OrderProductCustomizationsForViewing $customizations = null,
         string $mpn = '',
-        ?int $shipmentId = null
+        ?array $shipmentIds = []
     ) {
         $this->id = $id;
         $this->combinationId = $combinationId;
@@ -253,7 +253,7 @@ class OrderProductForViewing implements JsonSerializable
         $this->packItems = $packItems;
         $this->customizations = $customizations;
         $this->mpn = $mpn;
-        $this->shipmentId = $shipmentId;
+        $this->shipmentIds = $shipmentIds;
     }
 
     /**
@@ -276,9 +276,12 @@ class OrderProductForViewing implements JsonSerializable
         return $this->id;
     }
 
-    public function getShipmentId(): ?int
+    /**
+     * @return int[]
+     */
+    public function getShipmentIds(): array
     {
-        return $this->shipmentId;
+        return $this->shipmentIds;
     }
 
     /**

--- a/src/Core/Domain/Order/QueryResult/OrderProductForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderProductForViewing.php
@@ -196,7 +196,7 @@ class OrderProductForViewing implements JsonSerializable
      * @param array $packItems
      * @param OrderProductCustomizationsForViewing|null $customizations
      * @param string $mpn
-     * @param int[] $shipmentIdss
+     * @param int[] $shipmentIds
      */
     public function __construct(
         ?int $orderDetailId,

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -657,6 +657,7 @@ class OrderController extends PrestaShopAdminController
     {
         $shipmentId = (int) $request->query->get('shipmentId');
         $formData = $this->dispatchQuery(new GetShipmentForEditing($orderId, $shipmentId))->toArray();
+        $formData['shipment_id'] = $shipmentId;
         $form = $this->createForm(EditShipmentType::class, $formData, ['order_id' => $orderId, 'shipment_id' => $shipmentId]);
 
         return $this->render('@PrestaShop/Admin/Sell/Order/Order/Blocks/View/edit_shipment_form.html.twig', [
@@ -730,7 +731,7 @@ class OrderController extends PrestaShopAdminController
     {
         $shipmentId = (int) $request->query->get('shipmentId');
         $formData = $this->dispatchQuery(new GetShipmentForEditing($orderId, $shipmentId))->toArray();
-
+        $formData['shipment_id'] = $shipmentId;
         $form = $this->createForm(EditShipmentType::class, $formData, ['order_id' => $orderId, 'shipment_id' => $shipmentId]);
         $form->handleRequest($request);
         $submittedData = $request->request->all('edit_shipment');
@@ -813,8 +814,8 @@ class OrderController extends PrestaShopAdminController
         $shipmentId = $request->query->getInt('shipmentId');
         $productsFromQuery = $request->get('products', []);
         $selectedCarrier = $request->query->getInt('carrier');
-
         $orderShipmentProducts = $this->mergeProductsFromQueries($shipmentId, $productsFromQuery, $orderDetailRepository);
+        var_dump($shipmentId);
 
         $formIsValid = $this->checkFormValidity($orderShipmentProducts);
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -815,7 +815,6 @@ class OrderController extends PrestaShopAdminController
         $productsFromQuery = $request->get('products', []);
         $selectedCarrier = $request->query->getInt('carrier');
         $orderShipmentProducts = $this->mergeProductsFromQueries($shipmentId, $productsFromQuery, $orderDetailRepository);
-        var_dump($shipmentId);
 
         $formIsValid = $this->checkFormValidity($orderShipmentProducts);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Shipment/EditShipmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Shipment/EditShipmentType.php
@@ -49,6 +49,7 @@ class EditShipmentType extends AbstractType
             ->add('carrier', ChoiceType::class, [
                 'choices' => $this->availableCarriersForShipmentChoiceProvider->getChoices([
                     'selectedProducts' => $options['data']['selectedProducts'],
+                    'shipment_id' => $options['data']['shipment_id'],
                 ]),
                 'placeholder' => $this->translator->trans('Select a carrier', [], 'Admin.Orderscustomers.Feature'),
                 'required' => true,

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -51,10 +51,10 @@
           {{ product.supplierReference }}
         </p>
       {% endif %}
-      {% if isMultiShipmentFeatureFlagIsEnabled and product.shipmentId is not empty %}
+      {% if isMultiShipmentFeatureFlagIsEnabled and product.shipmentIds is not empty %}
         <p class="mb-0 productShipmentNumber">
           {{ 'Shipment number: %shipment_id%'|trans({
-              '%shipment_id%': product.shipmentId
+              '%shipment_id%': product.shipmentIds|join(", ")
           }, 'Admin.Orderscustomers.Feature') }}
         </p>
       {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -54,7 +54,7 @@
       {% if isMultiShipmentFeatureFlagIsEnabled and product.shipmentIds is not empty %}
         <p class="mb-0 productShipmentNumber">
           {{ 'Shipment number: %shipment_id%'|trans({
-              '%shipment_id%': product.shipmentIds|join(", ")
+              '%shipment_id%': product.shipmentIds|join(', ')
           }, 'Admin.Orderscustomers.Feature') }}
         </p>
       {% endif %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR aims to enhance the existing feature so that, instead of showing a single shipment number, the "Shipment number" field can display multiple shipment numbers associated with the same product. The values should be shown as a comma-separated list (e.g., Shipment number: 11, 9).
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a order with multiple products and shipments. Do a merge for getting a product with different shipments
| UI Tests          | [ui](https://github.com/PoulainMaxime/ga.tests.ui.pr/actions/runs/17495885726)
