### PR TITLE
Fix the canonical redirection when category slug is wrong but id is correct

### DIFF
--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -80,13 +80,13 @@ class CategoryControllerCore extends ProductListingFrontController
      */
     public function init(): void
     {
-        parent::init();
-
         // Get proper IDs
         $id_category = (int) Tools::getValue('id_category');
 
         // Try to load category object
         $this->category = new Category($id_category, $this->context->language->id);
+
+        parent::init();
 
         // Otherwise immediately show 404
         if (!Validate::isLoadedObject($this->category)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fix the canonical redirection when category slug is wrong but id is correct
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to any category page on the storefront.<br>Change the category slug name (this updates the friendly URL, just keep the id).<br>The category page redirect to the correct url
| Fixed issue or discussion?     | Fixes #39507 
| Sponsor company   | Agence Off
