### PR TITLE
Make sure address IDs are returned consistently

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -394,8 +394,7 @@ class AddressCore extends ObjectModel
     }
 
     /**
-     * Request to check if DNI field is required
-     * depending on the current selected country.
+     * Checks if DNI field is required for a given country.
      *
      * @param int $idCountry
      *
@@ -411,7 +410,7 @@ class AddressCore extends ObjectModel
     }
 
     /**
-     * Check if Address is used (at least one order placed).
+     * Checks if the address has been used in an order as delivery on invoice address.
      *
      * @return int|bool Order count for this Address
      */
@@ -484,7 +483,7 @@ class AddressCore extends ObjectModel
     }
 
     /**
-     * Check if the address is valid.
+     * Check if the address is valid - active and not deleted.
      *
      * @param int $id_address Address id
      *
@@ -520,7 +519,8 @@ class AddressCore extends ObjectModel
                 '
 				SELECT `id_address`
 				FROM `' . _DB_PREFIX_ . 'address`
-				WHERE `id_customer` = ' . (int) $id_customer . ' AND `deleted` = 0' . ($active ? ' AND `active` = 1' : '')
+				WHERE `id_customer` = ' . (int) $id_customer . ' AND `deleted` = 0' . ($active ? ' AND `active` = 1' : '') . '
+                ORDER BY `id_address` ASC'
             );
             Cache::store($cache_id, $result);
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This is not a fix exactly, but more just a security measure to make sure addresses are provided consistently. The process of getting a first address of a customer can be confusing even for long term users - I had to dive into the code to check what is happening in https://github.com/PrestaShop/PrestaShop/issues/39929, but it's actually an expected behavior. This PR makes sure that address that gets initialized in the context is really the first one the customer has, by ID, by adding `ORDER BY id_address ASC`
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | I think that auto test is fine, just to make sure I didn't make a typo.
| UI Tests          |https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/19227295753
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

cc @Progi1984 