### PR TITLE
Fix path to legacy mail folder

### DIFF
--- a/src/Core/Email/LegacyEmailTemplateLister.php
+++ b/src/Core/Email/LegacyEmailTemplateLister.php
@@ -52,7 +52,7 @@ class LegacyEmailTemplateLister
     {
         $templates = [];
 
-        $corePath = $this->mailsDir . $isoCode . '/';
+        $corePath = $this->mailsDir . '/' . $isoCode . '/';
         if (is_dir($corePath)) {
             $templates = array_merge($templates, $this->scanDirectory($corePath, '', true));
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fixes a typo in https://github.com/PrestaShop/PrestaShop/pull/39886 - missing slash in path, so the PR did not work. It does now. :-)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create `aaa.html` and `aaa.txt` in `mails/fr`. 2. Edit any order status in BO. 3. See the template is there now. Without this PR, it's not.
| UI Tests          | No need, it's not covered by them, when I discovered it manually.
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/40200
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

cc @webeshop 