### PR TITLE
Prevent duplicated CDN entries in .htaccess for multishop context

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2194,26 +2194,23 @@ class ToolsCore
 
         fwrite($write_fd, "RewriteEngine on\n");
 
+        $media_domains = '';
         if (
             !$medias
             && Configuration::getMultiShopValues('PS_MEDIA_SERVER_1')
             && Configuration::getMultiShopValues('PS_MEDIA_SERVER_2')
             && Configuration::getMultiShopValues('PS_MEDIA_SERVER_3')
         ) {
-            $medias = [
+            $medias = array_filter(array_unique(array_merge(
                 Configuration::getMultiShopValues('PS_MEDIA_SERVER_1'),
                 Configuration::getMultiShopValues('PS_MEDIA_SERVER_2'),
-                Configuration::getMultiShopValues('PS_MEDIA_SERVER_3'),
-            ];
-        }
+                Configuration::getMultiShopValues('PS_MEDIA_SERVER_3')
+            )), function($media) {
+                return is_string($media) && $media;
+            });
 
-        $media_domains = '';
-        foreach ($medias as $media) {
-            $media = array_unique($media);
-            foreach ($media as $media_url) {
-                if ($media_url) {
-                    $media_domains .= 'RewriteCond %{HTTP_HOST} ^' . $media_url . '$ [OR]' . PHP_EOL;
-                }
+            foreach ($medias as $media_url) {
+                $media_domains .= 'RewriteCond %{HTTP_HOST} ^' . $media_url . '$ [OR]' . PHP_EOL;
             }
         }
 

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2209,6 +2209,7 @@ class ToolsCore
 
         $media_domains = '';
         foreach ($medias as $media) {
+            $media = array_unique($media);
             foreach ($media as $media_url) {
                 if ($media_url) {
                     $media_domains .= 'RewriteCond %{HTTP_HOST} ^' . $media_url . '$ [OR]' . PHP_EOL;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | In multishop context, if using the same CDN domain, the same value is written into .htaccess file multiple file (as many as you have assigned same cdn to others shop), like below, these line are useless and can be removed, only one instruction is needed (can be cherry-picked for previous versions too).
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Automated test     |  https://github.com/paulnoelcholot/ga.tests.ui.pr/actions/runs/23589130037 KO
| How to test?      | Create multiple shop, assign the same CDN domain name for each of them, generate the .htaccess file and check the multiple values.
| Sponsor company   | VersusVenture (PrestaModule / BusinessTech)

Actual `.htaccess` content :

```
# Images
RewriteCond %{HTTP_HOST} ^cdn.mydomain.com$ [OR]
RewriteCond %{HTTP_HOST} ^cdn.mydomain.com$ [OR]
RewriteCond %{HTTP_HOST} ^cdn.mydomain.com$ [OR]
RewriteCond %{HTTP_HOST} ^cdn.mydomain.com$ [OR]
...

```
Expected `.htaccess` content :

```
# Images
RewriteCond %{HTTP_HOST} ^cdn.mydomain.com$ [OR]
...
```