### PR TITLE
Simplify cart rule minimal value by avoiding subtracting values

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -198,6 +198,7 @@ class CartCore extends ObjectModel
     public const ONLY_SHIPPING = 5;
     public const ONLY_WRAPPING = 6;
     public const ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING = 8;
+    public const ONLY_PRODUCTS_WITHOUT_GIFTS = 9;
 
     private const DEFAULT_ATTRIBUTES_KEYS = ['attributes' => '', 'attributes_small' => ''];
 
@@ -262,6 +263,8 @@ class CartCore extends ObjectModel
         if (isset(self::$_totalWeight[$this->id])) {
             unset(self::$_totalWeight[$this->id]);
         }
+        $this->_products = null;
+        $this->_products_with_separated_gifts = null;
     }
 
     /**
@@ -313,10 +316,8 @@ class CartCore extends ObjectModel
      */
     public function update($nullValues = false)
     {
-        // Wipe all product-related caches, because something may just change
+        // Wipe all product-related caches, because something may just changed and we will need fresh data
         $this->resetProductRelatedStaticCache();
-        $this->_products = null;
-        $this->_products_with_separated_gifts = null;
 
         $return = parent::update($nullValues);
         Hook::exec('actionCartSave', ['cart' => $this]);
@@ -1507,7 +1508,7 @@ class CartCore extends ObjectModel
             throw new PrestaShopException(sprintf('Product with ID "%s" could not be loaded.', $id_product));
         }
 
-        // Wipe all product-related caches, because something may just change
+        // Wipe all product-related caches, because something may just changed and we will need fresh data
         $this->resetProductRelatedStaticCache();
 
         $data = [
@@ -1776,7 +1777,12 @@ class CartCore extends ObjectModel
         bool $preserveGiftsRemoval = true,
         bool $useOrderPrices = false
     ) {
-        // Wipe all product-related caches, because something may just change
+        /*
+         * Wipe all product-related caches, because something may just changed and we will need fresh data.
+         * For example, if we are calling $this->getProductsWithSeparatedGifts() to get the gifts in cart,
+         * we need to be sure we have the latest data. If not, we could be calculating with is_gift date for
+         * cart rules that are being deleted from the cart.
+         */
         $this->resetProductRelatedStaticCache();
 
         // First, if we are deleting a product with customization, we delete it from the database
@@ -1801,7 +1807,7 @@ class CartCore extends ObjectModel
 
         // Now, we must check if there are any products added as gifts in the cart and keep them.
         // We do this only for products without customization, because we can't have a customized
-        // product added as a gift
+        // product added as a gift.
         $preservedGifts = [];
         $giftKey = (int) $id_product . '-' . (int) $id_product_attribute;
         if ($preserveGiftsRemoval && empty($id_customization)) {
@@ -1847,6 +1853,8 @@ class CartCore extends ObjectModel
     }
 
     /**
+     * Gets information about quantity of gifts in cart for a given product.
+     *
      * @param int $id_product
      * @param int $id_product_attribute
      *
@@ -1854,24 +1862,16 @@ class CartCore extends ObjectModel
      */
     protected function getProductsGifts($id_product, $id_product_attribute)
     {
-        $id_product_attribute = (int) $id_product_attribute;
-
-        $gifts = array_filter($this->getProductsWithSeparatedGifts(), function ($product) {
-            return array_key_exists('is_gift', $product) && $product['is_gift'];
-        });
-
-        $preservedGifts = [$id_product . '-' . $id_product_attribute => 0];
-
-        foreach ($gifts as $gift) {
-            if (
-                (int) $gift['id_product_attribute'] === $id_product_attribute
-                && (int) $gift['id_product'] === $id_product
-            ) {
-                ++$preservedGifts[$id_product . '-' . $id_product_attribute];
+        $giftCount = 0;
+        foreach ($this->getProductsWithSeparatedGifts() as $product) {
+            if (!empty($product['is_gift'])
+                && (int) $product['id_product'] === (int) $id_product
+                && (int) $product['id_product_attribute'] === (int) $id_product_attribute) {
+                ++$giftCount;
             }
         }
 
-        return $preservedGifts;
+        return [$id_product . '-' . $id_product_attribute => $giftCount];
     }
 
     /**
@@ -1940,6 +1940,7 @@ class CartCore extends ObjectModel
      *                  - BOTH_WITHOUT_SHIPPING
      *                  - ONLY_SHIPPING
      *                  - ONLY_WRAPPING
+     *                  - ONLY_PRODUCTS_WITHOUT_GIFTS
      *
      * @return string Formatted amount in Cart
      */
@@ -1984,6 +1985,7 @@ class CartCore extends ObjectModel
      *                  - Cart::ONLY_SHIPPING
      *                  - Cart::ONLY_WRAPPING
      *                  - Cart::ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING
+     *                  - Cart::ONLY_PRODUCTS_WITHOUT_GIFTS
      * @param array $products
      * @param int $id_carrier
      * @param bool $use_cache @deprecated
@@ -2015,6 +2017,7 @@ class CartCore extends ObjectModel
             Cart::ONLY_SHIPPING,
             Cart::ONLY_WRAPPING,
             Cart::ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING,
+            Cart::ONLY_PRODUCTS_WITHOUT_GIFTS,
         ];
         if (!in_array($type, $allowedTypes)) {
             throw new Exception('Invalid calculation type: ' . $type);
@@ -2044,7 +2047,16 @@ class CartCore extends ObjectModel
         // If no specific products list is provided, we get the full list of products in cart
         // In most cases, we calculate the total for all products in cart
         if (null === $products) {
-            $products = $this->getProducts(false, false, null, true, $keepOrderPrices);
+            if ($type == Cart::ONLY_PRODUCTS_WITHOUT_GIFTS) {
+                $products = $this->getProducts(false, false, null, true, $keepOrderPrices, true);
+                foreach ($products as $key => $product) {
+                    if (!empty($product['is_gift'])) {
+                        unset($products[$key]);
+                    }
+                }
+            } else {
+                $products = $this->getProducts(false, false, null, true, $keepOrderPrices, false);
+            }
         }
 
         // If we want to calculate only physical products without shipping,
@@ -2056,15 +2068,6 @@ class CartCore extends ObjectModel
                 }
             }
             $type = Cart::ONLY_PRODUCTS;
-        }
-
-        // If we want to calculate only products, we filter out gifts from the products list
-        if ($type == Cart::ONLY_PRODUCTS) {
-            foreach ($products as $key => $product) {
-                if (!empty($product['is_gift'])) {
-                    unset($products[$key]);
-                }
-            }
         }
 
         // If taxes are disabled in configuration, we calculate everything without taxes,
