### PR TITLE
fix #38808: Make international language locale field editable

### DIFF
--- a/src/Adapter/Language/CommandHandler/AddLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/AddLanguageHandler.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageConstraintExcep
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageException;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\IsoCode;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\Locale;
 
 /**
  * Handles command which adds new language using legacy object model
@@ -67,6 +68,7 @@ final class AddLanguageHandler extends AbstractLanguageHandler implements AddLan
     public function handle(AddLanguageCommand $command)
     {
         $this->assertLanguageWithIsoCodeDoesNotExist($command->getIsoCode());
+        $this->assertLanguageWithLocaleDoesNotExist($command->getLocale());
         if ($command->getNoPictureImagePath()) {
             $this->imageValidator->assertFileUploadLimits($command->getNoPictureImagePath());
             $this->imageValidator->assertIsValidImageType($command->getNoPictureImagePath());
@@ -103,6 +105,18 @@ final class AddLanguageHandler extends AbstractLanguageHandler implements AddLan
     }
 
     /**
+     * @param Locale $locale
+     *
+     * @throws LanguageConstraintException
+     */
+    private function assertLanguageWithLocaleDoesNotExist(Locale $locale)
+    {
+        if (Language::getIdByLocale($locale->getValue())) {
+            throw new LanguageConstraintException(sprintf('Language with Locale "%s" already exists', $locale->getValue()), LanguageConstraintException::DUPLICATE_LOCALE);
+        }
+    }
+
+    /**
      * Add language and shop association
      *
      * @param Language $language
@@ -126,9 +140,7 @@ final class AddLanguageHandler extends AbstractLanguageHandler implements AddLan
         $language = new Language();
         $language->name = $command->getName();
         $language->iso_code = $command->getIsoCode()->getValue();
-        if (false !== ($languageDetails = Language::getLangDetails($command->getIsoCode()->getValue()))) {
-            $language->locale = $languageDetails['locale'];
-        }
+        $language->locale = $command->getLocale()->getValue();
         $language->language_code = $command->getTagIETF()->getValue();
         $language->date_format_lite = $command->getShortDateFormat();
         $language->date_format_full = $command->getFullDateFormat();

--- a/src/Adapter/Language/CommandHandler/EditLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/EditLanguageHandler.php
@@ -74,6 +74,8 @@ final class EditLanguageHandler extends AbstractLanguageHandler implements EditL
         $language = $this->getLegacyLanguageObject($command->getLanguageId());
 
         $this->assertLanguageWithIsoCodeDoesNotExist($language, $command);
+        $this->assertLanguageWithLocaleDoesNotExist($language, $command);
+
         $this->assertDefaultLanguageIsNotDisabled($command);
 
         $this->updateEmployeeLanguage($command);
@@ -106,6 +108,10 @@ final class EditLanguageHandler extends AbstractLanguageHandler implements EditL
 
         if (null !== $command->getTagIETF()) {
             $language->language_code = $command->getTagIETF()->getValue();
+        }
+
+        if (null !== $command->getLocale()) {
+            $language->locale = $command->getLocale()->getValue();
         }
 
         if (null !== $command->getShortDateFormat()) {
@@ -255,6 +261,23 @@ final class EditLanguageHandler extends AbstractLanguageHandler implements EditL
 
         if ($language->iso_code !== $command->getIsoCode()->getValue() && Language::getIdByIso($command->getIsoCode()->getValue())) {
             throw new LanguageConstraintException(sprintf('Language with ISO code "%s" already exists', $command->getIsoCode()->getValue()), LanguageConstraintException::DUPLICATE_ISO_CODE);
+        }
+    }
+
+    /**
+     * Assert that language with updated Locale does not exist
+     *
+     * @param Language $language
+     * @param EditLanguageCommand $command
+     */
+    private function assertLanguageWithLocaleDoesNotExist(Language $language, EditLanguageCommand $command)
+    {
+        if (null === $command->getLocale()) {
+            return;
+        }
+
+        if ($language->locale !== $command->getLocale()->getValue() && Language::getIdByLocale($command->getLocale()->getValue())) {
+            throw new LanguageConstraintException(sprintf('Language with Locale "%s" already exists', $command->getLocale()->getValue()), LanguageConstraintException::DUPLICATE_LOCALE);
         }
     }
 }

