### PR TITLE
fix webservice output when output format is JSON

### DIFF
--- a/classes/webservice/WebserviceOutputJSON.php
+++ b/classes/webservice/WebserviceOutputJSON.php
@@ -164,9 +164,6 @@ class WebserviceOutputJSONCore implements WebserviceOutputInterface
 
     public function overrideContent($content)
     {
-        array_walk($this->content, function (&$item) {
-            $item = array_filter($item);
-        });
         $content = json_encode($this->content, JSON_UNESCAPED_UNICODE);
 
         return (false !== $content) ? $content : '';


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  Webservice isn't outputting the empty object fields if the specified output format is JSON
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | verify that the webservice is outputting NULL / empty values using the json format
| Sponsor company   | www.hostinato.it
