### PR TITLE
Allow .env setup without triggering changes to the repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# Copy this file as .env first and customize it to your needs.
 # You can specify here some variables to use in PrestaShop application
 # -> enable a feature flag: PS_FF_{FEATURE_FLAG_NAME}=true
 

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -42,6 +42,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    # Create .env from .env.example
+    - name: Create .env
+      shell: bash
+      run: cp .env.example .env
+
     # Certificate for SSL
     - name: Generate a Certificate
       if: inputs.ENABLE_SSL == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -138,10 +138,6 @@ themes/*-chunk.js.map
 !/install-dev/theme/custom/.gitkeep
 
 # Config
-/.env
-/.env.local
-/.env.local.php
-/.env.*.local
 config/defines_custom.inc.php
 config/settings.inc.php
 config/settings.old.php
@@ -226,6 +222,7 @@ docker-compose.override.yml
 .docker/ssl.key
 
 # DotEnv files
+/.env
 /.env.local
 /.env.local.php
 /.env.*.local

--- a/.gitignore
+++ b/.gitignore
@@ -138,7 +138,7 @@ themes/*-chunk.js.map
 !/install-dev/theme/custom/.gitkeep
 
 # Config
-
+/.env
 /.env.local
 /.env.local.php
 /.env.*.local


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Changing .env shouldn't trigger repo modification. The point of .env is to override default setup.
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | ~
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~