### PR TITLE
Fix: [Docker][Makefile] fix #39862

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ docker-down: ## Stop the docker hub
 docker-logs: ## Show live logs
 	$(DOCKER_COMP) logs --follow
 
-docker-sh: ## Connect to the PHP container via bash interactif
+docker-sh: ## Open an interactive bash session inside the PHP container
 	@$(DOCKER_COMP) exec -it prestashop-git bash
 
 ## —— PrestaShop 🛒 ———————————————————————————————————————————————————————————

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ DOCKER_COMP = docker compose
 # Determine if we are using docker
 DOCKER_RUNNING := $(shell docker compose ps -q)
 ifneq ($(strip $(DOCKER_RUNNING)),)
-	PHP_CONT = $(DOCKER_COMP) exec prestashop-git runuser -u www-data -g www-data --
+	PHP_CONT = $(DOCKER_COMP) exec -T prestashop-git runuser -u www-data -g www-data -- bash -lc
 endif
 
 # Executables (local or docker)
-PHP      = $(PHP_CONT) php
-COMPOSER = $(PHP_CONT) composer
-SYMFONY  = $(PHP_CONT) bin/console
+PHP      = $(PHP_CONT) "php"
+COMPOSER = $(PHP_CONT) "composer"
+SYMFONY  = $(PHP_CONT) "bin/console"
 
 # Misc
 .DEFAULT_GOAL = install
@@ -37,45 +37,45 @@ docker-down: ## Stop the docker hub
 docker-logs: ## Show live logs
 	$(DOCKER_COMP) logs --follow
 
-docker-sh: ## Connect to the PHP container via bash so up and down arrows go to previous commands
-	@$(PHP_CONT) bash
+docker-sh: ## Connect to the PHP container via bash interactif
+	@$(DOCKER_COMP) exec -it prestashop-git bash
 
 ## —— PrestaShop 🛒 ———————————————————————————————————————————————————————————
 install: composer cc assets  ## Install PHP dependencies and build the static assets
 
 install-prestashop: ## Install fresh PrestaShop database (requires containers to be running)
-	$(PHP_CONT) .docker/install/database.sh
+	$(PHP_CONT) ".docker/install/database.sh"
 
 ## —— Assets 🎨 ———————————————————————————————————————————————————————————————
 assets: admin front ## Build all assets
-	$(PHP_CONT) ./tools/assets/build.sh all --force
+	$(PHP_CONT) "./tools/assets/build.sh all --force"
 
 wait-assets: ## Wait for assets to be built
-	$(PHP_CONT) ./tools/assets/wait-build.sh
+	$(PHP_CONT) "./tools/assets/wait-build.sh"
 
 admin: ## Build admin assets
-	$(PHP_CONT) ./tools/assets/build.sh admin-default --force
-	$(PHP_CONT) ./tools/assets/build.sh admin-new-theme --force
+	$(PHP_CONT) "./tools/assets/build.sh admin-default --force"
+	$(PHP_CONT) "./tools/assets/build.sh admin-new-theme --force"
 
 front: ## Build front assets
-	$(PHP_CONT) ./tools/assets/build.sh front-core --force
-	$(PHP_CONT) ./tools/assets/build.sh front-classic --force
-	$(PHP_CONT) ./tools/assets/build.sh front-hummingbird --force
+	$(PHP_CONT) "./tools/assets/build.sh front-core --force"
+	$(PHP_CONT) "./tools/assets/build.sh front-classic --force"
+	$(PHP_CONT) "./tools/assets/build.sh front-hummingbird --force"
 
 admin-default: ## Build assets for default admin theme
-	$(PHP_CONT) ./tools/assets/build.sh admin-default --force
+	$(PHP_CONT) "./tools/assets/build.sh admin-default --force"
 
 admin-new-theme: ## Build assets for new admin theme
-	$(PHP_CONT) ./tools/assets/build.sh admin-new-theme --force
+	$(PHP_CONT) "./tools/assets/build.sh admin-new-theme --force"
 
 front-core: ## Build assets for core theme
-	$(PHP_CONT) ./tools/assets/build.sh front-core --force
+	$(PHP_CONT) "./tools/assets/build.sh front-core --force"
 
 front-classic: ## Build assets for classic theme
-	$(PHP_CONT) ./tools/assets/build.sh front-classic --force
+	$(PHP_CONT) "./tools/assets/build.sh front-classic --force"
 
 front-hummingbird: ## Build assets for hummingbird theme
-	$(PHP_CONT) ./tools/assets/build.sh front-hummingbird --force
+	$(PHP_CONT) "./tools/assets/build.sh front-hummingbird --force"
 
 ## —— Composer & Symfony 🧙 ————————————————————————————————————————————————————
 composer: ## Install PHP dependencies
