### PR TITLE
Fix: Doctrine auto-mapping in modules: only the first subfolder inside src/Entity is recognized

### DIFF
--- a/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
@@ -120,17 +120,14 @@ class ModulesDoctrineCompilerPass implements CompilerPassInterface
     private function getModuleNamespace(SplFileInfo $moduleFolder)
     {
         $finder = new Finder();
-        $finder->files()->in($moduleFolder->getRealPath() . '/src/Entity')->name('*.php');
+        $finder->files()->in($moduleFolder)->name('*.php');
         foreach ($finder as $phpFile) {
-            $phpContent = file_get_contents($phpFile->getRealPath());
-            if (preg_match('~namespace[ \t]+(.+)[ \t]*;~Um', $phpContent, $matches)) {
-                $namespace = trim($matches[1]);
-                if ($namespace === '') {
+            if (preg_match('~namespace[ \t]+(.*)[ \t]*;~Um', $phpFile->getContents(), $matches)) {
+                if (($namespace = trim($matches[1])) === '') {
                     continue;
                 }
 
-                $pos = strpos($namespace, '\\Entity');
-                if ($pos !== false) {
+                if (($pos = strpos($namespace, '\\Entity')) !== false) {
                     return substr($namespace, 0, $pos + strlen('\\Entity'));
                 }
 

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
@@ -124,7 +124,18 @@ class ModulesDoctrineCompilerPass implements CompilerPassInterface
         foreach ($finder as $phpFile) {
             $phpContent = file_get_contents($phpFile->getRealPath());
             if (preg_match('~namespace[ \t]+(.+)[ \t]*;~Um', $phpContent, $matches)) {
-                return $matches[1];
+                $namespace = trim($matches[1]);
+                if ($namespace === '') {
+                    continue;
+                }
+
+                $pos = strpos($namespace, '\\Entity');
+                if ($pos !== false) {
+                    return substr($namespace, 0, $pos + strlen('\\Entity'));
+                }
+
+                // Fallback: if for some reason there's no '\Entity', I'll use what was found anyway
+                return $namespace;
             }
         }
 

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
@@ -129,6 +129,10 @@ class ModulesDoctrineCompilerPass implements CompilerPassInterface
                     continue;
                 }
 
+                // We strip the last part of the namespace to get the namespace matching with the entity folder
+                // This is required in case you have sub-folders like src/Entity/Category/Category.php
+                // The first matching PHP file would be in a sub namespace and be returned, thus the Entity
+                // namespace would not be parsed completely
                 if (($pos = strpos($namespace, '\\Entity')) !== false) {
                     return substr($namespace, 0, $pos + strlen('\\Entity'));
                 }

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\DependencyInjection\Compiler;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
-use PrestaShop\PrestaShop\Core\Util\Inflector;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -75,12 +74,14 @@ class ModulesDoctrineCompilerPass implements CompilerPassInterface
             if (in_array($moduleFolder->getFilename(), $activeModules)
                 && is_dir($moduleFolder . '/src/Entity')
             ) {
-                $moduleNamespace = $this->getModuleNamespace($moduleFolder);
+                $moduleEntityDirectory = realpath($moduleFolder . '/src/Entity');
+                if ($moduleEntityDirectory === false) {
+                    continue;
+                }
+                $moduleNamespace = $this->getModuleNamespace($moduleEntityDirectory);
                 if (empty($moduleNamespace)) {
                     continue;
                 }
-                $modulePrefix = 'Module' . Inflector::getInflector()->camelize($moduleFolder->getFilename());
-                $moduleEntityDirectory = realpath($moduleFolder . '/src/Entity');
                 $mappingPass = $this->createAnnotationMappingDriver($moduleNamespace, $moduleEntityDirectory);
                 $mappingsPassList[$moduleEntityDirectory] = $mappingPass;
             }
@@ -113,14 +114,15 @@ class ModulesDoctrineCompilerPass implements CompilerPassInterface
     }
 
     /**
-     * @param SplFileInfo $moduleFolder
+     * @param string $moduleEntityDirectory
      *
      * @return string
      */
-    private function getModuleNamespace(SplFileInfo $moduleFolder)
+    private function getModuleNamespace(string $moduleEntityDirectory)
     {
         $finder = new Finder();
-        $finder->files()->in($moduleFolder)->name('*.php');
+        $finder->files()->in($moduleEntityDirectory)->name('*.php');
+
         foreach ($finder as $phpFile) {
             if (preg_match('~namespace[ \t]+(.*)[ \t]*;~Um', $phpFile->getContents(), $matches)) {
                 if (($namespace = trim($matches[1])) === '') {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR modifies the `getModuleNamespace()` method used for registering Doctrine entity mappings for modules.<br/>Instead of returning the full namespace of the first class found, the method now truncates the namespace up to the `\Entity` root, in order to obtain a namespace that is valid for all module entities (including those in subfolders).<br/><br/>_This PR allows organizing a module's Entities into multiple subfolders within `src/Entity`, while keeping the Doctrine mapping functional and improving the module's overall structure._
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install the module [entities_more_folders.zip](https://github.com/user-attachments/files/23047977/entities_more_folders.zip).<br/> 2. Go to the module configuration page in the back office.<br/> 3. You must display the page without errors as follows: <img width="1703" height="256" alt="Screenshot 2025-11-24 at 18-04-03 Module Manager • Codencode" src="https://github.com/user-attachments/assets/eef9b5c9-f636-4ca8-aa37-394b3eb3404a" />
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/21839303816
| Fixed issue or discussion?     | Fixes #39725
| Related PRs       | 
| Sponsor company   | Codencode snc

