### PR TITLE
AdminNotFoundController must return HTTP 404 status code

### DIFF
--- a/controllers/admin/AdminNotFoundController.php
+++ b/controllers/admin/AdminNotFoundController.php
@@ -48,6 +48,7 @@ class AdminNotFoundControllerCore extends AdminController
      */
     public function initContent()
     {
+        http_response_code(404);
         $this->errors[] = $this->trans('Page not found', [], 'Admin.Notifications.Error');
         $tpl_vars['controller'] = Tools::getValue('controllerUri', Tools::getValue('controller'));
         $this->context->smarty->assign($tpl_vars);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | The admin controller AdminNotFoundControllerCore must always return an HTTP 404 status code when an admin page is not found.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Access a non-existent admin URL, e.g. `/admin-dev/index.php?controller=UnknownController`.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #39850 
| Related PRs       | 
| Sponsor company   | PrestaShop
