### PR TITLE
Fix: When saving an Attribute is_color_group is not updated.

### DIFF
--- a/src/Adapter/AttributeGroup/CommandHandler/EditAttributeGroupHandler.php
+++ b/src/Adapter/AttributeGroup/CommandHandler/EditAttributeGroupHandler.php
@@ -66,6 +66,8 @@ final class EditAttributeGroupHandler implements EditAttributeGroupHandlerInterf
         if (null !== $command->getType()) {
             $propertiesToUpdate[] = 'group_type';
             $attributeGroup->group_type = $command->getType()->getValue();
+            $propertiesToUpdate[] = 'is_color_group';
+            $attributeGroup->is_color_group = $attributeGroup->group_type === 'color';
         }
         if (null !== $command->getAssociatedShopIds()) {
             $attributeGroup->id_shop_list = $command->getAssociatedShopIds();


### PR DESCRIPTION
… 

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | When editing an Attribute(Group) is_color_group is not updated
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Open **phpMyAdmin** <br/>2. Execute a query on the `PREFIX_attribute_group` table selecting the record with **ID = 2** <br/>3. Verify that the column `is_color_group` is initially set to **1** <br/>4. Go to **Catalog > Attributes & Features > Attributes** <br/>5. Edit the **Color** group attribute with **ID = 2** <br/>6. Change the attribute type to **Dropdown** <br/>7. Save <br/>8. Execute again the query on the `PREFIX_attribute_group` table for **ID = 2** <br/>9. Verify that the column `is_color_group` has been correctly updated to **0**
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/20986259345
| Fixed issue or discussion?     | Fixes #39769
| Related PRs       | #39758
| Sponsor company   | Codencode snc


---


### Note
This PR was initially created by @ChillCode (https://github.com/PrestaShop/PrestaShop/pull/39878), and I simply replicated it since he left the project, and therefore the original PR is no longer available.
Thanks @ChillCode