### PR TITLE
Fix discount edition when no cart conditions were defined

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
@@ -107,9 +107,9 @@ class DiscountFormDataProvider implements FormDataProviderInterface
             || !empty($productSegment[DiscountProductSegmentType::FEATURES]['groups'])
         ;
 
-        $selectedCondition = 'none';
-        $selectedCartCondition = 'none';
-        $selectedDeliveryCondition = 'none';
+        $selectedCondition = null;
+        $selectedCartCondition = null;
+        $selectedDeliveryCondition = null;
         if ($discountForEditing->getMinimumProductQuantity()) {
             $selectedCondition = DiscountConditionsType::CART_CONDITIONS;
             $selectedCartCondition = CartConditionsType::MINIMUM_PRODUCT_QUANTITY;
@@ -128,11 +128,6 @@ class DiscountFormDataProvider implements FormDataProviderInterface
         } elseif (!empty($discountForEditing->getCountryIds())) {
             $selectedCondition = DiscountConditionsType::DELIVERY_CONDITIONS;
             $selectedDeliveryCondition = DeliveryConditionsType::COUNTRY;
-            $selectedCondition = 'cart_conditions';
-            $selectedCartCondition = 'specific_products';
-        } elseif (!empty($productSegment['manufacturer']) || !empty($productSegment['category']) || !empty($productSegment['features'])) {
-            $selectedCondition = 'cart_conditions';
-            $selectedCartCondition = 'product_segment';
         }
 
         return [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | When I create a new discount with no cart conditions, this sub form is still displayed 
| Type?             | bug fix 
| Category?         |  BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #39705 
| UI Tests          | https://github.com/nicosomb/ga.tests.ui.pr/actions/runs/18314214222
| Fixed issue or discussion?     | Fixes #39705 
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA