### PR TITLE
Fix grid doctrine query builder to use context language instead of employee language

### DIFF
--- a/src/Core/Grid/Data/Factory/AttachmentGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/AttachmentGridDataFactoryDecorator.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
 
 use Doctrine\DBAL\Connection;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
@@ -42,49 +43,19 @@ final class AttachmentGridDataFactoryDecorator implements GridDataFactoryInterfa
     use TranslatorAwareTrait;
 
     /**
-     * @var GridDataFactoryInterface
-     */
-    private $attachmentDoctrineGridDataFactory;
-
-    /**
-     * @var int
-     */
-    private $employeeIdLang;
-
-    /**
-     * @var Connection
-     */
-    private $connection;
-
-    /**
-     * @var string
-     */
-    private $dbPrefix;
-
-    /**
-     * @var FileSizeConverter
-     */
-    private $fileSizeConverter;
-
-    /**
      * @param GridDataFactoryInterface $attachmentDoctrineGridDataFactory
-     * @param int $employeeIdLang
+     * @param LanguageContext $languageContext
      * @param Connection $connection
      * @param string $dbPrefix
      * @param FileSizeConverter $fileSizeConverter
      */
     public function __construct(
-        GridDataFactoryInterface $attachmentDoctrineGridDataFactory,
-        int $employeeIdLang,
-        Connection $connection,
-        string $dbPrefix,
-        FileSizeConverter $fileSizeConverter
+        private GridDataFactoryInterface $attachmentDoctrineGridDataFactory,
+        private LanguageContext $languageContext,
+        private Connection $connection,
+        private string $dbPrefix,
+        private FileSizeConverter $fileSizeConverter
     ) {
-        $this->attachmentDoctrineGridDataFactory = $attachmentDoctrineGridDataFactory;
-        $this->employeeIdLang = $employeeIdLang;
-        $this->connection = $connection;
-        $this->dbPrefix = $dbPrefix;
-        $this->fileSizeConverter = $fileSizeConverter;
     }
 
     /**
@@ -152,7 +123,7 @@ final class AttachmentGridDataFactoryDecorator implements GridDataFactoryInterfa
             )
             ->where('pa.`id_attachment` = :attachmentId')
             ->setParameter('attachmentId', $attachmentId)
-            ->setParameter('langId', $this->employeeIdLang);
+            ->setParameter('langId', $this->languageContext->getId());
 
         return $qb->executeQuery()->fetchFirstColumn();
     }

--- a/src/Core/Grid/Query/AttachmentQueryBuilder.php
+++ b/src/Core/Grid/Query/AttachmentQueryBuilder.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Query;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
@@ -41,7 +42,7 @@ final class AttachmentQueryBuilder extends AbstractDoctrineQueryBuilder
     private $searchCriteriaApplicator;
 
     /**
-     * @var string
+     * @var int
      */
     private $contextLanguageId;
 
@@ -49,18 +50,18 @@ final class AttachmentQueryBuilder extends AbstractDoctrineQueryBuilder
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
-     * @param string $contextLanguageId
+     * @param LanguageContext $languageContext
      */
     public function __construct(
         Connection $connection,
         string $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
-        string $contextLanguageId
+        LanguageContext $languageContext
     ) {
         parent::__construct($connection, $dbPrefix);
 
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
-        $this->contextLanguageId = $contextLanguageId;
+        $this->contextLanguageId = $languageContext->getId();
     }
 
     /**

--- a/src/Core/Grid/Query/AttachmentQueryBuilder.php
+++ b/src/Core/Grid/Query/AttachmentQueryBuilder.php
@@ -42,11 +42,6 @@ final class AttachmentQueryBuilder extends AbstractDoctrineQueryBuilder
     private $searchCriteriaApplicator;
 
     /**
-     * @var int
-     */
-    private $contextLanguageId;
-
-    /**
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
@@ -56,12 +51,11 @@ final class AttachmentQueryBuilder extends AbstractDoctrineQueryBuilder
         Connection $connection,
         string $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
-        LanguageContext $languageContext
+        private LanguageContext $languageContext
     ) {
         parent::__construct($connection, $dbPrefix);
 
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
-        $this->contextLanguageId = $languageContext->getId();
     }
 
     /**
@@ -127,7 +121,7 @@ final class AttachmentQueryBuilder extends AbstractDoctrineQueryBuilder
             'a.`id_attachment` = virtual_product_attachment.`id_attachment`');
 
         $qb->andWhere('al.`id_lang` = :employee_id_lang');
-        $qb->setParameter('employee_id_lang', $this->contextLanguageId);
+        $qb->setParameter('employee_id_lang', $this->languageContext->getId());
         $this->applyFilters($qb, $filters);
 
         return $qb;

--- a/src/Core/Grid/Query/AttachmentQueryBuilder.php
+++ b/src/Core/Grid/Query/AttachmentQueryBuilder.php
@@ -43,24 +43,24 @@ final class AttachmentQueryBuilder extends AbstractDoctrineQueryBuilder
     /**
      * @var string
      */
