### PR TITLE
Allow easily hooking into country and currency selection logic

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -285,14 +285,17 @@ class FrontControllerCore extends Controller
         }
 
         /*
-         * Here, we resolve the context->country, the default country that will be used to display
-         * prices, taxes, delivery options and other country specific data.
+         * The default country is already set in config.inc.php before loading the front controller. This country will be used
+         * to display prices, taxes, delivery options and other country specific data.
          *
-         * The country may further change further down in this method, if we have a cart with an address assigned to it.
+         * Here, the country can get modified based on geolocation or browser's preferred country.
+         *
+         * The country may also be changed further down in this method, if we have a cart with an address assigned to it.
          * If there is a cart already, the context country is set to the country of that cart.
          *
          * If you are looking to override the country selection logic, you can use actionFrontControllerInitBefore above
-         * and pre-set the things in beforehand.
+         * and pre-set the things in beforehand or actionFrontControllerInitContextCountryAfter below, if you want to use the built
+         * in geolocation logic and just modify the result.
          */
         if (Configuration::get('PS_GEOLOCATION_ENABLED')) {
             if (($new_default = $this->geolocationManagement($this->context->country)) && Validate::isLoadedObject($new_default)) {
@@ -319,7 +322,7 @@ class FrontControllerCore extends Controller
                     $id_country = Tools::getCountry();
                 }
 
-                $country = new Country($id_country, (int) $this->context->cookie->id_lang);
+                $country = new Country($id_country, (int) $this->context->language->id);
 
                 if (!$has_currency && Validate::isLoadedObject($country) && $this->context->country->id !== $country->id) {
                     $this->context->country = $country;
@@ -330,13 +333,34 @@ class FrontControllerCore extends Controller
         }
 
         /*
+         * Allow modules to override the country selection logic after running geolocation, if needed. Just do whatever you need
+         * and assign proper country to context->country.
+         */
+        Hook::exec(
+            'actionFrontControllerDetectContextCountryAfter',
+            [
+                'controller' => $this,
+            ]
+        );
+
+        /*
          * Get proper currency from the cookie and $_GET parameters. It will provide us with a requested currency
          * or a default currency, if the requested one is not valid anymore.
+         * Assign that currency to the context, so we can immediately use it for calculations.
          */
-        $currency = Tools::setCurrency($this->context->cookie);
+        $this->context->currency = Tools::setCurrency($this->context->cookie);
 
-        // Assign that currency to the context, so we can immediately use it for calculations.
-        $this->context->currency = $currency;
+        /*
+         * Allow modules to override the currency selection logic if needed. Just do whatever you need
+         * and assign proper currency to context->currency and context->cookie->id_currency. Useful if you want
+         * to implement custom currency selection logic, for example always force a currency based on country.
+         */
+        Hook::exec(
+            'actionFrontControllerInitContextCurrencyAfter',
+            [
+                'controller' => $this,
+            ]
+        );
 
         if (isset($_GET['logout']) || ($this->context->customer->logged && Customer::isBanned($this->context->customer->id))) {
             $this->context->customer->logout();
@@ -386,15 +410,15 @@ class FrontControllerCore extends Controller
              */
             } elseif (
                 $this->context->cookie->id_customer != $cart->id_customer
-                || $this->context->cookie->id_lang != $cart->id_lang
-                || $currency->id != $cart->id_currency
+                || $this->context->language->id != $cart->id_lang
+                || $this->context->currency->id != $cart->id_currency
             ) {
                 // update cart values
                 if ($this->context->cookie->id_customer) {
                     $cart->id_customer = (int) $this->context->cookie->id_customer;
                 }
-                $cart->id_lang = (int) $this->context->cookie->id_lang;
-                $cart->id_currency = (int) $currency->id;
+                $cart->id_lang = (int) $this->context->language->id;
+                $cart->id_currency = (int) $this->context->currency->id;
                 $cart->update();
             }
 
@@ -433,8 +457,8 @@ class FrontControllerCore extends Controller
          */
         if (!isset($cart) || !$cart->id) {
             $cart = new Cart();
-            $cart->id_lang = (int) $this->context->cookie->id_lang;
-            $cart->id_currency = (int) $this->context->cookie->id_currency;
+            $cart->id_lang = (int) $this->context->language->id;
+            $cart->id_currency = (int) $this->context->currency->id;
             $cart->id_guest = (int) $this->context->cookie->id_guest;
             $cart->id_shop_group = (int) $this->context->shop->id_shop_group;
             $cart->id_shop = $this->context->shop->id;

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -5523,5 +5523,15 @@
       <title>Override product quantity calculation</title>
       <description>Allows modules to override the final product quantity returned by Product::getQuantity(), including cart-aware calculations.</description>
     </hook>
+    <hook id="actionFrontControllerDetectContextCountryAfter">
+      <name>actionFrontControllerDetectContextCountryAfter</name>
+      <title>Action after detecting context country</title>
+      <description>Allows modules to modify the context country after it has been detected via geolocation.</description>
+    </hook>
+    <hook id="actionFrontControllerInitContextCurrencyAfter">
+      <name>actionFrontControllerInitContextCurrencyAfter</name>
+      <title>Action after initializing context currency</title>
+      <description>Allows modules to modify the context currency after it has been initialized.</description>
+    </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Adds new hook after default country and currency selection logic. Allows to easily alter the default country selected for a shop. Also, added a hook that allows to modify a currency based on custom rules. In all international shops I manage, we use a tied currency to a country - selling CZK in CZ, EUR in the rest of Europe - this allows to easily modify this. I also removed some dependence of values in cookies, we already have it in the context - better source of truth.
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/20485704917 🟢 
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/1582
| Sponsor company   | TRENDO s.r.o.