### PR TITLE
BO : Adresses : Fixed display of state if there is errors

### DIFF
--- a/admin-dev/themes/new-theme/js/components/country-state-selection-toggler.ts
+++ b/admin-dev/themes/new-theme/js/components/country-state-selection-toggler.ts
@@ -62,7 +62,8 @@ export default class CountryStateSelectionToggler {
     this.$countryStateSelector = $(countryStateSelector);
     this.$countryInput = $(countryInputSelector);
 
-    this.$countryInput.on('change', () => this.change());
+    this.$countryInput.on('change', () => this.onChange());
+    this.onChange();
   }
 
   /**
@@ -70,7 +71,7 @@ export default class CountryStateSelectionToggler {
    *
    * @private
    */
-  private change(): void {
+  private onChange(): void {
     const countryId = this.$countryInput.val();
 
     if (countryId === '') {
@@ -104,9 +105,13 @@ export default class CountryStateSelectionToggler {
   }
 
   toggle(): void {
+    // Display the field State if:
+    // - there is options in the select
+    // - (OR)
+    // - there is error for the field
     this.$stateSelectionBlock.toggleClass(
       'd-none',
-      this.$countryStateSelector.find('option').length === 0,
+      this.$countryStateSelector.find('option').length === 0 && !this.$stateSelectionBlock.hasClass('has-error'),
     );
   }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | BO : Adresses : Fixed display of state if there is errors
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | :arrow_down: 
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/19296701809
| Fixed issue or discussion?     | Fixes #31329
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

## How to test ?
* Select a country in "International -> Locations -> Countries" (ex: :afghanistan: Afghanistan)
* Enable "Contains states"
* Verify that the country in "International -> Locations -> States" don't have any State assigned
* Create new Address for a customer in "Customers -> Addresses"
* The form doesn't display the field "State"
* Fill all required fields (and choose Country "Afghanistan")
* Save
* **BEFORE** : The address is not saved, but no error message
* **AFTER** : An error message is now displayed <img width="1009" height="145" alt="image" src="https://github.com/user-attachments/assets/88341d66-a7ff-45f5-8188-b980c68b9d6e" />
