### PR TITLE
Refactor discount-map.ts to use discountContainer for currency select

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/discount/discount-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/discount/discount-map.ts
@@ -26,12 +26,12 @@ const discountContainer = '.discount-container';
 
 export default {
   currencySelect: '#discount_value_reduction_currency',
-  currencySelectContainer: '.price-reduction-currency-selector',
+  currencySelectContainer: `${discountContainer} .price-reduction-currency-selector`,
   discountContainer,
   includeTaxInput: '#discount_value_reduction_include_tax',
   reductionTypeSelect: '#discount_value_reduction_type',
   reductionValueSymbol: `${discountContainer} .price-reduction-value .input-group .input-group-append .input-group-text,
-   .price-reduction-value .input-group .input-group-prepend .input-group-text`,
+   ${discountContainer} .price-reduction-value .input-group .input-group-prepend .input-group-text`,
   freeGiftProductSearchContainer: '#discount_free_gift',
   discountTypeRadios: '#discount_type_selector_discount_type_selector input[type="radio"]',
   discountTypeSubmit: '#discountTypeSubmit',


### PR DESCRIPTION
…or and reduction value symbol paths

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Refactor discount-map.ts to use discountContainer for currency select
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | See Bellow
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #39858 
| Sponsor company   | PrestaShop SA


## How to Test
### Steps to Reproduce the Bug (Before Fix)

1. Navigate to **Catalog > Discounts** in the Back Office
2. Click **"Add new discount"** 
3. Select **"Discount for cart"** as the discount type
4. In the **"Value"** section, select **"Percentage (%)"** as the reduction type
5. Scroll down to **"Conditions"** section
6. Enable **"Cart conditions"** and select **"Minimum purchase amount"**

**❌ Bug:** The currency symbol in the "Minimum purchase amount" field incorrectly changes to **%** (should always be **€**)

7. Change the reduction type back to **"Amount (€)"** in the Value section

**❌ Bug:** The currency field in the "Minimum purchase amount" section incorrectly hides (should always be visible)

### Expected Behavior (After Fix)

✅ The **"Minimum purchase amount"** field should:
- Always display the currency symbol (**€**)
- Always show the currency selector dropdown
- Remain **unaffected** by changes to the discount value reduction type

✅ Only the **"Value"** section (top) should:
- Change between **%** and **€** based on the selected reduction type
- Show/hide the currency selector when switching between percentage and amount