### PR TITLE
Update _nav_bar.scss

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
@@ -456,7 +456,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 1999;
+  z-index: 500;
   display: none;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Description:
<img width="1081" height="667" alt="Bez názvu" src="https://github.com/user-attachments/assets/58fc696c-c1cd-4e22-8163-f8104e7eb075" />
Bug Fix - Menu on mobile not working clickable
When installing the new version 8.2.0.
After you open the administration on mobile and click on the burger menu. The menu will slide out, but it is completely covered by an overlay, so it is not clickable. Thanks to this change, the menu is working again.

Type: bug fix
Category: BO
BC breaks: no
Deprecations: no
How to test: 
  1. přihlásit se do administrace
  2. kliknout na burger menu
  3. Zkusit kliknout na některý odkaz
