### PR TITLE
Add stock location to Stock Overview API and export

### DIFF
--- a/src/PrestaShopBundle/Controller/Api/StockController.php
+++ b/src/PrestaShopBundle/Controller/Api/StockController.php
@@ -180,6 +180,7 @@ class StockController extends ApiController
             'supplier_name' => $this->translator->trans('Supplier', [], 'Admin.Global'),
             'active' => $this->translator->trans('Status', [], 'Admin.Global'),
             'product_physical_quantity' => $this->translator->trans('Physical quantity', [], 'Admin.Catalog.Feature'),
+            'stock_location' => $translator->trans('Stock location', [], 'Admin.Catalog.Feature'),
             'product_reserved_quantity' => $this->translator->trans('Reserved quantity', [], 'Admin.Catalog.Feature'),
             'product_available_quantity' => $this->translator->trans('Available quantity', [], 'Admin.Catalog.Feature'),
             'product_low_stock_threshold' => $this->translator->trans('Low stock level', [], 'Admin.Catalog.Feature'),

--- a/src/PrestaShopBundle/Entity/Repository/StockRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockRepository.php
@@ -276,6 +276,7 @@ class StockRepository extends StockManagementRepository
           sa.quantity                                                                       AS product_available_quantity,
           sa.physical_quantity                                                              AS product_physical_quantity,
           sa.reserved_quantity                                                              AS product_reserved_quantity,
+          sa.location                                                                       AS stock_location,
           IF(COALESCE(pa.id_product_attribute, 0) > 0, COALESCE(pas.low_stock_threshold, "N/A"),
              COALESCE(ps.low_stock_threshold,
                       "N/A"))                                                               AS product_low_stock_threshold,


### PR DESCRIPTION
## Description
Stock location exists in stock_available but is not exposed in Stock Overview API nor available in CSV export.

This PR adds `sa.location AS stock_location` to the stock query, making it available for:
- Stock Overview grid (Vue)
- API `/api/stocks`
- Stock export CSV

This is a read-only change.

## Type
Improvement

## Category
BO

## BC breaks
No

## Deprecations
No

## How to test
1. Go to Back Office
2. Open Catalog > Stock
3. Verify that stock location is displayed in the stock overview grid
4. Call `/api/stocks` and check that `stock_location` is present in the response
5. Export stock to CSV and verify that the stock location column is included
