### PR TITLE
Improve StockAvailable static cache for combinations - getQuantityAvailableByProduct

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -279,8 +279,8 @@ class StockAvailableCore extends ObjectModel
                 $query->where('id_product = ' . (int) $id_product);
                 $query = StockAvailable::addSqlShopRestriction($query, $id_shop);
                 $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
-                foreach($result as $r) {
-                    Cache::store('StockAvailable::getQuantityAvailableByProduct_' . (int) $id_product . '-' . (int) $r['id_product_attribute'] . '-' . (int) $id_shop, (int)$r['quantity']);
+                foreach ($result as $r) {
+                    Cache::store('StockAvailable::getQuantityAvailableByProduct_' . (int) $id_product . '-' . (int) $r['id_product_attribute'] . '-' . (int) $id_shop, (int) $r['quantity']);
                 }
                 Cache::store($key1, $result);
             }

--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -279,7 +279,7 @@ class StockAvailableCore extends ObjectModel
                 $query->where('id_product = ' . (int) $id_product);
                 $query = StockAvailable::addSqlShopRestriction($query, $id_shop);
                 $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
-                foreach($result as $r){
+                foreach($result as $r) {
                     Cache::store('StockAvailable::getQuantityAvailableByProduct_' . (int) $id_product . '-' . (int) $r['id_product_attribute'] . '-' . (int) $id_shop, (int)$r['quantity']);
                 }
                 Cache::store($key1, $result);

--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -269,7 +269,22 @@ class StockAvailableCore extends ObjectModel
         if ($id_product_attribute === null) {
             $id_product_attribute = 0;
         }
-
+        // cache quantity available for every combination of provided product id
+        if ($id_product !== null) {
+            $key1 = 'StockAvailable::getQuantityAvailableByProduct_Group_' . (int) $id_product . '-' . (int) $id_shop;
+            if (!Cache::isStored($key1)) {
+                $query = new DbQuery();
+                $query->select('quantity,id_product_attribute');
+                $query->from('stock_available');
+                $query->where('id_product = ' . (int) $id_product);
+                $query = StockAvailable::addSqlShopRestriction($query, $id_shop);
+                $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
+                foreach($result as $r){
+                    Cache::store('StockAvailable::getQuantityAvailableByProduct_' . (int) $id_product . '-' . (int) $r['id_product_attribute'] . '-' . (int) $id_shop, (int)$r['quantity']);
+                }
+                Cache::store($key1, $result);
+            }
+        }
         $key = 'StockAvailable::getQuantityAvailableByProduct_' . (int) $id_product . '-' . (int) $id_product_attribute . '-' . (int) $id_shop;
         if (!Cache::isStored($key)) {
             $query = new DbQuery();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Improve combination stock quantity cache for each variant. Right now every combination is cached one by one using same query SUM(quantity) from stock_available. After changes it's using one query to cache all variants and still keeps old method as a fallback.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Make product with 100+ combinations, enable profiler and see the double calls for stock_available SUM(quantity) on every combination. 
| UI Tests          | CI tests are green 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   

Small improvement for caching all combinations related to the product. Saves memory and removes doubles. 
Tested on 9.0.x, 8.2.x, 8.1.x, 1.7.8.x versions. 
Below you can see difference in loading product page with ~700 combinations, which looks like that from customer point of view.
<img width="634" height="477" alt="image" src="https://github.com/user-attachments/assets/1bf2f4d9-c6b3-45cd-ad06-1438667f8501" />
Before:
<img width="1648" height="281" alt="image" src="https://github.com/user-attachments/assets/c0779459-7024-459d-8a25-7f2cee93c68e" />
<img width="1053" height="80" alt="image" src="https://github.com/user-attachments/assets/b133a9bb-be2a-4904-b2d9-164fe468a1f8" />

After:
<img width="1648" height="292" alt="image" src="https://github.com/user-attachments/assets/801b630c-e677-48b7-8c05-5ee00cdde6dc" />
no doubles

This change also speeds up loading of cart when there are products that contain a lot of combinations.
This is example of cart containing 4 variants of the same product:
<img width="884" height="1156" alt="image" src="https://github.com/user-attachments/assets/0f5d8170-0d23-466a-b233-1f0f26921b6b" />
Before:
<img width="1630" height="284" alt="image" src="https://github.com/user-attachments/assets/5d15ace8-6239-4af9-ae89-e290e5cd8cb2" />
After:
<img width="1658" height="258" alt="image" src="https://github.com/user-attachments/assets/e5068758-a42e-42ab-9c86-8a38cbe5ce90" />

This example shows product page load with same cart as above:
Before:
<img width="1661" height="255" alt="image" src="https://github.com/user-attachments/assets/d6dd69b9-02df-4162-ab6d-83462436b04b" />
After:
<img width="1623" height="311" alt="image" src="https://github.com/user-attachments/assets/f9f29a8b-de28-4dba-a30a-91ed789c1476" />


