### PR TITLE
Fix redirect after editing root category to use current categoryId in stead of PS_HOME_CATEGORY

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -375,7 +375,7 @@ class CategoryController extends PrestaShopAdminController
                 $this->addFlash('success', $this->trans('Successful update', [], 'Admin.Notifications.Success'));
 
                 return $this->redirectToRoute('admin_categories_index', [
-                    'categoryId' => (int) $this->getConfiguration()->get('PS_ROOT_CATEGORY'),
+                    'categoryId' => $categoryId,
                 ]);
             }
         } catch (Exception $e) {

--- a/tests/UI/campaigns/functional/BO/03_catalog/02_categories/08_editHomeCategory.ts
+++ b/tests/UI/campaigns/functional/BO/03_catalog/02_categories/08_editHomeCategory.ts
@@ -19,15 +19,13 @@ import {
 
 const baseContext: string = 'functional_BO_catalog_categories_editHomeCategory';
 
-// Edit home category
 describe('BO - Catalog - Categories : Edit home category', async () => {
   let browserContext: BrowserContext;
   let page: Page;
   let categoryID: number;
 
-  const editCategoryData: FakerCategory = new FakerCategory({name: 'Home'});
+  const editCategoryData: FakerCategory = new FakerCategory({name: 'Home 123'});
 
-  // before and after functions
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
     page = await utilsPlaywright.newTab(browserContext);
@@ -77,14 +75,14 @@ describe('BO - Catalog - Categories : Edit home category', async () => {
   it('should update the category', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'updateCategory', baseContext);
 
+    categoryID = await boCategoriesCreatePage.getIDCategory(page);
+
     const textResult = await boCategoriesCreatePage.editHomeCategory(page, editCategoryData);
-    expect(textResult).to.equal(boCategoriesPage.pageRootTitle);
+    expect(textResult).to.equal(boCategoriesPage.pageTitle);
   });
 
   it('should go to FO and check the updated category', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'checkCreatedCategoryFO', baseContext);
-
-    categoryID = parseInt(await boCategoriesPage.getTextColumnFromTableCategories(page, 1, 'id_category'), 10);
     // View Shop
     page = await boCategoriesPage.viewMyShop(page);
     // Change FO language
@@ -125,15 +123,6 @@ describe('BO - Catalog - Categories : Edit home category', async () => {
     page = await foClassicCategoryPage.closePage(browserContext, page, 0);
 
     const pageTitle = await boCategoriesPage.getPageTitle(page);
-    expect(pageTitle).to.contains(boCategoriesPage.pageRootTitle);
-  });
-
-  it('should click on view category', async function () {
-    await testContext.addContextItem(this, 'testIdentifier', 'goToViewCreatedCategoryPage', baseContext);
-
-    await boCategoriesPage.goToViewSubCategoriesPage(page, 1);
-
-    const pageTitle = await boCategoriesPage.getPageTitle(page);
     expect(pageTitle).to.contains(boCategoriesPage.pageTitle);
   });
 
@@ -150,6 +139,6 @@ describe('BO - Catalog - Categories : Edit home category', async () => {
     await testContext.addContextItem(this, 'testIdentifier', 'resetUpdateCategory', baseContext);
 
     const textResult = await boCategoriesCreatePage.editHomeCategory(page, dataCategories.home);
-    expect(textResult).to.equal(boCategoriesPage.pageRootTitle);
+    expect(textResult).to.equal(boCategoriesPage.pageTitle);
   });
 });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This change fixes the redirect behavior after updating the root category.<br/>The controller previously used `PS_HOME_CATEGORY`, causing a redirect to the home category instead of the category that was actually edited.<br/>It now uses `$categoryId`, ensuring a consistent redirect back to the category that was just saved.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to Catalog > Categories.<br/> 2. Click on edit the current category.<br/> 3. Save and you will be redirected to the page showing the list of top-level categories.
| UI Tests          | 🟢 https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/19765037712
| Fixed issue or discussion?     | Fixes #36999
| Related PRs       | 
| Sponsor company   | Codencode snc
