### PR TITLE
Install Console : Allow characters "<" & ">" in admin password

### DIFF
--- a/install-dev/classes/datas.php
+++ b/install-dev/classes/datas.php
@@ -235,7 +235,7 @@ class Datas
 
         $args_ok = [];
         foreach ($argv as $arg) {
-            if (!preg_match('/^--([^=\'"><|`]+)(?:=([^=><|`]+)|(?!license))/i', trim($arg), $res)) {
+            if (!preg_match('/^--([^=\'"><|`]+)(?:=([^=|`]+)|(?!license))/i', trim($arg), $res)) {
                 continue;
             }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Install Console : Allow characters "<" & ">" in admin password
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | :arrow_down: 
| UI Tests          | https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/19581740480
| Fixed issue or discussion?     | Fixes #33123 
| Related PRs       | N/A
| Sponsor company   | lefevre.dev

## How to test?  
* Install PrestaShop in console with a admin password with "<" or ">" inside 
* :notebook: You can check the issue to have the command line