### PR TITLE
Remove old method to autoload/map doctrine entities

### DIFF
--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -26,8 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Adapter;
 
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
-use Doctrine\ORM\Tools\Setup;
 use Exception;
 use LegacyCompilerPass;
 use PrestaShop\PrestaShop\Adapter\Container\ContainerBuilderExtensionInterface;
@@ -42,7 +40,6 @@ use PrestaShop\PrestaShop\Core\EnvironmentInterface;
 use PrestaShopBundle\DependencyInjection\Compiler\LoadServicesFromModulesPass;
 use PrestaShopBundle\Exception\ServiceContainerException;
 use PrestaShopBundle\PrestaShopBundle;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Config\ConfigCache;
@@ -132,10 +129,6 @@ class ContainerBuilder
         $this->dumpFile = $this->environment->getCacheDir() . DIRECTORY_SEPARATOR . $this->containerClassName . '.php';
         $this->containerConfigCache = new ConfigCache($this->dumpFile, $this->environment->isDebug());
 
-        // These methods load required files like autoload or annotation metadata so we need to load
-        // them at each container creation, this can't be compiled.
-        $this->loadDoctrineAnnotationMetadata();
-
         if ($this->environment->getName() === 'test') {
             $cache = new NullAdapter();
         } else {
@@ -217,19 +210,6 @@ class ContainerBuilder
         );
 
         return $container;
-    }
-
-    /**
-     * In symfony context doctrine classes (like Table, Entity, ...) are available thanks to
-     * the autoloader. In this specific context we don't have the general autoloader, so we need
-     * to include these classes manually. This is performed in Doctrine\ORM\Configuration::newDefaultAnnotationDriver
-     * which is called in Setup::createAnnotationMetadataConfiguration.
-     */
-    private function loadDoctrineAnnotationMetadata()
-    {
-        // IMPORTANT: we need to provide a cache because doctrine tries to init a connection on redis, memcached, ... on its own
-        $cacheProvider = DoctrineProvider::wrap(new ArrayAdapter());
-        Setup::createAnnotationMetadataConfiguration([], $this->environment->isDebug(), null, $cacheProvider);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This method was used to autoload and automap doctrine entities but now is done internally by Symfony and PrestaShop loads theirs using autoloading and the mapping is done by `DoctrineBuilderExtension` and `ModulesDoctrineCompilerPass`. More info below.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Site works CI green
| UI Tests          | https://github.com/ChillCode/ga.tests.ui.pr/actions/runs/19744421979 https://github.com/ChillCode/ga.tests.ui.pr/actions/runs/19744432265
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/discussions/40108

I came across that in version 9.0 this autoload method did not register anymore the doctrine annotation classes:

In doctrine/orm versions : * 2.12.1 for PrestaShop 8 also registered the file to autoload the classes, but was also not necessary, for my checks and early AnnotationDriver takes care of this:

<img width="920" height="708" alt="image" src="https://github.com/user-attachments/assets/eb33a5ab-6c45-4559-9905-afa5fc3224ba" />

In doctrine/orm versions : * 2.20.0 for PrestaShop 9 doctrine/orm package does not even register the file anymore, so this `loadDoctrineAnnotationMetadata` does nothing useful for the application for what I understand, let's check the tests.

<img width="1204" height="837" alt="image" src="https://github.com/user-attachments/assets/558f5427-cf39-4859-ae8c-5289e8bf4a59" />
