### PR TITLE
Add customer groups limit for discounts

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/discount/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/discount/form/index.ts
@@ -38,6 +38,7 @@ $(() => {
       'ToggleChildrenChoice',
       'GeneratableInput',
       'ChoiceTree',
+      'ChoiceTable',
       'EventEmitter',
     ],
   );

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -217,12 +217,14 @@ class GroupCore extends ObjectModel
         if ($this->id == (int) Configuration::get('PS_CUSTOMER_GROUP')) {
             return false;
         }
+
         if (parent::delete()) {
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'cart_rule_group` WHERE `id_group` = ' . (int) $this->id);
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'customer_group` WHERE `id_group` = ' . (int) $this->id);
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'category_group` WHERE `id_group` = ' . (int) $this->id);
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'group_reduction` WHERE `id_group` = ' . (int) $this->id);
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'product_group_reduction_cache` WHERE `id_group` = ' . (int) $this->id);
+
             $this->truncateModulesRestrictions($this->id);
 
             // Add default group (id 3) to customers without groups

--- a/src/Adapter/Customer/Group/CommandHandler/DeleteCustomerGroupHandler.php
+++ b/src/Adapter/Customer/Group/CommandHandler/DeleteCustomerGroupHandler.php
@@ -37,7 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\Group\CommandHandler\DeleteCustom
 class DeleteCustomerGroupHandler implements DeleteCustomerGroupHandlerInterface
 {
     public function __construct(
-        private readonly GroupRepository $customerGroupRepository
+        private readonly GroupRepository $customerGroupRepository,
     ) {
     }
 

--- a/src/Adapter/Discount/CommandHandler/UpdateDiscountConditionsHandler.php
+++ b/src/Adapter/Discount/CommandHandler/UpdateDiscountConditionsHandler.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Adapter\Discount\Update\DiscountConditionsUpdater;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierId;
 use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Group\ValueObject\GroupId;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\UpdateDiscountConditionsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\CommandHandler\UpdateDiscountConditionsHandlerInterface;
 
@@ -51,6 +52,7 @@ class UpdateDiscountConditionsHandler implements UpdateDiscountConditionsHandler
             $command->getMinimumAmountShippingIncluded(),
             $command->getCarrierIds() ? array_map(fn (CarrierId $carrierId) => $carrierId->getValue(), $command->getCarrierIds()) : null,
             $command->getCountryIds() ? array_map(fn (CountryId $countryId) => $countryId->getValue(), $command->getCountryIds()) : null,
+            $command->getCustomerGroupIds() ? array_map(fn (GroupId $groupId) => $groupId->getValue(), $command->getCustomerGroupIds()) : null,
         );
     }
 }

--- a/src/Adapter/Discount/QueryHandler/GetDiscountForEditingHandler.php
+++ b/src/Adapter/Discount/QueryHandler/GetDiscountForEditingHandler.php
@@ -52,6 +52,7 @@ class GetDiscountForEditingHandler implements GetDiscountForEditingHandlerInterf
         $discountConditions = $this->discountRepository->getProductRulesGroup($query->getDiscountId());
         $carrierIds = $this->discountRepository->getCarriers($query->getDiscountId());
         $countryIds = $this->discountRepository->getCountries($query->getDiscountId());
+        $customerGroupIds = $this->discountRepository->getCustomerGroups($query->getDiscountId());
 
         return new DiscountForEditing(
             $query->getDiscountId()->getValue(),
@@ -83,6 +84,7 @@ class GetDiscountForEditingHandler implements GetDiscountForEditingHandlerInterf
             $cartRule->minimum_amount_shipping,
             $carrierIds,
             $countryIds,
+            $customerGroupIds,
         );
     }
 }

--- a/src/Adapter/Discount/Repository/DiscountRepository.php
+++ b/src/Adapter/Discount/Repository/DiscountRepository.php
@@ -176,6 +176,22 @@ class DiscountRepository extends AbstractObjectModelRepository
     }
 
     /**
+     * @return int[]
+     */
+    public function getCustomerGroups(DiscountId $discountId): array
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->select('*')
+            ->from($this->dbPrefix . 'cart_rule_group', 'crg')
+            ->where('crg.id_cart_rule = :discountId')
+            ->setparameter('discountId', $discountId->getValue())
+        ;
+
+        return array_map(fn (array $row) => (int) $row['id_group'], $qb->executeQuery()->fetchAllAssociative());
+    }
+
+    /**
      * Returns the ID of a discount by its code.
      * null is returned if the discount does not exist.
      */

--- a/src/Adapter/Discount/Update/DiscountConditionsUpdater.php
+++ b/src/Adapter/Discount/Update/DiscountConditionsUpdater.php
@@ -61,6 +61,7 @@ class DiscountConditionsUpdater
         ?bool $minimumShippingIncluded = null,
         ?array $carrierIds = null,
         ?array $countryIds = null,
