### PR TITLE
fix(CustomerMessage): increase user_agent length from 128 to 255 to prevent silent validation errors on some mobile contact form

### DIFF
--- a/classes/CustomerMessage.php
+++ b/classes/CustomerMessage.php
@@ -79,7 +79,7 @@ class CustomerMessageCore extends ObjectModel
             'ip_address' => ['type' => self::TYPE_STRING, 'validate' => 'isIp2Long', 'size' => 16],
             'message' => ['type' => self::TYPE_HTML, 'required' => true, 'size' => FormattedTextareaType::LIMIT_MEDIUMTEXT_UTF8_MB4, 'validate' => 'isCleanHtml'],
             'file_name' => ['type' => self::TYPE_STRING, 'size' => 18],
-            'user_agent' => ['type' => self::TYPE_STRING, 'size' => 128],
+            'user_agent' => ['type' => self::TYPE_STRING, 'size' => 255],
             'private' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'date_add' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
             'date_upd' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -666,7 +666,7 @@ CREATE TABLE `PREFIX_customer_message` (
   `message` MEDIUMTEXT NOT NULL,
   `file_name` varchar(18) DEFAULT NULL,
   `ip_address` varchar(16) DEFAULT NULL,
-  `user_agent` varchar(128) DEFAULT NULL,
+  `user_agent` varchar(255) DEFAULT NULL,
   `date_add` datetime NOT NULL,
   `date_upd` datetime NOT NULL,
   `private` TINYINT NOT NULL DEFAULT '0',


### PR DESCRIPTION
This PR backports the fix from #39605 to 9.0.x so it will be included in 9.0.1.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Increase the `user_agent` field length in the `ps_customer_message` table (128 → 255). <br> On mobile devices (especially iOS Safari), the `user_agent` string can exceed 128 characters, which triggers a silent validation error in PrestaShop (`ObjectModel::validateFields()`). <br> As a result, the contact form fails without displaying any message, and the customer message is not saved.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable the default contact form. <br> 2. On an iPhone/iPad using Safari (or a simulator), submit a message. <br> 3. Without this fix: the message is not saved (blank page). <br> 4. With this fix: the message is saved correctly and visible in the customer service messages.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/17970083014
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/39605
| Sponsor company   | 
