### PR TITLE
Fix: Front container lazy service declaration

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -24,11 +24,14 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+use PrestaShop\PrestaShop\Adapter\Module\Repository\CachedModuleRepository;
 use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Version;
 use PrestaShop\TranslationToolsBundle\TranslationToolsBundle;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileExistenceResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -43,7 +46,7 @@ abstract class AppKernel extends Kernel
     public const RELEASE_VERSION = Version::RELEASE_VERSION;
 
     /**
-     * @var ModuleRepository
+     * @var CachedModuleRepository
      */
     protected $moduleRepository = null;
 
@@ -300,10 +303,18 @@ abstract class AppKernel extends Kernel
         return realpath(__DIR__ . '/..');
     }
 
-    protected function getModuleRepository(): ModuleRepository
+    protected function getModuleRepository(): CachedModuleRepository
     {
         if ($this->moduleRepository === null) {
-            $this->moduleRepository = new ModuleRepository(_PS_ROOT_DIR_, _PS_MODULE_DIR_);
+            if ($this->getEnvironment() === 'test') {
+                $cache = new NullAdapter();
+            } else {
+                $cache = new FilesystemAdapter('modules', 0, $this->getCacheDir());
+            }
+            $this->moduleRepository = new CachedModuleRepository(
+                new ModuleRepository(_PS_ROOT_DIR_, _PS_MODULE_DIR_),
+                $cache
+            );
         }
 
         return $this->moduleRepository;

--- a/src/Adapter/Container/ContainerParametersExtension.php
+++ b/src/Adapter/Container/ContainerParametersExtension.php
@@ -26,8 +26,11 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Container;
 
+use PrestaShop\PrestaShop\Adapter\Module\Repository\CachedModuleRepository;
 use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use PrestaShop\PrestaShop\Core\EnvironmentInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -81,7 +84,15 @@ class ContainerParametersExtension implements ContainerBuilderExtensionInterface
         $container->setParameter('kernel.cache_dir', $this->environment->getCacheDir());
 
         // Init the active modules
-        $moduleRepository = new ModuleRepository(_PS_ROOT_DIR_, _PS_MODULE_DIR_);
+        if ($this->environment->getName() === 'test') {
+            $cache = new NullAdapter();
+        } else {
+            $cache = new FilesystemAdapter('modules', 0, $this->environment->getCacheDir());
+        }
+        $moduleRepository = new CachedModuleRepository(
+            new ModuleRepository(_PS_ROOT_DIR_, _PS_MODULE_DIR_),
+            $cache
+        );
         $activeModules = $moduleRepository->getActiveModules();
         /* @deprecated kernel.active_modules is deprecated. Use prestashop.active_modules instead. */
         $container->setParameter('kernel.active_modules', $activeModules);

--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -36,11 +36,15 @@ use PrestaShop\PrestaShop\Adapter\Container\DoctrineBuilderExtension;
 use PrestaShop\PrestaShop\Adapter\Container\LegacyContainer;
 use PrestaShop\PrestaShop\Adapter\Container\LegacyContainerBuilder;
 use PrestaShop\PrestaShop\Adapter\Doctrine\FrontDoctrineProxyWarmer;
+use PrestaShop\PrestaShop\Adapter\Module\Repository\CachedModuleRepository;
+use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use PrestaShop\PrestaShop\Core\EnvironmentInterface;
 use PrestaShopBundle\DependencyInjection\Compiler\LoadServicesFromModulesPass;
 use PrestaShopBundle\Exception\ServiceContainerException;
 use PrestaShopBundle\PrestaShopBundle;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileResource;
@@ -49,11 +53,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
-/**
- * Build the Container for PrestaShop Legacy.
- *
- * @deprecated since 9.0. Please use SymfonyContainer instead.
- */
 class ContainerBuilder
 {
     /**
@@ -137,11 +136,20 @@ class ContainerBuilder
         // them at each container creation, this can't be compiled.
         $this->loadDoctrineAnnotationMetadata();
 
+        if ($this->environment->getName() === 'test') {
+            $cache = new NullAdapter();
+        } else {
+            $cache = new FilesystemAdapter('modules', 0, _PS_CACHE_DIR_);
+        }
+        $moduleRepository = new CachedModuleRepository(
+            new ModuleRepository(_PS_ROOT_DIR_, _PS_MODULE_DIR_),
+            $cache
+        );
+        $this->loadModulesAutoloader($moduleRepository->getInstalledModules());
+
         $container = $this->loadDumpedContainer();
         if (null === $container) {
             $container = $this->compileContainer();
-        } else {
-            $this->loadModulesAutoloader($container);
         }
 
         // synthetic definitions can't be compiled
@@ -190,7 +198,7 @@ class ContainerBuilder
         }
 
         $this->loadServicesFromConfig($container);
-        $this->loadModulesAutoloader($container);
+        $this->loadModulesAutoloader($container->getParameter('prestashop.installed_modules'));
         $container->compile();
 
         if ($this->environment->isDebug() === false) {
@@ -247,13 +255,12 @@ class ContainerBuilder
      * be done in a compiler pass because they are only executed on compilation and this needs to
      * be done at each container instanciation.
      *
-     * @param ContainerInterface $container
+     * @param array $installedModules
      *
      * @throws Exception
      */
-    private function loadModulesAutoloader(ContainerInterface $container)
+    private function loadModulesAutoloader(array $installedModules)
     {
-        $installedModules = $container->getParameter('prestashop.installed_modules');
         /** @var array<string> $installedModules */
         foreach ($installedModules as $module) {
             $autoloader = _PS_MODULE_DIR_ . $module . '/vendor/autoload.php';

--- a/src/Adapter/Module/Repository/CachedModuleRepository.php
+++ b/src/Adapter/Module/Repository/CachedModuleRepository.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Module\Repository;
+
+use Symfony\Contracts\Cache\CacheInterface;
+
+class CachedModuleRepository
+{
+    private $decorated;
+    private $cache;
+
+    public function __construct(ModuleRepository $decorated, CacheInterface $cache)
+    {
+        $this->decorated = $decorated;
+        $this->cache = $cache;
+    }
+
+    public function getInstalledModules(): array
+    {
+        return $this->cache->get('installed_modules', function () {
+            return $this->decorated->getInstalledModules();
+        });
+    }
+
+    public function getPresentModules(): array
+    {
+        return $this->cache->get('present_modules', function () {
+            return $this->decorated->getPresentModules();
+        });
+    }
+
+    public function getActiveModules(): array
+    {
+        return $this->cache->get('active_modules', function () {
+            return $this->decorated->getActiveModules();
+        });
+    }
+}


### PR DESCRIPTION
[Core] Fix lazy services: register module autoloaders before FrontContainer

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | There is an issue when you declare a service with lazy loading. If there is no service cache generated, the front page is loaded without any problem, but when you load the same page the second time, the container is already generatedm but module autoload file is not launched yet and we receive the exception, that class is not found
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install the module: [pr39572.zip](https://github.com/user-attachments/files/22363506/pr39572.zip) - 2. display the site homepage - 3. verify that there are no errors and that the message **Value of lazy service** is present
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/18281837331
| Fixed issue or discussion?     | Fixes #39555
| Related PRs       | 
| Sponsor company   | @Codencode 



The problem occurs because, when the container is already built, it is included before the module autoloaders are registered.
If a service is declared with `lazy: true`, the container generates a Ghost class that extends the service class. At this point PHP throws an error because the parent class has not yet been imported.
Note: this issue does not occur when enabling the experimental New front container feature.
The adopted solution is to register the module autoloaders before including the FrontContainer.
To achieve this, the method `ContainerBuilder::loadModulesAutoloader()` was modified so that it receives the list of installed modules without retrieving it from the container (which is only available after the container has been included).


This may not be the definitive solution, but it highlights the root cause of the issue and could help move towards a proper fix.