### PR TITLE
Remove module tabs on module uninstallation

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -895,6 +895,9 @@ abstract class ModuleCore implements ModuleInterface
      * Uninstalls the module from database.
      *
      * @return bool result
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      */
     public function uninstall()
     {
@@ -963,6 +966,10 @@ abstract class ModuleCore implements ModuleInterface
 
         // Remove restrictions for client groups
         Group::truncateRestrictionsByModule($this->id);
+
+        // Remove module tabs
+        $tabs = Tab::getCollectionFromModule($this->name)->getResults();
+        array_map(static fn(Tab $tab) => $tab->delete(), $tabs);
 
         // Uninstall the module
         if (Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'module` WHERE `id_module` = ' . (int) $this->id)) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Function already delete several things associated to a module. Deleting its tabs it creates on installation is a logical thing to do.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install a module that creates new tabs. Uninstall the module. Check it disappeared from sidebar after refreshing the BO page.
| UI Tests          | NA
| Fixed issue or discussion?     | NA
| Related PRs       | NA
| Sponsor company   | Evolutive
