### PR TITLE
Feat: add logic for new display on multishipment for order summary

### DIFF
--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -102,6 +102,10 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
             unset($selectedDeliveryOption['product_list']);
         }
 
+        $productsCarrierMapping = $this->getCheckoutSession()->getProductsByCarrier();
+        $deliveryOptionKeys = array_filter(explode(',', $deliveryOptionKey));
+        $productsCarrierMapping = array_intersect_key($productsCarrierMapping, array_flip($deliveryOptionKeys));
+
         $assignedVars = [
             'is_free' => $isFree,
             'payment_options' => $paymentOptions,
@@ -110,7 +114,7 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
             'selected_delivery_option' => $selectedDeliveryOption,
             'show_final_summary' => Configuration::get('PS_FINAL_SUMMARY_ENABLED'),
             'multishipment_is_enabled' => $this->isMultiShipmentFeatureFlagEnabled,
-            'products_carrier_mapping' => $this->getCheckoutSession()->getProductsByCarrier(),
+            'products_carrier_mapping' => $productsCarrierMapping,
             'is_recyclable_packaging' => $this->getCheckoutSession()->isRecyclable(),
         ];
 

--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -122,11 +122,11 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
         $carriers = [];
         $langId = $this->getCheckoutSession()->getContext()->language->id;
 
-        foreach($carriersId as $id) {
+        foreach ($carriersId as $id) {
             $carrier = new Carrier($id);
             $carriers[$id] = [
                 'name' => $carrier->name,
-                'delay' => $carrier->delay[$langId]
+                'delay' => $carrier->delay[$langId],
             ];
         }
 

--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -110,7 +110,7 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
             'selected_delivery_option' => $selectedDeliveryOption,
             'show_final_summary' => Configuration::get('PS_FINAL_SUMMARY_ENABLED'),
             'multishipment_is_enabled' => $this->isMultiShipmentFeatureFlagEnabled,
-            'selected_carriers' => $this->getCheckoutSession()->getCarriersDetails(),
+            'products_carrier_mapping' => $this->getCheckoutSession()->getProductsByCarrier(),
             'is_recyclable_packaging' => $this->getCheckoutSession()->isRecyclable(),
         ];
 

--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -43,7 +43,7 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
     /**
      * @var bool
      */
-    public $multiShipmentIsEnabled;
+    public $isMultiShipmentFeatureFlagEnabled;
 
     /**
      * @param Context $context
@@ -56,12 +56,12 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
         TranslatorInterface $translator,
         PaymentOptionsFinder $paymentOptionsFinder,
         ConditionsToApproveFinder $conditionsToApproveFinder,
-        bool $multiShipmentIsEnabled,
+        bool $isMultiShipmentFeatureFlagEnabled,
     ) {
         parent::__construct($context, $translator);
         $this->paymentOptionsFinder = $paymentOptionsFinder;
         $this->conditionsToApproveFinder = $conditionsToApproveFinder;
-        $this->multiShipmentIsEnabled = $multiShipmentIsEnabled;
+        $this->isMultiShipmentFeatureFlagEnabled = $isMultiShipmentFeatureFlagEnabled;
     }
 
     public function handleRequest(array $requestParams = [])
@@ -109,27 +109,11 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
             'selected_payment_option' => $this->selected_payment_option,
             'selected_delivery_option' => $selectedDeliveryOption,
             'show_final_summary' => Configuration::get('PS_FINAL_SUMMARY_ENABLED'),
-            'multishipment_is_enabled' => $this->multiShipmentIsEnabled,
-            'selected_carriers' => $this->getCarriersDetails(array_filter(explode(',', trim($deliveryOptionKey)))),
+            'multishipment_is_enabled' => $this->isMultiShipmentFeatureFlagEnabled,
+            'selected_carriers' => $this->getCheckoutSession()->getCarriersDetails(),
             'is_recyclable_packaging' => $this->getCheckoutSession()->isRecyclable(),
         ];
 
         return $this->renderTemplate($this->getTemplate(), $extraParams, $assignedVars);
-    }
-
-    private function getCarriersDetails(array $carriersId)
-    {
-        $carriers = [];
-        $langId = $this->getCheckoutSession()->getContext()->language->id;
-
-        foreach ($carriersId as $id) {
-            $carrier = new Carrier($id);
-            $carriers[$id] = [
-                'name' => $carrier->name,
-                'delay' => $carrier->delay[$langId],
-            ];
-        }
-
-        return $carriers;
     }
 }

--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -113,7 +113,7 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
             'selected_payment_option' => $this->selected_payment_option,
             'selected_delivery_option' => $selectedDeliveryOption,
             'show_final_summary' => Configuration::get('PS_FINAL_SUMMARY_ENABLED'),
-            'multishipment_is_enabled' => $featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT),
+            'is_multishipment_enabled' => $featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT),
             'products_carrier_mapping' => $productsCarrierMapping,
             'is_recyclable_packaging' => $this->getCheckoutSession()->isRecyclable(),
         ];

--- a/classes/checkout/CheckoutPaymentStep.php
+++ b/classes/checkout/CheckoutPaymentStep.php
@@ -56,7 +56,7 @@ class CheckoutPaymentStepCore extends AbstractCheckoutStep
         TranslatorInterface $translator,
         PaymentOptionsFinder $paymentOptionsFinder,
         ConditionsToApproveFinder $conditionsToApproveFinder,
-        bool $isMultiShipmentFeatureFlagEnabled,
+        bool $isMultiShipmentFeatureFlagEnabled = false,
     ) {
         parent::__construct($context, $translator);
         $this->paymentOptionsFinder = $paymentOptionsFinder;

--- a/classes/checkout/CheckoutSession.php
+++ b/classes/checkout/CheckoutSession.php
@@ -157,10 +157,10 @@ class CheckoutSessionCore
         return $this->deliveryOptions->getSelectedDeliveryOption();
     }
 
-    public function getCarriersDetails()
+    public function getProductsByCarrier()
     {
         if ($this->deliveryOptions instanceof DeliveryOptionsProvider) {
-            return $this->deliveryOptions->getCarriers();
+            return $this->deliveryOptions->getProductsByCarrier();
         }
 
         return [];

--- a/classes/checkout/CheckoutSession.php
+++ b/classes/checkout/CheckoutSession.php
@@ -52,6 +52,14 @@ class CheckoutSessionCore
     }
 
     /**
+     * @return Context
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+
+    /**
      * @return Customer
      */
     public function getCustomer()

