### PR TITLE
Fix: Module update problem

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Adapter\LegacyLogger;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;
+use PrestaShop\PrestaShop\Core\Context\LegacyControllerContext;
 use PrestaShop\PrestaShop\Core\Exception\ContainerNotFoundException;
 use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem;
 use PrestaShop\PrestaShop\Core\Module\Legacy\ModuleInterface;
@@ -363,7 +364,9 @@ abstract class ModuleCore implements ModuleInterface
                 }
                 $this->_path = __PS_BASE_URI__ . 'modules/' . $this->name . '/';
             }
-            if (!$this->context->controller instanceof Controller) {
+
+            // In Symfony BO, context controller is not a legacy Controller (proxy/context), keep modules cache to preserve module id.
+            if (!$this->context->controller instanceof Controller && !$this->context->controller instanceof LegacyControllerContext) {
                 static::$modules_cache = null;
             }
             $this->local_path = _PS_MODULE_DIR_ . $this->name . '/';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.0.x
| Description?      | Since PrestaShop 9.0.2, the Modules page has been migrated to Symfony (see https://github.com/PrestaShop/PrestaShop/pull/36845), so module updates are now executed under a Symfony controller.<br/><br/>As the controller is no longer a legacy Controller, the Module constructor always resets the modules cache via `static::$modules_cache = null;`, because the following condition is always satisfied: <br/>```php if (!$this->context->controller instanceof Controller) {```<br/><br/>This PR prevents the modules cache from being reset in this context, ensuring module updates work correctly.
| Type?             | bug fix
| Category?         | BO 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | 1. Install the [issue40429.zip](https://github.com/user-attachments/files/24384071/issue40429.zip) module, which will be attached to the hookDisplayBackOfficeTop hook.<br/>2. Go to the configuration and you will see: `This module is registered on hookDisplayBackOfficeTop`.<br/>3. Open the issue40429.php file and change<br/>`$this->version = '1.0.0'` to `$this->version = '1.0.1'`.<br/>4. Now go to _Module > Module Manager > Updates_.<br/>5. Update the module. During the update, the system will "attempt" to detach the module from the `hookDisplayBackOfficeTop `hook.<br/>6. Now go back to the module configuration, you should see: `This module is NOT registered on hookDisplayBackOfficeTop`.
| UI Tests          |🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/20621152772
| Fixed issue or discussion?     | Fixes #40429
| Related PRs       | 
| Sponsor company   | Codencode snc
