### PR TITLE
BO - Permissions : Added authorization role for "More"

### DIFF
--- a/install-dev/data/xml/authorization_role.xml
+++ b/install-dev/data/xml/authorization_role.xml
@@ -462,5 +462,9 @@
     <authorization_role id="TAB_ADMINALIASES_CREATE" slug="ROLE_MOD_TAB_ADMINALIASES_CREATE"/>
     <authorization_role id="TAB_ADMINALIASES_UPDATE" slug="ROLE_MOD_TAB_ADMINALIASES_UPDATE"/>
     <authorization_role id="TAB_ADMINALIASES_DELETE" slug="ROLE_MOD_TAB_ADMINALIASES_DELETE"/>
+    <authorization_role id="TAB_DEFAULT_READ" slug="ROLE_MOD_TAB_DEFAULT_READ"/>
+    <authorization_role id="TAB_DEFAULT_CREATE" slug="ROLE_MOD_TAB_DEFAULT_CREATE"/>
+    <authorization_role id="TAB_DEFAULT_UPDATE" slug="ROLE_MOD_TAB_DEFAULT_UPDATE"/>
+    <authorization_role id="TAB_DEFAULT_DELETE" slug="ROLE_MOD_TAB_DEFAULT_DELETE"/>
   </entities>
 </entity_authorization_role>

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/06_team/permission/01_editMenu.ts
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/06_team/permission/01_editMenu.ts
@@ -157,7 +157,7 @@ describe('BO - Advanced Parameters - Team - Permission : Edit menu', async () =>
         await testContext.addContextItem(this, 'testIdentifier', `checkAfterRefreshPage${index}`, baseContext);
 
         const number = await boPermissionsPage.getNumberOfPagesUnChecked(page, test.args.action);
-        expect(number).to.eq(1);
+        expect(number).to.eq(0);
       });
     });
   });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | BO - Permissions : Added authorization role for "More"
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | :arrow_down: 
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/19067500652
| Fixed issue or discussion?     | Fixes #33338 
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

## How to test ?
1. Go to BO > Advanced parameters > Team > Permissions Tab
2. Go to Logistician Profile
3. Click on "All" column twice > nothing is checked
4. Scroll down to "More" > Check All
5. Refresh 
    * **BEFORE :** Nothing is saved
    * **AFTER :** It is saved