### PR TITLE
Backport Filemanager should load AdminKernel

### DIFF
--- a/admin-dev/filemanager/config/config.php
+++ b/admin-dev/filemanager/config/config.php
@@ -33,6 +33,20 @@ if (!defined('_PS_ADMIN_DIR_')) {
 }
 
 require_once _PS_ADMIN_DIR_.'/../config/config.inc.php';
+
+// Boot the Symfony kernel
+global $kernel;
+
+if (!$kernel) {
+    require_once _PS_ROOT_DIR_ . '/app/AdminKernel.php';
+
+    $kernel = new AdminKernel(
+        _PS_ENV_,
+        _PS_MODE_DEV_
+    );
+    $kernel->boot();
+}
+
 require_once _PS_ADMIN_DIR_.'/init.php';
 
 mb_internal_encoding('UTF-8');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | The filemanager is not booting the Symfony Kernel, and it may causes an Employee update if its bo_theme property is empty. Thus triggering Employee xor ObjectModel update hooks. Modules registered to those hooks that use the SymfonyContainer would crash the script.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to the develop branch and install my small test module : https://github.com/user-attachments/files/21484907/pr_filemanager.zip . Log to the BO with an employee that has its field bo_theme empty. Open the filemanager via this URL : https://your-localhost.com/admin-dev/filemanager/dialog.php . You should see a 500 error. Switch to my branch. Refresh the page. Filemanager should display.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShopCorp/ps_mbo/issues/800
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/39233
| Sponsor company   | @Codencode 
