### PR TITLE
Add hook support for image link overrides and adaptation

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1031,17 +1031,23 @@ class LinkCore
     {
         $idSupplier = (int) $idSupplier;
 
-        if (file_exists(_PS_SUPP_IMG_DIR_ . $idSupplier . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension))) {
-            $uriPath = _THEME_SUP_DIR_ . $idSupplier . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension);
-        } elseif (!empty($type) && file_exists(_PS_SUPP_IMG_DIR_ . $idSupplier . '.' . $extension)) { // !empty($type) because if is empty, is already tested
-            $uriPath = _THEME_SUP_DIR_ . $idSupplier . '.' . $extension;
-        } elseif (file_exists(_PS_SUPP_IMG_DIR_ . Context::getContext()->language->iso_code . (empty($type) ? '.' . $extension : '-default-' . $type . '.' . $extension))) {
-            $uriPath = _THEME_SUP_DIR_ . Context::getContext()->language->iso_code . (empty($type) ? '.' . $extension : '-default-' . $type . '.' . $extension);
-        } else {
-            $uriPath = _THEME_SUP_DIR_ . Context::getContext()->language->iso_code . '.' . $extension;
-        }
+        return $this->buildEntityImageLink(
+            'Supplier',
+            ['ids' => $idSupplier, 'type' => $type, 'extension' => $extension],
+            function () use ($idSupplier, $type, $extension) {
+                if (file_exists(_PS_SUPP_IMG_DIR_ . $idSupplier . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension))) {
+                    $uriPath = _THEME_SUP_DIR_ . $idSupplier . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension);
+                } elseif (!empty($type) && file_exists(_PS_SUPP_IMG_DIR_ . $idSupplier . '.' . $extension)) { // !empty($type) because if is empty, is already tested
+                    $uriPath = _THEME_SUP_DIR_ . $idSupplier . '.' . $extension;
+                } elseif (file_exists(_PS_SUPP_IMG_DIR_ . Context::getContext()->language->iso_code . (empty($type) ? '.' . $extension : '-default-' . $type . '.' . $extension))) {
+                    $uriPath = _THEME_SUP_DIR_ . Context::getContext()->language->iso_code . (empty($type) ? '.' . $extension : '-default-' . $type . '.' . $extension);
+                } else {
+                    $uriPath = _THEME_SUP_DIR_ . Context::getContext()->language->iso_code . '.' . $extension;
+                }
 
