### PR TITLE
Chore: Optimize cache clear in dev mode

### DIFF
--- a/src/PrestaShopBundle/DependencyInjection/Compiler/SkipDevOptionalCacheCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/SkipDevOptionalCacheCompilerPass.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class SkipDevOptionalCacheCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        // If we are in debug mode (dev), we don't need to warm all the Twig and Translation cache files
+        if ($container->hasDefinition('twig.template_cache_warmer') === true) {
+            $container->removeDefinition('twig.template_cache_warmer');
+        }
+        if ($container->hasDefinition('translation.warmer') === true) {
+            $container->removeDefinition('translation.warmer');
+        }
+    }
+}

--- a/src/PrestaShopBundle/PrestaShopBundle.php
+++ b/src/PrestaShopBundle/PrestaShopBundle.php
@@ -41,6 +41,7 @@ use PrestaShopBundle\DependencyInjection\Compiler\OverrideTranslatorServiceCompi
 use PrestaShopBundle\DependencyInjection\Compiler\PopulateTranslationProvidersPass;
 use PrestaShopBundle\DependencyInjection\Compiler\RemoveXmlCompiledContainerPass;
 use PrestaShopBundle\DependencyInjection\Compiler\RouterPass;
+use PrestaShopBundle\DependencyInjection\Compiler\SkipDevOptionalCacheCompilerPass;
 use PrestaShopBundle\DependencyInjection\Compiler\TestEnvironmentPass;
 use PrestaShopBundle\DependencyInjection\PrestaShopExtension;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
@@ -95,5 +96,8 @@ class PrestaShopBundle extends Bundle
         $container->addCompilerPass(new IdentifiableObjectFormTypesCollectorPass());
         $container->addCompilerPass(new TestEnvironmentPass());
         $container->addCompilerPass(new ApiPlatformCompilerPass());
+        if ($container->hasParameter('kernel.debug') === true) {
+            $container->addCompilerPass(new SkipDevOptionalCacheCompilerPass());
+        }
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | While in dev mode, I noticed a real struggle when I wanted to clear my Symfony cache.<br>After further study, it is mainly on translations / twig templates cache warming.<br>With this little change, I managed to make it really fast. Before, I couldn't even warm my cache `(Error: Allowed memory size of 536870912 bytes exhausted (tried to allocate 32768 bytes)`. With this change, I no longer have this error and the cache clearing operation is much faster. (See details below)
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run command `bin/console cache:clear -vvv`
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~

**Before:**
```bash
time bin/console cache:clear -vvv

 // Clearing the cache for the dev environment with debug true

 // Cache is fresh.

 // Warming up optional cache...

 [INFO] "Symfony\Bundle\FrameworkBundle\CacheWarmer\TranslationsCacheWarmer" completed in 1481.04ms.
 [INFO] "Symfony\Bundle\FrameworkBundle\CacheWarmer\RouterCacheWarmer" completed in 86.45ms.
 [INFO] "Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer" completed in 1.99ms.
 [INFO] "Symfony\Bundle\FrameworkBundle\CacheWarmer\SerializerCacheWarmer" completed in 0.54ms.
 [INFO] "Symfony\Bundle\FrameworkBundle\CacheWarmer\ValidatorCacheWarmer" completed in 84.39ms.
 [INFO] "Symfony\Bundle\SecurityBundle\CacheWarmer\ExpressionCacheWarmer" completed in 0.71ms.
 [INFO] "Symfony\Bundle\TwigBundle\CacheWarmer\TemplateCacheWarmer" completed in 23270.34ms.
 [INFO] "PrestaShopBundle\Routing\AnonymousRouteProvider" completed in 17.20ms.
 [INFO] "Symfony\UX\TwigComponent\CacheWarmer\TwigComponentCacheWarmer" completed in 5.21ms.

 // Removing old build and cache directory...

 // Finished

 [OK] Cache for the "dev" environment (debug=true) was successfully cleared.
```

> real    0m36.389s
> user    0m14.368s
> sys     0m21.758s

**After:**
```bash
time bin/console cache:clear -vvv

 // Clearing the cache for the dev environment with debug true

 // Cache is fresh.

 // Warming up optional cache...

 [INFO] "Symfony\Bundle\FrameworkBundle\CacheWarmer\RouterCacheWarmer" completed in 97.74ms.
 [INFO] "Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer" completed in 2.49ms.
 [INFO] "Symfony\Bundle\FrameworkBundle\CacheWarmer\SerializerCacheWarmer" completed in 0.80ms.
 [INFO] "Symfony\Bundle\FrameworkBundle\CacheWarmer\ValidatorCacheWarmer" completed in 33.90ms.
 [INFO] "Symfony\Bundle\SecurityBundle\CacheWarmer\ExpressionCacheWarmer" completed in 0.41ms.
 [INFO] "PrestaShopBundle\Routing\AnonymousRouteProvider" completed in 0.64ms.
 [INFO] "Symfony\UX\TwigComponent\CacheWarmer\TwigComponentCacheWarmer" completed in 1.00ms.

 // Finished

 [OK] Cache for the "dev" environment (debug=true) was successfully cleared.
```

> real    0m4.899s
> user    0m2.200s
> sys     0m2.680s