### PR TITLE
Add clickable product links in stock management pages

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/movements/index.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/movements/index.vue
@@ -149,6 +149,7 @@
     product_name: string;
     product_reference: string;
     product_thumbnail: string;
+    product_url: string;
     sign: number;
     supplier_id: number;
     supplier_name: string;

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/movements/movement-line.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/movements/movement-line.vue
@@ -34,7 +34,10 @@
           :thumbnail="thumbnail"
         >
           <p>
-            {{ product.product_name }}
+            <a
+              :href="product.product_url"
+              class="product-name-link"
+            >{{ product.product_name }}</a>
             <small v-if="hasCombination"><br>
               {{ product.combination_name }}
             </small>
@@ -107,3 +110,17 @@
     },
   });
 </script>
+
+<style lang="scss" scoped>
+@import '~@scss/config/_settings.scss';
+
+.product-name-link {
+  color: inherit;
+  text-decoration: none;
+
+  &:hover {
+    color: var(--#{$cdk}primary-500);
+    text-decoration: underline;
+  }
+}
+</style>

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/product-line.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/product-line.vue
@@ -45,7 +45,10 @@
           class="d-flex align-items-center ml-2"
           :thumbnail="thumbnail"
         >
-          {{ product.product_name }}
+          <a
+            :href="product.product_url"
+            class="product-name-link"
+          >{{ product.product_name }}</a>
           <small
             v-if="hasCombination"
             class="product-combinations"
@@ -245,5 +248,15 @@
 .product-combinations {
   padding-top: var(--#{$cdk}size-4);
   color: var(--#{$cdk}primary-500);
+}
+
+.product-name-link {
+  color: inherit;
+  text-decoration: none;
+
+  &:hover {
+    color: var(--#{$cdk}primary-500);
+    text-decoration: underline;
+  }
 }
 </style>

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/products-table.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/products-table.vue
@@ -166,6 +166,7 @@
     product_reference: string;
     product_reserved_quantity: number;
     product_thumbnail: string;
+    product_url: string;
     qty: number;
     supplier_id: number;
     supplier_name: string;

--- a/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
@@ -179,6 +179,25 @@ abstract class StockManagementRepository
     {
         $rows = $this->addCombinationsAndFeatures($rows);
         $rows = $this->addImageThumbnailPaths($rows);
+        $rows = $this->addProductLink($rows);
+
+        return $rows;
+    }
+
+    /**
+     * @param array $rows
+     *
+     * @return array
+     */
+    protected function addProductLink(array $rows)
+    {
+        $router = $this->container->get('router');
+
+        foreach ($rows as &$row) {
+            $row['product_url'] = $router->generate('admin_products_edit', [
+                'productId' => $row['product_id'],
+            ]);
+        }
 
         return $rows;
     }

--- a/src/PrestaShopBundle/Entity/Repository/StockRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockRepository.php
@@ -333,9 +333,8 @@ class StockRepository extends StockManagementRepository
      */
     protected function addAdditionalData(array $rows)
     {
-        $rows = $this->addCombinationsAndFeatures($rows);
-        $rows = $this->addImageThumbnailPaths($rows);
-        $rows = $this->addEditProductLink($rows);
+        $rows = parent::addAdditionalData($rows);
+        $rows = $this->addStockApiUrls($rows);
 
         return $rows;
     }
@@ -377,7 +376,7 @@ class StockRepository extends StockManagementRepository
         return $this->totalCombinations[$row['product_id']];
     }
 
-    private function addEditProductLink(array $rows)
+    private function addStockApiUrls(array $rows)
     {
         $router = $this->container->get('router');
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I've been adding this all the time, time to get that into the core. This PR adds a clickable product links in stock management pages.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check that you can now open a product page by clicking its name in the Stock page.
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/20866833182
| Fixed issue or discussion?     | n/a
| Related PRs       | n/a
| Sponsor company   | impSolutions
