### PR TITLE
Sanitize IP address via pSQL natively

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -363,12 +363,12 @@ class ToolsCore
             if (strpos($_SERVER['HTTP_X_FORWARDED_FOR'], ',')) {
                 $ips = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);
 
-                return $ips[0];
+                return pSQL($ips[0]);
             } else {
-                return $_SERVER['HTTP_X_FORWARDED_FOR'];
+                return pSQL($_SERVER['HTTP_X_FORWARDED_FOR']);
             }
         } else {
-            return $_SERVER['REMOTE_ADDR'];
+            return pSQL($_SERVER['REMOTE_ADDR']);
         }
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Check below
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | 
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | https://www.openservis.cz/

### DESCRIPTION

I’ve already seen dozens of hacked PrestaShop installations this year caused by poorly written modules that do not sanitize Tools::getRemoteAddr() with pSQL().

I understand that this is primarily the responsibility of module developers. However, as a platform, we should try to mitigate this class of issues at the core level whenever possible.

I believe it would make sense to sanitize the IP address natively inside Tools::getRemoteAddr(). This change could help prevent similar security issues in the future, even when third-party modules are implemented incorrectly.

That said, I’m aware this could introduce a backward-compatibility break. If pSQL() is added internally and some modules already apply pSQL() on top of it, the value would be escaped twice. For this reason, I think this change should be targeted for the next PrestaShop version 9.1 rather than a patch release.