### PR TITLE
Prevent saving ajax URL for future login redirection, or the redirect…

### DIFF
--- a/src/PrestaShopBundle/EventListener/Admin/EmployeeSessionSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/EmployeeSessionSubscriber.php
@@ -215,8 +215,11 @@ class EmployeeSessionSubscriber implements EventSubscriberInterface
         // Set the redirection so the process stops right away
         $event->setResponse(new RedirectResponse($this->router->generate('admin_login')));
 
-        // Save the target path so the next login will redirect to the url requested at the moment of the logout
-        $this->saveTargetPath($event->getRequest()->getSession(), 'main', $event->getRequest()->getUri());
+        // Save the target path so the next login will redirect to the url requested at the moment of the logout, avoid saving
+        // ajax requests or not GET request because the redirection would fail
+        if ($event->getRequest()->hasSession() && $event->getRequest()->isMethodSafe() && !$event->getRequest()->isXmlHttpRequest()) {
+            $this->saveTargetPath($event->getRequest()->getSession(), 'main', $event->getRequest()->getUri());
+        }
 
         // Stop the event propagation, nothing more needs to happen except for redirection, and it prevents the event to
         // keep travelling and be caught by other unwanted listeners (like the TokenizedUrlsListener)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Prevent saving ajax URL for future login redirection, or the redirection fails because the method is not accepted
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| UI Tests          | 
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~

### Context

When you leave your BO opened it regurlarly fetches the notifications in the header, when your session reaches its end this call is the last one done that detects your session expired and the notifications URI is saved for the future redirection after a reconnection Problem, this URL is only accessible in POST so you get an error after the redirection:

<img width="928" height="590" alt="Capture d’écran 2025-12-05 à 12 16 58" src="https://github.com/user-attachments/assets/09f043b2-18c7-4459-bf2b-2940d863cfc6" />


### How to test

1. Create another employee
2. Connect with this employee in a private browser window, keep the window opened and check the Network debug tab
3. With your initial employee go to Security > Employee sessions
4. Remove the session of the second employee (the one in private mode)
5. Now go back to your private browser and wait to see a call to notifications in the network tab (it can take a few minutes)
6. You should see the call fails and is redirected towards the login page

<img width="1142" height="258" alt="Capture d’écran 2025-12-05 à 12 14 06" src="https://github.com/user-attachments/assets/c7c5a467-897e-4558-8d6e-eb7c793888bf" />

7. Now open **a new tab** and open the url of `/admin-dev`
8. You are redirect to the login page, login successfully
9. You should be redirect to an error page

Do the same steps with the PR that fixes it, you shouldn't see the error page anymore after the login redirection (you will likely be redirected towards your homepage)