@@ -111,12 +111,12 @@ phpstan: ## Run phpstan analysis
 	$(COMPOSER) run phpstan
 
 scss-fixer: ## Run scss-fix
-	$(PHP_CONT) bash -l -c "cd admin-dev/themes/new-theme && npm run scss-fix"
-	$(PHP_CONT) bash -l -c "cd admin-dev/themes/default && npm run scss-fix"
-	$(PHP_CONT) bash -l -c "cd themes/classic/_dev && npm run scss-fix"
+	$(PHP_CONT) "cd admin-dev/themes/new-theme && npm run scss-fix"
+	$(PHP_CONT) "cd admin-dev/themes/default && npm run scss-fix"
+	$(PHP_CONT) "cd themes/classic/_dev && npm run scss-fix"
 
 es-linter: ## Run lint-fix
-	$(PHP_CONT) bash -l -c "cd admin-dev/themes/new-theme && npm run lint-fix"
-	$(PHP_CONT) bash -l -c "cd admin-dev/themes/default && npm run lint-fix"
-	$(PHP_CONT) bash -l -c "cd themes/classic/_dev && npm run lint-fix"
-	$(PHP_CONT) bash -l -c "cd themes && npm run lint-fix"
+	$(PHP_CONT) "cd admin-dev/themes/new-theme && npm run lint-fix"
+	$(PHP_CONT) "cd admin-dev/themes/default && npm run lint-fix"
+	$(PHP_CONT) "cd themes/classic/_dev && npm run lint-fix"
+	$(PHP_CONT) "cd themes && npm run lint-fix"

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,16 @@ DOCKER_COMP = docker compose
 # Determine if we are using docker
 DOCKER_RUNNING := $(shell docker compose ps -q)
 ifneq ($(strip $(DOCKER_RUNNING)),)
-	PHP_CONT = $(DOCKER_COMP) exec -T prestashop-git runuser -u www-data -g www-data -- bash -lc
+	PHP_CONT = $(DOCKER_COMP) exec -T prestashop-git runuser -u www-data -g www-data --
+	PHP_CONT_WITH_LOGIN = $(DOCKER_COMP) exec -T prestashop-git runuser -u www-data -g www-data -- bash -lc
 endif
 
 # Executables (local or docker)
-PHP      = $(PHP_CONT) "php"
-COMPOSER = $(PHP_CONT) "composer"
-SYMFONY  = $(PHP_CONT) "bin/console"
+PHP      = $(PHP_CONT) php
+COMPOSER = $(PHP_CONT) composer
+SYMFONY  = $(PHP_CONT) bin/console
 
-# Misc
+# Default target
 .DEFAULT_GOAL = install
 .PHONY        : help docker-build docker-up docker-start docker-restart docker-down docker-logs docker-sh composer cc test test-unit test-integration test-integration-behaviour test-api-module assets wait-assets admin front admin-default admin-new-theme front-core front-classic front-hummingbird install install-prestashop cs-fixer cs-fixer-dry phpstan scss-fixer es-linter
 
@@ -41,41 +42,41 @@ docker-sh: ## Open an interactive bash session inside the PHP container
 	@$(DOCKER_COMP) exec -it prestashop-git runuser -u www-data -g www-data -- bash -l
 
 ## —— PrestaShop 🛒 ———————————————————————————————————————————————————————————
-install: composer cc assets  ## Install PHP dependencies and build the static assets
+install: composer cc assets ## Install PHP dependencies and build static assets
 
 install-prestashop: ## Install fresh PrestaShop database (requires containers to be running)
-	$(PHP_CONT) ".docker/install/database.sh"
+	$(PHP_CONT) .docker/install/database.sh
 
 ## —— Assets 🎨 ———————————————————————————————————————————————————————————————
 assets: admin front ## Build all assets
-	$(PHP_CONT) "./tools/assets/build.sh all --force"
+	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh all --force"
 
 wait-assets: ## Wait for assets to be built
 	$(PHP_CONT) "./tools/assets/wait-build.sh"
 
 admin: ## Build admin assets
-	$(PHP_CONT) "./tools/assets/build.sh admin-default --force"
-	$(PHP_CONT) "./tools/assets/build.sh admin-new-theme --force"
+	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh admin-default --force"
+	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh admin-new-theme --force"
 
 front: ## Build front assets
-	$(PHP_CONT) "./tools/assets/build.sh front-core --force"
-	$(PHP_CONT) "./tools/assets/build.sh front-classic --force"
-	$(PHP_CONT) "./tools/assets/build.sh front-hummingbird --force"
+	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh front-core --force"
+	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh front-classic --force"
+	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh front-hummingbird --force"
 
 admin-default: ## Build assets for default admin theme
-	$(PHP_CONT) "./tools/assets/build.sh admin-default --force"
+	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh admin-default --force"
 
 admin-new-theme: ## Build assets for new admin theme
-	$(PHP_CONT) "./tools/assets/build.sh admin-new-theme --force"
+	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh admin-new-theme --force"
 
 front-core: ## Build assets for core theme
-	$(PHP_CONT) "./tools/assets/build.sh front-core --force"
+	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh front-core --force"
 
 front-classic: ## Build assets for classic theme
-	$(PHP_CONT) "./tools/assets/build.sh front-classic --force"
+	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh front-classic --force"
 
 front-hummingbird: ## Build assets for hummingbird theme
-	$(PHP_CONT) "./tools/assets/build.sh front-hummingbird --force"
+	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh front-hummingbird --force"
 
 ## —— Composer & Symfony 🧙 ————————————————————————————————————————————————————
 composer: ## Install PHP dependencies
@@ -111,12 +112,12 @@ phpstan: ## Run phpstan analysis
 	$(COMPOSER) run phpstan
 
 scss-fixer: ## Run scss-fix
-	$(PHP_CONT) "cd admin-dev/themes/new-theme && npm run scss-fix"
-	$(PHP_CONT) "cd admin-dev/themes/default && npm run scss-fix"
-	$(PHP_CONT) "cd themes/classic/_dev && npm run scss-fix"
+	$(PHP_CONT_WITH_LOGIN) "cd admin-dev/themes/new-theme && npm run scss-fix"
+	$(PHP_CONT_WITH_LOGIN) "cd admin-dev/themes/default && npm run scss-fix"
+	$(PHP_CONT_WITH_LOGIN) "cd themes/classic/_dev && npm run scss-fix"
 
 es-linter: ## Run lint-fix
-	$(PHP_CONT) "cd admin-dev/themes/new-theme && npm run lint-fix"
-	$(PHP_CONT) "cd admin-dev/themes/default && npm run lint-fix"
-	$(PHP_CONT) "cd themes/classic/_dev && npm run lint-fix"
-	$(PHP_CONT) "cd themes && npm run lint-fix"
+	$(PHP_CONT_WITH_LOGIN) "cd admin-dev/themes/new-theme && npm run lint-fix"
+	$(PHP_CONT_WITH_LOGIN) "cd admin-dev/themes/default && npm run lint-fix"
+	$(PHP_CONT_WITH_LOGIN) "cd themes/classic/_dev && npm run lint-fix"
+	$(PHP_CONT_WITH_LOGIN) "cd themes && npm run lint-fix"

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ docker-logs: ## Show live logs
 	$(DOCKER_COMP) logs --follow
 
 docker-sh: ## Open an interactive bash session inside the PHP container
-	@$(DOCKER_COMP) exec -it prestashop-git bash
+	@$(DOCKER_COMP) exec -it prestashop-git runuser -u www-data -g www-data -- bash -l
 
 ## —— PrestaShop 🛒 ———————————————————————————————————————————————————————————
 install: composer cc assets  ## Install PHP dependencies and build the static assets

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@ DOCKER_COMP = docker compose
 # Determine if we are using docker
 DOCKER_RUNNING := $(shell docker compose ps -q)
 ifneq ($(strip $(DOCKER_RUNNING)),)
-	PHP_CONT = $(DOCKER_COMP) exec -T prestashop-git runuser -u www-data -g www-data --
-	PHP_CONT_WITH_LOGIN = $(DOCKER_COMP) exec -T prestashop-git runuser -u www-data -g www-data -- bash -lc
+	PHP_CONT = $(DOCKER_COMP) exec -T prestashop-git runuser -u www-data -g www-data -- bash -l
 endif
 
 # Executables (local or docker)
@@ -13,7 +12,7 @@ PHP      = $(PHP_CONT) php
 COMPOSER = $(PHP_CONT) composer
 SYMFONY  = $(PHP_CONT) bin/console
 
-# Default target
+# Misc
 .DEFAULT_GOAL = install
 .PHONY        : help docker-build docker-up docker-start docker-restart docker-down docker-logs docker-sh composer cc test test-unit test-integration test-integration-behaviour test-api-module assets wait-assets admin front admin-default admin-new-theme front-core front-classic front-hummingbird install install-prestashop cs-fixer cs-fixer-dry phpstan scss-fixer es-linter
 
@@ -38,45 +37,45 @@ docker-down: ## Stop the docker hub
 docker-logs: ## Show live logs
 	$(DOCKER_COMP) logs --follow
 
-docker-sh: ## Open an interactive bash session inside the PHP container
+docker-sh: ## Connect to the PHP container via bash so up and down arrows go to previous commands
 	@$(DOCKER_COMP) exec -it prestashop-git runuser -u www-data -g www-data -- bash -l
 
 ## —— PrestaShop 🛒 ———————————————————————————————————————————————————————————
