### PR TITLE
Fix issue with null values on stores from import

### DIFF
--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -606,7 +606,7 @@ class AdminStoresControllerCore extends AdminController
      *
      * @return array
      */
-    protected function adaptHoursFormat(array $value)
+    protected function adaptHoursFormat(?array $value)
     {
         if (null === $value) {
             return [];

--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -608,6 +608,9 @@ class AdminStoresControllerCore extends AdminController
      */
     protected function adaptHoursFormat(array $value)
     {
+        if (null === $value) {
+            return [];
+        }
         $separator = array_fill(0, count($value), ' | ');
 
         return array_map('implode', $separator, $value);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | When importing store contacts and a store is missing opening hours, that store will not be possible to access from the BO due to null values from the DB not being allowed in conversion.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| UI tests     | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/18500948427
| How to test?      | Follow instructions in issue.
| Fixed issue or discussion?     | Fixes #34974
| Sponsor company   | Prestaworks AB
