### PR TITLE
add void return type for AbstractType compatibility

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/ApiClientType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/ApiClientType.php
@@ -43,7 +43,7 @@ use Symfony\Component\Validator\Constraints\Positive;
 
 class ApiClientType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // If an external issuer is specified most of the form is not editable or relevant
         $formData = $builder->getData();
@@ -133,7 +133,7 @@ class ApiClientType extends TranslatorAwareType
         }
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/ConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/ConfigurationType.php
@@ -44,7 +44,7 @@ class ConfigurationType extends TranslatorAwareType
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $enableAdminAPIHelp = $this->trans(
             'Before enabling the Admin API, you must be sure to:',
@@ -94,7 +94,7 @@ class ConfigurationType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/ResourceScopesType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/ResourceScopesType.php
@@ -55,7 +55,7 @@ class ResourceScopesType extends TranslatorAwareType implements DataMapperInterf
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $resourceScopes = $this->resourceScopeExtractor->getAllApiResourceScopes();
         foreach ($resourceScopes as $resourceScope) {
@@ -101,7 +101,7 @@ class ResourceScopesType extends TranslatorAwareType implements DataMapperInterf
         $viewData = $associatedScopes;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/SwitchScopeType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/SwitchScopeType.php
@@ -38,7 +38,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class SwitchScopeType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('scope', TextPreviewType::class, [
@@ -54,7 +54,7 @@ class SwitchScopeType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
@@ -46,7 +46,7 @@ class CachingType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('use_cache', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CombineCompressCacheType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CombineCompressCacheType.php
@@ -38,7 +38,7 @@ class CombineCompressCacheType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('smart_cache_css', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
@@ -39,7 +39,7 @@ class DebugModeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('disable_overrides', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MediaServersType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MediaServersType.php
@@ -38,7 +38,7 @@ class MediaServersType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('media_server_one', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MemcacheServerType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MemcacheServerType.php
@@ -38,7 +38,7 @@ class MemcacheServerType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('memcache_ip', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/OptionalFeaturesType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/OptionalFeaturesType.php
@@ -56,7 +56,7 @@ class OptionalFeaturesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('combinations', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/SmartyType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/SmartyType.php
@@ -39,7 +39,7 @@ class SmartyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('template_compilation', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
@@ -94,7 +94,7 @@ abstract class AbstractCategoryType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $genericCharactersHint = $this->trans('Invalid characters: %s', 'Admin.Notifications.Info', [TypedRegexValidator::CATALOG_CHARS]);
         /* @var EditableCategory $editableCategory */

--- a/src/PrestaShopBundle/Form/Admin/Catalog/Category/CategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Catalog/Category/CategoryType.php
@@ -38,7 +38,7 @@ class CategoryType extends AbstractCategoryType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
 
@@ -67,7 +67,7 @@ class CategoryType extends AbstractCategoryType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
@@ -43,7 +43,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('check_ip_address', SwitchType::class, [
@@ -70,7 +70,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/NotificationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/NotificationsType.php
@@ -36,7 +36,7 @@ class NotificationsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('show_notifs_new_orders', SwitchType::class, [
@@ -53,7 +53,7 @@ class NotificationsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
@@ -62,7 +62,7 @@ class UploadQuotaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $configuration = $this->configuration;
         $builder
@@ -167,7 +167,7 @@ class UploadQuotaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Backup/BackupOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Backup/BackupOptionsType.php
@@ -61,7 +61,7 @@ class BackupOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $backupAllHelp = $this->trans(
             'Drop existing tables during import.',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/DkimConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/DkimConfigurationType.php
@@ -41,7 +41,7 @@ class DkimConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('domain', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
@@ -70,7 +70,7 @@ class EmailConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('send_emails_to', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php
@@ -40,7 +40,7 @@ class SmtpConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('domain', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/TestEmailSendingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/TestEmailSendingType.php
@@ -39,7 +39,7 @@ class TestEmailSendingType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('send_email_to', EmailType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
@@ -60,7 +60,7 @@ class EmployeeOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $optionsLock = [];
         if (!$this->canOptionsBeChanged) {

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -119,7 +119,7 @@ final class EmployeeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $minScore = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_SCORE);
         $maxLength = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH);
@@ -261,7 +261,7 @@ final class EmployeeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagListType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagListType.php
@@ -40,7 +40,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class FeatureFlagListType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('feature_flags', CollectionType::class, [
@@ -56,7 +56,7 @@ class FeatureFlagListType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagType.php
@@ -53,7 +53,7 @@ class FeatureFlagType extends TranslatorAwareType
         $this->formCloner = $formCloner;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('enabled', FeatureFlagSwitchType::class, [
@@ -81,7 +81,7 @@ class FeatureFlagType extends TranslatorAwareType
         ]));
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportDataConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportDataConfigurationType.php
@@ -72,7 +72,7 @@ class ImportDataConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('matches', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
@@ -47,7 +47,7 @@ class ImportType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('csv', HiddenType::class)
@@ -146,7 +146,7 @@ class ImportType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/DatabaseLogsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/DatabaseLogsType.php
@@ -39,7 +39,7 @@ final class DatabaseLogsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('database_min_logger_level', LogSeverityChoiceType::class, [
@@ -59,7 +59,7 @@ final class DatabaseLogsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
@@ -40,7 +40,7 @@ final class LogsByEmailType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('logs_by_email', LogSeverityChoiceType::class, [
@@ -72,7 +72,7 @@ final class LogsByEmailType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
@@ -53,7 +53,7 @@ class ProfileType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestType.php
@@ -40,7 +40,7 @@ class SqlRequestType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/GeneralType.php
@@ -38,7 +38,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add(
             'token',
@@ -54,7 +54,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/PasswordPolicyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/PasswordPolicyType.php
@@ -40,7 +40,7 @@ class PasswordPolicyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(
@@ -88,7 +88,7 @@ class PasswordPolicyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceConfigurationType.php
@@ -41,7 +41,7 @@ class WebserviceConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $enableWebservicesHelp = $this->trans(
             'Before activating the webservice, you must be sure to: ',
@@ -85,7 +85,7 @@ class WebserviceConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -83,7 +83,7 @@ class WebserviceKeyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('key', GeneratableTextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
@@ -79,7 +79,7 @@ class ContactType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('title', TranslatableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
@@ -42,7 +42,7 @@ use Symfony\Component\Validator\Constraints\Type;
  */
 class GeneralType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('redisplay_cart_at_login', SwitchType::class, [
@@ -131,7 +131,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/TitleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/TitleType.php
@@ -43,7 +43,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class TitleType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
@@ -67,7 +67,7 @@ class MaintenanceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(
@@ -138,7 +138,7 @@ class MaintenanceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -95,7 +95,7 @@ class PreferencesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $configuration = $this->configuration;
 
@@ -209,7 +209,7 @@ class PreferencesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -75,7 +75,7 @@ class GeneralType extends TranslatorAwareType
         $this->currencyDataProvider = $currencyDataProvider;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $configuration = $this->configuration;
         $currencyIsoCode = $this->currencyDataProvider->getDefaultCurrencyIsoCode();
@@ -147,7 +147,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
@@ -91,7 +91,7 @@ class GiftOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $atcpShipWrap = (bool) $this->configuration->get('PS_ATCP_SHIPWRAP');
         $currencyIsoCode = $this->defaultCurrencyIsoCode;
@@ -140,7 +140,7 @@ class GiftOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
@@ -48,7 +48,7 @@ class OrderReturnStateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [
@@ -92,7 +92,7 @@ class OrderReturnStateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
@@ -113,7 +113,7 @@ class OrderStateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [
@@ -248,7 +248,7 @@ class OrderStateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -65,7 +65,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('catalog_mode', SwitchType::class, [
@@ -205,7 +205,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -41,7 +41,7 @@ class PageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('display_quantities', SwitchType::class, [
@@ -137,7 +137,7 @@ class PageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
@@ -41,7 +41,7 @@ class PaginationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('products_per_page', IntegerType::class, [
@@ -93,7 +93,7 @@ class PaginationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
@@ -45,7 +45,7 @@ class StockType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('stock_management', SwitchType::class, [
@@ -215,7 +215,7 @@ class StockType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Search/AliasType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Search/AliasType.php
@@ -43,7 +43,7 @@ class AliasType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('alias', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaType.php
@@ -81,7 +81,7 @@ class MetaType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('page_name', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SEOOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SEOOptionsType.php
@@ -40,7 +40,7 @@ class SEOOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('product_attributes_in_title', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
@@ -87,7 +87,7 @@ class SetUpUrlType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $friendlyUrlHelp = $this->trans(
             'Enable this option only if your server allows URL rewriting (recommended).',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/ShopUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/ShopUrlType.php
@@ -70,7 +70,7 @@ class ShopUrlType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if (!$this->isShopFeatureActive && $this->doesMainShopUrlExist) {
             $builder
@@ -98,7 +98,7 @@ class ShopUrlType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => false,

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
@@ -59,7 +59,7 @@ class UrlSchemaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('product_rule', TextType::class, [
@@ -123,7 +123,7 @@ class UrlSchemaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => false,

--- a/src/PrestaShopBundle/Form/Admin/CustomerService/CustomerThread/ForwardCustomerThreadType.php
+++ b/src/PrestaShopBundle/Form/Admin/CustomerService/CustomerThread/ForwardCustomerThreadType.php
@@ -63,7 +63,7 @@ class ForwardCustomerThreadType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $employeeChoices = $this->employeeChoiceProvider->getChoices();
         $employeeChoices[$this->translator->trans('Someone else', [], 'Admin.Orderscustomers.Feature')] = 0;

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/DeleteImageTypeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/DeleteImageTypeType.php
@@ -34,7 +34,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class DeleteImageTypeType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('delete_images_files_too', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageSettingsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageSettingsType.php
@@ -47,7 +47,7 @@ class ImageSettingsType extends TranslatorAwareType
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // Check if AVIF is enabled on the server
         $avifEnabled = $this->avifExtensionChecker->isAvailable();

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageTypeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageTypeType.php
@@ -45,7 +45,7 @@ class ImageTypeType extends TranslatorAwareType
     /** Maximum size for width and height in pixels for the image type */
     private const MAX_PX_SIZE = 9999;
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/RegenerateThumbnailsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/RegenerateThumbnailsType.php
@@ -46,7 +46,7 @@ class RegenerateThumbnailsType extends TranslatorAwareType
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('image', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/GenerateMailsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/GenerateMailsType.php
@@ -73,7 +73,7 @@ class GenerateMailsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $noTheme = $this->trans('Core (no theme selected)', 'Admin.International.Feature');
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/MailThemeConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/MailThemeConfigurationType.php
@@ -50,7 +50,7 @@ class MailThemeConfigurationType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('defaultTheme', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/TranslateMailsBodyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/TranslateMailsBodyType.php
@@ -39,7 +39,7 @@ class TranslateMailsBodyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('language', LocaleChoiceType::class)

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
@@ -77,7 +77,7 @@ class CmsPageCategoryType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $invalidCharactersForCatalogLabel = $this->trans('Invalid characters:', 'Admin.Global') . TypedRegexValidator::CATALOG_CHARS;
         $invalidCharactersForNameLabel = $this->trans('Invalid characters:', 'Admin.Global') . TypedRegexValidator::GENERIC_NAME_CHARS;

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -86,7 +86,7 @@ class CmsPageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $invalidCharsText = sprintf('%s <>{}', $this->trans('Invalid characters:', 'Admin.Notifications.Info'));
 
@@ -282,7 +282,7 @@ class CmsPageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/AdaptThemeToRTLLanguagesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/AdaptThemeToRTLLanguagesType.php
@@ -52,7 +52,7 @@ class AdaptThemeToRTLLanguagesType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('theme_to_adapt', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ImportThemeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ImportThemeType.php
@@ -62,7 +62,7 @@ class ImportThemeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('import_from_computer', FileType::class, [
@@ -102,7 +102,7 @@ class ImportThemeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'post_max_size_message' => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutsCustomizationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutsCustomizationType.php
@@ -52,7 +52,7 @@ class PageLayoutsCustomizationType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('layouts', CollectionType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ShopLogosType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ShopLogosType.php
@@ -77,7 +77,7 @@ class ShopLogosType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $shopLogoSettings = new ShopLogoSettings();
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyExchangeRateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyExchangeRateType.php
@@ -37,7 +37,7 @@ class CurrencyExchangeRateType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
@@ -82,7 +82,7 @@ class CurrencyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $newCurrency = !isset($options['data']['id']);
         $unofficialCurrency = isset($options['data']['unofficial']) ? (bool) $options['data']['unofficial'] : false;

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationByIpAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationByIpAddressType.php
@@ -39,7 +39,7 @@ class GeolocationByIpAddressType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('geolocation_enabled', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationIpAddressWhitelistType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationIpAddressWhitelistType.php
@@ -40,7 +40,7 @@ class GeolocationIpAddressWhitelistType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('geolocation_whitelist', TextareaType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php
@@ -70,7 +70,7 @@ class GeolocationOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('geolocation_behaviour', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
@@ -68,7 +68,7 @@ class LanguageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextType::class, [
@@ -205,7 +205,7 @@ class LanguageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/AdvancedConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/AdvancedConfigurationType.php
@@ -39,7 +39,7 @@ class AdvancedConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('language_identifier', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php
@@ -62,7 +62,7 @@ class ImportLocalizationPackType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('iso_localization_pack', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalUnitsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalUnitsType.php
@@ -39,7 +39,7 @@ class LocalUnitsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('weight_unit', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
@@ -68,7 +68,7 @@ class LocalizationConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('default_language', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryType.php
@@ -75,7 +75,7 @@ class CountryType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/StateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/StateType.php
@@ -79,7 +79,7 @@ class StateType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $stateIdValue = isset($builder->getData()['id_state']) && $builder->getData()['id_state'] instanceof StateId ?
             $builder->getData()['id_state']->getValue() :

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/ZoneType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/ZoneType.php
@@ -65,7 +65,7 @@ class ZoneType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
@@ -82,7 +82,7 @@ class TaxOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxRulesGroupType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxRulesGroupType.php
@@ -66,7 +66,7 @@ class TaxRulesGroupType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -47,7 +47,7 @@ class TaxType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $invalidCharsText = sprintf(
             '%s ' . TypedRegexValidator::GENERIC_NAME_CHARS,

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/AddUpdateLanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/AddUpdateLanguageType.php
@@ -59,7 +59,7 @@ class AddUpdateLanguageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('iso_localization_pack', ChoiceType::class, [
             'label' => $this->trans('Please select the language you want to add or update', 'Admin.International.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/CopyLanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/CopyLanguageType.php
@@ -60,7 +60,7 @@ class CopyLanguageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('from_language', LocaleChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportThemeLanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportThemeLanguageType.php
@@ -60,7 +60,7 @@ class ExportThemeLanguageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('iso_code', LocaleChoiceType::class)

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
@@ -86,7 +86,7 @@ class ModifyTranslationsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $noTheme = $this->trans('Core (no theme selected)', 'Admin.International.Feature');
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentModulePreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentModulePreferencesType.php
@@ -100,7 +100,7 @@ class PaymentModulePreferencesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('currency_restrictions', MaterialMultipleChoiceTableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/CarrierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/CarrierType.php
@@ -45,7 +45,7 @@ class CarrierType extends TranslatorAwareType
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder
@@ -66,7 +66,7 @@ class CarrierType extends TranslatorAwareType
         return NavigationTabType::class;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
@@ -55,7 +55,7 @@ class GeneralSettings extends TranslatorAwareType
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $maximumFileSize = (int) str_replace('M', '', strval(self::MAX_IMAGE_SIZE_IN_BYTES));
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/ShippingLocationsAndCostsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/ShippingLocationsAndCostsType.php
@@ -54,7 +54,7 @@ class ShippingLocationsAndCostsType extends TranslatorAwareType
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/SizeWeightSettings.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/SizeWeightSettings.php
@@ -53,7 +53,7 @@ class SizeWeightSettings extends TranslatorAwareType
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder
@@ -131,7 +131,7 @@ class SizeWeightSettings extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CarrierRangesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CarrierRangesType.php
@@ -48,7 +48,7 @@ class CarrierRangesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('data', HiddenType::class)
@@ -76,7 +76,7 @@ class CarrierRangesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => $this->trans('Ranges', 'Admin.Shipping.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeType.php
@@ -41,7 +41,7 @@ class CostsRangeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('range', TextPreviewType::class, [
@@ -70,7 +70,7 @@ class CostsRangeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => false,

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsZoneType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsZoneType.php
@@ -41,7 +41,7 @@ class CostsZoneType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('zoneId', HiddenType::class)
@@ -73,7 +73,7 @@ class CostsZoneType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => false,

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
@@ -72,7 +72,7 @@ class CarrierOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $carrierChoices = array_merge([
             'Best price' => (int) -1,
@@ -124,7 +124,7 @@ class CarrierOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shipping.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
@@ -68,7 +68,7 @@ class HandlingType extends TranslatorAwareType
         $this->configuration = $configuration;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $defaultCurrencyIsoCode = $this->currencyDataProvider->getDefaultCurrencyIsoCode();
         $weightUnit = $this->configuration->get('PS_WEIGHT_UNIT');
@@ -122,7 +122,7 @@ class HandlingType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shipping.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Login/LoginType.php
+++ b/src/PrestaShopBundle/Form/Admin/Login/LoginType.php
@@ -55,7 +55,7 @@ class LoginType extends AbstractType
         $this->isDemoModeEnabled = $shopConfiguration->getBoolean('_PS_MODE_DEMO_');
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('email', EmailType::class, [
@@ -95,7 +95,7 @@ class LoginType extends AbstractType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Login/RequestPasswordResetType.php
+++ b/src/PrestaShopBundle/Form/Admin/Login/RequestPasswordResetType.php
@@ -43,7 +43,7 @@ class RequestPasswordResetType extends AbstractType
     ) {
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('email_forgot', EmailType::class, [
@@ -73,7 +73,7 @@ class RequestPasswordResetType extends AbstractType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Login/ResetPasswordType.php
+++ b/src/PrestaShopBundle/Form/Admin/Login/ResetPasswordType.php
@@ -46,7 +46,7 @@ class ResetPasswordType extends AbstractType
     ) {
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $maxLength = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH);
@@ -96,7 +96,7 @@ class ResetPasswordType extends AbstractType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
@@ -97,7 +97,7 @@ class CustomerAddressType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $data = $builder->getData();
         $countryId = 0 !== $data['id_country'] ? $data['id_country'] : $this->contextCountryId;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
@@ -92,7 +92,7 @@ class ManufacturerAddressType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $nameHint = $this->trans('Invalid characters:', 'Admin.Global') . ' 0-9!<>,;?=+()@#"�{}_$%:';
         $data = $builder->getData();

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/RequiredFieldsAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/RequiredFieldsAddressType.php
@@ -52,7 +52,7 @@ class RequiredFieldsAddressType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('required_fields', MaterialChoiceTableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
@@ -47,7 +47,7 @@ class AttachmentType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $required = true;
         if (isset($options['data']['file_name']) && $options['data']['file_name']) {

--- a/src/PrestaShopBundle/Form/Admin/Sell/CartRule/ActionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CartRule/ActionsType.php
@@ -37,7 +37,7 @@ class ActionsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('free_shipping', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/CartRule/CartRuleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CartRule/CartRuleType.php
@@ -38,7 +38,7 @@ class CartRuleType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('information', InformationType::class, [
@@ -62,7 +62,7 @@ class CartRuleType extends TranslatorAwareType
         return NavigationTabType::class;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/CartRule/ConditionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CartRule/ConditionsType.php
@@ -35,7 +35,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class ConditionsType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('customer', CustomerSearchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/CartRule/DiscountType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CartRule/DiscountType.php
@@ -65,7 +65,7 @@ class DiscountType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('reduction', PriceReductionType::class, [
@@ -105,7 +105,7 @@ class DiscountType extends TranslatorAwareType
         ]);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/CartRule/InformationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CartRule/InformationType.php
@@ -46,7 +46,7 @@ class InformationType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/CartRule/MinimumAmountType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CartRule/MinimumAmountType.php
@@ -40,7 +40,7 @@ class MinimumAmountType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('amount', NumberType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Catalog/AttributeGroupType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Catalog/AttributeGroupType.php
@@ -59,7 +59,7 @@ class AttributeGroupType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Catalog/AttributeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Catalog/AttributeType.php
@@ -71,7 +71,7 @@ class AttributeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $attributeGroupId = $options['attribute_group'];
 
@@ -138,7 +138,7 @@ class AttributeType extends TranslatorAwareType
         }
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setRequired('attribute_group');
         parent::configureOptions($resolver);

--- a/src/PrestaShopBundle/Form/Admin/Sell/Catalog/FeatureType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Catalog/FeatureType.php
@@ -43,7 +43,7 @@ class FeatureType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [
@@ -67,7 +67,7 @@ class FeatureType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Catalog/FeatureValueType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Catalog/FeatureValueType.php
@@ -44,7 +44,7 @@ class FeatureValueType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('feature_value_id', HiddenType::class)
@@ -72,7 +72,7 @@ class FeatureValueType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'form_theme' => '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig',

--- a/src/PrestaShopBundle/Form/Admin/Sell/CatalogPriceRule/CatalogPriceRuleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CatalogPriceRule/CatalogPriceRuleType.php
@@ -89,7 +89,7 @@ class CatalogPriceRuleType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Category/DeleteCategoriesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Category/DeleteCategoriesType.php
@@ -54,7 +54,7 @@ class DeleteCategoriesType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('delete_mode', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -122,7 +122,7 @@ class CustomerType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // Initialize password strength configuration set in Security section of backoffice
         $minScore = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_SCORE);
@@ -402,7 +402,7 @@ class CustomerType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/DeleteCustomersType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/DeleteCustomersType.php
@@ -54,7 +54,7 @@ class DeleteCustomersType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('delete_method', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/PrivateNoteType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/PrivateNoteType.php
@@ -54,7 +54,7 @@ class PrivateNoteType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('note', TextareaType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/RequiredFieldsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/RequiredFieldsType.php
@@ -51,7 +51,7 @@ class RequiredFieldsType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('required_fields', MaterialChoiceTableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/SearchedCustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/SearchedCustomerType.php
@@ -37,7 +37,7 @@ class SearchedCustomerType extends CommonAbstractType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('id_customer', HiddenType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/TransferGuestAccountType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/TransferGuestAccountType.php
@@ -40,7 +40,7 @@ class TransferGuestAccountType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('id_customer', HiddenType::class)

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/MerchandiseReturn/MerchandiseReturnOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/MerchandiseReturn/MerchandiseReturnOptionsType.php
@@ -47,7 +47,7 @@ class MerchandiseReturnOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(static::FIELD_ENABLE_ORDER_RETURN, SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/MerchandiseReturn/OrderReturnType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/MerchandiseReturn/OrderReturnType.php
@@ -64,7 +64,7 @@ class OrderReturnType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('customer_name', TextPreviewType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/ReplyToCustomerThreadType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/ReplyToCustomerThreadType.php
@@ -51,7 +51,7 @@ class ReplyToCustomerThreadType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('reply_message', TextareaType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/CartConditionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/CartConditionsType.php
@@ -45,7 +45,7 @@ class CartConditionsType extends TranslatorAwareType
     public const SPECIFIC_PRODUCTS = 'specific_products';
     public const PRODUCT_SEGMENT = 'product_segment';
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DeliveryConditionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DeliveryConditionsType.php
@@ -40,7 +40,7 @@ class DeliveryConditionsType extends TranslatorAwareType
     public const CARRIERS = 'carriers';
     public const COUNTRY = 'country';
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(self::CARRIERS, CarrierChoiceType::class, [
@@ -82,7 +82,7 @@ class DeliveryConditionsType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountConditionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountConditionsType.php
@@ -38,7 +38,7 @@ class DiscountConditionsType extends TranslatorAwareType
     public const CART_CONDITIONS = 'cart_conditions';
     public const DELIVERY_CONDITIONS = 'delivery_conditions';
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $discountType = $options['discount_type'];
         $builder

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountInformationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountInformationType.php
@@ -40,7 +40,7 @@ use Symfony\Component\Validator\Constraints\Length;
 
 class DiscountInformationType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $discountType = $options['discount_type'];
         $builder
@@ -76,7 +76,7 @@ class DiscountInformationType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setRequired([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountProductSegmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountProductSegmentType.php
@@ -46,7 +46,7 @@ class DiscountProductSegmentType extends TranslatorAwareType
     public const SUPPLIER = 'supplier';
     public const ATTRIBUTES = 'attributes';
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(self::MANUFACTURER, ManufacturerType::class, [
@@ -99,7 +99,7 @@ class DiscountProductSegmentType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountType.php
@@ -42,7 +42,7 @@ class DiscountType extends TranslatorAwareType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
 
@@ -88,7 +88,7 @@ class DiscountType extends TranslatorAwareType
             ]);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorType.php
@@ -34,7 +34,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DiscountTypeSelectorType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder
@@ -75,7 +75,7 @@ class DiscountTypeSelectorType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountUsabilityModeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountUsabilityModeType.php
@@ -43,7 +43,7 @@ class DiscountUsabilityModeType extends TranslatorAwareType
     public const CODE_MODE = 'code';
     protected const GENERATED_CODE_LENGTH = 8;
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(self::AUTO_MODE, HiddenType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountUsabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountUsabilityType.php
@@ -32,7 +32,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class DiscountUsabilityType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('mode', DiscountUsabilityModeType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/MinimumAmountType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/MinimumAmountType.php
@@ -68,7 +68,7 @@ class MinimumAmountType extends TranslatorAwareType implements EventSubscriberIn
         ];
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('value', MoneyType::class, [
@@ -92,7 +92,7 @@ class MinimumAmountType extends TranslatorAwareType implements EventSubscriberIn
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/SpecificProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/SpecificProductType.php
@@ -69,7 +69,7 @@ class SpecificProductType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('id', HiddenType::class, [
@@ -186,7 +186,7 @@ class SpecificProductType extends TranslatorAwareType
         return 'entity_item';
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Manufacturer/ManufacturerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Manufacturer/ManufacturerType.php
@@ -69,7 +69,7 @@ class ManufacturerType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $invalidCharactersForCatalogLabel = $this->trans('Invalid characters:', 'Admin.Global') . '<>{}';
         $invalidCharactersForNameLabel = $this->trans('Invalid characters:', 'Admin.Global') . '<>{}';

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CartSummaryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CartSummaryType.php
@@ -72,7 +72,7 @@ class CartSummaryType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('cart_id', HiddenType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/ChangeOrdersStatusType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/ChangeOrdersStatusType.php
@@ -52,7 +52,7 @@ class ChangeOrdersStatusType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('new_order_status_id', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
@@ -41,7 +41,7 @@ final class CreditSlipOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('slip_prefix', TranslatableType::class, [
             'label' => $this->trans('Credit slip prefix', 'Admin.Orderscustomers.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
@@ -44,7 +44,7 @@ final class GeneratePdfByDateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $dateFormat = 'Y-m-d';
         $nowDate = (new \DateTime())->format($dateFormat);
@@ -87,7 +87,7 @@ final class GeneratePdfByDateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
@@ -41,7 +41,7 @@ class SlipOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipPdfType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipPdfType.php
@@ -39,7 +39,7 @@ class SlipPdfType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $now = (new DateTime())->format('Y-m-d');
         $builder

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/InternalNoteType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/InternalNoteType.php
@@ -56,7 +56,7 @@ class InternalNoteType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('note', TextareaType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByDateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByDateType.php
@@ -40,7 +40,7 @@ class GenerateByDateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('date_from', DatePickerType::class, [
@@ -56,7 +56,7 @@ class GenerateByDateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Orderscustomers.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByStatusType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByStatusType.php
@@ -70,7 +70,7 @@ class GenerateByStatusType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('order_states', ChoiceType::class, [
@@ -100,7 +100,7 @@ class GenerateByStatusType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Orderscustomers.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsType.php
@@ -79,7 +79,7 @@ class InvoiceOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(
@@ -249,7 +249,7 @@ class InvoiceOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Orderscustomers.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageType.php
@@ -69,7 +69,7 @@ class OrderMessageType extends AbstractType
         $this->translator = $translator;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('order_message', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderStatusType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderStatusType.php
@@ -55,7 +55,7 @@ class UpdateOrderStatusType extends AbstractType
         $this->statusChoiceAttributes = $statusChoiceAttributes;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $choiceProviderParams = [];
         if (!empty($options['data']['new_order_status_id'])) {

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
@@ -69,7 +69,7 @@ class CategoriesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('product_categories', CategoryTagsCollectionType::class)
@@ -93,7 +93,7 @@ class CategoriesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryFilterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryFilterType.php
@@ -83,7 +83,7 @@ class CategoryFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $nestedTree = $this->categoryProvider->getNestedCategories(null, $this->contextLangId, false);

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryTagsCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryTagsCollectionType.php
@@ -50,7 +50,7 @@ class CategoryTagsCollectionType extends CollectionType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryTreeSelectorType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryTreeSelectorType.php
@@ -56,7 +56,7 @@ class CategoryTreeSelectorType extends CollectionType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('product_categories', CategoryTagsCollectionType::class)
@@ -94,7 +94,7 @@ class CategoryTreeSelectorType extends CollectionType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/ProductCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/ProductCategoryType.php
@@ -35,7 +35,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class ProductCategoryType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('display_name', TextPreviewType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationImagesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationImagesType.php
@@ -36,7 +36,7 @@ class BulkCombinationImagesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('images', CombinationImagesChoiceType::class, [
             'product_id' => $options['product_id'],
@@ -47,7 +47,7 @@ class BulkCombinationImagesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationReferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationReferencesType.php
@@ -42,7 +42,7 @@ use Symfony\Component\Validator\Constraints\Length;
 
 class BulkCombinationReferencesType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('reference', TextType::class, [
@@ -102,7 +102,7 @@ class BulkCombinationReferencesType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
@@ -65,7 +65,7 @@ class BulkCombinationStockType extends TranslatorAwareType
         $this->stockManagementEnabled = $stockManagementEnabled;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if ($this->stockManagementEnabled) {
             $builder
@@ -169,7 +169,7 @@ class BulkCombinationStockType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationType.php
@@ -57,7 +57,7 @@ class BulkCombinationType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
@@ -67,7 +67,7 @@ class CombinationAvailabilityType extends TranslatorAwareType
         $this->router = $router;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('out_of_stock_type', ChoiceType::class, [
@@ -110,7 +110,7 @@ class CombinationAvailabilityType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationFormType.php
@@ -66,7 +66,7 @@ class CombinationFormType extends TranslatorAwareType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('cover_thumbnail_url', ImagePreviewType::class, [
@@ -103,7 +103,7 @@ class CombinationFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationHeaderType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationHeaderType.php
@@ -39,7 +39,7 @@ class CombinationHeaderType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder
@@ -63,7 +63,7 @@ class CombinationHeaderType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationImagesChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationImagesChoiceType.php
@@ -57,7 +57,7 @@ class CombinationImagesChoiceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationListType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationListType.php
@@ -38,7 +38,7 @@ class CombinationListType extends CollectionType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationManagerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationManagerType.php
@@ -67,7 +67,7 @@ class CombinationManagerType extends TranslatorAwareType
         $view->vars['isMultiStoreActive'] = $this->multiStoreFeature->isActive();
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationPriceImpactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationPriceImpactType.php
@@ -115,7 +115,7 @@ class CombinationPriceImpactType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('price_tax_excluded', MoneyType::class, [
@@ -287,7 +287,7 @@ class CombinationPriceImpactType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
@@ -46,7 +46,7 @@ class CombinationStockType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('quantities', QuantityType::class, [
@@ -111,7 +111,7 @@ class CombinationStockType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationsType.php
@@ -34,7 +34,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CombinationsType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('combination_manager', CombinationManagerType::class, [
@@ -44,7 +44,7 @@ class CombinationsType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/LowStockThresholdType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/LowStockThresholdType.php
@@ -51,7 +51,7 @@ class LowStockThresholdType extends TranslatorAwareType
         $this->router = $router;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('low_stock_alert', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/CreateProductFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/CreateProductFormType.php
@@ -42,7 +42,7 @@ class CreateProductFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('type', ProductTypeType::class)
@@ -70,7 +70,7 @@ class CreateProductFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/DescriptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/DescriptionType.php
@@ -81,7 +81,7 @@ class DescriptionType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $productId = $options['product_id'];
         $shopId = $options['shop_id'];
@@ -148,7 +148,7 @@ class DescriptionType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/CustomizationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/CustomizationsType.php
@@ -36,7 +36,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CustomizationsType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('customization_fields', CollectionType::class, [
@@ -58,7 +58,7 @@ class CustomizationsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/DetailsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/DetailsType.php
@@ -69,7 +69,7 @@ class DetailsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('references', ReferencesType::class);
 
@@ -105,7 +105,7 @@ class DetailsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeatureCollectionItemType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeatureCollectionItemType.php
@@ -36,7 +36,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 
 class FeatureCollectionItemType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('feature_id', HiddenType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeatureCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeatureCollectionType.php
@@ -33,7 +33,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FeatureCollectionType extends CollectionType
 {
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeatureValueType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeatureValueType.php
@@ -45,7 +45,7 @@ class FeatureValueType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('feature_value_id', HiddenType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeaturesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeaturesType.php
@@ -65,7 +65,7 @@ class FeaturesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $features = array_merge([
             $this->trans('Choose a feature', 'Admin.Catalog.Feature') => 0,
@@ -119,7 +119,7 @@ class FeaturesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/ReferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/ReferencesType.php
@@ -45,7 +45,7 @@ class ReferencesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('reference', TextType::class, [
@@ -103,7 +103,7 @@ class ReferencesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EditProductFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EditProductFormType.php
@@ -82,7 +82,7 @@ class EditProductFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $productId = $options['product_id'];
         $shopId = $options['shop_id'];
@@ -149,7 +149,7 @@ class EditProductFormType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ExtraModulesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ExtraModulesType.php
@@ -87,7 +87,7 @@ class ExtraModulesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
@@ -96,7 +96,7 @@ class FooterType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $productId = $options['product_id'];
 
@@ -220,7 +220,7 @@ class FooterType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
@@ -84,7 +84,7 @@ class HeaderType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('cover_thumbnail', ImagePreviewType::class, [
@@ -157,7 +157,7 @@ class HeaderType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Image/ImageDropzoneType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Image/ImageDropzoneType.php
@@ -64,7 +64,7 @@ class ImageDropzoneType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
 
@@ -95,7 +95,7 @@ class ImageDropzoneType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Image/ProductImageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Image/ProductImageType.php
@@ -42,7 +42,7 @@ class ProductImageType extends CommonAbstractType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/AttachedFileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/AttachedFileType.php
@@ -35,7 +35,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class AttachedFileType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->remove('image')

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/CustomizationFieldType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/CustomizationFieldType.php
@@ -59,7 +59,7 @@ class CustomizationFieldType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('id', HiddenType::class)

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/OptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/OptionsType.php
@@ -39,7 +39,7 @@ class OptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('visibility', VisibilityType::class)
@@ -51,7 +51,7 @@ class OptionsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductAttachmentsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductAttachmentsType.php
@@ -60,7 +60,7 @@ class ProductAttachmentsType extends TranslatorAwareType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('attached_files', EntitySearchInputType::class, [
@@ -96,7 +96,7 @@ class ProductAttachmentsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductSupplierCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductSupplierCollectionType.php
@@ -44,7 +44,7 @@ class ProductSupplierCollectionType extends CollectionType
         $this->translator = $translator;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductSupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductSupplierType.php
@@ -89,7 +89,7 @@ class ProductSupplierType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('supplier_id', HiddenType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/SuppliersType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/SuppliersType.php
@@ -59,7 +59,7 @@ class SuppliersType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $suppliers = $this->supplierNameByIdChoiceProvider->getChoices();
 
@@ -92,7 +92,7 @@ class SuppliersType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/VisibilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/VisibilityType.php
@@ -61,7 +61,7 @@ class VisibilityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('visibility', ChoiceType::class, [
@@ -101,7 +101,7 @@ class VisibilityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/ApplicableGroupsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/ApplicableGroupsType.php
@@ -129,7 +129,7 @@ class ApplicableGroupsType extends TranslatorAwareType
         return $choices;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/CatalogPriceRulesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/CatalogPriceRulesType.php
@@ -64,7 +64,7 @@ class CatalogPriceRulesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PriceSummaryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PriceSummaryType.php
@@ -33,7 +33,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PriceSummaryType extends TranslatorAwareType
 {
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => $this->trans('Summary', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
@@ -68,7 +68,7 @@ class PricingType extends TranslatorAwareType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('retail_price', RetailPriceType::class, [
@@ -122,7 +122,7 @@ class PricingType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
@@ -124,7 +124,7 @@ class RetailPriceType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if ($this->isTaxEnabled) {
             $ecotaxRate = $this->taxComputer->getTaxRate(new TaxRulesGroupId($this->ecoTaxGroupId), new CountryId($this->contextCountryId));
@@ -264,7 +264,7 @@ class RetailPriceType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceImpactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceImpactType.php
@@ -66,7 +66,7 @@ class SpecificPriceImpactType extends TranslatorAwareType
         $this->defaultCurrencyIsoCode = $defaultCurrencyIsoCode;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('reduction', PriceReductionType::class, [
@@ -116,7 +116,7 @@ class SpecificPriceImpactType extends TranslatorAwareType
         $builder->get('fixed_price_tax_excluded')->addViewTransformer(new SpecificPriceFixedPriceTransformer());
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPricePriorityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPricePriorityType.php
@@ -48,7 +48,7 @@ class SpecificPricePriorityType extends CollectionType
         $this->priorityChoiceProvider = $priorityChoiceProvider;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
@@ -170,7 +170,7 @@ class SpecificPriceType extends TranslatorAwareType
         $builder->addEventSubscriber($this->specificPriceCombinationListener);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPricesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPricesType.php
@@ -37,7 +37,7 @@ class SpecificPricesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('add_specific_price_btn', IconButtonType::class, [
@@ -56,7 +56,7 @@ class SpecificPricesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/UnitPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/UnitPriceType.php
@@ -66,7 +66,7 @@ class UnitPriceType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('price_tax_excluded', MoneyType::class, [
@@ -113,7 +113,7 @@ class UnitPriceType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductShopsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductShopsType.php
@@ -45,7 +45,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ProductShopsType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('source_shop_id', HiddenType::class)
@@ -81,7 +81,7 @@ class ProductShopsType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/RedirectOptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/RedirectOptionType.php
@@ -96,7 +96,7 @@ class RedirectOptionType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $entityAttributes = [
             'product' => [
@@ -178,7 +178,7 @@ class RedirectOptionType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
@@ -98,7 +98,7 @@ class SEOType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // Automatic update is only enabled when product is offline and the configuration is enabled
         $automaticUrlUpdate = false;
@@ -254,7 +254,7 @@ class SEOType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SerpType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SerpType.php
@@ -36,7 +36,7 @@ class SerpType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SearchedProductItemType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SearchedProductItemType.php
@@ -37,7 +37,7 @@ class SearchedProductItemType extends CommonAbstractType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('unique_identifier', HiddenType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DeliveryTimeNotesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DeliveryTimeNotesType.php
@@ -39,7 +39,7 @@ class DeliveryTimeNotesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('in_stock', TranslatableType::class, [
@@ -73,7 +73,7 @@ class DeliveryTimeNotesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DimensionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DimensionsType.php
@@ -69,7 +69,7 @@ class DimensionsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('width', NumberType::class, [
@@ -146,7 +146,7 @@ class DimensionsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/ShippingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/ShippingType.php
@@ -81,7 +81,7 @@ class ShippingType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('dimensions', DimensionsType::class)
@@ -135,7 +135,7 @@ class ShippingType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
@@ -74,7 +74,7 @@ class AvailabilityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('out_of_stock_type', ChoiceType::class, [
@@ -157,7 +157,7 @@ class AvailabilityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/PackedProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/PackedProductType.php
@@ -42,7 +42,7 @@ class PackedProductType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('reference', TextPreviewType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
@@ -71,7 +71,7 @@ class QuantityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if ($this->stockManagementEnabled) {
             $stockMovementsUrl = $this->router->generate('admin_stock_movements_overview', ['productId' => $options['product_id']]);
@@ -134,7 +134,7 @@ class QuantityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockMovementType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockMovementType.php
@@ -42,7 +42,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class StockMovementType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('date', TextPreviewType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockOptionsType.php
@@ -40,7 +40,7 @@ class StockOptionsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('stock_location', TextType::class, [
@@ -80,7 +80,7 @@ class StockOptionsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
@@ -77,7 +77,7 @@ class StockType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('packed_products', ProductSearchType::class, [
@@ -125,7 +125,7 @@ class StockType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/VirtualProductFileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/VirtualProductFileType.php
@@ -84,7 +84,7 @@ class VirtualProductFileType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $virtualProductFileDownloadUrl = null;
         if (!empty($options['virtual_product_file_id'])) {
@@ -181,7 +181,7 @@ class VirtualProductFileType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'virtual_product_file_id' => null,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -99,7 +99,7 @@ class SupplierType extends TranslatorAwareType
         $this->router = $router;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $data = $builder->getData();
         $countryId = 0 !== $data['id_country'] ? $data['id_country'] : $this->contextCountryId;

--- a/src/PrestaShopBundle/Form/Admin/Type/AccordionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/AccordionType.php
@@ -46,7 +46,7 @@ class AccordionType extends AbstractType
         $view->vars['display_one'] = $options['display_one'];
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'expand_first' => true,

--- a/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
@@ -41,12 +41,12 @@ class ApeType extends AbstractType implements DataTransformerInterface
 {
     use TranslatorAwareTrait;
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addModelTransformer($this);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Type/ButtonCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ButtonCollectionType.php
@@ -57,7 +57,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ButtonCollectionType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         foreach ($options['buttons'] as $buttonOptions) {
             $builder->add($buttonOptions['name'], $buttonOptions['type'], $buttonOptions['options']);
@@ -80,7 +80,7 @@ class ButtonCollectionType extends AbstractType
         $view->vars['use_button_groups'] = $options['use_button_groups'];
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/CategoryChoiceTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CategoryChoiceTreeType.php
@@ -51,7 +51,7 @@ class CategoryChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices_tree' => $this->categoryTreeChoices,

--- a/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
@@ -63,7 +63,7 @@ class ChangePasswordType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $maxLength = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH);
         $minLength = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH);

--- a/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
@@ -59,7 +59,7 @@ class ChoiceCategoriesTreeType extends CommonAbstractType
      *
      * Builds the form.
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('tree', ChoiceType::class, [
             'label' => false,
@@ -74,7 +74,7 @@ class ChoiceCategoriesTreeType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => '',

--- a/src/PrestaShopBundle/Form/Admin/Type/Common/Team/ProfileChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Common/Team/ProfileChoiceType.php
@@ -51,7 +51,7 @@ class ProfileChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/ConfigurableCountryChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ConfigurableCountryChoiceType.php
@@ -55,7 +55,7 @@ class ConfigurableCountryChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         // Set normalizer enables to use closure for choice generation with options
         $resolver->setNormalizer(

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomContentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomContentType.php
@@ -48,7 +48,7 @@ final class CustomContentType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomerSearchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomerSearchType.php
@@ -47,7 +47,7 @@ class CustomerSearchType extends EntitySearchInputType
         $this->router = $router;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
@@ -57,7 +57,7 @@ class DatePickerType extends AbstractType
         return TextType::class;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addViewTransformer($this->arabicToLatinDigitDataTransformer);
     }
@@ -73,7 +73,7 @@ class DatePickerType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'widget' => 'single_text',

--- a/src/PrestaShopBundle/Form/Admin/Type/DateRangeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DateRangeType.php
@@ -71,7 +71,7 @@ class DateRangeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('from', DatePickerType::class, [
@@ -132,7 +132,7 @@ class DateRangeType extends AbstractType
         }
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'date_format' => self::DEFAULT_DATE_FORMAT,

--- a/src/PrestaShopBundle/Form/Admin/Type/DeltaQuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DeltaQuantityType.php
@@ -52,7 +52,7 @@ class DeltaQuantityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('quantity', TextPreviewType::class, [
@@ -114,7 +114,7 @@ class DeltaQuantityType extends TranslatorAwareType
         $view->vars['initialQuantity'] = $initialQuantity;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Type/DisablingSwitchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DisablingSwitchType.php
@@ -42,7 +42,7 @@ class DisablingSwitchType extends SwitchType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/EmailType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/EmailType.php
@@ -41,12 +41,12 @@ class EmailType extends BaseEmailType
     ) {
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addViewTransformer($this->IDNConverterDataTransformer);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/EnrichedChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/EnrichedChoiceType.php
@@ -50,7 +50,7 @@ class EnrichedChoiceType extends ChoiceType
         $view->vars['flex_direction'] = $options['flex_direction'];
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/EntityItemType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/EntityItemType.php
@@ -39,7 +39,7 @@ class EntityItemType extends CommonAbstractType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('id', HiddenType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Type/EntitySearchInputType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/EntitySearchInputType.php
@@ -70,7 +70,7 @@ class EntitySearchInputType extends CollectionType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/FeatureFlagSwitchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/FeatureFlagSwitchType.php
@@ -43,7 +43,7 @@ class FeatureFlagSwitchType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'block_prefix' => 'feature_flag',

--- a/src/PrestaShopBundle/Form/Admin/Type/FormattedTextareaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/FormattedTextareaType.php
@@ -69,7 +69,7 @@ class FormattedTextareaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefined(['message'])

--- a/src/PrestaShopBundle/Form/Admin/Type/GeneratableTextType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/GeneratableTextType.php
@@ -42,7 +42,7 @@ class GeneratableTextType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/GroupedItemCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/GroupedItemCollectionType.php
@@ -74,7 +74,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class GroupedItemCollectionType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('groups', CollectionType::class, [
@@ -108,7 +108,7 @@ class GroupedItemCollectionType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/GroupedItemType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/GroupedItemType.php
@@ -36,7 +36,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class GroupedItemType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('id', HiddenType::class, [
@@ -56,7 +56,7 @@ class GroupedItemType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/IconButtonType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/IconButtonType.php
@@ -41,7 +41,7 @@ class IconButtonType extends ButtonType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Type/ImagePreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ImagePreviewType.php
@@ -53,7 +53,7 @@ class ImagePreviewType extends HiddenType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/ImageWithPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ImageWithPreviewType.php
@@ -55,7 +55,7 @@ class ImageWithPreviewType extends FileType
         $view->vars['warning_message'] = $options['warning_message'];
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/IntegerMinMaxFilterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/IntegerMinMaxFilterType.php
@@ -50,7 +50,7 @@ final class IntegerMinMaxFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'min_field_options' => [],
@@ -80,7 +80,7 @@ final class IntegerMinMaxFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if (!isset($options['min_field_options']['attr']['placeholder'])) {
             $options['min_field_options']['attr']['placeholder'] = $this->trans('Min', [], 'Admin.Global');

--- a/src/PrestaShopBundle/Form/Admin/Type/IpAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/IpAddressType.php
@@ -56,7 +56,7 @@ class IpAddressType extends TextType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/LinkPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/LinkPreviewType.php
@@ -61,7 +61,7 @@ class LinkPreviewType extends HiddenType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/LogSeverityChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/LogSeverityChoiceType.php
@@ -40,7 +40,7 @@ class LogSeverityChoiceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices' => $this->getSeveritysChoices(),

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableType.php
@@ -40,7 +40,7 @@ class MaterialChoiceTableType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'expanded' => true,

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTreeType.php
@@ -55,7 +55,7 @@ class MaterialChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialMultipleChoiceTableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialMultipleChoiceTableType.php
@@ -39,7 +39,7 @@ class MaterialMultipleChoiceTableType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         foreach ($options['multiple_choices'] as $choices) {
             $builder->add($choices['name'], ChoiceType::class, [
@@ -97,7 +97,7 @@ class MaterialMultipleChoiceTableType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([

--- a/src/PrestaShopBundle/Form/Admin/Type/MoneyWithSuffixType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/MoneyWithSuffixType.php
@@ -59,7 +59,7 @@ class MoneyWithSuffixType extends MoneyType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/MultipleZoneChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/MultipleZoneChoiceType.php
@@ -42,7 +42,7 @@ class MultipleZoneChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         // Set normalizer enables to use closure for choice generation with options
         $resolver->setNormalizer(

--- a/src/PrestaShopBundle/Form/Admin/Type/NavigationTabType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/NavigationTabType.php
@@ -66,7 +66,7 @@ class NavigationTabType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         if (!empty($options['toolbar_buttons'])) {
@@ -95,7 +95,7 @@ class NavigationTabType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Type/NumberMinMaxFilterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/NumberMinMaxFilterType.php
@@ -50,7 +50,7 @@ final class NumberMinMaxFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'min_field_options' => [],
@@ -80,7 +80,7 @@ final class NumberMinMaxFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if (!isset($options['min_field_options']['attr']['placeholder'])) {
             $options['min_field_options']['attr']['placeholder'] = $this->trans('Min', [], 'Admin.Global');

--- a/src/PrestaShopBundle/Form/Admin/Type/PriceReductionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/PriceReductionType.php
@@ -70,7 +70,7 @@ class PriceReductionType extends TranslatorAwareType
         $this->currencyDataProvider = $currencyDataProvider;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('value', MoneyType::class, [
@@ -107,7 +107,7 @@ class PriceReductionType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/ReorderPositionsButtonType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ReorderPositionsButtonType.php
@@ -37,7 +37,7 @@ class ReorderPositionsButtonType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('position', ButtonType::class, [
             'label' => $this->trans('Rearrange', 'Admin.Actions'),

--- a/src/PrestaShopBundle/Form/Admin/Type/SearchAndResetType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SearchAndResetType.php
@@ -97,7 +97,7 @@ class SearchAndResetType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/ShopChoiceTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ShopChoiceTreeType.php
@@ -81,7 +81,7 @@ class ShopChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addModelTransformer($this->stringArrayToIntegerArrayDataTransformer);
 
@@ -91,7 +91,7 @@ class ShopChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/ShopRestrictionCheckboxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ShopRestrictionCheckboxType.php
@@ -54,7 +54,7 @@ class ShopRestrictionCheckboxType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Type/SubmittableDeltaQuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SubmittableDeltaQuantityType.php
@@ -41,7 +41,7 @@ use Symfony\Component\Validator\Constraints\Type;
  */
 class SubmittableDeltaQuantityType extends DeltaQuantityType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder->add('delta', IntegerType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Type/SubmittableInputType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SubmittableInputType.php
@@ -44,7 +44,7 @@ class SubmittableInputType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('value', $options['type'], $options['type_options']);
     }
@@ -60,7 +60,7 @@ class SubmittableInputType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefault('type', NumberType::class)

--- a/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
@@ -42,7 +42,7 @@ class SwitchType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices' => [

--- a/src/PrestaShopBundle/Form/Admin/Type/TaggedItemCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TaggedItemCollectionType.php
@@ -47,7 +47,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class TaggedItemCollectionType extends CollectionType
 {
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/TaggedItemType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TaggedItemType.php
@@ -34,7 +34,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class TaggedItemType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextPreviewType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Type/TaxGroupChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TaxGroupChoiceType.php
@@ -42,7 +42,7 @@ class TaxGroupChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         // Set normalizer enables to use closure for choice generation with options
         $resolver->setNormalizer(

--- a/src/PrestaShopBundle/Form/Admin/Type/TextPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextPreviewType.php
@@ -68,7 +68,7 @@ class TextPreviewType extends TextType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/TextWithLengthCounterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextWithLengthCounterType.php
@@ -50,7 +50,7 @@ class TextWithLengthCounterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([

--- a/src/PrestaShopBundle/Form/Admin/Type/TextWithRecommendedLengthType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextWithRecommendedLengthType.php
@@ -50,7 +50,7 @@ class TextWithRecommendedLengthType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/ThemeChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ThemeChoiceType.php
@@ -52,7 +52,7 @@ class ThemeChoiceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices' => $this->themesChoiceProvider->getChoices(),

--- a/src/PrestaShopBundle/Form/Admin/Type/ToggleChildrenChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ToggleChildrenChoiceType.php
@@ -60,7 +60,7 @@ class ToggleChildrenChoiceType extends AbstractType
     ) {
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($options) {
@@ -90,7 +90,7 @@ class ToggleChildrenChoiceType extends AbstractType
         $form->add('children_selector', $options['choice_type'], $options['choice_options'] + $defaultChoiceOptions);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableChoiceType.php
@@ -48,7 +48,7 @@ class TranslatableChoiceType extends TranslatableType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'button' => [],

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -103,7 +103,7 @@ class TranslatableType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         foreach ($options['locales'] as $locale) {
             $typeOptions = $options['options'];
@@ -166,7 +166,7 @@ class TranslatableType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'type' => TextType::class,

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslateType.php
@@ -81,7 +81,7 @@ class TranslateType extends CommonAbstractType
      *
      * Builds form fields for each locales
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $i = 0;
         foreach ($options['locales'] as $locale) {
@@ -119,7 +119,7 @@ class TranslateType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'type' => null,

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadCustomerCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadCustomerCollectionType.php
@@ -93,7 +93,7 @@ class TypeaheadCustomerCollectionType extends CommonAbstractType
      *
      * Builds the form.
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('data', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', [
             'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\HiddenType',
@@ -108,7 +108,7 @@ class TypeaheadCustomerCollectionType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'remote_url' => '',

--- a/src/PrestaShopBundle/Form/Admin/Type/UnavailableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/UnavailableType.php
@@ -38,7 +38,7 @@ class UnavailableType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/YesAndNoChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/YesAndNoChoiceType.php
@@ -37,7 +37,7 @@ class YesAndNoChoiceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices' => [

--- a/src/PrestaShopBundle/Form/Admin/Type/ZoneChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ZoneChoiceType.php
@@ -55,7 +55,7 @@ class ZoneChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         // Set normalizer enables to use closure for choice generation with options
         $resolver->setNormalizer(

--- a/src/PrestaShopBundle/Form/Extension/AlertExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/AlertExtension.php
@@ -44,7 +44,7 @@ class AlertExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/ColumnsNumberExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/ColumnsNumberExtension.php
@@ -49,7 +49,7 @@ class ColumnsNumberExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/CustomMoneyTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/CustomMoneyTypeExtension.php
@@ -67,7 +67,7 @@ class CustomMoneyTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'precision' => null,

--- a/src/PrestaShopBundle/Form/Extension/DefaultEmptyDataExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/DefaultEmptyDataExtension.php
@@ -67,7 +67,7 @@ class DefaultEmptyDataExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         if (!isset($options['default_empty_data'])) {

--- a/src/PrestaShopBundle/Form/Extension/ExternalLinkExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/ExternalLinkExtension.php
@@ -52,7 +52,7 @@ class ExternalLinkExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/FormThemeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/FormThemeExtension.php
@@ -101,7 +101,7 @@ class FormThemeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/HelpTextExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/HelpTextExtension.php
@@ -40,7 +40,7 @@ class HelpTextExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/HintTextExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/HintTextExtension.php
@@ -41,7 +41,7 @@ class HintTextExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/IntegerTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/IntegerTypeExtension.php
@@ -55,7 +55,7 @@ class IntegerTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // We only want to replace/adapt the IntegerToLocalizedStringTransformer, so we save the current transformers
         // to restore them after replacing the new IntegerToLocalizedStringTransformer.

--- a/src/PrestaShopBundle/Form/Extension/LabelOptionsExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/LabelOptionsExtension.php
@@ -46,7 +46,7 @@ class LabelOptionsExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/NumberTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/NumberTypeExtension.php
@@ -55,7 +55,7 @@ class NumberTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // We only want to replace/adapt the NumberToLocalizedStringTransformer, so we save the current transformers
         // to restore them after replacing the new NumberToLocalizedStringTransformer.

--- a/src/PrestaShopBundle/Form/Extension/ResizableTextTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/ResizableTextTypeExtension.php
@@ -48,7 +48,7 @@ class ResizableTextTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefined('size')

--- a/src/PrestaShopBundle/Form/Extension/RowAttributesExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/RowAttributesExtension.php
@@ -48,7 +48,7 @@ class RowAttributesExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Extension/UnitTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/UnitTypeExtension.php
@@ -43,7 +43,7 @@ class UnitTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefined('unit')


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Hello ! Maybe it’s too early to fix this, because every page and module using Symfony forms will break. This change fixes all deprecation warnings related to forms (a few hundred). We also have to update ps_linklist for it to work (https://github.com/PrestaShop/ps_linklist/pull/206) Thanks
| Type?             | improvement
| Category?         |CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI must be green
| UI Tests          | https://github.com/MattKelvin/ga.tests.ui.pr/actions/runs/17645394973
| Fixed issue or discussion?     | Part of  #38985
| Sponsor company   | Mademoiselle bio
