### PR TITLE
Initialize dispatcher early and fix all $_FILES issues

### DIFF
--- a/admin-api/index.php
+++ b/admin-api/index.php
@@ -70,6 +70,15 @@ $kernel = new AdminAPIKernel(_PS_ENV_, _PS_MODE_DEV_);
 // When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter
 //Request::enableHttpMethodParameterOverride();
 $request = Request::createFromGlobals();
+
+/*
+ * Initialize legacy dispatcher request at the initial stage of the request. If we don't do it now,
+ * the dispatcher could be created later by legacy classes. But, at that point, the request
+ * could already be modified, for examply by move_uploaded_file. That would cause createFromGlobals
+ * to crash.
+ */
+Dispatcher::setRequest($request);
+
 Request::setTrustedProxies([], Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO);
 
 $response = $kernel->handle($request, HttpKernelInterface::MAIN_REQUEST, true);

--- a/admin-dev/index.php
+++ b/admin-dev/index.php
@@ -78,6 +78,15 @@ $kernel = new AdminKernel(_PS_ENV_, _PS_MODE_DEV_);
 // When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter
 Request::enableHttpMethodParameterOverride();
 $request = Request::createFromGlobals();
+
+/*
+ * Initialize legacy dispatcher request at the initial stage of the request. If we don't do it now,
+ * the dispatcher could be created later by legacy classes. But, at that point, the request
+ * could already be modified, for examply by move_uploaded_file. That would cause createFromGlobals
+ * to crash.
+ */
+Dispatcher::setRequest($request);
+
 Request::setTrustedProxies([], Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO);
 
 $response = $kernel->handle($request, HttpKernelInterface::MAIN_REQUEST, true);

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -44,7 +44,7 @@ class DispatcherCore
     /**
      * @var SymfonyRequest
      */
-    private $request;
+    private static $request;
 
     /**
      * @var array List of default routes
@@ -178,6 +178,16 @@ class DispatcherCore
     protected $front_controller = self::FC_FRONT;
 
     /**
+     * Initializes a request into the dispatcher. This should be done
+     * at the early stages of the application, before anything has a chance
+     * to modify the request.
+     */
+    public static function setRequest(SymfonyRequest $request)
+    {
+        self::$request = $request;
+    }
+
+    /**
      * Get current instance of dispatcher (singleton).
      *
      * @return Dispatcher
@@ -187,10 +197,22 @@ class DispatcherCore
     public static function getInstance(?SymfonyRequest $request = null)
     {
         if (!self::$instance) {
-            if (null === $request) {
-                $request = SymfonyRequest::createFromGlobals();
+            /*
+             * To run a Dispatcher, we will need a Symfony Request object. We can get it in several ways.
+             * 1. The best option is if it was set before by the application using Dispatcher::setRequest() method.
+             *    That ensures the request is exactly what the application wants to use.
+             * 2. If not set, we can use the request provided as parameter to getInstance() method.
+             * 3. Finally, if no request was provided, we create it from globals. However, this could be sometimes
+             *    dangerous and provide unexpected results, when a request data was already modified by the application.
+             */
+            if (self::$request == null) {
+                if (null !== $request) {
+                    self::$request = $request;
+                } else {
+                    self::$request = SymfonyRequest::createFromGlobals();
+                }
             }
-            self::$instance = new Dispatcher($request);
+            self::$instance = new Dispatcher();
         }
 
         return self::$instance;
@@ -199,14 +221,10 @@ class DispatcherCore
     /**
      * Needs to be instantiated from getInstance() method.
      *
-     * @param SymfonyRequest|null $request
-     *
      * @throws PrestaShopException
      */
-    protected function __construct(?SymfonyRequest $request = null)
+    protected function __construct()
     {
-        $this->setRequest($request);
-
         $this->use_routes = (bool) Configuration::get('PS_REWRITING_SETTINGS');
 
         // Select right front controller
@@ -236,27 +254,13 @@ class DispatcherCore
     }
 
     /**
-     * Either sets a given request or a new one.
-     *
-     * @param SymfonyRequest|null $request
-     */
-    private function setRequest(?SymfonyRequest $request = null)
-    {
-        if (null === $request) {
-            $request = SymfonyRequest::createFromGlobals();
-        }
-
-        $this->request = $request;
-    }
-
-    /**
      * Returns the request property.
      *
      * @return SymfonyRequest
      */
     private function getRequest()
     {
-        return $this->request;
+        return self::$request;
     }
 
     /**

--- a/index.php
+++ b/index.php
@@ -59,6 +59,14 @@ if (isset($_ENV['PS_FF_FRONT_CONTAINER_V2']) && filter_var($_ENV['PS_FF_FRONT_CO
     $kernel = new FrontKernel(_PS_ENV_, _PS_MODE_DEV_);
     $request = Request::createFromGlobals();
 
+    /*
+     * Initialize legacy dispatcher request at the initial stage of the request. If we don't do it now,
+     * the dispatcher could be created later by legacy classes. But, at that point, the request
+     * could already be modified, for examply by move_uploaded_file. That would cause createFromGlobals
+     * to crash.
+     */
+    Dispatcher::setRequest($request);
+
     // Try to handle request
     try {
         $response = $kernel->handle($request, HttpKernelInterface::MAIN_REQUEST, false);

--- a/src/Core/Form/IdentifiableObject/DataHandler/EmployeeFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/EmployeeFormDataHandler.php
@@ -234,23 +234,6 @@ final class EmployeeFormDataHandler implements FormDataHandlerInterface
             $this->legacyContextCookie->write();
         }
 
-        /**
-         * IMPORTANT : Apply all validations before file upload
-         *
-         * During avatar upload, EmployeeController::editAction takes image path
-         * from `$_FILES["employee"]["tmp_name"]["avatarUrl"]`
-         * But AbstractImageUploader::createTemporaryImage($image) executes
-         * `move_uploaded_file($image->getPathname(), $temporaryImageName))`
-         * that removes the image but keep $_FILES["employee"]["tmp_name"]["avatarUrl"] value.
-         *
-         * During data validation (`setXXX($value)` apply validation),
-         * any error would break the workflow and call `render(...)`
-         * (cf. EmployeeController::editAction).
-         * But `DispatcherCore::getInstance(...)` runs
-         * `$request = SymfonyRequest::createFromGlobals()` that take `$_FILES` global variable.
-         * Then during Request object creation,
-         * `$_FILES["employee"]["tmp_name"]["avatarUrl"]` is detected as invalid.
-         */
         /** @var UploadedFile $uploadedAvatar */
         $uploadedAvatar = $data['avatarUrl'];
         if ($uploadedAvatar instanceof UploadedFile) {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 
 use Category;
-use Dispatcher;
 use Exception;
 use ImageManager;
 use PrestaShop\PrestaShop\Adapter\Category\CategoryDataProvider;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -307,11 +307,6 @@ class CategoryController extends PrestaShopAdminController
 
         $defaultGroups = $defaultGroupsProvider->getGroups();
 
-        // If we don't create the dispatcher instance with the current request,
-        // a new instance will be created later using `SymfonyRequest::createFromGlobals()`
-        // but as we may have already uploaded files, this can throw an exception
-        Dispatcher::getInstance($request);
-
         return $this->render(
             '@PrestaShop/Admin/Sell/Catalog/Categories/edit.html.twig',
             [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Dispatcher can be initialized too late and call request builder with malformed data. This makes sure it's done at the beginning of the request.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See the related issue.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/19618799004
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/40022
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.
