### PR TITLE
Use URL when building urls to prevent subtle mistakes with &?

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/store/actions.ts
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/store/actions.ts
@@ -33,26 +33,33 @@ import {
 const isParamInvalid = (value: any) => isNil(value) || value.length <= 0;
 
 export const getStock = async ({commit}: {commit: Commit}, payload: Record<string, any>): Promise<void> => {
-  const url = window.data.apiStockUrl;
-  const params = new URLSearchParams(omitBy({
+  const url = new URL(window.data.apiStockUrl, window.location.origin);
+  const queryParams = omitBy({
     order: payload.order,
     page_size: payload.page_size,
     page_index: payload.page_index,
     keywords: payload.keywords,
     active: payload.active,
     low_stock: payload.low_stock,
-  }, isParamInvalid));
+  }, isParamInvalid);
+
+  Object.entries(queryParams).forEach(([key, value]) => {
+    url.searchParams.append(key, String(value));
+  });
 
   if (payload.suppliers) {
-    payload.suppliers.forEach((v: string) => params.append('supplier_id[]', v));
+    payload.suppliers.forEach((v: string) => {
+      url.searchParams.append('supplier_id[]', v);
+    });
   }
   if (payload.categories) {
-    payload.categories.forEach((v: string) => params.append('category_id[]', v));
+    payload.categories.forEach((v: string) => {
+      url.searchParams.append('category_id[]', v);
+    });
   }
-  const fetchUrl = `${url}${url.includes('?') ? '&' : '?'}${params.toString()}`;
 
   try {
-    const response = await fetch(fetchUrl);
+    const response = await fetch(url);
     const datas = await response.json();
 
     commit(types.LOADING_STATE, false);
@@ -88,8 +95,9 @@ export const getCategories = async ({commit}: {commit: Commit}): Promise<void> =
 };
 
 export const getMovements = async ({commit}: {commit: Commit}, payload: Record<string, any>): Promise<void> => {
-  const url = window.data.apiMovementsUrl;
-  const params = new URLSearchParams(omitBy({
+  const url = new URL(window.data.apiMovementsUrl, window.location.origin);
+
+  const queryParams = omitBy({
     order: payload.order,
     page_size: payload.page_size,
     page_index: payload.page_index,
@@ -98,20 +106,22 @@ export const getMovements = async ({commit}: {commit: Commit}, payload: Record<s
     category_id: payload.categories,
     id_stock_mvt_reason: payload.id_stock_mvt_reason,
     id_employee: payload.id_employee,
-  }, isParamInvalid));
+  }, isParamInvalid);
+
+  Object.entries(queryParams).forEach(([key, value]) => {
+    url.searchParams.append(key, String(value));
+  });
 
   if (payload.date_add?.sup) {
-    params.append('date_add[sup]', payload.date_add.sup);
+    url.searchParams.append('date_add[sup]', payload.date_add.sup);
   }
 
   if (payload.date_add?.inf) {
-    params.append('date_add[inf]', payload.date_add.inf);
+    url.searchParams.append('date_add[inf]', payload.date_add.inf);
   }
 
-  const fetchUrl = `${url}${url.includes('?') ? '&' : '?'}${params.toString()}`;
-
   try {
-    const response = await fetch(fetchUrl);
+    const response = await fetch(url);
     const datas = await response.json();
 
     commit(types.LOADING_STATE, false);

--- a/admin-dev/themes/new-theme/js/app/pages/translations/store/actions.ts
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/store/actions.ts
@@ -47,11 +47,18 @@ export const getTranslations = async ({commit}: {commit: Commit}): Promise<void>
 export const getCatalog = async ({commit}: {commit: Commit}, payload: Record<string, any>): Promise<void> => {
   commit(types.PRINCIPAL_LOADING, true);
 
+  const url = new URL(payload.url, window.location.origin);
+  const queryParams = omitBy({
+    page_size: payload.page_size,
+    page_index: payload.page_index,
+  }, isParamInvalid);
+
+  Object.entries(queryParams).forEach(([key, value]) => {
+    url.searchParams.append(key, String(value));
+  });
+
   try {
-    const response = await fetch(`${payload.url}&${new URLSearchParams(omitBy({
-      page_size: payload.page_size,
-      page_index: payload.page_index,
-    }, isParamInvalid))}`);
+    const response = await fetch(url);
     const datas = await response.json();
 
     commit(types.SET_TOTAL_PAGES, response.headers.get('Total-Pages'));
@@ -63,22 +70,17 @@ export const getCatalog = async ({commit}: {commit: Commit}, payload: Record<str
 };
 
 export const getDomainsTree = async ({commit}: {commit: Commit}, payload: Record<string, any>): Promise<void> => {
-  const url = window.data.domainsTreeUrl;
-  const params = new URLSearchParams();
+  const url = new URL(window.data.domainsTreeUrl, window.location.origin);
 
   commit(types.SIDEBAR_LOADING, true);
   commit(types.PRINCIPAL_LOADING, true);
 
-  if (payload.store.getters.searchTags.length) {
-    payload.store.getters.searchTags.forEach((searchTag: string) => {
-      params.append('search[]', searchTag);
-    });
-  }
-
-  const fetchUrl = `${url}${url.includes('?') ? '&' : '?'}${params.toString()}`;
+  payload.store.getters.searchTags.forEach((tag: any) => {
+    url.searchParams.append('search[]', tag);
+  });
 
   try {
-    const response = await fetch(fetchUrl);
+    const response = await fetch(url);
     const datas = await response.json();
 
     commit(types.SET_DOMAINS_TREE, datas);
@@ -90,18 +92,14 @@ export const getDomainsTree = async ({commit}: {commit: Commit}, payload: Record
 };
 
 export const refreshCounts = async ({commit}: {commit: Commit}, payload: Record<string, any>): Promise<void> => {
-  const url = window.data.domainsTreeUrl;
-  const params = new URLSearchParams();
+  const url = new URL(window.data.domainsTreeUrl, window.location.origin);
 
-  if (payload.store.getters.searchTags.length) {
-    payload.store.getters.searchTags.forEach((searchTag: string) => {
-      params.append('search[]', searchTag);
-    });
-  }
-  const fetchUrl = `${url}${url.includes('?') ? '&' : '?'}${params.toString()}`;
+  payload.store.getters.searchTags.forEach((tag: any) => {
+    url.searchParams.append('search[]', tag);
+  });
 
   try {
-    const response = await fetch(fetchUrl);
+    const response = await fetch(url);
     const datas = await response.json();
 
     commit(types.DECREASE_CURRENT_DOMAIN_TOTAL_MISSING_TRANSLATIONS, payload.successfullySaved);

--- a/admin-dev/themes/new-theme/js/header.ts
+++ b/admin-dev/themes/new-theme/js/header.ts
@@ -58,13 +58,20 @@ export default class Header {
         const url = $(e.target).data('url');
         const icon = $(e.target).data('icon');
 
+        const postUrl = new URL(postLink, window.location.origin);
+        postUrl.searchParams.append('action', 'GetUrl');
+        postUrl.searchParams.append('rand', String(rand));
+        postUrl.searchParams.append('ajax', '1');
+        postUrl.searchParams.append('method', String(method));
+        postUrl.searchParams.append('id_quick_access', String(quickLinkId));
+
         $.ajax({
           type: 'POST',
           headers: {
             'cache-control': 'no-cache',
           },
           async: true,
-          url: `${postLink}&action=GetUrl&rand=${rand}&ajax=1&method=${method}&id_quick_access=${quickLinkId}`,
+          url: postUrl.toString(),
           data: {
             url,
             name,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | some of the js tried to build the urls manually and use `?` or `&` correctly. This mostly works but is really error prone and fails in multiple places if backoffice token is disabled. This changes those problematic places (at least the ones I found) to use `URL` and `searchParams.append`. This has the added benefit that the request parameters are properly url encoded and using `?` and `&` is done automatically
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Disable backoffice token and try to do translations
| UI Tests          | https://github.com/tswfi/ga.tests.ui.pr/actions/runs/19543076310 (I feel that this should really be automated somehow...) https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/20851671229
| Fixed issue or discussion?     | Fixes #34859
| Related PRs       | https://github.com/PrestaShop/ps_faviconnotificationbo/pull/43 noticed the same problem in `ps_faviconnotificationbo`. 
| Sponsor company   | 

NOTE: there might still be places which I didn't find with some git grepping...