### PR TITLE
Chore: fix docker entrypoint wait assets script

### DIFF
--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -78,7 +78,7 @@ if [ "${DISABLE_MAKE}" != "1" ]; then
   runuser -g www-data -u www-data -- /var/www/html/tools/assets/build.sh
 
   echo "\n* Wait for assets built...";
-  /usr/bin/make wait-assets
+  runuser -g www-data -u www-data -- /var/www/html/tools/assets/wait-build.sh
 else
   echo "\n* Build of assets was disabled...";
 fi


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR fix an error in the docker entrypoint `make: docker: No such file or directory`
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | `make docker-down` `make docker-start` (CI is :white_check_mark:)
| UI Tests          | [mysql](https://github.com/tyloo/ga.tests.ui.pr/actions/runs/19227841909) / [mariadb](https://github.com/tyloo/ga.tests.ui.pr/actions/runs/19227846500)
| Fixed issue or discussion?     | Fixes #{issue number here}, Fixes #{another issue number here}, Fixes https://github.com/PrestaShop/PrestaShop/discussions/ {discussion number here}
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
