### PR TITLE
Fix wrong array used when fetching active states linked to delivered countries

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -664,7 +664,7 @@ class CarrierCore extends ObjectModel
         $states = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
             SELECT s.*
             FROM `' . _DB_PREFIX_ . 'state` s
-            WHERE s.id_country IN (' . implode(',', array_keys($countries)) . ')
+            WHERE s.id_country IN (' . implode(',', array_keys($result)) . ')
               AND s.active = 1
             ORDER BY s.`name` ASC'
         );


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | The new getDeliveredCountries() code has an error when fetching active states linked to delivered countries. This is because when using the $countries array in `array_keys($countries)` its keys are in numeric order starting from 0, not using id_country as keys. $countries has no id_country as keys. $result has them. This results in `SELECT` using `IN (0,1,2,3,....)` instead of correct country ids.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Just call the Carrier::getDeliveredCountries() function. You'll also get countries for which there aren't carriers available. For better proof, disable carriers for the countries with low states ID in them (like 0,1,2,3,4). They will be included anyway for the error explained in description.
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/40376
| Sponsor company   | Giuseppe Tripiciano
