### PR TITLE
Simplify some of cart logic to gradually move to single source of truth

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2143,13 +2143,13 @@ class CartCore extends ObjectModel
     }
 
     /**
+     * @deprecated since 9.1.0 - no longer used and will be removed
+     *
      * Get total in Cart using a tax calculation method.
      *
      * @param int $id_cart Cart ID
      *
      * @return string Formatted total amount in Cart
-     *
-     * @todo: What is this?
      */
     public static function getOrderTotalUsingTaxCalculationMethod($id_cart)
     {
@@ -2171,7 +2171,7 @@ class CartCore extends ObjectModel
      *                  - Cart::ONLY_PRODUCTS_WITHOUT_GIFTS
      * @param array $products
      * @param int $id_carrier
-     * @param bool $use_cache @deprecated
+     * @param bool $use_cache deprecated and has no effect
      * @param bool $keepOrderPrices When true use the Order saved prices instead of the most recent ones from catalog (if Order exists)
      *
      * @return float Order total
@@ -2384,6 +2384,8 @@ class CartCore extends ObjectModel
     }
 
     /**
+     * @deprecated since 9.1.0 - no longer used and will be removed
+     *
      * @return float
      */
     public function getDiscountSubtotalWithoutGifts($withTaxes = true)
@@ -4083,6 +4085,9 @@ class CartCore extends ObjectModel
     }
 
     /**
+     * @deprecated since 9.1.0 - used only by one core class and will be removed.
+     *             Use CartLazyArray as proper performant source of truth.
+     *
      * Return useful information about the cart for display purpose.
      * Products are splitted between paid ones and gift
      * Gift price and shipping (if shipping is free) are removed from Discounts
@@ -4101,6 +4106,9 @@ class CartCore extends ObjectModel
     }
 
     /**
+     * @deprecated since 9.1.0 - used only by one core class and will be removed.
+     *             Use CartLazyArray as proper performant source of truth.
+     *
      * Returns useful raw information about the cart.
      * Products, Discounts, Prices ... are returned in an array without any modification.
      *
@@ -5152,11 +5160,11 @@ class CartCore extends ObjectModel
      */
     public function getCartTotalPrice()
     {
-        $summary = $this->getSummaryDetails();
-
+        // Check if order exists for this cart
         $id_order = (int) Order::getIdByCartId($this->id);
         $order = new Order($id_order);
 
+        // And select appropriate tax display method
         if (Validate::isLoadedObject($order)) {
             $taxCalculationMethod = $order->getTaxCalculationMethod();
         } else {
@@ -5164,8 +5172,8 @@ class CartCore extends ObjectModel
         }
 
         return $taxCalculationMethod == PS_TAX_EXC ?
-            $summary['total_price_without_tax'] :
-            $summary['total_price'];
+            $this->getOrderTotal(false) :
+            $this->getOrderTotal(true);
     }
 
     /**

--- a/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
@@ -93,7 +93,6 @@ final class GetCartForViewingHandler implements GetCartForViewingHandlerInterfac
         $context->customer = $customer;
 
         $products = $cart->getProducts();
-        $summary = $cart->getSummaryDetails();
 
         $id_order = (int) Order::getIdByCartId($cart->id);
         $order = new Order($id_order);
@@ -107,17 +106,17 @@ final class GetCartForViewingHandler implements GetCartForViewingHandlerInterfac
         }
 
         if ($tax_calculation_method == PS_TAX_EXC) {
-            $total_products = $summary['total_products'];
-            $total_discounts = $summary['total_discounts_tax_exc'];
-            $total_wrapping = $summary['total_wrapping_tax_exc'];
-            $total_price = $summary['total_price_without_tax'];
-            $total_shipping = $summary['total_shipping_tax_exc'];
+            $total_products = $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS);
+            $total_discounts = $cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS);
+            $total_wrapping = $cart->getOrderTotal(false, Cart::ONLY_WRAPPING);
+            $total_price = $cart->getOrderTotal(false);
+            $total_shipping = $cart->getTotalShippingCost(null, false);
         } else {
-            $total_products = $summary['total_products_wt'];
-            $total_discounts = $summary['total_discounts'];
-            $total_wrapping = $summary['total_wrapping'];
-            $total_price = $summary['total_price'];
-            $total_shipping = $summary['total_shipping'];
+            $total_products = $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS);
+            $total_discounts = $cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS);
+            $total_wrapping = $cart->getOrderTotal(true, Cart::ONLY_WRAPPING);
+            $total_price = $cart->getOrderTotal(true);
+            $total_shipping = $cart->getTotalShippingCost();
         }
 
         // Sort products by Reference ID (and if equals (like combination) by Supplier Reference)

--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -107,7 +107,7 @@ class CartLazyArray extends AbstractLazyArray
         if ($this->shouldSeparateGifts) {
             $rawProducts = $this->cart->getProductsWithSeparatedGifts();
         } else {
-            $rawProducts = $this->cart->getProducts(true);
+            $rawProducts = $this->cart->getProducts();
         }
 
         /*
@@ -169,7 +169,7 @@ class CartLazyArray extends AbstractLazyArray
     {
         $subtotals = [];
         $totalCartAmount = $this->cart->getOrderTotal($this->cartPresenter->includeTaxes(), Cart::ONLY_PRODUCTS);
-        $total_discount = $this->cart->getDiscountSubtotalWithoutGifts($this->cartPresenter->includeTaxes());
+        $total_discount = $this->cart->getOrderTotal($this->cartPresenter->includeTaxes(), Cart::ONLY_DISCOUNTS);
         $subtotals['products'] = [
             'type' => 'products',
             'label' => $this->translator->trans('Subtotal', [], 'Shop.Theme.Checkout'),


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Simplifies some of the code and possibly gains performance, because we now avoid quite a big overhead and skip loading loads of data for nothing. Also, no need to force refresh `$cart->getProducts()` and load it again.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI + UI
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/21582209063
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.
