### PR TITLE
Fix: Product customization text field bug with using symbol {}

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -74,6 +74,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      */
     protected $isPreview = false;
 
+    /**
+     * @var bool
+     */
+    protected $hasCustomizationError = false;
+
     public function canonicalRedirection(string $canonical_url = ''): void
     {
         // This is there to prevent error, because this function is also called
@@ -316,7 +321,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      */
     public function initContent(): void
     {
-        if (!$this->errors) {
+        if (!$this->errors || $this->hasCustomizationError) {
             // Assign template vars related to the category + execute hooks related to the category
             $this->assignCategory();
 
@@ -942,8 +947,10 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 /* Original file */
                 if (!ImageManager::resize($tmp_name, _PS_UPLOAD_DIR_ . $file_name)) {
                     $this->errors[] = $this->trans('An error occurred during the image upload process.', [], 'Shop.Notifications.Error');
+                    $this->hasCustomizationError = true;
                 } elseif (!ImageManager::resize($tmp_name, _PS_UPLOAD_DIR_ . $file_name . '_small', $product_picture_width, $product_picture_height)) {
                     $this->errors[] = $this->trans('An error occurred during the image upload process.', [], 'Shop.Notifications.Error');
+                    $this->hasCustomizationError = true;
                 } else {
                     $this->context->cart->addPictureToProduct($this->product->id, $indexes[$field_name], Product::CUSTOMIZE_FILE, $file_name);
                 }
@@ -970,6 +977,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             if (in_array($field_name, $authorized_text_fields) && $value != '') {
                 if (!Validate::isMessage($value)) {
                     $this->errors[] = $this->trans('Invalid message.', [], 'Shop.Notifications.Error');
+                    $this->hasCustomizationError = true;
                 } else {
                     $this->context->cart->addTextFieldToProduct($this->product->id, $indexes[$field_name], Product::CUSTOMIZE_TEXTFIELD, $value);
                 }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -74,11 +74,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      */
     protected $isPreview = false;
 
-    /**
-     * @var bool
-     */
-    protected $hasCustomizationError = false;
-
     public function canonicalRedirection(string $canonical_url = ''): void
     {
         // This is there to prevent error, because this function is also called
@@ -321,104 +316,102 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      */
     public function initContent(): void
     {
-        if (!$this->errors || $this->hasCustomizationError) {
-            // Assign template vars related to the category + execute hooks related to the category
-            $this->assignCategory();
+        // Assign template vars related to the category + execute hooks related to the category
+        $this->assignCategory();
 
-            // Assign template vars related to manufacturer of the product
-            $this->assignManufacturer();
+        // Assign template vars related to manufacturer of the product
+        $this->assignManufacturer();
 
-            // Assign template vars related to the price and tax
-            $this->assignPriceAndTax();
+        // Assign template vars related to the price and tax
+        $this->assignPriceAndTax();
 
-            // Assign attributes combinations to the template
-            $this->assignAttributesCombinations();
+        // Assign attributes combinations to the template
+        $this->assignAttributesCombinations();
 
-            // Add notification about this product being in cart
-            $this->addCartQuantityNotification();
+        // Add notification about this product being in cart
+        $this->addCartQuantityNotification();
 
-            // Get our product itself
-            // At this phase, it's already a presented lazy array, ready to go
-            $product_for_template = $this->getTemplateVarProduct();
+        // Get our product itself
+        // At this phase, it's already a presented lazy array, ready to go
+        $product_for_template = $this->getTemplateVarProduct();
 
-            // Chained hook call - if multiple modules are hooked here, they will receive the result of the previous one as a parameter
-            $filteredProduct = Hook::exec(
-                'filterProductContent',
-                ['object' => $product_for_template],
-                null,
-                false,
-                true,
-                false,
-                null,
-                true
+        // Chained hook call - if multiple modules are hooked here, they will receive the result of the previous one as a parameter
+        $filteredProduct = Hook::exec(
+            'filterProductContent',
+            ['object' => $product_for_template],
+            null,
+            false,
+            true,
+            false,
+            null,
+            true
+        );
+        if (!empty($filteredProduct['object'])) {
+            $product_for_template = $filteredProduct['object'];
+        }
+
+        // Prepare product presenter for related items like packs and accessories
+        $assembler = new ProductAssembler($this->context);
+        $presenter = new ProductListingPresenter(
+            new ImageRetriever(
+                $this->context->link
+            ),
+            $this->context->link,
+            new PriceFormatter(),
+            new ProductColorsRetriever(),
+            $this->getTranslator()
+        );
+        $presentationSettings = $this->getProductPresentationSettings();
+
+        // Presenting pack items
+        $pack_items = $product_for_template['pack'] ? $product_for_template['packItems'] : [];
+        $pack_items = $assembler->assembleProducts($pack_items);
+        $presentedPackItems = [];
+        foreach ($pack_items as $item) {
+            $presentedPackItems[] = $presenter->present(
+                $presentationSettings,
+                $item,
+                $this->context->language
             );
-            if (!empty($filteredProduct['object'])) {
-                $product_for_template = $filteredProduct['object'];
-            }
+        }
 
-            // Prepare product presenter for related items like packs and accessories
-            $assembler = new ProductAssembler($this->context);
-            $presenter = new ProductListingPresenter(
-                new ImageRetriever(
-                    $this->context->link
-                ),
-                $this->context->link,
-                new PriceFormatter(),
-                new ProductColorsRetriever(),
-                $this->getTranslator()
-            );
-            $presentationSettings = $this->getProductPresentationSettings();
-
-            // Presenting pack items
-            $pack_items = $product_for_template['pack'] ? $product_for_template['packItems'] : [];
-            $pack_items = $assembler->assembleProducts($pack_items);
-            $presentedPackItems = [];
-            foreach ($pack_items as $item) {
-                $presentedPackItems[] = $presenter->present(
+        // Assign accessories
+        $accessories = $this->product->getAccessories($this->context->language->id);
+        if (is_array($accessories)) {
+            $accessories = $assembler->assembleProducts($accessories);
+            foreach ($accessories as &$accessory) {
+                $accessory = $presenter->present(
                     $presentationSettings,
-                    $item,
+                    $accessory,
                     $this->context->language
                 );
             }
-
-            // Assign accessories
-            $accessories = $this->product->getAccessories($this->context->language->id);
-            if (is_array($accessories)) {
-                $accessories = $assembler->assembleProducts($accessories);
-                foreach ($accessories as &$accessory) {
-                    $accessory = $presenter->present(
-                        $presentationSettings,
-                        $accessory,
-                        $this->context->language
-                    );
-                }
-                unset($accessory);
-            }
-
-            // Assign everything to the template
-            $this->context->smarty->assign([
-                'product' => $product_for_template,
-                // How to display prices, tax or no tax?
-                'priceDisplay' => Product::getTaxCalculationMethod((int) $this->context->cookie->id_customer),
-                // If product is customized but not added to cart, ID of the customization
-                'id_customization' => empty($product_for_template['id_customization']) ? null : $product_for_template['id_customization'],
-                // Related products
-                'accessories' => $accessories,
-                // Should price per unit be displayed?
-                'displayUnitPrice' => !empty($product_for_template['unit_price_tax_excluded']),
-                // If product is a pack, pack contents
-                'packItems' => $presentedPackItems,
-                // Price of the product if it wasn't in the pack (should be migrated to lazy array)
-                'noPackPrice' => $product_for_template['nopackprice_to_display'],
-                // Should display the price of product if it wasn't in the pack?
-                'displayPackPrice' => !empty($product_for_template['pack']) && $product_for_template['price_amount'] < $product_for_template['nopackprice'],
-                // Variable containing information about a pack that this product belongs to
-                'packs' => Pack::getPacksTable($this->product->id, $this->context->language->id, true, 1),
-            ]);
-
-            // Assign attribute groups to the template
-            $this->assignAttributesGroups($product_for_template);
+            unset($accessory);
         }
+
+        // Assign everything to the template
+        $this->context->smarty->assign([
+            'product' => $product_for_template,
+            // How to display prices, tax or no tax?
+            'priceDisplay' => Product::getTaxCalculationMethod((int) $this->context->cookie->id_customer),
+            // If product is customized but not added to cart, ID of the customization
+            'id_customization' => empty($product_for_template['id_customization']) ? null : $product_for_template['id_customization'],
+            // Related products
+            'accessories' => $accessories,
+            // Should price per unit be displayed?
+            'displayUnitPrice' => !empty($product_for_template['unit_price_tax_excluded']),
+            // If product is a pack, pack contents
+            'packItems' => $presentedPackItems,
+            // Price of the product if it wasn't in the pack (should be migrated to lazy array)
+            'noPackPrice' => $product_for_template['nopackprice_to_display'],
+            // Should display the price of product if it wasn't in the pack?
+            'displayPackPrice' => !empty($product_for_template['pack']) && $product_for_template['price_amount'] < $product_for_template['nopackprice'],
+            // Variable containing information about a pack that this product belongs to
+            'packs' => Pack::getPacksTable($this->product->id, $this->context->language->id, true, 1),
+        ]);
+
+        // Assign attribute groups to the template
+        $this->assignAttributesGroups($product_for_template);
 
         parent::initContent();
     }
@@ -947,10 +940,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 /* Original file */
                 if (!ImageManager::resize($tmp_name, _PS_UPLOAD_DIR_ . $file_name)) {
                     $this->errors[] = $this->trans('An error occurred during the image upload process.', [], 'Shop.Notifications.Error');
-                    $this->hasCustomizationError = true;
                 } elseif (!ImageManager::resize($tmp_name, _PS_UPLOAD_DIR_ . $file_name . '_small', $product_picture_width, $product_picture_height)) {
                     $this->errors[] = $this->trans('An error occurred during the image upload process.', [], 'Shop.Notifications.Error');
-                    $this->hasCustomizationError = true;
                 } else {
                     $this->context->cart->addPictureToProduct($this->product->id, $indexes[$field_name], Product::CUSTOMIZE_FILE, $file_name);
                 }
@@ -977,7 +968,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             if (in_array($field_name, $authorized_text_fields) && $value != '') {
                 if (!Validate::isMessage($value)) {
                     $this->errors[] = $this->trans('Invalid message.', [], 'Shop.Notifications.Error');
-                    $this->hasCustomizationError = true;
                 } else {
                     $this->context->cart->addTextFieldToProduct($this->product->id, $indexes[$field_name], Product::CUSTOMIZE_TEXTFIELD, $value);
                 }


### PR DESCRIPTION
FO: Allow product page to render when customization errors occur
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | If you attempt to create a customization for a product with invalid text, for example by entering {, the page throws an error, see #39580
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | 1. Go to an article that allows customization (e.g., ID: 19) - 2. Enter the character { as the customization text - 3. The system must correctly display the page with the error message: **Invalid message.**
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/17822516065
| Fixed issue or discussion?     | Fixes #39580
| Related PRs       | 
| Sponsor company   | @Codencode 

# Issue with productcomments module enabled
[with-productcomments-module.webm](https://github.com/user-attachments/assets/0d75888b-57c6-4ad8-a99f-04b2c9daeb32)

# Issue without productcomments module 
[without-productcomments-module.webm](https://github.com/user-attachments/assets/f9ddac5f-0fa7-46a8-bfa7-76ddaa76551d)

# With fix
[with-fix.webm](https://github.com/user-attachments/assets/0a220966-dc8d-4ba8-93dc-4a96a14a9618)



