### PR TITLE
Backport from PS9: use Tools adapter in modern code and implement missing adapter methods

### DIFF
--- a/src/Adapter/Tools.php
+++ b/src/Adapter/Tools.php
@@ -224,4 +224,24 @@ class Tools
     {
         return LegacyTools::truncateString($text, $length, $options);
     }
+
+    /**
+     * @see LegacyTools::convertBytes()
+     *
+     * @return int|string
+     */
+    public function convertBytes($value)
+    {
+        return LegacyTools::convertBytes($value);
+    }
+
+    /**
+     * @see LegacyTools::getMaxUploadSize()
+     *
+     * @return int max file size in bytes
+     */
+    public function getMaxUploadSize()
+    {
+        return LegacyTools::getMaxUploadSize();
+    }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaDataProvider.php
@@ -28,12 +28,12 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration;
 
+use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
 use PrestaShopBundle\Form\Exception\DataProviderException;
 use PrestaShopBundle\Form\Exception\InvalidConfigurationDataError;
 use PrestaShopBundle\Form\Exception\InvalidConfigurationDataErrorCollection;
-use Tools;
 
 /**
  * This class is responsible of managing the data manipulated using Upload Quota form
@@ -45,11 +45,17 @@ final class UploadQuotaDataProvider implements FormDataProviderInterface
      * @var DataConfigurationInterface
      */
     private $dataConfiguration;
+    /**
+     * @var Tools
+     */
+    private $tools;
 
     public function __construct(
-        DataConfigurationInterface $dataConfiguration
+        DataConfigurationInterface $dataConfiguration,
+        Tools $tools
     ) {
         $this->dataConfiguration = $dataConfiguration;
+        $this->tools = $tools;
     }
 
     /**
@@ -81,7 +87,7 @@ final class UploadQuotaDataProvider implements FormDataProviderInterface
 
         if (isset($data[UploadQuotaType::FIELD_MAX_SIZE_ATTACHED_FILES])) {
             $maxSizeAttachedFile = $data[UploadQuotaType::FIELD_MAX_SIZE_ATTACHED_FILES];
-            if (!is_numeric($maxSizeAttachedFile) || $maxSizeAttachedFile < 0 || Tools::convertBytes($maxSizeAttachedFile . 'm') > Tools::getMaxUploadSize()) {
+            if (!is_numeric($maxSizeAttachedFile) || $maxSizeAttachedFile < 0 || $this->tools->convertBytes($maxSizeAttachedFile . 'm') > $this->tools->getMaxUploadSize()) {
                 $errors->add(new InvalidConfigurationDataError(FormDataProvider::ERROR_MAX_SIZE_ATTACHED_FILES, UploadQuotaType::FIELD_MAX_SIZE_ATTACHED_FILES));
             }
         }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration;
 
+use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -34,7 +35,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Tools;
 
 class UploadQuotaType extends TranslatorAwareType
 {
@@ -46,11 +46,16 @@ class UploadQuotaType extends TranslatorAwareType
      * @var ConfigurationInterface
      */
     private $configuration;
+    /**
+     * @var Tools
+     */
+    private $tools;
 
-    public function __construct(TranslatorInterface $translator, array $locales, ConfigurationInterface $configuration)
+    public function __construct(TranslatorInterface $translator, array $locales, ConfigurationInterface $configuration, Tools $tools)
     {
         parent::__construct($translator, $locales);
         $this->configuration = $configuration;
+        $this->tools = $tools;
     }
 
     /**
@@ -72,7 +77,7 @@ class UploadQuotaType extends TranslatorAwareType
                         'Set the maximum size allowed for attachment files (in megabytes). This value has to be lower than or equal to the maximum file upload allotted by your server (currently: %size% MB).',
                         'Admin.Advparameters.Help',
                         [
-                            '%size%' => round(Tools::getMaxUploadSize() / 1048576)
+                            '%size%' => round($this->tools->getMaxUploadSize() / 1048576)
                         ]
                     ),
                     'unit' => $this->trans('megabytes', 'Admin.Advparameters.Feature'),

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
@@ -112,6 +112,7 @@ services:
     class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\UploadQuotaDataProvider'
     arguments:
       - '@prestashop.adapter.upload_quota.configuration'
+      - '@PrestaShop\PrestaShop\Adapter\Tools'
 
   prestashop.adapter.administration.notifications.form_provider:
     class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\FormDataProvider'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -407,6 +407,7 @@ services:
     parent: 'form.type.translatable.aware'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@PrestaShop\PrestaShop\Adapter\Tools'
     public: true
     tags:
       - { name: form.type }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.2.x
| Description?      | This PR replaces direct calls to the legacy Tools class with the corresponding Tools adapter, ensuring proper dependency injection and better testability. Additionally, two missing methods have been implemented in the Tools adapter to fully cover the functionalities previously used from the legacy class.
| Type?             | refacto
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | https://github.com/Codencode/ga.tests.ui.pr/actions/runs/18489843227
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/38543
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/38549
| Sponsor company   | Codencode snc
