### PR TITLE
Bump prestakit to v2.0.5

### DIFF
--- a/admin-dev/themes/default/package-lock.json
+++ b/admin-dev/themes/default/package-lock.json
@@ -20,7 +20,7 @@
         "open-sans-fonts": "^1.6.2",
         "path": "^0.12.7",
         "perfect-scrollbar": "^1.5.5",
-        "prestakit": "^2.0.1",
+        "prestakit": "^2.0.4",
         "terser-webpack-plugin": "^5.3.10",
         "vazirmatn": "33.0.3",
         "webpack-font-preload-plugin": "^1.5.0",
@@ -8853,10 +8853,9 @@
       }
     },
     "node_modules/prestakit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.2.tgz",
-      "integrity": "sha512-HnGlB+LdePKKcbZ/IN6/TIdzrT4Efd6OLKt+M+/8rF17181dTc0Ab35KIZltW2JQfkGSoxt6W8BKCLgYUGGapA==",
-      "license": "OSL-3.0",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.4.tgz",
+      "integrity": "sha512-p22UKxu59e1aOccFv9GcSKlTojsfVTRkOf6u7HeIjQg/HWpE9jmw0lxmIW/yG7UnIJpxLinwbNPp1V3TXKiGYg==",
       "dependencies": {
         "@fontsource/ibm-plex-sans": "^5.0.20",
         "@ttskch/select2-bootstrap4-theme": "^1.5.2",
@@ -18287,9 +18286,9 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prestakit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.2.tgz",
-      "integrity": "sha512-HnGlB+LdePKKcbZ/IN6/TIdzrT4Efd6OLKt+M+/8rF17181dTc0Ab35KIZltW2JQfkGSoxt6W8BKCLgYUGGapA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.4.tgz",
+      "integrity": "sha512-p22UKxu59e1aOccFv9GcSKlTojsfVTRkOf6u7HeIjQg/HWpE9jmw0lxmIW/yG7UnIJpxLinwbNPp1V3TXKiGYg==",
       "requires": {
         "@fontsource/ibm-plex-sans": "^5.0.20",
         "@ttskch/select2-bootstrap4-theme": "^1.5.2",

--- a/admin-dev/themes/default/package-lock.json
+++ b/admin-dev/themes/default/package-lock.json
@@ -20,7 +20,7 @@
         "open-sans-fonts": "^1.6.2",
         "path": "^0.12.7",
         "perfect-scrollbar": "^1.5.5",
-        "prestakit": "^2.0.4",
+        "prestakit": "^2.0.5",
         "terser-webpack-plugin": "^5.3.10",
         "vazirmatn": "33.0.3",
         "webpack-font-preload-plugin": "^1.5.0",
@@ -8853,9 +8853,10 @@
       }
     },
     "node_modules/prestakit": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.4.tgz",
-      "integrity": "sha512-p22UKxu59e1aOccFv9GcSKlTojsfVTRkOf6u7HeIjQg/HWpE9jmw0lxmIW/yG7UnIJpxLinwbNPp1V3TXKiGYg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.5.tgz",
+      "integrity": "sha512-dfpGyJvMku2fvyI8YPN0i4CL+9pXgc0A7vfgKm+y/CG0MVcIgh4Agyavmzi9o8HmGlwfPD0qtBwHqn4jtJrskg==",
+      "license": "OSL-3.0",
       "dependencies": {
         "@fontsource/ibm-plex-sans": "^5.0.20",
         "@ttskch/select2-bootstrap4-theme": "^1.5.2",
@@ -18286,9 +18287,9 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prestakit": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.4.tgz",
-      "integrity": "sha512-p22UKxu59e1aOccFv9GcSKlTojsfVTRkOf6u7HeIjQg/HWpE9jmw0lxmIW/yG7UnIJpxLinwbNPp1V3TXKiGYg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.5.tgz",
+      "integrity": "sha512-dfpGyJvMku2fvyI8YPN0i4CL+9pXgc0A7vfgKm+y/CG0MVcIgh4Agyavmzi9o8HmGlwfPD0qtBwHqn4jtJrskg==",
       "requires": {
         "@fontsource/ibm-plex-sans": "^5.0.20",
         "@ttskch/select2-bootstrap4-theme": "^1.5.2",

--- a/admin-dev/themes/default/package.json
+++ b/admin-dev/themes/default/package.json
@@ -50,7 +50,7 @@
     "open-sans-fonts": "^1.6.2",
     "path": "^0.12.7",
     "perfect-scrollbar": "^1.5.5",
-    "prestakit": "^2.0.1",
+    "prestakit": "^2.0.4",
     "terser-webpack-plugin": "^5.3.10",
     "vazirmatn": "33.0.3",
     "webpack-font-preload-plugin": "^1.5.0",

--- a/admin-dev/themes/default/package.json
+++ b/admin-dev/themes/default/package.json
@@ -50,7 +50,7 @@
     "open-sans-fonts": "^1.6.2",
     "path": "^0.12.7",
     "perfect-scrollbar": "^1.5.5",
-    "prestakit": "^2.0.4",
+    "prestakit": "^2.0.5",
     "terser-webpack-plugin": "^5.3.10",
     "vazirmatn": "33.0.3",
     "webpack-font-preload-plugin": "^1.5.0",

--- a/admin-dev/themes/new-theme/package-lock.json
+++ b/admin-dev/themes/new-theme/package-lock.json
@@ -29,7 +29,7 @@
         "perfect-scrollbar": "^1.5.5",
         "photoswipe": "^4.1.3",
         "postcss": "^8.4.47",
-        "prestakit": "^2.0.4",
+        "prestakit": "^2.0.5",
         "punycode": "^2.3.1",
         "resize-observer-polyfill": "^1.5.1",
         "sprintf-js": "^1.1.3",
@@ -11467,9 +11467,10 @@
       }
     },
     "node_modules/prestakit": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.4.tgz",
