### PR TITLE
Improve confirmation logic and remove module check

### DIFF
--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -107,7 +107,7 @@ class OrderConfirmationControllerCore extends FrontController
         }
 
         // Last step, initialize some other data
-        $this->id_module = Module::getModuleIdByName($this->order->module);
+        $this->id_module = $this->order->module == 'free_order' ? -1 : Module::getModuleIdByName($this->order->module);
 
         // This data is kept only for backward compatibility purposes
         $this->reference = (string) $this->order->reference;
@@ -246,6 +246,7 @@ class OrderConfirmationControllerCore extends FrontController
      */
     public function displayPaymentReturn(Order $order)
     {
+        // Check if we have a sensible module ID. Free orders have -1 as module ID
         if (!Validate::isUnsignedId($this->id_module)) {
             return false;
         }
@@ -298,7 +299,7 @@ class OrderConfirmationControllerCore extends FrontController
 
         /*
          * Redirect back to this page to display the order confirmation.
-         * Note the id_module parameter with value -1, it's only kept for 
+         * Note the id_module parameter with value -1, it's only kept for
          * backward compatibility, but not used anymore.
          */
         Tools::redirect($this->context->link->getPageLink(

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -73,7 +73,7 @@ class OrderConfirmationControllerCore extends FrontController
          * After the order is created, we redirect to the same page without free_order parameter
          * and display the confirmation as usual.
          */
-        if (true === (bool) Tools::getValue('free_order')) {
+        if ((bool) Tools::getValue('free_order') === true) {
             $this->checkFreeOrder();
         }
 
@@ -269,6 +269,14 @@ class OrderConfirmationControllerCore extends FrontController
      */
     protected function checkFreeOrder(): void
     {
+        /*
+         * Verify if this is not a faulty or duplicate call. If an order
+         * already exists for this cart, we do not create another one.
+         */
+        if (!empty(Order::getIdByCartId((int) $this->id_cart))) {
+            return;
+        }
+
         $cart = $this->context->cart;
         if ($cart->id_customer == 0 || $cart->id_address_delivery == 0 || $cart->id_address_invoice == 0) {
             Tools::redirect($this->context->link->getPageLink('order'));

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -65,8 +65,14 @@ class OrderConfirmationControllerCore extends FrontController
 
         parent::init();
 
-        // If we are coming to this page to finish free order we do extra checks and validations
-        // and redirect back here with bit more data.
+        /*
+         * There is a special case for free orders, when this page does more than just display
+         * the confirmation. It also creates the order if it is free. This is done if free_order
+         * parameter is passed to this page.
+         *
+         * After the order is created, we redirect to the same page without free_order parameter
+         * and display the confirmation as usual.
+         */
         if (true === (bool) Tools::getValue('free_order')) {
             $this->checkFreeOrder();
         }
@@ -75,44 +81,36 @@ class OrderConfirmationControllerCore extends FrontController
          * Because of order splitting scenarios, we must get the data by id_cart parameter (not id_order),
          * so we can display all orders made from this cart.
          *
-         * It's not implemented yet, however.
+         * It's not implemented yet, however, and probably won't be, because we are switching to a new
+         * logic of multiple shipments per order, which doesn't require splitting orders anymore.
          */
         $this->id_order = Order::getIdByCartId((int) $this->id_cart);
-        $this->secure_key = Tools::getValue('key', false);
+        if (empty($this->id_order)) {
+            Tools::redirect('pagenotfound');
+        }
+
+        // Now, load the order object and check validity
         $this->order = new Order((int) $this->id_order);
-        $this->id_module = (int) Tools::getValue('id_module', 0);
+        if (!Validate::isLoadedObject($this->order)) {
+            Tools::redirect('pagenotfound');
+        }
+
+        /*
+         * Now, to prevent users from seeing other customers' order confirmations, we are using
+         * a secure key mechanism. The confirmation link contains a unique key which is also saved
+         * in database when the order is created. If the key from the URL doesn't match the one
+         * in database, we redirect to "page not found".
+         */
+        $this->secure_key = Tools::getValue('key', false);
+        if (empty($this->secure_key) || $this->secure_key != $this->order->secure_key) {
+            Tools::redirect('pagenotfound');
+        }
+
+        // Last step, initialize some other data
+        $this->id_module = Module::getModuleIdByName($this->order->module);
 
         // This data is kept only for backward compatibility purposes
         $this->reference = (string) $this->order->reference;
-
-        $redirectLink = $this->context->link->getPageLink('history');
-
-        // The confirmation link must contain a unique order secure key matching the key saved in database,
-        // this prevents user to view other customer's order confirmations
-        if (!$this->id_order || !$this->id_module || !$this->secure_key || empty($this->secure_key)) {
-            if (Tools::isSubmit('slowvalidation')) {
-                Tools::redirect($this->context->link->getPageLink('history', null, null, ['slowvalidation' => '1']));
-            } else {
-                Tools::redirect($redirectLink);
-            }
-        }
-
-        if (!Validate::isLoadedObject($this->order) || $this->secure_key != $this->order->secure_key) {
-            Tools::redirect($redirectLink);
-        }
-
-        // Free order uses -1 as id_module, it has a special check here
-        if ($this->id_module == -1) {
-            if ($this->order->module !== 'free_order') {
-                Tools::redirect($redirectLink);
-            }
-        } else {
-            // Otherwise we run a normal check that module matches
-            $module = Module::getInstanceById((int) $this->id_module);
-            if ($this->order->module !== $module->name) {
-                Tools::redirect($redirectLink);
-            }
-        }
 
         // If checks passed, initialize customer, we will need him anyway
         $this->customer = new Customer((int) $this->order->id_customer);
@@ -243,7 +241,8 @@ class OrderConfirmationControllerCore extends FrontController
     }
 
     /**
-     * Execute the hook displayPaymentReturn.
+     * Execute the hook displayPaymentReturn. This hook should be used to display payment
+     * information on the order confirmation page. Payment status, instructions, QR code etc.
      */
     public function displayPaymentReturn(Order $order)
     {
@@ -264,7 +263,8 @@ class OrderConfirmationControllerCore extends FrontController
     }
 
     /**
-     * Check if an order is free and create it.
+     * Check if an order is free and create it. After creation, we redirect to the same page
+     * which will display the order confirmation as usual.
      */
     protected function checkFreeOrder(): void
     {
@@ -296,10 +296,11 @@ class OrderConfirmationControllerCore extends FrontController
             $cart->secure_key
         );
 
-        // redirect back to us with rest of the data
-        // note the id_module parameter with value -1
-        // it acts as a marker for the module check to use "free_payment"
-        // for the check
+        /*
+         * Redirect back to this page to display the order confirmation.
+         * Note the id_module parameter with value -1, it's only kept for 
+         * backward compatibility, but not used anymore.
+         */
         Tools::redirect($this->context->link->getPageLink(
             'order-confirmation',
             null,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Small refacto and commenting of order confirmation controller. See below for changes.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Auto test.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/19533803372
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### Changes
- No redirects to history page, but to 404. If an user visits this page with wrong parameters, it's probably a hack attempt anyway.
- id_module is not taken from the URL, but from the order itself, which is A) a better source of truth, B) allows people to visit the order confirmation even if you change the payment methods in backoffice (with external modules).
- Since we take the module ID from the order, we can remove the module ID check completely and make it much simplier. There is no way to tamper with the module ID in the URL now.
- Found a bug also - fixes https://github.com/PrestaShop/PrestaShop/issues/39944