### PR TITLE
Use node 20.19.5 by default to build assets

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -9,7 +9,7 @@ inputs:
   NODE_VERSION:
     required: false
     description: Node Version to Build Themes
-    default: 16.20.1
+    default: 20.19.5
   DB_SERVER:
     required: false
     description: Database Server for PrestaShop (mysql/mariadb)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         - VERSION=${VERSION:-8.1-apache}
         - USER_ID=${USER_ID:-1000}
         - GROUP_ID=${GROUP_ID:-1000}
-        - NODE_VERSION=${NODE_VERSION:-20.17.0}
+        - NODE_VERSION=${NODE_VERSION:-20.19.5}
         - INSTALL_XDEBUG=${INSTALL_XDEBUG:-false}
     environment:
       DISABLE_MAKE: ${DISABLE_MAKE:-0}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -150,7 +150,7 @@ make help # Show all available commands
 | **Admin** | `ADMIN_MAIL` | `demo@prestashop.com` | Admin email |
 | | `ADMIN_PASSWD` | `Correct Horse Battery Staple` | Admin password |
 | **Development** | `VERSION` | `8.1-apache` | PHP version |
-| | `NODE_VERSION` | `20.17.0` | Node.js version |
+| | `NODE_VERSION` | `20.19.5` | Node.js version |
 | | `INSTALL_XDEBUG` | `false` | Install Xdebug |
 | | `BLACKFIRE_ENABLE` | `0` | Enable Blackfire profiling |
 | | `BLACKFIRE_SERVER_ID` | `0` | Blackfire server ID |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Use node 20.19.5 by default to build assets, we anticipate this for HummingBird 2.0
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/20309213849
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
