### PR TITLE
Remove extra join

### DIFF
--- a/src/Adapter/Form/ChoiceProvider/OrderCountriesChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/OrderCountriesChoiceProvider.php
@@ -47,17 +47,15 @@ final class OrderCountriesChoiceProvider implements FormChoiceProviderInterface
         }
 
         $countries = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
-			SELECT c.id_country, cl.`name`
-            FROM `' . _DB_PREFIX_ . 'country` c
-            INNER JOIN `' . _DB_PREFIX_ . 'country_lang` cl
-			    ON (c.`id_country` = cl.`id_country` AND cl.`id_lang` = ' . (int) Context::getContext()->language->id . ')
+			SELECT cl.id_country, cl.`name`
+            FROM `' . _DB_PREFIX_ . 'country_lang` cl
             WHERE EXISTS (
                 SELECT 1
                 FROM `' . _DB_PREFIX_ . 'orders` o
                 INNER JOIN `' . _DB_PREFIX_ . 'address` a
 			        ON a.id_address = o.id_address_delivery
-                WHERE a.id_country = c.id_country
-            )
+                WHERE a.id_country = cl.id_country
+            ) AND cl.`id_lang` = ' . (int) Context::getContext()->language->id . '
 			ORDER BY cl.name ASC'
         );
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Improvement of https://github.com/PrestaShop/PrestaShop/pull/39900, could not comment in time. Removes extra join that is not needed. If a record in lang table is missing, the country would be excluded anyway.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Auto test
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.