### PR TITLE
Allow access to customized files preview without multi-lang enabled

### DIFF
--- a/upload/.htaccess
+++ b/upload/.htaccess
@@ -1,10 +1,14 @@
 # Apache 2.2
 <IfModule !mod_authz_core.c>
-    Order deny,allow
-    Deny from all
+    <FilesMatch "^[0-9a-f]{40}(_small)?$">
+        Order deny,allow
+        Deny from all
+    </FilesMatch>
 </IfModule>
 
 # Apache 2.4
 <IfModule mod_authz_core.c>
-    Require all denied
+    <FilesMatch "^[0-9a-f]{40}(_small)?$">
+        Require all denied
+    </FilesMatch>
 </IfModule>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR lightens .htaccess restriction to make sure customization files are accessible from FO if no multi-lang activated. Sha1 is always 40 chars, so it should be good. The file will still go through `UploadController` to check mime-type, etc.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow the instructions from the issue.
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/19993650970
| Fixed issue or discussion?     | Fixes #38494
| Related PRs       | n/a
| Sponsor company   | impSolutions
