### PR TITLE
Fix: Bad calculation cart row percentage discount

### DIFF
--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -458,8 +458,8 @@ class CartRow
         if ($percent < 0 || $percent > 100) {
             throw new Exception('Invalid percentage discount given: ' . $percent);
         }
-        $discountTaxIncluded = $this->finalTotalPrice->getTaxIncluded() * $percent / 100;
-        $discountTaxExcluded = $this->finalTotalPrice->getTaxExcluded() * $percent / 100;
+        $discountTaxIncluded = $this->initialTotalPrice->getTaxIncluded() * $percent / 100;
+        $discountTaxExcluded = $this->initialTotalPrice->getTaxExcluded() * $percent / 100;
         $amount = new AmountImmutable($discountTaxIncluded, $discountTaxExcluded);
         $this->applyFlatDiscount($amount);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When we have two discount codes that reduce the price of a given product by a percentage (e.g. both -10%), the discount value is calculated cascadely and incorrectly displayed in the applied discounts section
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Add two product restriction discount codes to reduce the product price by 10%. Add the selected product to your cart, apply both codes, and check if the total discount value matches the discount granted.
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

Before:
<img width="1108" height="428" alt="1" src="https://github.com/user-attachments/assets/d42be582-775a-4216-b5b3-8178a83a803a" />

After:
<img width="1108" height="428" alt="2" src="https://github.com/user-attachments/assets/4b5b2a05-2cef-4980-aa7f-4bd7a7520375" />


