### PR TITLE
Add check for enabled countries in cart and order

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4704,6 +4704,21 @@ class CartCore extends ObjectModel
         return true;
     }
 
+    public function checkCountriesAreEnabled()
+    {
+        $deliveryAddress = new Address($this->id_address_delivery);
+        $invoiceAddress = new Address($this->id_address_invoice);
+
+        $deliveryCountry = new Country($deliveryAddress->id_country);
+        $invoiceCountry = new Country($invoiceAddress->id_country);
+
+        if (!$deliveryCountry->active || !$invoiceCountry->active) {
+            return false;
+        }
+
+        return true;
+    }
+
     /**
      * @deprecated since 9.1.0 - it doesn't do anything and will be removed
      *

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -79,14 +79,22 @@ class CartControllerCore extends FrontController
         $this->id_address_delivery = (int) Tools::getValue('id_address_delivery');
         $this->preview = ('1' === Tools::getValue('preview'));
 
-        /* Check if the products in the cart are available */
         if ('show' === Tools::getValue('action')) {
+            /* Check if the products in the cart are available */
             $isAvailable = $this->areProductsAvailable();
             if (Tools::getIsset('checkout')) {
                 Tools::redirect($this->context->link->getPageLink('order'));
             }
             if (true !== $isAvailable) {
                 $this->errors[] = $isAvailable;
+            }
+            /* Check if countries used in the cart are enabled */
+            if (true !== $this->context->cart->checkCountriesAreEnabled()) {
+                $this->errors[] = $this->trans(
+                    'Some of the countries used in your cart are not available and cannot be used.',
+                    [],
+                    'Shop.Notifications.Error'
+                );
             }
         }
     }

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -285,8 +285,12 @@ class OrderControllerCore extends FrontController
         // Check that products are still orderable, at any point in checkout
         if ($this->context->cart->isAllProductsInStock() !== true
             || $this->context->cart->checkAllProductsAreStillAvailableInThisState() !== true
-            || $this->context->cart->checkAllProductsHaveMinimalQuantities() !== true
-            || $this->context->cart->checkCountriesAreEnabled() !== true) {
+            || $this->context->cart->checkAllProductsHaveMinimalQuantities() !== true) {
+            $shouldRedirectToCart = true;
+        }
+
+        // Additionally, check that the addresses are valid
+        if ($this->context->cart->checkCountriesAreEnabled() !== true) {
             $shouldRedirectToCart = true;
         }
 

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -246,7 +246,8 @@ class OrderControllerCore extends FrontController
 
         if ($this->context->cart->isAllProductsInStock() !== true
             || $this->context->cart->checkAllProductsAreStillAvailableInThisState() !== true
-            || $this->context->cart->checkAllProductsHaveMinimalQuantities() !== true) {
+            || $this->context->cart->checkAllProductsHaveMinimalQuantities() !== true
+            || $this->context->cart->checkCountriesAreEnabled() !== true) {
             $responseData['errors'] = true;
             $responseData['cartUrl'] = $this->context->link->getPageLink('cart', null, null, ['action' => 'show']);
         }
@@ -284,7 +285,8 @@ class OrderControllerCore extends FrontController
         // Check that products are still orderable, at any point in checkout
         if ($this->context->cart->isAllProductsInStock() !== true
             || $this->context->cart->checkAllProductsAreStillAvailableInThisState() !== true
-            || $this->context->cart->checkAllProductsHaveMinimalQuantities() !== true) {
+            || $this->context->cart->checkAllProductsHaveMinimalQuantities() !== true
+            || $this->context->cart->checkCountriesAreEnabled() !== true) {
             $shouldRedirectToCart = true;
         }
 


### PR DESCRIPTION
Introduces Cart::checkCountriesAreEnabled() to ensure both delivery and invoice countries are active. Integrates this check into CartController and OrderController to prevent checkout with disabled countries, improving validation and user feedback.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Check that countries are enabled before using them in a order validation.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| UI tests     |https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/18874820050
| How to test?      | See #39786 and check that you will not be able to reach payment step.
| Fixed issue or discussion?     | Fixes #39786
