### PR TITLE
Increase priority of DateImmutableNormalizer

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml
@@ -15,10 +15,11 @@ services:
     autowire: true
     tags:
       - { name: 'serializer.normalizer', priority: 10 }
+  # DateImmutableNormalizer needs a higher priority than DateTimeImmutableNormalizer, or DateImmutable are normalized by DateTimeImmutableNormalizer
   PrestaShopBundle\ApiPlatform\Normalizer\DateImmutableNormalizer:
     autowire: true
     tags:
-      - { name: 'serializer.normalizer', priority: 10 }
+      - { name: 'serializer.normalizer', priority: 20 }
   PrestaShopBundle\ApiPlatform\Normalizer\DecimalNumberNormalizer:
     autowire: true
     tags:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Increase priority of DateImmutableNormalizer, DateImmutableNormalizer needs a higher priority than DateTimeImmutableNormalizer, or DateImmutable are normalized by DateTimeImmutableNormalizer
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | ~
| UI Tests          | ~
| Fixed issue or discussion?     | Fixes #38787
| Related PRs       | ~
| Sponsor company   | ~
