### PR TITLE
Reintroduce email unicity validation

### DIFF
--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -123,9 +123,12 @@ class CustomerFormCore extends AbstractForm
 
     public function validate()
     {
+        // If email is being changed, check if it's free to use and doesn't belong to another customer
         if (!$this->context->customer->is_guest) {
             $emailField = $this->getField('email');
-            if (Customer::customerExists($emailField->getValue())) {
+            $id_customer = Customer::customerExists($emailField->getValue(), true);
+            $customer = $this->getCustomer();
+            if ($id_customer && $id_customer != $customer->id) {
                 $emailField->addError($this->translator->trans(
                     'The email is already used, please choose another one or sign in',
                     [],

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -123,6 +123,17 @@ class CustomerFormCore extends AbstractForm
 
     public function validate()
     {
+        if (!$this->context->customer->is_guest) {
+            $emailField = $this->getField('email');
+            if (Customer::customerExists($emailField->getValue())) {
+                $emailField->addError($this->translator->trans(
+                    'The email is already used, please choose another one or sign in',
+                    [],
+                    'Shop.Notifications.Error'
+                ));
+            }
+        }
+
         // check birthdayField against null case is mandatory.
         $birthdayField = $this->getField('birthday');
         if (!empty($birthdayField)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | The validation of the unicity of the email address is reinstated. This validation was in place in [version 8.2](https://github.com/PrestaShop/PrestaShop/blob/8.2.x/classes/form/CustomerForm.php#L129) but is not present in the [version 9.0](https://github.com/PrestaShop/PrestaShop/blob/develop/classes/form/CustomerForm.php#L124)
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to customer identity page<br>2. Change the email and set an email already used by another customer<br>3. An error message is displayed
| UI Tests          | https://github.com/bibips/ga.tests.ui.pr/actions/runs/17938704488
| Fixed issue or discussion?     | Fixes #39587 
