### PR TITLE
Fix: Backoffice data grids can yield different random results every time

### DIFF
--- a/src/Core/Grid/Query/AddressQueryBuilder.php
+++ b/src/Core/Grid/Query/AddressQueryBuilder.php
@@ -85,6 +85,7 @@ final class AddressQueryBuilder extends AbstractDoctrineQueryBuilder
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
             ->applySorting($searchCriteria, $qb)
+            ->applyDeterministicSorting($searchCriteria, $qb, 'ca', 'id_address')
         ;
 
         return $qb;

--- a/src/Core/Grid/Query/AddressQueryBuilder.php
+++ b/src/Core/Grid/Query/AddressQueryBuilder.php
@@ -85,7 +85,7 @@ final class AddressQueryBuilder extends AbstractDoctrineQueryBuilder
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
             ->applySorting($searchCriteria, $qb)
-            ->applyDeterministicSorting($searchCriteria, $qb, 'ca', 'id_address')
+            ->applyDeterministicSorting($searchCriteria, $qb, 'a', 'id_address')
         ;
 
         return $qb;

--- a/src/Core/Grid/Query/AttachmentQueryBuilder.php
+++ b/src/Core/Grid/Query/AttachmentQueryBuilder.php
@@ -73,6 +73,7 @@ final class AttachmentQueryBuilder extends AbstractDoctrineQueryBuilder
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
             ->applySorting($searchCriteria, $qb)
+            ->applyDeterministicSorting($searchCriteria, $qb, 'a', 'id_attachment')
         ;
 
         return $qb;

--- a/src/Core/Grid/Query/AttributeGroupQueryBuilder.php
+++ b/src/Core/Grid/Query/AttributeGroupQueryBuilder.php
@@ -93,7 +93,9 @@ final class AttributeGroupQueryBuilder extends AbstractDoctrineQueryBuilder
 
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
-            ->applySorting($searchCriteria, $qb);
+            ->applySorting($searchCriteria, $qb)
+            ->applyDeterministicSorting($searchCriteria, $qb, 'ag', 'id_attribute_group')
+        ;
 
         return $qb;
     }

--- a/src/Core/Grid/Query/AttributeQueryBuilder.php
+++ b/src/Core/Grid/Query/AttributeQueryBuilder.php
@@ -101,7 +101,9 @@ final class AttributeQueryBuilder extends AbstractDoctrineQueryBuilder
 
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
-            ->applySorting($searchCriteria, $qb);
+            ->applySorting($searchCriteria, $qb)
+            ->applyDeterministicSorting($searchCriteria, $qb, 'a', 'id_attribute')
+        ;
 
         return $qb;
     }

--- a/src/Core/Grid/Query/CartQueryBuilder.php
+++ b/src/Core/Grid/Query/CartQueryBuilder.php
@@ -83,6 +83,7 @@ final class CartQueryBuilder extends AbstractDoctrineQueryBuilder
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
             ->applySorting($searchCriteria, $qb)
+            ->applyDeterministicSorting($searchCriteria, $qb, 'c', 'id_cart')
         ;
 
         return $qb;

--- a/src/Core/Grid/Query/CartRuleQueryBuilder.php
+++ b/src/Core/Grid/Query/CartRuleQueryBuilder.php
@@ -82,6 +82,7 @@ final class CartRuleQueryBuilder extends AbstractDoctrineQueryBuilder
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
             ->applySorting($searchCriteria, $qb)
+            ->applyDeterministicSorting($searchCriteria, $qb, 'cr', 'id_cart_rule')
         ;
 
         return $qb;

--- a/src/Core/Grid/Query/CategoryQueryBuilder.php
+++ b/src/Core/Grid/Query/CategoryQueryBuilder.php
@@ -116,7 +116,9 @@ final class CategoryQueryBuilder extends AbstractDoctrineQueryBuilder
 
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
-            ->applySorting($searchCriteria, $qb);
+            ->applySorting($searchCriteria, $qb)
+            ->applyDeterministicSorting($searchCriteria, $qb, 'c', 'id_category')
+        ;
 
         return $qb;
     }

--- a/src/Core/Grid/Query/CustomerQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerQueryBuilder.php
@@ -84,10 +84,10 @@ final class CustomerQueryBuilder extends AbstractDoctrineQueryBuilder
         $this->appendLastVisitQuery($searchQueryBuilder);
         $this->applySorting($searchQueryBuilder, $searchCriteria);
 
-        $this->criteriaApplicator->applyPagination(
-            $searchCriteria,
-            $searchQueryBuilder
-        );
+        $this->criteriaApplicator
+            ->applyPagination($searchCriteria, $searchQueryBuilder)
+            ->applyDeterministicSorting($searchCriteria, $searchQueryBuilder, 'c', 'id_customer')
+        ;
 
         return $searchQueryBuilder;
     }

--- a/src/Core/Grid/Query/DoctrineSearchCriteriaApplicator.php
+++ b/src/Core/Grid/Query/DoctrineSearchCriteriaApplicator.php
@@ -64,4 +64,23 @@ final class DoctrineSearchCriteriaApplicator implements DoctrineSearchCriteriaAp
 
         return $this;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function applyDeterministicSorting(
+        SearchCriteriaInterface $searchCriteria,
+        QueryBuilder $queryBuilder,
+        string $alias,
+        string $primaryKey
+    ) {
+        if ($searchCriteria->getOrderBy() !== $primaryKey) {
+            $queryBuilder->addOrderBy(
+                sprintf('%s.`%s`', $alias, $primaryKey),
+                $searchCriteria->getOrderWay()
+            );
+        }
+
+        return $this;
+    }
 }

--- a/src/Core/Grid/Query/DoctrineSearchCriteriaApplicatorInterface.php
+++ b/src/Core/Grid/Query/DoctrineSearchCriteriaApplicatorInterface.php
@@ -53,4 +53,18 @@ interface DoctrineSearchCriteriaApplicatorInterface
      * @return self
      */
     public function applySorting(SearchCriteriaInterface $searchCriteria, QueryBuilder $queryBuilder);
+
+    /**
+     * Apply deterministic sorting (stable order) on query builder.
+     * Useful when the requested sorting may lead to non-deterministic results
+     * (e.g. same values across many rows), so it appends a tie-breaker.
+     *
+     * @param SearchCriteriaInterface $searchCriteria
+     * @param QueryBuilder $queryBuilder
+     * @param string $alias The root alias used in the query (e.g. "a")
+     * @param string $primaryKey The primary key field name (e.g. "id")
+     *
+     * @return self
+     */
+    public function applyDeterministicSorting(SearchCriteriaInterface $searchCriteria, QueryBuilder $queryBuilder, string $alias, string $primaryKey);
 }

--- a/src/Core/Grid/Query/ManufacturerQueryBuilder.php
+++ b/src/Core/Grid/Query/ManufacturerQueryBuilder.php
@@ -87,6 +87,7 @@ final class ManufacturerQueryBuilder extends AbstractDoctrineQueryBuilder
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
             ->applySorting($searchCriteria, $qb)
+            ->applyDeterministicSorting($searchCriteria, $qb, 'm', 'id_manufacturer')
         ;
 
         return $qb;

--- a/src/Core/Grid/Query/OrderQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderQueryBuilder.php
@@ -105,6 +105,7 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
 
         $this->criteriaApplicator
             ->applyPagination($searchCriteria, $qb)
+            ->applyDeterministicSorting($searchCriteria, $qb, 'o', 'id_order')
         ;
 
         return $qb;

--- a/src/Core/Grid/Query/ProductQueryBuilder.php
+++ b/src/Core/Grid/Query/ProductQueryBuilder.php
@@ -126,11 +126,7 @@ class ProductQueryBuilder extends AbstractDoctrineQueryBuilder
             $this->searchCriteriaApplicator->applySorting($searchCriteria, $qb);
         }
 
-        // Add a secondary ORDER BY on id_product to make results deterministic (stable sorting/pagination)
-        // when the primary sort is not id_product.
-        if ($searchCriteria->getOrderBy() !== 'id_product') {
-            $qb->addOrderBy('p.`id_product`', $searchCriteria->getOrderWay());
-        }
+        $this->searchCriteriaApplicator->applyDeterministicSorting($searchCriteria, $qb, 'p', 'id_product');
 
         return $qb;
     }

--- a/src/Core/Grid/Query/ProductQueryBuilder.php
+++ b/src/Core/Grid/Query/ProductQueryBuilder.php
@@ -126,6 +126,12 @@ class ProductQueryBuilder extends AbstractDoctrineQueryBuilder
             $this->searchCriteriaApplicator->applySorting($searchCriteria, $qb);
         }
 
+        // Add a secondary ORDER BY on id_product to make results deterministic (stable sorting/pagination)
+        // when the primary sort is not id_product.
+        if ($searchCriteria->getOrderBy() !== 'id_product') {
+            $qb->addOrderBy('p.`id_product`', $searchCriteria->getOrderWay());
+        }
+
         return $qb;
     }
 

--- a/src/Core/Grid/Query/SupplierQueryBuilder.php
+++ b/src/Core/Grid/Query/SupplierQueryBuilder.php
@@ -94,6 +94,7 @@ final class SupplierQueryBuilder extends AbstractDoctrineQueryBuilder
         $this->searchCriteriaApplicator
             ->applySorting($searchCriteria, $qb)
             ->applyPagination($searchCriteria, $qb)
+            ->applyDeterministicSorting($searchCriteria, $qb, 's', 'id_supplier')
         ;
 
         return $qb;

--- a/src/Core/Grid/Query/SupplierQueryBuilder.php
+++ b/src/Core/Grid/Query/SupplierQueryBuilder.php
@@ -94,8 +94,13 @@ final class SupplierQueryBuilder extends AbstractDoctrineQueryBuilder
         $this->searchCriteriaApplicator
             ->applySorting($searchCriteria, $qb)
             ->applyPagination($searchCriteria, $qb)
-            ->applyDeterministicSorting($searchCriteria, $qb, 's', 'id_supplier')
         ;
+
+        if ($isCountFilter) {
+            $this->searchCriteriaApplicator->applyDeterministicSorting($searchCriteria, $qb, 'subQuery', 'id_supplier');
+        } else {
+            $this->searchCriteriaApplicator->applyDeterministicSorting($searchCriteria, $qb, 's', 'id_supplier');
+        }
 
         return $qb;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR adds a secondary ORDER BY id_product to the QueryBuilder when the primary sorting field is different, ensuring deterministic ordering and preventing unstable results (e.g. pagination issues) in multiple Back Office sections relying on lists/grids.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | For products grids:<br/> - Create 3 - 5 products using "Article" as the name and 0 as the quantity<br/>- Go to the product list and sort by quantity in ascending order<br/>- Now refresh the page several times and you should always see the same order; without the fix, the sorting of products with the same quantity was not always consistent<br/>- Do the same thing sorting by the name field <br/><br/><br/>Repeat the same steps on other Back Office grids that rely on the same QueryBuilder logic (e.g. Orders, Carts, etc.): pick a sortable column that can have duplicates, sort it, then refresh multiple times and verify the order stays deterministic
| UI Tests          | mysql:  🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/21240437434 <br/> mariadb: 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/21240452430
| Fixed issue or discussion?     | Fixes #37259
| Related PRs       |
| Sponsor company   | Codencode snc
