### PR TITLE
Improve getSpecificPrice static cache for products with combinations

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3572,7 +3572,8 @@ class ProductCore extends ObjectModel
             $id_product_attribute,
             $id_customer,
             $id_cart,
-            $real_quantity
+            $real_quantity,
+            true
         );
 
         if (isset(self::$_prices[$cache_id])) {

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -518,7 +518,7 @@ class SpecificPriceCore extends ObjectModel
         $id_customer = 0,
         $id_cart = 0,
         $real_quantity = 0,
-        $cache_all_variants = true
+		$cache_all_variants = false
     ) {
         if (!SpecificPrice::isFeatureActive()) {
             return [];

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -580,85 +580,85 @@ class SpecificPriceCore extends ObjectModel
             $conditions = 'AND IF(`from_quantity` > 1, `from_quantity`, 0) <= ';
             $conditions .= (static::$psQtyDiscountOnCombination || !$id_cart || !$real_quantity) ? (int) $quantity : max(1, (int) $real_quantity);
             $conditions .= ' ORDER BY `id_product_attribute` DESC, `id_cart` DESC, `from_quantity` DESC, `id_specific_price_rule` ASC, `score` DESC, `to` DESC, `from` DESC';
-            
+
             $queryAll = $query;
             // keep the old query as a fallback
             $query .= $query_extra;
             $query .= $conditions;
-            if($id_product_attribute){
-                // we want to get specific prices for all product variants			
+            if ($id_product_attribute) {
+                // we want to get specific prices for all product variants	
                 $query_extraAll = self::computeExtraConditions($id_product, null, $id_customer, $id_cart);
                 $queryAll .= $query_extraAll;
                 $queryAll .= $conditions;
                 // cache all product variants to limit calls for the same product
                 $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($queryAll);
 
-                foreach(array_column(Product::getProductAttributesIds($id_product),'id_product_attribute') as $variantId){
-                    switch(true){
+                foreach (array_column(Product::getProductAttributesIds($id_product), 'id_product_attribute') as $variantId) {
+                    switch (true) {
                         // product variant matching specific price
-                        case in_array($variantId,array_column($result,'id_product_attribute')):
-                            $k=array_search($variantId,array_column($result,'id_product_attribute'));
+                        case in_array($variantId, array_column($result, 'id_product_attribute')):
+                            $k = array_search($variantId, array_column($result, 'id_product_attribute'));
                             $key = self::computeKey(
-                            $id_product,
-                            $id_shop,
-                            $id_currency,
-                            $id_country,
-                            $id_group,
-                            $quantity,
-                            (int)$variantId,
-                            $id_customer,
-                            $id_cart,
-                            $real_quantity
+                                $id_product,
+                                $id_shop,
+                                $id_currency,
+                                $id_country,
+                                $id_group,
+                                $quantity,
+                                (int)$variantId,
+                                $id_customer,
+                                $id_cart,
+                                $real_quantity
                             );
                             if(!array_key_exists($key, self::$_specificPriceCache)){
                                 self::$_specificPriceCache[$key] = $result[$k];
                             }
-                        break; 
-                        // specific price rules case where rule applies to all variants
-                        case in_array(0,array_column($result,'id_product_attribute')):
-                            $k=array_search(0,array_column($result,'id_product_attribute'));
+                            break;
+                            // specific price rules case where rule applies to all variants
+                        case in_array(0, array_column($result, 'id_product_attribute')):
+                            $k = array_search(0, array_column($result, 'id_product_attribute'));
                             $key = self::computeKey(
-                            $id_product,
-                            $id_shop,
-                            $id_currency,
-                            $id_country,
-                            $id_group,
-                            $quantity,
-                            (int)$variantId,
-                            $id_customer,
-                            $id_cart,
-                            $real_quantity
+                                $id_product,
+                                $id_shop,
+                                $id_currency,
+                                $id_country,
+                                $id_group,
+                                $quantity,
+                                (int)$variantId,
+                                $id_customer,
+                                $id_cart,
+                                $real_quantity
                             );
-                            if(!array_key_exists($key, self::$_specificPriceCache)){
+                            if (!array_key_exists($key, self::$_specificPriceCache)){
                                 self::$_specificPriceCache[$key] = $result[$k];
                             }
-                        break;
-                        // if product variant doesnt have any matching specific price we have to return false
+                            break;
+                            // if product variant doesnt have any matching specific price we have to return false
                         default:
                             $key = self::computeKey(
-                            $id_product,
-                            $id_shop,
-                            $id_currency,
-                            $id_country,
-                            $id_group,
-                            $quantity,
-                            (int)$variantId,
-                            $id_customer,
-                            $id_cart,
-                            $real_quantity
+                                $id_product,
+                                $id_shop,
+                                $id_currency,
+                                $id_country,
+                                $id_group,
+                                $quantity,
+                                (int)$variantId,
+                                $id_customer,
+                                $id_cart,
+                                $real_quantity
                             );
-                            if(!array_key_exists($key, self::$_specificPriceCache)){
+                            if (!array_key_exists($key, self::$_specificPriceCache)){
                                 self::$_specificPriceCache[$key] = false;
                             }
                         }
                     }
                 }
-            if(!array_key_exists($key, self::$_specificPriceCache)){
+            if (!array_key_exists($key, self::$_specificPriceCache)){
                 // keep the old query as a fallback
                 self::$_specificPriceCache[$key] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query);
             }
 
-        }   
+        } 
         return self::$_specificPriceCache[$key];
     }
 

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -503,7 +503,8 @@ class SpecificPriceCore extends ObjectModel
      * @param int $id_customer
      * @param int $id_cart
      * @param int $real_quantity
-     *
+     * @param int $all_variants set to false if you only want to get a single combination with provided $id_product_attribute
+     * 
      * @return array
      */
     public static function getSpecificPrice(
@@ -516,7 +517,8 @@ class SpecificPriceCore extends ObjectModel
         $id_product_attribute = null,
         $id_customer = 0,
         $id_cart = 0,
-        $real_quantity = 0
+        $real_quantity = 0,
+        $all_variants = true
     ) {
         if (!SpecificPrice::isFeatureActive()) {
             return [];
@@ -585,7 +587,7 @@ class SpecificPriceCore extends ObjectModel
             // keep the old query as a fallback
             $query .= $query_extra;
             $query .= $conditions;
-            if ($id_product_attribute) {
+            if ($id_product_attribute && $all_variants) {
                 // we want to get specific prices for all product variants
                 $query_extraAll = self::computeExtraConditions($id_product, null, $id_customer, $id_cart);
                 $queryAll .= $query_extraAll;
@@ -593,7 +595,7 @@ class SpecificPriceCore extends ObjectModel
                 // cache all product variants to limit calls for the same product
                 $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($queryAll);
 
-                foreach (array_column(Product::getProductAttributesIds($id_product), 'id_product_attribute') as $variantId) {
+                foreach (array_column(Product::getProductAttributesIds($id_product,true), 'id_product_attribute') as $variantId) {
                     switch (true) {
                         // product variant matching specific price
                         case in_array($variantId, array_column($result, 'id_product_attribute')):
@@ -610,7 +612,7 @@ class SpecificPriceCore extends ObjectModel
                                 $id_cart,
                                 $real_quantity
                             );
-                            if(!array_key_exists($key, self::$_specificPriceCache)){
+                            if (!array_key_exists($key, self::$_specificPriceCache)) {
                                 self::$_specificPriceCache[$key] = $result[$k];
                             }
                             break;
@@ -629,7 +631,7 @@ class SpecificPriceCore extends ObjectModel
                                 $id_cart,
                                 $real_quantity
                             );
-                            if (!array_key_exists($key, self::$_specificPriceCache)){
+                            if (!array_key_exists($key, self::$_specificPriceCache)) {
                                 self::$_specificPriceCache[$key] = $result[$k];
                             }
                             break;
@@ -650,8 +652,8 @@ class SpecificPriceCore extends ObjectModel
                             if (!array_key_exists($key, self::$_specificPriceCache)) {
                                 self::$_specificPriceCache[$key] = false;
                             }
-                        }
                     }
+                }
             }
             if (!array_key_exists($key, self::$_specificPriceCache)) {
                 // keep the old query as a fallback

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -503,7 +503,7 @@ class SpecificPriceCore extends ObjectModel
      * @param int $id_customer
      * @param int $id_cart
      * @param int $real_quantity
-     * @param int $all_variants set to false if you only want to get a single combination with provided $id_product_attribute
+     * @param bool $all_variants set to false if you only want to get a single combination with provided $id_product_attribute
      * 
      * @return array
      */
@@ -595,7 +595,7 @@ class SpecificPriceCore extends ObjectModel
                 // cache all product variants to limit calls for the same product
                 $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($queryAll);
 
-                foreach (array_column(Product::getProductAttributesIds($id_product,true), 'id_product_attribute') as $variantId) {
+                foreach (array_column(Product::getProductAttributesIds($id_product, true), 'id_product_attribute') as $variantId) {
                     switch (true) {
                         // product variant matching specific price
                         case in_array($variantId, array_column($result, 'id_product_attribute')):

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -586,7 +586,7 @@ class SpecificPriceCore extends ObjectModel
             $query .= $query_extra;
             $query .= $conditions;
             if ($id_product_attribute) {
-                // we want to get specific prices for all product variants	
+                // we want to get specific prices for all product variants
                 $query_extraAll = self::computeExtraConditions($id_product, null, $id_customer, $id_cart);
                 $queryAll .= $query_extraAll;
                 $queryAll .= $conditions;
@@ -605,7 +605,7 @@ class SpecificPriceCore extends ObjectModel
                                 $id_country,
                                 $id_group,
                                 $quantity,
-                                (int)$variantId,
+                                (int) $variantId,
                                 $id_customer,
                                 $id_cart,
                                 $real_quantity
@@ -624,7 +624,7 @@ class SpecificPriceCore extends ObjectModel
                                 $id_country,
                                 $id_group,
                                 $quantity,
-                                (int)$variantId,
+                                (int) $variantId,
                                 $id_customer,
                                 $id_cart,
                                 $real_quantity
@@ -642,23 +642,23 @@ class SpecificPriceCore extends ObjectModel
                                 $id_country,
                                 $id_group,
                                 $quantity,
-                                (int)$variantId,
+                                (int) $variantId,
                                 $id_customer,
                                 $id_cart,
                                 $real_quantity
                             );
-                            if (!array_key_exists($key, self::$_specificPriceCache)){
+                            if (!array_key_exists($key, self::$_specificPriceCache)) {
                                 self::$_specificPriceCache[$key] = false;
                             }
                         }
                     }
-                }
-            if (!array_key_exists($key, self::$_specificPriceCache)){
+            }
+            if (!array_key_exists($key, self::$_specificPriceCache)) {
                 // keep the old query as a fallback
                 self::$_specificPriceCache[$key] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query);
             }
 
-        } 
+        }
         return self::$_specificPriceCache[$key];
     }
 

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -575,14 +575,90 @@ class SpecificPriceCore extends ObjectModel
                 `id_shop` ' . self::formatIntInQuery(0, $id_shop) . ' AND
                 `id_currency` ' . self::formatIntInQuery(0, $id_currency) . ' AND
                 `id_country` ' . self::formatIntInQuery(0, $id_country) . ' AND
-                `id_group` ' . self::formatIntInQuery(0, $id_group) . ' ' . $query_extra . '
-				AND IF(`from_quantity` > 1, `from_quantity`, 0) <= ';
+                `id_group` ' . self::formatIntInQuery(0, $id_group) . ' ';
+            // additional conditions for query
+            $conditions = 'AND IF(`from_quantity` > 1, `from_quantity`, 0) <= ';
+            $conditions .= (static::$psQtyDiscountOnCombination || !$id_cart || !$real_quantity) ? (int) $quantity : max(1, (int) $real_quantity);
+            $conditions .= ' ORDER BY `id_product_attribute` DESC, `id_cart` DESC, `from_quantity` DESC, `id_specific_price_rule` ASC, `score` DESC, `to` DESC, `from` DESC';
+            
+            $queryAll = $query;
+            // keep the old query as a fallback
+            $query .= $query_extra;
+            $query .= $conditions;
+			if($id_product_attribute){
+				// we want to get specific prices for all product variants			
+				$query_extraAll = self::computeExtraConditions($id_product, null, $id_customer, $id_cart);
+				$queryAll .= $query_extraAll;
+				$queryAll .= $conditions;
+				// cache all product variants to limit calls for the same product
+				$result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($queryAll);
 
-            $query .= (static::$psQtyDiscountOnCombination || !$id_cart || !$real_quantity) ? (int) $quantity : max(1, (int) $real_quantity);
-            $query .= ' ORDER BY `id_product_attribute` DESC, `id_cart` DESC, `from_quantity` DESC, `id_specific_price_rule` ASC, `score` DESC, `to` DESC, `from` DESC';
-            self::$_specificPriceCache[$key] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query);
-        }
+				foreach(array_column(Product::getProductAttributesIds($id_product),'id_product_attribute') as $variantId){
+					switch(true){
+						// product variant matching specific price
+						case in_array($variantId,array_column($result,'id_product_attribute')):
+							$k=array_search($variantId,array_column($result,'id_product_attribute'));
+							$key = self::computeKey(
+								$id_product,
+								$id_shop,
+								$id_currency,
+								$id_country,
+								$id_group,
+								$quantity,
+								(int)$variantId,
+								$id_customer,
+								$id_cart,
+								$real_quantity
+							);
+							if(!array_key_exists($key, self::$_specificPriceCache)){
+								self::$_specificPriceCache[$key] = $result[$k];
+							}
+						break; 
+						// specific price rules case where rule applies to all variants
+						case in_array(0,array_column($result,'id_product_attribute')):
+							$k=array_search(0,array_column($result,'id_product_attribute'));
+							$key = self::computeKey(
+								$id_product,
+								$id_shop,
+								$id_currency,
+								$id_country,
+								$id_group,
+								$quantity,
+								(int)$variantId,
+								$id_customer,
+								$id_cart,
+								$real_quantity
+							);
+							if(!array_key_exists($key, self::$_specificPriceCache)){
+								self::$_specificPriceCache[$key] = $result[$k];
+							}
+						break;
+						// if product variant doesnt have any matching specific price we have to return false
+						default:
+							$key = self::computeKey(
+								$id_product,
+								$id_shop,
+								$id_currency,
+								$id_country,
+								$id_group,
+								$quantity,
+								(int)$variantId,
+								$id_customer,
+								$id_cart,
+								$real_quantity
+							);
+							if(!array_key_exists($key, self::$_specificPriceCache)){
+								self::$_specificPriceCache[$key] = false;
+							}
+					}
+				}
+			}
+            if(!array_key_exists($key, self::$_specificPriceCache)){
+                // keep the old query as a fallback
+               self::$_specificPriceCache[$key] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query);
+            }
 
+        }   
         return self::$_specificPriceCache[$key];
     }
 

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -585,77 +585,77 @@ class SpecificPriceCore extends ObjectModel
             // keep the old query as a fallback
             $query .= $query_extra;
             $query .= $conditions;
