### PR TITLE
Use product EmbeddedAttributes in quickview

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -449,7 +449,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
         $this->ajaxRender(json_encode([
             'quickview_html' => $this->render('catalog/_partials/quickview', $productForTemplate->jsonSerialize()),
-            'product' => $this->filterAjaxSensitiveAttributes($productForTemplate),
+            'product' => $productForTemplate->getEmbeddedAttributes(),
         ]));
     }
 
@@ -1582,25 +1582,5 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function setPreviewMode(bool $enabled = true)
     {
         $this->isPreview = $enabled;
-    }
-
-    /**
-     * Filters out sensitive attributes to ensure they are not exposed.
-     *
-     * These fields are removed to prevent any leakage of sensitive
-     * information that could be exploited for security or OSINT purposes.
-     *
-     * @return ProductLazyArray
-     */
-    private function filterAjaxSensitiveAttributes(ProductLazyArray $lazyArray)
-    {
-        $lazyArray->__unset('wholesale_price');
-
-        if (empty($lazyArray['show_quantities'])) {
-            $lazyArray->__unset('quantity');
-            $lazyArray->__unset('quantity_all_versions');
-        }
-
-        return $lazyArray;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The content returned by the productLazyArray is far too large for front-end and contains data that shouldn't be there. Only embedded attributes should be sent.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | The QuickView AJAX URL (ex: `/1-hummingbird-printed-t-shirt.html?controller=product&action=quickview&id_product=1&ajax=1`) no longer returns the entire product in question, but only embedded attributes.
| UI Tests          | https://github.com/paulnoelcholot/ga.tests.ui.pr/actions/runs/23538532529
| Fixed issue or discussion?     | -
| Related PRs       | github.com/PrestaShop/PrestaShop/pull/40248
| Sponsor company   | -