### PR TITLE
Fix: [BO] Admin Countries page redirect issue with multishop after changing shop

### DIFF
--- a/controllers/admin/AdminCountriesController.php
+++ b/controllers/admin/AdminCountriesController.php
@@ -119,7 +119,7 @@ class AdminCountriesControllerCore extends AdminController
     {
         if (empty($this->display)) {
             $this->page_header_toolbar_btn['new_country'] = [
-                'href' => self::$currentIndex . '&addcountry&token=' . $this->token,
+                'href' => $this->context->link->getAdminLink('AdminGroups', true, [], ['addcountry' => 1]),
                 'desc' => $this->trans('Add new country', [], 'Admin.International.Feature'),
                 'icon' => 'process-icon-new',
             ];

--- a/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
@@ -324,9 +324,18 @@ class ShopContextSubscriber implements EventSubscriberInterface
         }
         $legacyCookie->write();
 
+        // Rebuild the current URI from the Request components to avoid relying on /index.php in the raw URL
+        $request = $requestEvent->getRequest();
+
+        $uri = $request->getSchemeAndHttpHost() . $request->getBasePath() . $request->getPathInfo();
+        $queryString = $request->getQueryString();
+        if ($queryString) {
+            $uri .= '?' . $queryString;
+        }
+
         // Redirect to same url but remove setShopContext and conf parameters
         return new RedirectResponse(UrlCleaner::cleanUrl(
-            $requestEvent->getRequest()->getUri(),
+            $uri,
             ['setShopContext', 'conf']
         ));
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | I updated the redirect logic after changing the shop context to no longer rely on `Request::getUri()`, but instead rebuild the URL using the components of the `Request` (`getSchemeAndHttpHost()`, `getBasePath()`, `getPathInfo()`, `getQueryString()`).
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable multishop and create a second store<br> 2. Go to International > Locations > Countries<br> 3. Enable/disable a country<br> 4. Switch store<br> 5. Now you should be able to enable/disable/edit a country without getting a 404 error.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/19567664393
| Fixed issue or discussion?     | Fixes #40059
| Related PRs       | 
| Sponsor company   | Codencode snc
