### PR TITLE
Fix: Cart rule combinations lost when saving if lazy-loaded list (jscroll) is not fully loaded

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
@@ -238,7 +238,7 @@
 						<td>
 							<p>{l s='Uncombinable cart rules' d='Admin.Catalog.Feature'}</p>
 							<input id="cart_rule_select_1_filter" autocomplete="off" class="form-control uncombinable_search_filter" type="text" name="uncombinable_filter" placeholder="{l s='Search' d='Admin.Actions'}" value="">
-							<select id="cart_rule_select_1" class="jscroll" multiple="">
+							<select id="cart_rule_select_1" class="jscroll" multiple="" name="cart_rule_unselected[]">
 							</select>
 							<a class="jscroll-next btn btn-default btn-block clearfix" href="">{l s='Next' d='Admin.Global'}</a>
 							<a id="cart_rule_select_add" class="btn btn-default btn-block clearfix">{l s='Add' d='Admin.Actions'} <i class="icon-arrow-right"></i></a>

--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -241,6 +241,12 @@ $('#cart_rule_form').on('submit', () => {
     $(`#${restrictions[i]}_select_2 option`).each(function (i) {
       $(this).prop('selected', true);
     });
+
+    if (restrictions[i] === 'cart_rule') {
+      $(`#cart_rule_select_1 option`).each(function (i) {
+        $(this).prop('selected', true);
+      });
+    }
   }
 
   $('.product_rule_toselect option').each(function (i) {

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -80,7 +80,15 @@ class AdminCartRulesControllerCore extends AdminController
 
             /** @var CartRule $current_object */
             $current_object = $this->loadObject(true);
-            $cart_rules = $current_object->getAssociatedRestrictions('cart_rule', false, true, $page * $limit, $limit, $search);
+
+            if ($type == 'selected') {
+                $offset = $page * $limit;
+            } else {
+                $limit = null;
+                $offset = 0;
+            }
+
+            $cart_rules = $current_object->getAssociatedRestrictions('cart_rule', false, true, $offset, $limit, $search);
 
             if ($type == 'selected') {
                 $i = 1;
@@ -102,9 +110,6 @@ class AdminCartRulesControllerCore extends AdminController
                         break;
                     }
                     ++$i;
-                }
-                if ($i == $limit) {
-                    $next_link = Context::getContext()->link->getAdminLink('AdminCartRules') . '&ajaxMode=1&ajax=1&id_cart_rule=' . (int) $id_cart_rule . '&action=loadCartRules&limit=' . (int) $limit . '&type=unselected&count=' . ($count - 1 + count($cart_rules['unselected']) . '&search=' . urlencode($search));
                 }
             }
         }
@@ -338,14 +343,32 @@ class AdminCartRulesControllerCore extends AdminController
                 Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'cart_rule_' . $type . '` (`id_cart_rule`, `id_' . $type . '`) VALUES ' . implode(',', $values));
             }
         }
+
         // Add cart rule restrictions
-        if (Tools::getValue('cart_rule_restriction') && is_array($array = Tools::getValue('cart_rule_select')) && count($array)) {
-            $values = [];
-            foreach ($array as $id) {
-                $values[] = '(' . (int) $currentObject->id . ',' . (int) $id . ')';
+        if (Tools::getValue('cart_rule_unselected') && is_array($unselectedIds = Tools::getValue('cart_rule_unselected')) && count($unselectedIds)) {
+            $allCartRuleIds = Db::getInstance()->executeS('
+                SELECT id_cart_rule 
+                FROM `' . _DB_PREFIX_ . 'cart_rule`
+                WHERE id_cart_rule != ' . (int) $currentObject->id
+            );
+
+            $allCartRuleIds = array_map(
+                'intval',
+                array_column($allCartRuleIds, 'id_cart_rule')
+            );
+
+            $selectedIds = array_diff($allCartRuleIds, $unselectedIds);
+
+            if (!empty($selectedIds)) {
+                $values = [];
+                foreach ($selectedIds as $id) {
+                    $values[] = '(' . (int) $currentObject->id . ',' . (int) $id . ')';
+                }
+
+                Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'cart_rule_combination` (`id_cart_rule_1`, `id_cart_rule_2`) VALUES ' . implode(',', $values));
             }
-            Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'cart_rule_combination` (`id_cart_rule_1`, `id_cart_rule_2`) VALUES ' . implode(',', $values));
         }
+
         // Add product rule restrictions
         if (Tools::getValue('product_restriction') && is_array($ruleGroupArray = Tools::getValue('product_rule_group')) && count($ruleGroupArray)) {
             foreach ($ruleGroupArray as $ruleGroupId) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR fixes how cart rule combinations are saved when using an AJAX-loaded select. Previously only the options loaded in the dropdown were considered, so combinations could be incomplete if the user didn’t scroll the list. The form now submits the list of unselected cart rules, and the backend derives the selected ones from the full set, ensuring all intended combinations are stored correctly.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create 100 cartRules (you can use this script: [createCartRules.php](https://github.com/user-attachments/files/23744359/createCartRules.php))<br/> 2. Access the first created cartRule in edit mode.<br/> 3. In the **Conditions** section, select **Compatibility with other cart rules**. From the right-hand select box labeled **Combinable cart rules**, select the first 2 cartRules (without scrolling the select box) and click **Remove**. These 2 lines will appear in the left-hand select box labeled **Uncombinable cart rules**.<br/>4. Save and remain on the page.<br/>5. Once the page reloads, verify that the lines you previously selected are present in the **Uncombinable cart rules** section.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/23542540297
| Fixed issue or discussion?     | Fixes #40093, Fixes https://github.com/PrestaShop/PrestaShop/issues/17603
| Related PRs       | 
| Sponsor company   | Codencode snc

### NOTE:
Since the left selection box, **Compatibility with other cart rules**, is also loaded via AJAX (in the same way as the Combinable cart rules selection box), I thought about removing the data retrieval limit for this selection. This is because I "believe" the options in this selection should be fewer, as it only contains the cart_rules that should not be associated.
_It should be considered that this is a "stopgap" solution to handle the issue currently occurring with vouchers, and I "think" it will no longer be an issue in the new management system._

cc @Hlavtox @kpodemski 