-			if($id_product_attribute){
-				// we want to get specific prices for all product variants			
-				$query_extraAll = self::computeExtraConditions($id_product, null, $id_customer, $id_cart);
-				$queryAll .= $query_extraAll;
-				$queryAll .= $conditions;
-				// cache all product variants to limit calls for the same product
-				$result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($queryAll);
+            if($id_product_attribute){
+                // we want to get specific prices for all product variants			
+                $query_extraAll = self::computeExtraConditions($id_product, null, $id_customer, $id_cart);
+                $queryAll .= $query_extraAll;
+                $queryAll .= $conditions;
+                // cache all product variants to limit calls for the same product
+                $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($queryAll);
 
-				foreach(array_column(Product::getProductAttributesIds($id_product),'id_product_attribute') as $variantId){
-					switch(true){
-						// product variant matching specific price
-						case in_array($variantId,array_column($result,'id_product_attribute')):
-							$k=array_search($variantId,array_column($result,'id_product_attribute'));
-							$key = self::computeKey(
-								$id_product,
-								$id_shop,
-								$id_currency,
-								$id_country,
-								$id_group,
-								$quantity,
-								(int)$variantId,
-								$id_customer,
-								$id_cart,
-								$real_quantity
-							);
-							if(!array_key_exists($key, self::$_specificPriceCache)){
-								self::$_specificPriceCache[$key] = $result[$k];
-							}
-						break; 
-						// specific price rules case where rule applies to all variants
-						case in_array(0,array_column($result,'id_product_attribute')):
-							$k=array_search(0,array_column($result,'id_product_attribute'));
-							$key = self::computeKey(
-								$id_product,
-								$id_shop,
-								$id_currency,
-								$id_country,
-								$id_group,
-								$quantity,
-								(int)$variantId,
-								$id_customer,
-								$id_cart,
-								$real_quantity
-							);
-							if(!array_key_exists($key, self::$_specificPriceCache)){
-								self::$_specificPriceCache[$key] = $result[$k];
-							}
-						break;
-						// if product variant doesnt have any matching specific price we have to return false
-						default:
-							$key = self::computeKey(
-								$id_product,
-								$id_shop,
-								$id_currency,
-								$id_country,
-								$id_group,
-								$quantity,
-								(int)$variantId,
-								$id_customer,
-								$id_cart,
-								$real_quantity
-							);
-							if(!array_key_exists($key, self::$_specificPriceCache)){
-								self::$_specificPriceCache[$key] = false;
-							}
-					}
-				}
-			}
+                foreach(array_column(Product::getProductAttributesIds($id_product),'id_product_attribute') as $variantId){
+                    switch(true){
+                        // product variant matching specific price
+                        case in_array($variantId,array_column($result,'id_product_attribute')):
+                            $k=array_search($variantId,array_column($result,'id_product_attribute'));
+                            $key = self::computeKey(
+                            $id_product,
+                            $id_shop,
+                            $id_currency,
+                            $id_country,
+                            $id_group,
+                            $quantity,
+                            (int)$variantId,
+                            $id_customer,
+                            $id_cart,
+                            $real_quantity
+                            );
+                            if(!array_key_exists($key, self::$_specificPriceCache)){
+                                self::$_specificPriceCache[$key] = $result[$k];
+                            }
+                        break; 
+                        // specific price rules case where rule applies to all variants
+                        case in_array(0,array_column($result,'id_product_attribute')):
+                            $k=array_search(0,array_column($result,'id_product_attribute'));
+                            $key = self::computeKey(
+                            $id_product,
+                            $id_shop,
+                            $id_currency,
+                            $id_country,
+                            $id_group,
+                            $quantity,
+                            (int)$variantId,
+                            $id_customer,
+                            $id_cart,
+                            $real_quantity
+                            );
+                            if(!array_key_exists($key, self::$_specificPriceCache)){
+                                self::$_specificPriceCache[$key] = $result[$k];
+                            }
+                        break;
+                        // if product variant doesnt have any matching specific price we have to return false
+                        default:
+                            $key = self::computeKey(
+                            $id_product,
+                            $id_shop,
+                            $id_currency,
+                            $id_country,
+                            $id_group,
+                            $quantity,
+                            (int)$variantId,
+                            $id_customer,
+                            $id_cart,
+                            $real_quantity
+                            );
+                            if(!array_key_exists($key, self::$_specificPriceCache)){
+                                self::$_specificPriceCache[$key] = false;
+                            }
+                        }
+                    }
+                }
             if(!array_key_exists($key, self::$_specificPriceCache)){
                 // keep the old query as a fallback
-               self::$_specificPriceCache[$key] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query);
+                self::$_specificPriceCache[$key] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query);
             }
 
         }   

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -503,7 +503,7 @@ class SpecificPriceCore extends ObjectModel
      * @param int $id_customer
      * @param int $id_cart
      * @param int $real_quantity
