### PR TITLE
Fix: Ensure order status template keeps between saves

### DIFF
--- a/admin-dev/themes/new-theme/js/components/form/translatable-choice.ts
+++ b/admin-dev/themes/new-theme/js/components/form/translatable-choice.ts
@@ -42,6 +42,7 @@ export default class TranslatableChoice {
     );
 
     $('select.translatable_choice_language').trigger('change');
+    $('select.translatable_choice').trigger('change');
   }
 
   filterSelect(event: JQueryEventObject): void {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Ensure Order status template keeps between saves.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | #39709
| UI Tests          | https://github.com/ChillCode/ga.tests.ui.pr/actions/runs/18339657358
| Fixed issue or discussion?  | #39709

