### PR TITLE
Allow modules to use services.php and version-specific services.yml files to handle new Symfony services/changes/renames while preserving older versions compatibility

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -146,20 +146,21 @@ abstract class AppKernel extends Kernel
         }
 
         $activeModules = $this->getModuleRepository()->getActiveModules();
+        $servicesFilesList = [
+            'services.php',
+            sprintf('services-%d.%d.yml', Version::MAJOR_VERSION, Version::MINOR_VERSION),
+            sprintf('services-%d.yml', Version::MAJOR_VERSION),
+            'services.yml',
+        ];
+
         // We only load services of active modules (not simply installed)
         foreach ($activeModules as $activeModulePath) {
             $modulePath = _PS_MODULE_DIR_ . $activeModulePath;
 
-            $servicesFilesList = [
-                sprintf('services-%d.%d.yml', Version::MAJOR_VERSION, Version::MINOR_VERSION),
-                sprintf('services-%d.yml', Version::MAJOR_VERSION),
-                'services.yml',
-            ];
-
             foreach ($servicesFilesList as $servicesFile) {
                 $fullPath = sprintf('%s/config/%s', $modulePath, $servicesFile);
 
-                if (file_exists($fullPath) && is_file($fullPath)) {
+                if (is_file($fullPath)) {
                     $loader->load($fullPath);
                     // Prevent loading less specific services files if one was found
                     break;
@@ -169,7 +170,7 @@ abstract class AppKernel extends Kernel
             foreach ($servicesFilesList as $servicesFile) {
                 $fullPath = sprintf('%s/config/admin/%s', $modulePath, $servicesFile);
 
-                if (file_exists($fullPath) && is_file($fullPath)) {
+                if (is_file($fullPath)) {
                     $loader->load($fullPath);
                     // Prevent loading less specific services files if one was found
                     break;
@@ -181,7 +182,7 @@ abstract class AppKernel extends Kernel
             foreach ($servicesFilesList as $servicesFile) {
                 $fullPath = sprintf('%s/config/front/%s', $modulePath, $servicesFile);
 
-                if (file_exists($fullPath) && is_file($fullPath)) {
+                if (is_file($fullPath)) {
                     $loader->load($fullPath);
                     // Prevent loading less specific services files if one was found
                     break;

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -149,18 +149,45 @@ abstract class AppKernel extends Kernel
         // We only load services of active modules (not simply installed)
         foreach ($activeModules as $activeModulePath) {
             $modulePath = _PS_MODULE_DIR_ . $activeModulePath;
-            $configFiles = [
-                sprintf('%s/config/services.yml', $modulePath),
-                sprintf('%s/config/admin/services.yml', $modulePath),
-                // @todo Uncomment to Load this file once we'll have a unique container
-                // sprintf('%s/config/front/services.yml', $modulePath),
+
+            $servicesFilesList = [
+                sprintf('services-%d.%d.yml', Version::MAJOR_VERSION, Version::MINOR_VERSION),
+                sprintf('services-%d.yml', Version::MAJOR_VERSION),
+                'services.yml',
             ];
 
-            foreach ($configFiles as $file) {
-                if (is_file($file)) {
-                    $loader->load($file);
+            foreach ($servicesFilesList as $servicesFile) {
+                $fullPath = sprintf('%s/config/%s', $modulePath, $servicesFile);
+
+                if (file_exists($fullPath) && is_file($fullPath)) {
+                    $loader->load($fullPath);
+                    // Prevent loading less specific services files if one was found
+                    break;
                 }
             }
+
+            foreach ($servicesFilesList as $servicesFile) {
+                $fullPath = sprintf('%s/config/admin/%s', $modulePath, $servicesFile);
+
+                if (file_exists($fullPath) && is_file($fullPath)) {
+                    $loader->load($fullPath);
+                    // Prevent loading less specific services files if one was found
+                    break;
+                }
+            }
+
+            /*
+            // @todo Uncomment to Load this file once we'll have a unique container
+            foreach ($servicesFilesList as $servicesFile) {
+                $fullPath = sprintf('%s/config/front/%s', $modulePath, $servicesFile);
+
+                if (file_exists($fullPath) && is_file($fullPath)) {
+                    $loader->load($fullPath);
+                    // Prevent loading less specific services files if one was found
+                    break;
+                }
+            }
+            */
         }
 
         $installedModules = $this->getModuleRepository()->getInstalledModules();

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
@@ -6,6 +6,7 @@
 
 namespace PrestaShopBundle\DependencyInjection\Compiler;
 
+use PrestaShop\PrestaShop\Core\Version;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -46,14 +47,28 @@ class LoadServicesFromModulesPass implements CompilerPassInterface
         foreach ($installedModules as $moduleName) {
             $modulePath = $moduleDir . $moduleName;
             $moduleConfigPath = $modulePath . $this->configPath;
-            if (file_exists($moduleConfigPath . 'services.yml')) {
+
+            $servicesFilesList = [
+                sprintf('services-%d.%d.yml', Version::MAJOR_VERSION, Version::MINOR_VERSION),
+                sprintf('services-%d.yml', Version::MAJOR_VERSION),
+                'services.yml',
+            ];
+
+            foreach ($servicesFilesList as $servicesFile) {
+                if (!file_exists($moduleConfigPath . $servicesFile)) {
+                    continue;
+                }
+
                 $fileLocator = new FileLocator($moduleConfigPath);
                 $loader = new YamlFileLoader($container, $fileLocator);
                 $loader->setResolver(new LoaderResolver([
                     new PhpFileLoader($container, $fileLocator),
                     new XmlFileLoader($container, $fileLocator),
                 ]));
-                $loader->load('services.yml');
+
+                $loader->load($servicesFile);
+                // Prevent loading less specific services files if one was found
+                break;
             }
         }
     }

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
@@ -8,6 +8,7 @@ namespace PrestaShopBundle\DependencyInjection\Compiler;
 
 use PrestaShop\PrestaShop\Core\Version;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Loader\DelegatingLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -43,28 +44,28 @@ class LoadServicesFromModulesPass implements CompilerPassInterface
     {
         $installedModules = $container->getParameter('prestashop.installed_modules');
         $moduleDir = $container->getParameter('prestashop.module_dir');
+        $servicesFilesList = [
+            'services.php',
+            sprintf('services-%d.%d.yml', Version::MAJOR_VERSION, Version::MINOR_VERSION),
+            sprintf('services-%d.yml', Version::MAJOR_VERSION),
+            'services.yml',
+        ];
 
         foreach ($installedModules as $moduleName) {
             $modulePath = $moduleDir . $moduleName;
             $moduleConfigPath = $modulePath . $this->configPath;
-
-            $servicesFilesList = [
-                sprintf('services-%d.%d.yml', Version::MAJOR_VERSION, Version::MINOR_VERSION),
-                sprintf('services-%d.yml', Version::MAJOR_VERSION),
-                'services.yml',
-            ];
+            $fileLocator = new FileLocator($moduleConfigPath);
+            $resolver = new LoaderResolver([
+                new PhpFileLoader($container, $fileLocator),
+                new XmlFileLoader($container, $fileLocator),
+                new YamlFileLoader($container, $fileLocator),
+            ]);
+            $loader = new DelegatingLoader($resolver);
 
             foreach ($servicesFilesList as $servicesFile) {
-                if (!file_exists($moduleConfigPath . $servicesFile)) {
+                if (!is_file($moduleConfigPath . $servicesFile)) {
                     continue;
                 }
-
-                $fileLocator = new FileLocator($moduleConfigPath);
-                $loader = new YamlFileLoader($container, $fileLocator);
-                $loader->setResolver(new LoaderResolver([
-                    new PhpFileLoader($container, $fileLocator),
-                    new XmlFileLoader($container, $fileLocator),
-                ]));
 
                 $loader->load($servicesFile);
                 // Prevent loading less specific services files if one was found


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR allows module developers to provide more flexible service configuration files for PrestaShop modules. It adds support for `config/services.php` and keeps support for version-specific YAML service files such as `services-9.2.yml` and `services-9.yml`.<br><br>The loading priority is now:<br>1. `services.php`<br>2. `services-{major}.{minor}.yml`<br>3. `services-{major}.yml`<br>4. `services.yml`<br><br>This lets modules use Symfony PHP configuration in PrestaShop 9 while keeping YAML fallbacks for older PrestaShop versions. A module can also use `services.php` to implement explicit compatibility logic, for example by importing different service files depending on `_PS_VERSION_`.<br><br>This is backward compatible: existing modules using only `services.yml` continue to work as before.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In a module, create a `config/services.php` file and register a test service. Clear and warm up the cache: the service should be loaded without being parsed as YAML.<br><br>Then remove `services.php` and test the fallback order with `services-9.2.yml`, then `services-9.yml`, then `services.yml`.
| UI Tests          | <keep current link or replace after rerun>
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | VersusVenture (PrestaModule / BusinessTech)