### PR TITLE
Fix Manufacturer/Supplier controllers return types for their respective getters

### DIFF
--- a/controllers/front/listing/ManufacturerController.php
+++ b/controllers/front/listing/ManufacturerController.php
@@ -274,9 +274,9 @@ class ManufacturerControllerCore extends ProductListingFrontController
     }
 
     /**
-     * @return Manufacturer
+     * @return Manufacturer|null
      */
-    public function getManufacturer(): Manufacturer
+    public function getManufacturer(): ?Manufacturer
     {
         return $this->manufacturer;
     }

--- a/controllers/front/listing/SupplierController.php
+++ b/controllers/front/listing/SupplierController.php
@@ -272,9 +272,9 @@ class SupplierControllerCore extends ProductListingFrontController
     }
 
     /**
-     * @return Supplier
+     * @return Supplier|null
      */
-    public function getSupplier(): Supplier
+    public function getSupplier(): ?Supplier
     {
         return $this->supplier;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR fixes an error introduced with #37204 by updating the return types of the getManufacturer and getSupplier methods in their respective controllers.<br>The underlying property can be null if you are on the manufacturers/suppliers listing page, which is also managed by these same controllers.<br><br>Any module that might call that method to check whether they are on the listing or details of a manufacturer/supplier will trigger an error such as: <br>`Uncaught TypeError: SupplierControllerCore::getSupplier(): Return value must be of type Supplier, null returned`
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Use any module hooked on displayHeader, and use the code snippet below this table on the manufacturers listing page to trigger the error.
| UI Tests          | -
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | VersusVenture (PrestaModule / BusinessTech)


Formatted code snippet:
```php
public function hookDisplayHeader()
{
    if ($this->context->controller instanceof ManufacturerController
        && !empty($this->context->controller->getManufacturer())) {
        // Fatal error: Uncaught TypeError: ManufacturerControllerCore::getManufacturer(): Return value
        // must be of type Manufacturer, null returned
    }
    // ...
}
```
