### PR TITLE
Allow attribute groups colors/textures on groups with ID different than 2

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/attribute/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/attribute/form/index.ts
@@ -42,28 +42,22 @@ $(() => {
 });
 
 document.addEventListener('DOMContentLoaded', () => {
-  const attributeGroupSelect = document.querySelector(AttributeFormMap.attributeGroupSelect) as HTMLInputElement | null;
+  const attributeGroupSelect = document.querySelector(AttributeFormMap.attributeGroupSelect) as HTMLSelectElement | null;
   const attributeColorRow = document.querySelector(AttributeFormMap.attributeColorFormRow) as HTMLElement | null;
   const attributeTextureRow = document.querySelector(AttributeFormMap.attributeTextureFormRow) as HTMLElement | null;
-  const attributeGroupSelectValue = (attributeGroupSelect as HTMLInputElement | null)?.value;
 
-  const toggleDisplay = (value: string | null) => {
-    if (attributeColorRow && attributeTextureRow) {
-      const displayValue = value === '2' ? 'flex' : 'none';
-      attributeColorRow.style.display = displayValue;
-      attributeTextureRow.style.display = displayValue;
-    }
+  if (!attributeGroupSelect || !attributeColorRow || !attributeTextureRow) return;
+
+  const toggleDisplay = () => {
+    const selectedOption = attributeGroupSelect?.selectedOptions[0];
+    const isColorGroup = selectedOption?.dataset.iscolorgroup;
+    const displayValue = isColorGroup ? 'flex' : 'none';
+
+    attributeColorRow.style.display = displayValue;
+    attributeTextureRow.style.display = displayValue;
   };
 
-  if (attributeGroupSelectValue) {
-    toggleDisplay(attributeGroupSelectValue);
-  }
+  toggleDisplay();
 
-  attributeGroupSelect?.addEventListener('change', () => {
-    const NewattributeGroupSelectValue = (attributeGroupSelect as HTMLInputElement | null)?.value;
-
-    if (NewattributeGroupSelectValue) {
-      toggleDisplay(NewattributeGroupSelectValue);
-    }
-  });
+  attributeGroupSelect?.addEventListener('change', toggleDisplay);
 });

--- a/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
@@ -47,7 +47,7 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
     private $attributeGroupsChoices;
 
     /**
-     * @var array
+     * @var array<string, array{data-iscolorgroup: int}>
      */
     private $attributeGroupsChoicesAttributes;
 
@@ -66,7 +66,7 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
     /**
      * Get attribute groups choices
      *
-     * @return array
+     * @return array<string, int>
      */
     public function getChoices(): array
     {
@@ -78,7 +78,7 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
     /**
      * Get attribute groups choices attributes
      *
-     * @return array
+     * @return array<string, array{data-iscolorgroup: int}>
      */
     public function getChoicesAttributes(): array
     {

--- a/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
+
+use PrestaShop\PrestaShop\Core\Form\FormChoiceAttributeProviderInterface;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShopBundle\Entity\Repository\AttributeGroupRepository;
+
+/**
+ * Class AttributeGroupChoiceProvider provides attribute group choices and choices attributes.
+ */
+final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface, FormChoiceAttributeProviderInterface
+{
+    /**
+     * @var array
+     */
+    private $attributeGroups;
+
+    /**
+     * @var array
+     */
+    private $attributeGroupsChoiceAttributes;
+
+    /**
+     * @param AttributeGroupRepository $attributeGroupRepository
+     * @param int $langId
+     * @param int $shopId
+     */
+    public function __construct(
+        private readonly AttributeGroupRepository $attributeGroupRepository,
+        private int $langId,
+        private int $shopId,
+    ) {
+    }
+
+    /**
+     * Get attribute groups choices.
+     *
+     * @return array
+     */
+    public function getChoices()
+    {
+        return FormChoiceFormatter::formatFormChoices(
+            $this->getAttributeGroups(),
+            'attributeGroupId',
+            'attributeGroupName'
+        );
+    }
+
+    /**
+     * Get attribute groups choices attributes.
+     *
+     * @return array
+     */
+    public function getChoicesAttributes()
+    {
+        if (null === $this->attributeGroupsChoiceAttributes) {
+            $attributeGroups = $this->getAttributeGroups();
+
+            $this->attributeGroupsChoiceAttributes = [];
+
+            foreach ($attributeGroups as $attributeGroup) {
+                if ($attributeGroup['attributeGroupisColorGroup']) {
+                    $this->attributeGroupsChoiceAttributes[$attributeGroup['attributeGroupId']]['data-isColorGroup'] = $attributeGroup['attributeGroupId'];
+                }
+            }
+        }
+
+        return $this->attributeGroupsChoiceAttributes;
+    }
+
+    /**
+     * Get attribute groups.
+     *
+     * @return array
+     */
+    private function getAttributeGroups()
+    {
+        if (null === $this->attributeGroups) {
+            $this->attributeGroups = $this->attributeGroupRepository->findByLangAndShop($this->langId, $this->shopId);
+        }
+
+        if (empty($this->attributeGroups)) {
+            throw new \RuntimeException('No attribute groups available.');
+        }
+        return $this->attributeGroups;
+    }
+}

--- a/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
@@ -106,9 +106,6 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
             $this->attributeGroups = $this->attributeGroupRepository->findByLangAndShop($this->langId, $this->shopId);
         }
 
-        if (empty($this->attributeGroups)) {
-            throw new \RuntimeException('No attribute groups available.');
-        }
         return $this->attributeGroups;
     }
 }

