### PR TITLE
Always request a non cached result in Order::getIdByCartId

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1189,7 +1189,8 @@ class OrderCore extends ObjectModel
             WHERE `id_cart` = ' . (int) $id_cart .
             Shop::addSqlRestriction();
 
-        $result = Db::getInstance()->getValue($sql);
+        // No cache to avoid getting a wrong result in clustered environments
+        $result = Db::getInstance()->getValue($sql, false);
 
         return !empty($result) ? (int) $result : false;
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This resolves an issue with the order-confirmation controller evident in clustered environments using cache. (see #40007)
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Deploy in a clustered environment with APCu cache enabled.<br/>2. Enable a payment module which receives the payment validation via server-to-server communication from the PSP<br/>3. Place an order, pay and get redirected to confirmation page (before the fix you sometimes will get redirected away from the order confirmation page |
| UI Tests          | https://github.com/ilsalvopss/ga.tests.ui.pr/actions/runs/19537231628
| Fixed issue or discussion?     | Fixes #40007
| Related PRs       |  #40037
| Sponsor company   | N/A

 Same as #40037, targeting 9.0.x