### PR TITLE
Add more logs in database dumping script

### DIFF
--- a/tests/bin/create-test-db.php
+++ b/tests/bin/create-test-db.php
@@ -122,3 +122,4 @@ $resourceResetter->backupDownloads();
 $resourceResetter->backupTestModules();
 
 $logger->log('Test DB was successfully created');
+$logger->log('Clearing cache in progress, please wait...');

--- a/tests/bin/create-test-tables-dump.php
+++ b/tests/bin/create-test-tables-dump.php
@@ -25,6 +25,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Tests\Resources\DatabaseDump;
 
 define('_PS_ROOT_DIR_', dirname(__DIR__, 2));
@@ -32,7 +33,11 @@ const _PS_IN_TEST_ = true;
 const __PS_BASE_URI__ = '/';
 const _PS_MODULE_DIR_ = _PS_ROOT_DIR_ . '/tests/Resources/modules/';
 const _PS_ALL_THEMES_DIR_ = _PS_ROOT_DIR_ . '/tests/Resources/themes/';
-
 require_once _PS_ROOT_DIR_ . '/install-dev/init.php';
 
+$output = new ConsoleOutput();
+$logger = new SymfonyConsoleLogger($output, SymfonyConsoleLogger::DEBUG);
+
+$logger->log(message: 'Dumping tables');
 DatabaseDump::dumpTables();
+$logger->log('Dumping tables is now completed');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x 
| Description?      | The `composer create-test-db` told `Test DB was successfully created` and we thought that the script was done ... but in fact, no. 
| Type?             |  improvement
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | Execute `composer create-test-db` and you'll get more logs
| UI Tests          | N/A
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA

Now, you have more logs

<img width="880" height="662" alt="Capture d’écran 2025-11-28 à 15 27 03" src="https://github.com/user-attachments/assets/ea479c92-47e9-4fff-826b-fdeae062d29c" />


