### PR TITLE
Add position key in response when creating Attributes Group via AdminAPI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "prestashop/hummingbird": "^1.0.1",
         "prestashop/pagesnotfound": "^2",
         "prestashop/productcomments": "^7.0",
-        "prestashop/ps_apiresources": "dev-dev",
+        "prestashop/ps_apiresources": "dev-dev#884201aefe6a921a99b54f210165e6fc4d5e6774",
         "prestashop/ps_banner": "^2",
         "prestashop/ps_bestsellers": "^1.0",
         "prestashop/ps_brandlist": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "01030ac3c9fe67217e8b7682a6d3b099",
+    "content-hash": "a5a6c78c3ec779e05f6f7bf398708707",
     "packages": [
         {
             "name": "api-platform/core",
@@ -5265,12 +5265,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_apiresources.git",
-                "reference": "2bfd399966bb9346d0aca8908f1006cf22449c0b"
+                "reference": "884201aefe6a921a99b54f210165e6fc4d5e6774"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_apiresources/zipball/2bfd399966bb9346d0aca8908f1006cf22449c0b",
-                "reference": "2bfd399966bb9346d0aca8908f1006cf22449c0b",
+                "url": "https://api.github.com/repos/PrestaShop/ps_apiresources/zipball/884201aefe6a921a99b54f210165e6fc4d5e6774",
+                "reference": "884201aefe6a921a99b54f210165e6fc4d5e6774",
                 "shasum": ""
             },
             "require": {
@@ -5326,7 +5326,7 @@
             "support": {
                 "source": "https://github.com/PrestaShop/ps_apiresources/tree/dev"
             },
-            "time": "2025-10-30T11:06:47+00:00"
+            "time": "2025-11-07T08:38:41+00:00"
         },
         {
             "name": "prestashop/ps_banner",
@@ -18344,9 +18344,9 @@
         "ext-simplexml": "*",
         "ext-zip": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Adapter/AttributeGroup/QueryHandler/GetAttributeGroupForEditingHandler.php
+++ b/src/Adapter/AttributeGroup/QueryHandler/GetAttributeGroupForEditingHandler.php
@@ -61,7 +61,8 @@ final class GetAttributeGroupForEditingHandler implements GetAttributeGroupForEd
             $attributeGroup->name,
             $attributeGroup->public_name,
             $attributeGroup->group_type,
-            $attributeGroup->getAssociatedShops()
+            $attributeGroup->getAssociatedShops(),
+            (int) $attributeGroup->position
         );
     }
 }

--- a/src/Core/Domain/AttributeGroup/QueryResult/EditableAttributeGroup.php
+++ b/src/Core/Domain/AttributeGroup/QueryResult/EditableAttributeGroup.php
@@ -61,24 +61,32 @@ class EditableAttributeGroup
     private $type;
 
     /**
+     * @var int
+     */
+    private $position;
+
+    /**
      * @param int $attributeGroupId
      * @param string[] $name
      * @param array $publicName
      * @param string $type
      * @param int[] $associatedShopIds
+     * @param int $position
      */
     public function __construct(
         int $attributeGroupId,
         array $name,
         array $publicName,
         string $type,
-        array $associatedShopIds
+        array $associatedShopIds,
+        int $position
     ) {
         $this->attributeGroupId = new AttributeGroupId($attributeGroupId);
         $this->name = $name;
         $this->associatedShopIds = $associatedShopIds;
         $this->publicName = $publicName;
         $this->type = $type;
+        $this->position = $position;
     }
 
     /**
@@ -119,5 +127,13 @@ class EditableAttributeGroup
     public function getType(): string
     {
         return $this->type;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPosition(): int
+    {
+        return $this->position;
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x 
| Description?      | Add position key in response when creating Attributes Group via AdminAPI
| Type?             | bug fix 
| Category?         |  BO 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Steps are https://github.com/PrestaShop/PrestaShop/issues/39729 
| UI Tests          | https://github.com/nicosomb/ga.tests.ui.pr/actions/runs/19036844178
| Fixed issue or discussion?     | #39729 
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA 