### PR TITLE
perf: configuration updatevalue early check 9.0.x

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -459,6 +459,33 @@ class ConfigurationCore extends ObjectModel
             }, $values);
         }
 
+        // Performance optimization: Check if ALL values are identical to current values BEFORE doing anything
+        // This avoids unnecessary hook calls, database writes, and cache invalidations
+        $hasChanges = false;
+        foreach ($values as $lang => $value) {
+            $storedValue = Configuration::get($key, $lang, $idShopGroup, $idShop);
+            $valueHasChanged = ((!is_numeric($value) && $value !== $storedValue) || (is_numeric($value) && $value != $storedValue))
+                || !Configuration::hasKey($key, $lang, $idShopGroup, $idShop);
+
+            if ($valueHasChanged) {
+                $hasChanges = true;
+                break;
+            }
+        }
+
+        // Early return if nothing changed - avoids DB writes and cache invalidations
+        if (!$hasChanges) {
+            return true;
+        }
+
+        Hook::exec('actionConfigurationUpdateValueBefore', [
+            'key' => $key,
+            'values' => $values,
+            'html' => $html,
+            'idShopGroup' => $idShopGroup,
+            'idShop' => $idShop,
+        ]);
+
         $result = true;
         foreach ($values as $lang => $value) {
             $storedValue = Configuration::get($key, $lang, $idShopGroup, $idShop);

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -421,6 +421,44 @@ class ConfigurationCore extends ObjectModel
     }
 
     /**
+     * Get configuration value directly from database (bypassing cache).
+     *
+     * @param string $key Configuration key
+     * @param int $idLang Language ID (0 for non-multilang)
+     * @param int $idShopGroup Shop Group ID
+     * @param int $idShop Shop ID
+     *
+     * @return string|null Current value in database, or null if not found
+     */
+    private static function getValueFromDatabase($key, $idLang, $idShopGroup, $idShop)
+    {
+        if (!$idLang) {
+            // Non-multilingual configuration
+            $sql = 'SELECT `value`
+                    FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '`
+                    WHERE `name` = \'' . pSQL($key) . '\''
+                    . self::sqlRestriction($idShopGroup, $idShop);
+
+            $result = Db::getInstance()->getValue($sql);
+
+            return $result !== false ? $result : null;
+        } else {
+            // Multilingual configuration
+            $sql = 'SELECT cl.`value`
+                    FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '_lang` cl
+                    INNER JOIN `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '` c
+                        ON cl.`' . bqSQL(self::$definition['primary']) . '` = c.`' . bqSQL(self::$definition['primary']) . '`
+                    WHERE c.`name` = \'' . pSQL($key) . '\'
+                        AND cl.`id_lang` = ' . (int) $idLang
+                    . self::sqlRestriction($idShopGroup, $idShop);
+
+            $result = Db::getInstance()->getValue($sql);
+
+            return $result !== false ? $result : null;
+        }
+    }
+
+    /**
      * Update configuration key and value into database (automatically insert if key does not exist).
      *
      * Values are inserted/updated directly using SQL, because using (Configuration) ObjectModel
@@ -460,14 +498,30 @@ class ConfigurationCore extends ObjectModel
         }
 
         // Performance optimization: Check if ALL values are identical to current values BEFORE doing anything
-        // This avoids unnecessary hook calls, database writes, and cache invalidations
+        // This avoids unnecessary database writes and cache invalidations
+        // Strategy: First check cache (cheap), then verify with DB only if cache shows no change (guard against cache/DB desync)
         $hasChanges = false;
         foreach ($values as $lang => $value) {
-            $storedValue = Configuration::get($key, $lang, $idShopGroup, $idShop);
-            $valueHasChanged = ((!is_numeric($value) && $value !== $storedValue) || (is_numeric($value) && $value != $storedValue))
-                || !Configuration::hasKey($key, $lang, $idShopGroup, $idShop);
+            // First check against cached value (cheap memory read)
+            $cachedValue = Configuration::get($key, $lang, $idShopGroup, $idShop);
+            $keyExists = Configuration::hasKey($key, $lang, $idShopGroup, $idShop);
 
-            if ($valueHasChanged) {
+            // Compare values: strict for strings, loose for numeric
+            $cacheShowsChange = (!is_numeric($value) && $value !== $cachedValue)
+                || (is_numeric($value) && $value != $cachedValue)
+                || !$keyExists;
+
+            // If cache shows a change, we know we need to update - no need for DB query
+            if ($cacheShowsChange) {
+                $hasChanges = true;
+                break;
+            }
+
+            // Cache shows no change, but verify with DB to guard against cache/DB desynchronization
+            $dbValue = self::getValueFromDatabase($key, $lang, $idShopGroup, $idShop);
+
+            // If DB value differs from cache or new value, we need to update
+            if ($dbValue === null || $dbValue !== $cachedValue) {
                 $hasChanges = true;
                 break;
             }
@@ -477,14 +531,6 @@ class ConfigurationCore extends ObjectModel
         if (!$hasChanges) {
             return true;
         }
-
-        Hook::exec('actionConfigurationUpdateValueBefore', [
-            'key' => $key,
-            'values' => $values,
-            'html' => $html,
-            'idShopGroup' => $idShopGroup,
-            'idShop' => $idShop,
-        ]);
 
         $result = true;
         foreach ($values as $lang => $value) {

--- a/tests/Integration/Classes/ConfigurationTest.php
+++ b/tests/Integration/Classes/ConfigurationTest.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Classes;
 
 use Configuration;
+use Db;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationTest extends TestCase
@@ -62,5 +63,114 @@ class ConfigurationTest extends TestCase
         $this->assertEquals('RESULT_SHOP_OVERRIDDEN', Configuration::getGlobalValue('PS_TEST_SHOP_OVERRIDDEN'));
         $this->assertEquals('RESULT_GROUP_SHOP_OVERRIDDEN', Configuration::getGlobalValue('PS_TEST_GROUP_SHOP_OVERRIDDEN'));
         $this->assertFalse(Configuration::getGlobalValue('PS_TEST_DOES_NOT_EXIST'));
+    }
+
+    /**
+     * Test that updateValue() skips DB operations when value is unchanged
+     * This is a performance optimization to avoid unnecessary writes and cache invalidations
+     */
+    public function testUpdateValueSkipsDbWriteWhenValueUnchanged(): void
+    {
+        $testKey = 'PS_TEST_PERF_UNCHANGED_VALUE';
+        $testValue = 'initial_value_' . time();
+
+        // Initial insert
+        $result = Configuration::updateValue($testKey, $testValue);
+        $this->assertTrue($result);
+        $this->assertEquals($testValue, Configuration::get($testKey));
+
+        // Get initial date_upd to verify DB is not written
+        $initialDateUpd = Db::getInstance()->getValue(
+            'SELECT date_upd FROM ' . _DB_PREFIX_ . 'configuration WHERE name = \'' . pSQL($testKey) . '\''
+        );
+
+        // Wait 1 second to ensure date_upd would change if DB was written
+        sleep(1);
+
+        // Update with same value - should return true but not write to DB
+        $result = Configuration::updateValue($testKey, $testValue);
+        $this->assertTrue($result);
+        $this->assertEquals($testValue, Configuration::get($testKey));
+
+        // Verify date_upd was not changed (no DB write occurred)
+        $newDateUpd = Db::getInstance()->getValue(
+            'SELECT date_upd FROM ' . _DB_PREFIX_ . 'configuration WHERE name = \'' . pSQL($testKey) . '\''
+        );
+        $this->assertEquals(
+            $initialDateUpd,
+            $newDateUpd,
+            'date_upd should not change when value is unchanged - DB write should be skipped'
+        );
+
+        // Cleanup
+        Configuration::deleteByName($testKey);
+    }
+
+    /**
+     * Test that updateValue() performs DB write when value changes
+     */
+    public function testUpdateValueWritesDbWhenValueChanges(): void
+    {
+        $testKey = 'PS_TEST_PERF_CHANGED_VALUE';
+        $initialValue = 'initial_value_' . time();
+        $newValue = 'new_value_' . time();
+
+        // Initial insert
+        Configuration::updateValue($testKey, $initialValue);
+        $initialDateUpd = Db::getInstance()->getValue(
+            'SELECT date_upd FROM ' . _DB_PREFIX_ . 'configuration WHERE name = \'' . pSQL($testKey) . '\''
+        );
+
+        // Wait to ensure date_upd will be different
+        sleep(1);
+
+        // Update with different value - should write to DB
+        $result = Configuration::updateValue($testKey, $newValue);
+        $this->assertTrue($result);
+        $this->assertEquals($newValue, Configuration::get($testKey));
+
+        // Verify date_upd was changed (DB write occurred)
+        $newDateUpd = Db::getInstance()->getValue(
+            'SELECT date_upd FROM ' . _DB_PREFIX_ . 'configuration WHERE name = \'' . pSQL($testKey) . '\''
+        );
+        $this->assertNotEquals(
+            $initialDateUpd,
+            $newDateUpd,
+            'date_upd should change when value changes - DB write should occur'
+        );
+
+        // Cleanup
+        Configuration::deleteByName($testKey);
+    }
+
+    /**
+     * Test that numeric comparison works correctly (== vs ===)
+     */
+    public function testUpdateValueNumericComparison(): void
+    {
+        $testKey = 'PS_TEST_PERF_NUMERIC';
+
+        // Test with string '1'
+        Configuration::updateValue($testKey, '1');
+        $initialDateUpd = Db::getInstance()->getValue(
+            'SELECT date_upd FROM ' . _DB_PREFIX_ . 'configuration WHERE name = \'' . pSQL($testKey) . '\''
+        );
+
+        sleep(1);
+
+        // Update with integer 1 (should be considered same due to == comparison)
+        Configuration::updateValue($testKey, 1);
+        $newDateUpd = Db::getInstance()->getValue(
+            'SELECT date_upd FROM ' . _DB_PREFIX_ . 'configuration WHERE name = \'' . pSQL($testKey) . '\''
+        );
+
+        $this->assertEquals(
+            $initialDateUpd,
+            $newDateUpd,
+            'Numeric values should use loose comparison (==) - "1" and 1 should be considered equal'
+        );
+
+        // Cleanup
+        Configuration::deleteByName($testKey);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Avoid writing values in DB in Configuration::updateValue if they haven't changed
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See tests
| UI Tests          | NA
| Fixed issue or discussion?     | NA
| Related PRs       | NA
| Sponsor company   | Softizy