-    private $employeeIdLang;
+    private $contextLanguageId;
 
     /**
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
-     * @param string $employeeIdLang
+     * @param string $contextLanguageId
      */
     public function __construct(
         Connection $connection,
         string $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
-        string $employeeIdLang
+        string $contextLanguageId
     ) {
         parent::__construct($connection, $dbPrefix);
 
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
-        $this->employeeIdLang = $employeeIdLang;
+        $this->contextLanguageId = $contextLanguageId;
     }
 
     /**
@@ -126,7 +126,7 @@ final class AttachmentQueryBuilder extends AbstractDoctrineQueryBuilder
             'a.`id_attachment` = virtual_product_attachment.`id_attachment`');
 
         $qb->andWhere('al.`id_lang` = :employee_id_lang');
-        $qb->setParameter('employee_id_lang', $this->employeeIdLang);
+        $qb->setParameter('employee_id_lang', $this->contextLanguageId);
         $this->applyFilters($qb, $filters);
 
         return $qb;

--- a/src/Core/Grid/Query/ManufacturerAddressQueryBuilder.php
+++ b/src/Core/Grid/Query/ManufacturerAddressQueryBuilder.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Query;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
@@ -49,18 +50,18 @@ final class ManufacturerAddressQueryBuilder extends AbstractDoctrineQueryBuilder
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
-     * @param int $contextLangId
+     * @param LanguageContext $languageContext
      */
     public function __construct(
         Connection $connection,
         $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
-        $contextLangId
+        LanguageContext $languageContext
     ) {
         parent::__construct($connection, $dbPrefix);
 
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
-        $this->contextLangId = $contextLangId;
+        $this->contextLangId = $languageContext->getId();
     }
 
     /**

--- a/src/Core/Grid/Query/ManufacturerAddressQueryBuilder.php
+++ b/src/Core/Grid/Query/ManufacturerAddressQueryBuilder.php
@@ -42,11 +42,6 @@ final class ManufacturerAddressQueryBuilder extends AbstractDoctrineQueryBuilder
     private $searchCriteriaApplicator;
 
     /**
-     * @var int
-     */
-    private $contextLangId;
-
-    /**
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
@@ -56,12 +51,11 @@ final class ManufacturerAddressQueryBuilder extends AbstractDoctrineQueryBuilder
         Connection $connection,
         $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
-        LanguageContext $languageContext
+        private LanguageContext $languageContext
     ) {
         parent::__construct($connection, $dbPrefix);
 
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
-        $this->contextLangId = $languageContext->getId();
     }
 
     /**
@@ -109,7 +103,7 @@ final class ManufacturerAddressQueryBuilder extends AbstractDoctrineQueryBuilder
                 'cl',
                 'cl.id_country = a.id_country AND cl.id_lang = :lang'
             )
-            ->setParameter('lang', $this->contextLangId)
+            ->setParameter('lang', $this->languageContext->getId())
             ->leftJoin(
                 'a',
                 $this->dbPrefix . 'manufacturer',

--- a/src/Core/Grid/Query/StateQueryBuilder.php
+++ b/src/Core/Grid/Query/StateQueryBuilder.php
@@ -30,6 +30,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Query;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
@@ -51,17 +52,17 @@ class StateQueryBuilder extends AbstractDoctrineQueryBuilder
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
-     * @param int $contextLanguageId
+     * @param LanguageContext $languageContext
      */
     public function __construct(
         Connection $connection,
         string $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
-        int $contextLanguageId
+        LanguageContext $languageContext
     ) {
         parent::__construct($connection, $dbPrefix);
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
-        $this->contextLanguageId = $contextLanguageId;
+        $this->contextLanguageId = $languageContext->getId();
     }
 
     /**

--- a/src/Core/Grid/Query/StateQueryBuilder.php
+++ b/src/Core/Grid/Query/StateQueryBuilder.php
@@ -44,11 +44,6 @@ class StateQueryBuilder extends AbstractDoctrineQueryBuilder
     private $searchCriteriaApplicator;
 
     /**
-     * @var int
-     */
-    private $contextLanguageId;
-
-    /**
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
@@ -58,11 +53,10 @@ class StateQueryBuilder extends AbstractDoctrineQueryBuilder
         Connection $connection,
         string $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
-        LanguageContext $languageContext
+        private LanguageContext $languageContext
     ) {
         parent::__construct($connection, $dbPrefix);
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
-        $this->contextLanguageId = $languageContext->getId();
     }
 
     /**
@@ -135,7 +129,7 @@ class StateQueryBuilder extends AbstractDoctrineQueryBuilder
             's.`id_country` = cl.`id_country` AND cl.`id_lang` = :idLang '
         );
 
-        $qb->setParameter('idLang', $this->contextLanguageId);
+        $qb->setParameter('idLang', $this->languageContext->getId());
         $this->applyFilters($qb, $filters);
 
         return $qb;

--- a/src/Core/Grid/Query/StateQueryBuilder.php
+++ b/src/Core/Grid/Query/StateQueryBuilder.php
@@ -45,23 +45,23 @@ class StateQueryBuilder extends AbstractDoctrineQueryBuilder
     /**
      * @var int
      */
