### PR TITLE
Delete specific prices when group is removed

### DIFF
--- a/classes/Group.php
+++ b/classes/Group.php
@@ -232,7 +232,7 @@ class GroupCore extends ObjectModel
                 return false;
             }
             // Delete specific price rules associated to this group
-            if (!$this->deleteAssociatedSpecificPriceRules()) {
+            if ((int) $this->id > 0 && !$this->deleteAssociatedSpecificPriceRules()) {
                 return false;
             }
 

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -228,9 +228,13 @@ class GroupCore extends ObjectModel
             $this->truncateModulesRestrictions($this->id);
 
             // Delete specific prices associated to this group
-            $this->deleteAssociatedSpecificPrices();
+            if (!$this->deleteAssociatedSpecificPrices()) {
+                return false;
+            }
             // Delete specific price rules associated to this group
-            $this->deleteAssociatedSpecificPriceRules();
+            if (!$this->deleteAssociatedSpecificPriceRules()) {
+                return false;
+            }
 
             // Add default group (id 3) to customers without groups
             Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'customer_group` (
@@ -444,30 +448,24 @@ class GroupCore extends ObjectModel
     /**
      * Delete all specific prices associated to this group.
      *
-     * @return void
+     * @return bool
      */
-    public function deleteAssociatedSpecificPrices(): void
+    public function deleteAssociatedSpecificPrices(): bool
     {
-        $specific_price_ids = Db::getInstance()->executeS('SELECT sp.id_specific_price FROM `' . _DB_PREFIX_ . 'specific_price` sp WHERE sp.id_group = ' . (int) $this->id);
-
-        foreach ($specific_price_ids as $specific_price_id) {
-            $specific_price = new SpecificPrice((int) $specific_price_id['id_specific_price']);
-            $specific_price->delete();
-        }
+        return Db::getInstance()->delete('specific_price', 'id_group = ' . (int) $this->id);
     }
 
     /**
      * Delete all specific price rules associated to this group.
      *
-     * @return void
+     * @return bool
      */
-    public function deleteAssociatedSpecificPriceRules(): void
+    public function deleteAssociatedSpecificPriceRules(): bool
     {
-        $specific_price_rule_ids = Db::getInstance()->executeS('SELECT spr.id_specific_price_rule FROM `' . _DB_PREFIX_ . 'specific_price_rule` spr WHERE spr.id_group = ' . (int) $this->id);
+        $result_price_rule = Db::getInstance()->delete('specific_price_rule', 'id_group = ' . (int) $this->id);
+        $result_price_rule_condition_group = Db::getInstance()->delete('specific_price_rule_condition_group', 'id_specific_price_rule NOT IN (SELECT id_specific_price_rule FROM `' . _DB_PREFIX_ . 'specific_price_rule`)');
+        $result_price_rule_condition = Db::getInstance()->delete('specific_price_rule_condition', 'id_specific_price_rule_condition_group NOT IN (SELECT id_specific_price_rule_condition_group FROM `' . _DB_PREFIX_ . 'specific_price_rule_condition_group`)');
 
-        foreach ($specific_price_rule_ids as $specific_price_rule_id) {
-            $specific_price_rule = new SpecificPriceRule((int) $specific_price_rule_id['id_specific_price_rule']);
-            $specific_price_rule->delete();
-        }
+        return $result_price_rule && $result_price_rule_condition_group && $result_price_rule_condition;
     }
 }

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -228,11 +228,11 @@ class GroupCore extends ObjectModel
             $this->truncateModulesRestrictions($this->id);
 
             // Delete specific prices associated to this group
