### PR TITLE
Fix: Ensure is_color_group is updated after editing an AttributeGroup

### DIFF
--- a/src/Adapter/AttributeGroup/CommandHandler/EditAttributeGroupHandler.php
+++ b/src/Adapter/AttributeGroup/CommandHandler/EditAttributeGroupHandler.php
@@ -65,6 +65,7 @@ final class EditAttributeGroupHandler implements EditAttributeGroupHandlerInterf
         }
         if (null !== $command->getType()) {
             $propertiesToUpdate[] = 'group_type';
+            $propertiesToUpdate[] = 'is_color_group';
             $attributeGroup->group_type = $command->getType()->getValue();
         }
         if (null !== $command->getAssociatedShopIds()) {

--- a/src/Adapter/AttributeGroup/CommandHandler/EditAttributeGroupHandler.php
+++ b/src/Adapter/AttributeGroup/CommandHandler/EditAttributeGroupHandler.php
@@ -65,8 +65,9 @@ final class EditAttributeGroupHandler implements EditAttributeGroupHandlerInterf
         }
         if (null !== $command->getType()) {
             $propertiesToUpdate[] = 'group_type';
-            $propertiesToUpdate[] = 'is_color_group';
             $attributeGroup->group_type = $command->getType()->getValue();
+            $propertiesToUpdate[] = 'is_color_group';
+            $attributeGroup->is_color_group = $attributeGroup->group_type === 'color';
         }
         if (null !== $command->getAssociatedShopIds()) {
             $attributeGroup->id_shop_list = $command->getAssociatedShopIds();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | When editing an Attribute(Group) is_color_group is not updated
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See comment below
| UI Tests          | https://github.com/ChillCode/ga.tests.ui.pr/actions/runs/18945525632
| Fixed issue or discussion?     | Fixes #39769
| Related PRs       | #39758

How to test:

1. Go to Catalog > Attributes & Features >Attributes
2. Edit Color Attribute with ID 2
3. Change Attribute type to Drop-down list
4. Save
5. Add a new Attibute value, select Group with ID 2 and we should have have a Drop-down list instead of color picker