### PR TITLE
Add new hooks: actionOverrideQuantityAvailableByProduct - actionCheckAttributeQuantity - actionOverrideProductQuantity

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4082,6 +4082,28 @@ class ProductCore extends ObjectModel
         ?CartCore $cart = null,
         $idCustomization = null
     ) {
+        $result = Hook::exec(
+            'filterProductQuantity',
+            [
+                'id_product' => $idProduct,
+                'id_product_attribute' => $idProductAttribute,
+                'cart' => $cart,
+                'cacheIsPack' => $cacheIsPack,
+                'idCustomization' => $idCustomization,
+                'isCartProvided' => $cart !== null, // true if $cart is passed to reduce the quantity by the amount in cart
+            ],
+            null,
+            false,
+            true,
+            false,
+            null,
+            true
+        );
+
+        if (is_int($result)) {
+            return $result;
+        }
+
         // If the product is pack, we will handle the logic in another method, because pack stocks can be calculated
         // in multiple ways, depending on the configuration of the pack.
         if (Pack::isPack((int) $idProduct)) {

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4083,7 +4083,7 @@ class ProductCore extends ObjectModel
         $idCustomization = null
     ) {
         $result = Hook::exec(
-            'filterProductQuantity',
+            'actionOverrideProductQuantity',
             [
                 'id_product' => $idProduct,
                 'id_product_attribute' => $idProductAttribute,

--- a/classes/ProductAttribute.php
+++ b/classes/ProductAttribute.php
@@ -247,7 +247,7 @@ class ProductAttributeCore extends ObjectModel
         }
 
         $result = Hook::exec(
-            'filterCheckAttributeQty',
+            'actionCheckAttributeQuantity',
             [
                 'id_product_attribute' => $idProductAttribute,
                 'qty' => $qty,

--- a/classes/ProductAttribute.php
+++ b/classes/ProductAttribute.php
@@ -246,7 +246,24 @@ class ProductAttributeCore extends ObjectModel
             $shop = Context::getContext()->shop;
         }
 
-        $result = StockAvailable::getQuantityAvailableByProduct(null, (int) $idProductAttribute, $shop->id);
+        $result = Hook::exec(
+            'filterCheckAttributeQty',
+            [
+                'id_product_attribute' => $idProductAttribute,
+                'qty' => $qty,
+                'shop' => $shop,
+            ],
+            null,
+            false,
+            true,
+            false,
+            null,
+            true
+        );
+
+        if (!is_int($result)) {
+            $result = StockAvailable::getQuantityAvailableByProduct(null, (int) $idProductAttribute, $shop->id);
+        }
 
         return $result && $qty <= $result;
     }

--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -247,7 +247,7 @@ class StockAvailableCore extends ObjectModel
     public static function getQuantityAvailableByProduct($id_product = null, $id_product_attribute = null, $id_shop = null)
     {
         $quantity = Hook::exec(
-            'filterQuantityAvailableByProduct',
+            'actionOverrideQuantityAvailableByProduct',
             [
                 'id_product' => $id_product,
                 'id_product_attribute' => $id_product_attribute,

--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -246,6 +246,25 @@ class StockAvailableCore extends ObjectModel
      */
     public static function getQuantityAvailableByProduct($id_product = null, $id_product_attribute = null, $id_shop = null)
     {
+        $quantity = Hook::exec(
+            'filterQuantityAvailableByProduct',
+            [
+                'id_product' => $id_product,
+                'id_product_attribute' => $id_product_attribute,
+                'id_shop' => $id_shop,
+            ],
+            null,
+            false,
+            true,
+            false,
+            null,
+            true
+        );
+
+        if (is_int($quantity)) {
+            return $quantity;
+        }
+
         // if null, it's a product without attributes
         if ($id_product_attribute === null) {
             $id_product_attribute = 0;

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -5508,5 +5508,20 @@
       <title>Modify database logs options form saved data</title>
       <description>This hook allows to modify data of database logs options form after it was saved</description>
     </hook>
+    <hook id="actionOverrideQuantityAvailableByProduct">
+      <name>actionOverrideQuantityAvailableByProduct</name>
+      <title>Override available quantity by product</title>
+      <description>Allows modules to override the available quantity returned by StockAvailable::getQuantityAvailableByProduct().</description>
+    </hook>
+    <hook id="actionCheckAttributeQuantity">
+      <name>actionCheckAttributeQuantity</name>
+      <title>Check product attribute quantity availability</title>
+      <description>Allows modules to validate or override the stock availability check for a specific product combination.</description>
+    </hook>
+    <hook id="actionOverrideProductQuantity">
+      <name>actionOverrideProductQuantity</name>
+      <title>Override product quantity calculation</title>
+      <description>Allows modules to override the final product quantity returned by Product::getQuantity(), including cart-aware calculations.</description>
+    </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR adds 3 filter hooks for quantity/availability management:<br/>- `actionOverrideQuantityAvailableByProduct` (allows overriding `StockAvailable::getQuantityAvailableByProduct()`)<br/>- `actionCheckAttributeQuantity`(allows intervening in `ProductAttribute::checkAttributeQty()`)<br/>- `actionOverrideProductQuantity` (allows overriding `Product::getQuantity()`)<br/>In my opinion, these hooks let you flexibly redefine quantity logic (better ERP integration, fewer overrides). I’m proposing this PR because I’m upgrading a site from 1.7 where I had to introduce several overrides to implement dynamic quantity management driven by specific needs (handcrafted Made-in-Italy accessories sector).
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | I created the following module: [pr_testquantityhooks.zip](https://github.com/user-attachments/files/23341503/pr_testquantityhooks.zip) to test these 3 new hooks.<br/> 1. install & enable the module<br/> 2. for a product without combinations set **Reference** = **AVAILABLE**, set **Quantity** = 0 and **When out of stock** = **Deny orders**<br/> 3. go to the front-office and try to buy the product: it must be possible to purchase up to **100 units**<br/> 4. for a product without combinations set Reference = **UNAVAILABLE**, set **Quantity** to a value > 0<br/> 5. go to the front-office: the product must **not** be purchasable<br/> repeat the same steps for a product **with combinations**, setting the **combination reference** to **AVAILABLE/UNAVAILABLE** depending on whether you want the combination to be purchasable or not.<br/><br/> NOTE: on the product page (for products/combinations where the reference is **AVAILABLE/UNAVAILABLE**), under the **Add to cart** button you’ll see a small box with:<br/> - **REAL QTY**: real quantity set in Back Office<br/> - **VIRTUAL QTY (no cart)**: always 100 (set by the module)<br/> - **VIRTUAL QTY (with cart)**: virtual quantity minus any quantity already in the cart (remaining purchasable units)
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/19163206852
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/1529
| Sponsor company   | Codencode snc


<hr/>

### Example

I'm attaching a sample video of an article with combinations:

[screen-capture.webm](https://github.com/user-attachments/assets/dbc09055-aff3-40e4-8f3a-8a6941ca3abf)