-            if (!$this->deleteAssociatedSpecificPrices()) {
+            if (!$this->truncateSpecificPrices()) {
                 return false;
             }
             // Delete specific price rules associated to this group
-            if ((int) $this->id > 0 && !$this->deleteAssociatedSpecificPriceRules()) {
+            if (!$this->truncateSpecificPriceRules()) {
                 return false;
             }
 
@@ -450,8 +450,12 @@ class GroupCore extends ObjectModel
      *
      * @return bool
      */
-    public function deleteAssociatedSpecificPrices(): bool
+    public function truncateSpecificPrices(): bool
     {
+        if (empty($this->id)) {
+            return false;
+        }
+
         return Db::getInstance()->delete('specific_price', 'id_group = ' . (int) $this->id);
     }
 
@@ -460,8 +464,12 @@ class GroupCore extends ObjectModel
      *
      * @return bool
      */
-    public function deleteAssociatedSpecificPriceRules(): bool
+    public function truncateSpecificPriceRules(): bool
     {
+        if (empty($this->id)) {
+            return false;
+        }
+
         $result_price_rule = Db::getInstance()->delete('specific_price_rule', 'id_group = ' . (int) $this->id);
         $result_price_rule_condition_group = Db::getInstance()->delete('specific_price_rule_condition_group', 'id_specific_price_rule NOT IN (SELECT id_specific_price_rule FROM `' . _DB_PREFIX_ . 'specific_price_rule`)');
         $result_price_rule_condition = Db::getInstance()->delete('specific_price_rule_condition', 'id_specific_price_rule_condition_group NOT IN (SELECT id_specific_price_rule_condition_group FROM `' . _DB_PREFIX_ . 'specific_price_rule_condition_group`)');

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -445,10 +445,6 @@ class GroupCore extends ObjectModel
      * Delete all specific prices associated to this group.
      *
      * @return void
-     *
-     * @throws PrestaShopDatabaseException
-     *
-     * @throws PrestaShopException
      */
     public function deleteAssociatedSpecificPrices(): void
     {
@@ -464,10 +460,6 @@ class GroupCore extends ObjectModel
      * Delete all specific price rules associated to this group.
      *
      * @return void
-     *
-     * @throws PrestaShopDatabaseException
-     *
-     * @throws PrestaShopException
      */
     public function deleteAssociatedSpecificPriceRules(): void
     {

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -227,6 +227,11 @@ class GroupCore extends ObjectModel
 
             $this->truncateModulesRestrictions($this->id);
 
+            // Delete specific prices associated to this group
+            $this->deleteAssociatedSpecificPrices();
+            // Delete specific price rules associated to this group
+            $this->deleteAssociatedSpecificPriceRules();
+
             // Add default group (id 3) to customers without groups
             Db::getInstance()->execute('INSERT INTO `' . _DB_PREFIX_ . 'customer_group` (
 				SELECT c.id_customer, ' . (int) Configuration::get('PS_CUSTOMER_GROUP') . ' FROM `' . _DB_PREFIX_ . 'customer` c
@@ -434,5 +439,43 @@ class GroupCore extends ObjectModel
 				ON (g.`id_group` = gl.`id_group`)
 			WHERE `name` = \'' . pSQL($query) . '\'
 		');
+    }
+
+    /**
+     * Delete all specific prices associated to this group.
+     *
+     * @return void
+     *
+     * @throws PrestaShopDatabaseException
+     *
+     * @throws PrestaShopException
+     */
+    public function deleteAssociatedSpecificPrices(): void
+    {
+        $specific_price_ids = Db::getInstance()->executeS('SELECT sp.id_specific_price FROM `' . _DB_PREFIX_ . 'specific_price` sp WHERE sp.id_group = ' . (int) $this->id);
+
+        foreach ($specific_price_ids as $specific_price_id) {
+            $specific_price = new SpecificPrice((int) $specific_price_id['id_specific_price']);
+            $specific_price->delete();
+        }
+    }
+
+    /**
+     * Delete all specific price rules associated to this group.
+     *
+     * @return void
+     *
+     * @throws PrestaShopDatabaseException
+     *
+     * @throws PrestaShopException
+     */
+    public function deleteAssociatedSpecificPriceRules(): void
+    {
+        $specific_price_rule_ids = Db::getInstance()->executeS('SELECT spr.id_specific_price_rule FROM `' . _DB_PREFIX_ . 'specific_price_rule` spr WHERE spr.id_group = ' . (int) $this->id);
+
+        foreach ($specific_price_rule_ids as $specific_price_rule_id) {
+            $specific_price_rule = new SpecificPriceRule((int) $specific_price_rule_id['id_specific_price_rule']);
+            $specific_price_rule->delete();
+        }
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Delete specific prices and specific price rules when the group they are associated to is removed
| Type?             | improvement
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | - Create group A <br> - Create specific price / specific price rule that apply to group A <br> - Delete group A <br> - Specific price / specific price  is also deleted
| UI Tests | https://github.com/paulnoelcholot/ga.tests.ui.pr/actions/runs/23545164196
| Fixed issue or discussion?     | Issue #40109 gave me the idea
| Sponsor company   | Agence Off
