### PR TITLE
Chore(bo): New date filter component for discounts

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.ts
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.ts
@@ -52,6 +52,7 @@ import TranslatableInput from '@js/components/translatable-input';
 import EntitySearchInput from '@js/components/entity-search-input';
 import MultipleZoneChoice from '@js/components/form/multiple-zone-choice';
 import ToggleChildrenChoice from '@js/components/form/toggle-children-choice';
+import FilterLinkGroup from '@components/filter/filter-link-group';
 
 // Grid extensions
 import AsyncToggleColumnExtension from '@components/grid/extension/column/common/async-toggle-column-extension';
@@ -84,6 +85,7 @@ const GridExtensions = {
   ChoiceExtension,
   ColumnTogglingExtension,
   ExportToSqlManagerExtension,
+  FilterLinkGroup,
   FiltersResetExtension,
   FiltersSubmitButtonEnablerExtension,
   LinkRowActionExtension,

--- a/admin-dev/themes/new-theme/js/components/filter/filter-link-group.ts
+++ b/admin-dev/themes/new-theme/js/components/filter/filter-link-group.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ */
+
+type FilterField = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+
+const DEFAULT_CONTAINER_SELECTOR = '[data-filter-link-group]';
+const DEFAULT_ITEM_SELECTOR = '[data-filter-value]';
+const DEFAULT_ACTIVE_CLASS = 'is-active';
+const DEFAULT_SUBMIT_BUTTON_SELECTOR = '.grid-search-button';
+
+/**
+ * FilterLinkGroup turns a list of links into a form filter controller.
+ *
+ * Expected markup:
+ * <div
+ *   data-filter-link-group
+ *   data-filter-field-selector="#my-hidden-filter"
+ *   data-filter-submit-button-selector=".grid-search-button"
+ * >
+ *   <a data-filter-value="foo">Foo</a>
+ * </div>
+ */
+export default class FilterLinkGroup {
+  private readonly containerSelector: string;
+
+  constructor(containerSelector: string = DEFAULT_CONTAINER_SELECTOR) {
+    this.containerSelector = containerSelector;
+    this.init();
+  }
+
+  private init(): void {
+    const containers = document.querySelectorAll<HTMLElement>(this.containerSelector);
+
+    containers.forEach((container) => {
+      const fieldSelector = container.dataset.filterFieldSelector;
+
+      if (!fieldSelector) {
+        console.warn('[FilterLinkGroup] Missing "data-filter-field-selector" attribute on container.', container);
+
+        return;
+      }
+
+      const field = document.querySelector<FilterField>(fieldSelector);
+
+      if (!field) {
+        console.warn('[FilterLinkGroup] Unable to find filter field for selector:', fieldSelector);
+
+        return;
+      }
+
+      this.bindContainer(container, field);
+    });
+  }
+
+  private bindContainer(container: HTMLElement, field: FilterField): void {
+    const filterField = field;
+    const itemSelector = container.dataset.filterItemSelector ?? DEFAULT_ITEM_SELECTOR;
+    const activeClass = container.dataset.filterActiveClass ?? DEFAULT_ACTIVE_CLASS;
+    const submitButtonSelector = container.dataset.filterSubmitButtonSelector ?? DEFAULT_SUBMIT_BUTTON_SELECTOR;
+
+    const updateActiveState = (value: string): void => {
+      const items = container.querySelectorAll<HTMLElement>(itemSelector);
+
+      items.forEach((item) => {
+        const itemValue = item.dataset.filterValue ?? item.getAttribute('data-filter-value') ?? '';
+        const isActive = itemValue === value;
+
+        if (isActive) {
+          item.classList.add(activeClass);
+          item.setAttribute('aria-pressed', 'true');
+        } else {
+          item.classList.remove(activeClass);
+          item.setAttribute('aria-pressed', 'false');
+        }
+      });
+    };
+
+    const initialValue = container.dataset.filterInitialValue ?? filterField.value;
+    filterField.value = initialValue;
+    updateActiveState(initialValue);
+
+    container.addEventListener('click', (event: Event) => {
+      const target = (event.target as HTMLElement).closest<HTMLElement>(itemSelector);
+
+      if (!target) {
+        return;
+      }
+
+      const value = target.dataset.filterValue ?? target.getAttribute('data-filter-value');
+
+      if (value === null) {
+        return;
+      }
+
+      event.preventDefault();
+
+      if (filterField.value !== value) {
+        filterField.value = value;
+        filterField.dispatchEvent(new Event('change', {bubbles: true}));
+      }
+
+      updateActiveState(value);
+      this.submitForm(filterField, container, submitButtonSelector);
+    });
+
+    filterField.addEventListener('change', () => {
+      updateActiveState(filterField.value);
+    });
+  }
+
+  private submitForm(field: FilterField, container: HTMLElement, submitButtonSelector: string): void {
+    const form = field.closest('form');
+
+    if (!form) {
+      return;
+    }
+
+    if (submitButtonSelector !== 'none') {
+      const submitButton = form.querySelector<HTMLButtonElement>(submitButtonSelector)
+        ?? container.querySelector<HTMLButtonElement>(submitButtonSelector);
+
+      if (submitButton && !submitButton.disabled) {
+        submitButton.click();
+
+        return;
+      }
+    }
+
+    form.submit();
+  }
+}

--- a/admin-dev/themes/new-theme/js/pages/discount/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/discount/index.ts
@@ -38,6 +38,8 @@ $(() => {
   discountGrid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   discountGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
 
+  new window.prestashop.component.GridExtensions.FilterLinkGroup();
+
   // Check the type selected and update the submit button state
   const discountTypeRadios = document.querySelectorAll<HTMLInputElement>(DiscountMap.discountTypeRadios);
   discountTypeRadios.forEach((discountTypeRadio: HTMLInputElement) => {

--- a/admin-dev/themes/new-theme/scss/components/_grid.scss
+++ b/admin-dev/themes/new-theme/scss/components/_grid.scss
@@ -380,3 +380,43 @@ table {
     }
   }
 }
+
+// FilterLinkGroup component styles
+.filter-link-group {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--cdk-size-16);
+  margin-bottom: var(--cdk-size-16);
+
+  &__item {
+    padding-bottom: var(--cdk-size-4);
+    font-weight: 600;
+    color: var(--cdk-color-grey-700);
+    text-decoration: none;
+    border-bottom: 2px solid transparent;
+    transition: color var(--#{$cdk}default-transition-duration), border-color var(--#{$cdk}default-transition-duration);
+
+    &:hover,
+    &:focus {
+      color: var(--cdk-color-primary-600);
+      text-decoration: none;
+    }
+
+    &.is-active {
+      color: var(--cdk-color-primary-600);
+      border-color: var(--cdk-color-primary-500);
+    }
+  }
+}
+
+// Ensure FilterLinkGroup links don't have underline
+[data-filter-link-group] {
+  a {
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+    }
+  }
+}

--- a/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
@@ -14,7 +14,8 @@
       [class*="dropdown"],
       [class*="list-group-item"],
       [class*="kpi-container"],
-      [class*="nav-link"]) {
+      [class*="nav-link"],
+      [data-filter-link-group] a) {
         text-decoration: underline;
         text-underline-offset: var(--#{$cdk}size-2);
         transition: var(--#{$cdk}default-transition);

--- a/admin-dev/themes/new-theme/scss/pages/_discount.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_discount.scss
@@ -30,3 +30,4 @@
     margin-right: var(--cdk-size-8);
   }
 }
+

--- a/src/Core/Domain/Discount/DiscountSettings.php
+++ b/src/Core/Domain/Discount/DiscountSettings.php
@@ -31,4 +31,10 @@ class DiscountSettings
     public const MAX_NAME_LENGTH = 255;
     public const AMOUNT = 'amount';
     public const PERCENT = 'percentage';
+
+    // Period filter values
+    public const PERIOD_FILTER_ALL = 'all';
+    public const PERIOD_FILTER_ACTIVE = 'active';
+    public const PERIOD_FILTER_SCHEDULED = 'scheduled';
+    public const PERIOD_FILTER_EXPIRED = 'expired';
 }

--- a/src/Core/Grid/Definition/Factory/DiscountGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/DiscountGridDefinitionFactory.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
+use PrestaShop\PrestaShop\Core\Domain\Discount\DiscountSettings;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
@@ -40,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollectionInterface;
 use PrestaShopBundle\Form\Admin\Type\DateRangeType;
+use PrestaShopBundle\Form\Admin\Type\FilterLinkFilterType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -210,6 +212,27 @@ final class DiscountGridDefinitionFactory extends AbstractGridDefinitionFactory 
                         'required' => false,
                         'placeholder' => $this->trans('All', [], 'Admin.Global'),
                         'choice_translation_domain' => false,
+                    ])
+            )
+            ->add(
+                (new Filter('period_filter', FilterLinkFilterType::class))
+                    ->setTypeOptions([
+                        'filter_field_name' => 'period_filter',
+                        'filter_field_selector' => '[data-role="period_filter-filter-field"]',
+                        'default_value' => DiscountSettings::PERIOD_FILTER_ALL,
+                        'filter_options' => [
+                            DiscountSettings::PERIOD_FILTER_ALL => $this->trans('All', [], 'Admin.Global'),
+                            DiscountSettings::PERIOD_FILTER_ACTIVE => $this->trans('Active', [], 'Admin.Catalog.Feature'),
+                            DiscountSettings::PERIOD_FILTER_SCHEDULED => $this->trans('Scheduled', [], 'Admin.Catalog.Feature'),
+                            DiscountSettings::PERIOD_FILTER_EXPIRED => $this->trans('Expired', [], 'Admin.Catalog.Feature'),
+                        ],
+                        'attr' => [
+                            'class' => 'js-period-filter-field',
+                            'data-role' => 'period_filter-filter-field',
+                            'data-filter-field-name' => 'period_filter',
+                        ],
+                        'data' => DiscountSettings::PERIOD_FILTER_ALL,
+                        'empty_data' => DiscountSettings::PERIOD_FILTER_ALL,
                     ])
             )
             ->add((new Filter('date_from_filter', DateRangeType::class))

--- a/src/Core/Grid/Query/DiscountQueryBuilder.php
+++ b/src/Core/Grid/Query/DiscountQueryBuilder.php
@@ -28,9 +28,11 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Grid\Query;
 
+use DateTimeImmutable;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
+use PrestaShop\PrestaShop\Core\Domain\Discount\DiscountSettings;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
@@ -133,7 +135,15 @@ class DiscountQueryBuilder extends AbstractDoctrineQueryBuilder
 
         $exactMatchFilters = ['id_discount', 'type', 'active'];
 
+        $now = new DateTimeImmutable();
+
         foreach ($filters as $filterName => $value) {
+            if ($filterName === 'period_filter') {
+                $this->applyPeriodFilter($qb, $value, $now);
+
+                continue;
+            }
+
             if (!array_key_exists($filterName, $allowedFiltersAliasMap)
                 && $filterName !== 'date_from_filter'
                 && $filterName !== 'date_to_filter') {
@@ -172,6 +182,42 @@ class DiscountQueryBuilder extends AbstractDoctrineQueryBuilder
 
             $qb->andWhere($allowedFiltersAliasMap[$filterName] . ' LIKE :' . $filterName);
             $qb->setParameter($filterName, "%$value%");
+        }
+    }
+
+    private function applyPeriodFilter(QueryBuilder $qb, mixed $value, DateTimeImmutable $now): void
+    {
+        if (!is_string($value) || $value === '' || $value === DiscountSettings::PERIOD_FILTER_ALL) {
+            return;
+        }
+
+        $formattedNow = $now->format('Y-m-d H:i:s');
+
+        switch ($value) {
+            case DiscountSettings::PERIOD_FILTER_ACTIVE:
+                $qb->andWhere('cr.date_from <= :period_now_active');
+                $qb->andWhere('(
+                    cr.date_to >= :period_now_active
+                    OR cr.date_to IS NULL
+                    OR UNIX_TIMESTAMP(cr.date_to) IS NULL
+                )');
+                $qb->setParameter('period_now_active', $formattedNow);
+
+                break;
+
+            case DiscountSettings::PERIOD_FILTER_SCHEDULED:
+                $qb->andWhere('cr.date_from > :period_now_scheduled');
+                $qb->setParameter('period_now_scheduled', $formattedNow);
+
+                break;
+
+            case DiscountSettings::PERIOD_FILTER_EXPIRED:
+                $qb->andWhere('cr.date_to < :period_now_expired');
+                $qb->andWhere('cr.date_to IS NOT NULL');
+                $qb->andWhere('UNIX_TIMESTAMP(cr.date_to) IS NOT NULL');
+                $qb->setParameter('period_now_expired', $formattedNow);
+
+                break;
         }
     }
 }

