### PR TITLE
Fix log level create test db for `9.0.x`

### DIFF
--- a/tests/bin/create-test-db.php
+++ b/tests/bin/create-test-db.php
@@ -50,7 +50,7 @@ const _PS_ALL_THEMES_DIR_ = _PS_ROOT_DIR_ . '/tests/Resources/themes/';
 require_once _PS_ROOT_DIR_ . '/install-dev/init.php';
 
 $output = new ConsoleOutput();
-$logger = new SymfonyConsoleLogger($output, SymfonyConsoleLogger::INFO);
+$logger = new SymfonyConsoleLogger($output, SymfonyConsoleLogger::DEBUG);
 
 $translator = Context::getContext()->getTranslatorFromLocale('en');
 $install = new Install(null, null, $logger);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fix log level for create-test-db: INFO => DEBUG for `9.0.x` (cherry-pick from https://github.com/PrestaShop/PrestaShop/pull/39670)
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. run `composer run create-test-db`
| UI Tests          | ~
| Fixed issue or discussion?     | ~
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/39442/
| Sponsor company   | PrestaShop SA

**Before this PR**
<img width="657" height="70" alt="Capture d’écran 2025-10-01 à 17 48 03" src="https://github.com/user-attachments/assets/2f6795aa-7d98-4acd-928c-1ac45e09eae2" />
(But in final, its working, we have the database correctly installed in dbms server)

**After this PR**
<img width="700" height="394" alt="Capture d’écran 2025-10-01 à 17 48 08" src="https://github.com/user-attachments/assets/84657829-c1a9-4d83-86d3-f903036c6b63" />
(we have more info to really know what is going on!)

**note: it's totally normal to have a fail when installing ganalytics module**