### PR TITLE
Fix: Prevent cart rule with gift product when out of stock- Add stock…

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1017,15 +1017,17 @@ class CartRuleCore extends ObjectModel
         // Check if the gift product is available for order
         if ($this->gift_product) {
             $shopId = (int) Context::getContext()->shop->id;
-            $availableQuantity = StockAvailable::getQuantityAvailableByProduct(
+            $availableQuantity = Product::getQuantity(
                 $this->gift_product,
                 $this->gift_product_attribute,
-                $shopId
+                null,
+                $cart
             );
 
-            if ($availableQuantity < 1 && !Product::isAvailableWhenOutOfStock(
-                StockAvailable::outOfStock($this->gift_product, $shopId)
-            )) {
+            if (!$alreadyInCart && $availableQuantity < 1 && !Product::isAvailableWhenOutOfStock(
+                    StockAvailable::outOfStock($this->gift_product, $shopId)
+                )) {
+
                 return (!$display_error)
                     ? false
                     : $this->trans('This voucher is no longer available.', [], 'Shop.Notifications.Error');

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1013,6 +1013,25 @@ class CartRuleCore extends ObjectModel
         if ($check_carrier) {
             $otherCartRules = $cart->getCartRules(CartRule::FILTER_ACTION_ALL, false);
         }
+
+        // Check if the gift product is available for order
+        if ($this->gift_product) {
+            $shopId = (int) Context::getContext()->shop->id;
+            $availableQuantity = StockAvailable::getQuantityAvailableByProduct(
+                $this->gift_product,
+                $this->gift_product_attribute,
+                $shopId
+            );
+
+            if ($availableQuantity < 1 && !Product::isAvailableWhenOutOfStock(
+                StockAvailable::outOfStock($this->gift_product, $shopId)
+            )) {
+                return (!$display_error)
+                    ? false
+                    : $this->trans('This voucher is no longer available.', [], 'Shop.Notifications.Error');
+            }
+        }
+
         $nbOfCartRules = 0;
         if (count($otherCartRules)) {
             foreach ($otherCartRules as $otherCartRule) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR prevents cart rules with gift products from being applied when the gift product is out of stock and not available for order. <br><br>**Current behavior:** Customers can use vouchers with gift products even when the gift is unavailable, potentially causing order errors or confusion at checkout.<br><br>**New behavior:** The cart rule validation now checks gift product stock availability before allowing the voucher to be applied. If the gift product is out of stock and "Allow orders when out of stock" is disabled, an error message is displayed.<br><br>**Technical details:** Added stock validation in `CartRule::checkValidity()` method using `StockAvailable::getQuantityAvailableBy Product()` and `Product::isAvailableWhenOutOfStock()`.
| Type?             | bug fix
| Category?         | CO,FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create a product (e.g., "Gift Product")<br>2. Set the product stock quantity to 0<br>3. In product settings, set "When out of stock" to "Deny orders"<br>4. Create a cart rule: Marketing > Cart Rules > Add new cartrule<br>5. In the cart rule, set a gift product with the product created in step 1<br>6. On the frontend, add any product to the cart<br>7. Try to apply the cart rule code<br>8. **Expected result:** Error message "This voucher is no longer available." is displayed<br>9. **Additional test:** In the product settings, change "When out of stock" to "Allow orders", then verify the cart rule can now be applied successfully
| UI Tests          | Will run UI tests after initial review
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | N/A