### PR TITLE
Display right tab when the feature flag is enabled

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -606,7 +606,6 @@ class OrderController extends PrestaShopAdminController
             'meta_title' => $metatitle,
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'orderForViewing' => $orderForViewing,
-            'isMultiShipmentFeatureFlagIsEnabled' => $this->isFeatureFlagIsEnabledForMultiShipment(),
             'addOrderCartRuleForm' => $addOrderCartRuleForm->createView(),
             'updateOrderStatusForm' => $updateOrderStatusForm->createView(),
             'updateOrderStatusActionBarForm' => $updateOrderStatusActionBarForm->createView(),
@@ -630,6 +629,7 @@ class OrderController extends PrestaShopAdminController
             'isAvailableQuantityDisplayed' => (bool) $this->getConfiguration()->get('PS_STOCK_MANAGEMENT'),
             'internalNoteForm' => $internalNoteForm->createView(),
             'isImprovedShipmentFeatureFlagEnabled' => $featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT),
+            'orderHasShipment' => $this->orderHasShipment($orderForViewing->getId()),
             'shipmentsGrid' => $this->presentGrid($shipmentsGrid),
             'shipmentsLabel' => $tools->purifyHTML($shipmentsLabel),
             'carriersLabel' => $tools->purifyHTML($carriersLabel),
@@ -2401,11 +2401,11 @@ class OrderController extends PrestaShopAdminController
         ];
     }
 
-    private function isFeatureFlagIsEnabledForMultiShipment(): bool
+    private function orderHasShipment(int $orderId): bool
     {
-        /** @var FeatureFlagStateCheckerInterface $featureFlagManager */
-        $featureFlagManager = $this->getFeatureFlagStateChecker();
+        /** @var OrderShipment[] $shipments */
+        $shipments = $this->dispatchQuery(new GetOrderShipments($orderId));
 
-        return $featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT);
+        return (bool) count($shipments) > 0;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
@@ -49,7 +49,7 @@
         {{ documentsTitle }}
       </a>
     </li>
-    {% if isImprovedShipmentFeatureFlagEnabled %}
+    {% if isImprovedShipmentFeatureFlagEnabled and orderHasShipment == true %}
       <li class="nav-item">
         <a class="nav-link" id="orderShipmentsTab" data-toggle="tab" href="#orderShipmentsTabContent" role="tab" aria-controls="orderShipmentsTabContent" aria-expanded="true" aria-selected="false">
           <i class="material-icons">local_shipping</i>
@@ -96,7 +96,7 @@
         {% endblock %}
       {% endembed %}
     </div>
-    {% if isImprovedShipmentFeatureFlagEnabled %}
+    {% if isImprovedShipmentFeatureFlagEnabled and orderHasShipment == true %}
       <div class="tab-pane d-print-block fade" id="orderShipmentsTabContent" role="tabpanel" aria-labelledby="orderShipmentsTab">
         {% embed '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/details_card.html.twig' %}
           {% block header %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -51,7 +51,7 @@
           {{ product.supplierReference }}
         </p>
       {% endif %}
-      {% if isMultiShipmentFeatureFlagIsEnabled and product.shipmentIds is not empty %}
+      {% if isImprovedShipmentFeatureFlagEnabled and product.shipmentId is not empty %}
         <p class="mb-0 productShipmentNumber">
           {{ 'Shipment number: %shipment_id%'|trans({
               '%shipment_id%': product.shipmentIds|join(', ')

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -51,7 +51,7 @@
           {{ product.supplierReference }}
         </p>
       {% endif %}
-      {% if isImprovedShipmentFeatureFlagEnabled and product.shipmentId is not empty %}
+      {% if isImprovedShipmentFeatureFlagEnabled and product.shipmentIds is not empty %}
         <p class="mb-0 productShipmentNumber">
           {{ 'Shipment number: %shipment_id%'|trans({
               '%shipment_id%': product.shipmentIds|join(', ')


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | display right tab when the feature flag multishipment is enabled
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable the feature flag multishipment and make an order. the new order with ff enable should have the tab shipment and the old order should have carriers tab
| UI Tests          | incoming
