### PR TITLE
Add attachment ID to product attachments search and selection

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/manager/attachments-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/manager/attachments-manager.ts
@@ -98,6 +98,9 @@ export default class AttachmentsManager {
       onSelectedContent: () => {
         this.eventEmitter.emit(ProductEventMap.updateSubmitButtonState);
       },
+      suggestionTemplate: (entity: any): string => `
+        <div class="search-suggestion">${entity.attachment_id} - ${entity.name}</div>
+      `,
     });
   }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/AttachedFileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/AttachedFileType.php
@@ -30,7 +30,6 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product\Options;
 use PrestaShopBundle\Form\Admin\Type\EntityItemType;
 use PrestaShopBundle\Form\Admin\Type\TextPreviewType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class AttachedFileType extends TranslatorAwareType
@@ -38,9 +37,10 @@ class AttachedFileType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
+            ->remove('name')
             ->remove('image')
-            ->add('attachment_id', HiddenType::class, [
-                'label' => false,
+            ->add('attachment_id', TextPreviewType::class, [
+                'label' => $this->trans('ID', 'Admin.Global'),
             ])
             ->add('name', TextPreviewType::class, [
                 'label' => $this->trans('Title', 'Admin.Global'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR adds the **attachment ID** to each attachment name in both the **search results** and the **selected attachments list** of the product form. <br/>IIt improves clarity when handling multiple attachments with similar or identical names.
| Type?             |  improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create 4 attachments with the same name, e.g. **Technical data sheet**, in **Catalog > Files**<br/>2. Edit a product<br/>3. In the **Details** tab, under **Attached files**, search for **data**<br/>4. The system should display attachment names prefixed with their ID<br/>5. Select 2 attachments to add them to the product<br/>6. The displayed list must include the column with the attachment ID.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/19227632586
| Fixed issue or discussion?     |
| Related PRs       | 
| Sponsor company   | Codencode snc

---
### Search before fix
_In this case, I don't know which attachment I should select._
<img width="513" height="310" alt="search-before-fix" src="https://github.com/user-attachments/assets/654e2809-a2b2-4edf-9afb-673be51c97f7" />

---

### List before fix
_In this case, I don't know which attachment I should delete._
<img width="907" height="301" alt="list-before-fix" src="https://github.com/user-attachments/assets/a40f266f-368a-4be5-9fd3-452103c9713f" />

---

### Search after fix
<img width="626" height="283" alt="search-after-fix" src="https://github.com/user-attachments/assets/31d8a567-09ae-4739-8224-6ff05ad2763c" />

---

### List after fix
<img width="1337" height="254" alt="list-after-fix" src="https://github.com/user-attachments/assets/7b7d60f3-9089-4631-afdf-96b82df81e27" />