-    private $employeeIdLang;
+    private $contextLanguageId;
 
     /**
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
-     * @param int $employeeIdLang
+     * @param int $contextLanguageId
      */
     public function __construct(
         Connection $connection,
         string $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
-        int $employeeIdLang
+        int $contextLanguageId
     ) {
         parent::__construct($connection, $dbPrefix);
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
-        $this->employeeIdLang = $employeeIdLang;
+        $this->contextLanguageId = $contextLanguageId;
     }
 
     /**
@@ -134,7 +134,7 @@ class StateQueryBuilder extends AbstractDoctrineQueryBuilder
             's.`id_country` = cl.`id_country` AND cl.`id_lang` = :idLang '
         );
 
-        $qb->setParameter('idLang', $this->employeeIdLang);
+        $qb->setParameter('idLang', $this->contextLanguageId);
         $this->applyFilters($qb, $filters);
 
         return $qb;

--- a/src/Core/Grid/Query/TaxQueryBuilder.php
+++ b/src/Core/Grid/Query/TaxQueryBuilder.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Query;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
@@ -43,24 +44,24 @@ final class TaxQueryBuilder extends AbstractDoctrineQueryBuilder
     /**
      * @var int
      */
-    private $employeeIdLang;
+    private $contextLanguageId;
 
     /**
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
-     * @param int $employeeIdLang
+     * @param LanguageContext $languageContext
      */
     public function __construct(
         Connection $connection,
         $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
-        $employeeIdLang
+        LanguageContext $languageContext
     ) {
         parent::__construct($connection, $dbPrefix);
 
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
-        $this->employeeIdLang = $employeeIdLang;
+        $this->contextLanguageId = $languageContext->getId();
     }
 
     /**
@@ -115,7 +116,7 @@ final class TaxQueryBuilder extends AbstractDoctrineQueryBuilder
         $qb->andWhere('tl.`id_lang` = :employee_id_lang');
         $qb->andWhere('t.`deleted` = 0');
 
-        $qb->setParameter('employee_id_lang', $this->employeeIdLang);
+        $qb->setParameter('employee_id_lang', $this->contextLanguageId);
         $this->applyFilters($qb, $filters);
 
         return $qb;

--- a/src/Core/Grid/Query/TaxQueryBuilder.php
+++ b/src/Core/Grid/Query/TaxQueryBuilder.php
@@ -42,11 +42,6 @@ final class TaxQueryBuilder extends AbstractDoctrineQueryBuilder
     private $searchCriteriaApplicator;
 
     /**
-     * @var int
-     */
-    private $contextLanguageId;
-
-    /**
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
@@ -56,12 +51,11 @@ final class TaxQueryBuilder extends AbstractDoctrineQueryBuilder
         Connection $connection,
         $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
-        LanguageContext $languageContext
+        private LanguageContext $languageContext
     ) {
         parent::__construct($connection, $dbPrefix);
 
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
-        $this->contextLanguageId = $languageContext->getId();
     }
 
     /**
@@ -116,7 +110,7 @@ final class TaxQueryBuilder extends AbstractDoctrineQueryBuilder
         $qb->andWhere('tl.`id_lang` = :employee_id_lang');
         $qb->andWhere('t.`deleted` = 0');
 
-        $qb->setParameter('employee_id_lang', $this->contextLanguageId);
+        $qb->setParameter('employee_id_lang', $this->languageContext->getId());
         $this->applyFilters($qb, $filters);
 
         return $qb;

--- a/src/Core/Grid/Query/TaxRuleQueryBuilder.php
+++ b/src/Core/Grid/Query/TaxRuleQueryBuilder.php
@@ -30,6 +30,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Query;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
@@ -51,18 +52,18 @@ class TaxRuleQueryBuilder extends AbstractDoctrineQueryBuilder
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
-     * @param int $contextLanguageId
+     * @param LanguageContext $languageContext
      */
     public function __construct(
         Connection $connection,
         $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
-        int $contextLanguageId
+        LanguageContext $languageContext
     ) {
         parent::__construct($connection, $dbPrefix);
 
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
-        $this->contextLanguageId = $contextLanguageId;
+        $this->contextLanguageId = $languageContext->getId();
     }
 
     /**

--- a/src/Core/Grid/Query/TaxRuleQueryBuilder.php
+++ b/src/Core/Grid/Query/TaxRuleQueryBuilder.php
@@ -39,11 +39,6 @@ use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 class TaxRuleQueryBuilder extends AbstractDoctrineQueryBuilder
 {
     /**
-     * @var int
-     */
-    private $contextLanguageId;
-
-    /**
      * @var DoctrineSearchCriteriaApplicatorInterface
      */
     private $searchCriteriaApplicator;
