### PR TITLE
fix module translation catalogue in backoffice when there is no translation file found for the desired locale

### DIFF
--- a/src/Core/Translation/Storage/Provider/ModuleCatalogueLayersProvider.php
+++ b/src/Core/Translation/Storage/Provider/ModuleCatalogueLayersProvider.php
@@ -289,7 +289,6 @@ class ModuleCatalogueLayersProvider implements CatalogueLayersProviderInterface
         // with the hashes found in the module's legacy translation file.
 
         $legacyFilesCatalogue = new MessageCatalogue($locale);
-        $catalogueFromPhpAndSmartyFiles = $this->getDefaultCatalogue($locale);
 
         try {
             $catalogueFromLegacyTranslationFiles = $this->legacyFileLoader->load(
@@ -298,8 +297,10 @@ class ModuleCatalogueLayersProvider implements CatalogueLayersProviderInterface
             );
         } catch (UnsupportedLocaleException) {
             // this happens when there is no translation file found for the desired locale
-            return $catalogueFromPhpAndSmartyFiles;
+            return $legacyFilesCatalogue;
         }
+
+        $catalogueFromPhpAndSmartyFiles = $this->getDefaultCatalogue($locale);
 
         foreach ($catalogueFromPhpAndSmartyFiles->all() as $currentDomain => $items) {
             foreach (array_keys($items) as $translationKey) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  When you create a brand new language from the Backoffice, and then you open any module's translation page in Backoffice to translate that new language, you will see that the entire translation catalogue is already filled with each respective translation key. This PR tries to fix this wrong behaviour.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a new language in Backoffice. From Backoffice, try to translate a module in that new language which has no /translations/ directory (or has to /translations/lang.php file) . You should see the entire translation catalogue is empty
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #39912 
| Related PRs       |
| Sponsor company   | www.hostinato.it