### PR TITLE
Add new condition types

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -509,7 +509,7 @@ class ProductCore extends ObjectModel
             'available_for_order' => ['type' => self::TYPE_BOOL, 'shop' => true, 'validate' => 'isBool'],
             'available_date' => ['type' => self::TYPE_DATE, 'shop' => true, 'validate' => 'isDateFormat'],
             'show_condition' => ['type' => self::TYPE_BOOL, 'shop' => true, 'validate' => 'isBool'],
-            'condition' => ['type' => self::TYPE_STRING, 'shop' => true, 'validate' => 'isGenericName', 'values' => ['new', 'used', 'refurbished'], 'default' => 'new'],
+            'condition' => ['type' => self::TYPE_STRING, 'shop' => true, 'validate' => 'isGenericName', 'values' => ['new', 'used', 'refurbished', 'open_box', 'damaged', 'new_with_defects'], 'default' => 'new'],
             'show_price' => ['type' => self::TYPE_BOOL, 'shop' => true, 'validate' => 'isBool'],
             'indexed' => ['type' => self::TYPE_BOOL, 'shop' => true, 'validate' => 'isBool'],
             'visibility' => ['type' => self::TYPE_STRING, 'shop' => true, 'validate' => 'isProductVisibility', 'values' => ['both', 'catalog', 'search', 'none'], 'default' => 'both'],

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1661,7 +1661,7 @@ CREATE TABLE `PREFIX_product` (
   `available_for_order` tinyint(1) NOT NULL DEFAULT '1',
   `available_date` date DEFAULT NULL,
   `show_condition` tinyint(1) NOT NULL DEFAULT '0',
-  `condition` ENUM('new', 'used', 'refurbished') NOT NULL DEFAULT 'new',
+  `condition` ENUM('new', 'used', 'refurbished', 'open_box', 'damaged', 'new_with_defects') NOT NULL DEFAULT 'new',
   `show_price` tinyint(1) NOT NULL DEFAULT '1',
   `indexed` tinyint(1) NOT NULL DEFAULT '0',
   `visibility` ENUM(
@@ -1721,7 +1721,7 @@ CREATE TABLE IF NOT EXISTS `PREFIX_product_shop` (
   `available_for_order` tinyint(1) NOT NULL DEFAULT '1',
   `available_date` date DEFAULT NULL,
   `show_condition` tinyint(1) NOT NULL DEFAULT '1',
-  `condition` enum('new', 'used', 'refurbished') NOT NULL DEFAULT 'new',
+  `condition` enum('new', 'used', 'refurbished', 'open_box', 'damaged', 'new_with_defects') NOT NULL DEFAULT 'new',
   `show_price` tinyint(1) NOT NULL DEFAULT '1',
   `indexed` tinyint(1) NOT NULL DEFAULT '0',
   `visibility` enum(

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -310,6 +310,24 @@ class ProductLazyArray extends AbstractLazyArray
                     ),
                     'schema_url' => 'https://schema.org/RefurbishedCondition',
                 ];
+            case 'damaged':
+                return [
+                    'type' => 'damaged',
+                    'label' => $this->translator->trans('Damaged', [], 'Shop.Theme.Catalog'),
+                    'schema_url' => 'https://schema.org/DamagedCondition',
+                ];
+            case 'open_box':
+                return [
+                    'type' => 'open_box',
+                    'label' => $this->translator->trans('New, open box', [], 'Shop.Theme.Catalog'),
+                    'schema_url' => 'https://schema.org/NewCondition',
+                ];
+            case 'new_with_defects':
+                return [
+                    'type' => 'new_with_defects',
+                    'label' => $this->translator->trans('New, minor defects', [], 'Shop.Theme.Catalog'),
+                    'schema_url' => 'https://schema.org/NewCondition',
+                ];
             default:
                 return false;
         }

--- a/src/Core/Domain/Product/ValueObject/ProductCondition.php
+++ b/src/Core/Domain/Product/ValueObject/ProductCondition.php
@@ -38,6 +38,9 @@ class ProductCondition
     public const NEW = 'new';
     public const USED = 'used';
     public const REFURBISHED = 'refurbished';
+    public const OPEN_BOX = 'open_box';
+    public const DAMAGED = 'damaged';
+    public const NEW_WITH_DEFECTS = 'new_with_defects';
 
     /**
      * A list of available values
@@ -46,6 +49,9 @@ class ProductCondition
         self::NEW,
         self::USED,
         self::REFURBISHED,
+        self::OPEN_BOX,
+        self::DAMAGED,
+        self::NEW_WITH_DEFECTS,
     ];
 
     /**

--- a/src/Core/Form/ChoiceProvider/ProductConditionChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/ProductConditionChoiceProvider.php
@@ -55,8 +55,11 @@ final class ProductConditionChoiceProvider implements FormChoiceProviderInterfac
     {
         return [
             $this->translator->trans('New', [], 'Admin.Catalog.Feature') => ProductCondition::NEW,
+            $this->translator->trans('New, open box', [], 'Admin.Catalog.Feature') => ProductCondition::OPEN_BOX,
+            $this->translator->trans('New, minor defects', [], 'Admin.Catalog.Feature') => ProductCondition::NEW_WITH_DEFECTS,
             $this->translator->trans('Used', [], 'Admin.Catalog.Feature') => ProductCondition::USED,
             $this->translator->trans('Refurbished', [], 'Admin.Catalog.Feature') => ProductCondition::REFURBISHED,
+            $this->translator->trans('Damaged', [], 'Admin.Catalog.Feature') => ProductCondition::DAMAGED,
         ];
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | New take on conditions, after people blocking the PR are gone from PrestaShop SA. Adds three new conditon types to account for common business scenarios. Inspired by experience, [eBay](https://www.ebay.com/help/selling/listings/creating-managing-listings/item-conditions-category?id=4765), [Google](https://support.google.com/merchants/answer/6324469?hl=en) and other websites. Nothing shop specific, universal ones.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a new product, see that under product condition, there is three new options. Select one of them, go to FO and see that it's displayed there.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/19871518865 🟢 
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/discussions/35945
| Related PRs       | Autoupgrade PR must come.
| Sponsor company   | 

### New conditions
- Damaged - slight item damage, from shipping for example, but can be sold just fine.
- New, open box - items returned in 14 day return window, but new apart from having opened packaging.
- New, minor defects - items that are new, but have some slight manufacturing defects, but can be sold just fine.