### PR TITLE
Improve getQuantityAvailableByProduct static cache for products with combinations

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -436,7 +436,22 @@ class StockAvailableCore extends ObjectModel
         if ($id_product_attribute === null) {
             $id_product_attribute = 0;
         }
-
+        //cache quantity available for every combination of provided product id
+        if ($id_product !== null) {
+            $key1 = 'StockAvailable::getQuantityAvailableByProduct_Group_' . (int) $id_product. '-' . (int) $id_shop;
+            if (!Cache::isStored($key1)) {
+                $query = new DbQuery();
+                $query->select('quantity,id_product_attribute');
+                $query->from('stock_available');
+                $query->where('id_product = ' . (int) $id_product);
+                $query = StockAvailable::addSqlShopRestriction($query, $id_shop);
+                $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
+                foreach($result as $r){
+                    Cache::store('StockAvailable::getQuantityAvailableByProduct_' . (int) $id_product . '-' . (int) $r['id_product_attribute'] . '-' . (int) $id_shop, (int)$r['quantity']);
+                }
+                Cache::store($key1, $result);
+            }
+        }
         $key = 'StockAvailable::getQuantityAvailableByProduct_' . (int) $id_product . '-' . (int) $id_product_attribute . '-' . (int) $id_shop;
         if (!Cache::isStored($key)) {
             $query = new DbQuery();


### PR DESCRIPTION
Small improvement for caching all combinations related to the product. Saves memory and removes doubles.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Improve combination stock quantity cache for each variant. Right now every combination is cached one by one using same query SUM(quantity) from stock_available. After changes it's using one query to cache all variants and still keeps old method as a fallback.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Make product with 100+ combinations, enable profiler and see the double calls for stock_available SUM(quantity) on every combination. 
| UI Tests          | CI tests are green 
| Fixed issue or discussion?     | 
| Related PRs       | Followup to PR #39539 
| Sponsor company   