### PR TITLE
Fix cart rule validation in front office

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3107,7 +3107,7 @@ class CartCore extends ObjectModel
      *
      * @param array $delivery_option Delivery option array
      */
-    public function setDeliveryOption($delivery_option = null)
+    public function setDeliveryOption($delivery_option = null, bool $useOrderPrices = false)
     {
         if (empty($delivery_option)) {
             $this->delivery_option = '';
@@ -3137,8 +3137,8 @@ class CartCore extends ObjectModel
         $this->delivery_option = json_encode($delivery_option);
 
         // update auto cart rules
-        CartRule::autoRemoveFromCart();
-        CartRule::autoAddToCart();
+        CartRule::autoRemoveFromCart(null, $useOrderPrices);
+        CartRule::autoAddToCart(null, $useOrderPrices);
     }
 
     /**

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3106,6 +3106,7 @@ class CartCore extends ObjectModel
      * Set the delivery option and Carrier ID, if there is only one Carrier.
      *
      * @param array $delivery_option Delivery option array
+     * @param bool $useOrderPrices
      */
     public function setDeliveryOption($delivery_option = null, bool $useOrderPrices = false)
     {

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -745,57 +745,65 @@ class CartRuleCore extends ObjectModel
             return (!$display_error) ? true : null;
         }
 
-        // All these checks are necessary when you add the cart rule the first time, so when it's not in cart yet
-        // However when it's in the cart and you are checking if the cart rule is still valid (when performing auto remove)
-        // these rules are outdated For example:
-        //  - the cart rule can now be disabled but it was at the time it was applied, so it doesn't need to be removed
-        //  - the current date is not in the range any more but it was at the time
-        //  - the quantity is now zero but it was not when it was added
-        if (!$alreadyInCart) {
+        /*
+         * All these checks are relevant only for non-ordered carts. When an order has been already
+         * created from the cart, we do not check this. $useOrderPrices is a bit confusing as a name,
+         * but it indicates that we are validating a cart that has already been ordered.
+         */
+        if (!$useOrderPrices) {
+            // We verify that the cart rule is active
             if (!$this->active) {
                 return (!$display_error) ? false : $this->trans('This voucher is disabled', [], 'Shop.Notifications.Error');
             }
+
+            // We verify the total available quantity
             if (!$this->quantity) {
                 return (!$display_error) ? false : $this->trans('This voucher has already been used', [], 'Shop.Notifications.Error');
             }
+
+            // We verify the date range
             if (strtotime($this->date_from) > time()) {
                 return (!$display_error) ? false : $this->trans('This voucher is not valid yet', [], 'Shop.Notifications.Error');
             }
             if (strtotime($this->date_to) < time()) {
                 return (!$display_error) ? false : $this->trans('This voucher has expired', [], 'Shop.Notifications.Error');
             }
-        }
+        
+            // We verify the quantity per user, if customer is already assigned to the cart
+            if ($cart->id_customer) {
 
-        if ($cart->id_customer) {
-            $quantityUsed = Db::getInstance()->getValue('
-			SELECT count(*)
-			FROM `' . _DB_PREFIX_ . 'orders` o
-			LEFT JOIN `' . _DB_PREFIX_ . 'order_cart_rule` ocr ON o.`id_order` = ocr.`id_order`
-			WHERE o.`id_customer` = ' . $cart->id_customer . '
-			AND ocr.`deleted` = 0
-			AND ocr.`id_cart_rule` = ' . (int) $this->id . '
-			AND ' . (int) Configuration::get('PS_OS_ERROR') . ' != o.`current_state`
-			');
-
-            if ($alreadyInCart) {
-                // Sometimes a cart rule is already in a cart, but the cart is not yet attached to an order (when logging
-                // in for example), these cart rules are not taken into account by the query above:
-                // so we count cart rules that are already linked to the current cart but not attached to an order yet.
-
-                $quantityUsed += (int) Db::getInstance()->getValue('
-                    SELECT count(*)
-                    FROM `' . _DB_PREFIX_ . 'cart_cart_rule` ccr
-                    INNER JOIN `' . _DB_PREFIX_ . 'cart` c ON c.id_cart = ccr.id_cart
-                    LEFT JOIN `' . _DB_PREFIX_ . 'orders` o ON o.id_cart = c.id_cart
-                    WHERE c.id_customer = ' . $cart->id_customer . ' AND c.id_cart = ' . $cart->id . ' AND ccr.id_cart_rule = ' . (int) $this->id . ' AND o.id_order IS NULL
+                // First, we check if the customer has already used this cart rule in past orders
+                $quantityUsed = Db::getInstance()->getValue('
+                SELECT count(*)
+                FROM `' . _DB_PREFIX_ . 'orders` o
+                LEFT JOIN `' . _DB_PREFIX_ . 'order_cart_rule` ocr ON o.`id_order` = ocr.`id_order`
+                WHERE o.`id_customer` = ' . $cart->id_customer . '
+                AND ocr.`deleted` = 0
+                AND ocr.`id_cart_rule` = ' . (int) $this->id . '
+                AND ' . (int) Configuration::get('PS_OS_ERROR') . ' != o.`current_state`
                 ');
-            } else {
-                // When checking the cart rules present in that cart the request result is accurate
-                // When we check if using the cart rule one more time is valid then we increment this value
-                ++$quantityUsed;
-            }
-            if ($quantityUsed > $this->quantity_per_user) {
-                return (!$display_error) ? false : $this->trans('You cannot use this voucher anymore (usage limit reached)', [], 'Shop.Notifications.Error');
+
+                if ($alreadyInCart) {
+                    // Sometimes a cart rule is already in a cart, but the cart is not yet attached to an order (when logging
+                    // in for example), these cart rules are not taken into account by the query above:
+                    // so we count cart rules that are already linked to the current cart but not attached to an order yet.
+
+                    $quantityUsed += (int) Db::getInstance()->getValue('
+                        SELECT count(*)
+                        FROM `' . _DB_PREFIX_ . 'cart_cart_rule` ccr
+                        INNER JOIN `' . _DB_PREFIX_ . 'cart` c ON c.id_cart = ccr.id_cart
+                        LEFT JOIN `' . _DB_PREFIX_ . 'orders` o ON o.id_cart = c.id_cart
+                        WHERE c.id_customer = ' . $cart->id_customer . ' AND c.id_cart = ' . $cart->id . ' AND ccr.id_cart_rule = ' . (int) $this->id . ' AND o.id_order IS NULL
+                    ');
+                } else {
+                    // When checking the cart rules present in that cart the request result is accurate
+                    // When we check if using the cart rule one more time is valid then we increment this value
+                    ++$quantityUsed;
+                }
+
+                if ($quantityUsed > $this->quantity_per_user) {
+                    return (!$display_error) ? false : $this->trans('You cannot use this voucher anymore (usage limit reached)', [], 'Shop.Notifications.Error');
+                }
             }
         }
 

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -768,10 +768,9 @@ class CartRuleCore extends ObjectModel
             if (strtotime($this->date_to) < time()) {
                 return (!$display_error) ? false : $this->trans('This voucher has expired', [], 'Shop.Notifications.Error');
             }
-        
+
             // We verify the quantity per user, if customer is already assigned to the cart
             if ($cart->id_customer) {
-
                 // First, we check if the customer has already used this cart rule in past orders
                 $quantityUsed = Db::getInstance()->getValue('
                 SELECT count(*)

--- a/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
@@ -65,9 +65,10 @@ final class UpdateCartCarrierHandler extends AbstractCartHandler implements Upda
         $this->setCartContext($this->contextStateManager, $cart);
 
         try {
-            $cart->setDeliveryOption([
-                (int) $cart->id_address_delivery => $this->formatLegacyDeliveryOptionFromCarrierId($command->getNewCarrierId()),
-            ]);
+            $cart->setDeliveryOption(
+                [(int) $cart->id_address_delivery => $this->formatLegacyDeliveryOptionFromCarrierId($command->getNewCarrierId())],
+                true
+            );
             $cart->update();
         } finally {
             $this->contextStateManager->restorePreviousContext();

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -381,6 +381,8 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             0,
             new Shop($cart->id_shop),
             true,
+            true,
+            true,
             true
         );
 
@@ -461,7 +463,7 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             $freeShippingCartRule->add();
 
             // Add cart rule to cart and in order
-            $cart->addCartRule($freeShippingCartRule->id);
+            $cart->addCartRule($freeShippingCartRule->id, true);
             $values = [
                 'tax_incl' => $freeShippingCartRule->getContextualValue(true),
                 'tax_excl' => $freeShippingCartRule->getContextualValue(false),

--- a/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
@@ -107,9 +107,10 @@ final class ChangeOrderDeliveryAddressHandler extends AbstractOrderCommandHandle
             $comparator = new CartProductsComparator($cart);
 
             $cart->updateDeliveryAddressId((int) $cart->id_address_delivery, (int) $address->id);
-            $cart->setDeliveryOption([
-                (int) $cart->id_address_delivery => $this->formatLegacyDeliveryOptionFromCarrierId($order->id_carrier),
-            ]);
+            $cart->setDeliveryOption(
+                [(int) $cart->id_address_delivery => $this->formatLegacyDeliveryOptionFromCarrierId($order->id_carrier)],
+                true
+            );
             $cart->update();
 
             // gift could have been added/deleted when changing delivery address

--- a/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
@@ -94,9 +94,10 @@ final class UpdateOrderShippingDetailsHandler extends AbstractOrderHandler imple
             $oldCarrierId = (int) $orderCarrier->id_carrier;
             if ($oldCarrierId !== $carrierId) {
                 $cart = Cart::getCartByOrderId($order->id);
-                $cart->setDeliveryOption([
-                    (int) $cart->id_address_delivery => $this->formatLegacyDeliveryOptionFromCarrierId($carrierId),
-                ]);
+                $cart->setDeliveryOption(
+                    [(int) $cart->id_address_delivery => $this->formatLegacyDeliveryOptionFromCarrierId($carrierId)],
+                    true
+                );
                 $cart->save();
 
                 $orderCarrier->id_carrier = $carrierId;

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -432,14 +432,19 @@ class OrderAmountUpdater
         int $computingPrecision,
         ?int $orderInvoiceId
     ): void {
+        /*
+         * We need to run automatic cart rule actions.
+         * autoAddToCart is required to automatically assigning newly created cart rules with no code (automatic).
+         * autoRemoveFromCart is needed to verify, if the cart rules already in a cart are still valid.
+         * Note that we are calling both with a $useOrderPrice flag set to true.
+         */
         CartRule::autoAddToCart(null, true);
         CartRule::autoRemoveFromCart(null, true);
-        $carrierId = $order->id_carrier;
 
         $newCartRules = $cart->getCartRules(CartRule::FILTER_ACTION_ALL, false);
         // We need the calculator to compute the discount on the whole products because they can interact with each
         // other so they can't be computed independently, it needs to keep order prices
-        $calculator = $cart->newCalculator($cart->getProducts(), $newCartRules, $carrierId, $computingPrecision, $this->keepOrderPrices);
+        $calculator = $cart->newCalculator($cart->getProducts(), $newCartRules, $order->id_carrier, $computingPrecision, $this->keepOrderPrices);
         $calculator->processCalculation();
 
         foreach ($order->getCartRules() as $orderCartRuleData) {

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -441,7 +441,8 @@ class OrderAmountUpdater
         CartRule::autoAddToCart(null, true);
         CartRule::autoRemoveFromCart(null, true);
 
-        $newCartRules = $cart->getCartRules(CartRule::FILTER_ACTION_ALL, false);
+        $newCartRules = $cart->getCartRules(CartRule::FILTER_ACTION_ALL, false, true);
+
         // We need the calculator to compute the discount on the whole products because they can interact with each
         // other so they can't be computed independently, it needs to keep order prices
         $calculator = $cart->newCalculator($cart->getProducts(), $newCartRules, $order->id_carrier, $computingPrecision, $this->keepOrderPrices);

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -305,6 +305,9 @@ class OrderProductQuantityUpdater
          *
          * Here we are editing an order, not a cart, so what has been ordered
          * has already been substracted from the stock.
+         *
+         * Also, we need to make sure to call this method with $useOrderPrices
+         * enabled, so it properly behaves the update for an finished order.
          */
         $updateQuantityResult = $cart->updateQty(
             abs($deltaQuantity),
@@ -314,6 +317,8 @@ class OrderProductQuantityUpdater
             $deltaQuantity < 0 ? 'down' : 'up',
             0,
             new Shop($cart->id_shop),
+            true,
+            true,
             true,
             true
         );

--- a/src/Adapter/Order/Refund/OrderProductRemover.php
+++ b/src/Adapter/Order/Refund/OrderProductRemover.php
@@ -119,7 +119,8 @@ class OrderProductRemover
             null,
             true,
             false,
-            false // Do not preserve gift removal
+            false, // Do not preserve gift removal
+            true
         );
     }
 

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/cart_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/cart_to_order.feature
@@ -59,6 +59,8 @@ Feature: Check cart to order data copy
     Given I have an empty default cart
     Given email sending is disabled
     Given shipping handling fees are set to 2.0
+    And I edit cart rule "cartrule1" with following properties:
+      | total_quantity      | 1         |
     And there is a cart rule "cartrule2" with following properties:
       | name[en-US]         | cartrule2 |
       | priority            | 2         |
@@ -94,6 +96,49 @@ Feature: Check cart to order data copy
     Then current cart order shipping fees should be 7.0 tax excluded
     Then current cart order should have a discount in position 1 with an amount of 10.300000 tax included and 9.905000 tax excluded
     Then current cart order should have a discount in position 2 with an amount of 5.150000 tax included and 4.952500 tax excluded
+    Then customer "customer1" should have 0 cart rules that apply to him
+
+  @restore-cart-rules-after-scenario
+  Scenario: 1 product in cart, 2 cart rules, one of them unusable
+    Given I have an empty default cart
+    Given email sending is disabled
+    Given shipping handling fees are set to 2.0
+    And I edit cart rule "cartrule1" with following properties:
+      | total_quantity      | 0         |
+    And there is a cart rule "cartrule2" with following properties:
+      | name[en-US]         | cartrule2 |
+      | priority            | 2         |
+      | free_shipping       | false     |
+      | code                | foo2      |
+      | discount_percentage | 50        |
+    Given there is a country named "country1" and iso code "FR" in zone "zone1"
+    Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
+    Given there is an address named "address1" with postcode "1" in state "state1"
+    Given there is a tax named "tax1" and rate 4.0%
+    Given there is a tax rule named "taxrule1" in country "country1" and state "state1" where tax "tax1" is applied
+    Given product "product1" belongs to tax group "taxrule1"
+    Given there is a customer named "customer1" whose email is "fake@prestashop.com"
+    Given address "address1" is associated to customer "customer1"
+    And I create carrier "carrier1" with specified properties:
+      | name | carrier 1 |
+      | zones| zone1     |
+    Then I set ranges for carrier "carrier1" with specified properties for all shops:
+      | id_zone | range_from | range_to | range_price |
+      | zone1   | 0          | 10000    | 5.0         |
+    When I am logged in as "customer1"
+    When I add 1 items of product "product1" in my cart
+    When I use the discount "cartrule1"
+    When I use the discount "cartrule2"
+    When I select address "address1" in my cart
+    When I select carrier "carrier1" in my cart
+    When I validate my cart using payment module fake
+    Then current cart order total for products should be 20.600000 tax included
+    Then current cart order total for products should be 19.810000 tax excluded
+    Then current cart order total discount should be 10.300000 tax included
+    Then current cart order total discount should be 9.910000 tax excluded
+    Then current cart order shipping fees should be 7.0 tax included
+    Then current cart order shipping fees should be 7.0 tax excluded
+    Then current cart order should have a discount in position 1 with an amount of 10.300000 tax included and 9.905000 tax excluded
     Then customer "customer1" should have 0 cart rules that apply to him
 
   Scenario: 3 product in cart, 1 cart rule
@@ -133,10 +178,12 @@ Feature: Check cart to order data copy
     Then current cart order should have a discount in position 1 with an amount of 59.575000 tax included and 57.290000 tax excluded
     Then customer "customer1" should have 0 cart rules that apply to him
 
-  Scenario: 3 product in cart, 3 cart rules
+  Scenario: 3 product in cart, 2 cart rules
     Given I have an empty default cart
     Given email sending is disabled
     Given shipping handling fees are set to 2.0
+    Given I edit cart rule "cartrule1" with following properties:
+      | total_quantity      | 1         |
     Given there is a cart rule "cartrule2" with following properties:
       | name[en-US]         | cartrule2 |
       | priority            | 2         |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fixes one of the most irritating bugs in PrestaShop, where cart rules are not removed from cart if they are no longer active, expired or usage limit reached. Basicly, the whole fix is using a proper variable at the right place.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/19765034591 🟢 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/26235, Fixes https://github.com/PrestaShop/PrestaShop/issues/19393, Fixes https://github.com/PrestaShop/PrestaShop/issues/29493, Fixes https://github.com/PrestaShop/PrestaShop/issues/36982
| Related PRs       | 
| Sponsor company   | 

### How to test
Create a cart rule Test, 10% off, code `TEST`, 1 total, 1 per customer, some valid dates.

### Basic testing
- Add `TEST` to your cart in FO. Disable it in BO. Refresh page in FO ➡️ rule removed.
- Add `TEST` to your cart in FO. Change validity to something not valid right now in BO. Refresh page in FO ➡️ rule removed.
- Add `TEST` to your cart in FO. Change total available to 0 in BO. Refresh page in FO ➡️ rule removed.

### Quantity per customer
- Register and log in as some customer in FO. No guest order!
- Add some products to cart, make an order with this `TEST` cart rule.
- Add some products to cart again and try to use the rule `TEST` again ➡️ won't work.
- Change quantity per customer to 2 in BO. Go back to FO, try to use rule `TEST` ➡️ will work.
- Go back to BO, change quantity per customer back to 1. Go to FO, refresh page ➡️ rule removed.

### Test that I did not broke admin
- Open any order in backoffice and try to add manual discount. With previous attempts on fixing it, it immediately disappeared. Will stay now.
- Then, I discovered that the rule was removed when editing products in an order. The culprit was a wrong flag to `updateQty` call. Fixed also.
- Then, it was automatically removed when refreshing shipping on the order. The method also did not get proper parameters and was calling autoRemoveFromCart like in FO.
- Then, it was removed when deleting a product from order. Also needed a proper call to the legacy part.