### PR TITLE
Back office login throttling

### DIFF
--- a/app/config/admin/security.yml
+++ b/app/config/admin/security.yml
@@ -27,6 +27,7 @@ security:
     main:
       lazy: true
       provider: admin
+      login_throttling: '%prestashop.security.login_throttling%'
       form_login:
         login_path: admin_login
         check_path: admin_login

--- a/composer.json
+++ b/composer.json
@@ -163,6 +163,7 @@
         "symfony/property-info": "~6.4.0",
         "symfony/proxy-manager-bridge": "~6.4.0",
         "symfony/psr-http-message-bridge": "~6.4.0",
+        "symfony/rate-limiter": "~6.4.0",
         "symfony/routing": "~6.4.0",
         "symfony/security-bundle": "~6.4.0",
         "symfony/security-core": "~6.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "458b542e1b1c61f4b18ab656c7b483e5",
+    "content-hash": "aeb80208f589b3633d30c725e96ef892",
     "packages": [
         {
             "name": "api-platform/core",
@@ -12342,6 +12342,81 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/psr-http-message-bridge/tree/v6.4.24"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-10T08:14:14+00:00"
+        },
+        {
+            "name": "symfony/rate-limiter",
+            "version": "v6.4.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/rate-limiter.git",
+                "reference": "15a9a10fd0f060243c88ce98d5c29e9cc4b886e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/rate-limiter/zipball/15a9a10fd0f060243c88ce98d5c29e9cc4b886e7",
+                "reference": "15a9a10fd0f060243c88ce98d5c29e9cc4b886e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/options-resolver": "^5.4|^6.0|^7.0"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "symfony/lock": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\RateLimiter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Wouter de Jong",
+                    "email": "wouter@wouterj.nl"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a Token Bucket implementation to rate limit input and output in your application",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "limiter",
+                "rate-limiter"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/rate-limiter/tree/v6.4.24"
             },
             "funding": [
                 {

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -876,6 +876,18 @@ Country</value>
     <configuration id="PS_SECURITY_TOKEN" name="PS_SECURITY_TOKEN">
       <value>1</value>
     </configuration>
+    <configuration id="PS_SECURITY_ADMIN_LOGIN_THROTTLING_ENABLED" name="PS_SECURITY_ADMIN_LOGIN_THROTTLING_ENABLED">
+      <value>1</value>
+    </configuration>
+    <configuration id="PS_SECURITY_ADMIN_LOGIN_THROTTLING_MAX_ATTEMPTS" name="PS_SECURITY_ADMIN_LOGIN_THROTTLING_MAX_ATTEMPTS">
+      <value>5</value>
+    </configuration>
+    <configuration id="PS_SECURITY_ADMIN_LOGIN_THROTTLING_INTERVAL" name="PS_SECURITY_ADMIN_LOGIN_THROTTLING_INTERVAL">
+      <value>15</value>
+    </configuration>
+    <configuration id="PS_SECURITY_ADMIN_LOGIN_THROTTLING_STORAGE" name="PS_SECURITY_ADMIN_LOGIN_THROTTLING_STORAGE">
+      <value/>
+    </configuration>
     <configuration id="PS_SECURITY_PASSWORD_POLICY_MAXIMUM_LENGTH" name="PS_SECURITY_PASSWORD_POLICY_MAXIMUM_LENGTH">
       <value>72</value>
     </configuration>

--- a/src/Core/Security/AdminLoginFormThrottlingConfiguration.php
+++ b/src/Core/Security/AdminLoginFormThrottlingConfiguration.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Security;
+
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\RateLimiter\Storage\StorageInterface;
+use Tests\Unit\Core\Security\InMemoryConfiguration;
+
+/**
+ * Provides the Symfony firewall configuration array and persistence helpers for login throttling.
+ */
+class AdminLoginFormThrottlingConfiguration implements DataConfigurationInterface
+{
+    public const DEFAULT_MAX_ATTEMPTS = 5;
+    public const DEFAULT_INTERVAL_MINUTES = 15;
+    public const ERROR_KEY_INVALID_CONFIGURATION = 'The admin login throttling configuration is invalid.';
+    public const ERROR_KEY_INVALID_STORAGE = 'The selected login throttling storage service is invalid.';
+
+    /**
+     * @param Configuration|InMemoryConfiguration $configuration
+     */
+    public function __construct(
+        private readonly ConfigurationInterface $configuration,
+        private readonly ?ContainerInterface $container = null,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration(): array
+    {
+        $maxAttempts = $this->configuration->get('PS_SECURITY_ADMIN_LOGIN_THROTTLING_MAX_ATTEMPTS', self::DEFAULT_MAX_ATTEMPTS);
+        if ($maxAttempts <= 0) {
+            $maxAttempts = self::DEFAULT_MAX_ATTEMPTS;
+        }
+        $interval = (int) $this->configuration->get('PS_SECURITY_ADMIN_LOGIN_THROTTLING_INTERVAL', self::DEFAULT_INTERVAL_MINUTES);
+        if ($interval <= 0) {
+            $interval = self::DEFAULT_INTERVAL_MINUTES;
+        }
+
+        return [
+            'login_throttling_enabled' => (bool) $this->configuration->get('PS_SECURITY_ADMIN_LOGIN_THROTTLING_ENABLED', true),
+            'login_throttling_max_attempts' => $maxAttempts,
+            'login_throttling_interval' => $interval,
+            'login_throttling_storage' => (string) $this->configuration->get('PS_SECURITY_ADMIN_LOGIN_THROTTLING_STORAGE', ''),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateConfiguration(array $configuration): array
+    {
+        $errors = $this->getValidationErrors($configuration);
+
+        if (!empty($errors)) {
+            return $errors;
+        }
+
+        $this->configuration->set('PS_SECURITY_ADMIN_LOGIN_THROTTLING_ENABLED', (int) (bool) $configuration['login_throttling_enabled']);
+        $this->configuration->set('PS_SECURITY_ADMIN_LOGIN_THROTTLING_MAX_ATTEMPTS', (int) $configuration['login_throttling_max_attempts']);
+        $this->configuration->set('PS_SECURITY_ADMIN_LOGIN_THROTTLING_INTERVAL', (int) $configuration['login_throttling_interval']);
+        $this->configuration->set('PS_SECURITY_ADMIN_LOGIN_THROTTLING_STORAGE', trim((string) $configuration['login_throttling_storage']));
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateConfiguration(array $configuration): bool
+    {
+        return [] === $this->getValidationErrors($configuration);
+    }
+
+    public function getFirewallConfiguration(): array|bool
+    {
+        $configuration = $this->getConfiguration();
+        $enabled = (bool) $configuration['login_throttling_enabled'];
+        $maxAttempts = (int) $configuration['login_throttling_max_attempts'];
+        $intervalMinutes = (int) $configuration['login_throttling_interval'];
+        $storageService = (string) $configuration['login_throttling_storage'];
+
+        if (!$enabled) {
+            return false;
+        }
+
+        $intervalString = $intervalMinutes === 1 ? '1 minute' : sprintf('%d minutes', $intervalMinutes);
+
+        $configuration = [
+            'max_attempts' => $maxAttempts,
+            'interval' => $intervalString,
+        ];
+
+        if ($storageService !== '') {
+            $configuration['storage_service'] = $storageService;
+        }
+
+        return $configuration;
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     *
+     * @return array<int, array{key: string, parameters: array<string, mixed>, domain: string}>
+     */
+    private function getValidationErrors(array $configuration): array
+    {
+        $errors = [];
+
+        if (!isset(
+            $configuration['login_throttling_enabled'],
+            $configuration['login_throttling_max_attempts'],
+            $configuration['login_throttling_interval'],
+        )) {
+            $errors[] = $this->createError(self::ERROR_KEY_INVALID_CONFIGURATION);
+
+            return $errors;
+        }
+
+        if ((int) $configuration['login_throttling_max_attempts'] <= 0) {
+            $errors[] = $this->createError(self::ERROR_KEY_INVALID_CONFIGURATION);
+        }
+
+        if ((int) $configuration['login_throttling_interval'] <= 0) {
+            $errors[] = $this->createError(self::ERROR_KEY_INVALID_CONFIGURATION);
+        }
+
+        $storageError = $this->getStorageServiceError($configuration);
+
+        if (null !== $storageError) {
+            $errors[] = $storageError;
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    private function getStorageServiceError(array $configuration): ?array
+    {
+        if (!isset($configuration['login_throttling_storage'])) {
+            return null;
+        }
+
+        $storageServiceId = trim((string) $configuration['login_throttling_storage']);
+
+        if ($storageServiceId === '') {
+            return null;
+        }
+
+        if ($this->container === null) {
+            return $this->createError(self::ERROR_KEY_INVALID_STORAGE);
+        }
+
+        if (!$this->container->has($storageServiceId)) {
+            return $this->createError(self::ERROR_KEY_INVALID_STORAGE);
+        }
+
+        $service = $this->container->get($storageServiceId);
+
+        if (!$service instanceof StorageInterface && !$service instanceof CacheItemPoolInterface) {
+            return $this->createError(self::ERROR_KEY_INVALID_STORAGE);
+        }
+
+        return null;
+    }
+
+    private function createError(string $key): array
+    {
+        return [
+            'key' => $key,
+            'parameters' => [],
+            'domain' => 'Admin.Notifications.Error',
+        ];
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SecurityController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SecurityController.php
@@ -72,10 +72,13 @@ class SecurityController extends PrestaShopAdminController
         Request $request,
         #[Autowire(service: 'prestashop.adapter.security.general.form_handler')]
         FormHandlerInterface $generalFormHandler,
+        #[Autowire(service: 'prestashop.adapter.security.admin_login_throttling.form_handler')]
+        FormHandlerInterface $adminLoginThrottlingFormHandler,
         #[Autowire(service: 'prestashop.adapter.security.password_policy.form_handler')]
         FormHandlerInterface $passwordPolicyFormHandler,
     ): Response {
         $generalForm = $generalFormHandler->getForm();
+        $adminLoginThrottlingForm = $adminLoginThrottlingFormHandler->getForm();
         $passwordPolicyForm = $passwordPolicyFormHandler->getForm();
 
         return $this->render(
@@ -86,6 +89,7 @@ class SecurityController extends PrestaShopAdminController
                 'layoutTitle' => $this->trans('Security', [], 'Admin.Navigation.Menu'),
                 'passwordPolicyForm' => $passwordPolicyForm->createView(),
                 'generalForm' => $generalForm->createView(),
+                'adminLoginThrottlingForm' => $adminLoginThrottlingForm->createView(),
                 'multistoreInfoTip' => $this->trans(
                     'Note that this page is available in all shops context only, this is why your context has just switched.',
                     [],
@@ -114,6 +118,22 @@ class SecurityController extends PrestaShopAdminController
             $request,
             $generalFormHandler,
             'actionAdminSecurityControllerPostProcessGeneralBefore'
+        );
+    }
+
+    /**
+     * Process the Security admin throttling configuration form.
+     */
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))", redirectRoute: 'admin_security')]
+    public function processAdminLoginThrottlingFormAction(
+        Request $request,
+        #[Autowire(service: 'prestashop.adapter.security.admin_login_throttling.form_handler')]
+        FormHandlerInterface $adminLoginThrottlingFormHandler,
+    ): RedirectResponse {
+        return $this->processForm(
+            $request,
+            $adminLoginThrottlingFormHandler,
+            'actionAdminSecurityControllerPostProcessAdminThrottlingBefore'
         );
     }
 

--- a/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
+++ b/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\DependencyInjection;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Http\CookieOptions;
+use PrestaShop\PrestaShop\Core\Security\AdminLoginFormThrottlingConfiguration;
 use PrestaShop\PrestaShop\Core\Security\OAuth2\AuthorisationServerInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -43,6 +44,16 @@ use Throwable;
  */
 class PrestaShopExtension extends Extension implements PrependExtensionInterface
 {
+    /**
+     * @var Configuration
+     */
+    private ConfigurationInterface $configuration;
+
+    public function __construct()
+    {
+        $this->configuration = new Configuration();
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -79,6 +90,12 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('prestashop.admin_cookie_lifetime', $this->getAdminCookieLifetime());
         $this->preprendApiConfig($container);
         $this->preprendSessionConfig($container);
+        $this->prependSecurityConfig($container);
+    }
+
+    private function prependSecurityConfig(ContainerBuilder $container): void
+    {
+        $container->setParameter('prestashop.security.login_throttling', $this->getAdminLoginFormThrottlingConfiguration());
     }
 
     protected function preprendSessionConfig(ContainerBuilder $container)
@@ -94,9 +111,7 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
     protected function getCookieSameSite(): string
     {
         try {
-            /** @var ConfigurationInterface $configuration */
-            $configuration = new Configuration();
-            $cookieSamesite = $configuration->get('PS_COOKIE_SAMESITE');
+            $cookieSamesite = $this->configuration->get('PS_COOKIE_SAMESITE');
             $cookieSamesite = match ($cookieSamesite) {
                 CookieOptions::SAMESITE_NONE => Cookie::SAMESITE_NONE,
                 CookieOptions::SAMESITE_STRICT => Cookie::SAMESITE_STRICT,
@@ -112,9 +127,7 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
     protected function getAdminCookieLifetime(): int
     {
         try {
-            /** @var ConfigurationInterface $configuration */
-            $configuration = new Configuration();
-            $cookieLifetimeBo = (int) $configuration->get('PS_COOKIE_LIFETIME_BO');
+            $cookieLifetimeBo = (int) $this->configuration->get('PS_COOKIE_LIFETIME_BO');
             if (empty($cookieLifetimeBo) || $cookieLifetimeBo <= 0) {
                 $cookieLifetimeBo = CookieOptions::MAX_COOKIE_VALUE;
             }
@@ -124,6 +137,18 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
 
         // Configuration value (and default value) are expressed in HOURS, so we convert it into seconds
         return $cookieLifetimeBo * 3600;
+    }
+
+    private function getAdminLoginFormThrottlingConfiguration(): array|bool
+    {
+        try {
+            return (new AdminLoginFormThrottlingConfiguration($this->configuration))->getFirewallConfiguration();
+        } catch (Throwable) {
+            return [
+                'max_attempts' => 5,
+                'interval' => '15 minutes',
+            ];
+        }
     }
 
     protected function preprendApiConfig(ContainerBuilder $container)

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/AdminLoginFormThrottlingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/AdminLoginFormThrottlingType.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Security;
+
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class AdminLoginFormThrottlingType extends TranslatorAwareType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'login_throttling_enabled',
+                SwitchType::class,
+                [
+                    'required' => true,
+                    'label' => $this->trans('Monitor and limit login attempts', 'Admin.Advparameters.Feature'),
+                    'help' => $this->trans('Adds a short delay to repeated login attempts so bots and brute-force attacks cannot guess credentials at full speed.', 'Admin.Advparameters.Help'),
+                ]
+            )
+            ->add(
+                'login_throttling_max_attempts',
+                IntegerType::class,
+                [
+                    'required' => true,
+                    'attr' => [
+                        'min' => 1,
+                    ],
+                    'label' => $this->trans('Allowed attempts before slowing down', 'Admin.Advparameters.Feature'),
+                    'help' => $this->trans('How many incorrect logins are tolerated within the time window. Lower values stop password spraying faster.', 'Admin.Advparameters.Help'),
+                ]
+            )
+            ->add(
+                'login_throttling_interval',
+                IntegerType::class,
+                [
+                    'required' => true,
+                    'attr' => [
+                        'min' => 1,
+                    ],
+                    'label' => $this->trans('Protection time window (minutes)', 'Admin.Advparameters.Feature'),
+                    'help' => $this->trans('Duration used to count login attempts. A longer window covers extended attacks but might add delays for legitimate retries.', 'Admin.Advparameters.Help'),
+                ]
+            )
+            ->add(
+                'login_throttling_storage',
+                TextType::class,
+                [
+                    'required' => false,
+                    'label' => $this->trans('Custom storage service (advanced)', 'Admin.Advparameters.Feature'),
+                    'help' => $this->trans('Optional Symfony service ID for the RateLimiter storage (for example, cache.app). Use it if your hosting needs to persist counters outside the default storage.', 'Admin.Advparameters.Help'),
+                    'attr' => [
+                        'placeholder' => 'cache.app',
+                    ],
+                ]
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'Admin.Advparameters.Feature',
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'security_admin_login_throttling_block';
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/security.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/security.yml
@@ -15,6 +15,14 @@ admin_security_general_save:
     _legacy_controller: AdminSecurity
     _legacy_link: AdminSecurity
 
+admin_security_admin_login_throttling_save:
+  path: /admin-throttling
+  methods: [ POST ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\SecurityController::processAdminLoginThrottlingFormAction'
+    _legacy_controller: AdminSecurity
+    _legacy_link: AdminSecurity
+
 admin_security_password_policy_save:
   path: /password-policy
   methods: [ POST ]

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -301,6 +301,11 @@ services:
     arguments:
       - '@prestashop.adapter.legacy.configuration'
 
+  PrestaShop\PrestaShop\Core\Security\AdminLoginFormThrottlingConfiguration:
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'
+      - '@service_container'
+
   prestashop.adapter.security.password_policy.configuration:
     class: 'PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
@@ -301,6 +301,11 @@ services:
     arguments:
       - '@prestashop.adapter.security.general.configuration'
 
+  prestashop.adapter.security.admin_login_throttling.form_provider:
+    class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Security\FormDataProvider'
+    arguments:
+      - '@PrestaShop\PrestaShop\Core\Security\AdminLoginFormThrottlingConfiguration'
+
   prestashop.adapter.security.password_policy.form_provider:
     class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Security\FormDataProvider'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -570,6 +570,16 @@ services:
       - 'SecurityPageGeneral'
       - 'general'
 
+  prestashop.adapter.security.admin_login_throttling.form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\Handler'
+    arguments:
+      - '@form.factory'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.adapter.security.admin_login_throttling.form_provider'
+      - 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Security\AdminLoginFormThrottlingType'
+      - 'SecurityPageAdminThrottling'
+      - 'admin_login_throttling'
+
   prestashop.adapter.security.password_policy.form_handler:
     class: 'PrestaShop\PrestaShop\Core\Form\Handler'
     arguments:

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Security/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Security/index.html.twig
@@ -50,6 +50,27 @@
     {% endblock %}
   {{ form_end(generalForm) }}
 
+  {{ form_start(adminLoginThrottlingForm, {attr: {class: 'form'}, action: path('admin_security_admin_login_throttling_save')}) }}
+    {% block administration_form_admin_login_throttling %}
+      <div class="card" id="configuration_fieldset_admin_login_throttling">
+        <h3 class="card-header">
+          <i class="material-icons">security</i> {{ 'Admin login throttling'|trans({}, 'Admin.Advparameters.Feature') }}
+        </h3>
+        <div class="card-body">
+          <div class="form-wrapper">
+            {{ form_widget(adminLoginThrottlingForm) }}
+            {{ form_rest(adminLoginThrottlingForm) }}
+          </div>
+        </div>
+        <div class="card-footer">
+          <div class="d-flex justify-content-end">
+            <button type="submit" class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+          </div>
+        </div>
+      </div>
+    {% endblock %}
+  {{ form_end(adminLoginThrottlingForm) }}
+
   {{ form_start(passwordPolicyForm, {attr: {class: 'form'}, action: path('admin_security_password_policy_save')}) }}
     {% block administration_form_password_policy %}
       <div class="card" id="configuration_fieldset_password_policy">

--- a/tests/Integration/Behaviour/Features/Context/Domain/SecurityFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/SecurityFeatureContext.php
@@ -47,6 +47,7 @@ use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 class SecurityFeatureContext extends AbstractDomainFeatureContext
 {
     private const SECURITY_FORM_KEY = 'security-form';
+    private const SECURITY_ADMIN_LOGIN_THROTTLING_FORM_KEY = 'security-admin-login-throttling-form';
 
     /**
      * @Given I specify following properties for security form
@@ -172,5 +173,92 @@ class SecurityFeatureContext extends AbstractDomainFeatureContext
             'UPDATE ' . _DB_PREFIX_ . $databaseTable . ' SET date_upd = \' ' . pSQL($date->format('Y-m-d H:i:s')) . '\'' .
             'WHERE ' . $databaseIdentifier . ' = ' . $session->id
         );
+    }
+
+    /**
+     * @Given I specify following properties for admin throttling form
+     */
+    public function specifyPropertiesForAdminLoginThrottlingForm(TableNode $node): void
+    {
+        $data = $node->getRowsHash();
+
+        SharedStorage::getStorage()->set(self::SECURITY_ADMIN_LOGIN_THROTTLING_FORM_KEY, $data);
+    }
+
+    /**
+     * @When I submit the admin throttling form
+     */
+    public function submitTheAdminLoginThrottlingForm(): void
+    {
+        $data = SharedStorage::getStorage()->get(self::SECURITY_ADMIN_LOGIN_THROTTLING_FORM_KEY);
+
+        $request = Request::createFromGlobals();
+        $request->setMethod(Request::METHOD_POST);
+        $request->request->set(
+            'admin_login_throttling',
+            $data
+        );
+
+        $formHandler = $this->getContainer()->get('prestashop.adapter.security.admin_login_throttling.form_handler');
+        $form = $formHandler->getForm();
+        $form->handleRequest($request);
+
+        $data = $form->getData();
+        $saveErrors = $formHandler->save($data);
+
+        if (0 !== count($saveErrors)) {
+            $this->setLastException(new RuntimeException('Unable to save form: ' . print_r($saveErrors, true)));
+        }
+
+        SharedStorage::getStorage()->clear(self::SECURITY_ADMIN_LOGIN_THROTTLING_FORM_KEY);
+    }
+
+    /**
+     * @Then /^the login throttling configuration should be (disabled|enabled)$/
+     */
+    public function loginThrottlingConfigurationIsDisabledOrEnabled(string $status): void
+    {
+        $loginThrottling = $this->getContainer()->get('prestashop.adapter.legacy.configuration')->get('PS_SECURITY_ADMIN_LOGIN_THROTTLING_ENABLED');
+        Assert::assertSame($status === 'enabled', (bool) $loginThrottling);
+    }
+
+    /**
+     * @Then /^the login throttling configuration should allow (\d+) attempts every (\d+) minutes$/
+     */
+    public function loginThrottlingConfigurationAllowsAttemptsAndInterval(int $maxAttempts, int $interval): void
+    {
+        $configuration = $this->getContainer()->get('prestashop.adapter.legacy.configuration');
+
+        Assert::assertSame($maxAttempts, (int) $configuration->get('PS_SECURITY_ADMIN_LOGIN_THROTTLING_MAX_ATTEMPTS'));
+        Assert::assertSame($interval, (int) $configuration->get('PS_SECURITY_ADMIN_LOGIN_THROTTLING_INTERVAL'));
+    }
+
+    /**
+     * @Then /^the login throttling configuration should use storage "(.*)"$/
+     */
+    public function loginThrottlingConfigurationUsesStorage(string $storage): void
+    {
+        $configuration = $this->getContainer()->get('prestashop.adapter.legacy.configuration');
+
+        Assert::assertSame($storage, (string) $configuration->get('PS_SECURITY_ADMIN_LOGIN_THROTTLING_STORAGE'));
+    }
+
+    /**
+     * @Then /^the login throttling storage configuration should be "([^"]*)"$/
+     */
+    public function loginThrottlingStorageConfigurationShouldBe(string $storageService): void
+    {
+        $configuration = $this->getContainer()->get('prestashop.adapter.legacy.configuration');
+        $storedValue = $configuration->get('PS_SECURITY_ADMIN_LOGIN_THROTTLING_STORAGE');
+
+        Assert::assertSame($storageService, $storedValue === false ? '' : (string) $storedValue);
+    }
+
+    /**
+     * @Then the admin throttling form is valid
+     */
+    public function adminLoginThrottlingFormIsValid(): void
+    {
+        $this->assertLastErrorIsNull();
     }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Security/security_configuration.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Security/security_configuration.feature
@@ -18,6 +18,26 @@ Feature: Security configuration form
     Then the security form is valid
     Then the token configuration should be disabled
 
+  Scenario: Play with security configuration
+    Given I specify following properties for admin throttling form
+      | login_throttling_enabled      | 0                  |
+      | login_throttling_max_attempts | 7                  |
+      | login_throttling_interval     | 10                 |
+      | login_throttling_storage      | cache.app |
+    And shop configuration for "PS_SECURITY_ADMIN_LOGIN_THROTTLING_ENABLED" is set to 1
+    And shop configuration for "PS_SECURITY_ADMIN_LOGIN_THROTTLING_MAX_ATTEMPTS" is set to 5
+    And shop configuration for "PS_SECURITY_ADMIN_LOGIN_THROTTLING_INTERVAL" is set to 15
+    And shop configuration for "PS_SECURITY_ADMIN_LOGIN_THROTTLING_STORAGE" is set to cache.app
+    And the login throttling configuration should be enabled
+    And the login throttling configuration should allow 5 attempts every 15 minutes
+    And the login throttling configuration should use storage "cache.app"
+    When I submit the admin throttling form
+    Then the admin throttling form is valid
+    And the login throttling configuration should be disabled
+    And the login throttling configuration should allow 7 attempts every 10 minutes
+    And the login throttling configuration should use storage "cache.app"
+
+
   Scenario: Clear outdated customer sessions
     Given there is customer "John Doe" with email "john.doe@prestashop.com"
     And a session for customer named "John Doe" is created 1 hour ago

--- a/tests/Integration/PrestaShopBundle/Security/LoginThrottlingTest.php
+++ b/tests/Integration/PrestaShopBundle/Security/LoginThrottlingTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Security;
+
+use Symfony\Component\Routing\RouterInterface;
+use Tests\TestCase\SymfonyIntegrationTestCase;
+
+class LoginThrottlingTest extends SymfonyIntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testRepeatedFailuresTemporarilyBlockSuccessfulLogin(): void
+    {
+        $pool = self::$kernel->getContainer()->get('cache.rate_limiter');
+        $pool->clear();
+
+        /** @var RouterInterface $router */
+        $router = self::$kernel->getContainer()->get('router');
+        $loginUrl = $router->generate('admin_login');
+
+        $this->exhaustLoginAttempts($loginUrl, 5);
+
+        $this->submitLoginForm($loginUrl, 'test');
+        $crawler = $this->client->followRedirect();
+
+        $this->assertSame('admin_login', $this->client->getRequest()->attributes->get('_route'));
+        $this->assertSame(1, $crawler->filter('form#login_form')->count());
+    }
+
+    private function exhaustLoginAttempts(string $loginUrl, int $attempts): void
+    {
+        for ($i = 0; $i < $attempts; ++$i) {
+            $this->submitLoginForm($loginUrl, 'wrong-password');
+            $this->client->followRedirect();
+        }
+    }
+
+    private function submitLoginForm(string $loginUrl, string $password): void
+    {
+        $this->client->request('GET', $loginUrl);
+        $form = $this->client->getCrawler()->filter('form#login_form')->form([
+            'email' => 'test@prestashop.com',
+            'passwd' => $password,
+        ]);
+        $this->client->submit($form);
+    }
+}

--- a/tests/Unit/Core/Security/AdminLoginFormThrottlingConfigurationTest.php
+++ b/tests/Unit/Core/Security/AdminLoginFormThrottlingConfigurationTest.php
@@ -1,0 +1,431 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Security;
+
+use DateInterval;
+use DateTimeInterface;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Security\AdminLoginFormThrottlingConfiguration;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use RuntimeException;
+use stdClass;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\RateLimiter\LimiterStateInterface;
+use Symfony\Component\RateLimiter\Storage\StorageInterface;
+use UnitEnum;
+
+class AdminLoginFormThrottlingConfigurationTest extends TestCase
+{
+    public function testConfigurationDefaults(): void
+    {
+        $configuration = new AdminLoginFormThrottlingConfiguration(new InMemoryConfiguration([
+            'PS_SECURITY_ADMIN_LOGIN_THROTTLING_ENABLED' => true,
+            'PS_SECURITY_ADMIN_LOGIN_THROTTLING_MAX_ATTEMPTS' => 5,
+            'PS_SECURITY_ADMIN_LOGIN_THROTTLING_INTERVAL' => 15,
+            'PS_SECURITY_ADMIN_LOGIN_THROTTLING_STORAGE' => '',
+        ]));
+
+        $this->assertSame(
+            [
+                'login_throttling_enabled' => true,
+                'login_throttling_max_attempts' => 5,
+                'login_throttling_interval' => 15,
+                'login_throttling_storage' => '',
+            ],
+            $configuration->getConfiguration()
+        );
+    }
+
+    public function testUpdateConfigurationPersistsValues(): void
+    {
+        $inMemoryConfiguration = new InMemoryConfiguration([]);
+        $configuration = new AdminLoginFormThrottlingConfiguration(
+            $inMemoryConfiguration,
+            $this->createContainerWithCacheService('cache.system')
+        );
+
+        $this->assertSame([], $configuration->updateConfiguration([
+            'login_throttling_enabled' => false,
+            'login_throttling_max_attempts' => 9,
+            'login_throttling_interval' => 30,
+            'login_throttling_storage' => ' cache.system ',
+        ]));
+
+        $this->assertFalse((bool) $inMemoryConfiguration->get('PS_SECURITY_ADMIN_LOGIN_THROTTLING_ENABLED'));
+        $this->assertSame(9, $inMemoryConfiguration->get('PS_SECURITY_ADMIN_LOGIN_THROTTLING_MAX_ATTEMPTS'));
+        $this->assertSame(30, $inMemoryConfiguration->get('PS_SECURITY_ADMIN_LOGIN_THROTTLING_INTERVAL'));
+        $this->assertSame('cache.system', $inMemoryConfiguration->get('PS_SECURITY_ADMIN_LOGIN_THROTTLING_STORAGE'));
+    }
+
+    public function testUpdateConfigurationReturnsErrorForInvalidLimits(): void
+    {
+        $configuration = new AdminLoginFormThrottlingConfiguration(new InMemoryConfiguration([]));
+
+        $errors = $configuration->updateConfiguration([
+            'login_throttling_enabled' => true,
+            'login_throttling_max_attempts' => 0,
+            'login_throttling_interval' => 10,
+            'login_throttling_storage' => '',
+        ]);
+
+        $this->assertNotEmpty($errors);
+        $this->assertSame(AdminLoginFormThrottlingConfiguration::ERROR_KEY_INVALID_CONFIGURATION, $errors[0]['key']);
+    }
+
+    public function testUpdateConfigurationReturnsErrorForInvalidStorage(): void
+    {
+        $configuration = new AdminLoginFormThrottlingConfiguration(new InMemoryConfiguration([]));
+
+        $errors = $configuration->updateConfiguration([
+            'login_throttling_enabled' => true,
+            'login_throttling_max_attempts' => 3,
+            'login_throttling_interval' => 10,
+            'login_throttling_storage' => 'cache.invalid',
+        ]);
+
+        $this->assertNotEmpty($errors);
+        $this->assertSame(AdminLoginFormThrottlingConfiguration::ERROR_KEY_INVALID_STORAGE, $errors[0]['key']);
+    }
+
+    public function testValidateConfigurationRejectsInvalidNumbers(): void
+    {
+        $configuration = new AdminLoginFormThrottlingConfiguration(new InMemoryConfiguration([]));
+
+        $this->assertFalse($configuration->validateConfiguration([
+            'login_throttling_enabled' => true,
+            'login_throttling_max_attempts' => 0,
+            'login_throttling_interval' => 10,
+            'login_throttling_storage' => '',
+        ]));
+
+        $this->assertFalse($configuration->validateConfiguration([
+            'login_throttling_enabled' => true,
+            'login_throttling_max_attempts' => 1,
+            'login_throttling_interval' => 0,
+            'login_throttling_storage' => '',
+        ]));
+    }
+
+    public function testFirewallConfigurationUsesStoredValues(): void
+    {
+        $configuration = new AdminLoginFormThrottlingConfiguration(new InMemoryConfiguration([
+            'PS_SECURITY_ADMIN_LOGIN_THROTTLING_ENABLED' => 1,
+            'PS_SECURITY_ADMIN_LOGIN_THROTTLING_MAX_ATTEMPTS' => 12,
+            'PS_SECURITY_ADMIN_LOGIN_THROTTLING_INTERVAL' => 1,
+            'PS_SECURITY_ADMIN_LOGIN_THROTTLING_STORAGE' => 'cache.custom.rate_limiter',
+        ]), $this->createContainerWithStorageService('cache.custom.rate_limiter'));
+
+        $this->assertSame(
+            [
+                'max_attempts' => 12,
+                'interval' => '1 minute',
+                'storage_service' => 'cache.custom.rate_limiter',
+            ],
+            $configuration->getFirewallConfiguration()
+        );
+    }
+
+    public function testDisabledFirewallConfigurationReturnsFalse(): void
+    {
+        $configuration = new AdminLoginFormThrottlingConfiguration(new InMemoryConfiguration([
+            'PS_SECURITY_ADMIN_LOGIN_THROTTLING_ENABLED' => 0,
+        ]));
+
+        $this->assertFalse($configuration->getFirewallConfiguration());
+    }
+
+    public function testInvalidStoredValuesFallbackToDefaults(): void
+    {
+        $configuration = new AdminLoginFormThrottlingConfiguration(new InMemoryConfiguration([
+            'PS_SECURITY_ADMIN_LOGIN_THROTTLING_ENABLED' => 1,
+            'PS_SECURITY_ADMIN_LOGIN_THROTTLING_MAX_ATTEMPTS' => -1,
+            'PS_SECURITY_ADMIN_LOGIN_THROTTLING_INTERVAL' => 0,
+        ]));
+
+        $this->assertSame(
+            [
+                'max_attempts' => 5,
+                'interval' => '15 minutes',
+            ],
+            $configuration->getFirewallConfiguration()
+        );
+    }
+
+    public function testValidateConfigurationRejectsUnknownStorageService(): void
+    {
+        $configuration = new AdminLoginFormThrottlingConfiguration(new InMemoryConfiguration([]), new DummyContainer([]));
+
+        $this->assertFalse($configuration->validateConfiguration([
+            'login_throttling_enabled' => true,
+            'login_throttling_max_attempts' => 3,
+            'login_throttling_interval' => 10,
+            'login_throttling_storage' => 'cache.unknown',
+        ]));
+    }
+
+    public function testValidateConfigurationRejectsServiceWithInvalidType(): void
+    {
+        $configuration = new AdminLoginFormThrottlingConfiguration(new InMemoryConfiguration([]), new DummyContainer([
+            'cache.invalid' => new stdClass(),
+        ]));
+
+        $this->assertFalse($configuration->validateConfiguration([
+            'login_throttling_enabled' => true,
+            'login_throttling_max_attempts' => 3,
+            'login_throttling_interval' => 10,
+            'login_throttling_storage' => 'cache.invalid',
+        ]));
+    }
+
+    public function testValidateConfigurationAcceptsPsr6CacheService(): void
+    {
+        $configuration = new AdminLoginFormThrottlingConfiguration(
+            new InMemoryConfiguration([]),
+            $this->createContainerWithCacheService('cache.app')
+        );
+
+        $this->assertTrue($configuration->validateConfiguration([
+            'login_throttling_enabled' => true,
+            'login_throttling_max_attempts' => 3,
+            'login_throttling_interval' => 10,
+            'login_throttling_storage' => 'cache.app',
+        ]));
+    }
+
+    public function testValidateConfigurationAcceptsRateLimiterStorageService(): void
+    {
+        $configuration = new AdminLoginFormThrottlingConfiguration(
+            new InMemoryConfiguration([]),
+            $this->createContainerWithStorageService('cache.rate_limiter')
+        );
+
+        $this->assertTrue($configuration->validateConfiguration([
+            'login_throttling_enabled' => true,
+            'login_throttling_max_attempts' => 3,
+            'login_throttling_interval' => 10,
+            'login_throttling_storage' => 'cache.rate_limiter',
+        ]));
+    }
+
+    private function createContainerWithCacheService(string $serviceId): ContainerInterface
+    {
+        return new DummyContainer([
+            $serviceId => new DummyCacheItemPool(),
+        ]);
+    }
+
+    private function createContainerWithStorageService(string $serviceId): ContainerInterface
+    {
+        return new DummyContainer([
+            $serviceId => new DummyRateLimiterStorage(),
+        ]);
+    }
+}
+
+class InMemoryConfiguration implements ConfigurationInterface
+{
+    /**
+     * @param array<string, mixed> $values
+     */
+    public function __construct(private array $values)
+    {
+    }
+
+    public function get($key)
+    {
+        return $this->values[$key] ?? false;
+    }
+
+    public function set($key, $value)
+    {
+        $this->values[$key] = $value;
+    }
+}
+
+class DummyContainer implements ContainerInterface
+{
+    /**
+     * @param array<string, object> $services
+     */
+    public function __construct(private array $services)
+    {
+    }
+
+    public function set(string $id, ?object $service)
+    {
+        if ($service === null) {
+            unset($this->services[$id]);
+        } else {
+            $this->services[$id] = $service;
+        }
+    }
+
+    public function get(string $id, int $invalidBehavior = self::EXCEPTION_ON_INVALID_REFERENCE): ?object
+    {
+        if (!isset($this->services[$id])) {
+            if (self::NULL_ON_INVALID_REFERENCE === $invalidBehavior || self::IGNORE_ON_INVALID_REFERENCE === $invalidBehavior || self::IGNORE_ON_UNINITIALIZED_REFERENCE === $invalidBehavior) {
+                return null;
+            }
+
+            throw new RuntimeException(sprintf('Service "%s" not found.', $id));
+        }
+
+        return $this->services[$id];
+    }
+
+    public function has(string $id): bool
+    {
+        return isset($this->services[$id]);
+    }
+
+    public function initialized(string $id): bool
+    {
+        return isset($this->services[$id]);
+    }
+
+    public function getParameter(string $name)
+    {
+        throw new RuntimeException('Not implemented.');
+    }
+
+    public function hasParameter(string $name): bool
+    {
+        return false;
+    }
+
+    public function setParameter(string $name, array|bool|string|int|float|UnitEnum|null $value)
+    {
+        throw new RuntimeException('Not implemented.');
+    }
+}
+
+class DummyRateLimiterStorage implements StorageInterface
+{
+    public function save(LimiterStateInterface $limiterState): void
+    {
+    }
+
+    public function fetch(string $limiterStateId): ?LimiterStateInterface
+    {
+        return null;
+    }
+
+    public function delete(string $limiterStateId): void
+    {
+    }
+}
+
+class DummyCacheItemPool implements CacheItemPoolInterface
+{
+    public function getItem(string $key): CacheItemInterface
+    {
+        return new DummyCacheItem($key);
+    }
+
+    public function getItems(array $keys = []): iterable
+    {
+        foreach ($keys as $key) {
+            yield $key => $this->getItem($key);
+        }
+    }
+
+    public function hasItem(string $key): bool
+    {
+        return false;
+    }
+
+    public function clear(): bool
+    {
+        return true;
+    }
+
+    public function deleteItem(string $key): bool
+    {
+        return true;
+    }
+
+    public function deleteItems(array $keys): bool
+    {
+        return true;
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        return true;
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return true;
+    }
+
+    public function commit(): bool
+    {
+        return true;
+    }
+}
+
+class DummyCacheItem implements CacheItemInterface
+{
+    public function __construct(private string $key)
+    {
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function get(): mixed
+    {
+        return null;
+    }
+
+    public function isHit(): bool
+    {
+        return false;
+    }
+
+    public function set(mixed $value): static
+    {
+        return $this;
+    }
+
+    public function expiresAt(?DateTimeInterface $expiration): static
+    {
+        return $this;
+    }
+
+    public function expiresAfter(DateInterval|int|null $time): static
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please fill in the table below carefully to help maintainers review and merge your PR quickly.

Contribution guidelines:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

Types & categories:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds a configurable back-office login throttling feature with manageable configuration (enable flag, quota, interval, optional storage service). Configuration is handled via `AdminLoginFormThrottlingConfiguration` and wired into Symfony’s firewall using `PrestashopExtension` to enforce native rate limiting.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to BO > Configure > Advanced Parameters > Security and find the new “Admin login throttling” card.<br>2. Toggle on/off the feature, change values (attempts, interval) and save. Reload to confirm persistence.<br>3. When on simulate multiple failed logins on `/admin-dev`. After exceeding the quota, verify that attempts are delayed or blocked. Then log in with a valid password to ensure lockout is respected.<br>4. Configure an invalid storage service ID and confirm an error. Use `cache.app` (or another valid service) to confirm proper acceptance.
| UI Tests          | todo
| Sponsor company   | e-frogg

## Technical details

- **Core**
  - On startup the `PrestaShopExtension` publishes the parameter `prestashop.security.login_throttling` from the stored configuration.  
  - This parameter is injected into the `login_throttling` section of the main firewall (`app/config/admin/security.yml`), allowing Symfony’s security / rate limiter component to enforce attempt limitation natively.  
- **Back Office**:  
  - A new "Admin login throttling" card is added to the Security page.  
  - It is powered by a dedicated form type `AdminLoginFormThrottlingType` and wired with `prestashop.adapter.security.admin_login_throttling.form_handler` and `prestashop.adapter.security.admin_login_throttling.form_provider` through the service container
  - A specific POST route `admin_security_admin_login_throttling_save` has been added to persist the configuration from the form.  
- **Configuration**:  
  - Configuration is stored into legacy storage, exposed via shared form data provider, and handled by a dedicated form handler
  - It is possible to reference any Symfony service implementing `StorageInterface` or `CacheItemPoolInterface` as login throttler storage
  - Defaults configuration: enabled, 5 attempts / 15 minutes : provides sensible security out-of-the-box

## References

- Symfony Security – Login throttling: https://symfony.com/doc/6.4/security.html#login-throttling  
- Symfony RateLimiter – Configuring storage: https://symfony.com/doc/6.4/rate_limiter.html#storing-rate-limiter-state  