### PR TITLE
add environment variable for php binary path

### DIFF
--- a/src/Adapter/Cache/Clearer/Symfony/ExecKernelCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/Symfony/ExecKernelCacheClearer.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Adapter\Cache\Clearer\Symfony;
 
 use AppKernel;
-use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Cache\Clearer\SafeLoggerTrait;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;

--- a/src/Adapter/Cache/Clearer/Symfony/ExecKernelCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/Symfony/ExecKernelCacheClearer.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Cache\Clearer\Symfony;
 
 use AppKernel;
+use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Cache\Clearer\SafeLoggerTrait;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
@@ -92,7 +93,8 @@ class ExecKernelCacheClearer implements KernelCacheClearerInterface
 
     protected function execCommand(AppKernel $kernel, string $command, string $successMessage, $errorMessage): bool
     {
-        $commandLine = 'php -d memory_limit=-1 ' . $kernel->getProjectDir() . '/bin/console ' . $command;
+        $phpPath = $_ENV['PS_PHP_BIN_PATH'] ?? 'php';
+        $commandLine = $phpPath . ' -d memory_limit=-1 ' . $kernel->getProjectDir() . '/bin/console ' . $command;
         $output = [];
         $result = 0;
         exec($commandLine, $output, $result);

--- a/src/Adapter/Cache/Clearer/Symfony/ExecKernelCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/Symfony/ExecKernelCacheClearer.php
@@ -92,7 +92,7 @@ class ExecKernelCacheClearer implements KernelCacheClearerInterface
 
     protected function execCommand(AppKernel $kernel, string $command, string $successMessage, $errorMessage): bool
     {
-        $phpPath = $_ENV['PS_PHP_BIN_PATH'] ?? 'php';
+        $phpPath = getenv('PS_PHP_BIN_PATH') ?: 'php';
         $commandLine = $phpPath . ' -d memory_limit=-1 ' . $kernel->getProjectDir() . '/bin/console ' . $command;
         $output = [];
         $result = 0;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR adds the possibility to define the PHP Binary Path over environment variables for the ExecKernelCacheClearer.php. This is necessary for PrestaShop to operate correctly in some hosting environments.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set the PS_PHP_BIN_PATH environment variable to change the binary which should be used to run the cache clearer.
