### PR TITLE
BO: Email Layouts : Set table responsive

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/list_mail_theme_layouts.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/list_mail_theme_layouts.html.twig
@@ -32,78 +32,78 @@
     </h3>
 
     <div class="card-body">
+      <div class="table-responsive">
+        <table class="grid-table table">
+          <thead class="thead-default">
+            <tr class="column-headers">
+              <th scope="col">
+                {{ 'Name'|trans({}, 'Admin.Global') }}
+              </th>
+              <th scope="col">
+                {{ 'Module'|trans({}, 'Admin.Global') }}
+              </th>
+              <th scope="col">
+                <div class="grid-actions-header-text">
+                  {{ 'Actions'|trans({}, 'Admin.Global') }}
+                </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for mailLayout in mailTheme.layouts %}
+              <tr>
+                <td class="data-type">
+                  {{ mailLayout.name }}
+                </td>
+                <td class="data-type">
+                  {{ mailLayout.moduleName }}
+                </td>
+                <td class="action-type">
+                  {% if mailLayout.moduleName is empty %}
+                    {% set previewUrl = path('admin_mail_theme_preview_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'html'}) %}
+                    {% set rawUrl = path('admin_mail_theme_raw_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'html'}) %}
+                    {% set txtUrl = path('admin_mail_theme_raw_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'txt'}) %}
+                    {% set mailUrl = path('admin_mail_theme_send_test_mail', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name}) %}
+                  {% else %}
+                    {% set previewUrl = path('admin_mail_theme_preview_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'html'}) %}
+                    {% set rawUrl = path('admin_mail_theme_raw_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'html'}) %}
+                    {% set txtUrl = path('admin_mail_theme_raw_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'txt'}) %}
+                    {% set mailUrl = path('admin_mail_theme_send_test_module_mail', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name}) %}
+                  {% endif %}
 
-      <table class="grid-table table">
-        <thead class="thead-default">
-          <tr class="column-headers">
-            <th scope="col">
-              {{ 'Name'|trans({}, 'Admin.Global') }}
-            </th>
-            <th scope="col">
-              {{ 'Module'|trans({}, 'Admin.Global') }}
-            </th>
-            <th scope="col">
-              <div class="grid-actions-header-text">
-                {{ 'Actions'|trans({}, 'Admin.Global') }}
-              </div>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for mailLayout in mailTheme.layouts %}
-            <tr>
-              <td class="data-type">
-                {{ mailLayout.name }}
-              </td>
-              <td class="data-type">
-                {{ mailLayout.moduleName }}
-              </td>
-              <td class="action-type">
-                {% if mailLayout.moduleName is empty %}
-                  {% set previewUrl = path('admin_mail_theme_preview_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'html'}) %}
-                  {% set rawUrl = path('admin_mail_theme_raw_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'html'}) %}
-                  {% set txtUrl = path('admin_mail_theme_raw_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'txt'}) %}
-                  {% set mailUrl = path('admin_mail_theme_send_test_mail', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name}) %}
-                {% else %}
-                  {% set previewUrl = path('admin_mail_theme_preview_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'html'}) %}
-                  {% set rawUrl = path('admin_mail_theme_raw_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'html'}) %}
-                  {% set txtUrl = path('admin_mail_theme_raw_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'txt'}) %}
-                  {% set mailUrl = path('admin_mail_theme_send_test_module_mail', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name}) %}
-                {% endif %}
+                  <div class="btn-group-action text-right">
+                    <div class="btn-group">
+                      <a target="_blank" class="btn tooltip-link dropdown-item" href="{{ previewUrl }}">
+                        <i class="material-icons">http</i>
+                      </a>
 
-                <div class="btn-group-action text-right">
-                  <div class="btn-group">
-                    <a target="_blank" class="btn tooltip-link dropdown-item" href="{{ previewUrl }}">
-                      <i class="material-icons">http</i>
-                    </a>
-
-                    <a class="btn btn-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split no-rotate"
-                       data-toggle="dropdown"
-                       aria-haspopup="true"
-                       aria-expanded="false">
-                    </a>
-                    <div class="dropdown-menu dropdown-menu-right">
-                      <a target="_blank" class="btn tooltip-link dropdown-item raw-html-link" href="{{ rawUrl }}">
-                        <i class="material-icons">code</i>
-                        {{ 'Raw HTML'|trans({}, 'Admin.Design.Feature') }}
+                      <a class="btn btn-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split no-rotate"
+                        data-toggle="dropdown"
+                        aria-haspopup="true"
+                        aria-expanded="false">
                       </a>
-                      <a target="_blank" class="btn tooltip-link dropdown-item raw-text-link" href="{{ txtUrl }}">
-                        <i class="material-icons">subject</i>
-                        {{ 'Text'|trans({}, 'Admin.Design.Feature') }}
-                      </a>
-                      <a class="btn tooltip-link dropdown-item" href="{{ mailUrl }}">
-                        <i class="material-icons">email</i>
-                        {{ 'Send a test email'|trans({}, 'Admin.Advparameters.Feature') }}
-                      </a>
+                      <div class="dropdown-menu dropdown-menu-right">
+                        <a target="_blank" class="btn tooltip-link dropdown-item raw-html-link" href="{{ rawUrl }}">
+                          <i class="material-icons">code</i>
+                          {{ 'Raw HTML'|trans({}, 'Admin.Design.Feature') }}
+                        </a>
+                        <a target="_blank" class="btn tooltip-link dropdown-item raw-text-link" href="{{ txtUrl }}">
+                          <i class="material-icons">subject</i>
+                          {{ 'Text'|trans({}, 'Admin.Design.Feature') }}
+                        </a>
+                        <a class="btn tooltip-link dropdown-item" href="{{ mailUrl }}">
+                          <i class="material-icons">email</i>
+                          {{ 'Send a test email'|trans({}, 'Admin.Advparameters.Feature') }}
+                        </a>
+                      </div>
                     </div>
                   </div>
-                </div>
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
 
     <div class="card-footer">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | [BO] Email Layouts : Set table responsive
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | :arrow_down: 
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/18343255760
| Fixed issue or discussion?     | Fixes #26634
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

## How to test ?

1. **BO** > **IMPROVE** > **Design** > **Email Theme**
2. Scroll down to **Email themes**
3. Click on the **Loop** of `classic` or `modern`
4. **BEFORE** : The table is not responsive
5. **AFTER** : The table is responsive