### PR TITLE
Add DateImmutable for api type consistency

### DIFF
--- a/src/Core/Util/DateTime/DateImmutable.php
+++ b/src/Core/Util/DateTime/DateImmutable.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Util\DateTime;
+
+use DateTimeImmutable;
+use DateTimeZone;
+
+/**
+ * DateImmutable extends DateTimeImmutable to represent dates (without time) for API Platform.
+ * It serializes/unserializes using Y-m-d format instead of full datetime format.
+ */
+class DateImmutable extends DateTimeImmutable
+{
+    public function __construct(string $datetime = 'now', ?DateTimeZone $timezone = null)
+    {
+        parent::__construct($datetime, $timezone);
+    }
+}

--- a/src/PrestaShopBundle/ApiPlatform/Normalizer/DateImmutableNormalizer.php
+++ b/src/PrestaShopBundle/ApiPlatform/Normalizer/DateImmutableNormalizer.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\ApiPlatform\Normalizer;
+
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateImmutable;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Normalizes DateImmutable properties with Y-m-d format for API Platform.
+ * Ensures date-only values are serialized without time component.
+ */
+#[AutoconfigureTag('prestashop.api.normalizers')]
+class DateImmutableNormalizer implements DenormalizerInterface, NormalizerInterface
+{
+    /**
+     * @param mixed $data Date string in Y-m-d format
+     */
+    public function denormalize($data, string $type, ?string $format = null, array $context = [])
+    {
+        return new DateImmutable($data);
+    }
+
+    public function supportsDenormalization($data, string $type, ?string $format = null)
+    {
+        return DateImmutable::class === $type;
+    }
+
+    /**
+     * @param mixed $object Must be a DateImmutable instance
+     *
+     * @return string Date string in Y-m-d format
+     */
+    public function normalize(mixed $object, ?string $format = null, array $context = [])
+    {
+        if (!($object instanceof DateImmutable)) {
+            throw new InvalidArgumentException('Expected object to be a ' . DateImmutable::class);
+        }
+
+        return $object->format(DateTimeUtil::DEFAULT_DATE_FORMAT);
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null)
+    {
+        return $data instanceof DateImmutable;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            DateImmutable::class => true,
+        ];
+    }
+}

--- a/src/PrestaShopBundle/ApiPlatform/OpenApi/Factory/CQRSOpenApiFactory.php
+++ b/src/PrestaShopBundle/ApiPlatform/OpenApi/Factory/CQRSOpenApiFactory.php
@@ -45,6 +45,7 @@ use DateTimeInterface;
 use Exception;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Feature\MultistoreFeature;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateImmutable;
 use PrestaShopBundle\ApiPlatform\DomainObjectDetector;
 use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 use ReflectionClass;
@@ -109,6 +110,7 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
                     $resourceSchema = $parentOpenApi->getComponents()->getSchemas()->offsetGet($resourceDefinitionName);
                     $this->adaptLocalizedValues($resourceMetadata->getClass(), $resourceSchema);
                     $this->adaptDecimalNumbers($resourceMetadata->getClass(), $resourceSchema);
+                    $this->adaptDateProperties($resourceMetadata->getClass(), $resourceSchema);
                     // NEW: Synchronize schema with actual resource properties
                     $this->synchronizeSchemaWithResource($resourceMetadata->getClass(), $resourceSchema);
                 }
@@ -137,6 +139,8 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
                     $this->adaptLocalizedValues($operation->getClass(), $definition);
                     $this->adaptDecimalNumbers($operation->getClass(), $definition);
                     $this->synchronizeSchemaWithResource($operation->getClass(), $definition);
+                    // Adapt DateImmutable properties last to ensure examples are correctly set
+                    $this->adaptDateProperties($operation->getClass(), $definition);
                 }
             }
         }
