### PR TITLE
Fix(FO): Allow HEAD requests to be processed by canonicalRedirection …

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -825,7 +825,7 @@ class FrontControllerCore extends Controller
      */
     protected function canonicalRedirection(string $canonical_url = '')
     {
-        if (!$canonical_url || !Configuration::get('PS_CANONICAL_REDIRECT') || strtoupper($_SERVER['REQUEST_METHOD']) != 'GET') {
+        if (!$canonical_url || !Configuration::get('PS_CANONICAL_REDIRECT') || !in_array(strtoupper($_SERVER['REQUEST_METHOD']), ['GET', 'HEAD'])) {
             return;
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The `canonicalRedirection()` method in `FrontControllerCore` currently only processes GET requests.<br> This PR extends support to HEAD requests, ensuring HTTP protocol compliance (RFC 7231) and consistent SEO behavior.<br> HEAD requests are semantically identical to GET (without response body) and should receive the same canonical redirections.<br> This improves compatibility with search engine crawlers, monitoring tools, and CDN prefetch mechanisms.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable canonical redirection in BO → Shop Parameters → Traffic & SEO → "Redirect to canonical URL" = 301. <br> 2. Use `curl -I -X HEAD "https://shop.com/non-canonical-url"` and verify it returns 301/302 redirect. <br> 3. Compare with `curl -I -X GET` on the same URL - both should return identical redirect responses. <br> 4. Verify POST/PUT/DELETE requests still bypass canonical redirection (expected behavior).
| UI Tests          | N/A - This change affects HTTP HEAD requests which are not covered by browser-based UI tests. Manual testing with curl or similar HTTP tools is required.
| Fixed issue or discussion?     | N/A (improvement proposal based on RFC 7231 compliance)
| Related PRs       | N/A
| Sponsor company   | 