### PR TITLE
Admin API Openapi multistore context documentation

### DIFF
--- a/tests/Integration/PrestaShopBundle/ApiPlatform/CQRSOpenApiFactoryTest.php
+++ b/tests/Integration/PrestaShopBundle/ApiPlatform/CQRSOpenApiFactoryTest.php
@@ -141,6 +141,40 @@ class CQRSOpenApiFactoryTest extends KernelTestCase
         ];
     }
 
+    public function testMultishopParametersAreDocumentedWhenFeatureActive(): void
+    {
+        $configuration = $this->getContainer()->get('prestashop.adapter.legacy.configuration');
+        $configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+
+        /** @var OpenApiFactoryInterface $openApiFactory */
+        $openApiFactory = $this->getContainer()->get(OpenApiFactoryInterface::class);
+        /** @var OpenApi $openApi */
+        $openApi = $openApiFactory->__invoke();
+        $operation = $openApi->getPaths()->getPath('/products')->getGet();
+        $parameterNames = array_map(static fn ($parameter) => $parameter->getName(), $operation->getParameters());
+        $this->assertContains('shopId', $parameterNames);
+        $this->assertContains('shopGroupId', $parameterNames);
+        $this->assertContains('shopIds', $parameterNames);
+        $this->assertContains('allShops', $parameterNames);
+    }
+
+    public function testMultishopParametersAreNotDocumentedWhenFeatureInactive(): void
+    {
+        $configuration = $this->getContainer()->get('prestashop.adapter.legacy.configuration');
+        $configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', 0);
+
+        /** @var OpenApiFactoryInterface $openApiFactory */
+        $openApiFactory = $this->getContainer()->get(OpenApiFactoryInterface::class);
+        /** @var OpenApi $openApi */
+        $openApi = $openApiFactory->__invoke();
+        $operation = $openApi->getPaths()->getPath('/products')->getGet();
+        $parameterNames = array_map(static fn ($parameter) => $parameter->getName(), $operation->getParameters());
+        $this->assertNotContains('shopId', $parameterNames);
+        $this->assertNotContains('shopGroupId', $parameterNames);
+        $this->assertNotContains('shopIds', $parameterNames);
+        $this->assertNotContains('allShops', $parameterNames);
+    }
+
     /**
      * @dataProvider provideJsonSchemaFactoryCases
      */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR adds multistore context parameters to the OpenAPI documentation for the Admin API. When multistore feature is active, the API documentation now includes four optional query parameters: `shopId`, `shopGroupId`, `shopIds`, and `allShops`. The parameters are automatically added to all API endpoints when multistore is enabled, providing clear documentation on how to work with multistore environments.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable multistore feature <br>2. Enable the multistore admin api toggle feature <br>3. Access the Admin API documentation (OpenAPI JSON/Swagger UI)<br>4. Verify that all endpoints show the four new optional query parameters: `shopId`, `shopGroupId`, `shopIds`, and `allShops`<br>4. Disable multistore and verify parameters are not shown
| UI Tests          | [results](https://github.com/iNem0o/ga.tests.ui.pr/actions/runs/17642345286)
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | e-frogg