### PR TITLE
Fix: Issue retrieving product price when adding the first specific_price

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -159,13 +159,23 @@ class SpecificPriceCore extends ObjectModel
 
     public function add($autodate = true, $nullValues = false)
     {
+        $specificPriceUsed = (bool) Configuration::getGlobalValue('PS_SPECIFIC_PRICE_FEATURE_ACTIVE');
+
+        if (!$specificPriceUsed) {
+            // Set cache of feature detachable to true
+            Configuration::updateGlobalValue('PS_SPECIFIC_PRICE_FEATURE_ACTIVE', '1');
+        }
+
         if (parent::add($autodate, $nullValues)) {
             // Flush cache when we adding a new specific price
             $this->flushCache();
-            // Set cache of feature detachable to true
-            Configuration::updateGlobalValue('PS_SPECIFIC_PRICE_FEATURE_ACTIVE', '1');
 
             return true;
+        }
+
+        if (!$specificPriceUsed) {
+            // Restore previous PS_SPECIFIC_PRICE_FEATURE_ACTIVE state because the add operation failed
+            Configuration::updateGlobalValue('PS_SPECIFIC_PRICE_FEATURE_ACTIVE', false);
         }
 
         return false;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR ensures that `PS_SPECIFIC_PRICE_FEATURE_ACTIVE` is enabled before inserting the first specific price, allowing hooks to correctly retrieve discounted prices.<br/>If the insertion fails, the previous configuration value is restored to avoid leaving the system in an inconsistent state.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install the module [issue40255.zip](https://github.com/user-attachments/files/23959265/issue40255.zip).<br/> 2. Ensure that no specific prices exist in the catalog.<br/> 3. Open a product in edit mode.<br/> 4. In the Pricing section, add a new specific price.<br/> 5. When the popup reloads, you will see the message (added by the module): `Product price: DISCOUNTED_PRICE Reduction: REDUCTION` <br/> You need to display the discounted price and the discount amount
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/20056838551
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/40255
| Related PRs       |
| Sponsor company   | Codencode snc
