### PR TITLE
Add additional parameters to actionPresentCart hook

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -210,7 +210,11 @@ class CartPresenter implements PresenterInterface
         $cartLazyArray = new CartLazyArray($cart, $this, $shouldSeparateGifts);
 
         Hook::exec('actionPresentCart',
-            ['presentedCart' => &$cartLazyArray]
+            [
+                'presentedCart' => &$cartLazyArray,
+                'cart' => $cart,
+                'presenter' => $this,
+            ]
         );
 
         Cache::store($cache_id, $cartLazyArray);


### PR DESCRIPTION
## Context

The `actionPresentCart` hook is triggered when a cart is being presented/formatted, but the hook parameters only include the `presentedCart` array (which is the formatted output) without any reference to the original Cart object.

This makes it impossible for modules to:
- Identify which cart is being presented (no cart ID available)
- Access additional cart properties not included in the presented array
- Perform cart-specific operations based on the cart context

## Changes

Added two new parameters to the hook:
- `cart`: The original Cart object being presented
- `presenter`: The CartPresenter instance (useful for modules that need to use the presenter's functionality/parameters, like the presenter settings for example)

This change is backward compatible as it only adds new parameters without modifying existing ones.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Added `cart` and `presenter` parameters to the `actionPresentCart` hook to allow identification of the presented cart. Currently, the `presentedCart` array does not contain the cart ID, making it impossible to identify which cart is being presented in modules using this hook.
| Type?             | bug fix / improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create a module that hooks into `actionPresentCart`<br>2. In the hook, add `var_dump($params)` to verify the presence of the new `cart` and `presenter` keys<br>3. Verify that `$params['cart']->id` is accessible and matches the current cart ID<br>4. Verify that normal cart behavior is not affected (display, updates, etc.)
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | Web Premiere