### PR TITLE
Prevent NoResultException when checking for existing translations

### DIFF
--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -251,7 +251,7 @@ class TranslationService
             } else {
                 $queryBuilder->andWhere('t.theme IS NULL');
             }
-            $translation = $queryBuilder->getQuery()->getSingleResult();
+            $translation = $queryBuilder->getQuery()->getOneOrNullResult();
         } catch (Exception $exception) {
             $logger->error($exception->getMessage(), $log_context);
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | When saving a translation for first time we get a NoResultException for using getSingleResult instead of getOneOrNullResult. Null is an expected value in this case.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Commnet below
| UI Tests          | https://github.com/ChillCode/ga.tests.ui.pr/actions/runs/20225236595 https://github.com/ChillCode/ga.tests.ui.pr/actions/runs/20225250677
| Fixed issue or discussion?     | #37322

1. Install PrestaShop 9
2. Go to International->translations

Select this setup to fire the issue:

<img width="1694" height="428" alt="image" src="https://github.com/user-attachments/assets/a579c87c-723b-4b61-821d-289c0e30a05f" />

3. Click Modify
4. Start translating few different words

<img width="1700" height="647" alt="image" src="https://github.com/user-attachments/assets/31784552-0e22-42ac-b6f8-f45b016b4789" />

5. Click Save
6. Go to Advanced paramaters->log

<img width="1086" height="73" alt="image" src="https://github.com/user-attachments/assets/c1faa1b5-cc03-4c7e-aa2f-0337cb73ab21" />

Note: Errors only occur the first time a word is translated and as many words translated more errors we get.

After aplying this patch no more errors.
