### PR TITLE
fix: Module::_clearCache() incorrectly triggers full cache clear with "module:" template syntax

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2516,6 +2516,19 @@ abstract class ModuleCore implements ModuleInterface
             $compile_id = $this->getDefaultCompileId();
         }
 
+        // Handle module: prefixed templates - pass them directly to Smarty
+        // Smarty's clearCache() correctly handles the "module:" resource type
+        // since the cache identifier is based on resource_type:resource_name
+        if (false !== strpos($template, 'module:')) {
+            // During installation, Smarty's "module" resource isn't registered yet, skip cache clear
+            if (defined('PS_INSTALLATION_IN_PROGRESS')) {
+                return 0;
+            }
+        // Keep the module: template as-is, Smarty will resolve it correctly
+        } elseif (!file_exists(_PS_ROOT_DIR_ . '/' . $template)) {
+            $template = $this->getTemplatePath($template);
+        }
+
         if (static::$_batch_mode) {
             if ($ps_smarty_clear_cache == 'never') {
                 return 0;
@@ -2527,7 +2540,7 @@ abstract class ModuleCore implements ModuleInterface
 
             $key = $template . '-' . $cache_id . '-' . $compile_id;
             if (!isset(static::$_defered_clearCache[$key])) {
-                static::$_defered_clearCache[$key] = [$this->getTemplatePath($template), $cache_id, $compile_id];
+                static::$_defered_clearCache[$key] = [$template, $cache_id, $compile_id];
             }
 
             return 0;
@@ -2541,7 +2554,7 @@ abstract class ModuleCore implements ModuleInterface
             }
 
             Tools::enableCache();
-            $number_of_template_cleared = Tools::clearCache(Context::getContext()->smarty, $this->getTemplatePath($template), $cache_id, $compile_id);
+            $number_of_template_cleared = Tools::clearCache(Context::getContext()->smarty, $template, $cache_id, $compile_id);
             Tools::restoreCacheSettings();
 
             return $number_of_template_cleared;

--- a/tests/Integration/Classes/module/ModuleTest.php
+++ b/tests/Integration/Classes/module/ModuleTest.php
@@ -27,10 +27,15 @@
 namespace Tests\Integration\Classes\module;
 
 use Cache;
+use Configuration;
+use Context;
 use Module;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use ReflectionMethod;
+use Smarty;
+use SmartyResourceModule;
+use Test_ps_customtext;
 use Tests\Integration\Utility\ContextMockerTrait;
 
 /**
@@ -129,6 +134,501 @@ class ModuleTest extends TestCase
         $this->assertEquals('paymentOptions', $possibleHooksList[2]['name']);
 
         Module::getInstanceByName('bankwire')->uninstall();
+    }
+
+    /**
+     * Test that Smarty can clear cache for templates using "module:" resource.
+     * This test verifies the actual Smarty behavior, not mocked behavior.
+     */
+    public function testSmartyClearCacheWithModuleResource(): void
+    {
+        $smarty = Context::getContext()->smarty;
+        $cacheDir = $smarty->getCacheDir();
+
+        // Create a test module directory and template
+        $testModuleName = 'test_cache_module';
+        $testModuleDir = _PS_MODULE_DIR_ . $testModuleName;
+        $testTemplateDir = $testModuleDir . '/views/templates/hook';
+        $testTemplateName = 'test_template.tpl';
+        $testTemplateFile = $testTemplateDir . '/' . $testTemplateName;
+
+        // Clean up any previous test artifacts
+        if (is_dir($testModuleDir)) {
+            $this->recursiveDelete($testModuleDir);
+        }
+
+        // Create module directory structure
+        mkdir($testTemplateDir, 0777, true);
+        file_put_contents($testTemplateFile, '<div>Test content {$test_var}</div>');
+
+        // Register module resource with test paths (similar to smartyfront.config.inc.php)
+        $modulePaths = [
+            'modules' => _PS_MODULE_DIR_,
+        ];
+        $smarty->registerResource('module', new SmartyResourceModule($modulePaths));
+
+        // Enable caching
+        $originalCaching = $smarty->caching;
+        $smarty->caching = Smarty::CACHING_LIFETIME_CURRENT;
+        $smarty->cache_lifetime = 3600;
+
+        $moduleTemplate = 'module:' . $testModuleName . '/views/templates/hook/' . $testTemplateName;
+        $cacheId = 'test_cache_id';
+        $compileId = 'test_compile_id';
+
+        try {
+            // Step 1: Render template to create cache
+            $smarty->assign('test_var', 'Hello World');
+            $tpl = $smarty->createTemplate($moduleTemplate, $cacheId, $compileId);
+            $output = $tpl->fetch();
+
+            $this->assertStringContainsString('Hello World', $output);
+
+            // Step 2: Verify cache was created by checking isCached
+            $tpl2 = $smarty->createTemplate($moduleTemplate, $cacheId, $compileId);
+            $isCachedBefore = $tpl2->isCached();
+            $this->assertTrue($isCachedBefore, 'Template should be cached after rendering');
+
+            // Step 3: Try to clear cache using module: resource directly
+            $clearedCount = $smarty->clearCache($moduleTemplate, $cacheId, $compileId);
+
+            // Step 4: Verify cache was cleared
+            $tpl3 = $smarty->createTemplate($moduleTemplate, $cacheId, $compileId);
+            $isCachedAfter = $tpl3->isCached();
+
+            // Output debug info
+            echo "\n=== Smarty Cache Clear Test Results ===\n";
+            echo "Template: $moduleTemplate\n";
+            echo "Cache ID: $cacheId\n";
+            echo "Compile ID: $compileId\n";
+            echo 'Was cached before clear: ' . ($isCachedBefore ? 'YES' : 'NO') . "\n"; // @phpstan-ignore-line
+            echo "Files cleared: $clearedCount\n";
+            echo 'Is cached after clear: ' . ($isCachedAfter ? 'YES' : 'NO') . "\n"; // @phpstan-ignore-line
+            echo "========================================\n";
+
+            $this->assertFalse($isCachedAfter, 'Template should NOT be cached after clearCache with module: resource');
+            $this->assertGreaterThan(0, $clearedCount, 'clearCache should have cleared at least 1 file');
+        } finally {
+            // Restore original caching setting
+            $smarty->caching = $originalCaching;
+
+            // Clean up test module
+            if (is_dir($testModuleDir)) {
+                $this->recursiveDelete($testModuleDir);
+            }
+        }
+    }
+
+    /**
+     * Test comparing different cache clearing approaches for module: templates.
+     */
+    public function testCompareCacheClearingApproaches(): void
+    {
+        $smarty = Context::getContext()->smarty;
+
+        // Create a test module directory and template
+        $testModuleName = 'test_cache_compare';
+        $testModuleDir = _PS_MODULE_DIR_ . $testModuleName;
+        $testTemplateDir = $testModuleDir . '/views/templates/hook';
+        $testTemplateName = 'compare_template.tpl';
+        $testTemplateFile = $testTemplateDir . '/' . $testTemplateName;
+
+        // Clean up any previous test artifacts
+        if (is_dir($testModuleDir)) {
+            $this->recursiveDelete($testModuleDir);
+        }
+
+        // Create module directory structure
+        mkdir($testTemplateDir, 0777, true);
+        file_put_contents($testTemplateFile, '<div>Compare test {$var}</div>');
+
+        // Register module resource
+        $modulePaths = ['modules' => _PS_MODULE_DIR_];
+        $smarty->registerResource('module', new SmartyResourceModule($modulePaths));
+
+        // Enable caching
+        $originalCaching = $smarty->caching;
+        $smarty->caching = Smarty::CACHING_LIFETIME_CURRENT;
+        $smarty->cache_lifetime = 3600;
+
+        $moduleTemplate = 'module:' . $testModuleName . '/views/templates/hook/' . $testTemplateName;
+        $cacheId = $testModuleName;
+        $compileId = 'test_compile';
+
+        try {
+            echo "\n=== Comparing Cache Clearing Approaches ===\n";
+
+            // Test 1: Clear with module: resource directly
+            $smarty->assign('var', 'Test 1');
+            $smarty->fetch($moduleTemplate, $cacheId, $compileId);
+            $this->assertTrue($smarty->isCached($moduleTemplate, $cacheId, $compileId), 'Should be cached');
+
+            $cleared1 = $smarty->clearCache($moduleTemplate, $cacheId, $compileId);
+            $stillCached1 = $smarty->isCached($moduleTemplate, $cacheId, $compileId);
+            echo 'Approach 1 (module: directly): cleared=' . $cleared1 . ', stillCached=' . ($stillCached1 ? 'YES' : 'NO') . "\n"; // @phpstan-ignore-line
+
+            // Test 2: Clear with null template (by cache_id/compile_id only)
+            $smarty->assign('var', 'Test 2');
+            $smarty->fetch($moduleTemplate, $cacheId, $compileId);
+            $this->assertTrue($smarty->isCached($moduleTemplate, $cacheId, $compileId), 'Should be cached');
+
+            $cleared2 = $smarty->clearCache(null, $cacheId, $compileId); // @phpstan-ignore-line
+            $stillCached2 = $smarty->isCached($moduleTemplate, $cacheId, $compileId);
+            echo 'Approach 2 (null template): cleared=' . $cleared2 . ', stillCached=' . ($stillCached2 ? 'YES' : 'NO') . "\n"; // @phpstan-ignore-line
+
+            // Test 3: Clear with resolved absolute path
+            $smarty->assign('var', 'Test 3');
+            $smarty->fetch($moduleTemplate, $cacheId, $compileId);
+            $this->assertTrue($smarty->isCached($moduleTemplate, $cacheId, $compileId), 'Should be cached');
+
+            $cleared3 = $smarty->clearCache($testTemplateFile, $cacheId, $compileId);
+            $stillCached3 = $smarty->isCached($moduleTemplate, $cacheId, $compileId);
+            echo 'Approach 3 (absolute path): cleared=' . $cleared3 . ', stillCached=' . ($stillCached3 ? 'YES' : 'NO') . "\n"; // @phpstan-ignore-line
+
+            echo "============================================\n";
+
+            // Assertions - approaches 1 and 2 work, approach 3 does NOT work
+            $this->assertFalse($stillCached1, 'Approach 1 (module: directly) should clear cache');
+            $this->assertFalse($stillCached2, 'Approach 2 (null template) should clear cache');
+            $this->assertTrue($stillCached3, 'Approach 3 (absolute path) should NOT clear cache - cache identifier mismatch');
+        } finally {
+            $smarty->caching = $originalCaching;
+            if (is_dir($testModuleDir)) {
+                $this->recursiveDelete($testModuleDir);
+            }
+        }
+    }
+
+    /**
+     * Test cache_id prefix matching behavior (like ps_customtext clearing ps_customtext|0|1|1).
+     * This simulates what happens when a module renders with getCacheId() but clears with just module name.
+     */
+    public function testCacheIdPrefixMatching(): void
+    {
+        $smarty = Context::getContext()->smarty;
+
+        // Create a test module directory and template
+        $testModuleName = 'test_prefix_cache';
+        $testModuleDir = _PS_MODULE_DIR_ . $testModuleName;
+        $testTemplateDir = $testModuleDir . '/views/templates/hook';
+        $testTemplateName = 'prefix_template.tpl';
+        $testTemplateFile = $testTemplateDir . '/' . $testTemplateName;
+
+        // Clean up any previous test artifacts
+        if (is_dir($testModuleDir)) {
+            $this->recursiveDelete($testModuleDir);
+        }
+
+        // Create module directory structure
+        mkdir($testTemplateDir, 0777, true);
+        file_put_contents($testTemplateFile, '<div>Prefix test {$var}</div>');
+
+        // Register module resource
+        $modulePaths = ['modules' => _PS_MODULE_DIR_];
+        $smarty->registerResource('module', new SmartyResourceModule($modulePaths));
+
+        // Enable caching
+        $originalCaching = $smarty->caching;
+        $smarty->caching = Smarty::CACHING_LIFETIME_CURRENT;
+        $smarty->cache_lifetime = 3600;
+
+        $moduleTemplate = 'module:' . $testModuleName . '/views/templates/hook/' . $testTemplateName;
+        $compileId = 'test_compile';
+
+        // Simulate getCacheId() behavior: complex cache_id with shop/lang/etc
+        $complexCacheId = $testModuleName . '|0|1|1|1';
+        // Simulate _clearCache default: just the module name
+        $simpleCacheId = $testModuleName;
+
+        try {
+            echo "\n=== Cache ID Prefix Matching Test ===\n";
+            echo "Complex cache_id (render): $complexCacheId\n";
+            echo "Simple cache_id (clear): $simpleCacheId\n";
+
+            // Test 1: Create cache with complex cache_id, clear with null template + simple cache_id
+            $smarty->assign('var', 'Test 1');
+            $smarty->fetch($moduleTemplate, $complexCacheId, $compileId);
+            $isCached1 = $smarty->isCached($moduleTemplate, $complexCacheId, $compileId);
+            $this->assertTrue($isCached1, 'Should be cached with complex cache_id');
+
+            $cleared1 = $smarty->clearCache(null, $simpleCacheId, $compileId); // @phpstan-ignore-line
+            $stillCached1 = $smarty->isCached($moduleTemplate, $complexCacheId, $compileId);
+            echo 'Test 1 (null template + simple cache_id): cleared=' . $cleared1 . ', stillCached=' . ($stillCached1 ? 'YES' : 'NO') . "\n";
+
+            // Test 2: Create cache with complex cache_id, clear with module: template + simple cache_id
+            $smarty->assign('var', 'Test 2');
+            $smarty->fetch($moduleTemplate, $complexCacheId, $compileId);
+            $isCached2 = $smarty->isCached($moduleTemplate, $complexCacheId, $compileId);
+            $this->assertTrue($isCached2, 'Should be cached with complex cache_id');
+
+            $cleared2 = $smarty->clearCache($moduleTemplate, $simpleCacheId, $compileId);
+            $stillCached2 = $smarty->isCached($moduleTemplate, $complexCacheId, $compileId);
+            echo 'Test 2 (module: template + simple cache_id): cleared=' . $cleared2 . ', stillCached=' . ($stillCached2 ? 'YES' : 'NO') . "\n";
+
+            // Test 3: Create cache with complex cache_id, clear with module: template + complex cache_id (exact match)
+            $smarty->assign('var', 'Test 3');
+            $smarty->fetch($moduleTemplate, $complexCacheId, $compileId);
+            $isCached3 = $smarty->isCached($moduleTemplate, $complexCacheId, $compileId);
+            $this->assertTrue($isCached3, 'Should be cached with complex cache_id');
+
+            $cleared3 = $smarty->clearCache($moduleTemplate, $complexCacheId, $compileId);
+            $stillCached3 = $smarty->isCached($moduleTemplate, $complexCacheId, $compileId);
+            echo 'Test 3 (module: template + complex cache_id): cleared=' . $cleared3 . ', stillCached=' . ($stillCached3 ? 'YES' : 'NO') . "\n";
+
+            // Test 4: Create cache with complex cache_id, clear with null template + null cache_id
+            $smarty->assign('var', 'Test 4');
+            $smarty->fetch($moduleTemplate, $complexCacheId, $compileId);
+            $isCached4 = $smarty->isCached($moduleTemplate, $complexCacheId, $compileId);
+            $this->assertTrue($isCached4, 'Should be cached with complex cache_id');
+
+            $cleared4 = $smarty->clearCache(null, null, $compileId); // @phpstan-ignore-line
+            $stillCached4 = $smarty->isCached($moduleTemplate, $complexCacheId, $compileId);
+            echo 'Test 4 (null template + null cache_id): cleared=' . $cleared4 . ', stillCached=' . ($stillCached4 ? 'YES' : 'NO') . "\n";
+
+            echo "=========================================\n";
+
+            // Assertions based on what we expect
+            $this->assertFalse($stillCached1, 'Test 1: null template + simple cache_id should clear (prefix match)');
+            // Test 2 is the key question - does module: + simple cache_id work with prefix matching?
+            // $this->assertFalse($stillCached2, 'Test 2: module: template + simple cache_id should clear (prefix match)');
+            $this->assertFalse($stillCached3, 'Test 3: module: template + complex cache_id should clear (exact match)');
+            $this->assertFalse($stillCached4, 'Test 4: null template + null cache_id should clear all');
+        } finally {
+            $smarty->caching = $originalCaching;
+            if (is_dir($testModuleDir)) {
+                $this->recursiveDelete($testModuleDir);
+            }
+        }
+    }
+
+    /**
+     * Test cache clearing with template at module root (like ps_customtext/ps_customtext.tpl).
+     * This is different from templates in views/templates/hook/ subdirectory.
+     */
+    public function testCacheIdPrefixMatchingWithRootTemplate(): void
+    {
+        $smarty = Context::getContext()->smarty;
+
+        // Create a test module directory and template AT THE ROOT (like ps_customtext)
+        $testModuleName = 'test_root_tpl';
+        $testModuleDir = _PS_MODULE_DIR_ . $testModuleName;
+        $testTemplateName = $testModuleName . '.tpl'; // Same name as module, at root
+        $testTemplateFile = $testModuleDir . '/' . $testTemplateName;
+
+        // Clean up any previous test artifacts
+        if (is_dir($testModuleDir)) {
+            $this->recursiveDelete($testModuleDir);
+        }
+
+        // Create module directory - template at ROOT, not in subdirectory
+        mkdir($testModuleDir, 0777, true);
+        file_put_contents($testTemplateFile, '<div>Root template test {$var}</div>');
+
+        // Register module resource
+        $modulePaths = ['modules' => _PS_MODULE_DIR_];
+        $smarty->registerResource('module', new SmartyResourceModule($modulePaths));
+
+        // Enable caching
+        $originalCaching = $smarty->caching;
+        $smarty->caching = Smarty::CACHING_LIFETIME_CURRENT;
+        $smarty->cache_lifetime = 3600;
+
+        // Template at root: module:test_root_tpl/test_root_tpl.tpl (like ps_customtext)
+        $moduleTemplate = 'module:' . $testModuleName . '/' . $testTemplateName;
+        $compileId = 'test_compile';
+
+        // Simulate getCacheId() behavior: complex cache_id with shop/lang/etc
+        $complexCacheId = $testModuleName . '|0|1|1|1';
+        // Simulate _clearCache default: just the module name
+        $simpleCacheId = $testModuleName;
+
+        try {
+            echo "\n=== Root Template Cache Test (like ps_customtext) ===\n";
+            echo "Template: $moduleTemplate\n";
+            echo "Complex cache_id (render): $complexCacheId\n";
+            echo "Simple cache_id (clear): $simpleCacheId\n";
+
+            // Test 1: Create cache with complex cache_id, clear with null template + simple cache_id
+            $smarty->assign('var', 'Test 1');
+            $smarty->fetch($moduleTemplate, $complexCacheId, $compileId);
+            $isCached1 = $smarty->isCached($moduleTemplate, $complexCacheId, $compileId);
+            $this->assertTrue($isCached1, 'Should be cached with complex cache_id');
+
+            $cleared1 = $smarty->clearCache(null, $simpleCacheId, $compileId); // @phpstan-ignore-line
+            $stillCached1 = $smarty->isCached($moduleTemplate, $complexCacheId, $compileId);
+            echo 'Test 1 (null template + simple cache_id): cleared=' . $cleared1 . ', stillCached=' . ($stillCached1 ? 'YES' : 'NO') . "\n";
+
+            // Test 2: Create cache with complex cache_id, clear with module: template + simple cache_id
+            // THIS IS THE KEY TEST - simulates ps_customtext behavior
+            $smarty->assign('var', 'Test 2');
+            $smarty->fetch($moduleTemplate, $complexCacheId, $compileId);
+            $isCached2 = $smarty->isCached($moduleTemplate, $complexCacheId, $compileId);
+            $this->assertTrue($isCached2, 'Should be cached with complex cache_id');
+
+            $cleared2 = $smarty->clearCache($moduleTemplate, $simpleCacheId, $compileId);
+            $stillCached2 = $smarty->isCached($moduleTemplate, $complexCacheId, $compileId);
+            echo 'Test 2 (module: template + simple cache_id): cleared=' . $cleared2 . ', stillCached=' . ($stillCached2 ? 'YES' : 'NO') . "\n";
+
+            // Test 3: Create cache with complex cache_id, clear with module: template + complex cache_id (exact match)
+            $smarty->assign('var', 'Test 3');
+            $smarty->fetch($moduleTemplate, $complexCacheId, $compileId);
+            $isCached3 = $smarty->isCached($moduleTemplate, $complexCacheId, $compileId);
+            $this->assertTrue($isCached3, 'Should be cached with complex cache_id');
+
+            $cleared3 = $smarty->clearCache($moduleTemplate, $complexCacheId, $compileId);
+            $stillCached3 = $smarty->isCached($moduleTemplate, $complexCacheId, $compileId);
+            echo "Test 3 (module: template + complex cache_id): cleared=$cleared3, stillCached=" . ($stillCached3 ? 'YES' : 'NO') . "\n";
+
+            echo "=============================================\n";
+
+            // Document actual behavior - don't assert on Test 2 since we're investigating
+            $this->assertFalse($stillCached1, 'Test 1: null template + simple cache_id should clear (prefix match)');
+            $this->assertFalse($stillCached3, 'Test 3: module: template + complex cache_id should clear (exact match)');
+        } finally {
+            $smarty->caching = $originalCaching;
+            if (is_dir($testModuleDir)) {
+                $this->recursiveDelete($testModuleDir);
+            }
+        }
+    }
+
+    /**
+     * Test the exact ps_customtext behavior using PrestaShop's getCacheId() and _clearCache().
+     * This simulates the real module behavior, not just raw Smarty calls.
+     */
+    public function testPsCustomtextExactBehavior(): void
+    {
+        $smarty = Context::getContext()->smarty;
+
+        // Create a test module that mimics ps_customtext
+        $testModuleName = 'test_ps_customtext';
+        $testModuleDir = _PS_MODULE_DIR_ . $testModuleName;
+        $testTemplateName = $testModuleName . '.tpl';
+        $testTemplateFile = $testModuleDir . '/' . $testTemplateName;
+
+        // Clean up any previous test artifacts
+        if (is_dir($testModuleDir)) {
+            $this->recursiveDelete($testModuleDir);
+        }
+
+        // Create module directory with template at root
+        mkdir($testModuleDir, 0777, true);
+        file_put_contents($testTemplateFile, '<div>ps_customtext simulation {$content}</div>');
+
+        // Create a minimal module class file
+        $moduleClassContent = <<<'PHP'
+<?php
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class Test_ps_customtext extends Module
+{
+    public $templateFile;
+
+    public function __construct()
+    {
+        $this->name = 'test_ps_customtext';
+        $this->tab = 'front_office_features';
+        $this->version = '1.0.0';
+        parent::__construct();
+        $this->templateFile = 'module:test_ps_customtext/test_ps_customtext.tpl';
+    }
+
+    public function renderWidget($hookName = null, array $configuration = [])
+    {
+        if (!$this->isCached($this->templateFile, $this->getCacheId('test_ps_customtext'))) {
+            $this->smarty->assign(['content' => 'Hello World']);
+        }
+        return $this->fetch($this->templateFile, $this->getCacheId('test_ps_customtext'));
+    }
+
+    public function clearWidgetCache()
+    {
+        // This is exactly what ps_customtext does - just passes templateFile, no cache_id
+        return $this->_clearCache($this->templateFile);
+    }
+
+    // Expose protected methods for testing
+    public function testGetCacheId($name = null)
+    {
+        return $this->getCacheId($name);
+    }
+
+    public function testClearCache($template, $cache_id = null, $compile_id = null)
+    {
+        return $this->_clearCache($template, $cache_id, $compile_id);
+    }
+}
+PHP;
+        file_put_contents($testModuleDir . '/' . $testModuleName . '.php', $moduleClassContent);
+
+        // DON'T force caching - let PrestaShop's Tools::enableCache() handle it
+        $originalCaching = $smarty->caching;
+        echo "\n=== Initial Smarty caching state: " . $smarty->caching . " ===\n";
+
+        try {
+            // Load the module (dynamically created, PHPStan can't know about it)
+            require_once $testModuleDir . '/' . $testModuleName . '.php';
+            /** @var Module $module */
+            $module = new Test_ps_customtext(); // @phpstan-ignore-line
+
+            echo "\n=== ps_customtext Exact Behavior Test ===\n";
+
+            // Check PrestaShop cache settings
+            $psCacheConfig = Configuration::get('PS_SMARTY_CACHE');
+            echo 'PS_SMARTY_CACHE config: ' . var_export($psCacheConfig, true) . "\n";
+            echo 'Smarty caching setting: ' . $smarty->caching . "\n";
+            echo 'Smarty cache_lifetime: ' . $smarty->cache_lifetime . "\n";
+
+            // Get the cache IDs that will be used
+            $renderCacheId = $module->testGetCacheId('test_ps_customtext'); // @phpstan-ignore-line
+            echo "getCacheId('test_ps_customtext'): $renderCacheId\n";
+            echo "templateFile: {$module->templateFile}\n"; // @phpstan-ignore-line
+
+            // Step 1: Render the widget (creates cache)
+            $output = $module->renderWidget(); // @phpstan-ignore-line
+            echo 'Rendered output: ' . substr($output, 0, 50) . "...\n";
+
+            // Step 2: Check if cached using Module's isCached (like ps_customtext does)
+            $isCachedBefore = $module->isCached($module->templateFile, $renderCacheId); // @phpstan-ignore-line
+            echo 'Is cached after render: ' . ($isCachedBefore ? 'YES' : 'NO') . "\n";
+
+            // Step 3: Clear cache exactly like ps_customtext does
+            $cleared = $module->clearWidgetCache(); // @phpstan-ignore-line
+            echo "clearWidgetCache() returned: $cleared\n";
+
+            // Step 4: Check if still cached
+            $isCachedAfter = $module->isCached($module->templateFile, $renderCacheId); // @phpstan-ignore-line
+            echo 'Is cached after clear: ' . ($isCachedAfter ? 'YES' : 'NO') . "\n";
+
+            echo "==========================================\n";
+
+            $this->assertTrue($isCachedBefore, 'Template should be cached after render');
+            $this->assertFalse($isCachedAfter, 'Template should NOT be cached after clearWidgetCache()');
+        } finally {
+            if (is_dir($testModuleDir)) {
+                $this->recursiveDelete($testModuleDir);
+            }
+        }
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (is_dir($dir)) {
+            $objects = scandir($dir);
+            foreach ($objects as $object) {
+                if ($object !== '.' && $object !== '..') {
+                    $path = $dir . '/' . $object;
+                    if (is_dir($path)) {
+                        $this->recursiveDelete($path);
+                    } else {
+                        unlink($path);
+                    }
+                }
+            }
+            rmdir($dir);
+        }
     }
 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Module::_clearCache() incorrectly triggers full cache clear with "module:" template syntax
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See tests
| UI Tests          | NA
| Fixed issue or discussion?     | NA
| Related PRs       | NA
| Sponsor company   | Softizy
