### PR TITLE
Disable discount when the only selected customer group is removed

### DIFF
--- a/classes/Group.php
+++ b/classes/Group.php
@@ -441,32 +441,22 @@ class GroupCore extends ObjectModel
     /**
      * Disable cart rules which are associated to this group.
      *
-     * @param bool $strict either the group is the only one associated to the cart rule or not
-     *
      * @return void
-     *
-     * @throws PrestaShopDatabaseException
-     *
-     * @throws PrestaShopException
      */
-    public function disableAssociatedCartRules(bool $strict = false): void
+    public function disableAssociatedCartRules(): void
     {
         // Get all cart rules associated to this group
-        $cart_rule_ids = Db::getInstance()->executeS('SELECT cr.id_cart_rule FROM `' . _DB_PREFIX_ . 'cart_rule` cr INNER JOIN `' . _DB_PREFIX_ . 'cart_rule_group` crg ON cr.id_cart_rule = crg.id_cart_rule WHERE crg.id_group = ' . (int) $this->id);
+        $cart_rule_ids = Db::getInstance()->executeS('SELECT cr.id_cart_rule
+            FROM ' . _DB_PREFIX_ . 'cart_rule cr
+            INNER JOIN ' . _DB_PREFIX_ . 'cart_rule_group crg ON crg.id_cart_rule = cr.id_cart_rule AND crg.id_group = ' . (int) $this->id . '
+            LEFT JOIN ' . _DB_PREFIX_ . 'cart_rule_group crg_other ON crg_other.id_cart_rule = cr.id_cart_rule AND crg_other.id_group != ' . (int) $this->id . '
+            WHERE crg_other.id_group IS NULL AND cr.group_restriction = 1
+        ');
 
         foreach ($cart_rule_ids as $cart_rule_id) {
             $cart_rule = new CartRule((int) $cart_rule_id['id_cart_rule']);
 
-            // If strict mode is enabled, the cart rule must be associated to one group only
-            if($strict) {
-                $groups = Db::getInstance()->executeS('SELECT crg.id_group FROM `' . _DB_PREFIX_ . 'cart_rule_group` crg WHERE crg.id_cart_rule = ' . (int) $cart_rule->id);
-
-                if(count($groups) == 1) {
-                    $cart_rule->active = 0;
-                }
-            } else {
-                $cart_rule->active = 0;
-            }
+            $cart_rule->active = false;
 
             $cart_rule->update();
         }

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -227,7 +227,11 @@ class GroupCore extends ObjectModel
             $this->truncateModulesRestrictions($this->id);
 
             // Disable cart rules which are only associated to this group
-            $this->disableAssociatedCartRules(true);
+            if(!$this->disableAssociatedCartRules()) {
+                return false;
+            }
+
+            Db::getInstance()->delete('cart_rule_group','id_group = ' . (int) $this->id);
 
             // Add default group (id 3) to customers without groups
             Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'customer_group` (
@@ -441,9 +445,9 @@ class GroupCore extends ObjectModel
     /**
      * Disable cart rules which are associated to this group.
      *
-     * @return void
+     * @return bool
      */
-    public function disableAssociatedCartRules(): void
+    public function disableAssociatedCartRules(): bool
     {
         // Get all cart rules associated to this group
         $cart_rule_ids = Db::getInstance()->executeS('SELECT cr.id_cart_rule
@@ -461,6 +465,6 @@ class GroupCore extends ObjectModel
             $cart_rule->update();
         }
 
-        Db::getInstance()->delete('cart_rule_group','id_group = ' . (int) $this->id);
+        return true;
     }
 }

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -219,13 +219,15 @@ class GroupCore extends ObjectModel
         }
 
         if (parent::delete()) {
-            Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'cart_rule_group` WHERE `id_group` = ' . (int) $this->id);
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'customer_group` WHERE `id_group` = ' . (int) $this->id);
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'category_group` WHERE `id_group` = ' . (int) $this->id);
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'group_reduction` WHERE `id_group` = ' . (int) $this->id);
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'product_group_reduction_cache` WHERE `id_group` = ' . (int) $this->id);
 
             $this->truncateModulesRestrictions($this->id);
+
+            // Disable cart rules which are only associated to this group
+            $this->disableAssociatedCartRules(true);
 
             // Add default group (id 3) to customers without groups
             Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'customer_group` (
@@ -434,5 +436,41 @@ class GroupCore extends ObjectModel
 				ON (g.`id_group` = gl.`id_group`)
 			WHERE `name` = \'' . pSQL($query) . '\'
 		');
+    }
+
+    /**
+     * Disable cart rules which are associated to this group.
+     *
+     * @param bool $strict either the group is the only one associated to the cart rule or not
+     *
+     * @return void
+     *
+     * @throws PrestaShopDatabaseException
+     *
+     * @throws PrestaShopException
+     */
+    public function disableAssociatedCartRules(bool $strict = false): void
+    {
+        // Get all cart rules associated to this group
+        $cart_rule_ids = Db::getInstance()->executeS('SELECT cr.id_cart_rule FROM `' . _DB_PREFIX_ . 'cart_rule` cr INNER JOIN `' . _DB_PREFIX_ . 'cart_rule_group` crg ON cr.id_cart_rule = crg.id_cart_rule WHERE crg.id_group = ' . (int) $this->id);
+
+        foreach ($cart_rule_ids as $cart_rule_id) {
+            $cart_rule = new CartRule((int) $cart_rule_id['id_cart_rule']);
+
+            // If strict mode is enabled, the cart rule must be associated to one group only
+            if($strict) {
+                $groups = Db::getInstance()->executeS('SELECT crg.id_group FROM `' . _DB_PREFIX_ . 'cart_rule_group` crg WHERE crg.id_cart_rule = ' . (int) $cart_rule->id);
+
+                if(count($groups) == 1) {
+                    $cart_rule->active = 0;
+                }
+            } else {
+                $cart_rule->active = 0;
+            }
+
+            $cart_rule->update();
+        }
+
+        Db::getInstance()->delete('cart_rule_group','id_group = ' . (int) $this->id);
     }
 }

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -227,11 +227,11 @@ class GroupCore extends ObjectModel
             $this->truncateModulesRestrictions($this->id);
 
             // Disable cart rules which are only associated to this group
-            if(!$this->disableAssociatedCartRules()) {
+            if (!$this->disableAssociatedCartRules()) {
                 return false;
             }
 
-            Db::getInstance()->delete('cart_rule_group','id_group = ' . (int) $this->id);
+            Db::getInstance()->delete('cart_rule_group', 'id_group = ' . (int) $this->id);
 
             // Add default group (id 3) to customers without groups
             Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'customer_group` (


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | If a discount has only one customer group and this customer group is deleted, then the discount must be disabled.
| Type?             | improvement 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | - a discount with only one customer group selected <br> - I delete the customer group <br> - the discount is disabled
| UI Tests | Running...
| Fixed issue or discussion?     | Fixes #40109 
| Sponsor company   | Agence Off