### PR TITLE
Fix product patch

### DIFF
--- a/src/PrestaShopBundle/ApiPlatform/Normalizer/DateTimeImmutableNormalizer.php
+++ b/src/PrestaShopBundle/ApiPlatform/Normalizer/DateTimeImmutableNormalizer.php
@@ -57,6 +57,13 @@ class DateTimeImmutableNormalizer implements DenormalizerInterface, NormalizerIn
             throw new InvalidArgumentException('Expected object to be a ' . DateTimeImmutable::class);
         }
 
+        // If the time portion is 00:00:00, format as date-only to preserve date-only values
+        // This handles the case where a date-only value (e.g., "2026-05-26") is stored
+        // and retrieved, which becomes "2026-05-26 00:00:00" when converted to DateTimeImmutable
+        if ($object->format('H:i:s') === '00:00:00') {
+            return $object->format(DateTimeUtil::DEFAULT_DATE_FORMAT);
+        }
+
         return $object->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT);
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |9.0.x
| Description?      | Fixed the response of the patch for the available date
| Type?             | bug fix
| Category?         | CO 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Generate an api client </br> PATCH the product endpoint /admin-api/product/1 with the following payload `{"availableDate": "2026-05-26"}` </br> Check that only the date is returned on this field
| UI Tests          | https://github.com/tleon/ga.tests.ui.pr/actions/runs/19498465169
| Fixed issue or discussion?     | Fixes #38787 
| Sponsor company   | PrestaShop SA
