### PR TITLE
Remove very specific text about payment validation

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -687,7 +687,7 @@ abstract class PaymentModuleCore extends Module
                         '{id_order}' => $order->id,
                         '{date}' => Tools::displayDate(date('Y-m-d H:i:s'), true),
                         '{carrier}' => ($virtual_product || !isset($carrier->name)) ? $this->trans('No carrier', [], 'Admin.Payment.Notification') : $carrier->name,
-                        '{payment}' => Tools::substr($order->payment, 0, 255) . ($order->hasBeenPaid() ? '' : '&nbsp;' . $this->trans('(waiting for validation)', [], 'Emails.Body')),
+                        '{payment}' => $order->payment,
                         '{products}' => $product_list_html,
                         '{products_txt}' => $product_list_txt,
                         '{discounts}' => $cart_rules_list_html,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | In https://github.com/PrestaShop/PrestaShop/issues/15940 and https://github.com/PrestaShop/PrestaShop/pull/16063, somebody added a text "(waiting for validation)" next to payment method in emails. Although I warned about this being very specific, it was forgotten. This text is specific to very handful of payment methods. Bankwire - not applicable, Cash on delivery - not applicable, Cash when pickup - not aplicable. If a payment method needs to inform an user about a payment, it does so in separate emails or should hook itself to mailing process and add this text, not the core.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Not needed
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/19230532743
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### How modules should do it (and already do so in many cases)

```php
    public function hookActionEmailSendBefore($params)
    {
        if ($params['template'] == 'order_conf') {
            $params['templateVars']['{payment}'] .= ' (waiting for payment via Stripe or whatever)';
        }
    }
```