### PR TITLE
Improved generation of queries and commands

### DIFF
--- a/src/PrestaShopBundle/Command/ListCommandsAndQueriesCommand.php
+++ b/src/PrestaShopBundle/Command/ListCommandsAndQueriesCommand.php
@@ -26,12 +26,14 @@
 
 namespace PrestaShopBundle\Command;
 
+use ApiPlatform\Metadata\Resource\Factory\AttributesResourceNameCollectionFactory;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use Exception;
 use PrestaShop\PrestaShop\Core\CommandBus\Parser\CommandDefinition;
 use PrestaShop\PrestaShop\Core\CommandBus\Parser\CommandDefinitionParser;
-use PrestaShopBundle\Exception\DomainClassNameMalformedException;
+use PrestaShopBundle\ApiPlatform\Scopes\ApiResourceScopesExtractorInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\InputInterface;
@@ -54,7 +56,8 @@ class ListCommandsAndQueriesCommand extends Command
         private CommandDefinitionParser $commandDefinitionParser,
         private array $commandAndQueries,
         private ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory,
-        private ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory
+        private ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory,
+        private ApiResourceScopesExtractorInterface $apiResourceScopesExtractor
     ) {
         parent::__construct();
         $this->isFormatSimple = false;
@@ -119,7 +122,9 @@ class ListCommandsAndQueriesCommand extends Command
                 $output->writeln(++$key . '.');
                 $output->writeln('<blue>Class: </blue><info>' . $commandDefinition->getClassName() . '</info>');
                 $output->writeln('<blue>Type: </blue><info>' . $commandDefinition->getCommandType() . '</info>');
-                $output->writeln('<blue>API: </blue><info>' . $cqrsEndpointURI . '</info>');
+                if (!empty($cqrsEndpointURI)) {
+                    $output->writeln('<blue>API: </blue><info>' . $cqrsEndpointURI . '</info>');
+                }
                 $output->writeln('<comment>' . $commandDefinition->getDescription() . '</comment>');
                 $output->writeln('');
             }
