### PR TITLE
Remove `curl_close` obsolete function calls

### DIFF
--- a/admin-dev/filemanager/include/utils.php
+++ b/admin-dev/filemanager/include/utils.php
@@ -401,7 +401,6 @@ function get_file_by_url($url)
         curl_setopt($ch, CURLOPT_URL, $url);
 
         $data = curl_exec($ch);
-        curl_close($ch);
     } elseif (in_array(ini_get('allow_url_fopen'), array('On', 'on', '1'))) {
         $data = file_get_contents($url);
     }

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1823,7 +1823,6 @@ class ToolsCore
                 throw new Exception($errorMessage);
             }
 
-            curl_close($curl);
         }
 
         return $content;

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1822,7 +1822,6 @@ class ToolsCore
 
                 throw new Exception($errorMessage);
             }
-
         }
 
         return $content;

--- a/tools/build/Library/InstallUnpacker/classes/Download.php
+++ b/tools/build/Library/InstallUnpacker/classes/Download.php
@@ -106,7 +106,6 @@ class Download
                 }
             }
             $content = curl_exec($curl);
-            curl_close($curl);
 
             return $content;
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | check below
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | nothing to test
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/20815307329
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/

### Description

Function curl_close is obsolete from PHP 8.0, source: https://www.php.net/curl_close

> This function has no effect. Prior to PHP 8.0.0, this function was used to close the resource.

PrestaShop 9 does not support PHP 7, so there it's not necessary to use this anymore.

### Example of message in logs
`[8192] Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0
`