### PR TITLE
Check if function exec is disabled in ExecKernelCacheClearer

### DIFF
--- a/src/Adapter/Cache/Clearer/SafeLoggerTrait.php
+++ b/src/Adapter/Cache/Clearer/SafeLoggerTrait.php
@@ -42,6 +42,15 @@ trait SafeLoggerTrait
         }
     }
 
+    protected function logWarning(string $message): void
+    {
+        try {
+            $this->logger->warning($message);
+        } catch (Throwable) {
+            // Prevent the logger from raising an exception and breaking the cache clear
+        }
+    }
+
     protected function logInfo(string $message): void
     {
         try {

--- a/src/Adapter/Cache/Clearer/Symfony/ExecKernelCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/Symfony/ExecKernelCacheClearer.php
@@ -54,6 +54,16 @@ class ExecKernelCacheClearer implements KernelCacheClearerInterface
 
     public function clearKernelCache(AppKernel $kernel, string $environment): bool
     {
+        if ($this->isExecDisabled()) {
+            $this->logWarning(sprintf(
+                'ExecKernelCacheClearer: Could not clear cache for %s env %s because exec function is disabled',
+                $kernel->getAppId(),
+                $environment,
+            ));
+
+            return false;
+        }
+
         if (!$this->clearCache($kernel, $environment)) {
             return false;
         }
@@ -106,5 +116,13 @@ class ExecKernelCacheClearer implements KernelCacheClearerInterface
         $this->logInfo(sprintf($successMessage, $kernel->getAppId()));
 
         return true;
+    }
+
+    protected function isExecDisabled(): bool
+    {
+        $disabledFunctions = explode(',', ini_get('disable_functions'));
+        array_walk($disabledFunctions, fn ($disabledFunction) => trim($disabledFunction));
+
+        return in_array('exec', $disabledFunctions);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Check if function exec is disabled in ExecKernelCacheClearer, the check should be optional since we always catch for errors but in some server configuration the function may be disabled AND error setting force a fatal error so it's safer to check (and maybe a bit more optimized)
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See issue, probably should be tested by a dev since it implies chaning environment settings
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/19428764776
| Fixed issue or discussion?     | Fixes #39922
| Related PRs       | ~
| Sponsor company   | ~
