### PR TITLE
chore: Moved image asset mapping to Symfony routing

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 # -> enable a feature flag: PS_FF_{FEATURE_FLAG_NAME}=true
 
 # Enable new Symfony based front container
-PS_FF_FRONT_CONTAINER_V2=false
+PS_FF_FRONT_CONTAINER_V2=true
 # If your shop is behind a reverse proxy in HTTPs (ngrok or similar) the request may not be considered
 # secure so you either need to configure the accepted and trusted proxies (see https://symfony.com/doc/current/deployment/proxies.html)
 # For development purposes you can use the wildcard 127.0.0.1,REMOTE_ADDR

--- a/app/config/front/routing.yml
+++ b/app/config/front/routing.yml
@@ -1,0 +1,5 @@
+controllers:
+  resource:
+    path: ../../../src/PrestaShopBundle/Controller/Front/
+    namespace: PrestaShopBundle\Controller\Front
+  type: attribute

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2256,35 +2256,6 @@ class ToolsCore
                     fwrite($write_fd, $domain_rewrite_cond);
                     fwrite($write_fd, 'RewriteRule ^' . ltrim($uri['virtual'], '/') . '(.*) ' . $uri['physical'] . "$1 [L]\n\n");
                 }
-
-                if ($rewrite_settings) {
-                    // Compatibility with the old image filesystem
-                    fwrite($write_fd, "# Rewrites for product images (support up to < 10 million images)\n");
-
-                    // Rewrite product images < 10 millions
-                    $path_components = [];
-                    for ($i = 1; $i <= 7; ++$i) {
-                        $path_components[] = '$' . ($i + 1); // paths start on 2
-                        $path_images = implode('/', $path_components);
-                        fwrite($write_fd, $media_domains);
-                        fwrite($write_fd, $domain_rewrite_cond);
-                        fwrite($write_fd, 'RewriteRule ^(' . str_repeat('([\d])', $i) . '(?:\-[\w-]*)?)/.+(\.(?:jpe?g|webp|png|avif))$ %{ENV:REWRITEBASE}img/p/' . $path_images . '/$1$' . ($i + 2) . " [L]\n");
-                    }
-
-                    fwrite($write_fd, "# Rewrites for category images\n");
-                    fwrite($write_fd, $media_domains);
-                    fwrite($write_fd, $domain_rewrite_cond);
-                    fwrite($write_fd, 'RewriteRule ^c/([\d]+)(|_thumb)(\-[\.*\w-]*)/.+(\.(?:jpe?g|webp|png|avif))$ %{ENV:REWRITEBASE}img/c/$1$2$3$4 [L]' . PHP_EOL);
-                    fwrite($write_fd, $media_domains);
-                    fwrite($write_fd, $domain_rewrite_cond);
-                    fwrite($write_fd, 'RewriteRule ^c/([a-zA-Z_-]+)(|_thumb)(-[\d]+)?/.+(\.(?:jpe?g|webp|png|avif))$ %{ENV:REWRITEBASE}img/c/$1$2$3$4 [L]' . PHP_EOL);
-                }
-
-                fwrite($write_fd, "# AlphaImageLoader for IE and fancybox\n");
-                if (Shop::isFeatureActive()) {
-                    fwrite($write_fd, $domain_rewrite_cond);
-                }
-                fwrite($write_fd, 'RewriteRule ^images_ie/?([^/]+)\.(jpe?g|png|gif)$ %{ENV:REWRITEBASE}js/jquery/plugins/fancybox/images/$1.$2 [L]' . PHP_EOL);
             }
 
             // Redirections to dispatcher

--- a/src/PrestaShopBundle/Controller/Front/CategoryImageController.php
+++ b/src/PrestaShopBundle/Controller/Front/CategoryImageController.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\Controller\Front;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\Routing\Attribute\Route;
+
+class CategoryImageController extends AbstractController
+{
+    public function __construct(
+        #[Autowire(param: 'kernel.project_dir')]
+        private readonly string $projectDir,
+    ) {
+    }
+
+    #[Route('/c/{content}/{friendlyName}.{extension}', name: 'category_image', requirements: ['extension' => 'jpe?g|webp|png|avif'])]
+    public function __invoke(string $content, string $extension): Response
+    {
+        $categoryImage = new File("$this->projectDir/img/c/$content.$extension");
+
+        return $this->file($categoryImage, null, ResponseHeaderBag::DISPOSITION_INLINE);
+    }
+}

--- a/src/PrestaShopBundle/Controller/Front/FancyboxImageController.php
+++ b/src/PrestaShopBundle/Controller/Front/FancyboxImageController.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\Controller\Front;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\Routing\Attribute\Route;
+
+class FancyboxImageController extends AbstractController
+{
+    public function __construct(
+        #[Autowire(param: 'kernel.project_dir')]
+        private readonly string $projectDir,
+    ) {
+    }
+
+    #[Route('/images_ie/{imageName}.{extension}', name: 'fancybox_image', requirements: ['extension' => 'jpe?g|png|gif'])]
+    public function __invoke(string $imageName, string $extension): Response
+    {
+        $file = new File("$this->projectDir/js/jquery/plugins/fancybox/images/$imageName.$extension");
+
+        return $this->file($file, null, ResponseHeaderBag::DISPOSITION_INLINE);
+    }
+}
+

--- a/src/PrestaShopBundle/Controller/Front/ProductImageController.php
+++ b/src/PrestaShopBundle/Controller/Front/ProductImageController.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\Controller\Front;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\Routing\Attribute\Route;
+
+class ProductImageController extends AbstractController
+{
+    public function __construct(
+        #[Autowire(param: 'kernel.project_dir')]
+        private readonly string $projectDir,
+    ) {
+    }
+
+    #[Route('/{idImage}-{imageType}/{friendlyName}.{extension}', name: 'product_image', requirements: ['idImage' => '\d+', 'extension' => 'jpe?g|webp|png|avif'])]
+    #[Route('/{idImage}/{friendlyName}.{extension}', name: 'product_image_no_type', requirements: ['idImage' => '\d+', 'extension' => 'jpe?g|webp|png|avif'])]
+    public function __invoke(int $idImage, string $extension, ?string $imageType = null): Response
+    {
+        $idPath = implode('/', str_split((string) $idImage));
+        $filename = $imageType ? "$idImage-$imageType.$extension" : "$idImage.$extension";
+        $productImage = new File("$this->projectDir/img/p/$idPath/$filename");
+
+        return $this->file($productImage, null, ResponseHeaderBag::DISPOSITION_INLINE);
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR is a step toward Web Server agnostic mentality for PrestaShop. This way, all the product / category assets are automatically mapped through Symfony routing controllers. I now am fully able to run a shop with Symfony CLI :)<br>Drawback ? the `PS_FF_FRONT_CONTAINER_V2` must now be set to true...
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Images are still displayed after the changes.
| UI Tests          | [mysql](https://github.com/tyloo/ga.tests.ui.pr/actions/runs/19482491680) / [mariadb](https://github.com/tyloo/ga.tests.ui.pr/actions/runs/19482496613)
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
