### PR TITLE
Fix: SQL syntax for table checksum query (fixes #40383)

### DIFF
--- a/tests/Resources/DatabaseDump.php
+++ b/tests/Resources/DatabaseDump.php
@@ -337,7 +337,7 @@ class DatabaseDump
      */
     private function getTableChecksum(string $table): string
     {
-        $checksum = $this->db->executeS(sprintf('CHECKSUM TABLE %s;', $table));
+        $checksum = $this->db->executeS(sprintf('CHECKSUM TABLE `%s`;', $table));
         $checksum = $checksum[0]['Checksum'];
 
         // The content only is not enough we must make sure that the auto increment index is the same


### PR DESCRIPTION
https://github.com/PrestaShop/PrestaShop/issues/40383

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Solves array offset errors (`Trying to access array offset on false` or `Trying to access array offset on null`) when getting the the table checksum, if the table name is a SQL reserved word like `group`.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | No
| Deprecations?     | No
| How to test?      | Run `composer integration-tests` and check that no errors like above are present.
| UI Tests          | https://github.com/paulnoelcholot/ga.tests.ui.pr/actions/runs/23538552995
| Fixed issue or discussion?     | Fixes #40383
| Related PRs       | None

