### PR TITLE
Fix: actionCarrierUpdate not triggered on migrated carrier page

### DIFF
--- a/src/Adapter/Carrier/CommandHandler/EditCarrierHandler.php
+++ b/src/Adapter/Carrier/CommandHandler/EditCarrierHandler.php
@@ -18,6 +18,7 @@ use PrestaShop\PrestaShop\Core\Domain\Carrier\CommandHandler\EditCarrierHandlerI
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CannotUpdateCarrierException;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 
 /**
  * Edit Carrier
@@ -30,6 +31,7 @@ class EditCarrierHandler implements EditCarrierHandlerInterface
         private readonly CarrierLogoFileUploader $carrierLogoFileUploader,
         private readonly CarrierValidator $carrierValidator,
         private readonly ShopRepository $shopRepository,
+        private readonly HookDispatcherInterface $hookDispatcher
     ) {
     }
 
@@ -142,6 +144,14 @@ class EditCarrierHandler implements EditCarrierHandlerInterface
         if (null !== $command->getZones()) {
             $this->carrierRepository->updateAssociatedZones($newCarrierId, $command->getZones());
         }
+
+        $this->hookDispatcher->dispatchWithParameters(
+            'actionCarrierUpdate',
+            [
+                'id_carrier' => (int) $command->getCarrierId()->getValue(),
+                'carrier' => $newCarrier,
+            ]
+        );
 
         return $newCarrierId;
     }

--- a/src/Core/Form/IdentifiableObject/DataHandler/CarrierFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CarrierFormDataHandler.php
@@ -112,8 +112,6 @@ class CarrierFormDataHandler implements FormDataHandlerInterface
             'actionCarrierUpdate',
             [
                 'id_carrier' => (int) $id,
-                // BIG NOTE: 
-                // The hook "actionCarrierUpdate" expects the carrier (Carrier object) as a parameter, but we cannot use legacy classes here, so we need to decide how to proceed.
                 'carrier' => new Carrier((int) $carrierId->getValue()),
             ]
         );

--- a/src/Core/Form/IdentifiableObject/DataHandler/CarrierFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CarrierFormDataHandler.php
@@ -6,7 +6,6 @@
 
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
 
-use Carrier;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Command\AddCarrierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Command\EditCarrierCommand;
@@ -14,14 +13,12 @@ use PrestaShop\PrestaShop\Core\Domain\Carrier\Command\SetCarrierRangesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Command\SetCarrierTaxRuleGroupCommand;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
-use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class CarrierFormDataHandler implements FormDataHandlerInterface
 {
     public function __construct(
         private readonly CommandBusInterface $commandBus,
-        private readonly HookDispatcherInterface $hookDispatcher
     ) {
     }
 
@@ -107,14 +104,6 @@ class CarrierFormDataHandler implements FormDataHandlerInterface
 
         // Finally we save the tax rules group
         $carrierId = $this->setCarrierTaxRuleGroup($carrierId, $data);
-
-        $this->hookDispatcher->dispatchWithParameters(
-            'actionCarrierUpdate',
-            [
-                'id_carrier' => (int) $id,
-                'carrier' => new Carrier((int) $carrierId->getValue()),
-            ]
-        );
 
         return $carrierId->getValue();
     }

--- a/src/Core/Form/IdentifiableObject/DataHandler/CarrierFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CarrierFormDataHandler.php
@@ -6,6 +6,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
 
+use Carrier;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Command\AddCarrierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Command\EditCarrierCommand;
@@ -13,12 +14,14 @@ use PrestaShop\PrestaShop\Core\Domain\Carrier\Command\SetCarrierRangesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Command\SetCarrierTaxRuleGroupCommand;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class CarrierFormDataHandler implements FormDataHandlerInterface
 {
     public function __construct(
         private readonly CommandBusInterface $commandBus,
+        private readonly HookDispatcherInterface $hookDispatcher
     ) {
     }
 
@@ -104,6 +107,16 @@ class CarrierFormDataHandler implements FormDataHandlerInterface
 
         // Finally we save the tax rules group
         $carrierId = $this->setCarrierTaxRuleGroup($carrierId, $data);
+
+        $this->hookDispatcher->dispatchWithParameters(
+            'actionCarrierUpdate',
+            [
+                'id_carrier' => (int) $id,
+                // BIG NOTE: 
+                // The hook "actionCarrierUpdate" expects the carrier (Carrier object) as a parameter, but we cannot use legacy classes here, so we need to decide how to proceed.
+                'carrier' => new Carrier((int) $carrierId->getValue()),
+            ]
+        );
 
         return $carrierId->getValue();
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR adds the call to the actionCarrierUpdate hook for the new carrier page implemented in Symfony.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable the new **Carriers** feature in _Advanced Parameters > New & Experimental Features_ <br/> 2. Install the following module: [pr40070.zip](https://github.com/user-attachments/files/25919072/pr40070.zip)<br/> 3. Edit a carrier<br/> 4. After saving, the system should display **Hook hookActionCarrierUpdate executed with id_carrier: CARRIER_ID and new carrier ID: CARRIER_ID** as shown below:<br/> <img width="741" height="256" alt="Screenshot 2025-11-21 at 15-00-10 Editing carrier Click and collect mod 2 • Codencode" src="https://github.com/user-attachments/assets/b341e3f1-f90c-4ada-ba78-90a2eb92e22e" />
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/23542452434
| Fixed issue or discussion?     | Fixes #40067
| Related PRs       | 
| Sponsor company   | Codencode snc

            
