### PR TITLE
BO - Orders - View - Carrier Modal : The selected carrier is the correct

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/order-shipping-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/order-shipping-manager.ts
@@ -38,6 +38,9 @@ export default class OrderShippingManager {
 
       $(OrderViewPageMap.updateOrderShippingTrackingNumberInput).val($btn.data('order-tracking-number'));
       $(OrderViewPageMap.updateOrderShippingCurrentOrderCarrierIdInput).val($btn.data('order-carrier-id'));
+      $(OrderViewPageMap.updateOrderShippingNewCarrierIdSelect)
+        .val($btn.data('carrier-id'))
+        .trigger('change');
     });
   }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
@@ -59,6 +59,7 @@
                  class="js-update-shipping-btn d-print-none"
                  data-toggle="modal"
                  data-target="#updateOrderShippingModal"
+                 data-carrier-id="{{ carrier.carrierId }}"
                  data-order-carrier-id="{{ carrier.orderCarrierId }}"
                  data-order-tracking-number="{{ carrier.trackingNumber }}"
               >


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | BO - Orders - View - Carrier Modal : The selected carrier is the correct
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | :arrow_down: 
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/18778862429
| Fixed issue or discussion?     | Fixes #27745 
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

## How to test ?
* Go to BO
* Enable all carriers
* Go to orders
* Set an order to status Payment accepted
* View the order
* Go to tab Carriers
* Check the Carrier on the first row : I name it "Carrier ####"
* Click on Edit 
* The modal appears
* The selected carrier is "Carrier ####"
* Change the carrier to "Carrier XXXX"
* Cancel the modal
* Open the modal 
* :disappointed: **BEFORE** : The selected carrier is "Carrier XXXX" 
* :smiley: **AFTER** : The selected carrier is "Carrier ####" : it's the same on the row of the table 