-        return $this->getMediaLink($uriPath);
+                return $uriPath;
+            }
+        );
     }
 
     /**
@@ -1057,17 +1063,23 @@ class LinkCore
     {
         $idManufacturer = (int) $idManufacturer;
 
-        if (file_exists(_PS_MANU_IMG_DIR_ . $idManufacturer . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension))) {
-            $uriPath = _THEME_MANU_DIR_ . $idManufacturer . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension);
-        } elseif (!empty($type) && file_exists(_PS_MANU_IMG_DIR_ . $idManufacturer . '.' . $extension)) { // !empty($type) because if is empty, is already tested
-            $uriPath = _THEME_MANU_DIR_ . $idManufacturer . '.' . $extension;
-        } elseif (file_exists(_PS_MANU_IMG_DIR_ . Context::getContext()->language->iso_code . (empty($type) ? '.' . $extension : '-default-' . $type . '.' . $extension))) {
-            $uriPath = _THEME_MANU_DIR_ . Context::getContext()->language->iso_code . (empty($type) ? '.' . $extension : '-default-' . $type . '.' . $extension);
-        } else {
-            $uriPath = _THEME_MANU_DIR_ . Context::getContext()->language->iso_code . '.' . $extension;
-        }
+        return $this->buildEntityImageLink(
+            'Manufacturer',
+            ['ids' => $idManufacturer, 'type' => $type, 'extension' => $extension],
+            function () use ($idManufacturer, $type, $extension) {
+                if (file_exists(_PS_MANU_IMG_DIR_ . $idManufacturer . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension))) {
+                    $uriPath = _THEME_MANU_DIR_ . $idManufacturer . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension);
+                } elseif (!empty($type) && file_exists(_PS_MANU_IMG_DIR_ . $idManufacturer . '.' . $extension)) { // !empty($type) because if is empty, is already tested
+                    $uriPath = _THEME_MANU_DIR_ . $idManufacturer . '.' . $extension;
+                } elseif (file_exists(_PS_MANU_IMG_DIR_ . Context::getContext()->language->iso_code . (empty($type) ? '.' . $extension : '-default-' . $type . '.' . $extension))) {
+                    $uriPath = _THEME_MANU_DIR_ . Context::getContext()->language->iso_code . (empty($type) ? '.' . $extension : '-default-' . $type . '.' . $extension);
+                } else {
+                    $uriPath = _THEME_MANU_DIR_ . Context::getContext()->language->iso_code . '.' . $extension;
+                }
 
-        return $this->getMediaLink($uriPath);
+                return $uriPath;
+            }
+        );
     }
 
     /**
@@ -1084,17 +1096,23 @@ class LinkCore
     {
         $idStore = (int) $idStore;
 
-        if (file_exists(_PS_STORE_IMG_DIR_ . $idStore . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension))) {
-            $uriPath = _THEME_STORE_DIR_ . $idStore . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension);
-        } elseif (!empty($type) && file_exists(_PS_STORE_IMG_DIR_ . $idStore . '.' . $extension)) { // !empty($type) because if is empty, is already tested
-            $uriPath = _THEME_STORE_DIR_ . $idStore . '.' . $extension;
-        } elseif (file_exists(_PS_STORE_IMG_DIR_ . Context::getContext()->language->iso_code . (empty($type) ? '.' . $extension : $type . '.' . $extension))) {
-            $uriPath = _THEME_STORE_DIR_ . Context::getContext()->language->iso_code . (empty($type) ? '.' . $extension : $type . '.' . $extension);
-        } else {
-            $uriPath = _THEME_STORE_DIR_ . Context::getContext()->language->iso_code . '.' . $extension;
-        }
+        return $this->buildEntityImageLink(
+            'Store',
+            ['ids' => $idStore, 'name' => $name, 'type' => $type, 'extension' => $extension],
+            function () use ($idStore, $type, $extension) {
+                if (file_exists(_PS_STORE_IMG_DIR_ . $idStore . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension))) {
+                    $uriPath = _THEME_STORE_DIR_ . $idStore . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension);
+                } elseif (!empty($type) && file_exists(_PS_STORE_IMG_DIR_ . $idStore . '.' . $extension)) { // !empty($type) because if is empty, is already tested
+                    $uriPath = _THEME_STORE_DIR_ . $idStore . '.' . $extension;
+                } elseif (file_exists(_PS_STORE_IMG_DIR_ . Context::getContext()->language->iso_code . (empty($type) ? '.' . $extension : $type . '.' . $extension))) {
+                    $uriPath = _THEME_STORE_DIR_ . Context::getContext()->language->iso_code . (empty($type) ? '.' . $extension : $type . '.' . $extension);
+                } else {
+                    $uriPath = _THEME_STORE_DIR_ . Context::getContext()->language->iso_code . '.' . $extension;
+                }
 
-        return $this->getMediaLink($uriPath);
+                return $uriPath;
+            }
+        );
     }
 
     /**
@@ -1174,13 +1192,62 @@ class LinkCore
      */
     public function getCatImageLink($name, $idCategory, $type = null, string $extension = 'jpg')
     {
-        if ($this->allow && $type) {
-            $uriPath = __PS_BASE_URI__ . 'c/' . $idCategory . '-' . $type . '/' . $name . '.' . $extension;
-        } else {
-            $uriPath = _THEME_CAT_DIR_ . $idCategory . ($type ? '-' . $type : '') . '.' . $extension;
+        return $this->buildEntityImageLink(
+            'Category',
+            ['ids' => (int) $idCategory, 'name' => $name, 'type' => $type, 'extension' => $extension],
+            function () use ($idCategory, $name, $type, $extension) {
+                if ($this->allow && $type) {
+                    return __PS_BASE_URI__ . 'c/' . $idCategory . '-' . $type . '/' . $name . '.' . $extension;
+                }
+
+                return _THEME_CAT_DIR_ . $idCategory . ($type ? '-' . $type : '') . '.' . $extension;
+            }
+        );
+    }
+
+    /**
+     * Build an image link for a Link entity (Supplier, Manufacturer, Store, Category),
+     * firing the two hook stages consistently:
+     *
+     *  - overrideXImageLink : chainable short-circuit; first non-empty return wins and
+     *    is used as the final URL (nothing else is called). Modules can hijack the URL
+     *    entirely — useful for CDN routing, image proxies, dedicated hosts.
+     *  - adaptXImageLink    : called after the default URL is computed; modules can
+     *    mutate the URL by reference (e.g. append a signed query string, swap the
+     *    scheme). Non-blocking, all listeners fire.
+     *
+     * @param string   $entity     'Supplier'|'Manufacturer'|'Store'|'Category' — completes the hook name
+     * @param array    $params     Hook payload (ids, name, type, extension, …)
+     * @param callable $urlBuilder Called when no override was returned; must return the URI path
+     *                             to feed into getMediaLink() (i.e. the internal path before
+     *                             media server + protocol rewriting).
+     */
+    private function buildEntityImageLink(string $entity, array $params, callable $urlBuilder): string
+    {
+        // Hook::exec with $array_return=true returns [moduleName => value].
+        // The first non-empty scalar wins so a single module can short-circuit the URL.
+        $override = Hook::exec("override{$entity}ImageLink", $params, null, true);
+        if (is_array($override)) {
+            foreach ($override as $candidate) {
+                if (is_string($candidate) && $candidate !== '') {
+                    return $candidate;
+                }
+            }
+        } elseif (is_string($override) && $override !== '') {
+            return $override;
         }
 
-        return $this->getMediaLink($uriPath);
+        $uriPath = $urlBuilder();
+        $url = $this->getMediaLink($uriPath);
+
+        $adaptParams = $params + [
+            'protocol_content' => $this->protocol_content,
+            'uri_path' => $uriPath,
+            'url' => &$url,
+        ];
+        Hook::exec("adapt{$entity}ImageLink", $adaptParams);
+
+        return $url;
     }
 
     /**

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1209,15 +1209,15 @@ class LinkCore
      * Build an image link for a Link entity (Supplier, Manufacturer, Store, Category),
      * firing the two hook stages consistently:
      *
-     *  - overrideXImageLink : chainable short-circuit; first non-empty return wins and
+     *  - overrideXImageLink: chainable short-circuit; first non-empty return wins and
      *    is used as the final URL (nothing else is called). Modules can hijack the URL
      *    entirely — useful for CDN routing, image proxies, dedicated hosts.
-     *  - adaptXImageLink    : called after the default URL is computed; modules can
+     *  - adaptXImageLink: called after the default URL is computed; modules can
      *    mutate the URL by reference (e.g. append a signed query string, swap the
      *    scheme). Non-blocking, all listeners fire.
      *
-     * @param string   $entity     'Supplier'|'Manufacturer'|'Store'|'Category' — completes the hook name
-     * @param array    $params     Hook payload (ids, name, type, extension, …)
+     * @param string $entity Supplier'|'Manufacturer'|'Store'|'Category' — completes the hook name
+     * @param array $params Hook payload (ids, name, type, extension, …)
      * @param callable $urlBuilder Called when no override was returned; must return the URI path
      *                             to feed into getMediaLink() (i.e. the internal path before
      *                             media server + protocol rewriting).

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -952,7 +952,6 @@ class LinkCore
         $overrideUrl = Hook::exec(
             'overrideImageLink',
             [
-                'object' => 'image',
                 'name' => $name,
                 'ids' => $idImage,
                 'type' => $type,
@@ -1001,7 +1000,6 @@ class LinkCore
         Hook::exec(
             'adaptImageLink',
             [
-                'object' => 'image',
                 'protocol_content' => $this->protocol_content,
                 'uri_path' => $uriPath,
                 'url' => &$url,

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -952,6 +952,7 @@ class LinkCore
         $overrideUrl = Hook::exec(
             'overrideImageLink',
             [
+                'object' => 'image',
                 'name' => $name,
                 'ids' => $idImage,
                 'type' => $type,
@@ -1000,6 +1001,7 @@ class LinkCore
         Hook::exec(
             'adaptImageLink',
             [
+                'object' => 'image',
                 'protocol_content' => $this->protocol_content,
                 'uri_path' => $uriPath,
                 'url' => &$url,
@@ -1026,6 +1028,21 @@ class LinkCore
     {
         $idSupplier = (int) $idSupplier;
 
+        $overrideUrl = Hook::exec(
+            'overrideSupplierImageLink',
+            [
+                'ids' => $idSupplier,
+                'type' => $type,
+                'extension' => $extension,
+            ],
+            null,
+            true
+        );
+
+        if (!empty($overrideUrl)) {
+            return $overrideUrl;
+        }
+
         if (file_exists(_PS_SUPP_IMG_DIR_ . $idSupplier . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension))) {
             $uriPath = _THEME_SUP_DIR_ . $idSupplier . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension);
         } elseif (!empty($type) && file_exists(_PS_SUPP_IMG_DIR_ . $idSupplier . '.' . $extension)) { // !empty($type) because if is empty, is already tested
@@ -1036,7 +1053,21 @@ class LinkCore
             $uriPath = _THEME_SUP_DIR_ . Context::getContext()->language->iso_code . '.' . $extension;
         }
 
-        return $this->getMediaLink($uriPath);
+        $url = $this->getMediaLink($uriPath);
+
+        Hook::exec(
+            'adaptSupplierImageLink',
+            [
+                'protocol_content' => $this->protocol_content,
+                'uri_path' => $uriPath,
+                'url' => &$url,
+                'ids' => $idSupplier,
+                'type' => $type,
+                'extension' => $extension,
+            ]
+        );
+
+        return $url;
     }
 
     /**
@@ -1052,6 +1083,21 @@ class LinkCore
     {
         $idManufacturer = (int) $idManufacturer;
 
+        $overrideUrl = Hook::exec(
+            'overrideManufacturerImageLink',
+            [
+                'ids' => $idManufacturer,
+                'type' => $type,
+                'extension' => $extension,
+            ],
+            null,
+            true
+        );
+
+        if (!empty($overrideUrl)) {
+            return $overrideUrl;
+        }
+
         if (file_exists(_PS_MANU_IMG_DIR_ . $idManufacturer . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension))) {
             $uriPath = _THEME_MANU_DIR_ . $idManufacturer . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension);
         } elseif (!empty($type) && file_exists(_PS_MANU_IMG_DIR_ . $idManufacturer . '.' . $extension)) { // !empty($type) because if is empty, is already tested
@@ -1062,7 +1108,21 @@ class LinkCore
             $uriPath = _THEME_MANU_DIR_ . Context::getContext()->language->iso_code . '.' . $extension;
         }
 
-        return $this->getMediaLink($uriPath);
+        $url = $this->getMediaLink($uriPath);
+
+        Hook::exec(
+            'adaptManufacturerImageLink',
+            [
+                'protocol_content' => $this->protocol_content,
+                'uri_path' => $uriPath,
+                'url' => &$url,
+                'ids' => $idManufacturer,
+                'type' => $type,
+                'extension' => $extension,
+            ]
+        );
+
+        return $url;
     }
 
     /**
@@ -1079,6 +1139,22 @@ class LinkCore
     {
         $idStore = (int) $idStore;
 
+        $overrideUrl = Hook::exec(
+            'overrideStoreImageLink',
+            [
+                'ids' => $idStore,
+                'name' => $name,
+                'type' => $type,
+                'extension' => $extension,
+            ],
+            null,
+            true
+        );
+
+        if (!empty($overrideUrl)) {
+            return $overrideUrl;
+        }
+
         if (file_exists(_PS_STORE_IMG_DIR_ . $idStore . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension))) {
             $uriPath = _THEME_STORE_DIR_ . $idStore . (empty($type) ? '.' . $extension : '-' . $type . '.' . $extension);
         } elseif (!empty($type) && file_exists(_PS_STORE_IMG_DIR_ . $idStore . '.' . $extension)) { // !empty($type) because if is empty, is already tested
@@ -1089,7 +1165,22 @@ class LinkCore
             $uriPath = _THEME_STORE_DIR_ . Context::getContext()->language->iso_code . '.' . $extension;
         }
 
-        return $this->getMediaLink($uriPath);
+        $url = $this->getMediaLink($uriPath);
+
+        Hook::exec(
+            'adaptStoreImageLink',
+            [
+                'protocol_content' => $this->protocol_content,
+                'uri_path' => $uriPath,
+                'url' => &$url,
+                'ids' => $idStore,
+                'type' => $type,
+                'name' => $name,
+                'extension' => $extension,
+            ]
+        );
+
+        return $url;
     }
 
     /**
@@ -1169,13 +1260,46 @@ class LinkCore
      */
     public function getCatImageLink($name, $idCategory, $type = null, string $extension = 'jpg')
     {
+        $idCategory = (int) $idCategory;
+
+        $overrideUrl = Hook::exec(
+            'overrideCategoryImageLink',
+            [
+                'ids' => $idCategory,
+                'name' => $name,
+                'type' => $type,
+                'extension' => $extension,
+            ],
+            null,
+            true
+        );
+
+        if (!empty($overrideUrl)) {
+            return $overrideUrl;
+        }
+
         if ($this->allow && $type) {
             $uriPath = __PS_BASE_URI__ . 'c/' . $idCategory . '-' . $type . '/' . $name . '.' . $extension;
         } else {
             $uriPath = _THEME_CAT_DIR_ . $idCategory . ($type ? '-' . $type : '') . '.' . $extension;
         }
 
-        return $this->getMediaLink($uriPath);
+        $url = $this->getMediaLink($uriPath);
+
+        Hook::exec(
+            'adaptCategoryImageLink',
+            [
+                'protocol_content' => $this->protocol_content,
+                'uri_path' => $uriPath,
+                'url' => &$url,
+                'ids' => $idCategory,
+                'type' => $type,
+                'name' => $name,
+                'extension' => $extension,
+            ]
+        );
+
+        return $url;
     }
 
     /**


### PR DESCRIPTION
Introduces new hooks to allow overriding and adapting image URLs for suppliers, manufacturers, stores, and categories. This enables greater extensibility for modules to customize image link generation throughout the LinkCore class.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Handle more images links hooks
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Related PRs       | 