@@ -2106,6 +2109,7 @@ class CartCore extends ObjectModel
                 $amount = $calculator->getTotal(true);
                 break;
             case Cart::ONLY_PRODUCTS:
+            case Cart::ONLY_PRODUCTS_WITHOUT_GIFTS:
                 $calculator->calculateRows();
                 $amount = $calculator->getRowTotal();
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1867,7 +1867,7 @@ class CartCore extends ObjectModel
             if (!empty($product['is_gift'])
                 && (int) $product['id_product'] === (int) $id_product
                 && (int) $product['id_product_attribute'] === (int) $id_product_attribute) {
-                ++$giftCount;
+                $giftCount += (int) $product['quantity'];
             }
         }
 

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -908,7 +908,7 @@ class CartRuleCore extends ObjectModel
             // Let's get the full cart total first, add shipping price if the rule was configured like this.
             $cartTotal = $cart->getOrderTotal(
                 $this->minimum_amount_tax,
-                Cart::ONLY_PRODUCTS,
+                Cart::ONLY_PRODUCTS_WITHOUT_GIFTS,
                 null,
                 null,
                 false,
@@ -923,31 +923,6 @@ class CartRuleCore extends ObjectModel
                     false,
                     $useOrderPrices
                 );
-            }
-
-            /*
-             * Now, we will reduce the cart total by all already applied gifts in the cart.
-             *
-             * This is big magic happening here, because it's subtracting the gifts from the cart total one by one, by matching it.
-             *
-             * It would be much better if $cart->getOrderTotal returned the total without the gifts, which it should actually do by the way.
-             * Check inside of that method, if 'is_gift' is not empty, it should skip that product.
-             * But, that would require calling getProducts inside that method with $cart->shouldSplitGiftProductsQuantity enabled.
-             * But, if that started to work, it would mess up all places in the code, where it expects Cart::ONLY_PRODUCTS to include gifts.
-             *
-             * A solution would be to create Cart::ONLY_PRODUCTS_WITHOUT_GIFTS, that we could use here.
-             */
-            $products = $cart->getProducts();
-            $cart_rules = $cart->getCartRules(CartRule::FILTER_ACTION_ALL, false);
-
-            foreach ($cart_rules as $cart_rule) {
-                if ($cart_rule['gift_product']) {
-                    foreach ($products as $key => &$product) {
-                        if (empty($product['is_gift']) && $product['id_product'] == $cart_rule['gift_product'] && $product['id_product_attribute'] == $cart_rule['gift_product_attribute'] && empty($product['id_customization'])) {
-                            $cartTotal = Tools::ps_round($cartTotal - $product[$this->minimum_amount_tax ? 'price_wt' : 'price'], (int) $context->currency->decimals * Context::getContext()->getComputingPrecision());
-                        }
-                    }
-                }
             }
 
             if ($cartTotal < $minimum_amount) {

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_gift_cart_rule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_gift_cart_rule.feature
@@ -1225,7 +1225,7 @@ Feature: Order from Back Office (BO)
   I remove all cart rules,
   I remove the product
     Given there is a product in the catalog named "Product 12345" with a price of 12.0 and 100 items in stock
-    # Create a cart rule : No cade + Product restriction with min quanity + Discount 50%
+    # Create a cart rule : No code + Product restriction with min quanity + Discount 50%
     And there is a cart rule "cartRulePercentDiscountOnSpecificProduct" with following properties:
       | name[en-US]               | cartRulePercentDiscountOnSpecificProduct |
       | priority                  | 1                                        |
@@ -1237,7 +1237,7 @@ Feature: Order from Back Office (BO)
       | discount_product          | Product 12345                            |
     # @todo: restrictions are not yet implemented using CQRS, so we use old step. (the step itself is as well unclear- it is a mix between specific product and product restriction features)
     And cart rule "cartRulePercentDiscountOnSpecificProduct" is restricted to product "Product 12345" with a quantity of 2
-    # Create a cart rule : No cade + no conditions + free gift = demo_6
+    # Create a cart rule : No code + no conditions + free gift = demo_6
     And there is a cart rule "cartRuleFreeGift" with following properties:
       | name[en-US]       | cartRuleFreeGift |
       | priority          | 1                |
@@ -1337,7 +1337,7 @@ Feature: Order from Back Office (BO)
     And country "FR" is enabled
     And there is a product in the catalog named "Product 12345" with a price of 12.0 and 100 items in stock
     And there is a product in the catalog named "Gift product" with a price of 13.0 and 100 items in stock
-    # Create a cart rule : No cade + no conditions + free gift = demo_6
+    # Create a cart rule : No code + no conditions + free gift = demo_6
     And there is a cart rule "cartRuleFreeGift" with following properties:
       | name[en-US]       | cartRuleFreeGift |
       | priority          | 1                |
@@ -1467,7 +1467,7 @@ Feature: Order from Back Office (BO)
 
     Given there is a product in the catalog named "Product 12345" with a price of 12.0 and 100 items in stock
     And there is a product in the catalog named "Gift product" with a price of 13.0 and 100 items in stock
-    # Create a cart rule : No cade + no conditions + free gift = demo_6
+    # Create a cart rule : No code + no conditions + free gift = demo_6
     And there is a cart rule "cartRuleFreeGift" with following properties:
       | name[en-US]                      | cartRuleFreeGift |
       | priority                         | 1                |
@@ -1582,7 +1582,7 @@ Feature: Order from Back Office (BO)
 
     Given there is a product in the catalog named "Product 12345" with a price of 12.0 and 100 items in stock
     And there is a product in the catalog named "Gift product" with a price of 13.0 and 100 items in stock
-    # Create a cart rule : No cade + no conditions + free gift = demo_6
+    # Create a cart rule : No code + no conditions + free gift = demo_6
     And there is a cart rule "cartRuleFreeGift" with following properties:
       | name[en-US]                      | cartRuleFreeGift |
       | priority                         | 1                |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR allows `CartRule::checkValidity` to ask for cart total directly with gifts excluded. Without needing to do some subtracting magic, which can result in rounding errors and eats performance.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run UI test.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/20525751567 🟢 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/40409
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### Description
- `CartRule::checkValidity` when checking the minimal amount of order, first asked for cart products total, then subtracted all the gifts to get the real value. We now call it directly in one step, by using new cart calculation type `Cart::ONLY_PRODUCTS_WITHOUT_GIFTS`. So, I could then simplify the `CartRule::checkValidity` a lot and just remove the whole block of code.

### Benefits
- No need to call `$products = $cart->getProducts();`
- No need to call `$cart_rules = $cart->getCartRules(CartRule::FILTER_ACTION_ALL, false);`
- No possible rounding errors.
- Much cleaner, whole code of block removed.
- No BC break

### Other notes
- You may be confused a bit on the code - although `ONLY_PRODUCTS` should have returned the totals without gifts, it doesn't do so, because `is_gift` is never returned, at least the whole lifetime of 1.7. This dead code is removed and added a new constant `ONLY_PRODUCTS_WITHOUT_GIFTS`, which does this and asks for proper data, with gifts separated.
- I accidentaly discovered a possible race condition from my previous PRs, that wasn't a problem before. `getProductsGifts` returned is_gift even for a product that wasn't a gift anymore, because it was cached. `$this->_products = null;` and `$this->_products_with_separated_gifts = null;` should be wiped also with other static caches.
- The change inside `getProductsGifts` is a tiny refacto, so the method is simplier + a bug fix, which I found during testing of this.