### PR TITLE
Fix: handle SELECT fields without no_quotes in getSensitiveAttributes

### DIFF
--- a/src/Adapter/SqlManager/QueryHandler/GetSqlRequestExecutionResultHandler.php
+++ b/src/Adapter/SqlManager/QueryHandler/GetSqlRequestExecutionResultHandler.php
@@ -121,6 +121,9 @@ final class GetSqlRequestExecutionResultHandler implements GetSqlRequestExecutio
                 while (is_array($selectField['sub_tree'])) {
                     $selectField = $selectField['sub_tree'][0];
                 }
+                if (!isset($selectField['no_quotes']['parts'])) {
+                    continue;
+                }
                 $field = end($selectField['no_quotes']['parts']);
                 if (array_key_exists($field, $sensitiveAttributes)) {
                     $alias = str_replace(['"', "'", '`'], '', $alias);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.0.x
| Description?      | This PR fixes an error that occurs in the `SQL Manager` when executing queries that use concatenation via `CONCAT_WS()`. cc @mflasquin, @kpodemski @nicosomb 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to **Advanced Parameters > Database**<br/> 2. Create a new **SQL query** with this content: `SELECT CONCAT_WS(' ', lastname, firstname) AS full_name FROM ps_customer LIMIT 0,1`<br/> 3. View the query result
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/19105077114
| Fixed issue or discussion?     | Fixes #39910 
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/31416
| Sponsor company   | Codencode snc
