### PR TITLE
Fix: Backoffice: Cannot navigate on the login page with the keyboard

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/login/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/login/index.ts
@@ -52,4 +52,23 @@ onReady(() => {
   });
 
   new EmailInput();
+
+  const checkbox = document.querySelector<HTMLInputElement>(LoginFormMap.stayLoggedInCheckbox);
+
+  if (checkbox) {
+    const label = checkbox.labels?.[0];
+
+    if (label) {
+      label.setAttribute('tabindex', '0');
+
+      label.addEventListener('keydown', (event: KeyboardEvent) => {
+        if (event.key === ' ' || event.key === 'Spacebar' || event.key === 'Enter') {
+          event.preventDefault();
+          checkbox.checked = !checkbox.checked;
+          label.setAttribute('aria-checked', checkbox.checked ? 'true' : 'false');
+          checkbox.dispatchEvent(new Event('change', {bubbles: true}));
+        }
+      });
+    }
+  }
 });

--- a/admin-dev/themes/new-theme/js/pages/login/login-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/login/login-map.ts
@@ -36,4 +36,5 @@ export default {
   resetNewPasswordConfirmation: '#reset_password_new_password_second',
   resetSubmitButton: '#reset_password_submit_login',
   alertMessages: '.card-body .alert',
+  stayLoggedInCheckbox: '#stay_logged_in',
 };

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -381,7 +381,7 @@ class CategoryController extends PrestaShopAdminController
                 $this->addFlash('success', $this->trans('Successful update', [], 'Admin.Notifications.Success'));
 
                 return $this->redirectToRoute('admin_categories_index', [
-                    'categoryId' => (int) $this->getConfiguration()->get('PS_ROOT_CATEGORY'),
+                    'categoryId' => $categoryId,
                 ]);
             }
         } catch (Exception $e) {

--- a/src/PrestaShopBundle/Form/Admin/Login/LoginType.php
+++ b/src/PrestaShopBundle/Form/Admin/Login/LoginType.php
@@ -82,6 +82,9 @@ class LoginType extends AbstractType
             ->add('stay_logged_in', CheckboxType::class, [
                 'label' => $this->translator->trans('Stay logged in', [], 'Admin.Login.Feature'),
                 'required' => false,
+                'label_attr' => [
+                    'tabindex' => '0',
+                ],
                 'external_link' => [
                     'href' => '#forgotten_password',
                     'text' => $this->translator->trans('I forgot my password', [], 'Admin.Login.Feature'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Adds the stay_logged_in checkbox selector to LoginFormMap so it can be referenced and handled in the login page JavaScript. This improves consistency with other form elements and enables proper keyboard/focus behavior.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Open the Back Office login page.<br> 2. Press TAB until the focus reaches the “Stay connected” label.<br> 3. Press ENTER or SPACEBAR.<br> 4. Verify that the checkbox is correctly toggled on and off.
| UI Tests          |
| Fixed issue or discussion?     | Fixes #40000, fixes https://github.com/PrestaShop/PrestaShop/issues/37390
| Related PRs       | 
| Sponsor company   | Codencode snc
