### PR TITLE
Allow optional removal of id in urls

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -209,6 +209,35 @@ class DispatcherCore
 
         $this->use_routes = (bool) Configuration::get('PS_REWRITING_SETTINGS');
 
+        if (Configuration::get('PS_REWRITING_IDENTIFIER') == 'rewrite') {
+            // id is no more mandatory
+            unset($this->default_routes['category_rule']['keywords']['id']['param']);
+            unset($this->default_routes['product_rule']['keywords']['id']['param']);
+            unset($this->default_routes['cms_rule']['keywords']['id']['param']);
+            unset($this->default_routes['cms_category_rule']['keywords']['id']['param']);
+            unset($this->default_routes['supplier_rule']['keywords']['id']['param']);
+            unset($this->default_routes['manufacturer_rule']['keywords']['id']['param']);
+
+            $this->default_routes['category_rule']['keywords']['rewrite']['param'] = 'rewrite';
+            // require because the native regexp doesn't support trailing /
+            $this->default_routes['category_rule']['keywords']['rewrite']['regexp'] = '[_a-zA-Z0-9\x{0600}-\x{06FF}\pL\pS-]+?';
+
+            // cms page and category
+            // be carrefull : cms page and category share the same controller
+            $this->default_routes['cms_rule']['keywords']['rewrite']['param'] = 'rewrite';
+            $this->default_routes['cms_rule']['keywords']['rewrite']['regexp'] = '[_a-zA-Z0-9\x{0600}-\x{06FF}\pL\pS-]+?';
+            $this->default_routes['cms_category_rule']['keywords']['rewrite']['param'] = 'rewrite';
+            $this->default_routes['cms_category_rule']['keywords']['rewrite']['regexp'] = '[_a-zA-Z0-9\x{0600}-\x{06FF}\pL\pS-]+?';
+
+            // manufacturer
+            $this->default_routes['manufacturer_rule']['keywords']['rewrite']['param'] = 'rewrite';
+            // require because the native regexp doesn't support trailing /
+            $this->default_routes['manufacturer_rule']['keywords']['rewrite']['regexp'] = '[_a-zA-Z0-9\x{0600}-\x{06FF}\pL\pS-]+?';
+            // supplier
+            $this->default_routes['supplier_rule']['keywords']['rewrite']['param'] = 'rewrite';
+            // require because the native regexp doesn't support trailing /
+            $this->default_routes['supplier_rule']['keywords']['rewrite']['regexp'] = '[_a-zA-Z0-9\x{0600}-\x{06FF}\pL\pS-]+?';
+        }
         // Select right front controller
         if (defined('_PS_ADMIN_DIR_')) {
             $this->front_controller = self::FC_ADMIN;
@@ -1161,10 +1190,29 @@ class DispatcherCore
 
                 list($uri) = explode('?', $this->request_uri);
 
+                // if (Configuration::get('PS_REWRITING_IDENTIFIER') == 'rewrite' && $uri=='/') {
+                //     $controller = 'index';
+                // }
+
                 if (isset($this->routes[$id_shop][Context::getContext()->language->id])) {
-                    foreach ($this->routes[$id_shop][Context::getContext()->language->id] as $route) {
+                    foreach ($this->routes[$id_shop][Context::getContext()->language->id] as $routeName => $route) {
                         if (preg_match($route['regexp'], $uri, $m)) {
                             // Route found ! Now fill $_GET with parameters of uri
+                            if (Configuration::get('PS_REWRITING_IDENTIFIER') == 'rewrite' && empty($m['id_' . $route['controller']]) && !empty($m['rewrite'])) {
+                                // search for intity id if rewriting identifier is set to rewrite then set the corresponding GET variable.
+                                $foundedId = (int) $this->getIdFromRewrite($m['rewrite'], $route['controller'], $routeName);
+                                if (!empty($foundedId)) {
+                                    if ($routeName == 'cms_category_rule') {
+                                        // cms page and category share the same controller
+                                        $_GET['id_cms_category'] = $foundedId;
+                                    } else {
+                                        $_GET['id_' . $route['controller']] = $foundedId;
+                                    }
+                                } else {
+                                    continue;
+                                }
+                            }
+
                             foreach ($m as $k => $v) {
                                 if (!is_numeric($k)) {
                                     $_GET[$k] = $v;
@@ -1345,5 +1393,67 @@ class DispatcherCore
         }
 
         return $controllersPhpself;
+    }
+
+    /**
+     * Return id of entity matching rewrite
+     *
+     * @param string $rewrite
+     * @param string $controller
+     * @param string $routeName
+     *
+     * @return int the founded id
+     */
+    public function getIdFromRewrite($rewrite, $controller, $routeName): int
+    {
+        if (empty($rewrite) or empty($controller)) {
+            return 0;
+        }
+
+        $idLang = Context::getContext()->language->id;
+        $idShop = Context::getContext()->shop->id;
+
+        $query = new DbQuery();
+        $query->select('tl.id_' . $controller);
+        $query->from($controller . '_lang', 'tl');
+        $query->where('tl.`link_rewrite` = \'' . pSQL($rewrite) . '\'');
+        $query->where('tl.`id_lang` = ' . (int) $idLang);
+        $query->where('tl.`id_shop` = ' . (int) $idShop);
+        if ($controller == 'category') {
+            $query->innerJoin($controller, 't', 't.id_' . $controller . ' = tl.id_' . $controller);
+            $query->orderBy('t.active DESC, t.date_upd DESC');
+        }
+        if ($controller == 'product') {
+            $query->innerJoin($controller . '_shop', 'ts', 'ts.id_' . $controller . ' = tl.id_' . $controller . ' AND ts.`id_shop` = ' . (int) $idShop);
+            $query->orderBy('ts.active DESC, t.date_upd DESC');
+        }
+        if ($routeName == 'cms_rule') {
+            $query->innerJoin($controller . '_shop', 'ts', 'ts.id_' . $controller . ' = tl.id_' . $controller . ' AND ts.`id_shop` = ' . (int) $idShop);
+        }
+        if ($routeName == 'cms_category_rule') {
+            $query = new DbQuery();
+            $query->select('tl.id_cms_category');
+            $query->from('cms_category_lang', 'tl');
+            $query->where('tl.`link_rewrite` = \'' . pSQL($rewrite) . '\'');
+            $query->where('tl.`id_lang` = ' . (int) $idLang);
+            $query->where('tl.`id_shop` = ' . (int) $idShop);
+            $query->innerJoin('cms_category_shop', 'ts', 'ts.id_cms_category = tl.id_cms_category AND ts.`id_shop` = ' . (int) $idShop);
+        }
+        if ($controller == 'manufacturer') {
+            $query = new DbQuery();
+            $query->select('tl.id_manufacturer');
+            $query->from('manufacturer', 'tl');
+            $query->where('REPLACE(LOWER(`name`), \' \', \'-\') = \'' . pSQL($rewrite) . '\'');
+            $query->innerJoin('manufacturer_shop', 'ts', 'ts.id_manufacturer = tl.id_manufacturer AND ts.`id_shop` = ' . (int) $idShop);
+        }
+        if ($controller == 'supplier') {
+            $query = new DbQuery();
+            $query->select('tl.id_supplier');
+            $query->from('supplier', 'tl');
+            $query->where('REPLACE(LOWER(`name`), \' \', \'-\') = \'' . pSQL($rewrite) . '\'');
+            $query->innerJoin('supplier_shop', 'ts', 'ts.id_supplier = tl.id_supplier AND ts.`id_shop` = ' . (int) $idShop);
+        }
+
+        return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
     }
 }

--- a/src/Adapter/Meta/SetUpUrlsDataConfiguration.php
+++ b/src/Adapter/Meta/SetUpUrlsDataConfiguration.php
@@ -45,6 +45,7 @@ final class SetUpUrlsDataConfiguration extends AbstractMultistoreConfiguration
      */
     private const CONFIGURATION_FIELDS = [
         'friendly_url',
+        'friendly_url_identifier',
         'default_language_url_prefix',
         'accented_url',
         'canonical_url_redirection',
@@ -88,6 +89,7 @@ final class SetUpUrlsDataConfiguration extends AbstractMultistoreConfiguration
 
         return [
             'friendly_url' => (bool) $this->configuration->get('PS_REWRITING_SETTINGS', false, $shopConstraint),
+            'friendly_url_identifier' => $this->configuration->get('PS_REWRITING_IDENTIFIER', 'id', $shopConstraint),
             'default_language_url_prefix' => (bool) $this->configuration->get('PS_DEFAULT_LANGUAGE_URL_PREFIX', false, $shopConstraint),
             'accented_url' => (bool) $this->configuration->get('PS_ALLOW_ACCENTED_CHARS_URL', false, $shopConstraint),
             'canonical_url_redirection' => (int) $this->configuration->get('PS_CANONICAL_REDIRECT', 0, $shopConstraint),
@@ -107,6 +109,7 @@ final class SetUpUrlsDataConfiguration extends AbstractMultistoreConfiguration
             $shopConstraint = $this->getShopConstraint();
 
             $this->updateConfigurationValue('PS_REWRITING_SETTINGS', 'friendly_url', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_REWRITING_IDENTIFIER', 'friendly_url_identifier', $configuration, $shopConstraint);
             $this->updateConfigurationValue('PS_DEFAULT_LANGUAGE_URL_PREFIX', 'default_language_url_prefix', $configuration, $shopConstraint);
             $this->updateConfigurationValue('PS_ALLOW_ACCENTED_CHARS_URL', 'accented_url', $configuration, $shopConstraint);
             $this->updateConfigurationValue('PS_CANONICAL_REDIRECT', 'canonical_url_redirection', $configuration, $shopConstraint);
@@ -154,6 +157,7 @@ final class SetUpUrlsDataConfiguration extends AbstractMultistoreConfiguration
         $resolver = (new OptionsResolver())
             ->setDefined(self::CONFIGURATION_FIELDS)
             ->setAllowedTypes('friendly_url', 'bool')
+            ->setAllowedTypes('friendly_url_identifier', 'string')
             ->setAllowedTypes('default_language_url_prefix', 'bool')
             ->setAllowedTypes('accented_url', 'bool')
             ->setAllowedTypes('canonical_url_redirection', 'int')

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
@@ -108,6 +108,16 @@ class SetUpUrlType extends TranslatorAwareType
                 'help' => $friendlyUrlHelp,
                 'multistore_configuration_key' => 'PS_REWRITING_SETTINGS',
             ])
+            ->add(
+                'friendly_url_identifier',
+                ChoiceType::class,
+                [
+                    'choices' => [$this->trans('Id', 'Admin.Global') => 'id', $this->trans('Rewrite', 'Admin.Global') => 'rewrite'],
+                    'translation_domain' => false,
+                    'label' => $this->trans('Friendly URL identifier', 'Admin.Shopparameters.Feature'),
+                    'multistore_configuration_key' => 'PS_REWRITING_IDENTIFIER',
+                ]
+            )
             ->add('default_language_url_prefix', SwitchType::class, [
                 'label' => $this->trans('Use prefix for default language', 'Admin.Global'),
                 'help' => $this->trans(

--- a/tests/Unit/Adapter/Meta/SetUpUrlsDataConfigurationTest.php
+++ b/tests/Unit/Adapter/Meta/SetUpUrlsDataConfigurationTest.php
@@ -42,6 +42,7 @@ class SetUpUrlsDataConfigurationTest extends AbstractConfigurationTestCase
 
     private const VALID_CONFIGURATION = [
         'friendly_url' => true,
+        'friendly_url_identifier' => 'id',
         'default_language_url_prefix' => true,
         'accented_url' => true,
         'canonical_url_redirection' => 2,
@@ -117,6 +118,7 @@ class SetUpUrlsDataConfigurationTest extends AbstractConfigurationTestCase
             ->willReturnMap(
                 [
                     ['PS_REWRITING_SETTINGS', false, $shopConstraint, true],
+                    ['PS_REWRITING_IDENTIFIER', 'id', $shopConstraint, 'id'],
                     ['PS_DEFAULT_LANGUAGE_URL_PREFIX', false, $shopConstraint, true],
                     ['PS_ALLOW_ACCENTED_CHARS_URL', false, $shopConstraint, true],
                     ['PS_CANONICAL_REDIRECT', 0, $shopConstraint, 2],
@@ -157,6 +159,7 @@ class SetUpUrlsDataConfigurationTest extends AbstractConfigurationTestCase
         return [
             [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['friendly_url' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['friendly_url_identifier' => 123])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['default_language_url_prefix' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['accented_url' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['canonical_url_redirection' => 'wrong_type'])],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR allow to optionaly remove id in urls
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See bellow
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | Fixes (https://github.com/PrestaShop/PrestaShop/discussions/32074)
| Sponsor company   | Creabilis.com

**Why ?**
it seems to me a good feature to remove ids in url with an option in traffic & url to choose the rewriting identifier.
I mean, not by default but it make sense in specific cases :
- to avoid 301 redirects il you migrate from another cms that don't have ids in url.
- Ids are changing : by example if products are sync in a weird erp.

For the record, I've 3 merchands with this feature in production, mainly migrated from magento.
This pr is a first step, if maintainers approve it, others improvements will be done.

**How to test ?**

- Go to Traffic & SEO menu
- Set Friendly URL identifier to **rewrite** and save 
- Change Schema of URLs by removing {id} and save. For product url, you can set {rewrite}{-d:id_product_attribute}.html for better results.
- Empty PrestaShop cache
- Go to front and check that urls don't contain id anymore and respond correctly.


Here is my Schema structure :
<img width="777" height="594" alt="image" src="https://github.com/user-attachments/assets/c781215a-60ef-4b2d-b23d-6bb56bad9042" />

