### PR TITLE
Add new constraint to avoid having customizable product on free gift discount

### DIFF
--- a/src/Adapter/Discount/CommandHandler/AddDiscountHandler.php
+++ b/src/Adapter/Discount/CommandHandler/AddDiscountHandler.php
@@ -50,7 +50,8 @@ class AddDiscountHandler implements AddDiscountHandlerInterface
      */
     public function handle(AddDiscountCommand $command): DiscountId
     {
-        $this->discountValidator->validateDiscountPropertiesForType($command);
+        $discountType = $command->getDiscountType()->getValue();
+        $this->discountValidator->validateDiscountPropertiesForType($discountType, $command);
         $BuiltCartRule = $this->cartRuleBuilder->build($command);
         $discount = $this->discountRepository->add($BuiltCartRule);
 

--- a/src/Adapter/Discount/CommandHandler/UpdateDiscountHandler.php
+++ b/src/Adapter/Discount/CommandHandler/UpdateDiscountHandler.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Adapter\Discount\CommandHandler;
 
 use PrestaShop\PrestaShop\Adapter\Discount\Repository\DiscountRepository;
 use PrestaShop\PrestaShop\Adapter\Discount\Update\Filler\DiscountFiller;
+use PrestaShop\PrestaShop\Adapter\Discount\Validate\DiscountValidator;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\UpdateDiscountCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\CommandHandler\UpdateDiscountCommandHandlerInterface;
@@ -39,12 +40,14 @@ class UpdateDiscountHandler implements UpdateDiscountCommandHandlerInterface
     public function __construct(
         private readonly DiscountRepository $discountRepository,
         private readonly DiscountFiller $discountFiller,
+        private readonly DiscountValidator $discountValidator,
     ) {
     }
 
     public function handle(UpdateDiscountCommand $command): void
     {
         $cartRule = $this->discountRepository->get($command->getDiscountId());
+        $this->discountValidator->validateDiscountPropertiesForType($cartRule->type, $command);
 
         $updatableProperties = $this->discountFiller->fillUpdatableProperties($cartRule, $command);
 

--- a/src/Core/ConstraintValidator/Constraints/NotCustomizableProduct.php
+++ b/src/Core/ConstraintValidator/Constraints/NotCustomizableProduct.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\NotCustomizableProductValidator;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Validation constraint for making sure that the selected product isn't customizable.
+ */
+class NotCustomizableProduct extends Constraint
+{
+    public $message = 'Customizable product cannot be selected.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return NotCustomizableProductValidator::class;
+    }
+}

--- a/src/Core/ConstraintValidator/NotCustomizableProductValidator.php
+++ b/src/Core/ConstraintValidator/NotCustomizableProductValidator.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\ConstraintValidator;
+
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\NotCustomizableProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class NotCustomizableProductValidator extends ConstraintValidator
+{
+    public function __construct(
+        private ProductRepository $productRepository
+    ) {
+    }
+
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof NotCustomizableProduct) {
+            throw new UnexpectedTypeException($constraint, NotCustomizableProduct::class);
+        }
+
+        foreach ($value as $product) {
+            $dbProduct = $this->productRepository->getProductByDefaultShop(new ProductId($product['product_id']));
+            if ($dbProduct->customizable) {
+                $this->context->buildViolation($constraint->message)
+                    ->setTranslationDomain('Admin.Notifications.Error')
+                    ->addViolation();
+            }
+        }
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountType.php
@@ -26,12 +26,14 @@
 
 namespace PrestaShopBundle\Form\Admin\Sell\Discount;
 
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\NotCustomizableProduct;
 use PrestaShop\PrestaShop\Core\Domain\Discount\ValueObject\DiscountType as DiscountTypeVo;
 use PrestaShopBundle\Form\Admin\Type\EntitySearchInputType;
 use PrestaShopBundle\Form\Admin\Type\ProductSearchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
  * This is the form root element for discount form.
@@ -78,6 +80,10 @@ class DiscountType extends TranslatorAwareType
                     'empty_state' => $this->trans('No product selected', 'Admin.Catalog.Feature'),
                     'identifier_field' => 'gift_product',
                     'required' => true,
+                    'constraints' => [
+                        new NotBlank(),
+                        new NotCustomizableProduct(['message' => $this->trans('Product with required customization fields cannot be used as a gift.', 'Admin.Catalog.Notification')]),
+                    ],
                 ])
             ;
         }