--- a/src/Core/Search/Filters/DiscountFilters.php
+++ b/src/Core/Search/Filters/DiscountFilters.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Search\Filters;
 
+use PrestaShop\PrestaShop\Core\Domain\Discount\DiscountSettings;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\DiscountGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters;
 
@@ -49,7 +50,9 @@ final class DiscountFilters extends Filters
             'offset' => 0,
             'orderBy' => 'id_discount',
             'sortOrder' => 'desc',
-            'filters' => [],
+            'filters' => [
+                'period_filter' => DiscountSettings::PERIOD_FILTER_ALL,
+            ],
         ];
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Type/FilterLinkFilterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/FilterLinkFilterType.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Generic form type for filter link groups.
+ * This creates a hidden field that can be controlled by a FilterLinkGroup component.
+ */
+class FilterLinkFilterType extends AbstractType
+{
+    public function getParent(): string
+    {
+        return HiddenType::class;
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        parent::buildView($view, $form, $options);
+        $view->vars['filter_options'] = $options['filter_options'] ?? [];
+        $view->vars['filter_field_selector'] = $options['filter_field_selector'] ?? null;
+        $view->vars['default_value'] = $options['default_value'] ?? '';
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'label' => false,
+            'required' => false,
+            'filter_options' => [],
+            'filter_field_selector' => null,
+            'default_value' => '',
+            'attr' => [
+                'class' => 'js-filter-link-field',
+            ],
+            'row_attr' => [
+                'class' => 'd-none',
+            ],
+        ]);
+
+        $resolver->setDefined([
+            'filter_field_name',
+        ]);
+
+        $resolver->setAllowedTypes('filter_field_name', 'string');
+        $resolver->setAllowedTypes('filter_options', 'array');
+        $resolver->setAllowedTypes('filter_field_selector', ['string', 'null']);
+        $resolver->setAllowedTypes('default_value', 'string');
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'filter_link';
+    }
+}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/filter_link_group.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/filter_link_group.html.twig
@@ -1,0 +1,60 @@
+{# **
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * #}
+
+{% set filter = grid.filter_form[filter_name] %}
+{% set filter_name = filter_name|default(filter.vars.name) %}
+{% set filter_options = filter.vars.filter_options|default([]) %}
+{% set filter_field_selector = filter.vars.filter_field_selector|default('[data-role="' ~ filter_name ~ '-filter-field"]') %}
+{% set default_value = filter.vars.default_value|default('') %}
+{% set current_value = grid.filters[filter_name]|default(app.request.get(grid.form_prefix) is iterable
+  ? app.request.get(grid.form_prefix).filters[filter_name]|default(app.request.get(grid.form_prefix)[filter_name]|default(default_value))
+  : default_value
+) %}
+{% set container_class = container_class|default('filter-link-group') %}
+{% set item_class = item_class|default('filter-link-group__item') %}
+{% set active_class = active_class|default('is-active') %}
+
+<div
+  class="{{ container_class }}"
+  data-filter-link-group
+  data-filter-field-selector="{{ filter_field_selector }}"
+  data-filter-submit-button-selector=".grid-search-button"
+  data-filter-active-class="{{ active_class }}"
+  data-filter-form-prefix="{{ grid.form_prefix }}"
+  data-filter-initial-value="{{ current_value }}"
+  data-role="{{ filter_name }}-filter"
+>
+  {% for value, label in filter_options %}
+    <a href="#"
+       class="{{ item_class }}{% if current_value == value %} {{ active_class }}{% endif %}"
+       data-filter-value="{{ value }}"
+       role="button"
+       aria-pressed="{{ current_value == value ? 'true' : 'false' }}"
+       style="text-decoration: none;"
+    >
+      {{ label }}
+    </a>
+  {% endfor %}
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Discount/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Discount/index.html.twig
@@ -26,6 +26,10 @@
 
 {% block content %}
   {% block discount_listing %}
+    {{ include('@PrestaShop/Admin/Common/Grid/Blocks/filter_link_group.html.twig', {
+      grid: discountGrid,
+      filter_name: 'period_filter',
+    }) }}
     {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {grid: discountGrid}) }}
   {% endblock %}
 


### PR DESCRIPTION
| Questions         | Answers |
|-------------------|---------|
| Branch?           | develop |
| Description?      | Implement chip-style discount period filter using a reusable JS `FilterLinkGroup` component; render the period links in Twig, hide the persisted filter field, and adjust the Doctrine query to ignore zero-date expirations. |
| Type?             | improvement |
| Category?         | BO |
| BC breaks?        | no |
| Deprecations?     | no |
| How to test?      | `make admin-new-theme`; go to BO > Catalog > Discounts; click each period link (All, Active, Scheduled, Expired); after each reload the underline must stay on the selected link and the grid must show the expected discounts. |
| UI Tests          | https://github.com/tleon/ga.tests.ui.pr/actions/runs/19175812083 |
| Fixed issue or discussion? | Fixes #38665 |
| Related PRs       | n/a |
| Sponsor company   | PrestaShop SA