### PR TITLE
Fix minimum amount discount cart conditions tax/shipping incl. or excl.

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
@@ -208,7 +208,8 @@ class DiscountFormDataProvider implements FormDataProviderInterface
                     'minimum_amount' => [
                         'value' => $discountForEditing->getMinimumAmount() ? (float) (string) $discountForEditing->getMinimumAmount() : null,
                         'currency' => $discountForEditing->getMinimumAmountCurrencyId(),
-                        'include_tax' => $discountForEditing->getMinimumAmountTaxIncluded(),
+                        'tax_included' => $discountForEditing->getMinimumAmountTaxIncluded(),
+                        'shipping_included' => $discountForEditing->getMinimumAmountShippingIncluded(),
                     ],
                 ],
                 DiscountConditionsType::DELIVERY_CONDITIONS => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix minimum amount discount cart conditions tax/shipping incl. or excl.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to the BO (enable new discount FF)<br/>2. Create a "cart_level" discount and set minimal amount with tax excluded.<br/>3. Save the form<br/>4. The field for the selection of the tax incl. or excl. should be "Tax excluded" now.<br/>5. Test the same way for Shipping excluded.
| UI Tests          | https://github.com/paulnoelcholot/ga.tests.ui.pr/actions/runs/20024351647
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/issues/40268
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