--- a/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
@@ -37,7 +37,7 @@ use PrestaShopBundle\Entity\Repository\AttributeGroupRepository;
 final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface, FormChoiceAttributeProviderInterface
 {
     /**
-     * @var array
+     * @var \PrestaShopBundle\Entity\AttributeGroup[]
      */
     private $attributeGroups;
 
@@ -107,12 +107,14 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
                  * No need to filter duplicates like FormChoiceFormatter::formatFormChoices
                  * does since attributeGroupId has a PRIMARY key.
                 */
-                $attributeGroupFormattedName = sprintf('%s (#%d)', $attributeGroup['attributeGroupName'], $attributeGroup['attributeGroupId']);
+                /** @var \Doctrine\Common\Collections\Collection<\PrestaShopBundle\Entity\AttributeGroupLang> $attributeGroupLang */
+                $attributeGroupLang = $attributeGroup->getAttributeGroupLangs();
+                $attributeGroupFormattedName = sprintf('%s (#%d)', $attributeGroupLang->first()?->getName(), $attributeGroup->getId());
 
-                $this->attributeGroupsChoices[$attributeGroupFormattedName] = $attributeGroup['attributeGroupId'];
+                $this->attributeGroupsChoices[$attributeGroupFormattedName] = $attributeGroup->getId();
 
-                if ($attributeGroup['attributeGroupIsColorGroup']) {
-                    $this->attributeGroupsChoicesAttributes[$attributeGroupFormattedName]['data-iscolorgroup'] = $attributeGroup['attributeGroupId'];
+                if (true === $attributeGroup->getIsColorGroup()) {
+                    $this->attributeGroupsChoicesAttributes[$attributeGroupFormattedName]['data-iscolorgroup'] = $attributeGroup->getId();
                 }
             }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeController.php
@@ -35,7 +35,6 @@ use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\Attribute\Exception\Attribu
 use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\Attribute\Exception\DeleteAttributeException;
 use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\Exception\AttributeGroupNotFoundException;
 use PrestaShop\PrestaShop\Core\Exception\TranslatableCoreException;
-use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\AttributeGroupChoiceProvider;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
@@ -139,17 +138,8 @@ class AttributeController extends PrestaShopAdminController
         #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.attribute_form_builder')]
         FormBuilderInterface $attributeFormBuilder,
         #[Autowire(service: 'prestashop.core.form.identifiable_object.attribute_form_handler')]
-        FormHandlerInterface $attributeFormHandler,
-        AttributeGroupChoiceProvider $attributeGroupChoiceProvider,
+        FormHandlerInterface $attributeFormHandler
     ): Response {
-        $attributeGroupChoices = $attributeGroupChoiceProvider->getChoices();
-
-        if (empty($attributeGroupChoices)) {
-            $this->addFlash('error', $this->trans('Before adding a new value a new attribute must be created.', [], 'Admin.Notifications.Error'));
-
-            return $this->redirectToRoute('admin_attribute_groups_index');
-        }
-
         $attributeGroupId = (int) $request->query->get('attributeGroupId');
 
         $attributeForm = $attributeFormBuilder->getForm([], ['attribute_group' => $attributeGroupId]);
@@ -192,16 +182,7 @@ class AttributeController extends PrestaShopAdminController
         FormBuilderInterface $attributeFormBuilder,
         #[Autowire(service: 'prestashop.core.form.identifiable_object.attribute_form_handler')]
         FormHandlerInterface $attributeFormHandler,
-        AttributeGroupChoiceProvider $attributeGroupChoiceProvider,
     ): Response {
-        $attributeGroupChoices = $attributeGroupChoiceProvider->getChoices();
-
-        if (empty($attributeGroupChoices)) {
-            $this->addFlash('error', $this->trans('The attribute assinged to this value no longer exists.', [], 'Admin.Notifications.Error'));
-
-            return $this->redirectToRoute('admin_attribute_groups_index');
-        }
-
         $attributeForm = $attributeFormBuilder->getFormFor($attributeId, [], ['attribute_group' => $attributeGroupId])
             ->handleRequest($request);
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeController.php
@@ -145,7 +145,7 @@ class AttributeController extends PrestaShopAdminController
         $attributeGroupChoices = $attributeGroupChoiceProvider->getChoices();
 
         if (empty($attributeGroupChoices)) {
-            $this->addFlash('error', $this->trans('Before adding a new value a new attribute must be created.', [], 'Admin.Notifications.Success'));
+            $this->addFlash('error', $this->trans('Before adding a new value a new attribute must be created.', [], 'Admin.Notifications.Error'));
 
             return $this->redirectToRoute('admin_attribute_groups_index');
         }
@@ -198,7 +198,7 @@ class AttributeController extends PrestaShopAdminController
         $attributeGroupChoices = $attributeGroupChoiceProvider->getChoices();
 
         if (empty($attributeGroupChoices)) {
-            $this->addFlash('error', $this->trans('The attribute assinged to this value no longer exists.', [], 'Admin.Notifications.Success'));
+            $this->addFlash('error', $this->trans('The attribute assinged to this value no longer exists.', [], 'Admin.Notifications.Error'));
 
             return $this->redirectToRoute('admin_attribute_groups_index');
         }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeController.php
@@ -71,8 +71,7 @@ class AttributeController extends PrestaShopAdminController
      */
     #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute: 'admin_attributes_index', redirectQueryParamsToKeep: ['attributeGroupId'])]
     public function indexAction(
-        Request $request,
-        int $attributeGroupId,
+        Request $request, $attributeGroupId,
         AttributeFilters $attributeFilters,
         #[Autowire(service: 'prestashop.core.grid.factory.attribute')]
         GridFactoryInterface $attributeGridFactory,

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeController.php
@@ -194,7 +194,6 @@ class AttributeController extends PrestaShopAdminController
         FormHandlerInterface $attributeFormHandler,
         AttributeGroupChoiceProvider $attributeGroupChoiceProvider,
     ): Response {
-
         $attributeGroupChoices = $attributeGroupChoiceProvider->getChoices();
 
         if (empty($attributeGroupChoices)) {

--- a/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
@@ -44,17 +44,21 @@ class AttributeGroupRepository extends \Doctrine\ORM\EntityRepository
      * @param mixed $idLang Language ID
      * @param mixed $idShop Shop ID
      *
-     * @return array
+     * @return array<int, array{
+     *     attributeGroupId: int|null,
+     *     attributeGroupPosition: int|null,
+     *     attributeGroupIsColorGroup: bool|null,
+     *     attributeGroupName: string|null,
+     *     attributeGroupPublicName: string|null
+     * }>
      */
-    public function findByLangAndShop($idLang, $idShop)
+    public function findByLangAndShop($idLang, $idShop): array
     {
-        $attributeGroups = [];
-
         $qb = $this->createQueryBuilder('ag')
             ->select([
                 'ag.id AS attributeGroupId',
                 'ag.position AS attributeGroupPosition',
-                'ag.isColorGroup AS attributeGroupisColorGroup',
+                'ag.isColorGroup AS attributeGroupIsColorGroup',
                 'agl.name AS attributeGroupName',
                 'agl.publicName AS attributeGroupPublicName',
             ])
@@ -68,12 +72,6 @@ class AttributeGroupRepository extends \Doctrine\ORM\EntityRepository
                 new Parameter('idLang', $idLang),
             ]));
 
-        $result = $qb->getQuery()->getArrayResult();
-
-        foreach ($result as $attribute) {
-            $attributeGroups[$attribute['attributeGroupId']] = $attribute;
-        }
-
-        return $attributeGroups;
+        return $qb->getQuery()->getArrayResult();
     }
 }

