### PR TITLE
Fix PS_TRUSTED_PROXIES for backend office

### DIFF
--- a/admin-dev/index.php
+++ b/admin-dev/index.php
@@ -87,7 +87,9 @@ $request = Request::createFromGlobals();
  */
 Dispatcher::setRequest($request);
 
-Request::setTrustedProxies([], Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO);
+$trustedProxies = getenv('PS_TRUSTED_PROXIES') ?: ($_SERVER['PS_TRUSTED_PROXIES'] ?? '');
+$trustedProxiesArray = $trustedProxies ? array_filter(array_map('trim', explode(',', $trustedProxies))) : [];
+Request::setTrustedProxies($trustedProxiesArray, Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO);
 
 $response = $kernel->handle($request, HttpKernelInterface::MAIN_REQUEST, true);
 $response->send();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Backend Office don't check PS_TRUSTED_PROXIES env variable. When I'm running Prestashop behind reverse proxy like traefik this env variable is needed. Otherwise I can't login to admin panel. In my case prestashop is running through http and traefik generates SSL and handles https traffic.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Use reverse proxy in front of prestashop, for ex. traefik as reverse proxy and prestashop in docker container. Prestashop should have PS_TRUSTED_PROXIES env variable. Ex. `PS_TRUSTED_PROXIES=172.20.0.0/16`
| UI Tests          | N/A
| Fixed issue or discussion?     | Fixes #39657, Fixes #39190, **Fixes only 9.0.x, but bug occurs also in 8.x.x!**
| Related PRs       | 8.2.x https://github.com/PrestaShop/PrestaShop/pull/39801
| Sponsor company   | [Iksuri Code Craft](https://iksuri.com)
