### PR TITLE
remove leftover theme_name annotation from ImageType entity

### DIFF
--- a/src/PrestaShopBundle/Entity/ImageType.php
+++ b/src/PrestaShopBundle/Entity/ImageType.php
@@ -34,9 +34,9 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 /**
  * @ORM\Entity(repositoryClass="PrestaShopBundle\Entity\Repository\ImageTypeRepository")
  *
- * @ORM\Table(uniqueConstraints={@ORM\UniqueConstraint(columns={"name","theme_name"})})
+ * @ORM\Table(uniqueConstraints={@ORM\UniqueConstraint(columns={"name"})})
  *
- * @UniqueEntity({"name", "theme_name"})
+ * @UniqueEntity({"name"})
  */
 class ImageType
 {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Finishes pr39554 to revert pr38745, theme_name entity annotation was not reverted.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Comment below
| UI Tests          | https://github.com/ChillCode/ga.tests.ui.pr/actions/runs/20225250677 https://github.com/ChillCode/ga.tests.ui.pr/actions/runs/20392201154
| Related PRs       |https://github.com/PrestaShop/PrestaShop/pull/38767, https://github.com/PrestaShop/PrestaShop/pull/38745 and https://github.com/PrestaShop/PrestaShop/pull/39554
| Fixed issue or discussion?     | #40258

To test we need to open the CLI and from PrestaShop root directory run the following command:

`sudo -u www-data bin/console doctrine:schema:validate`

Mapping should be green Database is ok in red:

<img width="856" height="240" alt="image" src="https://github.com/user-attachments/assets/2cf8217d-01a5-40cb-9a3a-d02b5bdb3073" />

