### PR TITLE
Feat(FrontController): Add Specialized Hooks

### DIFF
--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -816,6 +816,6 @@ abstract class ControllerCore
 
     public function getControllerName(): string
     {
-        return Tools::toCamelCase($this->php_self, true);
+        return str_replace('Core', '', get_class($this));
     }
 }

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -813,4 +813,9 @@ abstract class ControllerCore
     {
         return $this->get(static::SERVICE_MULTISTORE_FEATURE)->isUsed();
     }
+
+    public function getControllerName(): string
+    {
+        return Tools::toCamelCase($this->php_self, true);
+    }
 }

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -816,6 +816,6 @@ abstract class ControllerCore
 
     public function getControllerName(): string
     {
-        return str_replace('Core', '', get_class($this));
+        return get_class($this);
     }
 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -225,6 +225,7 @@ class FrontControllerCore extends Controller
                 'controller' => $this,
             ]
         );
+        Hook::exec('actionFrontController' . $this->getControllerName() . 'InitBefore', ['controller' => $this]);
 
         /*
          * Globals are DEPRECATED as of version 1.5.0.1
@@ -492,6 +493,7 @@ class FrontControllerCore extends Controller
                 'controller' => $this,
             ]
         );
+        Hook::exec('actionFrontController' . $this->getControllerName() . 'InitAfter', ['controller' => $this]);
     }
 
     /**
@@ -506,6 +508,8 @@ class FrontControllerCore extends Controller
 
     /**
      * Initializes a set of commonly used variables, available for use in the template.
+     *
+     * @throws PrestaShopException
      */
     protected function assignGeneralPurposeVariables()
     {
@@ -514,6 +518,12 @@ class FrontControllerCore extends Controller
 
         Hook::exec(
             'actionFrontControllerSetVariablesBefore',
+            [
+                'templateVars' => &$templateVars,
+                'cart' => $cart,
+            ]
+        );
+        Hook::exec('actionFrontController' . $this->getControllerName() . 'SetVariablesBefore',
             [
                 'templateVars' => &$templateVars,
                 'cart' => $cart,
@@ -549,6 +559,16 @@ class FrontControllerCore extends Controller
             null,
             true
         );
+        $modulesVariables = array_merge(
+            $modulesVariables,
+            Hook::exec('actionFrontController' . $this->getControllerName() . 'SetVariables',
+                [
+                    'templateVars' => &$templateVars,
+                ],
+                null,
+                true
+            )
+        );
 
         if (is_array($modulesVariables)) {
             foreach ($modulesVariables as $moduleName => $variables) {
@@ -581,12 +601,17 @@ class FrontControllerCore extends Controller
         Hook::exec('actionBuildFrontEndObject', [
             'obj' => &$object,
         ]);
+        Hook::exec('actionBuildFront' . $this->getControllerName() . 'EndObject', [
+            'obj' => &$object,
+        ]);
 
         return $object;
     }
 
     /**
      * Initializes common front page content: header, footer and side columns.
+     *
+     * @throws PrestaShopException
      */
     public function initContent()
     {
@@ -594,7 +619,8 @@ class FrontControllerCore extends Controller
         $this->process();
 
         $this->context->smarty->assign([
-            'HOOK_HEADER' => Hook::exec('displayHeader'),
+            'HOOK_HEADER' => Hook::exec('displayHeader')
+                . Hook::exec('display' . $this->getControllerName() . 'Header'),
         ]);
     }
 
@@ -734,6 +760,7 @@ class FrontControllerCore extends Controller
         }
 
         Hook::exec('actionOutputHTMLBefore', ['html' => &$html]);
+        Hook::exec('actionOutput' . $this->getControllerName() . 'HTMLBefore', ['html' => &$html]);
         echo trim($html);
     }
 
@@ -783,7 +810,7 @@ class FrontControllerCore extends Controller
                 $this->context->smarty->assign([
                     'urls' => $this->getTemplateVarUrls(),
                     'shop' => $this->getTemplateVarShop(),
-                    'HOOK_MAINTENANCE' => Hook::exec('displayMaintenance', []),
+                    'HOOK_MAINTENANCE' => Hook::exec('displayMaintenance'),
                     'maintenance_text' => Configuration::get('PS_MAINTENANCE_TEXT', (int) $this->context->language->id),
                     'stylesheets' => $this->getStylesheets(),
                 ]);
@@ -935,6 +962,7 @@ class FrontControllerCore extends Controller
      * Sets controller CSS and JS files.
      *
      * @return bool
+     * @throws PrestaShopException
      */
     public function setMedia()
     {
@@ -962,7 +990,8 @@ class FrontControllerCore extends Controller
         }
 
         // Execute Hook FrontController SetMedia
-        Hook::exec('actionFrontControllerSetMedia', []);
+        Hook::exec('actionFrontControllerSetMedia');
+        Hook::exec('actionFrontController' . $this->getControllerName() . 'SetMedia');
 
         return true;
     }
