### PR TITLE
Fix: make /attachments/{attachmentId} endpoint work by adding AttachmentId to EditableAttachment and renaming attachmentIdValue to attachmentId in GetAttachmentForEditing

### DIFF
--- a/src/Adapter/Attachment/QueryHandler/GetAttachmentForEditingHandler.php
+++ b/src/Adapter/Attachment/QueryHandler/GetAttachmentForEditingHandler.php
@@ -66,6 +66,7 @@ final class GetAttachmentForEditingHandler implements GetAttachmentForEditingHan
         $file = file_exists($filePath) ? new SplFileInfo($filePath) : null;
 
         $editableAttachment = new EditableAttachment(
+            $query->getAttachmentId(),
             $attachment->file_name,
             $attachment->name,
             $attachment->description

--- a/src/Core/Domain/Attachment/Command/AddAttachmentCommand.php
+++ b/src/Core/Domain/Attachment/Command/AddAttachmentCommand.php
@@ -138,4 +138,32 @@ class AddAttachmentCommand
     {
         return $this->originalName;
     }
+
+    public function setPathName(string $pathName): self
+    {
+        $this->pathName = $pathName;
+
+        return $this;
+    }
+
+    public function setFileSize(int $fileSize): self
+    {
+        $this->fileSize = $fileSize;
+
+        return $this;
+    }
+
+    public function setMimeType(string $mimeType): self
+    {
+        $this->mimeType = $mimeType;
+
+        return $this;
+    }
+
+    public function setOriginalName(string $originalName): self
+    {
+        $this->originalName = $originalName;
+
+        return $this;
+    }
 }

--- a/src/Core/Domain/Attachment/Command/EditAttachmentCommand.php
+++ b/src/Core/Domain/Attachment/Command/EditAttachmentCommand.php
@@ -69,11 +69,11 @@ class EditAttachmentCommand
     private $fileSize;
 
     /**
-     * @param AttachmentId $attachmentId
+     * @param int $attachmentId
      */
-    public function __construct(AttachmentId $attachmentId)
+    public function __construct(int $attachmentId)
     {
-        $this->attachmentId = $attachmentId;
+        $this->attachmentId = new AttachmentId($attachmentId);
     }
 
     /**

--- a/src/Core/Domain/Attachment/Command/EditAttachmentCommand.php
+++ b/src/Core/Domain/Attachment/Command/EditAttachmentCommand.php
@@ -177,4 +177,32 @@ class EditAttachmentCommand
     {
         return $this->fileSize;
     }
+
+    public function setPathName(string $pathName): self
+    {
+        $this->pathName = $pathName;
+
+        return $this;
+    }
+
+    public function setFileSize(int $fileSize): self
+    {
+        $this->fileSize = $fileSize;
+
+        return $this;
+    }
+
+    public function setMimeType(string $mimeType): self
+    {
+        $this->mimeType = $mimeType;
+
+        return $this;
+    }
+
+    public function setOriginalName(string $originalName): self
+    {
+        $this->originalFileName = $originalName;
+
+        return $this;
+    }
 }

--- a/src/Core/Domain/Attachment/Query/GetAttachmentForEditing.php
+++ b/src/Core/Domain/Attachment/Query/GetAttachmentForEditing.php
@@ -40,13 +40,13 @@ class GetAttachmentForEditing
     private $attachmentId;
 
     /**
-     * @param int $attachmentIdValue
+     * @param int $attachmentId
      *
      * @throws AttachmentConstraintException
      */
-    public function __construct(int $attachmentIdValue)
+    public function __construct(int $attachmentId)
     {
-        $this->attachmentId = new AttachmentId($attachmentIdValue);
+        $this->attachmentId = new AttachmentId($attachmentId);
     }
 
     /**

--- a/src/Core/Domain/Attachment/QueryResult/EditableAttachment.php
+++ b/src/Core/Domain/Attachment/QueryResult/EditableAttachment.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Attachment\QueryResult;
 
+use PrestaShop\PrestaShop\Core\Domain\Attachment\ValueObject\AttachmentId;
 use SplFileInfo;
 
 /**
@@ -33,6 +34,11 @@ use SplFileInfo;
  */
 class EditableAttachment
 {
+    /**
+     * @var AttachmentId
+     */
+    private $attachmentId;
+
     /**
      * @var string
      */
@@ -59,10 +65,12 @@ class EditableAttachment
      * @param string[] $description
      */
     public function __construct(
+        AttachmentId $attachmentId,
         string $fileName,
         array $name,
         array $description
     ) {
+        $this->attachmentId = $attachmentId;
         $this->fileName = $fileName;
         $this->name = $name;
         $this->description = $description;
@@ -110,5 +118,10 @@ class EditableAttachment
         $this->file = $file;
 
         return $this;
+    }
+
+    public function getAttachmentId()
+    {
+        return $this->attachmentId;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataHandler/AttachmentFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/AttachmentFormDataHandler.php
@@ -93,7 +93,7 @@ final class AttachmentFormDataHandler implements FormDataHandlerInterface
         /** @var UploadedFile|null $fileObject */
         $fileObject = $data['file'];
 
-        $command = new EditAttachmentCommand($attachmentId);
+        $command = new EditAttachmentCommand($attachmentId->getValue());
         $command->setLocalizedNames($data['name']);
         $command->setLocalizedDescriptions($data['file_description']);
 


### PR DESCRIPTION
Add AttachmentId to EditableAttachment and rename attachmentIdValue to attachmentId in GetAttachmentForEditing (fix /attachments/{attachmentId} endpoint)

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR fixes and extends the handling of attachment entities to support the new `/attachments/{attachmentId}` API endpoint, currently being developed in PrestaShop/ps_apiresources#105.<br/><br/> **🐛 Fixes**<br/>- Fixed the `/attachments/{attachmentId}` endpoint by adding the `AttachmentId` parameter to `EditableAttachment` and renaming `attachmentIdValue` → `attachmentId` in `GetAttachmentForEditing`.<br/>- Ensures correct mapping and retrieval of attachment data for API serialization/deserialization.<br/><br/> **🧱 Refactors**<br/>- **`EditAttachmentCommand`**: constructor now accepts `int $attachmentId` instead of an `AttachmentId` value object, ensuring compatibility with API Platform.<br/>- **`AddAttachmentCommand`** and **`EditAttachmentCommand`**: added setters   `setPathName()`, `setFileSize()`, `setMimeType()`, `setOriginalName()`   to improve flexibility when building commands from uploaded file metadata.
| Type?             |  refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     |
| Related PRs       | https://github.com/PrestaShop/ps_apiresources/pull/105
| Sponsor company   | Codencode snc