### PR TITLE
BO: State Grid : Clean unuseful parameters

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -416,9 +416,6 @@ services:
   prestashop.core.grid.definition.factory.state:
     class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\StateGridDefinitionFactory'
     parent: PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory
-    arguments:
-      - "@=service('router').generate('admin_common_reset_search', {'controller': 'state', 'action': 'index'})"
-      - "@=service('router').generate('admin_states_index')"
     public: true
 
   prestashop.core.grid.definition.factory.title:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | [BO] State Grid : Clean unuseful parameters.<br /><br /> The constructor doesn't use these arguments. That fixes an error on `ps_apiresources` module.<br /><br /><img width="1377" height="280" alt="image" src="https://github.com/user-attachments/assets/32513212-b2af-4903-9b93-45580019150f" />
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | :arrow_down: 
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/18708046742
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

## How to test ?
* Go on BO
* Go on States pages
* Test filters & sort on grid