### PR TITLE
Add display parameter to generatePDF method

### DIFF
--- a/src/Adapter/PDF/PDFGenerator.php
+++ b/src/Adapter/PDF/PDFGenerator.php
@@ -61,9 +61,12 @@ final class PDFGenerator implements PDFGeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generatePDF(array $objectCollection, bool $display = true)
+    public function generatePDF(array $objectCollection, $display = true, $filename = null)
     {
         $pdf = new PDF($objectCollection, $this->templateTypeProvider->getPDFTemplateType(), $this->smarty);
+        if (null !== $filename) {
+            $pdf->filename = $filename;
+        }
         $pdf->render($display);
     }
 }

--- a/src/Adapter/PDF/PDFGenerator.php
+++ b/src/Adapter/PDF/PDFGenerator.php
@@ -61,9 +61,9 @@ final class PDFGenerator implements PDFGeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generatePDF(array $objectCollection)
+    public function generatePDF(array $objectCollection, bool $display = true)
     {
         $pdf = new PDF($objectCollection, $this->templateTypeProvider->getPDFTemplateType(), $this->smarty);
-        $pdf->render();
+        $pdf->render($display);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adapt the Adapter for PDF generation to allow to pass the display type parameter and also the filename to use. This render() method use the true option a default, to deserve the PDF inline. You be able to use this adapter (in a command, for example) with a specific render type in order to save the generated file, for example.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In fact, I know that it's tricky to test and see why it's needed. I need to handle something (with that) on another side to give you a full reason on why and how to test. But, technicaly, check that render() method use the true option as default and that it's working well. And trust me on this side :D

With this, I will be able to propose a export PDF command to handle the export of invoices as the Back Office do, but with CLI.