### PR TITLE
Add customer social title collection settings

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\Cart\CartPresenter;
 use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+use PrestaShop\PrestaShop\Core\Domain\Customer\CustomerSettings;
 use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -1977,6 +1978,7 @@ class FrontControllerCore extends Controller
         $formatter
             ->setAskForPartnerOptin(Configuration::get('PS_CUSTOMER_OPTIN'))
             ->setAskForBirthdate(Configuration::get('PS_CUSTOMER_BIRTHDATE'))
+            ->setAskForSocialTitle(Configuration::get('PS_CUSTOMER_ASK_FOR_SOCIAL_TITLE') == CustomerSettings::SOCIAL_TITLES_ENABLED_COLLECTED)
             ->setPartnerOptinRequired($customer->isFieldRequired('optin'));
 
         return $formatter;

--- a/classes/form/CustomerFormatter.php
+++ b/classes/form/CustomerFormatter.php
@@ -36,6 +36,7 @@ class CustomerFormatterCore implements FormFormatterInterface
     private $ask_for_password = true;
     private $password_is_required = true;
     private $ask_for_new_password = false;
+    private $ask_for_social_title = true;
 
     public function __construct(
         TranslatorInterface $translator,
@@ -48,6 +49,13 @@ class CustomerFormatterCore implements FormFormatterInterface
     public function setAskForBirthdate($ask_for_birthdate)
     {
         $this->ask_for_birthdate = $ask_for_birthdate;
+
+        return $this;
+    }
+
+    public function setAskForSocialTitle($ask_for_social_title)
+    {
+        $this->ask_for_social_title = $ask_for_social_title;
 
         return $this;
     }
@@ -91,22 +99,24 @@ class CustomerFormatterCore implements FormFormatterInterface
     {
         $format = [];
 
-        $genders = Gender::getGenders($this->language->id);
-        if ($genders->count() > 0) {
-            $genderField = (new FormField())
-                ->setName('id_gender')
-                ->setType('radio-buttons')
-                ->setLabel(
-                    $this->translator->trans(
-                        'Social title',
-                        [],
-                        'Shop.Forms.Labels'
-                    )
-                );
-            foreach ($genders as $gender) {
-                $genderField->addAvailableValue($gender->id, $gender->name);
+        if ($this->ask_for_social_title) {
+            $genders = Gender::getGenders($this->language->id);
+            if ($genders->count() > 0) {
+                $genderField = (new FormField())
+                    ->setName('id_gender')
+                    ->setType('radio-buttons')
+                    ->setLabel(
+                        $this->translator->trans(
+                            'Social title',
+                            [],
+                            'Shop.Forms.Labels'
+                        )
+                    );
+                foreach ($genders as $gender) {
+                    $genderField->addAvailableValue($gender->id, $gender->name);
+                }
+                $format[$genderField->getName()] = $genderField;
             }
-            $format[$genderField->getName()] = $genderField;
         }
 
         $format['firstname'] = (new FormField())

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -822,6 +822,9 @@ Country</value>
   <configuration id="PS_CUSTOMER_BIRTHDATE" name="PS_CUSTOMER_BIRTHDATE">
     <value>1</value>
   </configuration>
+  <configuration id="PS_CUSTOMER_ASK_FOR_SOCIAL_TITLE" name="PS_CUSTOMER_ASK_FOR_SOCIAL_TITLE">
+    <value>2</value>
+  </configuration>
   <configuration id="PS_PACK_STOCK_TYPE" name="PS_PACK_STOCK_TYPE">
     <value>0</value>
   </configuration>

--- a/src/Adapter/Customer/CustomerConfiguration.php
+++ b/src/Adapter/Customer/CustomerConfiguration.php
@@ -44,6 +44,7 @@ class CustomerConfiguration extends AbstractMultistoreConfiguration
         'enable_b2b_mode',
         'ask_for_birthday',
         'enable_offers',
+        'ask_for_social_title',
     ];
 
     /**
@@ -60,6 +61,7 @@ class CustomerConfiguration extends AbstractMultistoreConfiguration
             'enable_b2b_mode' => (bool) $this->configuration->get('PS_B2B_ENABLE', false, $shopConstraint),
             'ask_for_birthday' => (bool) $this->configuration->get('PS_CUSTOMER_BIRTHDATE', false, $shopConstraint),
             'enable_offers' => (bool) $this->configuration->get('PS_CUSTOMER_OPTIN', false, $shopConstraint),
+            'ask_for_social_title' => (int) $this->configuration->get('PS_CUSTOMER_ASK_FOR_SOCIAL_TITLE', false, $shopConstraint),
         ];
     }
 
@@ -77,6 +79,7 @@ class CustomerConfiguration extends AbstractMultistoreConfiguration
             $this->updateConfigurationValue('PS_B2B_ENABLE', 'enable_b2b_mode', $config, $shopConstraint);
             $this->updateConfigurationValue('PS_CUSTOMER_BIRTHDATE', 'ask_for_birthday', $config, $shopConstraint);
             $this->updateConfigurationValue('PS_CUSTOMER_OPTIN', 'enable_offers', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_CUSTOMER_ASK_FOR_SOCIAL_TITLE', 'ask_for_social_title', $config, $shopConstraint);
         }
 
         return [];
@@ -94,7 +97,8 @@ class CustomerConfiguration extends AbstractMultistoreConfiguration
             ->setAllowedTypes('password_reset_delay', 'int')
             ->setAllowedTypes('enable_b2b_mode', 'bool')
             ->setAllowedTypes('ask_for_birthday', 'bool')
-            ->setAllowedTypes('enable_offers', 'bool');
+            ->setAllowedTypes('enable_offers', 'bool')
+            ->setAllowedTypes('ask_for_social_title', 'int');
 
         return $resolver;
     }

--- a/src/Core/Domain/Customer/CustomerSettings.php
+++ b/src/Core/Domain/Customer/CustomerSettings.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Customer;
+
+/**
+ * Defines settings for customers.
+ */
+class CustomerSettings
+{
+    /**
+     * Class not supposed to be initialized, it only serves as static storage
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Bellow constants define options for social title settings
+     */
+    public const SOCIAL_TITLES_DISABLED = 0;
+    public const SOCIAL_TITLES_ENABLED = 1;
+    public const SOCIAL_TITLES_ENABLED_COLLECTED = 2;
+}

--- a/src/Core/Grid/Definition/Factory/CustomerGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerGridDefinitionFactory.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
+use PrestaShop\PrestaShop\Core\Domain\Customer\CustomerSettings;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\Customer\DeleteCustomersBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
@@ -81,24 +82,32 @@ final class CustomerGridDefinitionFactory extends AbstractGridDefinitionFactory
     private $contextDateFormat;
 
     /**
+     * @var int
+     */
+    private $customerSocialTitleSetting;
+
+    /**
      * @param HookDispatcherInterface $hookDispatcher
      * @param bool $isB2bFeatureEnabled
      * @param bool $isMultistoreFeatureEnabled
      * @param string $contextDateFormat
      * @param bool $isGroupsFeatureEnabled
+     * @param int $customerSocialTitleSetting
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
         $isB2bFeatureEnabled,
         $isMultistoreFeatureEnabled,
         string $contextDateFormat,
-        bool $isGroupsFeatureEnabled = true
+        bool $isGroupsFeatureEnabled = true,
+        int $customerSocialTitleSetting = CustomerSettings::SOCIAL_TITLES_DISABLED
     ) {
         parent::__construct($hookDispatcher);
         $this->isB2bFeatureEnabled = $isB2bFeatureEnabled;
         $this->isMultistoreFeatureEnabled = $isMultistoreFeatureEnabled;
         $this->contextDateFormat = $contextDateFormat;
         $this->isGroupsFeatureEnabled = $isGroupsFeatureEnabled;
+        $this->customerSocialTitleSetting = $customerSocialTitleSetting;
     }
 
     /**
@@ -134,13 +143,6 @@ final class CustomerGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ->setName($this->trans('ID', [], 'Admin.Global'))
                     ->setOptions([
                         'field' => 'id_customer',
-                    ])
-            )
-            ->add(
-                (new DataColumn('social_title'))
-                    ->setName($this->trans('Social title', [], 'Admin.Global'))
-                    ->setOptions([
-                        'field' => 'social_title',
                     ])
             )
             ->add(
@@ -255,6 +257,17 @@ final class CustomerGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ])
             );
 
+        if ($this->customerSocialTitleSetting !== CustomerSettings::SOCIAL_TITLES_DISABLED) {
+            $columns->addAfter(
+                'id_customer',
+                (new DataColumn('social_title'))
+                    ->setName($this->trans('Social title', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'social_title',
+                    ])
+            );
+        }
+
         if ($this->isB2bFeatureEnabled) {
             $columns->addAfter(
                 'email',
@@ -307,13 +320,6 @@ final class CustomerGridDefinitionFactory extends AbstractGridDefinitionFactory
                         'required' => false,
                     ])
                     ->setAssociatedColumn('id_customer')
-            )
-            ->add(
-                (new Filter('social_title', GenderType::class))
-                    ->setTypeOptions([
-                        'required' => false,
-                    ])
-                    ->setAssociatedColumn('social_title')
             )
             ->add(
                 (new Filter('firstname', TextType::class))
@@ -375,6 +381,16 @@ final class CustomerGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ])
                     ->setAssociatedColumn('actions')
             );
+
+        if ($this->customerSocialTitleSetting !== CustomerSettings::SOCIAL_TITLES_DISABLED) {
+            $filters->add(
+                (new Filter('social_title', GenderType::class))
+                    ->setTypeOptions([
+                        'required' => false,
+                    ])
+                    ->setAssociatedColumn('social_title')
+            );
+        }
 
         if ($this->isB2bFeatureEnabled) {
             $filters->add(

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\Command\EditCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\SetPrivateNoteAboutCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\SetRequiredFieldsForCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\TransformGuestToCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\CustomerSettings;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerByEmailNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerDefaultGroupAccessException;
@@ -373,6 +374,7 @@ class CustomerController extends PrestaShopAdminController
             'customerBoughtProductGrid' => $this->presentGrid($customerBoughtProductGrid),
             'customerViewedProductGrid' => $this->presentGrid($customerViewedProductGrid),
             'isMultistoreEnabled' => $this->getShopContext()->isMultiShopEnabled(),
+            'displayCustomerSocialTitle' => (int) $this->getConfiguration()->get('PS_CUSTOMER_ASK_FOR_SOCIAL_TITLE') != CustomerSettings::SOCIAL_TITLES_DISABLED,
             'transferGuestAccountForm' => $transferGuestAccountForm,
             'privateNoteForm' => $privateNoteForm->createView(),
             'layoutHeaderToolbarBtn' => $this->getCustomerViewToolbarButtons($customerId),

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Action\ActionsBarButtonsCollection;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartForOrderCreation;
 use PrestaShop\PrestaShop\Core\Domain\CartRule\Exception\InvalidCartRuleDiscountValueException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\CustomerSettings;
 use PrestaShop\PrestaShop\Core\Domain\CustomerMessage\Command\AddOrderCustomerMessageCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerMessage\Exception\CannotSendEmailException;
 use PrestaShop\PrestaShop\Core\Domain\CustomerMessage\Exception\CustomerMessageConstraintException;
@@ -636,6 +637,7 @@ class OrderController extends PrestaShopAdminController
             'shipmentsGrid' => $this->presentGrid($shipmentsGrid),
             'shipmentsLabel' => $tools->purifyHTML($shipmentsLabel),
             'carriersLabel' => $tools->purifyHTML($carriersLabel),
+            'displayCustomerSocialTitle' => (int) $this->getConfiguration()->get('PS_CUSTOMER_ASK_FOR_SOCIAL_TITLE') != CustomerSettings::SOCIAL_TITLES_DISABLED,
         ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
@@ -26,10 +26,12 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\CustomerPreferences;
 
+use PrestaShop\PrestaShop\Core\Domain\Customer\CustomerSettings;
 use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use PrestaShopBundle\Form\Extension\MultistoreConfigurationTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -125,6 +127,23 @@ class GeneralType extends TranslatorAwareType
                     'Admin.Shopparameters.Help'
                 ),
                 'multistore_configuration_key' => 'PS_CUSTOMER_OPTIN',
+            ])
+            ->add('ask_for_social_title', ChoiceType::class, [
+                'label' => $this->trans(
+                    'Customer social titles',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'Specify if you want to use social titles (Mr., Mrs.) for your customers.',
+                    'Admin.Shopparameters.Help'
+                ),
+                'choices' => [
+                    $this->trans('Disabled', 'Admin.Shopparameters.Feature') => CustomerSettings::SOCIAL_TITLES_DISABLED,
+                    $this->trans('Enabled for internal purposes only', 'Admin.Shopparameters.Feature') => CustomerSettings::SOCIAL_TITLES_ENABLED,
+                    $this->trans('Enabled', 'Admin.Shopparameters.Feature') => CustomerSettings::SOCIAL_TITLES_ENABLED_COLLECTED,
+                ],
+                'required' => true,
+                'multistore_configuration_key' => 'PS_CUSTOMER_ASK_FOR_SOCIAL_TITLE',
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Form\Admin\Sell\Customer;
 use PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\GroupByIdChoiceProvider;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CustomerName;
+use PrestaShop\PrestaShop\Core\Domain\Customer\CustomerSettings;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\FirstName;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\LastName;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email as DomainEmail;
@@ -85,10 +86,16 @@ class CustomerType extends TranslatorAwareType
      * @var FormCloner
      */
     protected $formCloner;
+
     /**
      * @var GroupByIdChoiceProvider
      */
     private $groupByIdChoiceProvider;
+
+    /**
+     * @var int
+     */
+    private $customerSocialTitleSetting;
 
     /**
      * @param TranslatorInterface $translator
@@ -99,6 +106,7 @@ class CustomerType extends TranslatorAwareType
      * @param bool $isPartnerOffersEnabled
      * @param ConfigurationInterface $configuration
      * @param FormCloner $formCloner
+     * @param int $customerSocialTitleSetting
      */
     public function __construct(
         TranslatorInterface $translator,
@@ -108,7 +116,8 @@ class CustomerType extends TranslatorAwareType
         $isB2bFeatureEnabled,
         $isPartnerOffersEnabled,
         ConfigurationInterface $configuration,
-        FormCloner $formCloner
+        FormCloner $formCloner,
+        int $customerSocialTitleSetting = CustomerSettings::SOCIAL_TITLES_DISABLED
     ) {
         parent::__construct($translator, $locales);
         $this->isB2bFeatureEnabled = $isB2bFeatureEnabled;
@@ -117,6 +126,7 @@ class CustomerType extends TranslatorAwareType
         $this->configuration = $configuration;
         $this->formCloner = $formCloner;
         $this->groupByIdChoiceProvider = $groupByIdChoiceProvider;
+        $this->customerSocialTitleSetting = $customerSocialTitleSetting;
     }
 
     /**
@@ -169,12 +179,17 @@ class CustomerType extends TranslatorAwareType
                 ]);
         }
 
+        // We show the social title field only when the feature is enabled
+        if ($this->customerSocialTitleSetting !== CustomerSettings::SOCIAL_TITLES_DISABLED) {
+            $builder
+                ->add('gender_id', GenderType::class, [
+                    'expanded' => true,
+                    'required' => false,
+                    'placeholder' => null,
+                ]);
+        }
+
         $builder
-            ->add('gender_id', GenderType::class, [
-                'expanded' => true,
-                'required' => false,
-                'placeholder' => null,
-            ])
             ->add('first_name', TextType::class, [
                 'label' => $this->trans('First name', 'Admin.Global'),
                 'help' => $this->trans(

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -248,6 +248,7 @@ services:
       $riskChoices: '@=service("prestashop.adapter.form.choice_provider.risk_by_id_choice_provider").getChoices()'
       $isB2bFeatureEnabled: '@=service("prestashop.core.b2b.b2b_feature").isActive()'
       $isPartnerOffersEnabled: '@=service("prestashop.adapter.legacy.configuration").get("PS_CUSTOMER_OPTIN")'
+      $customerSocialTitleSetting: '@=service("prestashop.adapter.legacy.configuration").get("PS_CUSTOMER_ASK_FOR_SOCIAL_TITLE")'
 
   PrestaShopBundle\Form\Admin\Improve\International\Currencies\CurrencyType:
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -77,6 +77,7 @@ services:
       - '@=service("prestashop.adapter.multistore_feature").isActive()'
       - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
       - '@=service("prestashop.adapter.feature.group_feature").isActive()'
+      - '@=service("prestashop.adapter.legacy.configuration").get("PS_CUSTOMER_ASK_FOR_SOCIAL_TITLE")'
     public: true
 
   prestashop.core.grid.definition.factory.customer.discount:

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/personal_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/personal_information.html.twig
@@ -45,14 +45,16 @@
     </a>
   </h3>
   <div class="card-body">
-    <div class="row mb-1">
-      <div class="col-sm-4 text-sm-right font-weight-bold">
-        {{ 'Social Title'|trans({}, 'Admin.Global') }}
+    {% if displayCustomerSocialTitle %}
+      <div class="row mb-1">
+        <div class="col-sm-4 text-sm-right font-weight-bold">
+          {{ 'Social Title'|trans({}, 'Admin.Global') }}
+        </div>
+        <div class="customer-social-title col-sm-8">
+          {{ customerInformation.personalInformation.socialTitle }}
+        </div>
       </div>
-      <div class="customer-social-title col-sm-8">
-        {{ customerInformation.personalInformation.socialTitle }}
-      </div>
-    </div>
+    {% endif %}
 
     <div class="row mb-1">
       <div class="col-sm-4 text-sm-right font-weight-bold">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -37,7 +37,7 @@
           <div class="col-xxl-7">
             <h2 class="mb-0">
               <i class="material-icons">account_box</i>
-              {{ orderForViewing.customer.gender }}
+              {% if displayCustomerSocialTitle %}{{ orderForViewing.customer.gender }}{% endif %}
               {{ orderForViewing.customer.firstName }}
               {{ orderForViewing.customer.lastName }}
             </h2>

--- a/tests/Unit/Adapter/Customer/CustomerConfigurationTest.php
+++ b/tests/Unit/Adapter/Customer/CustomerConfigurationTest.php
@@ -45,6 +45,7 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
         'enable_b2b_mode' => true,
         'ask_for_birthday' => true,
         'enable_offers' => true,
+        'ask_for_social_title' => 2,
     ];
 
     /**
@@ -74,6 +75,7 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
                     ['PS_B2B_ENABLE', false, $shopConstraint, true],
                     ['PS_CUSTOMER_BIRTHDATE', false, $shopConstraint, true],
                     ['PS_CUSTOMER_OPTIN', false, $shopConstraint, true],
+                    ['PS_CUSTOMER_ASK_FOR_SOCIAL_TITLE', 0, $shopConstraint, 2],
                 ]
             );
 
@@ -112,6 +114,7 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_b2b_mode' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['ask_for_birthday' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_offers' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['ask_for_social_title' => 'wrong_type'])],
         ];
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Implements a switch that allows to define if social titles should be used - https://github.com/PrestaShop/PrestaShop/issues/23914. Already accepted by PM in the issue.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | There is a new option in Customer settings. Try all three. You can disable social titles completely. You can keep them enabled, but don't collect them from customers in FO. You can enable them fully.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/23914
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.