--- a/src/Core/ConstraintValidator/Constraints/TypedRegex.php
+++ b/src/Core/ConstraintValidator/Constraints/TypedRegex.php
@@ -49,6 +49,7 @@ class TypedRegex extends Constraint
     public const TYPE_MESSAGE = 'message';
     public const TYPE_LANGUAGE_ISO_CODE = 'language_iso_code';
     public const TYPE_LANGUAGE_CODE = 'language_code';
+    public const TYPE_LOCALE = 'language_locale';
     public const TYPE_CURRENCY_ISO_CODE = 'currency_iso_code';
     public const TYPE_FILE_NAME = 'file_name';
     public const TYPE_DNI_LITE = 'dni_lite';

--- a/src/Core/ConstraintValidator/TypedRegexValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexValidator.php
@@ -134,6 +134,8 @@ class TypedRegexValidator extends ConstraintValidator
                 return IsoCode::PATTERN;
             case TypedRegex::TYPE_LANGUAGE_CODE:
                 return '/^[a-zA-Z]{2}(-[a-zA-Z]{2})?$/';
+            case TypedRegex::TYPE_LOCALE:
+                return '/^[a-z]{2}-[A-Z]{2}$/';
             case TypedRegex::TYPE_CURRENCY_ISO_CODE:
                 return AlphaIsoCode::PATTERN;
             case TypedRegex::TYPE_FILE_NAME:

--- a/src/Core/Domain/Language/Command/AddLanguageCommand.php
+++ b/src/Core/Domain/Language/Command/AddLanguageCommand.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Domain\Language\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\IsoCode;
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\Locale;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\TagIETF;
 
 /**
@@ -48,6 +49,11 @@ class AddLanguageCommand
      * @var TagIETF IETF language tag, e.g. en-US
      */
     private $tagIETF;
+
+    /**
+     * @var Locale IETF language tag, e.g. en-US
+     */
+    private $locale;
 
     /**
      * @var string
@@ -90,6 +96,7 @@ class AddLanguageCommand
      * @param string $name
      * @param string $isoCode
      * @param string $tagIETF
+     * @param string $locale
      * @param string $shortDateFormat
      * @param string $fullDateFormat
      * @param string $flagImagePath
@@ -102,6 +109,7 @@ class AddLanguageCommand
         $name,
         $isoCode,
         $tagIETF,
+        $locale,
         $shortDateFormat,
         $fullDateFormat,
         $flagImagePath,
@@ -113,6 +121,7 @@ class AddLanguageCommand
         $this->name = $name;
         $this->isoCode = new IsoCode($isoCode);
         $this->tagIETF = new TagIETF($tagIETF);
+        $this->locale = new Locale($locale);
         $this->shortDateFormat = $shortDateFormat;
         $this->fullDateFormat = $fullDateFormat;
         $this->flagImagePath = $flagImagePath;
@@ -144,6 +153,14 @@ class AddLanguageCommand
     public function getTagIETF()
     {
         return $this->tagIETF;
+    }
+
+    /**
+     * @return Locale
+     */
+    public function getLocale()
+    {
+        return $this->locale;
     }
 
     /**

--- a/src/Core/Domain/Language/Command/EditLanguageCommand.php
+++ b/src/Core/Domain/Language/Command/EditLanguageCommand.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Language\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\IsoCode;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\Locale;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\TagIETF;
 
 /**
@@ -54,6 +55,11 @@ class EditLanguageCommand
      * @var TagIETF|null
      */
     private $tagIETF;
+
+    /**
+     * @var Locale|null
+     */
+    private $locale;
 
     /**
      * @var string|null
@@ -174,6 +180,26 @@ class EditLanguageCommand
     public function setTagIETF($tagIETF)
     {
         $this->tagIETF = new TagIETF($tagIETF);
+
+        return $this;
+    }
+
+    /**
+     * @return Locale|null
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * @param string $locale
+     *
+     * @return self
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = new Locale($locale);
 
         return $this;
     }

--- a/src/Core/Domain/Language/ValueObject/Locale.php
+++ b/src/Core/Domain/Language/ValueObject/Locale.php
@@ -24,40 +24,54 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShop\PrestaShop\Core\Domain\Language\Exception;
+namespace PrestaShop\PrestaShop\Core\Domain\Language\ValueObject;
+
+use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageConstraintException;
 
 /**
- * Is thrown when invalid data is supplied for language
+ * Stores Locale tag value (e.g. en-US)
  */
