### PR TITLE
Prevent Exposure of Sensitive Product Attributes in Front Office

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -449,7 +449,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
         $this->ajaxRender(json_encode([
             'quickview_html' => $this->render('catalog/_partials/quickview', $productForTemplate->jsonSerialize()),
-            'product' => $productForTemplate,
+            'product' => $this->filterAjaxSensitiveAttributes($productForTemplate),
         ]));
     }
 
@@ -1582,5 +1582,25 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function setPreviewMode(bool $enabled = true)
     {
         $this->isPreview = $enabled;
+    }
+
+    /**
+     * Filters out sensitive attributes to ensure they are not exposed.
+     *
+     * These fields are removed to prevent any leakage of sensitive
+     * information that could be exploited for security or OSINT purposes.
+     *
+     * @return ProductLazyArray
+     */
+    private function filterAjaxSensitiveAttributes(ProductLazyArray $lazyArray)
+    {
+        $lazyArray->__unset('wholesale_price');
+
+        if (empty($lazyArray['show_quantities'])) {
+            $lazyArray->__unset('quantity');
+            $lazyArray->__unset('quantity_all_versions');
+        }
+
+        return $lazyArray;
     }
 }

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -1514,7 +1514,7 @@ class ProductLazyArray extends AbstractLazyArray
      */
     protected function getProductAttributeWhitelist()
     {
-        return [
+        $whitelist = [
             'active',
             'add_to_cart_url',
             'additional_shipping_cost',
@@ -1620,6 +1620,12 @@ class ProductLazyArray extends AbstractLazyArray
             'visibility',
             'weight_unit',
         ];
+
+        if (empty($this->product['show_quantities'])) {
+            $whitelist = array_diff($whitelist, ['quantity', 'quantity_all_versions']);
+        }
+
+        return $whitelist;
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This pull request introduces a safeguard to ensure that sensitive product attributes are not exposed in the Front Office (FO).<br/>A new method, filterSensitiveAttributes(), removes fields such as wholesale price and stock-related values to prevent unintended data disclosure.<br/>These attributes could otherwise be leveraged for security analysis or OSINT-based intelligence gathering, which may reveal business-critical information. By filtering them out, we strengthen data privacy and improve overall security.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | QA ping me
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/20025678298
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -
