### PR TITLE
CMS pages listed on CMS Category page should be presented properly

### DIFF
--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -240,9 +240,24 @@ class CmsControllerCore extends FrontController
             $categoryCms['sub_categories'][$subCategory['id_cms_category']]['link'] = $this->context->link->getCMSCategoryLink($subCategory['id_cms_category'], $subCategory['link_rewrite']);
         }
 
-        foreach (CMS::getCMSPages($this->context->language->id, (int) $this->cms_category->id, true, (int) $this->context->shop->id) as $cmsPages) {
-            $categoryCms['cms_pages'][$cmsPages['id_cms']] = $cmsPages;
-            $categoryCms['cms_pages'][$cmsPages['id_cms']]['link'] = $this->context->link->getCMSLink($cmsPages['id_cms'], $cmsPages['link_rewrite']);
+        foreach (CMS::getCMSPages($this->context->language->id, (int) $this->cms_category->id, true, (int) $this->context->shop->id) as $cmsPage) {
+            $cmsVar = $this->objectPresenter->present(new CMS((int) $cmsPage['id_cms'], (int) $this->context->language->id));
+            $filteredCmsContent = Hook::exec(
+                'filterCmsContent',
+                ['object' => $cmsVar],
+                null,
+                false,
+                true,
+                false,
+                null,
+                true
+            );
+            if (!empty($filteredCmsContent['object'])) {
+                $cmsVar = $filteredCmsContent['object'];
+            }
+
+            $categoryCms['cms_pages'][$cmsPage['id_cms']] = $cmsVar;
+            $categoryCms['cms_pages'][$cmsPage['id_cms']]['link'] = $this->context->link->getCMSLink($cmsPage['id_cms'], $cmsPage['link_rewrite']);
         }
 
         return $categoryCms;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add filter hook execution to the cms pages on the cms category page so that extra fields added from modules with be accessible.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Add a module to the shop that adds an extra fields to the CMS pages, print this fields in the template on the cms category page.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/22406900255
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/40306
| Sponsor company   | Prestaworks AB
