### PR TITLE
Update HTMLTemplateOrderSlip.php

### DIFF
--- a/classes/pdf/HTMLTemplateOrderSlip.php
+++ b/classes/pdf/HTMLTemplateOrderSlip.php
@@ -153,8 +153,11 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
 
         $order_details = $this->order->products;
         // Sort products by Reference ID (and if equals (like combination) by Supplier Reference)
-        $sorter = new Sorter();
-        $order_details = $sorter->natural($order_details, Sorter::ORDER_DESC, 'product_reference', 'product_supplier_reference');
+        // We must verify if any product is in the orderslip, as failure to do so will result in an Exception when $order_details is NULL.
+        if (!empty($order_details)) {
+            $sorter = new Sorter();
+            $order_details = $sorter->natural($order_details, Sorter::ORDER_DESC, 'product_reference', 'product_supplier_reference');
+        }
 
         $this->smarty->assign([
             'order' => $this->order,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When I create a order slip that contains no products, only shipping, an exception is thrown because the Sorter tries to sort a NULL value. Check screenshot.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | create order slip for shipping only (no products), then try open order slip and you will get exception (after this PR no exception and PDF is working well)
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/17941549325
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/


<img width="3840" height="2160" alt="Untitled" src="https://github.com/user-attachments/assets/39e6159a-e12c-401a-974c-6a2704bc16ec" />
