### PR TITLE
Fix installation theme step order

### DIFF
--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -172,15 +172,18 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
             }
         }
 
-        if (in_array('theme', $steps)) {
-            if (!$this->processInstallTheme()) {
-                $this->printErrors('processInstallTheme');
-            }
-        }
-
+        // First install modules
         if (in_array('modules', $steps)) {
             if (!$this->processInstallModules()) {
                 $this->printErrors('processInstallModules');
+            }
+        }
+
+        // Once modules are installed enabled selected theme since it could enable/disable
+        // some of the installed modules
+        if (in_array('theme', $steps)) {
+            if (!$this->processInstallTheme()) {
+                $this->printErrors('processInstallTheme');
             }
         }
 

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -108,11 +108,11 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
                     ->setProcessFOThemes([Theme::getDefaultTheme()])
                     ->process();
                 $this->processConfigureShop();
-            } elseif (Tools::getValue('installTheme') && !empty($this->session->process_validated['configureShop'])) {
-                $this->processInstallTheme();
-            } elseif (Tools::getValue('installModules') && (!empty($this->session->process_validated['installTheme']) || !$validateFixturesInstallation)) {
+            } elseif (Tools::getValue('installModules') && (!empty($this->session->process_validated['configureShop']) || !$validateFixturesInstallation)) {
                 $this->processInstallModules();
-            } elseif (Tools::getValue('installFixtures') && !empty($this->session->process_validated['installModules'])) {
+            } elseif (Tools::getValue('installTheme') && !empty($this->session->process_validated['installModules'])) {
+                $this->processInstallTheme();
+            } elseif (Tools::getValue('installFixtures') && !empty($this->session->process_validated['installTheme'])) {
                 $this->processInstallFixtures();
             } elseif (Tools::getValue('postInstall') && (!$validateFixturesInstallation || $fixturesInstalled)) {
                 $this->processPostInstall();
@@ -333,8 +333,9 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
         $this->process_steps[] = ['key' => 'populateDatabase', 'lang' => $this->translator->trans('Populate database tables', [], 'Install')];
         $this->process_steps[] = ['key' => 'configureShop', 'lang' => $this->translator->trans('Configure shop information', [], 'Install')];
 
-        $this->process_steps[] = ['key' => 'installTheme', 'lang' => $this->translator->trans('Install theme', [], 'Install')];
+        // We need to install modules first, then enable the theme which may in turn enable/disable some modules
         $this->process_steps[] = ['key' => 'installModules', 'lang' => $this->translator->trans('Install modules', [], 'Install')];
+        $this->process_steps[] = ['key' => 'installTheme', 'lang' => $this->translator->trans('Install theme', [], 'Install')];
 
         if ($this->session->content_install_fixtures) {
             $fixtures_step = ['key' => 'installFixtures', 'lang' => $this->translator->trans('Install demonstration data', [], 'Install')];

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -303,7 +303,7 @@ class Install extends AbstractInstall
      */
     public function installDatabase($clear_database = false)
     {
-        $this->getLogger()->log('Installing database');
+        $this->getLogger()->logInfo('Installing database');
 
         // Clear database (only tables with same prefix)
         require_once _PS_ROOT_DIR_ . '/' . $this->bootstrapFile;
@@ -347,7 +347,7 @@ class Install extends AbstractInstall
      */
     public function clearDatabase($truncate = false)
     {
-        $this->getLogger()->log($truncate ? 'Truncating database' : 'Dropping database tables');
+        $this->getLogger()->logInfo($truncate ? 'Truncating database' : 'Dropping database tables');
 
         $instance = Db::getInstance();
         $instance->execute('SET FOREIGN_KEY_CHECKS=0');
@@ -366,7 +366,7 @@ class Install extends AbstractInstall
      */
     public function initializeTestContext()
     {
-        $this->getLogger()->log('Initializing test context');
+        $this->getLogger()->logInfo('Initializing test context');
 
         $smarty = null;
         // Clean all cache values
@@ -429,7 +429,7 @@ class Install extends AbstractInstall
      */
     public function installDefaultData($shop_name, $iso_country = false, $all_languages = false, $clear_database = false)
     {
-        $this->getLogger()->log('Installing default data');
+        $this->getLogger()->logInfo('Installing default data');
 
         if ($clear_database) {
             $this->clearDatabase(true);
@@ -489,7 +489,7 @@ class Install extends AbstractInstall
      */
     public function populateDatabase($entity = null)
     {
-        $this->getLogger()->log('Populating database');
+        $this->getLogger()->logInfo('Populating database');
 
         $languages = [];
         foreach (EntityLanguage::getLanguages(true) as $lang) {
@@ -551,7 +551,7 @@ class Install extends AbstractInstall
 
     public function createShop($shop_name)
     {
-        $this->getLogger()->log('Creating shop');
+        $this->getLogger()->logInfo('Creating shop');
 
         // Create default group shop
         $shop_group = new ShopGroup();
@@ -609,7 +609,7 @@ class Install extends AbstractInstall
         if ($languages_list === null || (is_array($languages_list) && !count($languages_list))) {
             $languages_list = $this->language->getIsoList();
         }
-        $this->getLogger()->log('Installing languages: ' . implode(', ', $languages_list));
+        $this->getLogger()->logInfo('Installing languages: ' . implode(', ', $languages_list));
 
         $languages_list = array_unique($languages_list);
 
@@ -748,7 +748,7 @@ class Install extends AbstractInstall
      */
     public function configureShop(array $data = [])
     {
-        $this->getLogger()->log('Configuring shop');
+        $this->getLogger()->logInfo('Configuring shop');
 
         // clear image cache in tmp folder
         if (file_exists(_PS_TMP_IMG_DIR_)) {
@@ -997,7 +997,7 @@ class Install extends AbstractInstall
      */
     public function installModules(array $modules): bool
     {
-        $this->getLogger()->log('Installing modules on disk');
+        $this->getLogger()->logInfo('Installing modules on disk');
 
         ModuleEntity::updateTranslationsAfterInstall(false);
 
@@ -1098,7 +1098,7 @@ class Install extends AbstractInstall
      */
     public function installFixtures($entity = null, array $data = [])
     {
-        $this->getLogger()->log('Installing fixtures');
+        $this->getLogger()->logInfo('Installing fixtures');
 
         $fixtures_path = _PS_INSTALL_FIXTURES_PATH_ . 'fashion/';
         $fixtures_name = 'fashion';
@@ -1179,7 +1179,7 @@ class Install extends AbstractInstall
     public function installTheme(?string $themeName = null): bool
     {
         $themeName = $themeName ?: _THEME_NAME_;
-        $this->getLogger()->log('Installing theme ' . $themeName);
+        $this->getLogger()->logInfo('Installing theme ' . $themeName);
 
         $builder = new ThemeManagerBuilder(
             Context::getContext(),
@@ -1226,7 +1226,7 @@ class Install extends AbstractInstall
             // rename folder
             if (@rename(_PS_ROOT_DIR_ . '/admin/', _PS_ROOT_DIR_ . '/' . $randomizedAdminFolderName)) {
                 $successLogMessage = sprintf('The admin folder was renamed into %s', $randomizedAdminFolderName);
-                $this->getLogger()->log($successLogMessage);
+                $this->getLogger()->logInfo($successLogMessage);
                 $this->clearCache();
             } else {
                 $this->setError($this->translator->trans('The admin folder could not be renamed into %folderName%', ['%folderName%' => $randomizedAdminFolderName], 'Install'));
@@ -1246,7 +1246,7 @@ class Install extends AbstractInstall
         Context::getContext()->link = new Link();
         $adminUrl = rtrim(Context::getContext()->link->getAdminBaseLink(), '/') . '/' . $adminFolder;
 
-        $this->getLogger()->log(sprintf('You can now access your backoffice at %s.', $adminUrl));
+        $this->getLogger()->logInfo(sprintf('You can now access your backoffice at %s.', $adminUrl));
 
         return true;
     }

--- a/tests/UI/campaigns/functional/API/02_endpoints/07_module/04_patchModuleTechnicalNameReset.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/07_module/04_patchModuleTechnicalNameReset.ts
@@ -77,6 +77,8 @@ describe('API : PATCH /modules/{technicalName}/reset', async () => {
       expect(isModuleVisible).to.be.equal(true);
 
       moduleInfo = await boModuleManagerPage.getModuleInformationNth(page, 1);
+      // blockwishlist should be disabled by default
+      expect(moduleInfo.enabled).to.be.equal(false);
     });
 
     it(`should go to the configuration page of the module '${dataModules.blockwishlist.name}'`, async function () {
@@ -87,8 +89,9 @@ describe('API : PATCH /modules/{technicalName}/reset', async () => {
       const pageTitle = await modBlockwishlistBoMain.getPageTitle(page);
       expect(pageTitle).to.eq(modBlockwishlistBoMain.pageTitle);
 
+      // This module is disabled by Hummingbird 2.0, so the active tab should be "enable"
       const isConfigurationTabActive = await modBlockwishlistBoMain.isTabActive(page, 'Configuration');
-      expect(isConfigurationTabActive).to.eq(true);
+      expect(isConfigurationTabActive).to.eq(false);
 
       const wishlistDefaultTitle = await modBlockwishlistBoMain.getInputValue(page, 'wishlistDefaultTitle');
       expect(wishlistDefaultTitle).to.equals(modBlockwishlistBoMain.defaultValueWishlistDefaultTitle);
@@ -190,7 +193,8 @@ describe('API : PATCH /modules/{technicalName}/reset', async () => {
 
         expect(jsonResponse).to.have.property('enabled');
         expect(jsonResponse.enabled).to.be.a('boolean');
-        expect(jsonResponse.enabled).to.be.equal(moduleInfo.enabled);
+        // Since the module was reset it is now enabled
+        expect(jsonResponse.enabled).to.be.equal(true);
       });
 
       it('should check the JSON Response : `installed`', async function () {
@@ -218,6 +222,25 @@ describe('API : PATCH /modules/{technicalName}/reset', async () => {
           expect(textResult).to.contains(modBlockwishlistBoMain.successfulUpdateMessage);
         });
       }
+    });
+  });
+
+  describe('Disable the module so it goes back to its original state', async () => {
+    it('should go to \'Modules > Module Manager\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToModulesPageToDisable', baseContext);
+
+      await boDashboardPage.goToSubMenu(page, boDashboardPage.modulesParentLink, boDashboardPage.moduleManagerLink);
+      await boModuleManagerPage.closeSfToolBar(page);
+
+      const pageTitle = await boModuleManagerPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boModuleManagerPage.pageTitle);
+    });
+
+    it('should disabled blockwishlist module', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'disableBlockwishlistModule', baseContext);
+
+      const successMessage = await boModuleManagerPage.setActionInModule(page, dataModules.blockwishlist, 'disable');
+      expect(successMessage).to.eq(boModuleManagerPage.disableModuleSuccessMessage(dataModules.blockwishlist.tag));
     });
   });
 });

--- a/tests/UI/campaigns/functional/API/02_endpoints/07_module/05_putModuleTechnicalNameStatus.ts
+++ b/tests/UI/campaigns/functional/API/02_endpoints/07_module/05_putModuleTechnicalNameStatus.ts
@@ -80,8 +80,9 @@ describe('API : PUT /modules/{technicalName}/status', async () => {
   });
 
   [
-    false,
     true,
+    // Leave the module as disabled after the test is finished (initial state)
+    false,
   ].forEach((argStatus: boolean, index: number) => {
     describe(`API : Check Data with status = ${argStatus}`, async () => {
       it('should request the endpoint /modules/{technicalName}/status', async function () {

--- a/tests/UI/campaigns/sanity/01_installShop/01_installShop.ts
+++ b/tests/UI/campaigns/sanity/01_installShop/01_installShop.ts
@@ -165,8 +165,8 @@ describe('Install Prestashop', async () => {
       args:
         {
           step: {
-            name: 'Install theme',
-            timeout: 60000,
+            name: 'Install modules',
+            timeout: 30000,
           },
         },
     },
@@ -174,8 +174,8 @@ describe('Install Prestashop', async () => {
       args:
         {
           step: {
-            name: 'Install modules',
-            timeout: 30000,
+            name: 'Install theme',
+            timeout: 60000,
           },
         },
     },


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fix installation theme step order
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install the shop (with CLI and browser) using Hummingbird as the theme (selected by default anyway) After the install go to the module manager The module `blockwislist` should be disabled
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/20811109452
| Fixed issue or discussion?     | Fixes #40454
| Related PRs       | ~
| Sponsor company   | ~