-      "integrity": "sha512-p22UKxu59e1aOccFv9GcSKlTojsfVTRkOf6u7HeIjQg/HWpE9jmw0lxmIW/yG7UnIJpxLinwbNPp1V3TXKiGYg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.5.tgz",
+      "integrity": "sha512-dfpGyJvMku2fvyI8YPN0i4CL+9pXgc0A7vfgKm+y/CG0MVcIgh4Agyavmzi9o8HmGlwfPD0qtBwHqn4jtJrskg==",
+      "license": "OSL-3.0",
       "dependencies": {
         "@fontsource/ibm-plex-sans": "^5.0.20",
         "@ttskch/select2-bootstrap4-theme": "^1.5.2",
@@ -22997,9 +22998,9 @@
       "dev": true
     },
     "prestakit": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.4.tgz",
-      "integrity": "sha512-p22UKxu59e1aOccFv9GcSKlTojsfVTRkOf6u7HeIjQg/HWpE9jmw0lxmIW/yG7UnIJpxLinwbNPp1V3TXKiGYg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.5.tgz",
+      "integrity": "sha512-dfpGyJvMku2fvyI8YPN0i4CL+9pXgc0A7vfgKm+y/CG0MVcIgh4Agyavmzi9o8HmGlwfPD0qtBwHqn4jtJrskg==",
       "requires": {
         "@fontsource/ibm-plex-sans": "^5.0.20",
         "@ttskch/select2-bootstrap4-theme": "^1.5.2",

--- a/admin-dev/themes/new-theme/package-lock.json
+++ b/admin-dev/themes/new-theme/package-lock.json
@@ -29,7 +29,7 @@
         "perfect-scrollbar": "^1.5.5",
         "photoswipe": "^4.1.3",
         "postcss": "^8.4.47",
-        "prestakit": "^2.0.1",
+        "prestakit": "^2.0.4",
         "punycode": "^2.3.1",
         "resize-observer-polyfill": "^1.5.1",
         "sprintf-js": "^1.1.3",
@@ -11467,10 +11467,9 @@
       }
     },
     "node_modules/prestakit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.2.tgz",
-      "integrity": "sha512-HnGlB+LdePKKcbZ/IN6/TIdzrT4Efd6OLKt+M+/8rF17181dTc0Ab35KIZltW2JQfkGSoxt6W8BKCLgYUGGapA==",
-      "license": "OSL-3.0",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.4.tgz",
+      "integrity": "sha512-p22UKxu59e1aOccFv9GcSKlTojsfVTRkOf6u7HeIjQg/HWpE9jmw0lxmIW/yG7UnIJpxLinwbNPp1V3TXKiGYg==",
       "dependencies": {
         "@fontsource/ibm-plex-sans": "^5.0.20",
         "@ttskch/select2-bootstrap4-theme": "^1.5.2",
@@ -22998,9 +22997,9 @@
       "dev": true
     },
     "prestakit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.2.tgz",
-      "integrity": "sha512-HnGlB+LdePKKcbZ/IN6/TIdzrT4Efd6OLKt+M+/8rF17181dTc0Ab35KIZltW2JQfkGSoxt6W8BKCLgYUGGapA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-2.0.4.tgz",
+      "integrity": "sha512-p22UKxu59e1aOccFv9GcSKlTojsfVTRkOf6u7HeIjQg/HWpE9jmw0lxmIW/yG7UnIJpxLinwbNPp1V3TXKiGYg==",
       "requires": {
         "@fontsource/ibm-plex-sans": "^5.0.20",
         "@ttskch/select2-bootstrap4-theme": "^1.5.2",

--- a/admin-dev/themes/new-theme/package.json
+++ b/admin-dev/themes/new-theme/package.json
@@ -37,7 +37,7 @@
     "perfect-scrollbar": "^1.5.5",
     "photoswipe": "^4.1.3",
     "postcss": "^8.4.47",
-    "prestakit": "^2.0.4",
+    "prestakit": "^2.0.5",
     "punycode": "^2.3.1",
     "resize-observer-polyfill": "^1.5.1",
     "sprintf-js": "^1.1.3",

--- a/admin-dev/themes/new-theme/package.json
+++ b/admin-dev/themes/new-theme/package.json
@@ -37,7 +37,7 @@
     "perfect-scrollbar": "^1.5.5",
     "photoswipe": "^4.1.3",
     "postcss": "^8.4.47",
-    "prestakit": "^2.0.1",
+    "prestakit": "^2.0.4",
     "punycode": "^2.3.1",
     "resize-observer-polyfill": "^1.5.1",
     "sprintf-js": "^1.1.3",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | With a recent update of the backoffice pages, it appeared we couldn't browse thr forms by using the keyboard. Thanks to a change of @tblivet on https://github.com/PrestaShop/prestashop-ui-kit/pull/248, using tab allows to focus checkboxes.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Build assets, then open the login page of the backoffice. By using the `tab` button of your keyboard, you must be able to focus the checkbox "Stay connected".
| UI Tests          | https://github.com/Quetzacoalt91/ga.tests.ui.pr/actions/runs/19706072158
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/37390
| Related PRs       | https://github.com/PrestaShop/prestashop-ui-kit/pull/248
| Sponsor company   | @PrestaShopCorp