### PR TITLE
Disable temporary order level discount to avoid issues

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorType.php
@@ -47,7 +47,8 @@ class DiscountTypeSelectorType extends TranslatorAwareType
                     $this->trans('On catalog products', 'Admin.Catalog.Feature') => DiscountType::PRODUCT_LEVEL,
                     $this->trans('Free gift', 'Admin.Catalog.Feature') => DiscountType::FREE_GIFT,
                     $this->trans('On free shipping', 'Admin.Catalog.Feature') => DiscountType::FREE_SHIPPING,
-                    $this->trans('On total order', 'Admin.Catalog.Feature') => DiscountType::ORDER_LEVEL,
+                    // $this->trans('On total order', 'Admin.Catalog.Feature') => DiscountType::ORDER_LEVEL,
+                    // (Disabled temporarily, because of infinite loop issue with this kind of discount. See issue #39419)
                 ],
                 'choice_attr' => [
                     $this->trans('On cart amount', 'Admin.Catalog.Feature') => [
@@ -66,10 +67,12 @@ class DiscountTypeSelectorType extends TranslatorAwareType
                         'icon' => 'local_shipping',
                         'help' => $this->trans('Apply on shipping fees', 'Admin.Catalog.Feature'),
                     ],
+                    /*
                     $this->trans('On total order', 'Admin.Catalog.Feature') => [
                         'icon' => 'article',
                         'help' => $this->trans('Apply on cart and shipping fees', 'Admin.Catalog.Feature'),
                     ],
+                    */
                 ],
             ])
         ;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | As explain in this issue https://github.com/PrestaShop/PrestaShop/issues/39419, we have some issues with new order level discount type.<br>After some research about it, we facing a infinite loop because of some functions calls...<br>To reenable this discount type, we need to find a better way to apply this kind of discount.<br>Maybe at the totally end??
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to the BO and discount admin page.<br>2. Add new discount.<br>3. "On total order" discount type can't be select anymore.
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/17771240080
| Fixed issue or discussion?     | Fixes #39419
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/38450/files#diff-4cd26080116acbbf5326976d2d4476ae725f220dc9f68b77ec34c21a42a0a4fcR1354
| Sponsor company   | PrestaShop SA
