### PR TITLE
Adds help text to product page fields

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationReferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationReferencesType.php
@@ -48,7 +48,7 @@ class BulkCombinationReferencesType extends TranslatorAwareType
             ->add('reference', TextType::class, [
                 'required' => false,
                 'label' => $this->trans('Reference', 'Admin.Global'),
-                'label_help_box' => $this->trans('Allowed special characters: %allowed_characters%', 'Admin.Global', ['%allowed_characters%' => '.-_#']),
+                'label_help_box' => $this->trans('Your own primary unique product code used to identify this product. We recommend using a clear and consistent scheme that helps you keep everything organized. Allowed special characters: %allowed_characters%', 'Admin.Global', ['%allowed_characters%' => '.-_#']),
                 'constraints' => [
                     new TypedRegex(TypedRegex::TYPE_REFERENCE),
                     new Length(['max' => Reference::MAX_LENGTH]),
@@ -59,7 +59,7 @@ class BulkCombinationReferencesType extends TranslatorAwareType
             ->add('mpn', TextType::class, [
                 'required' => false,
                 'label' => $this->trans('MPN', 'Admin.Catalog.Feature'),
-                'label_help_box' => $this->trans('MPN is used internationally to identify the Manufacturer Part Number.', 'Admin.Catalog.Help'),
+                'label_help_box' => $this->trans('Manufacturer part number that allows to identify this product internationally.', 'Admin.Catalog.Help'),
                 'constraints' => [
                     new Length(['max' => ProductSettings::MAX_MPN_LENGTH]),
                 ],
@@ -79,8 +79,8 @@ class BulkCombinationReferencesType extends TranslatorAwareType
             ])
             ->add('ean_13', TextType::class, [
                 'required' => false,
-                'label' => $this->trans('EAN-13 or JAN barcode', 'Admin.Catalog.Feature'),
-                'label_help_box' => $this->trans('This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America.', 'Admin.Catalog.Help'),
+                'label' => $this->trans('GTIN (EAN, JA, ITF or UCC code)', 'Admin.Catalog.Feature'),
+                'label_help_box' => $this->trans('The product\'s worldwide barcode. Filling this field improves product traceability, catalog management, and overall searchability.', 'Admin.Catalog.Help'),
                 'constraints' => [
                     new TypedRegex(TypedRegex::TYPE_GTIN),
                     new Length(['max' => Gtin::MAX_LENGTH]),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/DescriptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/DescriptionType.php
@@ -101,6 +101,7 @@ class DescriptionType extends TranslatorAwareType
             ->add('description_short', TranslatableType::class, [
                 'required' => false,
                 'label' => $this->trans('Summary', 'Admin.Global'),
+                'label_help_box' => $this->trans('Short description of the product. We recommend two to three sentences or a few clear phrases that describe the item. It\'s displayed near the product name, used in the meta description, and shown in several other places. Avoid duplicating this text across different products.', 'Admin.Catalog.Help'),
                 'type' => FormattedTextareaType::class,
                 'options' => [
                     'limit' => $shortDescriptionLimit,
@@ -114,6 +115,7 @@ class DescriptionType extends TranslatorAwareType
             ->add('description', TranslatableType::class, [
                 'required' => false,
                 'label' => $this->trans('Description', 'Admin.Global'),
+                'label_help_box' => $this->trans('Optional detailed information about the product, such as its features, specifications, images, videos, or package contents. Use this field when you need to provide more details beyond the short summary.', 'Admin.Catalog.Help'),
                 'type' => FormattedTextareaType::class,
                 'options' => [
                     'limit' => ProductSettings::MAX_DESCRIPTION_LENGTH,
@@ -131,6 +133,7 @@ class DescriptionType extends TranslatorAwareType
                 'include_combinations' => false,
                 'label' => $this->trans('Related products', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h3',
+                'label_help_box' => $this->trans('Products closely connected to this item, such as accessories or complementary goods. Adding them helps customers discover relevant items and improves product navigation.', 'Admin.Catalog.Help'),
                 'entry_options' => [
                     'block_prefix' => 'related_product',
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/ReferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/ReferencesType.php
@@ -51,7 +51,7 @@ class ReferencesType extends TranslatorAwareType
             ->add('reference', TextType::class, [
                 'required' => false,
                 'label' => $this->trans('Reference', 'Admin.Global'),
-                'label_help_box' => $this->trans('Allowed special characters: %allowed_characters%', 'Admin.Global', ['%allowed_characters%' => '.-_#']),
+                'label_help_box' => $this->trans('Your own primary unique product code used to identify this product. We recommend using a clear and consistent scheme that helps you keep everything organized. Allowed special characters: %allowed_characters%', 'Admin.Global', ['%allowed_characters%' => '.-_#']),
                 'constraints' => [
                     new TypedRegex(TypedRegex::TYPE_REFERENCE),
                     new Length(['max' => Reference::MAX_LENGTH]),
@@ -61,7 +61,7 @@ class ReferencesType extends TranslatorAwareType
             ->add('mpn', TextType::class, [
                 'required' => false,
                 'label' => $this->trans('MPN', 'Admin.Catalog.Feature'),
-                'label_help_box' => $this->trans('MPN is used internationally to identify the Manufacturer Part Number.', 'Admin.Catalog.Help'),
+                'label_help_box' => $this->trans('Manufacturer part number that allows to identify this product internationally.', 'Admin.Catalog.Help'),
                 'constraints' => [
                     new Length(['max' => ProductSettings::MAX_MPN_LENGTH]),
                 ],
@@ -80,7 +80,7 @@ class ReferencesType extends TranslatorAwareType
             ->add('ean_13', TextType::class, [
                 'required' => false,
                 'label' => $this->trans('GTIN (EAN, JA, ITF or UCC code)', 'Admin.Catalog.Feature'),
-                'label_help_box' => $this->trans('This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America.', 'Admin.Catalog.Help'),
+                'label_help_box' => $this->trans('The product\'s worldwide barcode. Filling this field improves product traceability, catalog management, and overall searchability.', 'Admin.Catalog.Help'),
                 'constraints' => [
                     new TypedRegex(TypedRegex::TYPE_GTIN),
                     new Length(['max' => Gtin::MAX_LENGTH]),
@@ -109,6 +109,7 @@ class ReferencesType extends TranslatorAwareType
         $resolver->setDefaults([
             'label' => $this->trans('References', 'Admin.Catalog.Feature'),
             'label_tag_name' => 'h3',
+            'label_help_box' => $this->trans('All existing identifiers of the product. We recommend filling in every relevant field you can obtain, as it will improve the product\'s searchability and management.', 'Admin.Catalog.Help'),
             'required' => false,
             'columns_number' => 3,
         ]);

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
@@ -79,6 +79,7 @@ class PricingType extends TranslatorAwareType
                 'label' => $this->trans('Cost price', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h3',
                 'label_subtitle' => $this->trans('Cost price (tax excl.)', 'Admin.Catalog.Feature'),
+                'label_help_box' => $this->trans('Internal purchase price of the product. You can use it for margin calculations, statistics, and internal reporting. This value is not shown to customers.', 'Admin.Catalog.Help'),
                 'attr' => ['data-display-price-precision' => FormHelper::DEFAULT_PRICE_PRECISION],
                 'currency' => $this->defaultCurrencyIsoCode,
                 'modify_all_shops' => true,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Improves wording on product page to better inform merchants on how to fill each fields. Nothing specific, general information useful for 99% of merchants.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See that there are new help texts on some fields on product page.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/19871490893 🟢 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/30245
| Related PRs       | 
| Sponsor company   | 

cc @Codencode @kpodemski @Touxten 