### PR TITLE
Ensure cache is cleared on each module action even when they fail

### DIFF
--- a/src/Core/Module/EventSubscriber.php
+++ b/src/Core/Module/EventSubscriber.php
@@ -53,6 +53,7 @@ class EventSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
+            ModuleManagementEvent::PRE_ACTION => 'onModuleStateChanged',
             ModuleManagementEvent::INSTALL => 'onModuleStateChanged',
             ModuleManagementEvent::POST_INSTALL => 'onModuleStateChanged',
             ModuleManagementEvent::UNINSTALL => 'onModuleStateChanged',

--- a/src/PrestaShopBundle/Event/ModuleManagementEvent.php
+++ b/src/PrestaShopBundle/Event/ModuleManagementEvent.php
@@ -31,6 +31,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class ModuleManagementEvent extends Event
 {
+    public const PRE_ACTION = 'module.pre_action';
     public const INSTALL = 'module.install';
     public const POST_INSTALL = 'module.post.install';
     public const UNINSTALL = 'module.uninstall';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Distpatch a PRE_ACTION module event befire any action, except upload, so that we trigger the cache clear after the action no matter what It ensures the cache is cleared even when the module failed to install
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install a module that is sure to fail on install (it can be a test module that returns false on install), check that the cache is cleared even if the installation failed.
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/18061614523
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~

Not fixing but related to the discussion in this issue https://github.com/PrestaShop/PrestaShop/issues/39100