### PR TITLE
[BO] Added DataCollector for Legacy Profiling

### DIFF
--- a/src/PrestaShopBundle/DataCollector/LegacyCollector.php
+++ b/src/PrestaShopBundle/DataCollector/LegacyCollector.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\DataCollector;
+
+use Profiler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Throwable;
+
+/**
+ * Collects data from the legacy debug profiling (e.g. queries coming from Db class)
+ */
+final class LegacyCollector extends DataCollector
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function collect(Request $request, Response $response, ?Throwable $exception = null)
+    {
+        $this->data = [
+            'isProfilerEnabled' => false,
+        ];
+        if (_PS_DEBUG_PROFILING_) {
+            // Process all profiling data
+            $profiler = Profiler::getInstance();
+            $profiler->processData();
+            $dataVariables = $profiler->getSmartyVariables();
+            if (empty($dataVariables)) {
+                return;
+            }
+            // Clean data (else that explodes the profiler)
+            foreach ($dataVariables['hooks']['perfs'] as &$dataVariableHook) {
+                foreach ($dataVariableHook['modules'] as &$dataVariableHookModule) {
+                    $dataVariableHookModule['params'] = [];
+                }
+            }
+            $this->data = [
+                'isProfilerEnabled' => true,
+                'summary' => $dataVariables['summary'],
+                'configuration' => $dataVariables['configuration'],
+                'run' => $dataVariables['run'],
+                'hooks' => $dataVariables['hooks'],
+                'modules' => $dataVariables['modules'],
+                'stopwatch' => $dataVariables['stopwatchQueries'],
+                'doubles' => $dataVariables['doublesQueries'],
+                'sqlTableStress' => $dataVariables['tableStress'],
+                'objectModelInstances' => $dataVariables['objectmodel'],
+                'includedFiles' => $dataVariables['files'],
+            ];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'ps.legacy_collector';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data = [];
+    }
+
+    /**
+     * @return bool
+     */
+    public function isProfilerEnabled(): bool
+    {
+        return $this->data['isProfilerEnabled'];
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfiguration(): array
+    {
+        return $this->data['configuration'];
+    }
+
+    /**
+     * @return array
+     */
+    public function getDoubles(): array
+    {
+        return $this->data['doubles'];
+    }
+
+    /**
+     * @return array
+     */
+    public function getHooks(): array
+    {
+        return $this->data['hooks'];
+    }
+
+    /**
+     * @return array
+     */
+    public function getIncludedFiles(): array
+    {
+        return $this->data['includedFiles'];
+    }
+
+    /**
+     * @return array
+     */
+    public function getModules(): array
+    {
+        return $this->data['modules'];
+    }
+
+    /**
+     * @return array
+     */
+    public function getObjectModelInstances(): array
+    {
+        return $this->data['objectModelInstances'];
+    }
+
+    /**
+     * @return array
+     */
+    public function getRun(): array
+    {
+        return $this->data['run'];
+    }
+
+    /**
+     * @return array
+     */
+    public function getSqlTableStress(): array
+    {
+        return $this->data['sqlTableStress'];
+    }
+
+    /**
+     * @return array
+     */
+    public function getStopwatch(): array
+    {
+        return $this->data['stopwatch'];
+    }
+
+    /**
+     * @return array
+     */
+    public function getSummary(): array
+    {
+        return $this->data['summary'];
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/data_collector.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/data_collector.yml
@@ -10,7 +10,9 @@ services:
     arguments: [ '@prestashop.hooks_registry' ]
     public: false
     tags:
-      - { name: data_collector, template: '@PrestaShop/Admin/WebProfiler/hooks_collector.html.twig', id: 'ps.hooks_collector' }
+      - name: data_collector
+        id: ps.hooks_collector
+        template: '@PrestaShop/Admin/WebProfiler/hooks_collector.html.twig'
 
   PrestaShopBundle\DataCollector\CommandsAndQueriesDataCollector:
     autowire: true
@@ -19,6 +21,14 @@ services:
       - name: data_collector
         id: ps.commands_and_queries_collector
         template: '@PrestaShop/Admin/WebProfiler/commands_and_queries.html.twig'
+
+  PrestaShopBundle\DataCollector\LegacyCollector:
+    autowire: true
+    public: false
+    tags:
+      - name: data_collector
+        id: ps.legacy_collector
+        template: '@PrestaShop/Admin/WebProfiler/legacy.html.twig'
 
   # Web Profiler Bundle
   data_collector.config:

--- a/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/legacy.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/legacy.html.twig
@@ -1,0 +1,427 @@
+{# **
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * #}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+
+{% block toolbar %}
+  {% set icon %}
+    {% if collector.isProfilerEnabled %}
+    🕵️‍♂️&nbsp;<span class="sf-toolbar-value">Legacy</span>
+    {% endif %}
+  {% endset %}
+
+  {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', {link: true}) }}
+{% endblock %}
+
+{% block menu %}
+  {% if collector.isProfilerEnabled %}
+  <span class="label">
+    <span class="icon">🕵️‍♂️</span>
+    <strong>Legacy</strong>
+  </span>
+  {% endif %}
+{% endblock %}
+
+{% block panel %}
+  {% if collector.isProfilerEnabled %}
+    {% set constRootDir = constant('_PS_ROOT_DIR_') ~ '/' %}
+    <div class="sf-tabs">
+      <div class="tab">
+        <h3 class="tab-title">Summary</h3>
+        <div class="tab-content">
+          <div class="metrics">
+            {% if collector.summary.loadTime is not null %}
+            <div class="metric">
+                <span class="value">{{ '%01.3f'|format(collector.summary.loadTime) }} <span class="unit">ms</span></span>
+                <span class="label">Load Time</span>
+            </div>
+            {% endif %}
+            <div class="metric">
+                <span class="value">{{ collector.summary.queryTime }} <span class="unit">ms</span></span>
+                <span class="label">Querying Time</span>
+            </div>
+            <div class="metric">
+                <span class="value">{{ collector.summary.nbQueries }}</span>
+                <span class="label">Queries</span>
+            </div>
+            {% if collector.summary.peakMemoryUsage is not null %}
+            <div class="metric">
+                <span class="value">{{ '%0.1f'|format((collector.summary.peakMemoryUsage / 1048576)|round(2)) }} <span class="unit">Mb</span></span>
+                <span class="label">Memory Peak Usage</span>
+            </div>
+            {% endif %}
+            <div class="metric">
+                <span class="value">{{ collector.summary.includedFiles }} <span class="unit">files</span> - {{ '%0.2f'|format((collector.summary.totalFileSize / 1048576)|round(2)) }} <span class="unit">Mb</span></span>
+                <span class="label">Included Files</span>
+            </div>
+            <div class="metric">
+                <span class="value">{{ '%0.2f'|format((collector.summary.totalCacheSize / 1048576)|round(2)) }} <span class="unit">Mb</span></span>
+                <span class="label">PS Cache Size</span>
+            </div>
+          </div>
+          {% if collector.summary.globalVarSize is not empty %}
+            <h3>Global vars</h3>
+            <div class="metrics">
+              <div class="metric">
+                  <span class="value">{{ '%0.2f'|format((collector.summary.totalGlobalVarSize / 1048576)|round(2)) }} <span class="unit">Mb</span></span>
+                  <span class="label">Global vars</span>
+              </div>
+            </div>
+            <div class="sf-toolbar-info-piece">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Variable</th>
+                    <th>Size</th>
+                  </tr>
+                </thead>
+                <tbody class="sf-toolbar-ajax-request-list">
+                  {% for key, value in collector.summary.globalVarSize %}
+                    <tr>
+                      <td class="text-small">{{ key }}</td>
+                      <td>{{ value }}k</td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+                </table>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+      <div class="tab">
+        <h3 class="tab-title">Configuration</h3>
+        <div class="tab-content">
+          <div class="metrics">
+            <div class="metric">
+              <span class="value">{{ collector.configuration.psVersion }}</span>
+              <span class="label">PrestaShop Version</span>
+            </div>
+            <div class="metric">
+              <span class="value">{{ collector.configuration.phpVersion }}</span>
+              <span class="label">PHP Version</span>
+            </div>
+            <div class="metric">
+              <span class="value">{{ collector.configuration.mysqlVersion }}</span>
+              <span class="label">MySQL Version</span>
+            </div>
+            <div class="metric">
+              <span class="value">{{ collector.configuration.memoryLimit }}</span>
+              <span class="label">Memory Limit</span>
+            </div>
+            <div class="metric">
+              <span class="value">{{ collector.configuration.maxExecutionTime }}</span>
+              <span class="label">Max Execution Time</span>
+            </div>
+            <div class="metric">
+              <span class="value">{{ collector.configuration.smartyCache is same as '1' ? 'enabled' : 'disabled' }}</span>
+              <span class="label">Smarty Cache</span>
+            </div>
+            <div class="metric">
+              <span class="value">
+                {% if collector.configuration.smartyCompilation is same as '0' %}
+                  never recompile
+                {% elseif collector.configuration.smartyCompilation is same as '1' %}
+                  auto
+                {% else %}
+                  force compile
+                {% endif %}
+              </span>
+              <span class="label">Smarty Compilation</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      {% if collector.run.profiler|length > 0 %}
+      <div class="tab">
+        <h3 class="tab-title">Run <span class="badge">{{ collector.run.profiler|length }}</span></h3>
+        <div class="tab-content">
+          <div class="sf-toolbar-info-piece">
+            <table>
+              <thead>
+                <tr>
+                  <th></th>
+                  <th>Time</th>
+                  <th>Cumulated Time</th>
+                  <th>Memory Usage</th>
+                  <th>Memory Peak Usage</th>
+                </tr>
+              </thead>
+              <tbody class="sf-toolbar-ajax-request-list">
+                {% set profilerLastTime = collector.run.startTime %}
+                {% set profilerLastMemUsage = 0 %}
+                {% for profilerRow in collector.run.profiler %}
+                  {% if not (profilerRow.block == 'checkAccess' and profilerRow.time == profilerLastTime) %}
+                  <tr>
+                    <td class="text-small">{{ profilerRow.block }}</td>
+                    <td>{{ '%01.3f'|format(profilerRow.time - profilerLastTime) }}</td>
+                    <td>{{ '%01.3f'|format(profilerRow.time - collector.run.startTime) }}</td>
+                    <td>{{ '%0.2f'|format(((profilerRow.memory_usage - profilerLastMemUsage) / 1048576)|round(2)) }} Mb</td>
+                    <td>{{ '%0.1f'|format((profilerRow.peak_memory_usage / 1048576)|round(2)) }} Mb</td>
+                  </tr>
+                  {% endif %}
+                  {% set profilerLastTime = profilerRow.time %}
+                  {% set profilerLastMemUsage = profilerRow.memory_usage %}
+                {% endfor %}
+              </tbody>
+              </table>
+          </div>
+        </div>
+      </div>
+      {% endif %}
+      <div class="tab">
+        <h3 class="tab-title">Hooks <span class="badge">{{ collector.hooks.perfs|length }}</span></h3>
+        <div class="tab-content">
+          <div class="sf-toolbar-info-piece">
+            <table>
+              <thead>
+                <tr>
+                  <th>Hook</th>
+                  <th>Time</th>
+                  <th>Memory Usage</th>
+                </tr>
+              </thead>
+              <tbody class="sf-toolbar-ajax-request-list">
+                {% for profilerHookName, profilerHookPerf in collector.hooks.perfs %}
+                <tr>
+                  <td class="font-normal">{{ profilerHookName }}</td>
+                  <td>{{ '%01.3f'|format(profilerHookPerf.time) }} ms</td>
+                  <td>{{ '%0.2f'|format((profilerHookPerf.memory / 1048576)|round(2)) }} Mb</td>
+                </tr>
+                  {% for profilerModule in profilerHookPerf.modules %}
+                  <tr>
+                    <td class="text-right">
+                      <strong>
+                        <span class="sf-dump-str">{{ profilerModule.module }}</span>
+                      </strong>
+                    </td>
+                    <td>{{ '%01.3f'|format(profilerModule.time) }} ms</td>
+                    <td>{{ '%0.2f'|format((profilerModule.memory / 1048576)|round(2)) }} Mb</td>
+                  </tr>
+                  {% endfor %}
+                {% endfor %}
+              </tbody>
+              <tfoot>
+                <tr>
+                  <th>{{ collector.hooks.perfs|length }} hooks</th>
+                  <th>{{ '%01.3f'|format(collector.hooks.totalHooksTime) }} ms</th>
+                  <th>{{ '%0.2f'|format((collector.hooks.totalHooksMemory / 1048576)|round(2)) }} Mb</th>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="tab">
+        <h3 class="tab-title">Modules <span class="badge">{{ collector.modules.perfs|length }}</span></h3>
+        <div class="tab-content">
+          <div class="sf-toolbar-info-piece">
+            <table>
+              <thead>
+                <tr>
+                  <th>Module</th>
+                  <th>Time</th>
+                  <th>Memory Usage</th>
+                </tr>
+              </thead>
+              <tbody class="sf-toolbar-ajax-request-list">
+                {% for profilerModuleName, profilerModulePerf in collector.modules.perfs %}
+                <tr>
+                  <td class="font-normal">{{ profilerModuleName }}</td>
+                  <td>{{ '%01.3f'|format(profilerModulePerf.total_time) }} ms</td>
+                  <td>{{ '%0.2f'|format((profilerModulePerf.total_memory / 1048576)|round(2)) }} Mb</td>
+                </tr>
+                  {% for profilerDetail in profilerModulePerf.details %}
+                  <tr>
+                    <td class="text-right">
+                      <strong>
+                        <span class="sf-dump-str">{{ profilerDetail.method }}</span>
+                      </strong>
+                    </td>
+                    <td>{{ '%01.3f'|format(profilerDetail.time) }} ms</td>
+                    <td>{{ '%0.2f'|format((profilerDetail.memory / 1048576)|round(2)) }} Mb</td>
+                  </tr>
+                  {% endfor %}
+                {% endfor %}
+              </tbody>
+              <tfoot>
+                <tr>
+                  <th>{{ collector.modules.perfs|length }} modules</th>
+                  <th>{{ '%01.3f'|format(collector.modules.totalHooksTime) }} ms</th>
+                  <th>{{ '%0.2f'|format((collector.modules.totalHooksMemory / 1048576)|round(2)) }} Mb</th>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="tab">
+        <h3 class="tab-title">Stopwatch SQL <span class="badge">{{ collector.summary.nbQueries }}</span></h3>
+        <div class="tab-content">
+          <div class="sf-toolbar-info-piece">
+            <table>
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Query</th>
+                  <th>Time (ms)</th>
+                  <th>Rows</th>
+                  <th>Filesort</th>
+                  <th>Group By</th>
+                  <th>Location</th>
+                </tr>
+              </thead>
+              <tbody class="sf-toolbar-ajax-request-list">
+                {% for profilerStopwatch in collector.stopwatch %}
+                <tr>
+                  <td class="font-normal">{{ profilerStopwatch.id }}</td>
+                  <td>
+                    <span class="sf-dump-str">{{ profilerStopwatch.query }}</span>
+                  </td>
+                  <td class="font-normal">{{ '%01.3f'|format(profilerStopwatch.time * 1000) }}&nbsp;ms</td>
+                  <td class="font-normal text-right">{{ profilerStopwatch.rows }}</td>
+                  <td class="font-normal">{% if profilerStopwatch.filesort %}Yes{% else %}No{% endif %}</td>
+                  <td class="font-normal">{% if profilerStopwatch.group_by %}Yes{% else %}No{% endif %}</td>
+                  <td>
+                    <strong>{{ profilerStopwatch.location }}</strong><br />
+                    {% for profilerStopwatchStack in profilerStopwatch.stack %}
+                      {{ profilerStopwatchStack }}<br />
+                    {% endfor %}
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="tab">
+        <h3 class="tab-title">Double queries <span class="badge">{{ collector.doubles|filter((numQueries, query) => numQueries > 1)|length }}</span></h3>
+        <div class="tab-content">
+          <div class="sf-toolbar-info-piece">
+            <table>
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Query</th>
+                </tr>
+              </thead>
+              <tbody class="sf-toolbar-ajax-request-list">
+                {% for query, numQueries in collector.doubles|filter((numQueries, query) => numQueries > 1) %}
+                <tr>
+                  <td class="font-normal">{{ numQueries }}</td>
+                  <td>
+                    <strong>
+                      <span class="sf-dump-str">{{ query }}</span>
+                    </strong>
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="tab">
+        <h3 class="tab-title">SQL Table Stress <span class="badge">{{ collector.sqlTableStress|length }}</span></h3>
+        <div class="tab-content">
+          <div class="sf-toolbar-info-piece">
+            <table>
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Table</th>
+                </tr>
+              </thead>
+              <tbody class="sf-toolbar-ajax-request-list">
+                {% for table, numRows in collector.sqlTableStress %}
+                <tr>
+                  <td class="font-normal">{{ numRows }}</td>
+                  <td>
+                    <strong>
+                      <span class="sf-dump-str">{{ table }}</span>
+                    </strong>
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="tab">
+        <h3 class="tab-title">ObjectModel Instances <span class="badge">{{ collector.objectModelInstances|length }}</span></h3>
+        <div class="tab-content">
+          <div class="sf-toolbar-info-piece">
+            <table>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Instances</th>
+                  <th>Source</th>
+                </tr>
+              </thead>
+              <tbody class="sf-toolbar-ajax-request-list">
+                {% for objectModelClass, objectModelInfo in collector.objectModelInstances %}
+                <tr>
+                  <td>{{ objectModelClass }}</td>
+                  <td class="font-normal">{{ objectModelInfo|length }}</td>
+                  <td>
+                    {% for objectModelInfoItem in objectModelInfo %}
+                      {{ objectModelInfoItem.file|replace({(constRootDir): ''}) }}:{{ objectModelInfoItem.line }} ({{ objectModelInfoItem.function }}) [id: {{ objectModelInfoItem.id }}]
+                      <br />
+                    {% endfor %}
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="tab">
+        <h3 class="tab-title">Included files <span class="badge">{{ collector.includedFiles|filter((includedFile) => '/tools/profiling/' not in includedFile)|length }}</span></h3>
+        <div class="tab-content">
+          <div class="sf-toolbar-info-piece">
+            <table>
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Filename</th>
+                </tr>
+              </thead>
+              <tbody class="sf-toolbar-ajax-request-list">
+                {% for k, includedFile in collector.includedFiles|filter((includedFile) => '/tools/profiling/' not in includedFile) %}
+                <tr>
+                  <td class="font-normal">{{ k }}</td>
+                  <td>{{ includedFile|replace({(constRootDir): ''}) }}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/tools/profiling/Profiler.php
+++ b/tools/profiling/Profiler.php
@@ -331,10 +331,10 @@ class Profiler
 
         return [
             'summary' => [
-                'loadTime' => $this->profiler[count($this->profiler) - 1]['time'] - $this->startTime,
+                'loadTime' => empty($this->profiler) ? null : $this->profiler[count($this->profiler) - 1]['time'] - $this->startTime,
                 'queryTime' => round(1000 * $this->totalQueryTime),
                 'nbQueries' => count($this->queries),
-                'peakMemoryUsage' => $this->profiler[count($this->profiler) - 1]['peak_memory_usage'],
+                'peakMemoryUsage' => empty($this->profiler) ? null : $this->profiler[count($this->profiler) - 1]['peak_memory_usage'],
                 'globalVarSize' => $this->globalVarSize,
                 'includedFiles' => count(get_included_files()),
                 'totalFileSize' => $this->totalFilesize,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | [BO] Added DataCollector for Legacy Profiling
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | :arrow_down: 
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/18375589383
| Fixed issue or discussion?     | Fixes #35473
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

## How to test ?
* Go to BO
* Enable Debug Mode
* Enable Profiler
* Check in Symfony Bar
* A new block is added named `Legacy`
<img width="980" height="532" alt="image" src="https://github.com/user-attachments/assets/9e371ac6-f373-4f44-bd94-9633f2129731" />