--- a/classes/checkout/CheckoutSession.php
+++ b/classes/checkout/CheckoutSession.php
@@ -25,6 +25,7 @@
  */
 
 use PrestaShop\PrestaShop\Adapter\Shipment\DeliveryOptionsInterface;
+use PrestaShop\PrestaShop\Adapter\Shipment\DeliveryOptionsProvider;
 
 class CheckoutSessionCore
 {
@@ -49,14 +50,6 @@ class CheckoutSessionCore
     public function customerHasLoggedIn()
     {
         return $this->context->customer->isLogged();
-    }
-
-    /**
-     * @return Context
-     */
-    public function getContext()
-    {
-        return $this->context;
     }
 
     /**
@@ -162,6 +155,15 @@ class CheckoutSessionCore
     public function getSelectedDeliveryOption()
     {
         return $this->deliveryOptions->getSelectedDeliveryOption();
+    }
+
+    public function getCarriersDetails()
+    {
+        if ($this->deliveryOptions instanceof DeliveryOptionsProvider) {
+            return $this->deliveryOptions->getCarriers();
+        }
+
+        return [];
     }
 
     public function getDeliveryOptions()

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -396,9 +396,6 @@ class OrderControllerCore extends FrontController
             $session
         );
 
-        /** @var FeatureFlagStateCheckerInterface $featureFlagManager */
-        $featureFlagManager = $this->get(FeatureFlagStateCheckerInterface::class);
-
         $checkoutProcess
             ->addStep(new CheckoutPersonalInformationStep(
                 $this->context,
@@ -444,7 +441,6 @@ class OrderControllerCore extends FrontController
                     $this->context,
                     $translator
                 ),
-                $featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT)
             ));
 
         return $checkoutProcess;

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -129,7 +129,8 @@ class OrderControllerCore extends FrontController
                 $this->context,
                 $this->getTranslator(),
                 $this->objectPresenter,
-                new PriceFormatter()
+                new PriceFormatter(),
+                $this->cart_presenter,
             );
         } else {
             $deliveryOptionsFinder = new DeliveryOptionsFinder(

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -395,6 +395,9 @@ class OrderControllerCore extends FrontController
             $session
         );
 
+        /** @var FeatureFlagStateCheckerInterface $featureFlagManager */
+        $featureFlagManager = $this->get(FeatureFlagStateCheckerInterface::class);
+
         $checkoutProcess
             ->addStep(new CheckoutPersonalInformationStep(
                 $this->context,
@@ -439,7 +442,8 @@ class OrderControllerCore extends FrontController
                 new ConditionsToApproveFinder(
                     $this->context,
                     $translator
-                )
+                ),
+                $featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT)
             ));
 
         return $checkoutProcess;

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -168,9 +168,7 @@ class ProductLazyArray extends AbstractLazyArray
 
         $product = new Product((int) $this->product['id_product']);
 
