### PR TITLE
Remove obsolete logic tied to PS_DISABLE_NON_NATIVE_MODULE

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -67,6 +67,9 @@ class HookCore extends ObjectModel
      */
     public static $executed_hooks = [];
 
+    /**
+     * @deprecated since 8.0.0
+     */
     public static $native_module;
 
     protected static $disabledHookModules = [];
@@ -931,14 +934,6 @@ class HookCore extends ObjectModel
             $array_return = false;
         }
 
-        // Check if we should execute non native modules
-        static $disable_non_native_modules = null;
-        if ($disable_non_native_modules === null) {
-            $disable_non_native_modules = (bool) Configuration::get(
-                'PS_DISABLE_NON_NATIVE_MODULE'
-            );
-        }
-
         // Check arguments validity
         if (
             ($id_module && !is_numeric($id_module))
@@ -982,12 +977,6 @@ class HookCore extends ObjectModel
         $altern = 0;
         $output = $array_return ? [] : '';
 
-        // If non native modules are disabled, we must get the list of native ones
-        // that came bundled with the store.
-        if ($disable_non_native_modules && !isset(Hook::$native_module)) {
-            Hook::$native_module = Module::getNativeModuleList();
-        }
-
         $different_shop = false;
         if (
             $id_shop !== null
@@ -1008,16 +997,6 @@ class HookCore extends ObjectModel
             // If the caller provided a specific module ID for which ONLY this hook
             // should be executed, we check if it matches.
             if ($id_module && $id_module != $hookRegistration['id_module']) {
-                continue;
-            }
-
-            // If non native modules are disabled and this module is not a native one.
-            if (
-                (bool) $disable_non_native_modules
-                && Hook::$native_module
-                && count(Hook::$native_module)
-                && !in_array($hookRegistration['module'], Hook::$native_module)
-            ) {
                 continue;
             }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR removes the obsolete logic related to PS_DISABLE_NON_NATIVE_MODULE
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See comment.
| UI Tests          | https://github.com/ChillCode/ga.tests.ui.pr/actions/runs/19138611086
| Fixed issue or discussion?     | #39616 

1. Install PS 1.7.8.11
2. Go to BO->Advanced Parameters->Performance Modules section and check the radio box to disable non native modules.
3. Upgrade the site to 8 or 9
4. Install a non native module with hooks.
5. Hooks of those modules does work.



