### PR TITLE
Add virtual product filter for shipments

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1348,8 +1348,20 @@ abstract class PaymentModuleCore extends Module
 
         /** @var OrderShipmentCreator $orderShipmentCreator */
         $orderShipmentCreator = $this->get('PrestaShop\PrestaShop\Adapter\Shipment\OrderShipmentCreator');
+        $physicalProductsByCarrier = [];
 
-        $orderShipmentCreator->addShipmentOrder($order, $productsByCarrier);
+        foreach ($productsByCarrier as $carrierId => $products) {
+            $filteredProducts = array_filter($products['product_list'], function (array $product) {
+                return !$product['is_virtual'];
+            });
+
+            if (!empty($filteredProducts)) {
+                $physicalProductsByCarrier[$carrierId]['product_list'] = array_values($filteredProducts);
+                $physicalProductsByCarrier[$carrierId]['total_shipping_tax_excl'] = $products['total_shipping_tax_excl'];
+                $physicalProductsByCarrier[$carrierId]['total_shipping_tax_incl'] = $products['total_shipping_tax_incl'];
+            }
+        }
+        $orderShipmentCreator->addShipmentOrder($order, $physicalProductsByCarrier);
     }
 
     private function isFeatureFlagIsEnabledForMultiShipment()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | It is unnecessary to include virtual products in shipments; this introduces undesirable behavior when splitting and merging shipments, as well as when creating a shipment containing only virtual products
| Type?             | bug fix
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | -
| UI Tests          | -
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -