### PR TITLE
Fix: Incorrect redirect from HTTP to HTTPS on the admin login page when PrestaShop is in a subfolder

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/LoginController.php
+++ b/src/PrestaShopBundle/Controller/Admin/LoginController.php
@@ -261,7 +261,15 @@ class LoginController extends PrestaShopAdminController
             }
 
             if (!$isMaintainer) {
-                $securedUrl = rtrim(str_replace('http://', 'https://', $this->shopContext->getBaseURL()), '/') . '/' . trim($this->generateUrl('admin_login'), '/');
+                $securedUrl = rtrim(str_replace('http://', 'https://', $this->shopContext->getBaseURL()), '/') . '/';
+
+                $physicalUri = $this->shopContext->getPhysicalUri();
+                if (str_ends_with($securedUrl, $physicalUri)) {
+                    $securedUrl = substr($securedUrl, 0, -strlen($physicalUri));
+                }
+
+                $securedUrl .= '/' . trim($this->generateUrl('admin_login'), '/');
+
                 $requiredActions[] = $this->trans(
                     'SSL is activated. Please connect using the following link to [1]log in to secure mode (https://)[/1]',
                     ['[1]' => '<a href="' . $securedUrl . '">', '[/1]' => '</a>'],

--- a/src/PrestaShopBundle/Controller/Admin/LoginController.php
+++ b/src/PrestaShopBundle/Controller/Admin/LoginController.php
@@ -261,14 +261,14 @@ class LoginController extends PrestaShopAdminController
             }
 
             if (!$isMaintainer) {
-                $securedUrl = rtrim(str_replace('http://', 'https://', $this->shopContext->getBaseURL()), '/') . '/';
+                $securedUrl = str_replace('http://', 'https://', $this->shopContext->getBaseURL());
 
                 $physicalUri = $this->shopContext->getPhysicalUri();
                 if (str_ends_with($securedUrl, $physicalUri)) {
                     $securedUrl = substr($securedUrl, 0, -strlen($physicalUri));
                 }
 
-                $securedUrl .= '/' . trim($this->generateUrl('admin_login'), '/');
+                $securedUrl .= $this->generateUrl('admin_login');
 
                 $requiredActions[] = $this->trans(
                     'SSL is activated. Please connect using the following link to [1]log in to secure mode (https://)[/1]',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | When PrestaShop is installed in a subfolder and HTTPS usage is enabled, accessing the admin login page via HTTP correctly displays a prompt requiring the use of HTTPS. However, the link shown in the prompt is incorrect: it does not account for the subfolder and leads to an invalid URL, which returns a 404 - Page Not Found. <br/>To fix the issue, I took inspiration from this other similar PR: https://github.com/PrestaShop/PrestaShop/pull/38048
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install PrestaShop in a subfolder.<br/> 2. Enable HTTPS in the back office.<br/> 3. Visit the admin login page via HTTP.<br/>4. Click on the displayed link and the system must redirect to the same page but using HTTPS.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/20428230084
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/40049
| Related PRs       | 
| Sponsor company   | Codencode snc
