### PR TITLE
Change matching method in ShopContextSubscriber

### DIFF
--- a/app/config/admin/services.yml
+++ b/app/config/admin/services.yml
@@ -58,7 +58,13 @@ services:
   # Context listeners, these are event subscribers, so they define their priority themselves
   PrestaShopBundle\EventListener\Admin\Context\EmployeeContextSubscriber: ~
   PrestaShopBundle\EventListener\Admin\Context\LanguageContextSubscriber: ~
-  PrestaShopBundle\EventListener\Admin\Context\ShopContextSubscriber: ~
+
+  PrestaShopBundle\EventListener\Admin\Context\ShopContextSubscriber:
+    autowire: true
+    autoconfigure: true
+    arguments:
+     $router: '@router'
+
   PrestaShopBundle\EventListener\Admin\Context\CurrencyContextSubscriber: ~
   PrestaShopBundle\EventListener\Admin\Context\CountryContextSubscriber: ~
   PrestaShopBundle\EventListener\Admin\Context\LegacyControllerContextSubscriber: ~

--- a/app/config/admin/services.yml
+++ b/app/config/admin/services.yml
@@ -63,7 +63,7 @@ services:
     autowire: true
     autoconfigure: true
     arguments:
-     $router: '@router'
+      $router: '@router'
 
   PrestaShopBundle\EventListener\Admin\Context\CurrencyContextSubscriber: ~
   PrestaShopBundle\EventListener\Admin\Context\CountryContextSubscriber: ~

--- a/app/config/admin/services.yml
+++ b/app/config/admin/services.yml
@@ -57,7 +57,7 @@ services:
 
   # Context listeners, these are event subscribers, so they define their priority themselves
   PrestaShopBundle\EventListener\Admin\Context\EmployeeContextSubscriber: ~
-  PrestaShopBundle\EventListener\Admin\Context\LanguageContextSubscriber: 
+  PrestaShopBundle\EventListener\Admin\Context\LanguageContextSubscriber: ~
   
   PrestaShopBundle\EventListener\Admin\Context\ShopContextSubscriber:
     autowire: true

--- a/app/config/admin/services.yml
+++ b/app/config/admin/services.yml
@@ -58,13 +58,7 @@ services:
   # Context listeners, these are event subscribers, so they define their priority themselves
   PrestaShopBundle\EventListener\Admin\Context\EmployeeContextSubscriber: ~
   PrestaShopBundle\EventListener\Admin\Context\LanguageContextSubscriber: ~
-
-  PrestaShopBundle\EventListener\Admin\Context\ShopContextSubscriber:
-    autowire: true
-    autoconfigure: true
-    arguments:
-      $router: '@router'
-
+  PrestaShopBundle\EventListener\Admin\Context\ShopContextSubscriber: ~
   PrestaShopBundle\EventListener\Admin\Context\CurrencyContextSubscriber: ~
   PrestaShopBundle\EventListener\Admin\Context\CountryContextSubscriber: ~
   PrestaShopBundle\EventListener\Admin\Context\LegacyControllerContextSubscriber: ~

--- a/app/config/admin/services.yml
+++ b/app/config/admin/services.yml
@@ -58,13 +58,13 @@ services:
   # Context listeners, these are event subscribers, so they define their priority themselves
   PrestaShopBundle\EventListener\Admin\Context\EmployeeContextSubscriber: ~
   PrestaShopBundle\EventListener\Admin\Context\LanguageContextSubscriber: ~
-  
+
   PrestaShopBundle\EventListener\Admin\Context\ShopContextSubscriber:
     autowire: true
     autoconfigure: true
     arguments:
       $router: '@router'
-  
+
   PrestaShopBundle\EventListener\Admin\Context\CurrencyContextSubscriber: ~
   PrestaShopBundle\EventListener\Admin\Context\CountryContextSubscriber: ~
   PrestaShopBundle\EventListener\Admin\Context\LegacyControllerContextSubscriber: ~

--- a/app/config/admin/services.yml
+++ b/app/config/admin/services.yml
@@ -57,8 +57,14 @@ services:
 
   # Context listeners, these are event subscribers, so they define their priority themselves
   PrestaShopBundle\EventListener\Admin\Context\EmployeeContextSubscriber: ~
-  PrestaShopBundle\EventListener\Admin\Context\LanguageContextSubscriber: ~
-  PrestaShopBundle\EventListener\Admin\Context\ShopContextSubscriber: ~
+  PrestaShopBundle\EventListener\Admin\Context\LanguageContextSubscriber: 
+  
+  PrestaShopBundle\EventListener\Admin\Context\ShopContextSubscriber:
+    autowire: true
+    autoconfigure: true
+    arguments:
+      $router: '@router'
+  
   PrestaShopBundle\EventListener\Admin\Context\CurrencyContextSubscriber: ~
   PrestaShopBundle\EventListener\Admin\Context\CountryContextSubscriber: ~
   PrestaShopBundle\EventListener\Admin\Context\LegacyControllerContextSubscriber: ~

