### PR TITLE
Add two-step process for module upgrade (download then install)

### DIFF
--- a/admin-dev/themes/new-theme/js/components/module-card.ts
+++ b/admin-dev/themes/new-theme/js/components/module-card.ts
@@ -208,17 +208,15 @@ export default class ModuleCard {
           },
 
           () => self.dispatchPreEvent('update', this)
-            && self.confirmAction('update', this)
-            && self.requestToController('update', $(this)),
+          && self.confirmAction('update', this)
+          && self.upgradeWithUploadFallback(this),
         );
 
         updateConfirmModal.show();
       } else {
-        return (
-          self.dispatchPreEvent('update', this)
+        return self.dispatchPreEvent('update', this)
           && self.confirmAction('update', this)
-          && self.requestToController('update', $(this))
-        );
+          && self.upgradeWithUploadFallback(this);
       }
 
       return false;
@@ -320,7 +318,7 @@ export default class ModuleCard {
     action: string,
     element: JQuery,
     forceDeletion: string | boolean = false,
-    callback = () => true,
+    callback: (response?: any) => boolean = () => true,
   ): boolean {
     if (this.pendingRequest) {
       $.growl.warning({
@@ -336,14 +334,18 @@ export default class ModuleCard {
     const spinnerObj = $(
       '<button class="btn-primary-reverse onclick unbind spinner "></button>',
     );
-    const url = `//${window.location.host}${form.attr('action')}`;
+    // Use custom upload_url for 'upgrade' if available, otherwise use the default URL.
+    let url = `//${window.location.host}${form.attr('action')}`;
+
+    if (action === 'upload' && form.data('upload-url')) {
+      url = form.data('upload-url');
+    }
     const actionParams = form.serializeArray();
     let refreshNeeded = false;
 
     if (forceDeletion === 'true' || forceDeletion === true) {
       actionParams.push({name: 'actionParams[deletion]', value: 'true'});
     }
-
     $.ajax({
       url,
       dataType: 'json',
@@ -374,11 +376,6 @@ export default class ModuleCard {
           $.growl.error({message: result[moduleTechName].msg, fixed: true});
           return;
         }
-
-        $.growl({
-          message: result[moduleTechName].msg,
-          duration: 6000,
-        });
 
         if (result[moduleTechName].refresh_needed === true) {
           refreshNeeded = true;
@@ -426,11 +423,18 @@ export default class ModuleCard {
           this.eventEmitter.emit('Module Upgraded', mainElement);
         }
 
-        // Since we replace the DOM content
-        // we need to update the jquery object reference to target the new content,
-        // and we need to hide the new content which is not hidden by default
-        jqElementObj = $(result[moduleTechName].action_menu_html).replaceAll(jqElementObj);
-        jqElementObj.hide();
+        if (action !== 'upload') {
+          $.growl({
+            message: result[moduleTechName].msg,
+            duration: 6000,
+          });
+
+          // Since we replace the DOM content
+          // we need to update the jquery object reference to target the new content,
+          // and we need to hide the new content which is not hidden by default
+          jqElementObj = $(result[moduleTechName].action_menu_html).replaceAll(jqElementObj);
+          jqElementObj.hide();
+        }
       })
       .fail(() => {
         const moduleItem = jqElementObj.closest('module-item-list');
@@ -440,7 +444,7 @@ export default class ModuleCard {
           fixed: true,
         });
       })
-      .always(() => {
+      .always((response) => {
         if (refreshNeeded) {
           document.location.reload();
           return;
@@ -450,10 +454,31 @@ export default class ModuleCard {
         this.pendingRequest = false;
 
         if (callback) {
-          callback();
+          callback(Object.values(response)[0]);
         }
       });
 
     return false;
+  }
+
+  upgradeWithUploadFallback(element: string, callback = () => true): boolean {
+    const form = $(element).closest('form');
+
+    // If the form contains a data-upload-url attribute, we use two step workflow.
+    if (form.data('upload-url')) {
+      try {
+        return this.requestToController('upload', $(element), false, (response): boolean => {
+          if (response.status === true) {
+            return this.requestToController('upgrade', $(element), false, callback);
+          }
+          return false;
+        });
+      } catch (error) {
+        console.error('Error making request', error);
+        return false;
+      }
+    } else {
+      return this.requestToController('upgrade', $(element), false, callback);
+    }
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -814,12 +814,16 @@ class AdminModuleController {
         return;
       }
 
-      self.moduleCardController.requestToController(
-        bulkModuleAction,
-        actionMenuLink,
-        forceDeletion,
-        unstackModulesActions,
-      );
+      if (bulkModuleAction !== 'upgrade') {
+        self.moduleCardController.requestToController(
+          bulkModuleAction,
+          actionMenuLink,
+          forceDeletion,
+          unstackModulesActions,
+        );
+      } else {
+        self.moduleCardController.upgradeWithUploadFallback(actionMenuLink, unstackModulesActions);
+      }
     }
 
     function unstackModulesActions() {

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -54,6 +54,7 @@ class AdminModuleDataProvider implements ModuleInterface
         Module::ACTION_DISABLE => 'Disable',
         Module::ACTION_RESET => 'Reset',
         Module::ACTION_UPGRADE => 'Update',
+        Module::ACTION_UPLOAD => 'Upload',
         Module::ACTION_CONFIGURE => 'Configure',
         Module::ACTION_DELETE => 'Delete',
     ];
@@ -212,9 +213,6 @@ class AdminModuleDataProvider implements ModuleInterface
                     'action' => $action,
                     'module_name' => $moduleAttributes->get('name'),
                 ];
-                if ($action === 'upgrade' && $moduleAttributes->get('download_url') !== null) {
-                    $parameters['source'] = $moduleAttributes->get('download_url');
-                }
                 $urls[$action] = $this->router->generate('admin_module_manage_action', $parameters);
             }
 
@@ -237,6 +235,15 @@ class AdminModuleDataProvider implements ModuleInterface
 
                 if (!$module->canBeUpgraded()) {
                     unset($urls['upgrade']);
+                } elseif ($moduleAttributes->get('download_url') !== null) {
+                    // If the module can be upgraded and has a download URL,
+                    // we also generate an upload URL to be used for uploading the archive during the module upgrade process.
+                    $upload_url = $this->router->generate('admin_module_manage_action', [
+                        'action' => 'upload',
+                        'module_name' => $moduleAttributes->get('name'),
+                        'source' => $moduleAttributes->get('download_url'),
+                    ]);
+                    $moduleAttributes->set('upload_url', $upload_url);
                 }
 
                 if (!$module->isConfigurable()) {

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -45,6 +45,7 @@ class Module implements ModuleInterface
     public const ACTION_DISABLE = 'disable';
     public const ACTION_RESET = 'reset';
     public const ACTION_UPGRADE = 'upgrade';
+    public const ACTION_UPLOAD = 'upload';
     public const ACTION_CONFIGURE = 'configure';
     public const ACTION_DELETE = 'delete';
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -197,6 +197,7 @@ class ModuleController extends ModuleAbstractController
             case ModuleAdapter::ACTION_UPGRADE:
             case ModuleAdapter::ACTION_RESET:
             case ModuleAdapter::ACTION_ENABLE:
+            case ModuleAdapter::ACTION_UPLOAD:
             case ModuleAdapter::ACTION_DISABLE:
                 $deniedAccess = !$this->isGranted(Permission::UPDATE, self::CONTROLLER_NAME);
                 break;
@@ -254,8 +255,12 @@ class ModuleController extends ModuleAbstractController
                 $response[$moduleName]['refresh_needed'] = false;
                 $response[$moduleName]['has_download_url'] = $moduleInstance->attributes->has('download_url');
             }
-
-            $response[$moduleName]['status'] = call_user_func([$moduleManager, $action], ...$args);
+            if ($action === ModuleAdapter::ACTION_UPLOAD) {
+                $response[$moduleName]['status'] = (bool) call_user_func([$moduleManager, $action], ...[$source]);
+                $response[$moduleName]['refresh_needed'] = false;
+            } else {
+                $response[$moduleName]['status'] = call_user_func([$moduleManager, $action], ...$args);
+            }
         } catch (Exception $e) {
             $response[$moduleName]['status'] = false;
             $response[$moduleName]['msg'] = $this->trans(

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/modules/_modules.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/modules/_modules.yml
@@ -16,7 +16,7 @@ admin_module_manage_action:
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Improve\ModuleController::moduleAction
   requirements:
-    action: install|uninstall|enable|disable|reset|upgrade|delete
+    action: install|uninstall|enable|disable|reset|upgrade|upload|delete
 
 admin_module_configure_action:
   path: /manage/action/configure/{module_name}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_button.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_button.html.twig
@@ -28,7 +28,8 @@
     {{ label }}
   </a>
 {% else %}
-  <form class="{{ classes_form|default() }}" method="post" action="{{ url }}">
+  {# For the 'upgrade' action, if an upload_url is provided, it is added as a data-upload-url attribute to allow file upload during module upgrade via JavaScript #}
+  <form class="{{ classes_form|default() }}" method="post" action="{{ url }}" {% if action == 'upgrade' and upload_url is not empty %}data-upload-url="{{ upload_url }}"{% endif %}>
     <button type="submit" class="{{ classes }} module_action_menu_{{ action }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ action }}">
       {{ label }}
     </button>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -31,7 +31,8 @@
         classes: 'btn btn-primary-reverse btn-outline-secondary',
         url: module.attributes.urls[module.attributes.url_active],
         action: module.attributes.url_active,
-        label: module.attributes.urls_labels[module.attributes.url_active]}
+        label: module.attributes.urls_labels[module.attributes.url_active],
+        upload_url: module.attributes.upload_url|default(null)}
     ) }}
     {% if (module.attributes.urls|length > 1) %}
         <input type="hidden" class="btn" />
@@ -43,13 +44,14 @@
           {% for module_action, module_url in module.attributes.urls %}
             {% if module_action != module.attributes.url_active %}
                 <li>
-                  {{ include('@PrestaShop/Admin/Module/Includes/action_button.html.twig', {
-                      name: module.attributes.name,
-                      classes: 'dropdown-item',
-                      url: module_url,
-                      action: module_action,
-                      label: module.attributes.urls_labels[module_action]}
-                  ) }}
+                    {{ include('@PrestaShop/Admin/Module/Includes/action_button.html.twig', {
+                        name: module.attributes.name,
+                        classes: 'dropdown-item',
+                        url: module_url,
+                        action: module_action,
+                        label: module.attributes.urls_labels[module_action],
+                        upload_url: module.attributes.upload_url|default(null)}
+                    ) }}
                 </li>
             {% endif %}
           {% endfor %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Split module upgrade into two AJAX requests to fix Symfony cache conflicts
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. BO > Modules > Module Catalog. <br>2. Trigger the upgrade action for a module coming from Marketplace (requires upload+upgrade). <br>3. Confirm the modal; the UI should upload first, show errors if upload fails, then perform the upgrade and refresh action menu. <br>4. Bulk-upgrade several modules: the flow should still work and no console logs should remain. <br>5. Verify drag‑and‑drop upload (import) still works since ModuleManager::upload() returns the module name.
| UI Tests          | Not run (manual verification only).
| Fixed issue or discussion?     |  N/A
| Related PRs       | N/A
| Sponsor company   | N/A

## Problem

During module updates, a cache conflict can occur:

1. User triggers a module update
2. Source files are downloaded and replaced on disk
3. The Symfony cache still holds references to old class definitions in memory
4. Cache purge only happens at the end of the PHP process
5. **Result**: File/cache mismatch → fatal errors, 500 pages, broken module states

This affects any module update that modifies Symfony services or cached classes. The only current workaround is manually clearing cache, then re-running the update.

## Solution

Split the upgrade into **two separate AJAX requests**:

| Request 1 | Request 2 |
|-----------|-----------|
| Download + unzip + cache purge | Migration scripts + DB version update |
| Ends PHP process | Starts with fresh cache |

This ensures the installation phase runs with a cache state that matches the files on disk.

## How to test

1. Install a module from Marketplace that has an available update
2. Trigger the upgrade action for a Marketplace module
3. Confirm the modal; UI should upload first, show errors if upload fails, then perform upgrade and refresh action menu
4. Bulk-upgrade several modules: flow should work without console errors
5. Verify drag-and-drop upload (import) still works (`ModuleManager::upload()` returns the module name)