### PR TITLE
BO : Product (Virtual) : Set number of days without expiration date

### DIFF
--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -256,9 +256,11 @@ class GetFileControllerCore extends FrontController
                 $this->displayCustomError('The product deadline is in the past.');
             }
 
-            $customer_deadline = (int) strtotime($info['date_expiration']);
-            if ($now > $customer_deadline && $info['date_expiration'] != '0000-00-00 00:00:00') {
-                $this->displayCustomError('Expiration date has passed, you cannot download this product');
+            if ($info['date_expiration'] !== '0000-00-00 00:00:00') {
+                $customer_deadline = (int) strtotime($info['date_expiration']);
+                if ($now > $customer_deadline) {
+                    $this->displayCustomError('Expiration date has passed, you cannot download this product');
+                }
             }
 
             if ($info['download_nb'] >= $info['nb_downloadable'] && $info['nb_downloadable']) {

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/VirtualProductFileCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/VirtualProductFileCommandsBuilder.php
@@ -89,7 +89,9 @@ final class VirtualProductFileCommandsBuilder implements ProductCommandsBuilderI
             $virtualProductFileData['name'],
             isset($virtualProductFileData['access_days_limit']) ? (int) $virtualProductFileData['access_days_limit'] : null,
             isset($virtualProductFileData['download_times_limit']) ? (int) $virtualProductFileData['download_times_limit'] : null,
-            isset($virtualProductFileData['expiration_date']) ? new DateTime($virtualProductFileData['expiration_date']) : null
+            isset($virtualProductFileData['expiration_date']) && $virtualProductFileData['expiration_date'] !== ''
+             ? new DateTime($virtualProductFileData['expiration_date'])
+             : null
         );
     }
 

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/VirtualProductFileCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/VirtualProductFileCommandsBuilderTest.php
@@ -92,6 +92,30 @@ class VirtualProductFileCommandsBuilderTest extends AbstractProductCommandBuilde
             $dummyFile->getPathname(),
             'The file',
             1,
+            5
+        );
+        yield [
+            [
+                'stock' => [
+                    'virtual_product_file' => [
+                        'has_file' => true,
+                        'virtual_product_file_id' => null,
+                        'file' => $dummyFile,
+                        'name' => 'The file',
+                        'access_days_limit' => 1,
+                        'download_times_limit' => 5,
+                        'expiration_date' => null,
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new AddVirtualProductFileCommand(
+            $this->getProductId()->getValue(),
+            $dummyFile->getPathname(),
+            'The file',
+            1,
             5,
             new DateTimeImmutable('2020-10-20')
         );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | BO : Product (Virtual) : Set number of days without expiration date
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | :arrow_down: 
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/19365100952
| Fixed issue or discussion?     | Fixes #34935
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

## How to test ?

1. Go to BO > Advanced Parameters > Configure your email to receive them
2. Enable Add downloadable file > Add a download to a virtual product
3. Add Number of allowed downloads = 1
4. Add Number of days = 5
5. In FO > Log into a customer account
6. Add this product to your cart > Process to checkout
7. In BO > Change status to Payment accepted
8. In FO > Check details or order 
9. :arrow_down: 
   *  **BEFORE** : Download your file > Error "Expiration date has passed, you cannot download this product" ❌ 
   *  **AFTER** : Download your file > :+1:  
10. In your email check the email "The virtual product that you bought is available for download"
11. Click on the download link:
    *  **BEFORE** : :x:
    *  **AFTER** :  :+1:  