### PR TITLE
Chore: show carrier deleted on edit shipment to avoid blocking edit

### DIFF
--- a/src/Adapter/Carrier/QueryHandler/GetAvailableCarriersHandler.php
+++ b/src/Adapter/Carrier/QueryHandler/GetAvailableCarriersHandler.php
@@ -103,6 +103,14 @@ class GetAvailableCarriersHandler implements GetAvailableCarriersHandlerInterfac
             $availableCarriers[] = new CarrierSummary($carrier['id_carrier'], $carrier['name']);
         }
 
+        $currentCarrierId = $query->getCurrentCarrierId();
+        if ($currentCarrierId !== null && !in_array($currentCarrierId, $eligibleCarrierIds, true)) {
+            $currentCarrier = $this->carrierRepository->get(new CarrierId($currentCarrierId));
+            if ($currentCarrier !== null) {
+                $availableCarriers[] = new CarrierSummary($currentCarrier->id, $currentCarrier->name);
+            }
+        }
+
         // Compute filtered carriers (carriers not available for all products)
         $removedCarriers = [];
         $allCarrierIds = $this->mapCarrierToProducts($carriersMapping);

--- a/src/Adapter/Carrier/QueryHandler/GetAvailableCarriersHandler.php
+++ b/src/Adapter/Carrier/QueryHandler/GetAvailableCarriersHandler.php
@@ -104,7 +104,7 @@ class GetAvailableCarriersHandler implements GetAvailableCarriersHandlerInterfac
         }
 
         $currentCarrierId = $query->getCurrentCarrierId();
-        if ($currentCarrierId !== null && !in_array($currentCarrierId, $eligibleCarrierIds, true)) {
+        if ($currentCarrierId !== null && !in_array($currentCarrierId, $eligibleCarrierIds)) {
             $currentCarrier = $this->carrierRepository->get(new CarrierId($currentCarrierId));
             if ($currentCarrier !== null) {
                 $availableCarriers[] = new CarrierSummary($currentCarrier->id, $currentCarrier->name);

--- a/src/Adapter/Form/ChoiceProvider/AvailableCarriersForShipmentChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/AvailableCarriersForShipmentChoiceProvider.php
@@ -67,7 +67,11 @@ final class AvailableCarriersForShipmentChoiceProvider implements ConfigurableFo
         }
 
         /** @var GetCarriersResult $carriers */
-        $carriers = $this->commandBus->handle(new GetAvailableCarriers($productQuantities, new AddressId($shipment->getAddressId())));
+        $carriers = $this->commandBus->handle(new GetAvailableCarriers(
+            $productQuantities,
+            new AddressId($shipment->getAddressId()),
+            $shipment->getCarrierId()
+        ));
 
         return FormChoiceFormatter::formatFormChoices(
             $carriers->getAvailableCarriersToArray(),

--- a/src/Core/Domain/Carrier/Query/GetAvailableCarriers.php
+++ b/src/Core/Domain/Carrier/Query/GetAvailableCarriers.php
@@ -42,12 +42,18 @@ class GetAvailableCarriers
     private $productQuantities;
 
     /**
+     * @var int|null
+     */
+    private $currentCarrierId;
+
+    /**
      * @param ProductQuantity[] $productQuantities
      */
-    public function __construct(array $productQuantities, AddressId $addressId)
+    public function __construct(array $productQuantities, AddressId $addressId, ?int $currentCarrierId = null)
     {
         $this->productQuantities = $productQuantities;
         $this->addressId = $addressId;
+        $this->currentCarrierId = $currentCarrierId;
     }
 
     /**
@@ -77,5 +83,10 @@ class GetAvailableCarriers
     public function setAddressId(AddressId $addressId): void
     {
         $this->addressId = $addressId;
+    }
+
+    public function getCurrentCarrierId(): ?int
+    {
+        return $this->currentCarrierId;
     }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_available.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_available.feature
@@ -18,6 +18,22 @@ Feature: Carrier available
     And there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     And there is an address named "address1" with postcode "1" in state "state1"
 
+Scenario: Carrier available when is deleted
+  Given I add product "s3_product1" with following information:
+    | name[en-US] | product D |
+    | type        | standard  |
+  And I create carrier "s42_carrier" with specified properties:
+    | name  | Deleted Carrier |
+    | zones | zone1           |
+  And I assign product "s3_product1" with following carriers:
+    | s42_carrier |
+  And I soft delete carrier "s42_carrier"
+  Then the products "s3_product1" should have the following carriers with address "address1":
+    | carrier          | carrier_reference | state     | products  |
+    | Deleted Carrier  | s42_carrier       | available | product D |
+    | Click and collect|                   | filtered  | product D |
+    | My carrier       |                   | filtered  | product D |
+
 Scenario: Get available carriers for existing order
   Given I add product "s0_product1" with following information:
     | name[fr-FR] | bouteille de bière |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When a customer make a order we create shipment with the carrier selected. When we delete the carrier used for order an shipment we are blocked on the edit because no carrier is available because we fetch only carrier actif and not deleted
| Type?             | bug fix
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Make an order with the FF and go to the order detail. disable the carrier used and try to edit a shipment
| UI Tests          | no need with FF
