### PR TITLE
Legacy email template scan

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -734,6 +734,18 @@ class MailCore extends ObjectModel
             }
         }
 
+        if ($moduleName === false && is_dir(_PS_MODULE_DIR_)) {
+            $modulesDir = new DirectoryIterator(_PS_MODULE_DIR_);
+            foreach ($modulesDir as $moduleDir) {
+                if ($moduleDir->isDir() && !$moduleDir->isDot()) {
+                    $moduleTemplatePath = $moduleDir->getPathname() . '/mails/' . $isoTemplate;
+                    if (file_exists($moduleTemplatePath . '.txt') || file_exists($moduleTemplatePath . '.html')) {
+                        return $moduleDir->getPathname() . '/mails/';
+                    }
+                }
+            }
+        }
+
         return '';
     }
 

--- a/src/Core/Email/LegacyEmailTemplateLister.php
+++ b/src/Core/Email/LegacyEmailTemplateLister.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Email;
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * Scans and lists legacy email templates (HTML/TXT files) from /mails/{language}/ and /modules/{modulename}/mails/{language}/
+ */
+class LegacyEmailTemplateLister
+{
+    private string $mailsDir;
+    private string $modulesDir;
+
+    public function __construct(string $mailsDir = _PS_MAIL_DIR_, string $modulesDir = _PS_MODULE_DIR_)
+    {
+        $this->mailsDir = $mailsDir;
+        $this->modulesDir = $modulesDir;
+    }
+
+    /**
+     * @return array ['template_name' => ['module' => '', 'is_core' => true, ...], ...]
+     */
+    public function getLegacyTemplates(string $isoCode): array
+    {
+        $templates = [];
+
+        $corePath = $this->mailsDir . $isoCode . '/';
+        if (is_dir($corePath)) {
+            $templates = array_merge($templates, $this->scanDirectory($corePath, '', true));
+        }
+
+        $templates = array_merge($templates, $this->scanModuleTemplates($isoCode));
+
+        return $templates;
+    }
+
+    private function scanDirectory(string $path, string $moduleName, bool $isCore = false): array
+    {
+        $templates = [];
+
+        if (!is_dir($path)) {
+            return $templates;
+        }
+
+        $finder = new Finder();
+        $finder->files()->in($path)->depth(0)->name('*.html');
+
+        /** @var SplFileInfo $file */
+        foreach ($finder as $file) {
+            $templateName = $file->getBasename('.html');
+
+            if ($templateName[0] === '.') {
+                continue;
+            }
+
+            $txtFile = $path . $templateName . '.txt';
+
+            if (file_exists($txtFile)) {
+                $templates[$templateName] = [
+                    'module' => $moduleName,
+                    'is_core' => $isCore,
+                    'html_path' => $file->getPathname(),
+                    'txt_path' => $txtFile,
+                ];
+            }
+        }
+
+        return $templates;
+    }
+
+    private function scanModuleTemplates(string $isoCode): array
+    {
+        $templates = [];
+
+        if (!is_dir($this->modulesDir)) {
+            return $templates;
+        }
+
+        $moduleFinder = new Finder();
+        $moduleFinder->directories()->in($this->modulesDir)->depth(0);
+
+        /** @var SplFileInfo $moduleDir */
+        foreach ($moduleFinder as $moduleDir) {
+            $moduleName = $moduleDir->getFilename();
+            $modulePath = $moduleDir->getPathname() . '/mails/' . $isoCode . '/';
+
+            if (is_dir($modulePath)) {
+                $moduleTemplates = $this->scanDirectory($modulePath, $moduleName, false);
+                $templates = array_merge($templates, $moduleTemplates);
+            }
+        }
+
+        return $templates;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -548,6 +548,7 @@ services:
   PrestaShopBundle\Form\Admin\Configure\ShopParameters\OrderStates\OrderStateType:
     arguments:
       $themeCatalog: "@prestashop.core.mail_template.theme_catalog"
+      $legacyTemplateLister: '@prestashop.core.email.legacy_template_lister'
 
   PrestaShopBundle\Form\Admin\Improve\International\Locations\ZoneType:
   PrestaShopBundle\Form\Admin\Improve\International\Locations\CountryType:

--- a/src/PrestaShopBundle/Resources/config/services/core/mail_template.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/mail_template.yml
@@ -41,6 +41,12 @@ services:
   prestashop.core.mail_template.transformation.html_textify:
     class: 'PrestaShop\PrestaShop\Core\MailTemplate\Transformation\HTMLToTextTransformation'
 
+  prestashop.core.email.legacy_template_lister:
+    class: 'PrestaShop\PrestaShop\Core\Email\LegacyEmailTemplateLister'
+    arguments:
+      $mailsDir: '%kernel.project_dir%/mails'
+      $modulesDir: '%modules_dir%'
+
   prestashop.core.mail_template.command_handler.generate_theme_mails_handler:
     class: 'PrestaShop\PrestaShop\Core\Domain\MailTemplate\CommandHandler\GenerateThemeMailTemplatesHandler'
     arguments:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fixes issue where legacy email templates (HTML/TXT files) from modules were not shown in the Order Status form dropdown after migration to Symfony.<br><br>After the migration, the form only displayed templates from `mails/themes/{theme}/` (Twig templates), completely ignoring legacy templates from:<br>- `/mails/{language}/` (core legacy templates)<br>- `/modules/{modulename}/mails/{language}/` (module legacy templates)<br><br>**Changes made:**<br>1. Created `LegacyEmailTemplateLister` service to scan for legacy HTML/TXT templates in both core and module directories<br>2. Updated `OrderStateType` form to inject `LegacyEmailTemplateLister` and merge legacy templates with modern Twig layouts in the dropdown<br>3. Enhanced `Mail::getTemplateBasePath()` to search all module `mails/` folders when a template isn't found in standard locations
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | **Prerequisites:** Install any module with legacy email templates (HTML/TXT files in `modules/{modulename}/mails/{language}/`) <br><br>**Test Steps:**<br>1. Verify templates appear in dropdown:<br>   - Go to Shop Parameters > Order Settings > Statuses<br>   - Click "Add new order status" (or edit existing)<br>   - Check "Send an email to the customer when their order status has changed"<br>   - Open the "Template" dropdown<br>   - Verify legacy templates appear alongside modern Twig templates<br><br>2. Test email sending:<br>   - Create an order status with a legacy template selected<br>   - Create or open an existing order<br>   - Change the order status to the one using the legacy template<br>   - Verify email is sent successfully (check MailDev at http://localhost:1080 or email logs)<br>   - Verify email content matches the legacy template<br><br>3. Test with existing modules:<br>   - Check modules like `ps_emailalerts` or payment modules that have legacy templates<br>   - Verify their templates appear in the dropdown<br><br>**Expected Results:**<br>- All legacy HTML/TXT templates from `/mails/{lang}/` and `/modules/{modulename}/mails/{lang}/` appear in the template dropdown<br>- Legacy templates can be selected and used for order status emails<br>- Modern Twig templates continue to work as before<br>- Modern templates take precedence if there's a name conflict
| UI Tests          | https://github.com/tleon/ga.tests.ui.pr/actions/runs/18975920254
| Fixed issue or discussion?     | Fixes #39421
| Sponsor company   | PrestaShop SA