### PR TITLE
Docker : Fixed Install of xdebug

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -26,7 +26,7 @@ ENV NODE_VERSION       $NODE_VERSION
 RUN php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');" && php /tmp/composer-setup.php --no-ansi --install-dir=/usr/local/bin --filename=composer && rm -rf /tmp/composer-setup.php
 
 RUN if [ "$INSTALL_XDEBUG" = "true" ]; then \
-    pecl install xdebug-3.1.3 \
+    pecl install xdebug \
     && docker-php-ext-enable xdebug \
     && echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Docker : Fixed Install of xdebug<br />Let pecl decide of the version for XDebug<br /><br />FYI : @matthieu-rolland, you have made the first PR about XDebug
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: + Docker is well executed (but it is tested by E2E Tests)
| UI Tests          |  https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/19757561683 (the :red_circle: is normal today => @jolelievre is on the way to fix it).
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | lefevre.dev