### PR TITLE
fix(CustomerMessage): increase user_agent length from 128 to 255 to prevent silent error on mobile contact form

### DIFF
--- a/classes/CustomerMessage.php
+++ b/classes/CustomerMessage.php
@@ -79,7 +79,7 @@ class CustomerMessageCore extends ObjectModel
             'ip_address' => ['type' => self::TYPE_STRING, 'validate' => 'isIp2Long', 'size' => 16],
             'message' => ['type' => self::TYPE_HTML, 'required' => true, 'size' => FormattedTextareaType::LIMIT_MEDIUMTEXT_UTF8_MB4, 'validate' => 'isCleanHtml'],
             'file_name' => ['type' => self::TYPE_STRING, 'size' => 18],
-            'user_agent' => ['type' => self::TYPE_STRING, 'size' => 128],
+            'user_agent' => ['type' => self::TYPE_STRING, 'size' => 255],
             'private' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'date_add' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
             'date_upd' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -672,7 +672,7 @@ CREATE TABLE `PREFIX_customer_message` (
   `message` MEDIUMTEXT NOT NULL,
   `file_name` varchar(18) DEFAULT NULL,
   `ip_address` varchar(16) DEFAULT NULL,
-  `user_agent` varchar(128) DEFAULT NULL,
+  `user_agent` varchar(255) DEFAULT NULL,
   `date_add` datetime NOT NULL,
   `date_upd` datetime NOT NULL,
   `private` TINYINT NOT NULL DEFAULT '0',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Increase the `user_agent` field length in the `ps_customer_message` table (128 → 255). On some mobile devices (especially iOS Safari), the `user_agent` string can exceed 128 characters, which triggers a silent validation error in PrestaShop (`ObjectModel::validateFields()`). As a result, the contact form fails without displaying any message, and the customer message is not saved. This PR fixes the issue by aligning the database column size with the `CustomerMessage` model definition.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable the default contact form. 2. On an iPhone/iPad using Safari (or a simulator), submit a message. (need user_agent more than 128 characters) 3. Without this fix: the message is not saved (blank page). 4. With this fix: the message is saved correctly and visible in the customer service messages.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 
