### PR TITLE
Chore(Makefile): fix Makefile shell detection issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 # Executables (local)
 DOCKER_COMP = docker compose
+PHP_CONT =
+PHP_CONT_WITH_LOGIN = bash -l
 
 # Determine if we are using docker
 DOCKER_RUNNING := $(shell docker compose ps -q)
 ifneq ($(strip $(DOCKER_RUNNING)),)
-	PHP_CONT = $(DOCKER_COMP) exec prestashop-git runuser -u www-data -g www-data --
+	PHP_CONT = $(DOCKER_COMP) exec -T prestashop-git runuser -u www-data -g www-data --
+	PHP_CONT_WITH_LOGIN = $(DOCKER_COMP) exec -T prestashop-git runuser -u www-data -g www-data -- bash -l
 endif
 
 # Executables (local or docker)
@@ -38,7 +41,7 @@ docker-logs: ## Show live logs
 	$(DOCKER_COMP) logs --follow
 
 docker-sh: ## Connect to the PHP container via bash so up and down arrows go to previous commands
-	@$(PHP_CONT) bash
+	@$(DOCKER_COMP) exec -it prestashop-git runuser -u www-data -g www-data -- bash -l
 
 ## —— PrestaShop 🛒 ———————————————————————————————————————————————————————————
 install: composer cc assets  ## Install PHP dependencies and build the static assets
@@ -48,34 +51,34 @@ install-prestashop: ## Install fresh PrestaShop database (requires containers to
 
 ## —— Assets 🎨 ———————————————————————————————————————————————————————————————
 assets: admin front ## Build all assets
-	$(PHP_CONT) ./tools/assets/build.sh all --force
+	$(PHP_CONT_WITH_LOGIN) ./tools/assets/build.sh all --force
 
 wait-assets: ## Wait for assets to be built
-	$(PHP_CONT) ./tools/assets/wait-build.sh
+	$(PHP_CONT_WITH_LOGIN) ./tools/assets/wait-build.sh
 
 admin: ## Build admin assets
-	$(PHP_CONT) ./tools/assets/build.sh admin-default --force
-	$(PHP_CONT) ./tools/assets/build.sh admin-new-theme --force
+	$(PHP_CONT_WITH_LOGIN) ./tools/assets/build.sh admin-default --force
+	$(PHP_CONT_WITH_LOGIN) ./tools/assets/build.sh admin-new-theme --force
 
 front: ## Build front assets
-	$(PHP_CONT) ./tools/assets/build.sh front-core --force
-	$(PHP_CONT) ./tools/assets/build.sh front-classic --force
-	$(PHP_CONT) ./tools/assets/build.sh front-hummingbird --force
+	$(PHP_CONT_WITH_LOGIN) ./tools/assets/build.sh front-core --force
+	$(PHP_CONT_WITH_LOGIN) ./tools/assets/build.sh front-classic --force
+	$(PHP_CONT_WITH_LOGIN) ./tools/assets/build.sh front-hummingbird --force
 
 admin-default: ## Build assets for default admin theme
-	$(PHP_CONT) ./tools/assets/build.sh admin-default --force
+	$(PHP_CONT_WITH_LOGIN) ./tools/assets/build.sh admin-default --force
 
 admin-new-theme: ## Build assets for new admin theme
-	$(PHP_CONT) ./tools/assets/build.sh admin-new-theme --force
+	$(PHP_CONT_WITH_LOGIN) ./tools/assets/build.sh admin-new-theme --force
 
 front-core: ## Build assets for core theme
-	$(PHP_CONT) ./tools/assets/build.sh front-core --force
+	$(PHP_CONT_WITH_LOGIN) ./tools/assets/build.sh front-core --force
 
 front-classic: ## Build assets for classic theme
-	$(PHP_CONT) ./tools/assets/build.sh front-classic --force
+	$(PHP_CONT_WITH_LOGIN) ./tools/assets/build.sh front-classic --force
 
 front-hummingbird: ## Build assets for hummingbird theme
-	$(PHP_CONT) ./tools/assets/build.sh front-hummingbird --force
+	$(PHP_CONT_WITH_LOGIN) ./tools/assets/build.sh front-hummingbird --force
 
 ## —— Composer & Symfony 🧙 ————————————————————————————————————————————————————
 composer: ## Install PHP dependencies
@@ -111,12 +114,12 @@ phpstan: ## Run phpstan analysis
 	$(COMPOSER) run phpstan
 
 scss-fixer: ## Run scss-fix
-	$(PHP_CONT) bash -l -c "cd admin-dev/themes/new-theme && npm run scss-fix"
-	$(PHP_CONT) bash -l -c "cd admin-dev/themes/default && npm run scss-fix"
-	$(PHP_CONT) bash -l -c "cd themes/classic/_dev && npm run scss-fix"
+	$(PHP_CONT_WITH_LOGIN) -c "cd admin-dev/themes/new-theme && (test -d node_modules || npm install) && npm run scss-fix"
+	$(PHP_CONT_WITH_LOGIN) -c "cd admin-dev/themes/default && (test -d node_modules || npm install) && npm run scss-fix"
+	$(PHP_CONT_WITH_LOGIN) -c "cd themes/classic/_dev && (test -d node_modules || npm install) && npm run scss-fix"
 
 es-linter: ## Run lint-fix
-	$(PHP_CONT) bash -l -c "cd admin-dev/themes/new-theme && npm run lint-fix"
-	$(PHP_CONT) bash -l -c "cd admin-dev/themes/default && npm run lint-fix"
-	$(PHP_CONT) bash -l -c "cd themes/classic/_dev && npm run lint-fix"
-	$(PHP_CONT) bash -l -c "cd themes && npm run lint-fix"
+	$(PHP_CONT_WITH_LOGIN) -c "cd admin-dev/themes/new-theme && (test -d node_modules || npm install) && npm run lint-fix"
+	$(PHP_CONT_WITH_LOGIN) -c "cd admin-dev/themes/default && (test -d node_modules || npm install) && npm run lint-fix"
+	$(PHP_CONT_WITH_LOGIN) -c "cd themes/classic/_dev && (test -d node_modules || npm install) && npm run lint-fix"
+	$(PHP_CONT_WITH_LOGIN) -c "cd themes && (test -d node_modules || npm install) && npm run lint-fix"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR fix the `Makefile` usage on non-docker environment. It detects the current shell and pipe it if docker is not running. #40092 tried to fix it but left "-c" left-overs in `scss-fixer` and `es-linter` commands. Plus it was targeted to develop branch instead of 9.0.x branch.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run `make scss-fixer`or/and `make admin-new-theme`
| UI Tests          | [mysql](https://github.com/tyloo/ga.tests.ui.pr/actions/runs/19710448532) ⌛  / [mariadb](https://github.com/tyloo/ga.tests.ui.pr/actions/runs/19710453723) ⌛ 
| Fixed issue or discussion?     | Fixes #40090
| Related PRs       | #40092
| Sponsor company   | PrestaShop SA
