### PR TITLE
BO - Multistore : Fixed link "Add new group"

### DIFF
--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -163,7 +163,7 @@ class AdminGroupsControllerCore extends AdminController
     {
         if (Group::isFeatureActive() && empty($this->display)) {
             $this->page_header_toolbar_btn['new_group'] = [
-                'href' => self::$currentIndex . '&addgroup&token=' . $this->token,
+                'href' => $this->context->link->getAdminLink('AdminGroups', true, [], ['addgroup' => 1]),
                 'desc' => $this->trans('Add new group', [], 'Admin.Shopparameters.Feature'),
                 'icon' => 'process-icon-new',
             ];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | BO - Multistore : Fixed link "Add new group"
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | :arrow_down: 
| UI Tests          |  https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/19537543912
| Fixed issue or discussion?     | Fixes #37690
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

## How to test?
1. Go to Shop parameters > General > Enable Multistore
2. Go to Advanced parameters > Multistore > Create a second store
3. Set the context to "Shop 1"
4. Go to Shop Parameters > Customer > Group tab > Create a new customer group ✅
5. On the same page, change the context to "Shop 2"
6. Click on the button "Add new group" on the header button list
7. **BEFORE** : Create a new customer group :x: Exception thrown
8. **AFTER** : The form is well opened