@@ -58,12 +53,11 @@ class TaxRuleQueryBuilder extends AbstractDoctrineQueryBuilder
         Connection $connection,
         $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
-        LanguageContext $languageContext
+        private LanguageContext $languageContext
     ) {
         parent::__construct($connection, $dbPrefix);
 
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
-        $this->contextLanguageId = $languageContext->getId();
     }
 
     /**
@@ -143,7 +137,7 @@ class TaxRuleQueryBuilder extends AbstractDoctrineQueryBuilder
                 'tr.`id_tax` = t.`id_tax`'
             )
             ->andWhere('tr.`id_tax_rules_group` = :idTaxRulesGroup')
-            ->setParameter('idLang', $this->contextLanguageId)
+            ->setParameter('idLang', $this->languageContext->getId())
             ->setParameter('idTaxRulesGroup', $filters['taxRulesGroupId']);
     }
 }

--- a/src/Core/Grid/Query/TaxRuleQueryBuilder.php
+++ b/src/Core/Grid/Query/TaxRuleQueryBuilder.php
@@ -40,7 +40,7 @@ class TaxRuleQueryBuilder extends AbstractDoctrineQueryBuilder
     /**
      * @var int
      */
-    private $employeeIdLang;
+    private $contextLanguageId;
 
     /**
      * @var DoctrineSearchCriteriaApplicatorInterface
@@ -51,18 +51,18 @@ class TaxRuleQueryBuilder extends AbstractDoctrineQueryBuilder
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
-     * @param int $employeeIdLang
+     * @param int $contextLanguageId
      */
     public function __construct(
         Connection $connection,
         $dbPrefix,
         DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
-        int $employeeIdLang
+        int $contextLanguageId
     ) {
         parent::__construct($connection, $dbPrefix);
 
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
-        $this->employeeIdLang = $employeeIdLang;
+        $this->contextLanguageId = $contextLanguageId;
     }
 
     /**
@@ -142,7 +142,7 @@ class TaxRuleQueryBuilder extends AbstractDoctrineQueryBuilder
                 'tr.`id_tax` = t.`id_tax`'
             )
             ->andWhere('tr.`id_tax_rules_group` = :idTaxRulesGroup')
-            ->setParameter('idLang', $this->employeeIdLang)
+            ->setParameter('idLang', $this->contextLanguageId)
             ->setParameter('idTaxRulesGroup', $filters['taxRulesGroupId']);
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -179,7 +179,7 @@ services:
     parent: 'prestashop.core.grid.abstract_query_builder'
     arguments:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
-      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
+      - "@=service('prestashop.default.language.context')"
     public: true
 
   prestashop.core.grid.query_builder.manufacturer:
@@ -195,7 +195,7 @@ services:
     parent: 'prestashop.core.grid.abstract_query_builder'
     arguments:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
-      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
+      - "@=service('prestashop.default.language.context')"
     public: true
 
   prestashop.core.grid.query_builder.category:
@@ -318,7 +318,7 @@ services:
     parent: 'prestashop.core.grid.abstract_query_builder'
     arguments:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
-      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
+      - "@=service('prestashop.default.language.context')"
     public: true
 
   prestashop.core.grid.query_builder.attribute:
@@ -474,7 +474,7 @@ services:
     public: true
     arguments:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
-      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
+      - "@=service('prestashop.default.language.context')"
 
   prestashop.core.grid.query.builder.title:
     class: 'PrestaShop\PrestaShop\Core\Grid\Query\TitleQueryBuilder'
@@ -511,7 +511,7 @@ services:
     parent: 'prestashop.core.grid.abstract_query_builder'
     arguments:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
-      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
+      - "@=service('prestashop.default.language.context')"
     public: false
 
   PrestaShop\PrestaShop\Core\Grid\Query\AliasQueryBuilder:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -177,10 +177,8 @@ services:
   prestashop.core.grid.query_builder.tax:
     class: 'PrestaShop\PrestaShop\Core\Grid\Query\TaxQueryBuilder'
     parent: 'prestashop.core.grid.abstract_query_builder'
-    arguments:
-      - '@prestashop.core.query.doctrine_search_criteria_applicator'
-      - "@=service('prestashop.default.language.context')"
     public: true
+    autowire: true
 
   prestashop.core.grid.query_builder.manufacturer:
     class: 'PrestaShop\PrestaShop\Core\Grid\Query\ManufacturerQueryBuilder'
@@ -193,10 +191,8 @@ services:
   prestashop.core.grid.query_builder.manufacturer_address:
     class: 'PrestaShop\PrestaShop\Core\Grid\Query\ManufacturerAddressQueryBuilder'
     parent: 'prestashop.core.grid.abstract_query_builder'
-    arguments:
-      - '@prestashop.core.query.doctrine_search_criteria_applicator'
-      - "@=service('prestashop.default.language.context')"
     public: true
+    autowire: true
 
   prestashop.core.grid.query_builder.category:
     class: 'PrestaShop\PrestaShop\Core\Grid\Query\CategoryQueryBuilder'
@@ -316,10 +312,8 @@ services:
   prestashop.core.grid.query_builder.attachment:
     class: 'PrestaShop\PrestaShop\Core\Grid\Query\AttachmentQueryBuilder'
     parent: 'prestashop.core.grid.abstract_query_builder'
-    arguments:
-      - '@prestashop.core.query.doctrine_search_criteria_applicator'
-      - "@=service('prestashop.default.language.context')"
     public: true
+    autowire: true
 
   prestashop.core.grid.query_builder.attribute:
     class: 'PrestaShop\PrestaShop\Core\Grid\Query\AttributeQueryBuilder'
@@ -472,9 +466,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Grid\Query\StateQueryBuilder'
     parent: 'prestashop.core.grid.abstract_query_builder'
     public: true
-    arguments:
-      - '@prestashop.core.query.doctrine_search_criteria_applicator'
-      - "@=service('prestashop.default.language.context')"
+    autowire: true
 
   prestashop.core.grid.query.builder.title:
     class: 'PrestaShop\PrestaShop\Core\Grid\Query\TitleQueryBuilder'
@@ -509,10 +501,8 @@ services:
 
   PrestaShop\PrestaShop\Core\Grid\Query\TaxRuleQueryBuilder:
     parent: 'prestashop.core.grid.abstract_query_builder'
-    arguments:
-      - '@prestashop.core.query.doctrine_search_criteria_applicator'
-      - "@=service('prestashop.default.language.context')"
     public: false
+    autowire: true
 
   PrestaShop\PrestaShop\Core\Grid\Query\AliasQueryBuilder:
     parent: 'prestashop.core.grid.abstract_query_builder'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -179,7 +179,7 @@ services:
     parent: 'prestashop.core.grid.abstract_query_builder'
     arguments:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
-      - "@=service('prestashop.adapter.legacy.context').getContext().employee.id_lang"
+      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
     public: true
 
   prestashop.core.grid.query_builder.manufacturer:
@@ -195,7 +195,7 @@ services:
     parent: 'prestashop.core.grid.abstract_query_builder'
     arguments:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
-      - "@=service('prestashop.adapter.legacy.context').getContext().employee.id_lang"
+      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
     public: true
 
   prestashop.core.grid.query_builder.category:
@@ -318,7 +318,7 @@ services:
     parent: 'prestashop.core.grid.abstract_query_builder'
     arguments:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
-      - "@=service('prestashop.adapter.legacy.context').getContext().employee.id_lang"
+      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
     public: true
 
   prestashop.core.grid.query_builder.attribute:
@@ -474,7 +474,7 @@ services:
     public: true
     arguments:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
-      - "@=service('prestashop.adapter.legacy.context').getContext().employee.id_lang"
+      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
 
   prestashop.core.grid.query.builder.title:
     class: 'PrestaShop\PrestaShop\Core\Grid\Query\TitleQueryBuilder'
@@ -511,7 +511,7 @@ services:
     parent: 'prestashop.core.grid.abstract_query_builder'
     arguments:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
-      - "@=service('prestashop.adapter.legacy.context').getContext().employee.id_lang"
+      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
     public: false
 
   PrestaShop\PrestaShop\Core\Grid\Query\AliasQueryBuilder:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -376,7 +376,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\AttachmentGridDataFactoryDecorator'
     arguments:
       - '@prestashop.core.grid.data_factory.attachment'
-      - "@=service('prestashop.adapter.legacy.context').getContext().employee.id_lang"
+      - '@PrestaShop\PrestaShop\Core\Context\LanguageContext'
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
       - '@PrestaShop\PrestaShop\Core\Util\File\FileSizeConverter'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x 
| Description?      | This PR fixes an issue in `src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml` where the grid query builder was using the employee language (employee.id_lang) instead of the context language (language.id). The problem occurs when using the API (e.g. [ps_apiresources#82](https://github.com/PrestaShop/ps_apiresources/pull/82), since in API context there is no logged employee, which leads to errors.
| Type?            | bug fix 
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install the module: [pr39669.zip](https://github.com/user-attachments/files/23182395/pr39669.zip) - 2. Make sure you have some files uploaded in Catalog > Files - 3. Go to Catalog > Files - you should be able to see the uploaded files - 4. Go to International > Taxes - you should be able to see the taxes.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/19236289511
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/ps_apiresources/pull/82
| Sponsor company   | @Codencode 
