### PR TITLE
Improve getSpecificPrice static cache for products with combinations

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -545,9 +545,7 @@ class SpecificPriceCore extends ObjectModel
         }
 
         if (!array_key_exists($key, self::$_specificPriceCache)) {
-            $query_extra = self::computeExtraConditions($id_product, $id_product_attribute, $id_customer, $id_cart);
-            //we want to get specific prices for all product variants
-            $query_extraAll = self::computeExtraConditions($id_product, null, $id_customer, $id_cart);            
+            $query_extra = self::computeExtraConditions($id_product, $id_product_attribute, $id_customer, $id_cart);         
             if ($key === null) {
                 // compute the key after calling computeExtraConditions as it initializes some useful cache
                 $key = self::computeKey(
@@ -575,75 +573,78 @@ class SpecificPriceCore extends ObjectModel
             $conditions = 'AND IF(`from_quantity` > 1, `from_quantity`, 0) <= ';
             $conditions .= (static::$psQtyDiscountOnCombination || !$id_cart || !$real_quantity) ? (int) $quantity : max(1, (int) $real_quantity);
             $conditions .= ' ORDER BY `id_product_attribute` DESC, `id_cart` DESC, `from_quantity` DESC, `id_specific_price_rule` ASC, `score` DESC, `to` DESC, `from` DESC';
-            
+            //copy part of query for all variants
             $queryAll = $query;
-            //keep the old query as a fallback
             $query .= $query_extra;
             $query .= $conditions;
-            $queryAll .= $query_extraAll;
-            $queryAll .= $conditions;
-            //cache all product variants to limit calls for the same product
-            $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($queryAll);
-            $variantsId = Product::getProductAttributesIds($id_product);
-            foreach(array_column($variantsId,'id_product_attribute') as $variantId){
-                switch(true){
-                    //product variant matching specific price
-                    case in_array($variantId,array_column($result,'id_product_attribute')):
-                        $k=array_search($variantId,array_column($result,'id_product_attribute'));
-                        $key = self::computeKey(
-                            $id_product,
-                            $id_shop,
-                            $id_currency,
-                            $id_country,
-                            $id_group,
-                            $quantity,
-                            (int)$variantId,
-                            $id_customer,
-                            $id_cart,
-                            $real_quantity
-                        );
-                        if(!array_key_exists($key, self::$_specificPriceCache)){
-                            self::$_specificPriceCache[$key] = $result[$k];
-                        }
-                    break; 
-                    //specific price rules case where rule applies to all variants
-                    case in_array(0,array_column($result,'id_product_attribute')):
-                        $k=array_search(0,array_column($result,'id_product_attribute'));
-                        $key = self::computeKey(
-                            $id_product,
-                            $id_shop,
-                            $id_currency,
-                            $id_country,
-                            $id_group,
-                            $quantity,
-                            (int)$variantId,
-                            $id_customer,
-                            $id_cart,
-                            $real_quantity
-                        );
-                        if(!array_key_exists($key, self::$_specificPriceCache)){
-                            self::$_specificPriceCache[$key] = $result[$k];
-                        }
-                    break;
-                    //if product variant doesnt have any matching specific price we have to return false
-                    default:
-                        $key = self::computeKey(
-                            $id_product,
-                            $id_shop,
-                            $id_currency,
-                            $id_country,
-                            $id_group,
-                            $quantity,
-                            (int)$variantId,
-                            $id_customer,
-                            $id_cart,
-                            $real_quantity
-                        );
-                        if(!array_key_exists($key, self::$_specificPriceCache)){
-                            self::$_specificPriceCache[$key] = false;
-                        }
-                }
-            }
+			if($id_product_attribute){
+				//we want to get specific prices for all product variants			
+				$query_extraAll = self::computeExtraConditions($id_product, null, $id_customer, $id_cart);
+				$queryAll .= $query_extraAll;
+				$queryAll .= $conditions;
+				//cache all product variants to limit calls for the same product
+				$result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($queryAll);
+				
+				foreach(array_column(Product::getProductAttributesIds($id_product),'id_product_attribute') as $variantId){
+					switch(true){
+						//product variant matching specific price
+						case in_array($variantId,array_column($result,'id_product_attribute')):
+							$k=array_search($variantId,array_column($result,'id_product_attribute'));
+							$key = self::computeKey(
+								$id_product,
+								$id_shop,
+								$id_currency,
+								$id_country,
+								$id_group,
+								$quantity,
+								(int)$variantId,
+								$id_customer,
+								$id_cart,
+								$real_quantity
+							);
+							if(!array_key_exists($key, self::$_specificPriceCache)){
+								self::$_specificPriceCache[$key] = $result[$k];
+							}
+						break; 
+						//specific price rules case where rule applies to all variants
+						case in_array(0,array_column($result,'id_product_attribute')):
+							$k=array_search(0,array_column($result,'id_product_attribute'));
+							$key = self::computeKey(
+								$id_product,
+								$id_shop,
+								$id_currency,
+								$id_country,
+								$id_group,
+								$quantity,
+								(int)$variantId,
+								$id_customer,
+								$id_cart,
+								$real_quantity
+							);
+							if(!array_key_exists($key, self::$_specificPriceCache)){
+								self::$_specificPriceCache[$key] = $result[$k];
+							}
+						break;
+						//if product variant doesnt have any matching specific price we have to return false
+						default:
+							$key = self::computeKey(
+								$id_product,
+								$id_shop,
+								$id_currency,
+								$id_country,
+								$id_group,
+								$quantity,
+								(int)$variantId,
+								$id_customer,
+								$id_cart,
+								$real_quantity
+							);
+							if(!array_key_exists($key, self::$_specificPriceCache)){
+								self::$_specificPriceCache[$key] = false;
+							}
+					}
+				}
+			}
             if(!array_key_exists($key, self::$_specificPriceCache)){
                 //keep the old query as a fallback
                self::$_specificPriceCache[$key] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query);

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -546,6 +546,8 @@ class SpecificPriceCore extends ObjectModel
 
         if (!array_key_exists($key, self::$_specificPriceCache)) {
             $query_extra = self::computeExtraConditions($id_product, $id_product_attribute, $id_customer, $id_cart);
+            //we want to get specific prices for all product variants
+            $query_extraAll = self::computeExtraConditions($id_product, null, $id_customer, $id_cart);            
             if ($key === null) {
                 // compute the key after calling computeExtraConditions as it initializes some useful cache
                 $key = self::computeKey(
@@ -568,16 +570,24 @@ class SpecificPriceCore extends ObjectModel
                 `id_shop` ' . self::formatIntInQuery(0, $id_shop) . ' AND
                 `id_currency` ' . self::formatIntInQuery(0, $id_currency) . ' AND
                 `id_country` ' . self::formatIntInQuery(0, $id_country) . ' AND
-                `id_group` ' . self::formatIntInQuery(0, $id_group) . ' ' . $query_extra . '
-				AND IF(`from_quantity` > 1, `from_quantity`, 0) <= ';
-
-            $query .= (static::$psQtyDiscountOnCombination || !$id_cart || !$real_quantity) ? (int) $quantity : max(1, (int) $real_quantity);
-            $query .= ' ORDER BY `id_product_attribute` DESC, `id_cart` DESC, `from_quantity` DESC, `id_specific_price_rule` ASC, `score` DESC, `to` DESC, `from` DESC';
-            $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(str_replace("AND `id_product_attribute` = 0",'AND `id_product_attribute` >= 0',$query));
-            //cache product variants to limit calls for the same product
+                `id_group` ' . self::formatIntInQuery(0, $id_group) . ' ';
+            //additional conditions for query
+            $conditions = 'AND IF(`from_quantity` > 1, `from_quantity`, 0) <= ';
+            $conditions .= (static::$psQtyDiscountOnCombination || !$id_cart || !$real_quantity) ? (int) $quantity : max(1, (int) $real_quantity);
+            $conditions .= ' ORDER BY `id_product_attribute` DESC, `id_cart` DESC, `from_quantity` DESC, `id_specific_price_rule` ASC, `score` DESC, `to` DESC, `from` DESC';
+            
+            $queryAll = $query;
+            //keep the old query as a fallback
+            $query .= $query_extra;
+            $query .= $conditions;
+            $queryAll .= $query_extraAll;
+            $queryAll .= $conditions;
+            //cache all product variants to limit calls for the same product
+            $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($queryAll);
             $variantsId = Product::getProductAttributesIds($id_product);
             foreach(array_column($variantsId,'id_product_attribute') as $variantId){
                 switch(true){
+                    //product variant matching specific price
                     case in_array($variantId,array_column($result,'id_product_attribute')):
                         $k=array_search($variantId,array_column($result,'id_product_attribute'));
                         $key = self::computeKey(
@@ -596,6 +606,7 @@ class SpecificPriceCore extends ObjectModel
                             self::$_specificPriceCache[$key] = $result[$k];
                         }
                     break; 
+                    //specific price rules case where rule applies to all variants
                     case in_array(0,array_column($result,'id_product_attribute')):
                         $k=array_search(0,array_column($result,'id_product_attribute'));
                         $key = self::computeKey(
@@ -614,6 +625,7 @@ class SpecificPriceCore extends ObjectModel
                             self::$_specificPriceCache[$key] = $result[$k];
                         }
                     break;
+                    //if product variant doesnt have any matching specific price we have to return false
                     default:
                         $key = self::computeKey(
                             $id_product,
@@ -633,7 +645,7 @@ class SpecificPriceCore extends ObjectModel
                 }
             }
             if(!array_key_exists($key, self::$_specificPriceCache)){
-                
+                //keep the old query as a fallback
                self::$_specificPriceCache[$key] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query);
             }
             

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -573,9 +573,71 @@ class SpecificPriceCore extends ObjectModel
 
             $query .= (static::$psQtyDiscountOnCombination || !$id_cart || !$real_quantity) ? (int) $quantity : max(1, (int) $real_quantity);
             $query .= ' ORDER BY `id_product_attribute` DESC, `id_cart` DESC, `from_quantity` DESC, `id_specific_price_rule` ASC, `score` DESC, `to` DESC, `from` DESC';
-            self::$_specificPriceCache[$key] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query);
-        }
-
+            $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(str_replace("AND `id_product_attribute` = 0",'AND `id_product_attribute` >= 0',$query));
+            //cache product variants to limit calls for the same product
+            $variantsId = Product::getProductAttributesIds($id_product);
+            foreach(array_column($variantsId,'id_product_attribute') as $variantId){
+                switch(true){
+                    case in_array($variantId,array_column($result,'id_product_attribute')):
+                        $k=array_search($variantId,array_column($result,'id_product_attribute'));
+                        $key = self::computeKey(
+                            $id_product,
+                            $id_shop,
+                            $id_currency,
+                            $id_country,
+                            $id_group,
+                            $quantity,
+                            (int)$variantId,
+                            $id_customer,
+                            $id_cart,
+                            $real_quantity
+                        );
+                        if(!array_key_exists($key, self::$_specificPriceCache)){
+                            self::$_specificPriceCache[$key] = $result[$k];
+                        }
+                    break; 
+                    case in_array(0,array_column($result,'id_product_attribute')):
+                        $k=array_search(0,array_column($result,'id_product_attribute'));
+                        $key = self::computeKey(
+                            $id_product,
+                            $id_shop,
+                            $id_currency,
+                            $id_country,
+                            $id_group,
+                            $quantity,
+                            (int)$variantId,
+                            $id_customer,
+                            $id_cart,
+                            $real_quantity
+                        );
+                        if(!array_key_exists($key, self::$_specificPriceCache)){
+                            self::$_specificPriceCache[$key] = $result[$k];
+                        }
+                    break;
+                    default:
+                        $key = self::computeKey(
+                            $id_product,
+                            $id_shop,
+                            $id_currency,
+                            $id_country,
+                            $id_group,
+                            $quantity,
+                            (int)$variantId,
+                            $id_customer,
+                            $id_cart,
+                            $real_quantity
+                        );
+                        if(!array_key_exists($key, self::$_specificPriceCache)){
+                            self::$_specificPriceCache[$key] = false;
+                        }
+                }
+            }
+            if(!array_key_exists($key, self::$_specificPriceCache)){
+                
+               self::$_specificPriceCache[$key] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query);
+            }
+            
+        }   
         return self::$_specificPriceCache[$key];
     }
 

--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -436,23 +436,6 @@ class StockAvailableCore extends ObjectModel
         if ($id_product_attribute === null) {
             $id_product_attribute = 0;
         }
-
-        //cache quantity available for every combination of provided product id
-        if ($id_product !== null) {
-            $key1 = 'StockAvailable::getQuantityAvailableByProduct_Group_' . (int) $id_product. '-' . (int) $id_shop;
-            if (!Cache::isStored($key1)) {
-                $query = new DbQuery();
-                $query->select('quantity,id_product_attribute');
-                $query->from('stock_available');
-                $query->where('id_product = ' . (int) $id_product);
-                $query = StockAvailable::addSqlShopRestriction($query, $id_shop);
-                $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
-                foreach($result as $r){
-                    Cache::store('StockAvailable::getQuantityAvailableByProduct_' . (int) $id_product . '-' . (int) $r['id_product_attribute'] . '-' . (int) $id_shop, (int)$r['quantity']);
-                }
-                Cache::store($key1, $result);
-            }
-        }
         $key = 'StockAvailable::getQuantityAvailableByProduct_' . (int) $id_product . '-' . (int) $id_product_attribute . '-' . (int) $id_shop;
         if (!Cache::isStored($key)) {
             $query = new DbQuery();

--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -437,6 +437,22 @@ class StockAvailableCore extends ObjectModel
             $id_product_attribute = 0;
         }
 
+        //cache quantity available for every combination of provided product id
+        if ($id_product !== null) {
+            $key1 = 'StockAvailable::getQuantityAvailableByProduct_Group_' . (int) $id_product. '-' . (int) $id_shop;
+            if (!Cache::isStored($key1)) {
+                $query = new DbQuery();
+                $query->select('quantity,id_product_attribute');
+                $query->from('stock_available');
+                $query->where('id_product = ' . (int) $id_product);
+                $query = StockAvailable::addSqlShopRestriction($query, $id_shop);
+                $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
+                foreach($result as $r){
+                    Cache::store('StockAvailable::getQuantityAvailableByProduct_' . (int) $id_product . '-' . (int) $r['id_product_attribute'] . '-' . (int) $id_shop, (int)$r['quantity']);
+                }
+                Cache::store($key1, $result);
+            }
+        }
         $key = 'StockAvailable::getQuantityAvailableByProduct_' . (int) $id_product . '-' . (int) $id_product_attribute . '-' . (int) $id_shop;
         if (!Cache::isStored($key)) {
             $query = new DbQuery();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | getSpecificPrice is called on every combination for product and caching one result at a time. Instead we should call it once for all product variants and cache them. This way we reduce memory usage, query doubles and loading speed. Specific prices is allways returned with results from query or false if no match found. Tested on 8.2.2 and 8.1.7. The more combinations product has the bigger improvement you will notice.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | create product with a lot of combinations 50-100+. Below you can find improvements on product with 800 combinations. 
| UI Tests          |  CI test are green
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

Should work on higher version but i dont have 
Below you can see difference in loading product page with 800 combinations, which looks like that from customer point of view.
<img width="623" height="328" alt="image" src="https://github.com/user-attachments/assets/4ba0b21b-4301-48e6-8ba6-9feac41aaeaa" />
Before change:
<img width="1135" height="611" alt="image" src="https://github.com/user-attachments/assets/3f4aedb6-89b7-4c8b-bb9f-13cb12d62b9f" />

After change:
<img width="1103" height="581" alt="image" src="https://github.com/user-attachments/assets/f2c93033-a7db-4533-a8a2-d2f8229961c1" />

In combination with another change improving caching of StockAvailable::getQuantityAvailableByProduct, we can go even lower with memory usage and loading speed.
before StockAvailable cache change
<img width="1249" height="603" alt="image" src="https://github.com/user-attachments/assets/17ac6ff8-574a-42c8-add3-1da3c78807ba" />
After StockAvailable cache change
<img width="1251" height="607" alt="image" src="https://github.com/user-attachments/assets/b70f48af-8ded-4e4d-8dca-e4bcf4d01a73" />
