### PR TITLE
Prevent 500 error when testing memcache and when memcached is restarted

### DIFF
--- a/classes/cache/CacheMemcached.php
+++ b/classes/cache/CacheMemcached.php
@@ -79,7 +79,9 @@ class CacheMemcachedCore extends Cache
             $this->memcached->addServer($server['ip'], $server['port'], (int) $server['weight']);
         }
 
-        $this->is_connected = in_array('255.255.255', $this->memcached->getVersion(), true) === false;
+        $version = $this->memcached->getVersion();
+
+        $this->is_connected = is_array($version) && false === in_array('255.255.255', $version, true);
     }
 
     /**

--- a/src/Adapter/Cache/MemcacheServerManager.php
+++ b/src/Adapter/Cache/MemcacheServerManager.php
@@ -92,9 +92,13 @@ class MemcacheServerManager
             return is_array($version) && false === in_array('255.255.255', $version, true);
         }
 
-        $memcache = new Memcache();
+        if (extension_loaded('memcache')) {
+            $memcache = new Memcache();
 
-        return true === $memcache->connect($serverIp, (int) $serverPort);
+            return true === $memcache->connect($serverIp, (int) $serverPort);
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Prevent 500 error when testing memcache and when memcached is restarted
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | #38149 & #38204
| UI Tests          | https://github.com/ChillCode/ga.tests.ui.pr/actions/runs/19511303749
| Fixed issue or discussion?     | Fixes #38149, Fixes #38204

This PR only fixes the 500 error part not the possibility to add & test servers when no cache extension is enabled.

Also fixes https://github.com/PrestaShop/PrestaShop/issues/38149, just added the same is_array check as in the test part to prevent the 500, this commit can be removed if does not fit this PR.