### PR TITLE
Fix PHP 8.1 deprecated warnings (null params)

### DIFF
--- a/classes/DateRange.php
+++ b/classes/DateRange.php
@@ -55,15 +55,27 @@ class DateRangeCore extends ObjectModel
     public static function getCurrentRange()
     {
         $result = Db::getInstance()->getRow('
-		SELECT `id_date_range`, `time_end`
-		FROM `' . _DB_PREFIX_ . 'date_range`
-		WHERE `time_end` = (SELECT MAX(`time_end`) FROM `' . _DB_PREFIX_ . 'date_range`)');
-        if (!isset($result['id_date_range']) || strtotime($result['time_end']) < strtotime(date('Y-m-d H:i:s'))) {
-            // The default range is set to 1 day less 1 second (in seconds)
+            SELECT `id_date_range`, `time_end`
+            FROM `' . _DB_PREFIX_ . 'date_range`
+            WHERE `time_end` = (
+                SELECT MAX(`time_end`)
+                FROM `' . _DB_PREFIX_ . 'date_range`
+            )'
+        );
+
+        if (!isset($result['id_date_range']) ||
+            strtotime($result['time_end']) < time()
+        ) {
+            // 1 día menos 1 segundo
             $rangeSize = 86399;
+
             $dateRange = new DateRange();
             $dateRange->time_start = date('Y-m-d');
-            $dateRange->time_end = strftime('%Y-%m-%d %H:%M:%S', strtotime($dateRange->time_start) + $rangeSize);
+
+            $start = new DateTime($dateRange->time_start);
+            $start->modify('+' . $rangeSize . ' seconds');
+            $dateRange->time_end = $start->format('Y-m-d H:i:s');
+
             $dateRange->add();
 
             return $dateRange->id;

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -341,7 +341,7 @@ class MetaCore extends ObjectModel
         if (Validate::isLoadedObject($product) && $product->active) {
             $row = Meta::getPresentedObject($product);
             if (empty($row['meta_description'])) {
-                $row['meta_description'] = strip_tags($row['description_short']);
+                $row['meta_description'] = strip_tags($row['description_short']  ?? '');
             }
 
             return Meta::completeMetaTags($row, $row['name']);

--- a/classes/Smarty/SmartyLazyRegister.php
+++ b/classes/Smarty/SmartyLazyRegister.php
@@ -72,7 +72,7 @@ class SmartyLazyRegister
 
         foreach ($arguments as $a => $argument) {
             if ($a == 0) {
-                $args[] = $arguments[0];
+                $args[] = $argument ?? '';
             } else {
                 $args[] = &$arguments[$a];
             }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -901,7 +901,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         }
     }
 
-    protected function transformDescriptionWithImg(string $desc)
+    protected function transformDescriptionWithImg(string $desc = ''): string
     {
         $reg = '/\[img\-([0-9]+)\-(left|right)\-([a-zA-Z0-9-_]+)\]/';
         while (preg_match($reg, $desc, $matches)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix PHP 8.1+ deprecated warnings in core (preg_match, strip_tags, nl2br, strftime). These warnings appear in production logs when using PHP 8.1+ with PrestaShop.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable PHP 8.1+, open a product page with missing descriptions or metas. Check that no PHP Deprecated warnings are logged and pages render correctly.
| UI Tests          | Not run (no UI changes)
| Related PRs       | N/A
| Fixed issue or discussion?     | Fixes #40386
| Sponsor company   | Imationgroup