+        ?array $customerGroupIds = null,
     ): void {
         // todo: when other conditions are added we check that only one is provided
         $discount = $this->discountRepository->get($discountId);
@@ -84,6 +85,10 @@ class DiscountConditionsUpdater
 
         if (null !== $countryIds) {
             $updatableProperties = array_merge($updatableProperties, $this->applyCountryConditions($discount, $countryIds));
+        }
+
+        if (null !== $customerGroupIds) {
+            $updatableProperties = array_merge($updatableProperties, $this->applyCustomerGroupConditions($discount, $customerGroupIds));
         }
 
         $updatableProperties = array_unique($updatableProperties);
@@ -237,6 +242,7 @@ class DiscountConditionsUpdater
             $this->cleanDiscountProductRules($discount),
             $this->cleanDiscountCarriers($discount),
             $this->cleanDiscountCountries($discount),
+            $this->cleanCustomerGroups($discount),
             [
                 'minimum_product_quantity',
                 'minimum_amount',
@@ -304,5 +310,53 @@ class DiscountConditionsUpdater
         ;
 
         return ['country_restriction'];
+    }
+
+    /**
+     * Update customer group restrictions for a discount.
+     *
+     * @param CartRule $discount
+     * @param int[] $customerGroupIds
+     *
+     * @return array List of updated properties
+     */
+    private function applyCustomerGroupConditions(CartRule $discount, array $customerGroupIds): array
+    {
+        if (!empty($customerGroupIds)) {
+            $discount->group_restriction = true;
+            foreach ($customerGroupIds as $groupId) {
+                $this->connection->createQueryBuilder()
+                    ->insert($this->dbPrefix . 'cart_rule_group')
+                    ->values([
+                        'id_cart_rule' => (int) $discount->id,
+                        'id_group' => $groupId,
+                    ])
+                    ->executeStatement()
+                ;
+            }
+
+            return ['group_restriction'];
+        }
+
+        return ['group_restriction'];
+    }
+
+    /**
+     * Clean all customer groups for a discount.
+     *
+     * @return array List of updated properties
+     */
+    private function cleanCustomerGroups(CartRule $discount): array
+    {
+        $discount->group_restriction = false;
+
+        $this->connection->createQueryBuilder()
+            ->delete($this->dbPrefix . 'cart_rule_group', 'crg')
+            ->where('crg.id_cart_rule = :discountId')
+            ->setParameter('discountId', (int) $discount->id)
+            ->executeStatement()
+        ;
+
+        return ['group_restriction'];
     }
 }

--- a/src/Core/Domain/Discount/Command/UpdateDiscountConditionsCommand.php
+++ b/src/Core/Domain/Discount/Command/UpdateDiscountConditionsCommand.php
@@ -30,6 +30,7 @@ use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierId;
 use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Group\ValueObject\GroupId;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Exception\DiscountConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Discount\ProductRuleGroup;
 use PrestaShop\PrestaShop\Core\Domain\Discount\ValueObject\DiscountId;
@@ -53,6 +54,11 @@ class UpdateDiscountConditionsCommand
     private ?array $carrierIds = null;
 
     private ?array $countryIds = null;
+
+    /**
+     * @var GroupId[]|null
+     */
+    private ?array $customerGroupIds = null;
 
     public function __construct(int $discountId)
     {
@@ -180,6 +186,24 @@ class UpdateDiscountConditionsCommand
     public function setCountryIds(?array $countryIds): self
     {
         $this->countryIds = array_map(fn (int $countryId) => new CountryId($countryId), $countryIds);
+
+        return $this;
+    }
+
+    /**
+     * @return GroupId[]|null
+     */
+    public function getCustomerGroupIds(): ?array
+    {
+        return $this->customerGroupIds;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setCustomerGroupIds(?array $customerGroupIds): self
+    {
+        $this->customerGroupIds = $customerGroupIds ? array_map(fn (int $groupId) => new GroupId($groupId), $customerGroupIds) : null;
 
         return $this;
     }

--- a/src/Core/Domain/Discount/QueryResult/DiscountForEditing.php
+++ b/src/Core/Domain/Discount/QueryResult/DiscountForEditing.php
@@ -63,6 +63,7 @@ class DiscountForEditing
         private readonly ?bool $minimumAmountShippingIncluded,
         private readonly array $carrierIds,
         private readonly array $countryIds,
+        private readonly array $customerGroupIds = [],
     ) {
     }
 
@@ -215,5 +216,13 @@ class DiscountForEditing
     public function getCountryIds(): array
     {
         return $this->countryIds;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getCustomerGroupIds(): array
+    {
+        return $this->customerGroupIds;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataHandler/DiscountFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/DiscountFormDataHandler.php
@@ -385,6 +385,19 @@ class DiscountFormDataHandler implements FormDataHandlerInterface
             $conditionsCommand->setCountryIds($data['conditions'][DiscountConditionsType::DELIVERY_CONDITIONS][DeliveryConditionsType::COUNTRY]);
         }
 
+        // Customer eligibility conditions
+        if (isset($data['customer_eligibility']['eligibility'])) {
+            $customerEligibility = $data['customer_eligibility']['eligibility'];
+            $selectedOption = $customerEligibility['children_selector'] ?? DiscountCustomerEligibilityChoiceType::ALL_CUSTOMERS;
+
+            if ($selectedOption === DiscountCustomerEligibilityChoiceType::CUSTOMER_GROUPS) {
+                $groupIds = $this->extractCustomerGroupIds($customerEligibility[DiscountCustomerEligibilityChoiceType::CUSTOMER_GROUPS] ?? []);
+                $conditionsCommand->setCustomerGroupIds($groupIds);
+            } else {
+                $conditionsCommand->setCustomerGroupIds([]);
+            }
+        }
+
         $this->commandBus->handle($conditionsCommand);
     }
 
@@ -455,5 +468,19 @@ class DiscountFormDataHandler implements FormDataHandlerInterface
                 $command->setCustomerId((int) $customerData[0]['id_customer']);
             }
         }
