### PR TITLE
Refactor attachment download URLs to use SEO-friendly pattern /attachment/{id}-{filename}

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -112,6 +112,14 @@ class DispatcherCore
                 'tags' => ['regexp' => '[a-zA-Z0-9-\pL]*'],
             ],
         ],
+        'attachment_rule' => [
+            'controller' => 'attachment',
+            'rule' => 'attachment/{id}-{rewrite}',
+            'keywords' => [
+                'id' => ['regexp' => '[0-9]+', 'param' => 'id_attachment'],
+                'rewrite' => ['regexp' => self::REWRITE_PATTERN],
+            ],
+        ],
     ];
 
     /**

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1231,6 +1231,48 @@ class LinkCore
     }
 
     /**
+     * Create a link to an Attachmnt download.
+     *
+     * @param Attachment|int $attachment Attachment object
+     * @param string|null $alias
+     * @param bool|null $ssl
+     * @param int|null $idLang
+     * @param int|null $idShop
+     * @param bool $relativeProtocol
+     *
+     * @return string
+     */
+    public function getAttachmentLink(
+        $attachment,
+        $alias = null,
+        $ssl = null,
+        $idLang = null,
+        $idShop = null,
+        $relativeProtocol = false
+    ) {
+        if (!$idLang) {
+            $idLang = Context::getContext()->language->id;
+        }
+
+        $url = $this->getBaseLink($idShop, $ssl, $relativeProtocol) . $this->getLangLink($idLang, null, $idShop);
+
+        $dispatcher = Dispatcher::getInstance();
+        if (!is_object($attachment)) {
+            if ($alias !== null && !$dispatcher->hasKeyword('attachment_rule', $idLang, 'meta_title', $idShop)) {
+                return $url . $dispatcher->createUrl('attachment_rule', $idLang, ['id' => (int) $attachment, 'rewrite' => (string) $alias], $this->allow, '', $idShop);
+            }
+            $attachment = new Attachment($attachment, $idLang);
+        }
+
+        // Set available keywords
+        $params = [];
+        $params['id'] = $attachment->id;
+        $params['rewrite'] = Tools::str2url((!$alias) ? (is_array($attachment->file_name) ? $attachment->file_name[(int) $idLang] : $attachment->file_name) : $alias);
+
+        return $url . $dispatcher->createUrl('attachment_rule', $idLang, $params, $this->allow, '', $idShop);
+    }
+
+    /**
      * @param string $url
      * @param int $p
      *
@@ -1586,6 +1628,18 @@ class LinkCore
                     $params['name'],
                     $params['controller'],
                     $params['params'],
+                    $params['ssl'],
+                    $params['id_lang'],
+                    $params['id_shop'],
+                    $params['relative_protocol']
+                );
+
+                break;
+
+            case 'attachment':
+                $link = $context->link->getAttachmentLink(
+                    new Attachment(isset($params['id']) ? $params['id'] : $params['params']['id_attachment'], $params['id_lang']),
+                    $params['alias'],
                     $params['ssl'],
                     $params['id_lang'],
                     $params['id_shop'],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR updates the attachment download URLs to use a friendly and SEO-oriented format (/attachment/{id}-{filename}) instead of the legacy query-string pattern.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Add an attachment to a product and set its name to **attachment name**<br/>2. Go to the product page in the front office<br/>3. Hover over the attachment link and make sure the URL looks like **attachment/2-attachment-name**
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/23617230181
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | Codencode snc

### NOTE
The URL rewrite is generated based on the attachment name. A future improvement could be to add a specific field (e.g. `link_rewrite`) to customize the link, but this is already a good starting point to have a URL like `www.site.com/attachment/2-filename` instead of `www.site.com/?controller=attachment&id_attachment=2`.
