### PR TITLE
Include data-placeholder for select field

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -347,7 +347,8 @@
 												{if isset($input.multiple) && $input.multiple} multiple="multiple"{/if}
 												{if isset($input.size)} size="{$input.size|escape:'html':'utf-8'}"{/if}
 												{if isset($input.onchange)} onchange="{$input.onchange|escape:'html':'utf-8'}"{/if}
-												{if isset($input.disabled) && $input.disabled} disabled="disabled"{/if}>
+												{if isset($input.disabled) && $input.disabled} disabled="disabled"{/if}
+												{if isset($input.placeholder) && $input.placeholder} data-placeholder="{$input.placeholder|escape:'html':'utf-8'}"{/if}>
 											{if isset($input.options.default)}
 												<option value="{$input.options.default.value|escape:'html':'utf-8'}">{$input.options.default.label|escape:'html':'utf-8'}</option>
 											{/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allow to change the placeholder on select elements with multiple/choosen option in HelperForm.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.

Add the following field to any `HelperForm` definition (a module configuration page or an `AdminController`):

```php
[
    'type' => 'select',
    'label' => 'select multiple with chosen',
    'name' => 'type_select_multiple_chosen[]',
    'class' => 'chosen',
    'multiple' => true,
    'placeholder' => 'Place holder',
    'options' => [
        'query' => Country::getCountries((int) Context::getContext()->cookie->id_lang),
        'id' => 'id_country',
        'name' => 'name',
    ],
],
```

And make sure the matching value is defined:

```php
$helper->fields_value['type_select_multiple_chosen[]'] = [];
```

Without this PR, you will see the default "Select Some Options".
With it, you will see the "Place holder" text in the select.

> [!IMPORTANT]
> The `[]` suffix in `name` and the `fields_value` entry are both required, otherwise the page errors out — this is unrelated to this PR.
>
> When `'multiple' => true` is set, `HelperForm::generate()` appends `[]` to the field name (`classes/helper/HelperForm.php`, `case 'select'`), but `fields_value` is left untouched. `form.tpl` then runs `{foreach $fields_value[$input.name] as $field_value}` with the renamed key, which raises `Undefined array key "type_select_multiple_chosen[]"` when that key does not exist.
>
> In an `AdminController` this usually goes unnoticed, because `getFieldsValue()` creates an entry for every input (possibly `false`, which Smarty happily iterates). In a module you build `fields_value` yourself, so nothing fills the gap.
