### PR TITLE
Address without linked brand

### DIFF
--- a/src/Core/Grid/Query/ManufacturerAddressQueryBuilder.php
+++ b/src/Core/Grid/Query/ManufacturerAddressQueryBuilder.php
@@ -118,6 +118,7 @@ final class ManufacturerAddressQueryBuilder extends AbstractDoctrineQueryBuilder
             ->andWhere('a.id_supplier = 0')
             ->andWhere('a.id_warehouse = 0')
             ->andWhere('a.deleted = 0')
+            ->andWhere('a.id_manufacturer > 0')
         ;
         $this->applyFilters($qb, $filters);
 

--- a/src/Core/Grid/Query/ManufacturerAddressQueryBuilder.php
+++ b/src/Core/Grid/Query/ManufacturerAddressQueryBuilder.php
@@ -118,7 +118,6 @@ final class ManufacturerAddressQueryBuilder extends AbstractDoctrineQueryBuilder
             ->andWhere('a.id_supplier = 0')
             ->andWhere('a.id_warehouse = 0')
             ->andWhere('a.deleted = 0')
-            ->andWhere('a.id_manufacturer > 0')
         ;
         $this->applyFilters($qb, $filters);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
@@ -106,7 +106,7 @@ class ManufacturerAddressType extends TranslatorAwareType
                 'choices' => $this->getManufacturersChoiceList(),
                 'translation_domain' => false,
                 'placeholder' => false,
-                'required' => false,
+                'required' => true,
             ])
             ->add('last_name', TextType::class, [
                 'label' => $this->trans('Last name', 'Admin.Global'),
@@ -341,8 +341,6 @@ class ManufacturerAddressType extends TranslatorAwareType
      */
     private function getManufacturersChoiceList()
     {
-        $this->manufacturerChoices['--'] = 0;
-
         return $this->manufacturerChoices;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | A new brand address without linked brand is not listed in BO<br>The bug occured because of : https://github.com/PrestaShop/PrestaShop/pull/37668
| Type?             | improvement
| BC breaks?       | No
| Deprecations? | No
| Category?         | BO 
| How to test?      | Add a manufacturer address, manufacturer select is mandatory. <br>Old "ghost" addresses created without a manufacturer appear in the manufacturer address listing and can be deleted
| UI test | https://github.com/aomaxime/ga.tests.ui.pr/actions/runs/18532998445
| Fixed issue or discussion?     | Fixes #39747 
| Related PRs       | #37668 
| Sponsor company   | Agence Off
