### PR TITLE
Remove feature choices count check so that it always display the input to add custom values on product page in BO

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureValueController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureValueController.php
@@ -287,12 +287,12 @@ class FeatureValueController extends PrestaShopAdminController
         $featuresChoices = $featureValuesChoiceProvider->getChoices(['feature_id' => $featureId, 'custom' => false]);
 
         $data = [];
-        if (count($featuresChoices) !== 0) {
-            $data[] = [
-                'id' => 0,
-                'value' => $this->trans('Choose a value', [], 'Admin.Catalog.Feature'),
-            ];
-        }
+
+        // We add this choice no matter what otherwise the feature select on the product page even if you don't have feature values yet
+        $data[] = [
+            'id' => 0,
+            'value' => $this->trans('Choose a value', [], 'Admin.Catalog.Feature'),
+        ];
 
         foreach ($featuresChoices as $featureName => $featureId) {
             $data[] = [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Remove feature choices count check so that it always display the input to add custom values on product page in BO
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Do the same as the video @florine2623 recorded in issue #37285 <br><br>1. Go to BO > Catalog > Attributes & Features > Tab Feature<br>2. Add a new feature "preston"<br>3. Go to BO > Catalog > Products > Edit any product<br>4. Add the feature "preston"<br>5. See that the field is not greyed anymore and you can add a customized value even if no predefined values were added
| Fixed issue or discussion?     | Fixes #37285
| Sponsor company   | Agence Off
