### PR TITLE
Remove from the list of free gifts products with a minimum quantity

### DIFF
--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -642,15 +642,26 @@ class AdminCartRulesControllerCore extends AdminController
     protected function searchProducts(string $searchString)
     {
         if ($products = Product::searchByName((int) $this->context->language->id, $searchString)) {
-            foreach ($products as &$product) {
+            foreach ($products as $k => &$product) {
                 $combinations = [];
                 $productObj = new Product((int) $product['id_product'], false, (int) $this->context->language->id);
+                // Product with a minimal quantity greater than 1 cannot be gifted
+                if ($productObj->minimal_quantity > 1) {
+                    // Unset so that product isn't returned
+                    unset($products[$k]);
+                    continue;
+                }
                 $attributes = $productObj->getAttributesGroups((int) $this->context->language->id);
                 $product['formatted_price'] = $product['price_tax_incl']
                     ? $this->context->getCurrentLocale()->formatPrice(Tools::convertPrice($product['price_tax_incl'], $this->context->currency), $this->context->currency->iso_code)
                     : '';
 
                 foreach ($attributes as $attribute) {
+                    // Combination with a minimal quantity greater than 1 cannot be gifted
+                    if ($attribute['minimal_quantity'] > 1) {
+                        // Using continue is enought because $combination is not fullfiled before
+                        continue;
+                    }
                     if (!isset($combinations[$attribute['id_product_attribute']]['attributes'])) {
                         $combinations[$attribute['id_product_attribute']]['attributes'] = '';
                     }
@@ -663,10 +674,15 @@ class AdminCartRulesControllerCore extends AdminController
                         : '';
                 }
 
-                foreach ($combinations as &$combination) {
-                    $combination['attributes'] = rtrim($combination['attributes'], ' - ');
+                if (!empty($combinations)) {
+                    foreach ($combinations as &$combination) {
+                        $combination['attributes'] = rtrim($combination['attributes'], ' - ');
+                    }
+                    $product['combinations'] = $combinations;
+                }else{
+                    // if $combinations is empty $product shouldn't be returned
+                    unset($products[$k]);
                 }
-                $product['combinations'] = $combinations;
             }
 
             return [

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -679,7 +679,7 @@ class AdminCartRulesControllerCore extends AdminController
                         $combination['attributes'] = rtrim($combination['attributes'], ' - ');
                     }
                     $product['combinations'] = $combinations;
-                }else{
+                } else {
                     // if $combinations is empty $product shouldn't be returned
                     unset($products[$k]);
                 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Product with a minimum quantity shouldn't be available when creating a discount with gifted product
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a simple product or a product with attributes<br>Add a minimum quantity greater than 1<br>Add a cart rule -> go to "actions" tab<br>Enable product gift and look for this product<br>It should not shown
| UI Tests          | https://github.com/aomaxime/ga.tests.ui.pr/actions/runs/18750482101
| Fixed issue or discussion?     | Fixes #39803 
| Sponsor company   | Agence Off
