### PR TITLE
Fixed inconsistancy use of variable in CartRule.php

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -516,7 +516,7 @@ class CartRuleCore extends ObjectModel
             foreach ($result as $key => $cart_rule) {
                 if ($cart_rule['product_restriction']) {
                     $cr = new CartRule((int) $cart_rule['id_cart_rule']);
-                    $r = $cr->checkProductRestrictionsFromCart(Context::getContext()->cart, false, false);
+                    $r = $cr->checkProductRestrictionsFromCart($cart, false, false);
                     if ($r !== false) {
                         continue;
                     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | It has been checked previously that the cart exists and has been initialized by `if (isset($cart, $cart->id))`, but this check is useless as the cart in Context is used instead: `Context::getContext()->cart` and can lead to inconsistancy as the cart in Context may be null.<br>This change is now using the `cart` previously checked instead of the one in Context.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Simply call the `getCustomerCartRules` method in `CartRule`
| Sponsor company   | AlienGen

https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/20910615562  
Related issue as requested: https://github.com/PrestaShop/PrestaShop/issues/40581