--- a/src/PrestaShopBundle/Resources/config/services/core/constraint_validator.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/constraint_validator.yml
@@ -82,3 +82,7 @@ services:
   PrestaShop\PrestaShop\Core\ConstraintValidator\UniqueDiscountCodeValidator:
     autowire: true
     autoconfigure: true
+
+  PrestaShop\PrestaShop\Core\ConstraintValidator\NotCustomizableProductValidator:
+    autowire: true
+    autoconfigure: true

--- a/tests/Integration/Behaviour/Features/Context/Domain/Discount/DiscountFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Discount/DiscountFeatureContext.php
@@ -57,6 +57,7 @@ class DiscountFeatureContext extends AbstractDomainFeatureContext
     {
         $errorCode = match ($field) {
             'name' => DiscountConstraintException::INVALID_NAME,
+            'gift_product' => DiscountConstraintException::INVALID_GIFT_PRODUCT,
             default => null,
         };
 

--- a/tests/Integration/Behaviour/Features/Scenario/Discount/BO/add_free_gift_discount.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Discount/BO/add_free_gift_discount.feature
@@ -35,3 +35,16 @@ Feature: Add discount
       | valid_to     | 2019-12-01 00:00:00 |
       | code         | FREE_GIFT_2019      |
       | gift_product | hummingbird-tshirt  |
+
+  Scenario: Create a complete discount with free gift but customizable product
+    Given there is a product in the catalog named "customizable-mug" with a price of 20.0 and 1000 items in stock
+    Given product "customizable-mug" has a customization field named "custo1"
+    When I create a "free_gift" discount "complete_free_gift_discount_customizable_product" with following properties:
+      | name[en-US]  | Promotion           |
+      | name[fr-FR]  | Promotion fr        |
+      | active       | true                |
+      | valid_from   | 2019-01-01 11:05:00 |
+      | valid_to     | 2019-12-01 00:00:00 |
+      | code         | FREE_GIFT_2025      |
+      | gift_product | customizable-mug    |
+    Then I should get error that discount field gift_product is invalid

--- a/tests/Integration/Behaviour/Features/Scenario/Discount/BO/update_free_gift_discount.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Discount/BO/update_free_gift_discount.feature
@@ -15,7 +15,7 @@ Feature: Update discount
     And language with iso code "en" is the default one
     And language "french" with locale "fr-FR" exists
 
-  Scenario: Create a complete cart level discount
+  Scenario: Create a complete cart level discount and update it
     Given there is a product in the catalog named "Free Product" with a price of 20.0 and 1000 items in stock
     Given there is a product "hummingbird-tshirt" with name "Hummingbird printed t-shirt"
     Given there is a product "hummingbird-notebook" with name "Hummingbird notebook"
@@ -47,3 +47,27 @@ Feature: Update discount
       | valid_to     | 2019-12-01 00:00:00  |
       | code         | FREE_GIFT_2019       |
       | gift_product | hummingbird-notebook |
+
+  Scenario: Create a complete discount and update it with customizable product
+    Given there is a product in the catalog named "customizable-mug" with a price of 20.0 and 1000 items in stock
+    Given product "customizable-mug" has a customization field named "custo1"
+    When I create a "free_gift" discount "complete_free_gift_discount_customizable_product" with following properties:
+      | name[en-US]  | Promotion           |
+      | name[fr-FR]  | Promotion fr        |
+      | active       | true                |
+      | valid_from   | 2019-01-01 11:05:00 |
+      | valid_to     | 2019-12-01 00:00:00 |
+      | code         | FREE_GIFT_2025      |
+      | gift_product | hummingbird-tshirt  |
+    Then discount "complete_free_gift_discount_customizable_product" should have the following properties:
+      | name[en-US]  | Promotion           |
+      | name[fr-FR]  | Promotion fr        |
+      | type         | free_gift           |
+      | active       | true                |
+      | valid_from   | 2019-01-01 11:05:00 |
+      | valid_to     | 2019-12-01 00:00:00 |
+      | code         | FREE_GIFT_2025      |
+      | gift_product | hummingbird-tshirt  |
+    Then I update discount "complete_free_gift_discount_customizable_product" with the following properties:
+      | gift_product | customizable-mug    |
+    Then I should get error that discount field gift_product is invalid


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add new constraint to avoid having customizable product on free gift discount, as we have in legacy with the old system.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to the BO and add new discount "Free gift".<br>2. Select "Customizable mug" then click on save.<br>3. You must see a new error message.<br>4. Test with a no customizable mug to save your new discount.
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/17858164938
| Fixed issue or discussion?     | Fixes #39429
| Related PRs       | 
| Sponsor company   | PrestaShop SA
