### PR TITLE
BO - Products : Enable/Disable actions depending on permissions

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -385,6 +385,8 @@ services:
       - '@form.factory'
       - '@PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\ProductSingleShopAssociatedAccessibilityChecker'
       - '@PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\ProductMultipleShopsAssociatedAccessibilityChecker'
+      - '@PrestaShop\PrestaShop\Adapter\Security\Access'
+      - '@prestashop.adapter.data_provider.employee'
     public: true
 
   prestashop.core.grid.definition.factory.product.shops:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | BO - Products : Enable/Disable actions depending on permissions
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | :arrow_down: 
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/18934576372
| Fixed issue or discussion?     | Fixes #12636
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

## How to test ?
* Create a user "A" with the profile "Logistician"
* With User SuperAdmin, On the profile "Logistician", disable the access "Delete" on  "BO > Products" page
* With User A, On the page Products, the button Delete is not displayed on rows 
* With User SuperAdmin, On the profile "Logistician", disable the access "Edit" on  "BO > Products" page
* With User A, On the page Products, the button Edit is not displayed on rows 
* With User SuperAdmin, On the profile "Logistician", disable the access "Add" on  "BO > Products" page
* With User A, On the page Products, the button Create is not displayed on rows 