### PR TITLE
Fix: Fatal Error : Doctrine proxy classes and cache in production mode Prestashop 9.0.0

### DIFF
--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Adapter\Container\ContainerParametersExtension;
 use PrestaShop\PrestaShop\Adapter\Container\DoctrineBuilderExtension;
 use PrestaShop\PrestaShop\Adapter\Container\LegacyContainer;
 use PrestaShop\PrestaShop\Adapter\Container\LegacyContainerBuilder;
+use PrestaShop\PrestaShop\Adapter\Doctrine\FrontDoctrineProxyWarmer;
 use PrestaShop\PrestaShop\Core\EnvironmentInterface;
 use PrestaShopBundle\DependencyInjection\Compiler\LoadServicesFromModulesPass;
 use PrestaShopBundle\Exception\ServiceContainerException;
@@ -191,6 +192,11 @@ class ContainerBuilder
         $this->loadServicesFromConfig($container);
         $this->loadModulesAutoloader($container);
         $container->compile();
+
+        if ($this->environment->isDebug() === false) {
+            $proxyWarmer = new FrontDoctrineProxyWarmer($container);
+            $proxyWarmer->run();
+        }
 
         // Dump the container file
         $dumper = new PhpDumper($container);

--- a/src/Adapter/Doctrine/FrontDoctrineProxyWarmer.php
+++ b/src/Adapter/Doctrine/FrontDoctrineProxyWarmer.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Container\ContainerInterface;
+use Throwable;
+
+final class FrontDoctrineProxyWarmer
+{
+    /** @var ContainerInterface */
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function run(): void
+    {
+        if (!$this->container->has('doctrine')) {
+            return;
+        }
+
+        try {
+            /** @var ManagerRegistry $doctrine */
+            $doctrine = $this->container->get('doctrine');
+
+            foreach ($doctrine->getManagers() as $entityManager) {
+                if (!$entityManager instanceof EntityManagerInterface || !method_exists($entityManager, 'getProxyFactory')) {
+                    continue;
+                }
+
+                $metadata = $entityManager->getMetadataFactory()->getAllMetadata();
+                if (!$metadata) {
+                    continue;
+                }
+
+                $entityManager->getProxyFactory()->generateProxyClasses($metadata, $entityManager->getConfiguration()->getProxyDir());
+            }
+        } catch (Throwable $exception) {
+            if ($this->container->has('logger')) {
+                $this->container->get('logger')->error('[Doctrine Proxy] Proxy generation error: ' . $exception->getMessage());
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | In the Front Office legacy container, Doctrine proxy classes were not being generated when running in production mode with `auto_generate_proxy_classes = 0`. As a result, entity proxies were missing, causing runtime errors when Doctrine tried to lazy-load entities.
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install the [demodoctrine ](https://github.com/PrestaShop/example-modules/tree/master/demodoctrine) module and the created entities must be displayed on the site's homepage.
| UI Tests          | https://github.com/Codencode/ga.tests.ui.pr/actions/runs/17767618957
| Fixed issue or discussion?     | Fixes #39100
| Related PRs       | 
| Sponsor company   | @Codencode 