@@ -443,6 +447,75 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
     }
 
     /**
+     * Adapts DateImmutable properties to use 'date' format instead of 'date-time' in OpenAPI schema.
+     * Checks both property types and getter/setter method signatures to detect DateImmutable usage.
+     */
+    protected function adaptDateProperties(string $class, ArrayObject $definition): void
+    {
+        if (empty($definition['properties'])) {
+            return;
+        }
+
+        $resourceClassMetadata = $this->classMetadataFactory->getMetadataFor($class);
+        $resourceReflectionClass = $resourceClassMetadata->getReflectionClass();
+
+        foreach ($definition['properties'] as $propertyName => $propertySchema) {
+            // Check if property exists and get its type
+            $propertyType = null;
+            if ($resourceReflectionClass->hasProperty($propertyName)) {
+                $property = $resourceReflectionClass->getProperty($propertyName);
+                if ($property->hasType() && $property->getType() instanceof ReflectionNamedType) {
+                    $propertyType = $property->getType()->getName();
+                }
+            }
+
+            // If property not found or has no type, check getter/setter methods
+            if (!$propertyType) {
+                $camelCasePropertyName = ucfirst($propertyName);
+                $getterMethodName = 'get' . $camelCasePropertyName;
+                $setterMethodName = 'set' . $camelCasePropertyName;
+
+                if ($resourceReflectionClass->hasMethod($getterMethodName)) {
+                    $getterMethod = $resourceReflectionClass->getMethod($getterMethodName);
+                    if ($getterMethod->hasReturnType() && $getterMethod->getReturnType() instanceof ReflectionNamedType) {
+                        $propertyType = $getterMethod->getReturnType()->getName();
+                    }
+                } elseif ($resourceReflectionClass->hasMethod($setterMethodName)) {
+                    $setterMethod = $resourceReflectionClass->getMethod($setterMethodName);
+                    $parameters = $setterMethod->getParameters();
+                    if (!empty($parameters) && $parameters[0]->hasType() && $parameters[0]->getType() instanceof ReflectionNamedType) {
+                        $propertyType = $parameters[0]->getType()->getName();
+                    }
+                }
+            }
+
+            // If property type is DateImmutable, change format from date-time to date and update example
+            if ($propertyType === DateImmutable::class || is_subclass_of($propertyType, DateImmutable::class)) {
+                // Always set format to 'date' for DateImmutable properties
+                $definition['properties'][$propertyName]['format'] = 'date';
+
+                // Always update example to use date format (Y-m-d) - overwrite any existing example
+                $example = $definition['properties'][$propertyName]['example'] ?? null;
+                if (is_string($example)) {
+                    // If example is a datetime string (ISO 8601 or similar), extract just the date part
+                    if (preg_match('/^(\d{4}-\d{2}-\d{2})(T|\s|$)/', $example, $matches)) {
+                        $definition['properties'][$propertyName]['example'] = $matches[1];
+                    } elseif (preg_match('/^(\d{4}-\d{2}-\d{2})/', $example, $matches)) {
+                        // Already a date format, keep it
+                        $definition['properties'][$propertyName]['example'] = $matches[1];
+                    } else {
+                        // Set a default date example if format is unrecognized
+                        $definition['properties'][$propertyName]['example'] = '2025-11-05';
+                    }
+                } else {
+                    // Add a date example if none exists
+                    $definition['properties'][$propertyName]['example'] = '2025-11-05';
+                }
+            }
+        }
+    }
+
+    /**
      * Some CQRS commands rely on multi-parameters setters, this is usually done to force specifying related parameters
      * all together because only one is not enough. For such setters we expect the method parameters to be provided in
      * a sub object, so this method transforms the schema to match this expected sib object.
@@ -485,10 +558,17 @@ class CQRSOpenApiFactory implements OpenApiFactoryInterface
 
                 // If one of the parameters is not a built-in value we skip it (too complex to handle, but could be improved someday)
                 if ($this->isDateTime($methodParameter->getType())) {
+                    $parameterTypeName = $methodParameter->getType()->getName();
+                    $isDateImmutable = ($parameterTypeName === DateImmutable::class || is_subclass_of($parameterTypeName, DateImmutable::class));
+                    $format = $isDateImmutable ? 'date' : 'date-time';
                     $methodParameterSchema = new ArrayObject([
-                        'format' => 'date-time',
+                        'format' => $format,
                         'type' => 'string',
                     ]);
+                    // Add date example for DateImmutable parameters
+                    if ($isDateImmutable) {
+                        $methodParameterSchema['example'] = '2025-11-05';
+                    }
                 } elseif ($methodParameter->getType()->isBuiltin()) {
                     $methodParameterSchema = new ArrayObject([
                         'type' => $this->getSchemaType($methodParameter->getType()->getName()),

--- a/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
@@ -15,6 +15,10 @@ services:
     autowire: true
     tags:
       - { name: 'serializer.normalizer', priority: 10 }
+  PrestaShopBundle\ApiPlatform\Normalizer\DateImmutableNormalizer:
+    autowire: true
+    tags:
+      - { name: 'serializer.normalizer', priority: 10 }
   PrestaShopBundle\ApiPlatform\Normalizer\DecimalNumberNormalizer:
     autowire: true
     tags:


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fixes `availableDate` field in Product API showing incorrect `date-time` format instead of `date`. The database column is MySQL `date` type (Y-m-d only), but the API documentation showed datetime format with examples like `"2025-11-05T16:50:38.250Z"`, causing confusion and potential data truncation.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Check OpenAPI docs: `availableDate` should show format `date` with example `"2025-11-05"` <br> 2. PATCH `/product/{id}` with `{"availableDate": "2026-05-26"}` <br> 3. GET `/product/{id}` - verify response shows date only, no time component
| UI Tests          | https://github.com/tleon/ga.tests.ui.pr/actions/runs/19111958056
| Fixed issue or discussion?     | Fixes #38787
| Related PRs       | [Module update required: Update `ps_apiresources/Product.php` to use `DateImmutable` type](https://github.com/PrestaShop/ps_apiresources/pull/103)
| Sponsor company   | PrestaShop SA