### PR TITLE
Prevent database inconsistencies by preventing faulty group delete calls

### DIFF
--- a/classes/Group.php
+++ b/classes/Group.php
@@ -219,11 +219,6 @@ class GroupCore extends ObjectModel
             return false;
         }
 
-        // Prevent deletion of default non-removable groups
-        if (in_array($this->id, [1, 2, 3]))  {
-            throw new PrestaShopException('You cannot delete one of the default groups.');
-        }
-
         // Prevent deletion of groups currently used in configuration
         if (in_array($this->id, [
             (int) Configuration::get('PS_UNIDENTIFIED_GROUP'),

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -214,9 +214,25 @@ class GroupCore extends ObjectModel
 
     public function delete()
     {
-        if ($this->id == (int) Configuration::get('PS_CUSTOMER_GROUP')) {
+        // Prevent calling the logic in case of an invalid object
+        if (empty($this->id)) {
             return false;
         }
+
+        // Prevent deletion of default non-removable groups
+        if (in_array($this->id, [1, 2, 3]))  {
+            throw new PrestaShopException('You cannot delete one of the default groups.');
+        }
+
+        // Prevent deletion of groups currently used in configuration
+        if (in_array($this->id, [
+            (int) Configuration::get('PS_UNIDENTIFIED_GROUP'),
+            (int) Configuration::get('PS_GUEST_GROUP'),
+            (int) Configuration::get('PS_CUSTOMER_GROUP'),
+        ])) {
+            throw new PrestaShopException('You cannot delete a group that is used in the shop configuration.');
+        }
+
         if (parent::delete()) {
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'cart_rule_group` WHERE `id_group` = ' . (int) $this->id);
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'customer_group` WHERE `id_group` = ' . (int) $this->id);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Protects the stability of the software by blocking few group delete calls. Groups that are 1,2,3 - the default groups from fixtures, empty group object to prevent potential side effects and groups that are currently used in shop configuration.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Automatic test
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/20045409140 🟢 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.
