### PR TITLE
Enhance logo handling for SVG support and size conversion

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1654,13 +1654,61 @@ class FrontControllerCore extends Controller
             return [];
         }
 
-        list($logoWidth, $logoHeight) = getimagesize($logoFileDir);
+        $ext = pathinfo($logoFileDir, PATHINFO_EXTENSION);
+        if ($ext == 'svg') {
+            $svg = new DomDocument();
+            $svg->load($logoFileDir);
+            $logoWidth = $this->getPixelValue($svg->documentElement->getAttribute('width'));
+            $logoHeight = $this->getPixelValue($svg->documentElement->getAttribute('height'));
+            /* If width and height is not explicitly set, use the aspect ratio from the viewBox attribute as base size */
+            if (!$logoWidth || !$logoHeight) {
+                $viewBox = preg_split('/[\s,]+/', $svg->documentElement->getAttribute('viewBox') ?: '');
+                $logoWidth = (int) (round($viewBox[2]) ?? 0);
+                $logoHeight = (int) (round($viewBox[3]) ?? 0);
+            }
+        } else {
+            list($logoWidth, $logoHeight) = getimagesize($logoFileDir);
+        }
 
         return [
             'src' => ($this->getTemplateVarUrls()['img_ps_url'] ?? _PS_IMG_) . $logoFileName,
             'width' => $logoWidth,
             'height' => $logoHeight,
         ];
+    }
+
+    /**
+     * Converts sizes like 2em, 10cm or 12pt to pixels.
+     *
+     * @return int
+     */
+    private function getPixelValue(string $size): int
+    {
+        $map = [
+            'px' => 1,
+            'em' => 16,
+            'ex' => 16 / 2,
+            'pt' => 16 / 12,
+            'pc' => 16,
+            'in' => 16 * 6,
+            'cm' => 16 / (2.54 / 6),
+            'mm' => 16 / (25.4 / 6),
+        ];
+
+        $size = trim($size);
+
+        $value = substr($size, 0, -2);
+        $unit = substr($size, -2);
+
+        if (is_numeric($value) && isset($map[$unit])) {
+            $pixelValue = ((float) $value) * $map[$unit];
+        } elseif (is_numeric($size)) {
+            $pixelValue = (float) $size;
+        } else {
+            $pixelValue = 0;
+        }
+
+        return (int) round($pixelValue);
     }
 
     public function getCoreJsPublicPath()

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1663,8 +1663,8 @@ class FrontControllerCore extends Controller
             /* If width and height is not explicitly set, use the aspect ratio from the viewBox attribute as base size */
             if (!$logoWidth || !$logoHeight) {
                 $viewBox = preg_split('/[\s,]+/', $svg->documentElement->getAttribute('viewBox') ?: '');
-                $logoWidth = (int) (round($viewBox[2]) ?? 0);
-                $logoHeight = (int) (round($viewBox[3]) ?? 0);
+                $logoWidth = (round((float) $viewBox[2]) ?? 0);
+                $logoHeight = (round((float) $viewBox[3]) ?? 0);
             }
         } else {
             list($logoWidth, $logoHeight) = getimagesize($logoFileDir);


### PR DESCRIPTION
When logo format is SVG the logo_details array used in themes can't be calculated (smarty function renderLogo in templates/_partials/helpers.tpl).
Added support for SVG logos by extracting width and height from the SVG attributes.
Introduced a new method to convert various size units to pixels.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | Any
| Description?      | When logo format is SVG the logo_details array used in themes can't be calculated (smarty function renderLogo in templates/_partials/helpers.tpl). This PR fixes it.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Upload an SVG logo to use in the site header. Check it's invisible because the html size tags aren't set. Apply this patch & chack again.
| Author   | Giuseppe Tripiciano
