### PR TITLE
Fix legacy profiler in the back office

### DIFF
--- a/tools/profiling/Profiler.php
+++ b/tools/profiling/Profiler.php
@@ -213,7 +213,9 @@ class Profiler
     {
         // Including a lot of files uses memory
         foreach (get_included_files() as $file) {
-            $this->totalFilesize += filesize($file);
+            if (file_exists($file)) {
+                $this->totalFilesize += filesize($file);
+            }
         }
 
         foreach ($GLOBALS as $key => $value) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x 
| Description?      | If you have a legacy profiler enabled, when you clear the cache, there's an error
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Clear the cache with legacy profiler, before and after this change. QA by dev.
| UI Tests          | Not needed. UI tests don't use profiler.
| Fixed issue or discussion?     | n/a
| Related PRs       | n/a
| Sponsor company   | impSolutions
