### PR TITLE
fix hook displayBackOfficeEmployeeMenu not displayed

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/employee_dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/Layout/employee_dropdown.html.twig
@@ -48,7 +48,7 @@
 
         <p class="divider"></p>
 
-        {% for menuItem in displayBackOfficeEmployeeMenu %}
+        {% for menuItem in this.displayBackOfficeEmployeeMenu %}
           {% set menuItemProperties = menuItem.getProperties %}
           <a class="dropdown-item {{ menuItem.getClass }}" href="{{ menuItemProperties.link }}" {% if menuItemProperties.isExternalLink %} target="_blank"{% endif %} rel="noopener noreferrer nofollow">
             {% if menuItemProperties.icon is defined %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/employee_dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Component/LegacyLayout/employee_dropdown.html.twig
@@ -40,7 +40,7 @@
       <li class="employee-wrapper-profile"><a class="admin-link" href="{{ path('admin_employees_edit', {employeeId: this.employee.id}) }}"><i class="material-icons">edit</i> {{ 'Your profile'|trans({}, 'Admin.Navigation.Header') }}</a></li>
       <li class="divider"></li>
 
-      {% for menuItem in displayBackOfficeEmployeeMenu %}
+      {% for menuItem in this.displayBackOfficeEmployeeMenu %}
         {% set menuItemProperties = menuItem.getProperties %}
         <li class="{{ menuItem.getClass }}">
           <a class="dropdown-item" href="{{ menuItemProperties.link }}" {% if menuItemProperties.isExternalLink %} target="_blank"{% endif %} rel="noopener noreferrer nofollow">

--- a/src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
+++ b/src/PrestaShopBundle/Twig/Component/EmployeeDropdown.php
@@ -37,7 +37,7 @@ use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 #[AsTwigComponent(template: '@PrestaShop/Admin/Component/Layout/employee_dropdown.html.twig')]
 class EmployeeDropdown
 {
-    public ?ActionsBarButtonsCollection $displayBackOfficeEmployeeMenu = null;
+    protected ?ActionsBarButtonsCollection $displayBackOfficeEmployeeMenu = null;
 
     public function __construct(
         protected readonly HookDispatcherInterface $hookDispatcher,
@@ -45,12 +45,18 @@ class EmployeeDropdown
     ) {
     }
 
+    /**
+     * @return Employee|null
+     */
     public function getEmployee(): ?Employee
     {
         return $this->employeeContext->getEmployee();
     }
 
-    public function getDisplayBackOfficeEmployeeMenu()
+    /**
+     * @return ActionsBarButtonsCollection|null
+     */
+    public function getDisplayBackOfficeEmployeeMenu(): ?ActionsBarButtonsCollection
     {
         if ($this->displayBackOfficeEmployeeMenu === null) {
             $menuLinksCollections = new ActionsBarButtonsCollection();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | fix hook displayBackOfficeEmployeeMenu not displayed
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Comment below
| UI Tests          | https://github.com/ChillCode/ga.tests.ui.pr/actions/runs/20391396741 https://github.com/ChillCode/ga.tests.ui.pr/actions/runs/20391407692
| Fixed issue or discussion?     | Fixes #38359

1. Install and activate autoupgrade
2. Click the top-right Employee profile Icon

Profile have a new link:

<img width="304" height="278" alt="image" src="https://github.com/user-attachments/assets/07b7af89-e6b3-4210-a60c-61f1db477917" />