-     * @param bool $all_variants set to false if you only want to get a single combination with provided $id_product_attribute
+     * @param bool $cache_all_variants set to false if you only want to cache a single combination with provided $id_product_attribute
      * 
      * @return array
      */
@@ -518,7 +518,7 @@ class SpecificPriceCore extends ObjectModel
         $id_customer = 0,
         $id_cart = 0,
         $real_quantity = 0,
-        $all_variants = true
+        $cache_all_variants = true
     ) {
         if (!SpecificPrice::isFeatureActive()) {
             return [];
@@ -587,7 +587,7 @@ class SpecificPriceCore extends ObjectModel
             // keep the old query as a fallback
             $query .= $query_extra;
             $query .= $conditions;
-            if ($id_product_attribute && $all_variants) {
+            if ($id_product_attribute && $cache_all_variants) {
                 // we want to get specific prices for all product variants
                 $query_extraAll = self::computeExtraConditions($id_product, null, $id_customer, $id_cart);
                 $queryAll .= $query_extraAll;
@@ -659,8 +659,8 @@ class SpecificPriceCore extends ObjectModel
                 // keep the old query as a fallback
                 self::$_specificPriceCache[$key] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query);
             }
-
         }
+ 
         return self::$_specificPriceCache[$key];
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | getSpecificPrice is called on every combination for product and caching one result at a time. Instead we should call it once for all product variants and cache them. This way we reduce memory usage, query doubles and loading speed. Specific prices is allways returned with results from query or false if no match found. The more combinations product has the bigger improvement you will notice.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | create product with a lot of combinations 50-100+. Below you can find improvements on product with 700 combinations. 
| UI Tests          |  CI test are green
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

Tested on 9.0.x,8.2.x,1.7.8.x.  Below you can see difference in loading product page with ~700 combinations, which looks like that from customer point of view.
<img width="532" height="428" alt="image" src="https://github.com/user-attachments/assets/84463644-5a88-4d9e-b1aa-7a80bb6512dc" />

Before change:
<img width="1679" height="250" alt="image" src="https://github.com/user-attachments/assets/0a00aaa3-885c-427b-a802-60663d6a0280" />

After change:
<img width="1664" height="255" alt="image" src="https://github.com/user-attachments/assets/46910354-1265-4573-92a7-4df8d2b79848" />

