### PR TITLE
Improve front office customer form validation to fix issues with guests and emails

### DIFF
--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -128,7 +128,7 @@ class CustomerFormCore extends AbstractForm
          * We only do this if we have a valid customer in the context (logged in user) and if it's not a guest account.
          * We cannot just check for is_guest only, because an empty customer object will return false for is_guest.
          */
-        /** @phpstan-ignore-next-line */
+        /* @phpstan-ignore-next-line */
         if (!empty($this->context->customer->id) && !$this->context->customer->is_guest) {
             // We check if there is a customer with the same email, registered only
             $id_customer = Customer::customerExists($this->getField('email')->getValue(), true);

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -123,13 +123,18 @@ class CustomerFormCore extends AbstractForm
 
     public function validate()
     {
-        // If email is being changed, check if it's free to use and doesn't belong to another customer
-        if (!$this->context->customer->is_guest) {
-            $emailField = $this->getField('email');
-            $id_customer = Customer::customerExists($emailField->getValue(), true);
-            $customer = $this->getCustomer();
-            if ($id_customer && $id_customer != $customer->id) {
-                $emailField->addError($this->translator->trans(
+        /*
+         * If email is being changed, check if it's free to use and doesn't belong to another customer.
+         * We only do this if we have a valid customer in the context (logged in user) and if it's not a guest account.
+         * We cannot just check for is_guest only, because an empty customer object will return false for is_guest.
+         */
+        if (!empty($this->context->customer->id) && !$this->context->customer->is_guest) {
+            // We check if there is a customer with the same email, registered only
+            $id_customer = Customer::customerExists($this->getField('email')->getValue(), true);
+
+            // If we found a customer and it's not the current one, it's an error
+            if ($id_customer && $id_customer != $this->getCustomer()->id) {
+                $this->getField('email')->addError($this->translator->trans(
                     'The email is already used, please choose another one or sign in',
                     [],
                     'Shop.Notifications.Error'

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -128,6 +128,7 @@ class CustomerFormCore extends AbstractForm
          * We only do this if we have a valid customer in the context (logged in user) and if it's not a guest account.
          * We cannot just check for is_guest only, because an empty customer object will return false for is_guest.
          */
+        /** @phpstan-ignore-next-line */
         if (!empty($this->context->customer->id) && !$this->context->customer->is_guest) {
             // We check if there is a customer with the same email, registered only
             $id_customer = Customer::customerExists($this->getField('email')->getValue(), true);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fixes customer validation in context. When there is no customer in the context, the is_guest property is false, so our check in checkout is failing. We need to check if we have a valid customer AND the original condition.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/19495993541
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39816
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### How to test
- Check you can order as a guest for `customerone@test.com`. SHOULD WORK.
- Register as `customerone@test.com`.
- Log out.
- Register as `customertwo@test.com`, try to change email in my account zone to `customerone@test.com`. SHOULD NOT WORK.
- Try to change email in checkout to `customerone@test.com`. SHOULD NOT WORK.
- Try to change email to `customerthree@test.com`, SHOULD WORK.
- Log out.
- Again, check you can order as a guest for `customerone@test.com`. SHOULD WORK.

cc @PrestaShop/qa-automation Guys, can you please create UI tests for this? It's a basic shop functionality, it must be automatically tested.