--- a/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
@@ -351,7 +351,7 @@ class ShopContextSubscriber implements EventSubscriberInterface
     private function getShopConstraintFromRouteAttribute(Request $request): ?ShopConstraint
     {
         try {
-            $routeInfo = $this->router->match($request->getPathInfo());
+            $routeInfo = $this->router->matchRequest($request);
             $controller = $routeInfo['_controller'];
             [$className, $methodName] = explode('::', $controller);
 

--- a/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
@@ -351,8 +351,12 @@ class ShopContextSubscriber implements EventSubscriberInterface
     private function getShopConstraintFromRouteAttribute(Request $request): ?ShopConstraint
     {
         try {
-            $routeInfo = $this->router->matchRequest($request);
-            $controller = $routeInfo['_controller'];
+            $controller = $request->attributes->get('_controller');
+            if (empty($controller)) {
+                // If the attribute is not present yet we handle the matching ourselves and get the controller via routing info
+                $routeInfo = $this->router->matchRequest($request);
+                $controller = $routeInfo['_controller'];
+            }
             [$className, $methodName] = explode('::', $controller);
 
             $reflectionClass = new ReflectionClass($className);

--- a/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
@@ -29,7 +29,7 @@ use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Exception\NoConfigurationException;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -53,7 +53,7 @@ class ShopContextSubscriber implements EventSubscriberInterface
         private readonly EmployeeContext $employeeContext,
         private readonly ShopConfigurationInterface $configuration,
         private readonly MultistoreFeature $multistoreFeature,
-        private readonly Router $router,
+        private readonly RequestMatcherInterface $router,
         private readonly Security $security,
         private readonly LegacyContext $legacyContext,
         private readonly TranslatorInterface $translator,

--- a/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
@@ -29,7 +29,7 @@ use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Exception\NoConfigurationException;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Router;
 use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -53,7 +53,7 @@ class ShopContextSubscriber implements EventSubscriberInterface
         private readonly EmployeeContext $employeeContext,
         private readonly ShopConfigurationInterface $configuration,
         private readonly MultistoreFeature $multistoreFeature,
-        private readonly RouterInterface $router,
+        private readonly Router $router,
         private readonly Security $security,
         private readonly LegacyContext $legacyContext,
         private readonly TranslatorInterface $translator,

--- a/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
@@ -29,7 +29,7 @@ use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Exception\NoConfigurationException;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -53,7 +53,7 @@ class ShopContextSubscriber implements EventSubscriberInterface
         private readonly EmployeeContext $employeeContext,
         private readonly ShopConfigurationInterface $configuration,
         private readonly MultistoreFeature $multistoreFeature,
-        private readonly Router $router,
+        private readonly RouterInterface $router,
         private readonly Security $security,
         private readonly LegacyContext $legacyContext,
         private readonly TranslatorInterface $translator,

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
@@ -21,7 +21,7 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\NoConfigurationException;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
@@ -524,13 +524,9 @@ class ShopContextSubscriberTest extends ContextEventListenerTestCase
         ];
     }
 
-    private function mockRouter(): RouterInterface&RequestMatcherInterface|MockObject
+    private function mockRouter(): RequestMatcherInterface|MockObject
     {
-        $router = $this->getMockBuilder(RouterInterface::class)
-            ->addMethods(['matchRequest']) // Ajoute la méthode manquante
-            ->getMock()
-        ;
-    
+        $router = $this->createMock(RequestMatcherInterface::class);
         $router
             ->method('matchRequest')
             ->willThrowException(new NoConfigurationException())

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
@@ -524,9 +524,13 @@ class ShopContextSubscriberTest extends ContextEventListenerTestCase
         ];
     }
 
-    private function mockRouter(): RouterInterface|MockObject
+    private function mockRouter(): RouterInterface&RequestMatcherInterface|MockObject
     {
-        $router = $this->createMock(RouterInterface::class);
+        $router = $this->getMockBuilder(RouterInterface::class)
+            ->addMethods(['matchRequest']) // Ajoute la méthode manquante
+            ->getMock()
+        ;
+    
         $router
             ->method('matchRequest')
             ->willThrowException(new NoConfigurationException())

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
@@ -21,7 +21,7 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\NoConfigurationException;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
@@ -524,9 +524,9 @@ class ShopContextSubscriberTest extends ContextEventListenerTestCase
         ];
     }
 
-    private function mockRouter(): Router|MockObject
+    private function mockRouter(): RequestMatcherInterface|MockObject
     {
-        $router = $this->createMock(Router::class);
+        $router = $this->createMock(RequestMatcherInterface::class);
         $router
             ->method('matchRequest')
             ->willThrowException(new NoConfigurationException())

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
@@ -21,7 +21,7 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\NoConfigurationException;
-use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
+use Symfony\Component\Routing\Router;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
@@ -524,9 +524,9 @@ class ShopContextSubscriberTest extends ContextEventListenerTestCase
         ];
     }
 
-    private function mockRouter(): RequestMatcherInterface|MockObject
+    private function mockRouter(): Router|MockObject
     {
-        $router = $this->createMock(RequestMatcherInterface::class);
+        $router = $this->createMock(Router::class);
         $router
             ->method('matchRequest')
             ->willThrowException(new NoConfigurationException())

--- a/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
+++ b/tests/Unit/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriberTest.php
@@ -528,7 +528,7 @@ class ShopContextSubscriberTest extends ContextEventListenerTestCase
     {
         $router = $this->createMock(RouterInterface::class);
         $router
-            ->method('match')
+            ->method('matchRequest')
             ->willThrowException(new NoConfigurationException())
         ;
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixed routing issue where using `match()` instead of `matchRequest()` caused the full Request object not to be passed to the router. This resulted in `Symfony\Component\Routing\Matcher\Dumper\CompiledUrlMatcherTrait` generating a "pseudo" request without headers, breaking route conditions that rely on request properties (e.g., `request.isXmlHttpRequest()` on the `admin_emails_send_test` route).
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Navigate to the email configuration page in the Back Office in a multishop environment<br>2. Try to send a test email using the AJAX request<br>3. Verify that the request is properly handled and the `isXmlHttpRequest()` condition is correctly evaluated<br>4. Check that routes with request-based conditions (like header checks) work as expected
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/26416354197
| Fixed issue or discussion?     |  #37572, https://github.com/PrestaShop/PrestaShop/issues/39991
| Related PRs       | 
| Sponsor company   | Web Premiere