### PR TITLE
Multi-carrier: added a property in OrderLazyArray

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2357,23 +2357,6 @@ class OrderCore extends ObjectModel
                 WHERE `id_order` = ' . (int) $this->id);
     }
 
-    /**
-     * @return int[]|false
-     */
-    public function getOrderCarrierIds()
-    {
-        $carrierIds = Db::getInstance()->executeS('
-                SELECT `id_carrier`
-                FROM `' . _DB_PREFIX_ . 'order_carrier`
-                WHERE `id_order` = ' . (int) $this->id);
-
-        if ($carrierIds) {
-            $carrierIds = array_column($carrierIds, 'id_carrier');
-        }
-
-        return $carrierIds;
-    }
-
     public static function sortDocuments($a, $b)
     {
         if ($a->date_add == $b->date_add) {

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2357,6 +2357,23 @@ class OrderCore extends ObjectModel
                 WHERE `id_order` = ' . (int) $this->id);
     }
 
+    /**
+     * @return int[]|false
+     */
+    public function getOrderCarrierIds()
+    {
+        $carrierIds = Db::getInstance()->executeS('
+                SELECT `id_carrier`
+                FROM `' . _DB_PREFIX_ . 'order_carrier`
+                WHERE `id_order` = ' . (int) $this->id);
+
+        if ($carrierIds) {
+            $carrierIds = array_column($carrierIds, 'id_carrier');
+        }
+
+        return $carrierIds;
+    }
+
     public static function sortDocuments($a, $b)
     {
         if ($a->date_add == $b->date_add) {

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -238,7 +238,7 @@ class OrderConfirmationControllerCore extends FrontController
             'HOOK_PAYMENT_RETURN' => $this->displayPaymentReturn($this->order),
             'order' => (new OrderPresenter())->present($this->order),
             'order_customer' => $this->objectPresenter->present($this->customer),
-            'is_multishipment_feature_flag_enabled' => $featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT),
+            'is_multishipment_enabled' => $featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT),
             'registered_customer_exists' => Customer::customerExists($this->customer->email),
         ]);
         $this->setTemplate('checkout/order-confirmation');

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -23,6 +23,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 use PrestaShop\PrestaShop\Adapter\Presenter\Order\OrderPresenter;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 use PrestaShop\PrestaShop\Adapter\Presenter\Order\OrderPresenter;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 use ZxcvbnPhp\Zxcvbn;
 
@@ -227,11 +229,15 @@ class OrderConfirmationControllerCore extends FrontController
     {
         parent::initContent();
 
+        /** @var FeatureFlagStateCheckerInterface $featureFlagManager */
+        $featureFlagManager = $this->get(FeatureFlagStateCheckerInterface::class);
+
         $this->context->smarty->assign([
             'HOOK_ORDER_CONFIRMATION' => $this->displayOrderConfirmation($this->order),
             'HOOK_PAYMENT_RETURN' => $this->displayPaymentReturn($this->order),
             'order' => (new OrderPresenter())->present($this->order),
             'order_customer' => $this->objectPresenter->present($this->customer),
+            'is_multishipment_feature_flag_enabled' => $featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT),
             'registered_customer_exists' => Customer::customerExists($this->customer->email),
         ]);
         $this->setTemplate('checkout/order-confirmation');

--- a/src/Adapter/Presenter/Order/OrderLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderLazyArray.php
@@ -234,75 +234,36 @@ class OrderLazyArray extends AbstractLazyArray
         $cart = new Cart($this->order->id_cart);
         $cartProducts = $this->cartPresenter->present($cart)['products'];
         $shipments = $this->shipmentRepository->findByOrderId($this->order->id);
+
         /** @var OrderDetail[] $orderDetails */
         $orderDetails = $this->order->getOrderDetailList();
         $orderProducts = $this->order->getProducts();
+
         $langId = Context::getContext()->language->id;
         $includeTaxes = $this->includeTaxes();
-        $carriersProductsMapping = [];
 
-        $orderDetailToCartProduct = [];
-        foreach ($orderDetails as $detail) {
-            foreach ($orderProducts as $orderProduct) {
-                if (
-                    $detail['product_id'] === $orderProduct['id_product'] && $detail['product_attribute_id'] === $orderProduct['product_attribute_id']
-                ) {
-                    $product = $orderProduct;
-                    // Use data from OrderDetail in case that the Product has been deleted
-                    $product['name'] = $product['product_name'];
-                    $product['quantity'] = $product['product_quantity'];
-                    $product['id_product'] = $product['product_id'];
-                    $product['id_product_attribute'] = $product['product_attribute_id'];
+        // Build a mapping between order details and their enriched product data
+        $orderDetailToProduct = $this->mapOrderDetailsToProducts(
+            $orderDetails,
+            $orderProducts,
+            $cartProducts,
+            $includeTaxes
+        );
 
-                    $productPrice = $includeTaxes ? 'product_price_wt' : 'product_price';
-                    $totalPrice = $includeTaxes ? 'total_wt' : 'total_price';
-
-                    $product['price'] = $this->priceFormatter->format(
-                        $product[$productPrice],
-                        Currency::getCurrencyInstance((int) $this->order->id_currency)
-                    );
-                    $product['total'] = $this->priceFormatter->format(
-                        $product[$totalPrice],
-                        Currency::getCurrencyInstance((int) $this->order->id_currency)
-                    );
-
-                    foreach ($cartProducts as $cartProduct) {
-                        if (
-                            $product['product_id'] === $cartProduct['id_product'] && $product['product_attribute_id'] === $cartProduct['id_product_attribute']
-                        ) {
-                            if (isset($cartProduct['attributes'])) {
-                                $product['attributes'] = $cartProduct['attributes'];
-                            } else {
-                                $product['attributes'] = [];
-                            }
-                            $product['cover'] = $cartProduct['cover'];
-                            $product['default_image'] = $cartProduct['default_image'];
-                            $product['unit_price_full'] = $cartProduct['unit_price_full'];
-                            break;
-                        }
-                    }
-
-                    $orderDetailToCartProduct[$detail['id_order_detail']] = $product;
-                    break;
-                }
-            }
-        }
+        $carriersProducts = [];
 
         foreach ($shipments as $shipment) {
             $carrier = new Carrier($shipment->getCarrierId());
 
-            $mappedProducts = [];
-            foreach ($shipment->getProducts() as $shipmentProduct) {
-                $orderDetailId = $shipmentProduct->getOrderDetailId();
-                if (isset($orderDetailToCartProduct[$orderDetailId])) {
-                    $mappedProducts[] = $orderDetailToCartProduct[$orderDetailId];
-                }
-            }
+            // Retrieve products linked to this shipment
+            $mappedProducts = $this->mapShipmentProductsToCartProducts($shipment, $orderDetailToProduct);
+
+            // Add customizations and returned quantities
             $mappedProducts = $this->cartPresenter->addCustomizedData($mappedProducts, $cart);
             OrderReturn::addReturnedQuantity($mappedProducts, $this->order->id);
 
             if (!empty($mappedProducts)) {
-                $carriersProductsMapping[] = [
+                $carriersProducts[] = [
                     'carrier' => [
                         'name' => $carrier->name,
                         'delay' => $carrier->delay[$langId] ?? $carrier->delay,
@@ -312,7 +273,95 @@ class OrderLazyArray extends AbstractLazyArray
             }
         }
 
-        return $carriersProductsMapping;
+        return $carriersProducts;
+    }
+
+    /**
+     * Maps each OrderDetail to its corresponding enriched product data.
+     */
+    private function mapOrderDetailsToProducts(
+        array $orderDetails,
+        array $orderProducts,
+        array $cartProducts,
+        bool $includeTaxes
+    ): array {
+        $orderDetailToProduct = [];
+
+        foreach ($orderDetails as $detail) {
+            foreach ($orderProducts as $orderProduct) {
+                if (
+                    $detail['product_id'] !== $orderProduct['id_product']
+                    || $detail['product_attribute_id'] !== $orderProduct['product_attribute_id']
+                ) {
+                    continue;
+                }
+
+                $product = $this->buildOrderProductData($orderProduct, $cartProducts, $includeTaxes);
+                $orderDetailToProduct[$detail['id_order_detail']] = $product;
+
+                break; // stop when the match is found
+            }
+        }
+
+        return $orderDetailToProduct;
+    }
+
+    /**
+     * Builds a fully enriched product entry with pricing, attributes, and images.
+     */
+    private function buildOrderProductData(
+        array $orderProduct,
+        array $cartProducts,
+        bool $includeTaxes
+    ): array {
+        $product = $orderProduct;
+
+        // Fallback for deleted products
+        $product['name'] = $product['product_name'];
+        $product['quantity'] = $product['product_quantity'];
+        $product['id_product'] = $product['product_id'];
+        $product['id_product_attribute'] = $product['product_attribute_id'];
+
+        $productPriceKey = $includeTaxes ? 'product_price_wt' : 'product_price';
+        $totalPriceKey = $includeTaxes ? 'total_wt' : 'total_price';
+
+        $currency = Currency::getCurrencyInstance((int) $this->order->id_currency);
+        $product['price'] = $this->priceFormatter->format($product[$productPriceKey], $currency);
+        $product['total'] = $this->priceFormatter->format($product[$totalPriceKey], $currency);
+
+        // Merge additional data from cart product (attributes, images, etc.)
+        foreach ($cartProducts as $cartProduct) {
+            if (
+                $product['product_id'] === $cartProduct['id_product']
+                && $product['product_attribute_id'] === $cartProduct['id_product_attribute']
+            ) {
+                $product['attributes'] = $cartProduct['attributes'] ?? [];
+                $product['cover'] = $cartProduct['cover'];
+                $product['default_image'] = $cartProduct['default_image'];
+                $product['unit_price_full'] = $cartProduct['unit_price_full'];
+                break;
+            }
+        }
+
+        return $product;
+    }
+
+    /**
+     * Returns all products for a shipment, mapped to their corresponding cart products.
+     */
+    private function mapShipmentProductsToCartProducts($shipment, array $orderDetailToProduct): array
+    {
+        $mappedProducts = [];
+
+        foreach ($shipment->getProducts() as $shipmentProduct) {
+            $orderDetailId = $shipmentProduct->getOrderDetailId();
+
+            if (isset($orderDetailToProduct[$orderDetailId])) {
+                $mappedProducts[] = $orderDetailToProduct[$orderDetailId];
+            }
+        }
+
+        return $mappedProducts;
     }
 
     /**

--- a/src/Adapter/Presenter/Order/OrderLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderLazyArray.php
@@ -255,7 +255,7 @@ class OrderLazyArray extends AbstractLazyArray
             if (!empty($product['is_virtual'])) {
                 $virtualProducts[] = $product;
             } else {
-                $indexedOrderProducts[$product['order_detail_id']] = $product;
+                $indexedOrderProducts[$product['id_order_detail']] = $product;
             }
         }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/common.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/common.yml
@@ -14,6 +14,7 @@ services:
     arguments:
       - PrestaShopBundle\Entity\Shipment
     lazy: true
+    public: true
 
   PrestaShopBundle\Entity\Repository\TabRepository:
     factory: [ '@doctrine.orm.default_entity_manager', getRepository ]


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | added a property in OrderLazyArray allowing Carrier/Product mapping for a more detailed display in FO tables
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | This cannot be tested without the "improved shipment" feature flag, and without the new classic/humingbird templates.
| UI Tests          | -
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -