### PR TITLE
Add supplier_reference_to_display to ProductLazyArray

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7211,7 +7211,7 @@ class ProductCore extends ObjectModel
         if (!Cache::isStored($cache_id)) {
             $result = Db::getInstance()->executeS('
             SELECT a.`id_attribute`, a.`id_attribute_group`, al.`name`, agl.`name` as `group`, agl.`public_name` as `public_group`,
-            pa.`reference`, pa.`ean13`, pa.`isbn`, pa.`upc`, pa.`mpn`,
+            pa.`reference`, pa.`ean13`, pa.`isbn`, pa.`upc`, pa.`mpn`,  pa.`supplier_reference`,
             pal.`available_now`, pal.`available_later`
             FROM `' . _DB_PREFIX_ . 'attribute` a
             LEFT JOIN `' . _DB_PREFIX_ . 'attribute_lang` al
@@ -7244,7 +7244,7 @@ class ProductCore extends ObjectModel
     public static function getAttributesInformationsByProduct($id_product)
     {
         $result = Db::getInstance()->executeS('
-        SELECT DISTINCT a.`id_attribute`, a.`id_attribute_group`, al.`name` as `attribute`, agl.`name` as `group`,pa.`reference`, pa.`ean13`, pa.`isbn`, pa.`upc`, pa.`mpn`
+        SELECT DISTINCT a.`id_attribute`, a.`id_attribute_group`, al.`name` as `attribute`, agl.`name` as `group`,pa.`reference`, pa.`ean13`, pa.`isbn`, pa.`upc`, pa.`mpn`,  pa.`supplier_reference`
         FROM `' . _DB_PREFIX_ . 'attribute` a
         LEFT JOIN `' . _DB_PREFIX_ . 'attribute_lang` al
             ON (a.`id_attribute` = al.`id_attribute` AND al.`id_lang` = ' . (int) Context::getContext()->language->id . ')

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7211,7 +7211,7 @@ class ProductCore extends ObjectModel
         if (!Cache::isStored($cache_id)) {
             $result = Db::getInstance()->executeS('
             SELECT a.`id_attribute`, a.`id_attribute_group`, al.`name`, agl.`name` as `group`, agl.`public_name` as `public_group`,
-            pa.`reference`, pa.`ean13`, pa.`isbn`, pa.`upc`, pa.`mpn`,  pa.`supplier_reference`,
+            pa.`reference`, pa.`ean13`, pa.`isbn`, pa.`upc`, pa.`mpn`, pa.`supplier_reference`,
             pal.`available_now`, pal.`available_later`
             FROM `' . _DB_PREFIX_ . 'attribute` a
             LEFT JOIN `' . _DB_PREFIX_ . 'attribute_lang` al

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -454,6 +454,31 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
+     * Returns the supplier reference to display.
+     * For combinations, returns the combination's supplier reference if available.
+     * Falls back to the product's supplier reference.
+     *
+     * @return string|null
+     */
+    #[LazyArrayAttribute(arrayAccess: true)]
+    public function getSupplierReferenceToDisplay(): ?string
+    {
+        $combinationData = $this->getCombinationSpecificData();
+        if (
+            isset($combinationData['supplier_reference'])
+            && !empty($combinationData['supplier_reference'])
+        ) {
+            return $combinationData['supplier_reference'];
+        }
+
+        if (isset($this->product['supplier_reference']) && '' !== $this->product['supplier_reference']) {
+            return $this->product['supplier_reference'];
+        }
+
+        return null;
+    }
+
+    /**
      * Returns all product features, not grouped yet for performance reasons.
      *
      * @return array
@@ -1603,6 +1628,7 @@ class ProductLazyArray extends AbstractLazyArray
             'reduction',
             'reference',
             'reference_to_display',
+            'supplier_reference_to_display',
             'show_availability',
             'show_condition',
             'show_price',

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -464,14 +464,11 @@ class ProductLazyArray extends AbstractLazyArray
     public function getSupplierReferenceToDisplay(): ?string
     {
         $combinationData = $this->getCombinationSpecificData();
-        if (
-            isset($combinationData['supplier_reference'])
-            && !empty($combinationData['supplier_reference'])
-        ) {
+        if (!empty($combinationData['supplier_reference'])) {
             return $combinationData['supplier_reference'];
         }
 
-        if (isset($this->product['supplier_reference']) && '' !== $this->product['supplier_reference']) {
+        if (!empty($this->product['supplier_reference'])) {
             return $this->product['supplier_reference'];
         }
 


### PR DESCRIPTION
This change exposes the supplier reference for products and combinations in the same way reference_to_display works. The value is automatically updated when changing combinations via JavaScript.

- Add getSupplierReferenceToDisplay() method with LazyArrayAttribute
- Add supplier_reference_to_display to embedded attributes whitelist

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add `supplier_reference_to_display` property to `ProductLazyArray` to expose supplier reference for products and combinations in front-office templates, with dynamic update support when changing combinations (same behavior as `reference_to_display`).
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create a product with a supplier reference<br>2. Add combinations with different supplier references<br>3. In theme template `product-details.tpl`, add: `{if $product.supplier_reference_to_display}<span>{$product.supplier_reference_to_display}</span>{/if}`<br>4. Visit product page and change combinations - verify supplier reference updates dynamically
| UI Tests          | N/A (no UI changes in core)
| Fixed issue or discussion? | N/A
| Related PRs       | N/A
| Sponsor company   | N/A