### PR TITLE
Avoid specific price rule saved with 0€ discount

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1121,7 +1121,7 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
                 throw new PrestaShopException($this->trans('Validation function not found: %s.', [$data['validate']], 'Admin.Notifications.Error'));
             }
 
-            if (!empty($value)) {
+            if (!empty($value) || $value === '0') {
                 $res = true;
                 if (Tools::strtolower($data['validate']) === 'iscleanhtml') {
                     if (!call_user_func(['Validate', $data['validate']], $value, $ps_allow_html_iframe)) {

--- a/classes/SpecificPriceRule.php
+++ b/classes/SpecificPriceRule.php
@@ -54,7 +54,7 @@ class SpecificPriceRuleCore extends ObjectModel
             'id_group' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true],
             'from_quantity' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'required' => true],
             'price' => ['type' => self::TYPE_FLOAT, 'validate' => 'isNegativePrice', 'required' => true],
-            'reduction' => ['type' => self::TYPE_FLOAT, 'validate' => 'isPrice', 'required' => true],
+            'reduction' => ['type' => self::TYPE_FLOAT, 'validate' => 'isPositivePrice', 'required' => true],
             'reduction_tax' => ['type' => self::TYPE_INT, 'validate' => 'isBool', 'required' => true],
             'reduction_type' => ['type' => self::TYPE_STRING, 'validate' => 'isReductionType', 'required' => true],
             'from' => ['type' => self::TYPE_DATE, 'validate' => 'isDateFormat', 'required' => false],

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -318,6 +318,18 @@ class ValidateCore
     }
 
     /**
+     * Check for price validity (including positive price).
+     *
+     * @param string $price Price to validate
+     *
+     * @return bool Validity is ok or not
+     */
+    public static function isPositivePrice($price)
+    {
+        return self::isPrice($price) && (float) $price > 0;
+    }
+
+    /**
      * Check for language code (ISO) validity.
      *
      * @param string $iso_code Language code (ISO) to validate


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | When creating a catalog price rule, it is possible to set a 0€ discount and save the rule without any error message being displayed
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to BO → Catalog → Discounts → Catalog Price Rules<br>Click Add new catalog price rule<br>Fill in all mandatory fields (name, currency, etc.)<br>Set Reduction = 0€<br>Click Save<br>You have an error message saying incorrect price
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/20130209977
| Fixed issue or discussion?     | Fixes #39684 
| Related PRs       | 
| Sponsor company   | Agence Off