-        if (!empty($product)) {
-            $this->product['carriers'] = array_column($product->getCarriers(), 'id_carrier');
-        }
+        $this->product['carriers'] = array_column($product->getCarriers(), 'id_carrier');
 
         return $this->product['carriers'];
     }
@@ -331,7 +329,6 @@ class ProductLazyArray extends AbstractLazyArray
                 return false;
         }
     }
-
 
     /**
      * @return string|null

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -159,21 +159,6 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @return array
-     */
-    #[LazyArrayAttribute(arrayAccess: true)]
-    public function getCarriers()
-    {
-        $this->product['carriers'] = [];
-
-        $product = new Product((int) $this->product['id_product']);
-
-        $this->product['carriers'] = array_column($product->getCarriers(), 'id_carrier');
-
-        return $this->product['carriers'];
-    }
-
-    /**
      * @return array|mixed
      */
     #[LazyArrayAttribute(arrayAccess: true)]

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -159,6 +159,23 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
+     * @return array
+     */
+    #[LazyArrayAttribute(arrayAccess: true)]
+    public function getCarriers()
+    {
+        $this->product['carriers'] = [];
+
+        $product = new Product((int) $this->product['id_product']);
+
+        if (!empty($product)) {
+            $this->product['carriers'] = array_column($product->getCarriers(), 'id_carrier');
+        }
+
+        return $this->product['carriers'];
+    }
+
+    /**
      * @return array|mixed
      */
     #[LazyArrayAttribute(arrayAccess: true)]
@@ -314,6 +331,7 @@ class ProductLazyArray extends AbstractLazyArray
                 return false;
         }
     }
