### PR TITLE
No more nightly for 8.0.x and 8.1.x

### DIFF
--- a/.github/workflows/cron_nightly_build.yml
+++ b/.github/workflows/cron_nightly_build.yml
@@ -3,7 +3,7 @@ name: Nightly Build
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '30 22 * * *'
   workflow_dispatch:
 
 permissions:
@@ -22,8 +22,6 @@ jobs:
           - develop
           - 9.0.x
           - 8.2.x
-          - 8.1.x
-          - 8.0.x
         include:
           - BRANCH: develop
             node: 20
@@ -31,10 +29,6 @@ jobs:
             node: 20
           - BRANCH: 8.2.x
             node: 16
-          - BRANCH: 8.1.x
-            node: 16
-          - BRANCH: 8.0.x
-            node: 14
 
     env:
       PHP_VERSION: '7.4'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | No more nightly for 8.0.x and 8.1.x
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green (maybe we can manually run the cron dispatch, or we wait for this night?)
| UI Tests          | ~
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