@@ -2197,5 +2226,10 @@ class FrontControllerCore extends Controller
         }
 
         return Validate::isUrl($data);
+    }
+
+    protected function getControllerName(): string
+    {
+        return Tools::toCamelCase($this->php_self, true);
     }
 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -225,7 +225,7 @@ class FrontControllerCore extends Controller
                 'controller' => $this,
             ]
         );
-        Hook::exec('actionFrontController' . $this->getControllerName() . 'InitBefore', ['controller' => $this]);
+        Hook::exec('action' . $this->getControllerName() . 'InitBefore', ['controller' => $this]);
 
         /*
          * Globals are DEPRECATED as of version 1.5.0.1
@@ -493,7 +493,7 @@ class FrontControllerCore extends Controller
                 'controller' => $this,
             ]
         );
-        Hook::exec('actionFrontController' . $this->getControllerName() . 'InitAfter', ['controller' => $this]);
+        Hook::exec('action' . $this->getControllerName() . 'InitAfter', ['controller' => $this]);
     }
 
     /**
@@ -523,7 +523,7 @@ class FrontControllerCore extends Controller
                 'cart' => $cart,
             ]
         );
-        Hook::exec('actionFrontController' . $this->getControllerName() . 'SetVariablesBefore',
+        Hook::exec('action' . $this->getControllerName() . 'SetVariablesBefore',
             [
                 'templateVars' => &$templateVars,
                 'cart' => $cart,
@@ -561,7 +561,7 @@ class FrontControllerCore extends Controller
         );
         $modulesVariables = array_merge(
             $modulesVariables,
-            Hook::exec('actionFrontController' . $this->getControllerName() . 'SetVariables',
+            Hook::exec('action' . $this->getControllerName() . 'SetVariables',
                 [
                     'templateVars' => &$templateVars,
                 ],
@@ -601,7 +601,7 @@ class FrontControllerCore extends Controller
         Hook::exec('actionBuildFrontEndObject', [
             'obj' => &$object,
         ]);
-        Hook::exec('actionBuildFront' . $this->getControllerName() . 'EndObject', [
+        Hook::exec('actionBuild' . $this->getControllerName() . 'FrontEndObject', [
             'obj' => &$object,
         ]);
 
@@ -992,7 +992,7 @@ class FrontControllerCore extends Controller
 
         // Execute Hook FrontController SetMedia
         Hook::exec('actionFrontControllerSetMedia');
-        Hook::exec('actionFrontController' . $this->getControllerName() . 'SetMedia');
+        Hook::exec('action' . $this->getControllerName() . 'SetMedia');
 
         return true;
     }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -2228,9 +2228,4 @@ class FrontControllerCore extends Controller
 
         return Validate::isUrl($data);
     }
-
-    protected function getControllerName(): string
-    {
-        return Tools::toCamelCase($this->php_self, true);
-    }
 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -962,6 +962,7 @@ class FrontControllerCore extends Controller
      * Sets controller CSS and JS files.
      *
      * @return bool
+     *
      * @throws PrestaShopException
      */
     public function setMedia()


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Many modules are using FrontController hooks and are forced to check which controller is actually used (when done, some are not even testing it, executing code on each page when not required). Following the ObjectModel method to execute specialized hook adding the name of the current ObjectModel to the hook, I added several specialized hooks in the FrontControllerCore.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install my test module from here : https://github.com/Kaikina/test_newfronthooks . All hooks are registered on the Authentication front controller (Sign in button). Visit different pages such as home page, category page, product page, ... nothing will happen. Click on Sign In, you'll see the names of each hook called.
| UI Tests          | NA
| Fixed issue or discussion?     | NA
| Related PRs       | NA
| Sponsor company   | Evolutive
