### PR TITLE
Prevent random fatal errors on systems that handle gc by adjusting gc_probability

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -59,6 +59,7 @@ framework:
   default_locale: "%locale%"
   trusted_hosts: ~
   session:
+    gc_probability: null
     handler_id: ~
   fragments: ~
   http_method_override: true


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Symfony overrides gc_probability ini value causing random fatal errors on systems that handles garbage collection, like Debian does. The correct setting is allow php.ini to decide, setting it to null in config.yaml. 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Comment below.
| UI Tests          | 
| Fixed issue or discussion?     | #39089

On Debian systems pnp.ini value is set to 0 by default and Symfony 6.4 does not respect this setting:

> However, some operating systems (e.g. Debian) do their own session handling and set the session.gc_probability variable to 0 to stop PHP doing garbage collection. That's why Symfony now overwrites this value to 1.

https://symfony.com/doc/6.4/session.html

So the fatal error appears randomly and also Debian cleans sessions every 30 minutes (1800") while php does every 24 minutes (1440") passing `gc_maxlifetime` to Symfony and this disparity will also give random fatal errors and cookie issues, and almost we will have this issue when login to BO behind proxies and ssl activated.

Been solving this since 1.7, just setting `gc_probability` to 0 but to respect php.ini must be set to null and in future versions Symfony respects php.ini.

> However, some operating systems (e.g. Debian) manage session handling differently and set the session.gc_probability variable to 0 to prevent PHP from performing garbage collection. By default, Symfony uses the value of the gc_probability directive set in the php.ini file. If you can't modify this PHP setting, you can configure it directly in Symfony:

https://symfony.com/doc/current/session.html

```

# config/packages/framework.yaml
framework:
    session:
        # ...
        gc_probability: null
```
