### PR TITLE
Feat : Add crop center when regenerate image

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -194,7 +194,8 @@ class ImageManagerCore
         &$targetHeight = null,
         $quality = 5,
         &$sourceWidth = null,
-        &$sourceHeight = null
+        &$sourceHeight = null,
+        $useCenterCrop = false
     ) {
         clearstatcache(true, $sourceFile);
 
@@ -330,6 +331,41 @@ class ImageManagerCore
             imagecopyresized($destImage, $srcImage, (int) (($destinationWidth - $nextWidth) / 2), (int) (($destinationHeight - $nextHeight) / 2), 0, 0, $nextWidth, $nextHeight, $sourceWidth, $sourceHeight);
         } else {
             ImageManager::imagecopyresampled($destImage, $srcImage, (int) (($destinationWidth - $nextWidth) / 2), (int) (($destinationHeight - $nextHeight) / 2), 0, 0, $nextWidth, $nextHeight, $sourceWidth, $sourceHeight, $quality);
+        }
+
+        if ($useCenterCrop) {
+            // Calculate aspect ratios
+            $srcRatio = $sourceWidth / $sourceHeight;
+            $dstRatio = $destinationWidth / $destinationHeight;
+
+            // Determine crop dimensions (centered)
+            if ($srcRatio > $dstRatio) {
+                // Too wide → crop the sides
+                $cropHeight = $sourceHeight;
+                $cropWidth = (int) ($sourceHeight * $dstRatio);
+                $srcX = (int) (($sourceWidth - $cropWidth) / 2);
+                $srcY = 0;
+            } else {
+                // too high → crop at the top and bottom
+                $cropWidth = $sourceWidth;
+                $cropHeight = (int) ($sourceWidth / $dstRatio);
+                $srcX = 0;
+                $srcY = (int) (($sourceHeight - $cropHeight) / 2);
+            }
+
+            ImageManager::imagecopyresampled(
+                $destImage,
+                $srcImage,
+                0,
+                0,
+                $srcX,
+                $srcY,
+                $destinationWidth,
+                $destinationHeight,
+                $cropWidth,
+                $cropHeight,
+                $quality
+            );
         }
         $writeFile = ImageManager::write($destinationFileType, $destImage, $destinationFile);
         Hook::exec('actionOnImageResizeAfter', ['dst_file' => $destinationFile, 'file_type' => $destinationFileType]);

--- a/tests/Unit/Classes/ImageManagerTest.php
+++ b/tests/Unit/Classes/ImageManagerTest.php
@@ -33,6 +33,27 @@ use PHPUnit\Framework\TestCase;
 
 class ImageManagerTest extends TestCase
 {
+    private string $fixturesDir;
+    private string $originalCover;
+    private string $croppedCover;
+
+    protected function setUp(): void
+    {
+        $this->originalCover = 'original.jpg';
+        $this->croppedCover = 'cropped.jpg';
+        $this->fixturesDir = __DIR__ . '/fixtures';
+
+        if (!is_dir($this->fixturesDir)) {
+            mkdir($this->fixturesDir, 0777, true);
+        }
+
+        $url = 'https://picsum.photos/800/600';
+        $testImagePath = $this->fixturesDir . '/' . $this->originalCover;
+
+        $imageData = file_get_contents($url);
+        file_put_contents($testImagePath, $imageData);
+    }
+
     /**
      * @dataProvider dataProviderIsCorrectImageFileExt
      *
@@ -96,4 +117,44 @@ class ImageManagerTest extends TestCase
             ['file', 'image/jpeg'],
         ];
     }
+
+    public function testResizeWithCenterCrop(): void
+    {
+        $src = $this->fixturesDir . '/' . $this->originalCover;
+        $dst = $this->fixturesDir . '/' . $this->croppedCover;
+
+        $error = 0;
+        $targetWidth = '';
+        $targetHeight = '';
+        $sourceWidth = '';
+        $sourceHeight = '';
+
+        $result = ImageManager::resize(
+            $src,
+            $dst,
+            400,
+            400,
+            'jpg',
+            false,
+            $error,
+            $targetWidth,
+            $targetHeight,
+            5,
+            $sourceWidth,
+            $sourceHeight,
+            true
+        );
+
+        self::assertTrue($result);
+        [$w, $h] = getimagesize($dst);
+        self::assertEquals(400, $w);
+        self::assertEquals(400, $h);
+    }
+
+    protected function tearDown(): void
+    {
+        array_map('unlink', glob($this->fixturesDir . '/*'));
+        rmdir($this->fixturesDir);
+    }
+
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Actually regenerate image don't make real crop, but add white space on the side or bottom of the image; I add a new params $useCenterCrop default to false on resize method; If is true then the resize make a center crop to the image; If the PR is validate, next step will be to add a new option on Design / Image that give the choice to the user to crop on center or just leave the classic crop  
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Use ImageManager test or use Image::Resize with true on last params.
| UI Tests          | https://github.com/azralth/ga.tests.ui.pr/actions/runs/18353726608
| Sponsor company   | Lk Interactive.