+    }
+
+    /**
+     * Extract customer group IDs from the form data.
+     * MaterialChoiceTableType returns a flat array of selected group IDs.
+     *
+     * @param array $groupData
+     *
+     * @return int[]
+     */
+    private function extractCustomerGroupIds(array $groupData): array
+    {
+        // MaterialChoiceTableType returns a flat array like [3, 4, 5]
+        return array_map('intval', array_filter($groupData, 'is_numeric'));
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
@@ -101,6 +101,7 @@ class DiscountFormDataProvider implements FormDataProviderInterface
             'customer_eligibility' => [
                 'eligibility' => [
                     'children_selector' => DiscountCustomerEligibilityChoiceType::ALL_CUSTOMERS,
+                    DiscountCustomerEligibilityChoiceType::CUSTOMER_GROUPS => [],
                     DiscountCustomerEligibilityChoiceType::SINGLE_CUSTOMER => [],
                 ],
             ],
@@ -448,39 +449,39 @@ class DiscountFormDataProvider implements FormDataProviderInterface
     private function getCustomerEligibilityData(DiscountForEditing $discountForEditing): array
     {
         $customerId = $discountForEditing->getCustomerId();
+        $customerGroupIds = $discountForEditing->getCustomerGroupIds();
 
-        if (!$customerId) {
-            return [
-                'children_selector' => DiscountCustomerEligibilityChoiceType::ALL_CUSTOMERS,
-                DiscountCustomerEligibilityChoiceType::SINGLE_CUSTOMER => [],
-            ];
-        }
-
-        try {
-            $customer = $this->customerRepository->get(new CustomerId($customerId));
-        } catch (CustomerNotFoundException $e) {
-            return [
-                'children_selector' => DiscountCustomerEligibilityChoiceType::ALL_CUSTOMERS,
-                DiscountCustomerEligibilityChoiceType::SINGLE_CUSTOMER => [],
-            ];
-        }
-
-        $fullnameAndEmail = sprintf(
-            '%s %s - %s',
-            $customer->firstname,
-            $customer->lastname,
-            $customer->email
-        );
-
-        return [
-            'children_selector' => DiscountCustomerEligibilityChoiceType::SINGLE_CUSTOMER,
-            DiscountCustomerEligibilityChoiceType::SINGLE_CUSTOMER => [
-                [
-                    'id_customer' => $customerId,
-                    'fullname_and_email' => $fullnameAndEmail,
-                ],
-            ],
+        $data = [
+            'children_selector' => DiscountCustomerEligibilityChoiceType::ALL_CUSTOMERS,
+            DiscountCustomerEligibilityChoiceType::CUSTOMER_GROUPS => [],
+            DiscountCustomerEligibilityChoiceType::SINGLE_CUSTOMER => [],
         ];
+
+        if (!empty($customerGroupIds)) {
+            $data['children_selector'] = DiscountCustomerEligibilityChoiceType::CUSTOMER_GROUPS;
+            $data[DiscountCustomerEligibilityChoiceType::CUSTOMER_GROUPS] = $customerGroupIds;
+        } elseif ($customerId) {
+            try {
+                $customer = $this->customerRepository->get(new CustomerId($customerId));
+                $fullnameAndEmail = sprintf(
+                    '%s %s - %s',
+                    $customer->firstname,
+                    $customer->lastname,
+                    $customer->email
+                );
+
+                $data['children_selector'] = DiscountCustomerEligibilityChoiceType::SINGLE_CUSTOMER;
+                $data[DiscountCustomerEligibilityChoiceType::SINGLE_CUSTOMER] = [
+                    [
+                        'id_customer' => $customerId,
+                        'fullname_and_email' => $fullnameAndEmail,
+                    ],
+                ];
+            } catch (CustomerNotFoundException $e) {
+            }
+        }
+
+        return $data;
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/OptionProvider/DiscountFormOptionsProvider.php
+++ b/src/Core/Form/IdentifiableObject/OptionProvider/DiscountFormOptionsProvider.php
@@ -31,7 +31,7 @@ use PrestaShop\PrestaShop\Adapter\Discount\Repository\DiscountTypeRepository;
 class DiscountFormOptionsProvider implements FormOptionsProviderInterface
 {
     public function __construct(
-        private readonly DiscountTypeRepository $discountTypeRepository
+        private readonly DiscountTypeRepository $discountTypeRepository,
     ) {
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountCustomerEligibilityChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountCustomerEligibilityChoiceType.php
@@ -26,15 +26,19 @@
 
 namespace PrestaShopBundle\Form\Admin\Sell\Discount;
 
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\CustomerSearchType;
 use PrestaShopBundle\Form\Admin\Type\EntitySearchInputType;
+use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTableType;
 use PrestaShopBundle\Form\Admin\Type\ToggleChildrenChoiceType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\When;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DiscountCustomerEligibilityChoiceType extends TranslatorAwareType
 {
@@ -42,17 +46,44 @@ class DiscountCustomerEligibilityChoiceType extends TranslatorAwareType
     public const CUSTOMER_GROUPS = 'customer_groups';
     public const SINGLE_CUSTOMER = 'single_customer';
 
+    private FormChoiceProviderInterface $groupByIdChoiceProvider;
+
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        FormChoiceProviderInterface $groupByIdChoiceProvider
+    ) {
+        parent::__construct($translator, $locales);
+        $this->groupByIdChoiceProvider = $groupByIdChoiceProvider;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
             ->add(self::ALL_CUSTOMERS, HiddenType::class, [
                 'label' => $this->trans('All customers', 'Admin.Catalog.Feature'),
             ])
-            ->add(self::CUSTOMER_GROUPS, HiddenType::class, [
+            ->add(self::CUSTOMER_GROUPS, MaterialChoiceTableType::class, [
                 'label' => $this->trans('Customer groups', 'Admin.Catalog.Feature'),
-                'disabled' => true,
-                'attr' => [
-                    'class' => 'js-customer-groups-placeholder',
+                'required' => false,
+                'choices' => $this->groupByIdChoiceProvider->getChoices(),
+                'display_total_items' => true,
+                'constraints' => [
+                    new When(
+                        expression: sprintf(
+                            'this.getParent().get("children_selector").getData() === "%s"',
+                            self::CUSTOMER_GROUPS,
+                        ),
+                        constraints: [
+                            new Count([
+                                'min' => 1,
+                                'minMessage' => $this->trans(
+                                    'Please select at least one group.',
+                                    'Admin.Catalog.Notification'
+                                ),
+                            ]),
+                        ],
+                    ),
                 ],
             ])
             ->add(self::SINGLE_CUSTOMER, CustomerSearchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountCustomerEligibilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountCustomerEligibilityType.php
@@ -33,16 +33,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DiscountCustomerEligibilityType extends TranslatorAwareType
 {
-    public const ALL_CUSTOMERS = 'all_customers';
-    public const CUSTOMER_GROUPS = 'customer_groups';
-    public const SINGLE_CUSTOMER = 'single_customer';
-
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('eligibility', DiscountCustomerEligibilityChoiceType::class, [
-                'required' => false,
-            ])
+            ->add('eligibility', DiscountCustomerEligibilityChoiceType::class)
         ;
     }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -439,6 +439,10 @@ services:
     arguments:
       $featuresChoiceProvider: '@prestashop.adapter.form.choice_provider.features_choice_provider'
 
+  PrestaShopBundle\Form\Admin\Sell\Discount\DiscountCustomerEligibilityChoiceType:
+    arguments:
+      $groupByIdChoiceProvider: '@prestashop.core.form.choice_provider.group_by_id'
+
   PrestaShopBundle\Form\Admin\Sell\Product\Category\CategoriesType:
     arguments:
       $defaultCategoryChoiceProvider: '@prestashop.adapter.form.choice_provider.product_default_category_choice_provider'

--- a/tests/Integration/Behaviour/Features/Context/CustomerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CustomerFeatureContext.php
@@ -66,6 +66,19 @@ class CustomerFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Given /^customer "(.+)" belongs to group "(.+)"$/
+     */
+    public function assignCustomerToGroup(string $customerReference, string $groupReference): void
+    {
+        $customerId = SharedStorage::getStorage()->get($customerReference);
+        $groupId = SharedStorage::getStorage()->get($groupReference);
+
+        $customer = new Customer($customerId);
+        // Add the group to the customer's groups
+        $customer->addGroups([$groupId]);
+    }
+
+    /**
      * @Given there is customer :reference with email :customerEmail
      */
     public function customerExists($reference, $customerEmail)

--- a/tests/Integration/Behaviour/Features/Context/Domain/Discount/DiscountFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Discount/DiscountFeatureContext.php
@@ -40,6 +40,7 @@ use PrestaShop\PrestaShop\Core\Domain\Discount\Command\AddDiscountCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\BulkUpdateDiscountsStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\DeleteDiscountCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\UpdateDiscountCommand;
+use PrestaShop\PrestaShop\Core\Domain\Discount\Command\UpdateDiscountConditionsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\DiscountSettings;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Exception\DiscountConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Exception\DiscountException;
@@ -227,6 +228,13 @@ class DiscountFeatureContext extends AbstractDomainFeatureContext
             /** @var DiscountId $discountId */
             $discountId = $this->getCommandBus()->handle($command);
             $this->getSharedStorage()->set($discountReference, $discountId->getValue());
+
+            // Handle customer groups using conditions command
+            if (isset($data['customer_groups'])) {
+                $conditionsCommand = new UpdateDiscountConditionsCommand($discountId->getValue());
+                $conditionsCommand->setCustomerGroupIds($this->referencesToIds($data['customer_groups']));
+                $this->getCommandBus()->handle($conditionsCommand);
+            }
         } catch (DiscountConstraintException $e) {
             $this->setLastException($e);
         }
@@ -361,6 +369,13 @@ class DiscountFeatureContext extends AbstractDomainFeatureContext
         try {
             /* @var DiscountId $discountId */
             $this->getCommandBus()->handle($command);
+
+            // Handle customer groups using conditions command
+            if (isset($data['customer_groups'])) {
+                $conditionsCommand = new UpdateDiscountConditionsCommand($discountId);
+                $conditionsCommand->setCustomerGroupIds($this->referencesToIds($data['customer_groups']));
+                $this->getCommandBus()->handle($conditionsCommand);
+            }
         } catch (DiscountConstraintException $e) {
             $this->setLastException($e);
         }
@@ -426,6 +441,18 @@ class DiscountFeatureContext extends AbstractDomainFeatureContext
                 $expectedCustomerId,
                 $actualCustomerId,
                 'Unexpected customer id'
+            );
+        }
+
+        if (isset($expectedData['customer_groups'])) {
+            $expectedGroupIds = $this->referencesToIds($expectedData['customer_groups']);
+            $actualGroupIds = $discountForEditing->getCustomerGroupIds();
+            sort($expectedGroupIds);
+            sort($actualGroupIds);
+            Assert::assertSame(
+                $expectedGroupIds,
+                $actualGroupIds,
+                'Unexpected customer group ids'
             );
         }
         if (isset($expectedData['priority'])) {

--- a/tests/Integration/Behaviour/Features/Scenario/Discount/BO/add_discount_with_customer_groups_eligibility.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Discount/BO/add_discount_with_customer_groups_eligibility.feature
@@ -1,0 +1,191 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s discount --tags add-discount-customer-groups
+@restore-all-tables-before-feature
+@restore-languages-after-feature
+@add-discount-customer-groups
+Feature: Add discount with customer groups eligibility
+  PrestaShop allows BO users to create discounts limited to specific customer groups
+  As a BO user
+  I must be able to create discounts that are only available to specific customer groups
+
+  Background:
+    Given shop "shop1" with name "test_shop" exists
+    Given there is a currency named "usd" with iso code "USD" and exchange rate of 0.92
+    Given currency "usd" is the default one
+    And language with iso code "en" is the default one
+    And language "french" with locale "fr-FR" exists
+    And I create a customer group "group1" with the following details:
+      | name[en-US]             | VIP Members       |
+      | name[fr-FR]             | Membres VIP       |
+      | reduction               | 0.0               |
+      | displayPriceTaxExcluded | false             |
+      | showPrice               | true              |
+      | shopIds                 | shop1             |
+    And I create a customer group "group2" with the following details:
+      | name[en-US]             | Premium Members   |
+      | name[fr-FR]             | Membres Premium   |
+      | reduction               | 0.0               |
+      | displayPriceTaxExcluded | false             |
+      | showPrice               | true              |
+      | shopIds                 | shop1             |
+
+  Scenario: Create a discount limited to a single customer group
+    When I create a "cart_level" discount "discount_for_vip" with following properties:
+      | name[en-US]              | VIP discount        |
+      | name[fr-FR]              | Réduction VIP       |
+      | active                   | true                |
+      | valid_from               | 2025-01-01 00:00:00 |
+      | valid_to                 | 2025-12-31 23:59:59 |
+      | code                     | VIP_GROUP_2025      |
+      | reduction_percent        | 20.0                |
+      | customer_groups          | group1              |
+      | total_quantity           | 100                 |
+      | quantity_per_user        | 1                   |
+      | minimum_product_quantity | 0                   |
+    Then discount "discount_for_vip" should have the following properties:
+      | name[en-US]       | VIP discount        |
+      | name[fr-FR]       | Réduction VIP       |
+      | type              | cart_level          |
+      | active            | true                |
+      | valid_from        | 2025-01-01 00:00:00 |
+      | valid_to          | 2025-12-31 23:59:59 |
+      | code              | VIP_GROUP_2025      |
+      | reduction_percent | 20.0                |
+      | customer_groups   | group1              |
+
+  Scenario: Create a discount limited to multiple customer groups
+    When I create a "cart_level" discount "discount_for_vip_and_premium" with following properties:
+      | name[en-US]              | VIP and Premium discount |
+      | name[fr-FR]              | Réduction VIP et Premium |
+      | active                   | true                     |
+      | valid_from               | 2025-01-01 00:00:00      |
+      | valid_to                 | 2025-12-31 23:59:59      |
+      | code                     | VIP_PREMIUM_2025         |
+      | reduction_percent        | 15.0                     |
+      | customer_groups          | group1,group2            |
+      | total_quantity           | 100                      |
+      | quantity_per_user        | 1                        |
+      | minimum_product_quantity | 0                        |
+    Then discount "discount_for_vip_and_premium" should have the following properties:
+      | name[en-US]       | VIP and Premium discount |
+      | name[fr-FR]       | Réduction VIP et Premium |
+      | type              | cart_level               |
+      | active            | true                     |
+      | valid_from        | 2025-01-01 00:00:00      |
+      | valid_to          | 2025-12-31 23:59:59      |
+      | code              | VIP_PREMIUM_2025         |
+      | reduction_percent | 15.0                     |
+      | customer_groups   | group1,group2            |
+
+  Scenario: Create a discount without customer group restriction (all customers)
+    When I create a "cart_level" discount "discount_for_all" with following properties:
+      | name[en-US]              | Public discount     |
+      | name[fr-FR]              | Réduction publique  |
+      | active                   | true                |
+      | valid_from               | 2025-01-01 00:00:00 |
+      | valid_to                 | 2025-12-31 23:59:59 |
+      | code                     | PUBLIC_2025         |
+      | reduction_percent        | 10.0                |
+      | total_quantity           | 100                 |
+      | quantity_per_user        | 1                   |
+      | minimum_product_quantity | 0                   |
+    Then discount "discount_for_all" should have the following properties:
+      | name[en-US]       | Public discount     |
+      | name[fr-FR]       | Réduction publique  |
+      | type              | cart_level          |
+      | active            | true                |
+      | valid_from        | 2025-01-01 00:00:00 |
+      | valid_to          | 2025-12-31 23:59:59 |
+      | code              | PUBLIC_2025         |
+      | reduction_percent | 10.0                |
+      | customer_groups   |                     |
+
+  Scenario: Update a discount to limit it to specific customer groups
+    When I create a "cart_level" discount "discount_public_to_groups" with following properties:
+      | name[en-US]              | General discount    |
+      | name[fr-FR]              | Réduction générale  |
+      | active                   | true                |
+      | valid_from               | 2025-01-01 00:00:00 |
+      | valid_to                 | 2025-12-31 23:59:59 |
+      | code                     | GENERAL_2025        |
+      | reduction_percent        | 15.0                |
+      | total_quantity           | 100                 |
+      | quantity_per_user        | 1                   |
+      | minimum_product_quantity | 0                   |
+    And discount "discount_public_to_groups" should have the following properties:
+      | name[en-US]       | General discount   |
+      | name[fr-FR]       | Réduction générale |
+    When I update discount "discount_public_to_groups" with the following properties:
+      | name[en-US]       | VIP only            |
+      | name[fr-FR]       | Réservé VIP         |
+      | customer_groups   | group1              |
+    Then discount "discount_public_to_groups" should have the following properties:
+      | name[en-US]       | VIP only     |
+      | name[fr-FR]       | Réservé VIP  |
+      | customer_groups   | group1       |
+
+  Scenario: Update a discount to change customer groups
+    When I create a "cart_level" discount "discount_change_groups" with following properties:
+      | name[en-US]              | VIP discount        |
+      | name[fr-FR]              | Réduction VIP       |
+      | active                   | true                |
+      | valid_from               | 2025-01-01 00:00:00 |
+      | valid_to                 | 2025-12-31 23:59:59 |
+      | code                     | VIP_ONLY_2025       |
+      | reduction_percent        | 25.0                |
+      | customer_groups          | group1              |
+      | total_quantity           | 100                 |
+      | quantity_per_user        | 1                   |
+      | minimum_product_quantity | 0                   |
+    And discount "discount_change_groups" should have the following properties:
+      | customer_groups   | group1           |
+    When I update discount "discount_change_groups" with the following properties:
+      | name[en-US]       | Premium discount  |
+      | name[fr-FR]       | Réduction Premium |
+      | customer_groups   | group2            |
+    Then discount "discount_change_groups" should have the following properties:
+      | name[en-US]       | Premium discount  |
+      | name[fr-FR]       | Réduction Premium |
+      | customer_groups   | group2            |
+
+  Scenario: Update a discount to remove all customer groups (switch to all customers)
+    When I create a "cart_level" discount "discount_remove_groups" with following properties:
+      | name[en-US]              | VIP discount        |
+      | name[fr-FR]              | Réduction VIP       |
+      | active                   | true                |
+      | valid_from               | 2025-01-01 00:00:00 |
+      | valid_to                 | 2025-12-31 23:59:59 |
+      | code                     | VIP_TEMP_2025       |
+      | reduction_percent        | 20.0                |
+      | customer_groups          | group1              |
+      | total_quantity           | 100                 |
+      | quantity_per_user        | 1                   |
+      | minimum_product_quantity | 0                   |
+    And discount "discount_remove_groups" should have the following properties:
+      | customer_groups   | group1           |
+    When I update discount "discount_remove_groups" with the following properties:
+      | name[en-US]       | Public discount    |
+      | name[fr-FR]       | Réduction publique |
+      | customer_groups   |                    |
+    Then discount "discount_remove_groups" should have the following properties:
+      | name[en-US]       | Public discount    |
+      | name[fr-FR]       | Réduction publique |
+      | customer_groups   |                    |
+
+  Scenario: Create a free shipping discount limited to customer groups
+    When I create a "free_shipping" discount "free_shipping_for_vip" with following properties:
+      | name[en-US]              | Free shipping VIP      |
+      | name[fr-FR]              | Livraison gratuite VIP |
+      | active                   | true                   |
+      | valid_from               | 2025-01-01 00:00:00    |
+      | valid_to                 | 2025-12-31 23:59:59    |
+      | code                     | FREESHIP_VIP           |
+      | customer_groups          | group1                 |
+      | total_quantity           | 100                    |
+      | quantity_per_user        | 1                      |
+      | minimum_product_quantity | 0                      |
+    Then discount "free_shipping_for_vip" should have the following properties:
+      | name[en-US]       | Free shipping VIP      |
+      | name[fr-FR]       | Livraison gratuite VIP |
+      | type              | free_shipping          |
+      | customer_groups   | group1                 |
+

--- a/tests/Integration/Behaviour/Features/Scenario/Discount/FO/discount_with_customer_groups_eligibility.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Discount/FO/discount_with_customer_groups_eligibility.feature
@@ -1,0 +1,225 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s discount --tags discount-customer-groups-fo
+@restore-all-tables-before-feature
+@restore-languages-after-feature
+@discount-customer-groups-fo
+Feature: Customer using discount with customer groups eligibility
+  PrestaShop allows customers to use discounts that are limited to their customer group
+  As a customer
+  I should be able to use a discount code that is available for my customer group
+  And I should not be able to use a discount code that is not available for my customer group
+
+  Background:
+    Given shop "shop1" with name "test_shop" exists
+    And there is a currency named "usd" with iso code "USD" and exchange rate of 0.92
+    And currency "usd" is the default one
+    And language with iso code "en" is the default one
+    And language "french" with locale "fr-FR" exists
+    And there is a product in the catalog named "product1" with a price of 25.00 and 1000 items in stock
+    And there is a product in the catalog named "product2" with a price of 15.00 and 1000 items in stock
+    And I create a customer group "group1" with the following details:
+      | name[en-US]             | VIP Members       |
+      | name[fr-FR]             | Membres VIP       |
+      | reduction               | 0.0               |
+      | displayPriceTaxExcluded | false             |
+      | showPrice               | true              |
+      | shopIds                 | shop1             |
+    And I create a customer group "group2" with the following details:
+      | name[en-US]             | Premium Members   |
+      | name[fr-FR]             | Membres Premium   |
+      | reduction               | 0.0               |
+      | displayPriceTaxExcluded | false             |
+      | showPrice               | true              |
+      | shopIds                 | shop1             |
+    And there is a customer named "john_vip" whose email is "john.vip@example.com"
+    And there is a customer named "jane_premium" whose email is "jane.premium@example.com"
+    And there is a customer named "bob_regular" whose email is "bob.regular@example.com"
+    And customer "john_vip" belongs to group "group1"
+    And customer "jane_premium" belongs to group "group2"
+
+  Scenario: Customer in eligible group can use the discount
+    Given I create a "cart_level" discount "vip_discount" with following properties:
+      | name[en-US]              | VIP discount        |
+      | name[fr-FR]              | Réduction VIP       |
+      | active                   | true                |
+      | valid_from               | 2025-01-01 00:00:00 |
+      | valid_to                 | 2025-12-31 23:59:59 |
+      | code                     | VIP_GROUP_20        |
+      | reduction_percent        | 20.0                |
+      | customer_groups          | group1              |
+      | total_quantity           | 100                 |
+      | quantity_per_user        | 1                   |
+      | minimum_product_quantity | 0                   |
+    And discount "vip_discount" should have the following properties:
+      | customer_groups   | group1           |
+    When I create an empty cart "john_cart" for customer "john_vip"
+    And I add 2 product "product1" to the cart "john_cart"
+    Then cart "john_cart" total with tax included should be '$57.00'
+    And my cart "john_cart" should have the following details:
+      | total_products | $50.00 |
+      | shipping       | $7.00  |
+      | total_discount | $0.00  |
+      | total          | $57.00 |
+    When I use a voucher "vip_discount" on the cart "john_cart"
+    Then cart "john_cart" total with tax included should be '$47.00'
+    And my cart "john_cart" should have the following details:
+      | total_products | $50.00  |
+      | shipping       | $7.00   |
+      | total_discount | -$10.00 |
+      | total          | $47.00  |
+
+  Scenario: Customer not in eligible group cannot use the discount
+    Given I create a "cart_level" discount "vip_only_discount" with following properties:
+      | name[en-US]              | VIP exclusive       |
+      | name[fr-FR]              | Exclusif VIP        |
+      | active                   | true                |
+      | valid_from               | 2025-01-01 00:00:00 |
+      | valid_to                 | 2025-12-31 23:59:59 |
+      | code                     | VIP_EXCLUSIVE       |
+      | reduction_percent        | 25.0                |
+      | customer_groups          | group1              |
+      | total_quantity           | 100                 |
+      | quantity_per_user        | 1                   |
+      | minimum_product_quantity | 0                   |
+    And discount "vip_only_discount" should have the following properties:
+      | customer_groups   | group1           |
+    # Bob (regular customer, not in VIP group) tries to use VIP discount
+    When I create an empty cart "bob_cart" for customer "bob_regular"
+    And I add 2 product "product1" to the cart "bob_cart"
+    Then cart "bob_cart" total with tax included should be '$57.00'
+    And my cart "bob_cart" should have the following details:
+      | total_products | $50.00 |
+      | shipping       | $7.00  |
+      | total_discount | $0.00  |
+      | total          | $57.00 |
+    When I use a voucher "vip_only_discount" on the cart "bob_cart"
+    Then I should get cart rule validation error
+    And cart "bob_cart" total with tax included should be '$57.00'
+    And my cart "bob_cart" should have the following details:
+      | total_products | $50.00 |
+      | shipping       | $7.00  |
+      | total_discount | $0.00  |
+      | total          | $57.00 |
+
+  Scenario: Customer in one of multiple eligible groups can use the discount
+    Given I create a "cart_level" discount "multi_group_discount" with following properties:
+      | name[en-US]              | Special promotion        |
+      | name[fr-FR]              | Promotion spéciale       |
+      | active                   | true                     |
+      | valid_from               | 2025-01-01 00:00:00      |
+      | valid_to                 | 2025-12-31 23:59:59      |
+      | code                     | SPECIAL_30               |
+      | reduction_percent        | 30.0                     |
+      | customer_groups          | group1,group2            |
+      | total_quantity           | 100                      |
+      | quantity_per_user        | 1                        |
+      | minimum_product_quantity | 0                        |
+    # John (VIP group) can use it
+    When I create an empty cart "john_multi_cart" for customer "john_vip"
+    And I add 3 product "product2" to the cart "john_multi_cart"
+    Then cart "john_multi_cart" total with tax included should be '$52.00'
+    And my cart "john_multi_cart" should have the following details:
+      | total_products | $45.00 |
+      | shipping       | $7.00  |
+      | total_discount | $0.00  |
+      | total          | $52.00 |
+    When I use a voucher "multi_group_discount" on the cart "john_multi_cart"
+    Then cart "john_multi_cart" total with tax included should be '$38.50'
+    And my cart "john_multi_cart" should have the following details:
+      | total_products | $45.00  |
+      | shipping       | $7.00   |
+      | total_discount | -$13.50 |
+      | total          | $38.50  |
+    # Jane (Premium group) can also use it
+    When I create an empty cart "jane_multi_cart" for customer "jane_premium"
+    And I add 2 product "product1" to the cart "jane_multi_cart"
+    Then cart "jane_multi_cart" total with tax included should be '$57.00'
+    When I use a voucher "multi_group_discount" on the cart "jane_multi_cart"
+    Then cart "jane_multi_cart" total with tax included should be '$42.00'
+    And my cart "jane_multi_cart" should have the following details:
+      | total_products | $50.00  |
+      | shipping       | $7.00   |
+      | total_discount | -$15.00 |
+      | total          | $42.00  |
+    # Bob (not in either group) cannot use it
+    When I create an empty cart "bob_multi_cart" for customer "bob_regular"
+    And I add 2 product "product1" to the cart "bob_multi_cart"
+    And I use a voucher "multi_group_discount" on the cart "bob_multi_cart"
+    Then I should get cart rule validation error
+    And cart "bob_multi_cart" total with tax included should be '$57.00'
+
+  Scenario: Free shipping discount limited to customer groups
+    Given I create a "free_shipping" discount "free_ship_premium" with following properties:
+      | name[en-US]              | Free shipping Premium      |
+      | name[fr-FR]              | Livraison gratuite Premium |
+      | active                   | true                       |
+      | valid_from               | 2025-01-01 00:00:00        |
+      | valid_to                 | 2025-12-31 23:59:59        |
+      | code                     | FREESHIP_PREMIUM           |
+      | customer_groups          | group2                     |
+      | total_quantity           | 100                        |
+      | quantity_per_user        | 1                          |
+      | minimum_product_quantity | 0                          |
+    # Jane (Premium member) can use it
+    When I create an empty cart "jane_shipping_cart" for customer "jane_premium"
+    And I add 1 product "product1" to the cart "jane_shipping_cart"
+    Then cart "jane_shipping_cart" total with tax included should be '$32.00'
+    When I use a voucher "free_ship_premium" on the cart "jane_shipping_cart"
+    Then cart "jane_shipping_cart" total with tax included should be '$25.00'
+    And my cart "jane_shipping_cart" should have the following details:
+      | total_products | $25.00 |
+      | shipping       | $7.00  |
+      | total_discount | -$7.00 |
+      | total          | $25.00 |
+    # John (VIP, not Premium) tries to use Premium free shipping
+    When I create an empty cart "john_shipping_cart" for customer "john_vip"
+    And I add 1 product "product1" to the cart "john_shipping_cart"
+    And I use a voucher "free_ship_premium" on the cart "john_shipping_cart"
+    Then I should get cart rule validation error
+    And cart "john_shipping_cart" total with tax included should be '$32.00'
+
+  Scenario: Public discount can be used by any customer regardless of group
+    Given I create a "cart_level" discount "public_discount" with following properties:
+      | name[en-US]              | Summer sale         |
+      | name[fr-FR]              | Soldes d'été        |
+      | active                   | true                |
+      | valid_from               | 2025-01-01 00:00:00 |
+      | valid_to                 | 2025-12-31 23:59:59 |
+      | code                     | SUMMER_10           |
+      | reduction_percent        | 10.0                |
+      | total_quantity           | 100                 |
+      | quantity_per_user        | 1                   |
+      | minimum_product_quantity | 0                   |
+    And discount "public_discount" should have the following properties:
+      | name[en-US]       | Summer sale  |
+      | name[fr-FR]       | Soldes d'été |
+    # John (VIP) can use it
+    When I create an empty cart "john_public_cart" for customer "john_vip"
+    And I add 2 product "product1" to the cart "john_public_cart"
+    And I use a voucher "public_discount" on the cart "john_public_cart"
+    Then cart "john_public_cart" total with tax included should be '$52.00'
+    And my cart "john_public_cart" should have the following details:
+      | total_products | $50.00 |
+      | shipping       | $7.00  |
+      | total_discount | -$5.00 |
+      | total          | $52.00 |
+    # Jane (Premium) can use it too
+    When I create an empty cart "jane_public_cart" for customer "jane_premium"
+    And I add 2 product "product2" to the cart "jane_public_cart"
+    And I use a voucher "public_discount" on the cart "jane_public_cart"
+    Then cart "jane_public_cart" total with tax included should be '$34.00'
+    And my cart "jane_public_cart" should have the following details:
+      | total_products | $30.00 |
+      | shipping       | $7.00  |
+      | total_discount | -$3.00 |
+      | total          | $34.00 |
+    # Bob (Regular, no special group) can use it as well
+    When I create an empty cart "bob_public_cart" for customer "bob_regular"
+    And I add 1 product "product1" to the cart "bob_public_cart"
+    And I use a voucher "public_discount" on the cart "bob_public_cart"
+    Then cart "bob_public_cart" total with tax included should be '$29.50'
+    And my cart "bob_public_cart" should have the following details:
+      | total_products | $25.00 |
+      | shipping       | $7.00  |
+      | total_discount | -$2.50 |
+      | total          | $29.50 |
+

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -63,7 +63,9 @@ default:
         - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Configuration\CommonConfigurationFeatureContext
         - Tests\Integration\Behaviour\Features\Context\CustomerFeatureContext
+        - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\CustomerGroupFeatureContext
+        - Tests\Integration\Behaviour\Features\Context\Domain\Discount\DiscountFeatureContext
         - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
         - Tests\Integration\Behaviour\Features\Transform\LocalizedArrayTransformContext
         - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
@@ -318,6 +320,7 @@ default:
         - Tests\Integration\Behaviour\Features\Context\Domain\CartFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\CategoryFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\CustomerFeatureContext
+        - Tests\Integration\Behaviour\Features\Context\Domain\CustomerGroupFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\Discount\DiscountConditionsFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\Discount\DiscountFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
@@ -348,6 +351,7 @@ default:
         - Tests\Integration\Behaviour\Features\Context\Domain\FeatureValueFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\FeatureFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductFeatureValuesFeatureContext
+        - Tests\Integration\Behaviour\Features\Transform\LocalizedArrayTransformContext
         - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
 
     catalog_price_rule:


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Add customer groups limit for discounts
| Type?             | improvement
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Steps are available here #38662
| UI Tests          | https://github.com/nicosomb/ga.tests.ui.pr/actions/runs/19764290418 ✅ 
| Fixed issue or discussion?     | Fixes #38662
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA 

As explained by @Hlavtox, I reused an existing component 

<img width="974" height="248" alt="506765005-79c53bd8-f2d5-4732-9e76-5cde22d94d47" src="https://github.com/user-attachments/assets/e26deadf-5c51-4838-9998-ab8d8be2b9c1" />