+
 
     /**
      * @return string|null

--- a/src/Adapter/Shipment/DeliveryOptionsProvider.php
+++ b/src/Adapter/Shipment/DeliveryOptionsProvider.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Shipment;
 
-use Carrier;
 use Context;
 use DeliveryOptionsFinderCore;
 use Hook;
@@ -96,7 +95,7 @@ class DeliveryOptionsProvider extends DeliveryOptionsFinderCore
         return $carriers;
     }
 
-    public function getCarriersDetails(array $deliveryOption): array
+    private function getCarriersDetails(array $deliveryOption): array
     {
         $carriers = $deliveryOption['carrier_list'];
 

--- a/src/Adapter/Shipment/DeliveryOptionsProvider.php
+++ b/src/Adapter/Shipment/DeliveryOptionsProvider.php
@@ -96,7 +96,7 @@ class DeliveryOptionsProvider extends DeliveryOptionsFinderCore
         return $carriers;
     }
 
-    public function formatCarrierWithProducts(array $carrierData): array
+    private function formatCarrierWithProducts(array $carrierData): array
     {
         $carrierProductIds = array_map(function ($product) {
             return $product['id_product'];

--- a/src/Adapter/Shipment/DeliveryOptionsProvider.php
+++ b/src/Adapter/Shipment/DeliveryOptionsProvider.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Shipment;
 
+use Carrier;
 use Context;
 use DeliveryOptionsFinderCore;
 use Hook;
@@ -72,7 +73,30 @@ class DeliveryOptionsProvider extends DeliveryOptionsFinderCore
         return $parentOutput;
     }
 
-    private function getCarriersDetails(array $deliveryOption): array
+    /**
+     * @return array
+     */
+    public function getCarriers()
+    {
+        $deliveryOptions = $this->context->cart->getDeliveryOptionList();
+        $currentAddressDeliveryOptions = $deliveryOptions[$this->context->cart->id_address_delivery];
+        $carriers = [];
+
+        foreach ($currentAddressDeliveryOptions as $deliveryOption) {
+            foreach ($deliveryOption['carrier_list'] as $carrier) {
+                $carriers[$carrier['instance']->id] = [
+                    'name' => $carrier['instance']->name,
+                    'delay' => $carrier['instance']->delay[$this->context->language->id],
+                ];
+                $names[] = $carrier['instance']->name;
+                $delays[] = $carrier['instance']->delay[$this->context->language->id];
+            }
+        }
+
+        return $carriers;
+    }
+
+    public function getCarriersDetails(array $deliveryOption): array
     {
         $carriers = $deliveryOption['carrier_list'];
 

--- a/src/Adapter/Shipment/DeliveryOptionsProvider.php
+++ b/src/Adapter/Shipment/DeliveryOptionsProvider.php
@@ -88,8 +88,8 @@ class DeliveryOptionsProvider extends DeliveryOptionsFinderCore
         $carriers = [];
 
         foreach ($currentAddressDeliveryOptions as $deliveryOption) {
-            foreach ($deliveryOption['carrier_list'] as $carrier) {
-                $carriers[] = $this->formatCarrierWithProducts($carrier);
+            foreach ($deliveryOption['carrier_list'] as $carrierId => $carrier) {
+                $carriers[$carrierId] = $this->formatCarrierWithProducts($carrier);
             }
         }
 

--- a/src/Adapter/Shipment/DeliveryOptionsProvider.php
+++ b/src/Adapter/Shipment/DeliveryOptionsProvider.php
@@ -32,6 +32,7 @@ use Context;
 use DeliveryOptionsFinderCore;
 use Hook;
 use Module;
+use PrestaShop\PrestaShop\Adapter\Presenter\Cart\CartPresenter;
 use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -40,14 +41,19 @@ class DeliveryOptionsProvider extends DeliveryOptionsFinderCore
 {
     private $context;
 
+    /** @var CartPresenter */
+    private $cartPresenter;
+
     public function __construct(
         Context $context,
         TranslatorInterface $translator,
         ObjectPresenter $objectPresenter,
-        PriceFormatter $priceFormatter
+        PriceFormatter $priceFormatter,
+        CartPresenter $cartPresenter
     ) {
         parent::__construct($context, $translator, $objectPresenter, $priceFormatter);
         $this->context = $context;
+        $this->cartPresenter = $cartPresenter;
     }
 
     public function getDeliveryOptions()
@@ -75,7 +81,7 @@ class DeliveryOptionsProvider extends DeliveryOptionsFinderCore
     /**
      * @return array
      */
-    public function getCarriers()
+    public function getProductsByCarrier()
     {
         $deliveryOptions = $this->context->cart->getDeliveryOptionList();
         $currentAddressDeliveryOptions = $deliveryOptions[$this->context->cart->id_address_delivery];
@@ -83,16 +89,31 @@ class DeliveryOptionsProvider extends DeliveryOptionsFinderCore
 
         foreach ($currentAddressDeliveryOptions as $deliveryOption) {
             foreach ($deliveryOption['carrier_list'] as $carrier) {
-                $carriers[$carrier['instance']->id] = [
-                    'name' => $carrier['instance']->name,
-                    'delay' => $carrier['instance']->delay[$this->context->language->id],
-                ];
-                $names[] = $carrier['instance']->name;
-                $delays[] = $carrier['instance']->delay[$this->context->language->id];
+                $carriers[] = $this->formatCarrierWithProducts($carrier);
             }
         }
 
         return $carriers;
+    }
+
+    public function formatCarrierWithProducts(array $carrierData): array
+    {
+        $carrierProductIds = array_map(function ($product) {
+            return $product['id_product'];
+        }, $carrierData['product_list']);
+
+        $cartProducts = $this->cartPresenter->present($this->context->cart);
+        $filteredProducts = array_filter($cartProducts->getProducts(), function ($product) use ($carrierProductIds) {
+            return in_array($product['id_product'], $carrierProductIds);
+        });
+
+        return [
+            'carrier' => [
+                'name' => $carrierData['instance']->name,
+                'delay' => $carrierData['instance']->delay[$this->context->language->id] ?? $carrierData['instance']->delay,
+            ],
+            'products' => $filteredProducts,
+        ];
     }
 
     private function getCarriersDetails(array $deliveryOption): array

--- a/var/class_stub.php
+++ b/var/class_stub.php
@@ -60,6 +60,7 @@ class CccReducer extends CccReducerCore {};
 class Chart extends ChartCore {};
 class CheckoutAddressesStep extends CheckoutAddressesStepCore {};
 class CheckoutDeliveryStep extends CheckoutDeliveryStepCore {};
+class CheckoutShipmentStep extends CheckoutShipmentStepCore {};
 class CheckoutPaymentStep extends CheckoutPaymentStepCore {};
 class CheckoutPersonalInformationStep extends CheckoutPersonalInformationStepCore {};
 class CheckoutProcess extends CheckoutProcessCore {};


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add logic to implement new view for order summary for multishipment
| Type?             | new feature
| Category?         | FO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | Enable the feature flag & order summary. Before order modify two product and set differents carriers. Make a order with products modified and see the new templating
| UI Tests          | No need because we using FF