-class LanguageConstraintException extends LanguageException
+class Locale
 {
     /**
-     * @var int Code is used when invalid language IETF tag is encountered
+     * Regexp to validate Locale
      */
-    public const INVALID_IETF_TAG = 1;
+    public const LOCALE_REGEXP = '^[a-z]{2}-[A-Z]{2}$';
 
     /**
-     * @var int Code is used when invalid language ISO code in encountered
+     * @var string
      */
-    public const INVALID_ISO_CODE = 2;
+    private $locale;
 
     /**
-     * @var int Code is used when duplicate language ISO code in encountered when creating new language
+     * @param string $locale
+     *
+     * @throws LanguageConstraintException
      */
-    public const DUPLICATE_ISO_CODE = 3;
+    public function __construct($locale)
+    {
+        $this->assertIsLocale($locale);
+
+        $this->locale = $locale;
+    }
 
     /**
-     * @var int Code is used when empty data is used when deleting languages
+     * @return string
      */
-    public const EMPTY_BULK_DELETE = 4;
+    public function getValue()
+    {
+        return $this->locale;
+    }
 
     /**
-     * @var int Code is used when invalid language locale is encountered
+     * @param string $locale
+     *
+     * @throws LanguageConstraintException
      */
-    public const INVALID_LOCALE = 5;
-
-    /**
-     * @var int Code is used when duplicate language Locale in encountered when creating new language
-     */
-    public const DUPLICATE_LOCALE = 6;
+    private function assertIsLocale($locale)
+    {
+        if (!is_string($locale) || empty($locale) || !preg_match(sprintf('/%s/', static::LOCALE_REGEXP), $locale)) {
+            throw new LanguageConstraintException(sprintf('Invalid Locale %s provided', var_export($locale, true)), LanguageConstraintException::INVALID_LOCALE);
+        }
+    }
 }

--- a/src/Core/Form/IdentifiableObject/DataHandler/LanguageFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/LanguageFormDataHandler.php
@@ -69,6 +69,7 @@ final class LanguageFormDataHandler implements FormDataHandlerInterface
             $data['name'],
             $data['iso_code'],
             $data['tag_ietf'],
+            $data['locale'],
             $data['short_date_format'],
             $data['full_date_format'],
             $uploadedFlagImage->getPathname(),
@@ -90,6 +91,7 @@ final class LanguageFormDataHandler implements FormDataHandlerInterface
             ->setName((string) $data['name'])
             ->setIsoCode((string) $data['iso_code'])
             ->setTagIETF((string) $data['tag_ietf'])
+            ->setLocale((string) $data['locale'])
             ->setShortDateFormat((string) $data['short_date_format'])
             ->setFullDateFormat((string) $data['full_date_format'])
             ->setIsRtl($data['is_rtl'])

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
@@ -380,8 +380,18 @@ class LanguageController extends PrestaShopAdminController
                     [sprintf('"%s"', $this->trans('Language code', [], 'Admin.International.Feature'))],
                     'Admin.Notifications.Error'
                 ),
+                LanguageConstraintException::INVALID_LOCALE => $this->trans(
+                    'The %s field is invalid.',
+                    [sprintf('"%s"', $this->trans('Locale', [], 'Admin.International.Feature'))],
+                    'Admin.Notifications.Error'
+                ),
                 LanguageConstraintException::DUPLICATE_ISO_CODE => $this->trans(
                     'This ISO code is already linked to another language.',
+                    [],
+                    'Admin.International.Notification'
+                ),
+                LanguageConstraintException::DUPLICATE_LOCALE => $this->trans(
+                    'This Locale is already linked to another language.',
                     [],
                     'Admin.International.Notification'
                 ),

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
@@ -29,7 +29,6 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Language;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use PrestaShopBundle\Form\Admin\Type\TextPreviewType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
@@ -125,7 +125,7 @@ class LanguageType extends TranslatorAwareType
                         'message' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
                     ]),
                     new TypedRegex([
-                        'type' => 'language_locale'
+                        'type' => 'language_locale',
                     ]),
                 ],
             ])

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
@@ -124,9 +124,8 @@ class LanguageType extends TranslatorAwareType
                     new NotBlank([
                         'message' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
                     ]),