-install: composer cc assets ## Install PHP dependencies and build static assets
+install: composer cc assets  ## Install PHP dependencies and build the static assets
 
 install-prestashop: ## Install fresh PrestaShop database (requires containers to be running)
 	$(PHP_CONT) .docker/install/database.sh
 
 ## —— Assets 🎨 ———————————————————————————————————————————————————————————————
 assets: admin front ## Build all assets
-	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh all --force"
+	$(PHP_CONT) ./tools/assets/build.sh all --force
 
 wait-assets: ## Wait for assets to be built
-	$(PHP_CONT) "./tools/assets/wait-build.sh"
+	$(PHP_CONT) ./tools/assets/wait-build.sh
 
 admin: ## Build admin assets
-	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh admin-default --force"
-	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh admin-new-theme --force"
+	$(PHP_CONT) ./tools/assets/build.sh admin-default --force
+	$(PHP_CONT) ./tools/assets/build.sh admin-new-theme --force
 
 front: ## Build front assets
-	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh front-core --force"
-	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh front-classic --force"
-	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh front-hummingbird --force"
+	$(PHP_CONT) ./tools/assets/build.sh front-core --force
+	$(PHP_CONT) ./tools/assets/build.sh front-classic --force
+	$(PHP_CONT) ./tools/assets/build.sh front-hummingbird --force
 
 admin-default: ## Build assets for default admin theme
-	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh admin-default --force"
+	$(PHP_CONT) ./tools/assets/build.sh admin-default --force
 
 admin-new-theme: ## Build assets for new admin theme
-	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh admin-new-theme --force"
+	$(PHP_CONT) ./tools/assets/build.sh admin-new-theme --force
 
 front-core: ## Build assets for core theme
-	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh front-core --force"
+	$(PHP_CONT) ./tools/assets/build.sh front-core --force
 
 front-classic: ## Build assets for classic theme
-	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh front-classic --force"
+	$(PHP_CONT) ./tools/assets/build.sh front-classic --force
 
 front-hummingbird: ## Build assets for hummingbird theme
-	$(PHP_CONT_WITH_LOGIN) "./tools/assets/build.sh front-hummingbird --force"
+	$(PHP_CONT) ./tools/assets/build.sh front-hummingbird --force
 
 ## —— Composer & Symfony 🧙 ————————————————————————————————————————————————————
 composer: ## Install PHP dependencies
@@ -112,12 +111,12 @@ phpstan: ## Run phpstan analysis
 	$(COMPOSER) run phpstan
 
 scss-fixer: ## Run scss-fix
-	$(PHP_CONT_WITH_LOGIN) "cd admin-dev/themes/new-theme && npm run scss-fix"
-	$(PHP_CONT_WITH_LOGIN) "cd admin-dev/themes/default && npm run scss-fix"
-	$(PHP_CONT_WITH_LOGIN) "cd themes/classic/_dev && npm run scss-fix"
+	$(PHP_CONT) cd admin-dev/themes/new-theme && npm run scss-fix
+	$(PHP_CONT) cd admin-dev/themes/default && npm run scss-fix
+	$(PHP_CONT) cd themes/classic/_dev && npm run scss-fix
 
 es-linter: ## Run lint-fix
-	$(PHP_CONT_WITH_LOGIN) "cd admin-dev/themes/new-theme && npm run lint-fix"
-	$(PHP_CONT_WITH_LOGIN) "cd admin-dev/themes/default && npm run lint-fix"
-	$(PHP_CONT_WITH_LOGIN) "cd themes/classic/_dev && npm run lint-fix"
-	$(PHP_CONT_WITH_LOGIN) "cd themes && npm run lint-fix"
+	$(PHP_CONT) cd admin-dev/themes/new-theme && npm run lint-fix
+	$(PHP_CONT) cd admin-dev/themes/default && npm run lint-fix
+	$(PHP_CONT) cd themes/classic/_dev && npm run lint-fix
+	$(PHP_CONT) cd themes && npm run lint-fix


### PR DESCRIPTION
**Changes:**

Adds `-T` arg  to docker compose exec to avoid TTY allocation issues in non-interactive Makefile commands (can avoid problems for Windows and Mac users)

Executes `bash -l` inside the container to ensure a login shell  for make assets commands (like scss-fixer and es-linter commands) => **correctly loading environment variables and PATH** .

Resolves `npm: command not found` errors when building assets

**Impact:**

Makefile commands now work both from host and CI environments.

No more manual shell workarounds needed to build assets.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |Executes bash -l to ensure a login shell, correctly loading environment variables and PATH.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see #39862 
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/19509056823
| Fixed issue or discussion?     | Fixes #39862
| Related PRs       |
| Sponsor company   | @PrestaShopCorp
