### PR TITLE
Fix: Quick Access links redirect to root instead of subdirectory, causing 404

### DIFF
--- a/src/Core/QuickAccess/QuickAccessGenerator.php
+++ b/src/Core/QuickAccess/QuickAccessGenerator.php
@@ -125,14 +125,7 @@ class QuickAccessGenerator
             }
 
             // Preparation of the link to display in component view.
-            $quick['link'] = basename(_PS_ADMIN_DIR_) . '/' . $cleanLink;
-
-            // Add subfolder if set
-            if ($this->shopContext->getPhysicalUri()) {
-                $quick['link'] = $this->shopContext->getPhysicalUri() . $quick['link'];
-            } else {
-                $quick['link'] = '/' . $quick['link'];
-            }
+            $quick['link'] = $this->legacyContext->getContext()->link->getAdminBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . $cleanLink;
 
             // Add token if needed
             $quick['link'] = $this->getTokenizedUrl($quick['link']);

--- a/src/Core/QuickAccess/QuickAccessGenerator.php
+++ b/src/Core/QuickAccess/QuickAccessGenerator.php
@@ -125,7 +125,14 @@ class QuickAccessGenerator
             }
 
             // Preparation of the link to display in component view.
-            $quick['link'] = '/' . basename(_PS_ADMIN_DIR_) . '/' . $cleanLink;
+            $quick['link'] = basename(_PS_ADMIN_DIR_) . '/' . $cleanLink;
+
+            // Add subfolder if set
+            if ($this->shopContext->getPhysicalUri()) {
+                $quick['link'] = $this->shopContext->getPhysicalUri() . $quick['link'];
+            } else {
+                $quick['link'] = '/' . $quick['link'];
+            }
 
             // Add token if needed
             $quick['link'] = $this->getTokenizedUrl($quick['link']);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Adds the shop subdirectory (physical URI) prefix to admin quick links when present.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install PrestaShop in a subfolder - 2. Click on the quick access links in the backoffice and view the corresponding pages
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/20851689034
| Fixed issue or discussion?     | Fixes #39819 
| Related PRs       | 
| Sponsor company   | Codencode snc