-                    new Regex([
-                        'pattern' => '/^[a-z]{2}-[A-Z]{2}$/',
-                        'message' => $this->trans('This field is invalid.', 'Admin.Notifications.Error'),
+                    new TypedRegex([
+                        'type' => 'language_locale'
                     ]),
                 ],
             ])

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
@@ -115,9 +115,21 @@ class LanguageType extends TranslatorAwareType
                     ]),
                 ],
             ])
-            ->add('locale', TextPreviewType::class, [
+            ->add('locale', TextType::class, [
+                'attr' => [
+                    'maxLength' => 5,
+                ],
                 'label' => $this->trans('Locale', 'Admin.International.Feature'),
                 'help' => $this->trans('IETF language tag (e.g. en-US, pt-BR).', 'Admin.International.Help'),
+                'constraints' => [
+                    new NotBlank([
+                        'message' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
+                    ]),
+                    new Regex([
+                        'pattern' => '/^[a-z]{2}-[A-Z]{2}$/',
+                        'message' => $this->trans('This field is invalid.', 'Admin.Notifications.Error'),
+                    ]),
+                ],
             ])
             ->add('short_date_format', TextType::class, [
                 'label' => $this->trans('Date format', 'Admin.International.Feature'),

--- a/tests/Integration/Behaviour/Features/Context/Domain/LanguageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/LanguageFeatureContext.php
@@ -321,7 +321,7 @@ class LanguageFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then I should get an error that a language with this ISO code already exists
+     * @Then I should get an error that a language with this Locale already exists
      */
     public function checkDuplicateLocale(): void
     {

--- a/tests/Integration/Behaviour/Features/Context/Domain/LanguageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/LanguageFeatureContext.php
@@ -74,6 +74,7 @@ class LanguageFeatureContext extends AbstractDomainFeatureContext
                 $data['name'],
                 $data['isoCode'],
                 $data['tagIETF'],
+                $data['locale'],
                 $data['shortDateFormat'],
                 $data['fullDateFormat'],
                 _PS_TMP_IMG_DIR_ . $data['isoCode'] . '.jpg',
@@ -109,6 +110,9 @@ class LanguageFeatureContext extends AbstractDomainFeatureContext
         }
         if (isset($data['tagIETF'])) {
             $editableLanguage->setTagIETF($data['tagIETF']);
+        }
+        if (isset($data['locale'])) {
+            $editableLanguage->setLocale($data['locale']);
         }
         if (isset($data['shortDateFormat'])) {
             $editableLanguage->setShortDateFormat($data['shortDateFormat']);
@@ -313,6 +317,17 @@ class LanguageFeatureContext extends AbstractDomainFeatureContext
         $this->assertLastErrorIs(
             LanguageConstraintException::class,
             LanguageConstraintException::DUPLICATE_ISO_CODE
+        );
+    }
+
+    /**
+     * @Then I should get an error that a language with this ISO code already exists
+     */
+    public function checkDuplicateLocale(): void
+    {
+        $this->assertLastErrorIs(
+            LanguageConstraintException::class,
+            LanguageConstraintException::DUPLICATE_LOCALE
         );
     }
 

--- a/tests/Integration/Behaviour/Features/Scenario/Language/language.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Language/language.feature
@@ -206,8 +206,8 @@ Feature: Language
     # Adding new language with Locale already existing is forbidden
     And I add a new language "french2" with the following details:
       | name            | Français (French) |
-      | isoCode         | fr                |
-      | tagIETF         | fr                |
+      | isoCode         | ca                |
+      | tagIETF         | ca                |
       | locale          | fr-FR             |
       | shortDateFormat | d/m/Y             |
       | fullDateFormat  | d/m/Y H:i:s       |

--- a/tests/Integration/Behaviour/Features/Scenario/Language/language.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Language/language.feature
@@ -207,7 +207,7 @@ Feature: Language
     And I add a new language "french2" with the following details:
       | name            | Français (French) |
       | isoCode         | ca                |
-      | tagIETF         | ca                |
+      | tagIETF         | ca-ES             |
       | locale          | fr-FR             |
       | shortDateFormat | d/m/Y             |
       | fullDateFormat  | d/m/Y H:i:s       |

--- a/tests/Integration/Behaviour/Features/Scenario/Language/language.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Language/language.feature
@@ -9,6 +9,7 @@ Feature: Language
       | name            | Français (French) |
       | isoCode         | fr                |
       | tagIETF         | fr                |
+      | locale          | fr-FR             |
       | shortDateFormat | d/m/Y             |
       | fullDateFormat  | d/m/Y H:i:s       |
       | isRtl           | 0                 |
@@ -29,6 +30,7 @@ Feature: Language
       | name            | English GB (English) |
       | isoCode         | gb                   |
       | tagIETF         | en-gb                |
+      | locale          | en-GB                |
       | shortDateFormat | Y-m-d                |
       | fullDateFormat  | Y-m-d H:i:s          |
       | isRtl           | 0                    |
@@ -54,6 +56,7 @@ Feature: Language
       | name            | Español AR (Spanish) |
       | isoCode         | ag                   |
       | tagIETF         | es-ar                |
+      | locale          | es-AR                |
       | shortDateFormat | Y-m-d                |
       | fullDateFormat  | Y-m-d H:i:s          |
       | isRtl           | 0                    |
@@ -78,6 +81,7 @@ Feature: Language
     When I update the language "french" with the following details:
       | name            | Language    |
       | tagIETF         | it          |
+      | locale          | fr-FR       |
       | shortDateFormat | Y-m-d       |
       | fullDateFormat  | Y-m-d H:i:s |
       | isRtl           | 0           |
@@ -185,6 +189,7 @@ Feature: Language
       | name            | Français (French) |
       | isoCode         | fr                |
       | tagIETF         | fr                |
+      | locale          | fr-fr             |
       | shortDateFormat | d/m/Y             |
       | fullDateFormat  | d/m/Y H:i:s       |
       | isRtl           | 0                 |
@@ -196,3 +201,22 @@ Feature: Language
       | name    | Language |
       | isoCode | gb       |
     Then I should get an error that a language with this ISO code already exists
+
+  Scenario: Adding a language with a Locale already in database is forbidden
+    # Adding new language with Locale already existing is forbidden
+    And I add a new language "french2" with the following details:
+      | name            | Français (French) |
+      | isoCode         | fr                |
+      | tagIETF         | fr                |
+      | locale          | fr-FR             |
+      | shortDateFormat | d/m/Y             |
+      | fullDateFormat  | d/m/Y H:i:s       |
+      | isRtl           | 0                 |
+      | isActive        | 1                 |
+      | shop            | shop1             |
+    Then I should get an error that a language with this Locale already exists
+    # Updating a language with Locale already existing is also forbidden
+    When I update the language "french" with the following details:
+      | name    | Language |
+      | locale  | gb       |
+    Then I should get an error that a language with this Locale already exists

--- a/tests/Integration/Behaviour/Features/Scenario/Language/language.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Language/language.feature
@@ -189,7 +189,7 @@ Feature: Language
       | name            | Français (French) |
       | isoCode         | fr                |
       | tagIETF         | fr                |
-      | locale          | fr-fr             |
+      | locale          | fr-FR             |
       | shortDateFormat | d/m/Y             |
       | fullDateFormat  | d/m/Y H:i:s       |
       | isRtl           | 0                 |
@@ -218,5 +218,5 @@ Feature: Language
     # Updating a language with Locale already existing is also forbidden
     When I update the language "french" with the following details:
       | name    | Language |
-      | locale  | gb       |
+      | locale  | en-GB    |
     Then I should get an error that a language with this Locale already exists

--- a/tests/Integration/Utility/LanguageTrait.php
+++ b/tests/Integration/Utility/LanguageTrait.php
@@ -49,6 +49,7 @@ trait LanguageTrait
             $locale,
             $isoCode,
             $locale,
+            $locale,
             'd/m/Y',
             'd/m/Y H:i:s',
             $tmpFlagImage,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Make language Locale editable
| Type?             | bug fix
| Category?         | BO |
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Edit a Language and Locale should be editable now.
| UI Tests          | Red.
| Fixed issue or discussion?     | Fixes #38808
| Related PRs       | New PR needed for ps_apiresources

