### PR TITLE
Optimize category input

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -519,6 +519,11 @@ $product-page-padding-bottom: 80px !default;
     }
   }
 
+  /* Let default category selector take full width */
+  #product_description_categories .form-group.select-widget {
+    max-width: 100%;
+  }
+
   .hide {
     display: none;
   }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
@@ -73,17 +73,18 @@ class CategoriesType extends TranslatorAwareType
     {
         $builder
             ->add('product_categories', CategoryTagsCollectionType::class)
+            ->add('add_categories_btn', ButtonType::class, [
+                'label' => $this->trans('Choose categories', 'Admin.Catalog.Feature'),
+                'attr' => [
+                    'class' => 'add-categories-btn btn-outline-secondary',
+                ],
+            ])
             ->add('default_category_id', ChoiceType::class, [
                 'constraints' => [],
                 'choices' => $this->defaultCategoryChoiceProvider->getChoices(['product_id' => $options['product_id']]),
                 'label' => $this->trans('Default category', 'Admin.Catalog.Feature'),
+                'help' => $this->trans('Defines the product\'s primary placement, usually the deepest category in the hierarchy. It\'s used in breadcrumbs, URLs, structured data and many other parts of the shop.', 'Admin.Catalog.Help'),
                 'autocomplete' => true,
-            ])
-            ->add('add_categories_btn', ButtonType::class, [
-                'label' => $this->trans('Add categories', 'Admin.Catalog.Feature'),
-                'attr' => [
-                    'class' => 'add-categories-btn btn-outline-secondary',
-                ],
             ])
         ;
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Few tiny optimizations on the category input. See screenshot. Moves button below the category selects, where it belongs I think. Renames Add categories to Choose categories - because you both add and remove them there. I added helptext to default category to make merchants understand it's IMPORTANT to select it and not Home category. Make it full width, because it just overflows every time. cc @kpodemski @ibahloul-ps @Codencode @tblivet 
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open admin page, see nothing is broken.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### Screenshot (from 8.2.3)
<img width="1588" height="330" alt="Snímek obrazovky 2025-10-31 181426" src="https://github.com/user-attachments/assets/06777e8b-64b6-4c4c-a870-c66842a2b14e" />
