### PR TITLE
Fix issue with search indexing after HTML stripping + Better handling of outfile/dumpfile block in executeS

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -193,6 +193,8 @@ class SearchCore
 
         // The string gets into this method in a raw form of, like "Prestashop Tést A-1000".
         // This get rid of all tags, special characters and convert everything to lowercase.
+        // Add spaces after closing block html elements to avoid malformed words
+        $string = preg_replace('/(<\/(p|div|li|br|h[1-6]|ul|ol|table|tr|td)>)/i', '$1 ', $string);
         $string = Tools::strtolower(strip_tags($string));
         $string = html_entity_decode($string, ENT_NOQUOTES, 'utf-8');
         $string = preg_replace('/([' . PREG_CLASS_NUMBERS . ']+)[' . PREG_CLASS_PUNCTUATION . ']+(?=[' . PREG_CLASS_NUMBERS . '])/u', '\1', $string);

--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -609,8 +609,7 @@ abstract class DbCore
         // This method must be used only with queries which display results
         if (
             !preg_match('#^\s*\(?\s*(select|show|explain|describe|desc|checksum)\s#i', $sql)
-            || stripos($sql, 'outfile') !== false
-            || stripos($sql, 'dumpfile') !== false
+            || preg_match('#\bIN\s*\([^)]*\)(*SKIP)(*FAIL)|\binto\s+(?:outfile|dumpfile)\b#i', $sql)
         ) {
             throw new PrestaShopDatabaseException('Db->executeS() must be used only with select, show, explain or describe queries');
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | Any
| Description?      | Avoids accidantally forming DB->executeS forbidden words (like outfile) by joining 2 words separated only by tags which results in a 500 error while reindexing.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | If a product description (but can be any indexed field) contains for example `<ul><li>Position: out</li><li>File format: mp3</li></ul>` the strip_tags makes it `Position: outFile format: mp3` and then the indexed word will be "outfile". But since outfile is one of the blocked words of the DB class executeS https://github.com/PrestaShop/PrestaShop/blob/65df0991033604b53a9344beb517c89a5ae23682/classes/db/Db.php#L612-L613 the indexing fails with error 500 (PrestaShopDatabaseException).
| Fixed issue or discussion? | [#40244](https://github.com/PrestaShop/PrestaShop/issues/40244)
| Author   | Giuseppe Tripiciano