### PR TITLE
Disable E_USER_DEPRECATED in docker php ini

### DIFF
--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -115,6 +115,9 @@ else
   echo "error_log=/var/www/html/var/logs/php.log" >> /usr/local/etc/php/php.ini
 fi
 
+# Disable deprecated warnings
+echo "error_reporting=E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED" >> /usr/local/etc/php/php.ini
+
 if [ ! -f ./app/config/parameters.php ]; then
     if [ $PS_INSTALL_AUTO = 1 ]; then
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Disable E_USER_DEPRECATED in docker php ini
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Start docker start in local.<br>2. Add a `phpinfo(); exit;` on first line in `index.php`.<br>3. Go the your browser to display the homepage of PS, you should see the php configuration.<br>4. Find `error_reporting` variable and check if E_USER_DEPRECATED is disabled. (It's a bitmask, so you can check the value with this tools: https://maximivanov.github.io/php-error-reporting-calculator/)
| UI Tests          | ~
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
