### PR TITLE
BO : Product SEO - Display attribute in SEO preview

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/serp/index.js
+++ b/admin-dev/themes/new-theme/js/app/utils/serp/index.js
@@ -64,6 +64,8 @@ class SerpApp {
       description: '',
     };
 
+    this.appendTitle = selectors.appendTitle ? $(selectors.appendTitle).val() : '';
+
     this.initializeSelectors(selectors);
     this.attachInputEvents();
   }
@@ -152,7 +154,7 @@ class SerpApp {
     const title1 = watchedTitle.length ? watchedTitle.val() : '';
     const title2 = defaultTitle.length ? defaultTitle.val() : '';
 
-    this.setTitle(title1 === '' ? title2 : title1);
+    this.setTitle(`${title1 === '' ? title2 : title1}${this.appendTitle ? ` ${this.appendTitle}` : ''}`);
     // Always check for url if title change
     this.checkUrl();
     this.updateComponent();

--- a/admin-dev/themes/new-theme/js/pages/product/edit/manager/product-seo-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/manager/product-seo-manager.ts
@@ -70,6 +70,7 @@ export default class ProductSEOManager {
         container: ProductMap.seo.container,
         defaultTitle: ProductMap.seo.defaultTitle,
         watchedTitle: ProductMap.seo.watchedTitle,
+        appendTitle: ProductMap.seo.appendTitle,
         defaultDescription: ProductMap.seo.defaultDescription,
         watchedDescription: ProductMap.seo.watchedDescription,
         watchedMetaUrl: ProductMap.seo.watchedMetaUrl,

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -272,6 +272,7 @@ export default {
     container: '#product_seo_serp',
     defaultTitle: '.serp-default-title:input',
     watchedTitle: '.serp-watched-title:input',
+    appendTitle: '#product_seo_combination_title',
     defaultDescription: '.serp-default-description',
     watchedDescription: '.serp-watched-description',
     watchedMetaUrl: '.serp-watched-url:input',

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -31,6 +31,10 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
 use PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\FeaturesChoiceProvider;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\GetCombinationForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\GetCombinationIds;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query\GetProductCustomizationFields;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\QueryResult\CustomizationField;
 use PrestaShop\PrestaShop\Core\Domain\Product\FeatureValue\Query\GetProductFeatureValues;
@@ -133,7 +137,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
             'details' => $this->extractDetailsData($productForEditing, $shopConstraint),
             'stock' => $this->extractStockData($productForEditing, $shopConstraint),
             'pricing' => $this->extractPricingData($productForEditing),
-            'seo' => $this->extractSEOData($productForEditing),
+            'seo' => $this->extractSEOData($productForEditing, $shopConstraint),
             'shipping' => $this->extractShippingData($productForEditing),
             'options' => $this->extractOptionsData($productForEditing),
         ];
@@ -507,17 +511,34 @@ class ProductFormDataProvider implements FormDataProviderInterface
      *
      * @return array
      */
-    private function extractSEOData(ProductForEditing $productForEditing): array
+    private function extractSEOData(ProductForEditing $productForEditing, ShopConstraint $shopConstraint): array
     {
         $seoOptions = $productForEditing->getProductSeoOptions();
 
-        return [
+        $seoData = [
             'meta_title' => $seoOptions->getLocalizedMetaTitles(),
             'meta_description' => $seoOptions->getLocalizedMetaDescriptions(),
             'link_rewrite' => $seoOptions->getLocalizedLinkRewrites(),
             'redirect_option' => $this->extractRedirectOptionData($productForEditing),
             'tags' => $this->presentTags($productForEditing->getBasicInformation()->getLocalizedTags()),
         ];
+        if ($productForEditing->getType() === ProductType::TYPE_COMBINATIONS) {
+            if ((bool) $this->configuration->get('PS_PRODUCT_ATTRIBUTES_IN_TITLE')) {
+                /** @var CombinationId[] $combinationIds */
+                $combinationIds = $this->queryBus->handle(
+                    new GetCombinationIds($productForEditing->getProductId(), $shopConstraint, 1)
+                );
+                if (!empty($combinationIds)) {
+                    /** @var CombinationForEditing $combinationForEditing */
+                    $combinationForEditing = $this->queryBus->handle(
+                        new GetCombinationForEditing($combinationIds[0]->getValue(), $shopConstraint)
+                    );
+                    $seoData['combination_title'] = $combinationForEditing->getName();
+                }
+            }
+        }
+
+        return $seoData;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ProductSettings;
 use PrestaShopBundle\Form\Admin\Type\TextWithLengthCounterType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -108,6 +109,7 @@ class SEOType extends TranslatorAwareType
 
         $builder
             ->add('serp', SerpType::class)
+            ->add('combination_title', HiddenType::class)
             ->add('meta_title', TranslatableType::class, [
                 'label' => $this->trans('Meta title', 'Admin.Catalog.Feature'),
                 'label_help_box' => $this->trans('Public title that may appear in the browser and search engines. The recommended length is about 60 characters (including spaces). If you leave it blank, the product name will be used.', 'Admin.Catalog.Help'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | BO : Product SEO - Display attribute in SEO preview
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | :arrow_down:
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/19344907650
| Fixed issue or discussion?     | Fixes #18134
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

## How to test ?
1. BO > SEO and URL > SEO setting > Set show attributes in the product meta title to YES.
2. Go to Catalog > Products > Edit a product "Hummingbird printed t-shirt"
3. Tab - SEO : Check the preview
4. **BEFORE** Meta title preview does not contain attribute preview.
5. **AFTER** Meta title preview contains attribute preview.