@@ -157,18 +162,69 @@ class ListCommandsAndQueriesCommand extends Command
     }
 
     /**
-     * This method rebuild the resources from the api platform attributes.
+     * This method rebuild the resources from the api platform attributes including modules.
      *
      * @return ResourceMetadataCollection[]
      */
     private function getResourceList(): array
     {
         $resourceMetadataCollection = [];
+
+        // Get core resources (original working logic)
         foreach ($this->resourceNameCollectionFactory->create() as $resourceClass) {
-            $resourceMetadataCollection[] = $this->resourceMetadataFactory->create($resourceClass);
+            try {
+                $resourceMetadataCollection[] = $this->resourceMetadataFactory->create($resourceClass);
+            } catch (Exception $e) {
+                // Skip resources that can't be loaded
+                continue;
+            }
+        }
+
+        // Get resource classes from modules
+        $moduleApiResourceScopes = array_filter(
+            $this->apiResourceScopesExtractor->getAllApiResourceScopes(),
+            fn ($scope) => !$scope->fromCore()
+        );
+
+        foreach ($moduleApiResourceScopes as $apiResourceScope) {
+            $moduleName = $apiResourceScope->getModuleName();
+            $moduleResourcePaths = $this->getModuleResourcePaths($moduleName);
+
+            if (empty($moduleResourcePaths)) {
+                continue;
+            }
+
+            try {
+                $moduleResourceExtractor = new AttributesResourceNameCollectionFactory($moduleResourcePaths);
+                foreach ($moduleResourceExtractor->create() as $resourceClass) {
+                    try {
+                        $resourceMetadataCollection[] = $this->resourceMetadataFactory->create($resourceClass);
+                    } catch (Exception $e) {
+                        // Skip individual resources that can't be loaded (e.g., missing dependencies)
+                        continue;
+                    }
+                }
+            } catch (Exception $e) {
+                // Skip entire module if resource factory fails (e.g., invalid path)
+                continue;
+            }
         }
 
         return $resourceMetadataCollection;
+    }
+
+    private function getModuleResourcePaths(string $moduleName): array
+    {
+        $paths = [];
+        $modulePath = _PS_MODULE_DIR_ . $moduleName;
+
+        // Folder containing ApiPlatform resources classes
+        $moduleResourcesPath = sprintf('%s/src/ApiPlatform/Resources', $modulePath);
+        if (file_exists($moduleResourcesPath)) {
+            $paths[] = $moduleResourcesPath;
+        }
+
+        return $paths;
     }
 
     /**
@@ -177,38 +233,58 @@ class ListCommandsAndQueriesCommand extends Command
      */
     private function getCQRSEndpointURI(CommandDefinition $commandDefinition): string
     {
-        $domainArray = explode('\\', $commandDefinition->getClassName());
-        if (count($domainArray) >= 5) {
-            $domain = $domainArray[4];
-        } else {
-            throw new DomainClassNameMalformedException();
-        }
+        $cqrsClassName = $commandDefinition->getClassName();
+        $matchingEndpoints = [];
 
         foreach ($this->apiResourcesList as $apiResources) {
             foreach ($apiResources as $resource) {
-                if ($resource->getShortName() !== $domain) {
-                    return '';
-                }
-
                 $apiResourceOperations = $resource->getOperations();
                 foreach ($apiResourceOperations as $operation) {
-                    if ($this->doesMethodsMatchType($operation->getMethod(), $commandDefinition->getCommandType())) {
-                        return $operation->getUriTemplate();
+                    $extraProperties = $operation->getExtraProperties();
+
+                    // Check if this operation uses the same CQRS class
+                    $operationCQRSClass = null;
+                    if (!empty($extraProperties['CQRSQuery'])) {
+                        $operationCQRSClass = $extraProperties['CQRSQuery'];
+                    } elseif (!empty($extraProperties['CQRSCommand'])) {
+                        $operationCQRSClass = $extraProperties['CQRSCommand'];
+                    }
+
+                    if ($operationCQRSClass === $cqrsClassName
+                        && $this->doesMethodsMatchType($operation->getMethod(), $commandDefinition->getCommandType())) {
+                        $matchingEndpoints[] = [
+                            'method' => $operation->getMethod(),
+                            'uri' => $operation->getUriTemplate(),
+                        ];
                     }
                 }
             }
         }
 
-        return '';
+        if (empty($matchingEndpoints)) {
+            return '';
+        }
+
+        if (count($matchingEndpoints) === 1) {
+            return $matchingEndpoints[0]['method'] . ' ' . $matchingEndpoints[0]['uri'];
+        }
+
+        // Multiple endpoints - format as method:uri pairs
+        $formattedEndpoints = array_map(
+            fn ($endpoint) => $endpoint['method'] . ' ' . $endpoint['uri'],
+            $matchingEndpoints
+        );
+
+        return implode(', ', array_unique($formattedEndpoints));
     }
 
     private function doesMethodsMatchType(string $method, string $commandType): bool
     {
         switch ($commandType) {
             case 'Command':
-                return $method === 'POST' || $method === 'PUT';
+                return in_array($method, ['POST', 'PUT', 'PATCH', 'DELETE']);
             case 'Query':
-                return $method === 'GET' || $method === 'DELETE';
+                return $method === 'GET';
             default:
                 return false;
         }

--- a/src/PrestaShopBundle/Command/ListCommandsAndQueriesCommand.php
+++ b/src/PrestaShopBundle/Command/ListCommandsAndQueriesCommand.php
@@ -57,7 +57,8 @@ class ListCommandsAndQueriesCommand extends Command
         private array $commandAndQueries,
         private ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory,
         private ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory,
-        private ApiResourceScopesExtractorInterface $apiResourceScopesExtractor
+        private ApiResourceScopesExtractorInterface $apiResourceScopesExtractor,
+        private string $moduleDir
     ) {
         parent::__construct();
         $this->isFormatSimple = false;
@@ -216,7 +217,7 @@ class ListCommandsAndQueriesCommand extends Command
     private function getModuleResourcePaths(string $moduleName): array
     {
         $paths = [];
-        $modulePath = _PS_MODULE_DIR_ . $moduleName;
+        $modulePath = $this->moduleDir . $moduleName;
 
         // Folder containing ApiPlatform resources classes
         $moduleResourcesPath = sprintf('%s/src/ApiPlatform/Resources', $modulePath);

--- a/src/PrestaShopBundle/Resources/config/services_dev/bundle/command.yml
+++ b/src/PrestaShopBundle/Resources/config/services_dev/bundle/command.yml
@@ -44,6 +44,7 @@ services:
       - '%prestashop.commands_and_queries%'
       - '@api_platform.metadata.resource.name_collection_factory.attributes'
       - '@api_platform.metadata.resource.metadata_collection_factory.attributes'
+      - '@PrestaShopBundle\ApiPlatform\Scopes\ApiResourceScopesExtractorInterface'
     tags:
       - 'console.command'
 

--- a/src/PrestaShopBundle/Resources/config/services_dev/bundle/command.yml
+++ b/src/PrestaShopBundle/Resources/config/services_dev/bundle/command.yml
@@ -45,6 +45,7 @@ services:
       - '@api_platform.metadata.resource.name_collection_factory.attributes'
       - '@api_platform.metadata.resource.metadata_collection_factory.attributes'
       - '@PrestaShopBundle\ApiPlatform\Scopes\ApiResourceScopesExtractorInterface'
+      - '%prestashop.module_dir%'
     tags:
       - 'console.command'
 

--- a/tests/Unit/PrestaShopBundle/Command/ListCommandsAndQueriesCommandTest.php
+++ b/tests/Unit/PrestaShopBundle/Command/ListCommandsAndQueriesCommandTest.php
@@ -71,7 +71,8 @@ class ListCommandsAndQueriesCommandTest extends TestCase
             $this->getListOfCQRSCommands(),
             $this->resourceNameCollectionMock,
             $this->resourceMetadataCollectionMock,
-            $this->apiResourceScopesExtractorMock
+            $this->apiResourceScopesExtractorMock,
+            '/test/modules/'
         );
 
         $this->commandTester = new CommandTester($command);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Improved command for generating command and queries. We include endpoints modules to better understand the actual coverage of the resources vs. CQRS
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | With `ps_apiresources` module installed and enabled, when you run `php bin/console prestashop:list:commands-and-queries --hasApiEndpoint=1` with and without the PR you'll see a different results
| UI Tests          | Not needed
| Fixed issue or discussion?     | n/a
| Related PRs       | n/a
| Sponsor company   | PrestaShop
