### PR TITLE
Fix: ProductController::findProductCombinationById() incorrect return type

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1282,7 +1282,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     /**
      * @param int $combinationId
      *
-     * @return ProductController|null
+     * @return array<string, mixed>|null
      */
     public function findProductCombinationById(int $combinationId)
     {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Adds a detailed `@return array<string, mixed>` annotation to the `findProductCombinationById `method to clarify the expected return structure and improve static analysis accuracy.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #38146
| Related PRs       | 
| Sponsor company   | Codencode snc
