### PR TITLE
fix: Module::_clearCache() incorrectly triggers full cache clear with "module:" template syntax

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2402,6 +2402,19 @@ abstract class ModuleCore implements ModuleInterface
             $compile_id = $this->getDefaultCompileId();
         }
 
+        // Resolve template path only if not using Smarty's "module:" syntax
+        // When using "module:" format, Smarty handles the path resolution internally via SmartyResourceModule
+        // Calling getTemplatePath() on "module:" templates returns null, which would trigger clearAllCache()
+        if (false !== strpos($template, 'module:')) {
+            // During installation, Smarty's "module" resource isn't registered yet, skip cache clear
+            if (defined('PS_INSTALLATION_IN_PROGRESS')) {
+                return 0;
+            }
+            // Template path is already in the correct format for Smarty, no transformation needed
+        } elseif (!file_exists(_PS_ROOT_DIR_ . '/' . $template)) {
+            $template = $this->getTemplatePath($template);
+        }
+
         if (static::$_batch_mode) {
             if ($ps_smarty_clear_cache == 'never') {
                 return 0;
@@ -2413,7 +2426,7 @@ abstract class ModuleCore implements ModuleInterface
 
             $key = $template . '-' . $cache_id . '-' . $compile_id;
             if (!isset(static::$_defered_clearCache[$key])) {
-                static::$_defered_clearCache[$key] = [$this->getTemplatePath($template), $cache_id, $compile_id];
+                static::$_defered_clearCache[$key] = [$template, $cache_id, $compile_id];
             }
 
             return 0;
@@ -2427,7 +2440,7 @@ abstract class ModuleCore implements ModuleInterface
             }
 
             Tools::enableCache();
-            $number_of_template_cleared = Tools::clearCache(Context::getContext()->smarty, $this->getTemplatePath($template), $cache_id, $compile_id);
+            $number_of_template_cleared = Tools::clearCache(Context::getContext()->smarty, $template, $cache_id, $compile_id);
             Tools::restoreCacheSettings();
 
             return $number_of_template_cleared;

--- a/tests/Integration/Classes/module/ModuleTest.php
+++ b/tests/Integration/Classes/module/ModuleTest.php
@@ -129,6 +129,69 @@ class ModuleTest extends TestCase
 
         Module::getInstanceByName('bankwire')->uninstall();
     }
+
+    /**
+     * Test that _clearCache correctly handles templates with "module:" prefix.
+     * Templates using "module:" syntax should be passed directly to Smarty
+     * without transformation via getTemplatePath() to avoid returning null
+     * which would trigger clearAllCache().
+     *
+     * @dataProvider templatePathProvider
+     */
+    public function testClearCacheHandlesModuleTemplatesCorrectly(string $template, bool $shouldTransform): void
+    {
+        $module = $this->getMockBuilder(Module::class)
+            ->onlyMethods(['getTemplatePath', 'getDefaultCompileId'])
+            ->getMock();
+
+        $module->method('getDefaultCompileId')
+            ->willReturn('default');
+
+        if ($shouldTransform) {
+            $module->expects($this->once())
+                ->method('getTemplatePath')
+                ->with($template)
+                ->willReturn('/resolved/path/template.tpl');
+        } else {
+            $module->expects($this->never())
+                ->method('getTemplatePath');
+        }
+
+        $reflection = new ReflectionClass($module);
+        $method = $reflection->getMethod('_clearCache');
+        $method->setAccessible(true);
+
+        $batchModeProperty = $reflection->getProperty('_batch_mode');
+        $batchModeProperty->setAccessible(true);
+        $batchModeProperty->setValue($module, true);
+
+        $result = $method->invoke($module, $template);
+
+        $this->assertEquals(0, $result);
+
+        $batchModeProperty->setValue($module, false);
+    }
+
+    /**
+     * @return array<string, array{string, bool}>
+     */
+    public function templatePathProvider(): array
+    {
+        return [
+            'module template should not transform' => [
+                'module:ps_currencyselector/ps_currencyselector.tpl',
+                false,
+            ],
+            'module template with subpath' => [
+                'module:ps_socialfollow/views/templates/hook/socialfollow.tpl',
+                false,
+            ],
+            'regular template should transform' => [
+                'views/templates/hook/template.tpl',
+                true,
+            ],
+        ];
+    }
 }
 
 define('_RESSOURCE_MODULE_DIR_', realpath(dirname(__FILE__, 4) . '/Resources/modules_tests/'));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | Module::_clearCache() incorrectly triggers full cache clear with "module:" template syntax
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See tests
| UI Tests          | NA
| Fixed issue or discussion?     | NA
| Related PRs       | NA
| Sponsor company   | Softizy