--- a/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
@@ -38,6 +38,13 @@ use Doctrine\ORM\Query\Parameter;
  */
 class AttributeGroupRepository extends \Doctrine\ORM\EntityRepository
 {
+    /**
+     * Finds attribute groups by language and shop.
+     *
+     * @param mixed $idLang Language ID.
+     * @param mixed $idShop Shop ID.
+     * @return array
+     */
     public function findByLangAndShop($idLang, $idShop)
     {
         $attributeGroups = [];

--- a/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -26,6 +27,9 @@
 
 namespace PrestaShopBundle\Entity\Repository;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Query\Parameter;
+
 /**
  * AttributeGroupRepository.
  *
@@ -34,4 +38,34 @@ namespace PrestaShopBundle\Entity\Repository;
  */
 class AttributeGroupRepository extends \Doctrine\ORM\EntityRepository
 {
+    public function findByLangAndShop($idLang, $idShop)
+    {
+        $attributeGroups = [];
+
+        $qb = $this->createQueryBuilder('ag')
+            ->select([
+                'ag.id AS attributeGroupId',
+                'ag.position AS attributeGroupPosition',
+                'ag.isColorGroup AS attributeGroupisColorGroup',
+                'agl.name AS attributeGroupName',
+                'agl.publicName AS attributeGroupPublicName',
+            ])
+            ->join('ag.shops', 's')
+            ->join('ag.attributeGroupLangs', 'agl')
+            ->andWhere('agl.lang = :idLang')
+            ->andWhere('s.id = :idShop')
+            ->orderBy('attributeGroupPosition')
+            ->setParameters(new ArrayCollection([
+                new Parameter('idShop', $idShop),
+                new Parameter('idLang', $idLang),
+            ]));
+
+        $result = $qb->getQuery()->getArrayResult();
+
+        foreach ($result as $attribute) {
+            $attributeGroups[$attribute['attributeGroupId']] = $attribute;
+        }
+
+        return $attributeGroups;
+    }
 }

--- a/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
@@ -43,6 +43,7 @@ class AttributeGroupRepository extends \Doctrine\ORM\EntityRepository
      *
      * @param mixed $idLang Language ID
      * @param mixed $idShop Shop ID
+     *
      * @return array
      */
     public function findByLangAndShop($idLang, $idShop)

--- a/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
@@ -41,8 +41,8 @@ class AttributeGroupRepository extends \Doctrine\ORM\EntityRepository
     /**
      * Finds attribute groups by language and shop.
      *
-     * @param mixed $idLang Language ID.
-     * @param mixed $idShop Shop ID.
+     * @param mixed $idLang Language ID
+     * @param mixed $idShop Shop ID
      * @return array
      */
     public function findByLangAndShop($idLang, $idShop)

--- a/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
@@ -27,9 +27,6 @@
 
 namespace PrestaShopBundle\Entity\Repository;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\Query\Parameter;
-
 /**
  * AttributeGroupRepository.
  *
@@ -41,37 +38,23 @@ class AttributeGroupRepository extends \Doctrine\ORM\EntityRepository
     /**
      * Finds attribute groups by language and shop.
      *
-     * @param mixed $idLang Language ID
-     * @param mixed $idShop Shop ID
+     * @param int $idLang Language ID
+     * @param int $idShop Shop ID
      *
-     * @return array<int, array{
-     *     attributeGroupId: int|null,
-     *     attributeGroupPosition: int|null,
-     *     attributeGroupIsColorGroup: bool|null,
-     *     attributeGroupName: string|null,
-     *     attributeGroupPublicName: string|null
-     * }>
+     * @return \PrestaShopBundle\Entity\AttributeGroup[]
      */
-    public function findByLangAndShop($idLang, $idShop): array
+    public function findByLangAndShop(int $idLang, int $idShop): array
     {
-        $qb = $this->createQueryBuilder('ag')
-            ->select([
-                'ag.id AS attributeGroupId',
-                'ag.position AS attributeGroupPosition',
-                'ag.isColorGroup AS attributeGroupIsColorGroup',
-                'agl.name AS attributeGroupName',
-                'agl.publicName AS attributeGroupPublicName',
-            ])
-            ->join('ag.shops', 's')
+        return $this->createQueryBuilder('ag')
+            ->addSelect('agl')
+            ->join('ag.shops', 'ags')
             ->join('ag.attributeGroupLangs', 'agl')
             ->andWhere('agl.lang = :idLang')
-            ->andWhere('s.id = :idShop')
-            ->orderBy('attributeGroupPosition')
-            ->setParameters(new ArrayCollection([
-                new Parameter('idShop', $idShop),
-                new Parameter('idLang', $idLang),
-            ]));
-
-        return $qb->getQuery()->getArrayResult();
+            ->andWhere('ags.id = :idShop')
+            ->orderBy('ag.position', 'ASC')
+            ->setParameters([
+                'idShop' => $idShop,
+                'idLang' => $idLang,
+            ])->getQuery()->getResult();
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Catalog/AttributeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Catalog/AttributeType.php
@@ -53,8 +53,8 @@ class AttributeType extends TranslatorAwareType
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        private readonly AttributeGroupChoiceProvider $attributeGroupChoiceProvider,
-        protected FeatureInterface $multistoreFeature
+        protected readonly AttributeGroupChoiceProvider $attributeGroupChoiceProvider,
+        protected readonly FeatureInterface $multistoreFeature
     ) {
         parent::__construct($translator, $locales);
     }
@@ -64,7 +64,7 @@ class AttributeType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $hasAttributeGroupId = $options['attribute_group'] > 0;
+        $attributeGroupId = (is_int($options['attribute_group']) && $options['attribute_group'] > 0) ? $options['attribute_group'] : '';
 
         $builder
             ->add('attribute_group', ChoiceType::class, [
@@ -72,7 +72,7 @@ class AttributeType extends TranslatorAwareType
                 'help' => $this->trans('The way the attribute\'s values will be presented to the customers in the product\'s page.', 'Admin.Catalog.Help'),
                 'choices' => $this->attributeGroupChoiceProvider->getChoices(),
                 'choice_attr' => $this->attributeGroupChoiceProvider->getChoicesAttributes(),
-                'data' => $hasAttributeGroupId ? $options['attribute_group'] : '',
+                'data' => $attributeGroupId,
             ])
             ->add('name', TranslatableType::class, [
                 'type' => TextType::class,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Catalog/AttributeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Catalog/AttributeType.php
@@ -33,12 +33,12 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\AttributeGroupChoiceProvider;
+use PrestaShopBundle\Form\Admin\Type\ImageWithPreviewType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\ColorType;
-use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -95,12 +95,14 @@ class AttributeType extends TranslatorAwareType
                 ],
                 'required' => false,
             ])
-            ->add('texture', FileType::class, [
+            ->add('texture', ImageWithPreviewType::class, [
                 'label' => $this->trans('Texture', 'Admin.Global'),
                 'row_attr' => [
                     'class' => 'js-attribute-type-texture-form-row',
                 ],
                 'required' => false,
+                'can_be_deleted' => true,
+                'show_size' => true,
             ]);
 
         if ($this->multistoreFeature->isUsed()) {

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -363,7 +363,7 @@ services:
   PrestaShopBundle\Form\Admin\Sell\Catalog\AttributeType:
     public: true
     arguments:
-      $attributeGroupRepository: '@PrestaShop\PrestaShop\Adapter\AttributeGroup\Repository\AttributeGroupRepository'
+      $attributeGroupChoiceProvider: '@PrestaShop\PrestaShop\Core\Form\ChoiceProvider\AttributeGroupChoiceProvider'
       $multistoreFeature: '@prestashop.adapter.multistore_feature'
     tags:
       - { name: form.type }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
@@ -171,3 +171,8 @@ services:
       - PrestaShopBundle\Entity\Employee\Employee
     calls:
       - setIdnConverter: [ '@PrestaShop\PrestaShop\Core\Util\InternationalizedDomainNameConverter' ]
+
+  PrestaShopBundle\Entity\Repository\AttributeGroupRepository:
+    factory: [ '@doctrine.orm.default_entity_manager', getRepository ]
+    arguments:
+      - PrestaShopBundle\Entity\AttributeGroup

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -138,3 +138,8 @@ services:
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImageTypeChoiceProvider:
     autowire: true
+
+  PrestaShop\PrestaShop\Core\Form\ChoiceProvider\AttributeGroupChoiceProvider:
+    autowire: true
+    arguments:
+      $shopId: '@=service("prestashop.adapter.shop.context").getContextShopID()'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | #38766 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Comment below
| UI Tests          | https://github.com/ChillCode/ga.tests.ui.pr/actions/runs/18537397682
| Fixed issue or discussion?     | #38766 

Is a duplicate of #39423 but meaby there is more luck and gets accepted.

1. Visis Catalog->Attributes & Features->Attributes
2. Click on Add a new Attribute with Attribute type selected "Color & Texture"
3. Save
4. Add new value
5. Select the previously group we created in the previous step
6. With this PR we can now select a Texture or Color

A related issue is that values can be added without groups in the list so when saved we get an exception.
An another issue related to this is that is_color_group is not updated when saving an existing group.