### PR TITLE
Fix: After duplicating product and editing features after save disappear some features

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/manager/feature-values-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/manager/feature-values-manager.ts
@@ -228,11 +228,84 @@ export default class FeatureValuesManager {
             const $featureRow = $(ProductMap.featureValues.featureRowByFeatureId(featureId), this.$collectionRowsContainer);
             $featureRow.remove();
           }
+
+          this.reindexCollection();
+
           this.eventEmitter.emit(ProductEventMap.updateSubmitButtonState);
           this.$collectionContainer.toggleClass('d-none', this.$collectionRowsContainer.children().length === 0);
         },
       );
       modal.show();
+    });
+  }
+
+  private reindexCollection(): void {
+    const $featureRows = $('tr.product-feature-collection', this.$collectionRowsContainer);
+
+    $featureRows.each((i, featureRowEl) => {
+      const $featureRow = $(featureRowEl);
+      const oldIndexMatch = $featureRow.attr('id')?.match(/feature_collection_(\d+)/);
+
+      if (!oldIndexMatch) {
+        return;
+      }
+
+      const oldIndex = oldIndexMatch[1];
+      const newIndex = i;
+
+      // Update ID and NAME of the main row
+      const featureRowId = $featureRow.attr('id') ?? '';
+      const featureRowName = $featureRow.attr('name') ?? '';
+
+      $featureRow.attr('id', featureRowId.replace(`feature_collection_${oldIndex}`, `feature_collection_${newIndex}`));
+      $featureRow.attr('name', featureRowName.replace(`[${oldIndex}]`, `[${newIndex}]`));
+
+      // Update internal fields (id and name)
+      $featureRow.find('[id]').each((_, el) => {
+        const element = el as HTMLElement;
+
+        if (element.id) {
+          element.id = element.id.replace(`feature_collection_${oldIndex}`, `feature_collection_${newIndex}`);
+        }
+      });
+
+      $featureRow.find('[name]').each((_, el) => {
+        const element = el as HTMLInputElement;
+
+        if (element.name) {
+          element.name = element.name.replace(
+            `[feature_collection][${oldIndex}]`,
+            `[feature_collection][${newIndex}]`,
+          );
+        }
+      });
+
+      // Also update any related value rows (product-feature-value)
+      const featureId = $featureRow.attr('feature-id');
+      const $valueRows = $(`tr.product-feature-value[feature-id="${featureId}"]`, this.$collectionRowsContainer);
+
+      $valueRows.each((_, valueRowEl) => {
+        const $valueRow = $(valueRowEl);
+
+        $valueRow.find('[id]').each((__, el) => {
+          const element = el as HTMLElement;
+
+          if (element.id) {
+            element.id = element.id.replace(`feature_collection_${oldIndex}`, `feature_collection_${newIndex}`);
+          }
+        });
+
+        $valueRow.find('[name]').each((__, el) => {
+          const element = el as HTMLInputElement;
+
+          if (element.name) {
+            element.name = element.name.replace(
+              `[feature_collection][${oldIndex}]`,
+              `[feature_collection][${newIndex}]`,
+            );
+          }
+        });
+      });
     });
   }
 

--- a/admin-dev/themes/new-theme/js/pages/product/edit/manager/feature-values-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/manager/feature-values-manager.ts
@@ -62,6 +62,8 @@ export default class FeatureValuesManager {
 
   featureValues: Array<FeatureValue[]> = [];
 
+  nextIndex: number = 0;
+
   /**
    * @param eventEmitter {EventEmitter}
    */
@@ -80,6 +82,8 @@ export default class FeatureValuesManager {
 
     this.$collectionContainer = $(ProductMap.featureValues.collectionContainer);
     this.$collectionRowsContainer = $(ProductMap.featureValues.collectionRowsContainer);
+
+    this.nextIndex = $(ProductMap.featureValues.featureRow, this.$collectionRowsContainer).length;
 
     this.watchFeatureSelectors();
     this.watchDeleteButtons();
@@ -121,9 +125,10 @@ export default class FeatureValuesManager {
       if (!$featureRow.length) {
         const featurePrototype = this.$collectionContainer.data('prototype');
         const featurePrototypeName = this.$collectionContainer.data('prototypeName');
-        const newIndex = $(ProductMap.featureValues.featureRow, this.$collectionRowsContainer).length;
 
-        const $newFeatureRow = $(featurePrototype.replace(new RegExp(featurePrototypeName, 'g'), newIndex)).first();
+        const $newFeatureRow = $(featurePrototype.replace(new RegExp(featurePrototypeName, 'g'), this.nextIndex)).first();
+        this.nextIndex += 1;
+
         $newFeatureRow.attr('feature-id', featureId);
         this.$collectionRowsContainer.append($newFeatureRow);
         $(ProductMap.featureValues.featureIdInput, $newFeatureRow).val(featureId);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR reassigns the indexes of the product **features** collection after a feature is deleted.<br/>This prevents data loss when a feature is removed and another one is added before submitting the Symfony form.| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |Prerequisites:<br/>1. Create the following features (Catalog > Attributes & Features > Features): **Feature 1**, **Feature 2**, **Feature 3**<br/>2. For each one, create the value **Value 1**<br/>3. Edit an product by specifying: **Feature 1 > Value 1**, **Feature 2 > Value 1**<br/>4. Save<br/><br/>Now do the following:<br/>1. Access the product you just modified<br/>2. Delete **Feature 1**<br/>3. Add **Feature 3 > Value 1**<br/>4. Save<br/><br/>You should now have:<br/>**Feature 2 > Value 1<br/>Feature 3 > Value 1**
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #39896
| Related PRs       | 
| Sponsor company   | Codencode snc
