### PR TITLE
[Webpack][admin-themes]  Ignore the node_modules folders in watch mode

### DIFF
--- a/admin-dev/themes/default/webpack.config.js
+++ b/admin-dev/themes/default/webpack.config.js
@@ -38,6 +38,9 @@ module.exports = (env, argv) => {
 
   const config = {
     mode: argv.mode || 'production',
+    watchOptions: {
+      ignored: /node_modules/,
+    },
     entry: {
       theme: './js/theme.js',
       rtl: './scss/rtl.scss',

--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -36,6 +36,9 @@ const FontPreloadPlugin = require('webpack-font-preload-plugin');
 const CssoWebpackPlugin = require('csso-webpack-plugin').default;
 
 module.exports = {
+  watchOptions: {
+    ignored: /node_modules/,
+  },
   externals: {
     jquery: 'jQuery',
   },


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | see #39884 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | npm run dev on themes/default or themes/new-theme
| UI Tests          |
| Fixed issue or discussion?     | Fixes #39884
| Related PRs       |
| Sponsor company   | @PrestaShopCorp
