### PR TITLE
Skip removed modules on enable theme

### DIFF
--- a/classes/log/PSRLoggerAdapter.php
+++ b/classes/log/PSRLoggerAdapter.php
@@ -39,6 +39,12 @@ class PSRLoggerAdapter implements LoggerInterface
      */
     private $logger;
 
+    private bool $saveMessages = false;
+    /**
+     * @var array<string, string[]>
+     */
+    private array $savedMessages;
+
     public function __construct(PrestaShopLoggerInterface $logger)
     {
         $this->logger = $logger;
@@ -47,36 +53,43 @@ class PSRLoggerAdapter implements LoggerInterface
     public function emergency($message, array $context = []): void
     {
         $this->logger->logError($message);
+        $this->saveMessage(LogLevel::EMERGENCY, $message);
     }
 
     public function alert($message, array $context = []): void
     {
         $this->logger->logError($message);
+        $this->saveMessage(LogLevel::ALERT, $message);
     }
 
     public function critical($message, array $context = []): void
     {
         $this->logger->logError($message);
+        $this->saveMessage(LogLevel::CRITICAL, $message);
     }
 
     public function error($message, array $context = []): void
     {
         $this->logger->logError($message);
+        $this->saveMessage(LogLevel::ERROR, $message);
     }
 
     public function warning($message, array $context = []): void
     {
         $this->logger->logWarning($message);
+        $this->saveMessage(LogLevel::WARNING, $message);
     }
 
     public function notice($message, array $context = []): void
     {
         $this->logger->logInfo($message);
+        $this->saveMessage(LogLevel::NOTICE, $message);
     }
 
     public function info($message, array $context = []): void
     {
         $this->logger->logInfo($message);
+        $this->saveMessage(LogLevel::INFO, $message);
     }
 
     public function debug($message, array $context = []): void
@@ -106,5 +119,43 @@ class PSRLoggerAdapter implements LoggerInterface
                 break;
         }
         $this->logger->log($message, $legacyLevel);
+        if ($level == LogLevel::DEBUG) {
+            $this->saveMessage($level, $message);
+        }
+    }
+
+    /**
+     * All messages logged after this method is called are stored in a class field.
+     */
+    public function startSavingMessages(): void
+    {
+        $this->saveMessages = true;
+    }
+
+    /**
+     * Stop saving log records and clear the saved records.
+     */
+    public function stopSavingMessages(): void
+    {
+        $this->saveMessages = false;
+        $this->savedMessages = [];
+    }
+
+    public function getAllSavedMessages(): array
+    {
+        return $this->savedMessages;
+    }
+
+    public function getSavedMessages(string $level): array
+    {
+        return $this->savedMessages[$level] ?? [];
+    }
+
+    protected function saveMessage($level, $message): void
+    {
+        if (!$this->saveMessages) {
+            return;
+        }
+        $this->savedMessages[$level][] = $message;
     }
 }

--- a/config/services/admin/services_prod.yml
+++ b/config/services/admin/services_prod.yml
@@ -17,7 +17,7 @@ services:
 
     hook_configurator:
         class: PrestaShop\PrestaShop\Core\Module\HookConfigurator
-        arguments: ["@hook_repository"]
+        arguments: ["@hook_repository", "@logger", "@prestashop.module.manager"]
 
     theme_validator:
         class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeValidator

--- a/install-dev/classes/controllerHttp.php
+++ b/install-dev/classes/controllerHttp.php
@@ -378,7 +378,7 @@ class InstallControllerHttp
      * @param bool $success
      * @param string $message
      */
-    public function ajaxJsonAnswer(bool $success, $message = ''): void
+    public function ajaxJsonAnswer(bool $success, $message = '', $warning = ''): void
     {
         if (!$success && empty($message)) {
             $message = print_r(@error_get_last(), true);
@@ -387,6 +387,7 @@ class InstallControllerHttp
         die(json_encode([
             'success' => (bool) $success,
             'message' => $message,
+            'warning' => $warning,
         ]));
     }
 

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -317,7 +317,12 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
             $this->ajaxJsonAnswer(false, $this->model_install->getErrors());
         }
         $this->session->process_validated = array_merge($this->session->process_validated, ['installTheme' => true]);
-        $this->ajaxJsonAnswer(true);
+        $warning = '';
+        if (!empty($this->model_install->getWarnings())) {
+            $warning = implode('<br />', $this->model_install->getWarnings());
+            $this->model_install->resetWarnings();
+        }
+        $this->ajaxJsonAnswer(true, '', $warning);
     }
 
     /**

--- a/install-dev/theme/js/process.js
+++ b/install-dev/theme/js/process.js
@@ -68,6 +68,10 @@ function process_install(step) {
     success: function(json) {
       // No error during this step
       if (json && json.success === true) {
+        if (json.warning && json.warning !== '') {
+          install_warning(json.warning);
+        }
+
         $('#process_step_'+step.key).addClass('success');
         current_step++;
         if (current_step >= process_steps.length) {
@@ -125,6 +129,10 @@ function process_install_subtask(step, current_subtask) {
         $('#progress_bar .total .progress').animate({'width': '+='+subtask_process_pixel+'px'}, 500);
         $('#progress_bar .total span').html(Math.ceil((current_step * (100 / process_steps.length)) + Math.ceil(current_subtask * ((100 / process_steps.length) / step.subtasks.length)))+'%');
 
+        if (json.warning && json.warning !== '') {
+          install_warning(json.warning);
+        }
+
         if (current_subtask >= step.subtasks.length) {
           current_step++;
           $('#process_step_'+step.key).show().addClass('success');
@@ -146,6 +154,12 @@ function process_install_subtask(step, current_subtask) {
       install_error(step, errorMsg);
     }
   });
+}
+
+function install_warning(warning) {
+  console.log('install_warning', warning);
+  $('#warning_process').show();
+  $('#warning_process').append('<p>' + warning + '</p>');
 }
 
 function install_error(step, errors) {

--- a/install-dev/theme/view.css
+++ b/install-dev/theme/view.css
@@ -1095,6 +1095,27 @@ ul#optional_update li.ok {
   text-decoration: underline;
 }
 
+#warning_process {
+  background: var(--cdk-yellow-50) url(img/warning.svg) no-repeat calc(100% - var(--cdk-size-8)) center;
+  padding: var(--cdk-size-16);
+  border: 1px solid var(--cdk-yellow-500);
+  margin: var(--cdk-size-16) 0;
+  display: none;
+}
+#warning_process h3 {
+  color: var(--cdk-red-500);
+}
+#warning_process p {
+  margin-left: 20px;
+}
+#warning_process p a {
+  font-weight: bold;
+}
+#warning_process p a:hover {
+  text-decoration: underline;
+}
+
+
 #install_process_success {
   display: none;
 }

--- a/install-dev/theme/views/process.php
+++ b/install-dev/theme/views/process.php
@@ -56,6 +56,10 @@
     </div>
 </div>
 
+<div id="warning_process">
+    <h3><?php echo $this->translator->trans('A warning was triggered during installation', [], 'Install'); ?></h3>
+</div>
+
 <div id="install_process_success">
     <div class="clearfix">
         <h2><?php echo $this->translator->trans('Your installation is finished!', [], 'Install'); ?></h2>
@@ -98,7 +102,7 @@
                 </a>
               </div>
           </div>
-  
+
           <div id="foBlock" class="blockInfoEnd last clearfix" onclick="window.open('../')">
               <img src="theme/img/visu_foBlock.png" alt="" />
               <div class="bo-infos">

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -297,6 +297,12 @@ class ThemeManager implements AddonManagerInterface
         $moduleManager = $moduleManagerBuilder->build();
 
         foreach ($modules as $moduleName) {
+            // If module has been removed we ignore it but inform via a warning
+            if (!$moduleManager->isOnDisk($moduleName)) {
+                $this->logger->warning(sprintf('Module %s was removed from disk, no need to disable it', $moduleName));
+                continue;
+            }
+
             if ($moduleManager->isInstalled($moduleName) && $moduleManager->isEnabled($moduleName)) {
                 $moduleManager->disable($moduleName);
             }
@@ -318,6 +324,12 @@ class ThemeManager implements AddonManagerInterface
         $moduleManager = $moduleManagerBuilder->build();
 
         foreach ($modules as $moduleName) {
+            // If module has been removed we ignore it but inform via a warning
+            if (!$moduleManager->isOnDisk($moduleName)) {
+                $this->logger->warning(sprintf('Module %s was removed from disk, impossible to enable it', $moduleName));
+                continue;
+            }
+
             if (!$moduleManager->isInstalled($moduleName)
                 && !$moduleManager->install($moduleName)
             ) {
@@ -344,6 +356,12 @@ class ThemeManager implements AddonManagerInterface
         $moduleManager = $moduleManagerBuilder->build();
 
         foreach ($modules as $moduleName) {
+            // If module has been removed we ignore it but inform via a warning
+            if (!$moduleManager->isOnDisk($moduleName)) {
+                $this->logger->warning(sprintf('Module %s was removed from disk, impossible to reset it', $moduleName));
+                continue;
+            }
+
             if ($moduleManager->isInstalled($moduleName)) {
                 $moduleManager->reset($moduleName);
             }

--- a/src/Core/Addon/Theme/ThemeManagerBuilder.php
+++ b/src/Core/Addon/Theme/ThemeManagerBuilder.php
@@ -31,6 +31,7 @@ use Db;
 use Employee;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Hook\HookInformationProvider;
+use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use PrestaShop\PrestaShop\Core\Context\ApiClientContext;
 use PrestaShop\PrestaShop\Core\Image\ImageTypeRepository;
 use PrestaShop\PrestaShop\Core\Module\HookConfigurator;
@@ -68,6 +69,9 @@ class ThemeManagerBuilder
             $this->context->employee = new Employee();
         }
 
+        $moduleManagerBuilder = ModuleManagerBuilder::getInstance();
+        $moduleManager = $moduleManagerBuilder->build();
+
         return new ThemeManager(
             $this->context->shop,
             $configuration,
@@ -81,7 +85,9 @@ class ThemeManagerBuilder
                     new HookInformationProvider(),
                     $this->context->shop,
                     $this->db
-                )
+                ),
+                $this->logger,
+                $moduleManager,
             ),
             $this->buildRepository($this->context->shop),
             new ImageTypeRepository($this->db),

--- a/src/Core/Module/HookConfigurator.php
+++ b/src/Core/Module/HookConfigurator.php
@@ -26,13 +26,15 @@
 
 namespace PrestaShop\PrestaShop\Core\Module;
 
+use Psr\Log\LoggerInterface;
+
 class HookConfigurator
 {
-    private $hookRepository;
-
-    public function __construct(HookRepository $hookRepository)
-    {
-        $this->hookRepository = $hookRepository;
+    public function __construct(
+        private readonly HookRepository $hookRepository,
+        private readonly ?LoggerInterface $logger = null,
+        private readonly ?ModuleManager $moduleManager = null,
+    ) {
     }
 
     /**
@@ -77,11 +79,26 @@ class HookConfigurator
                 if ($module === null && $firstNullValueFound) {
                     $firstNullValueFound = false;
                     foreach ($existing as $m) {
+                        // If module has been removed we ignore it but inform via a warning
+                        if ($this->moduleManager && !$this->moduleManager->isOnDisk($m)) {
+                            $this->logger?->warning(sprintf('Module %s was removed from disk, impossible to hook it', $m));
+                            continue;
+                        }
                         $currentHooks[$hookName][] = $m;
                     }
                 } elseif (is_array($module)) {
+                    // If module has been removed we ignore it but inform via a warning
+                    if ($this->moduleManager && !$this->moduleManager->isOnDisk($key)) {
+                        $this->logger?->warning(sprintf('Module %s was removed from disk, impossible to hook it', $key));
+                        continue;
+                    }
                     $currentHooks[$hookName][$key] = $module;
                 } elseif ($module !== null) {
+                    // If module has been removed we ignore it but inform via a warning
+                    if ($this->moduleManager && !$this->moduleManager->isOnDisk($module)) {
+                        $this->logger?->warning(sprintf('Module %s was removed from disk, impossible to hook it', $module));
+                        continue;
+                    }
                     $currentHooks[$hookName][] = $module;
                 }
             }

--- a/src/Core/Module/ModuleManager.php
+++ b/src/Core/Module/ModuleManager.php
@@ -321,6 +321,11 @@ class ModuleManager implements ModuleManagerInterface
         return $this->moduleDataProvider->isEnabled($name);
     }
 
+    public function isOnDisk(string $name): bool
+    {
+        return $this->moduleDataProvider->isOnDisk($name);
+    }
+
     public function getError(string $name): string
     {
         $module = $this->moduleRepository->getModule($name);

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Improve\Design;
 
 use Exception;
+use Monolog\Logger;
 use PrestaShop\PrestaShop\Adapter\Language\RTL\InstalledLanguageChecker;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeExporter;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemePageLayoutsCustomizer;
@@ -63,6 +64,7 @@ use PrestaShopBundle\Form\Admin\Improve\Design\Theme\ImportThemeType;
 use PrestaShopBundle\Form\Admin\Improve\Design\Theme\PageLayoutCustomizationFormFactory;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use PrestaShopBundle\Security\Attribute\DemoRestricted;
+use PrestaShopBundle\Service\Log\LogHandler;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -245,9 +247,10 @@ class ThemeController extends PrestaShopAdminController
      */
     #[DemoRestricted(redirectRoute: 'admin_themes_index')]
     #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_themes_index', message: 'You do not have permission to edit this.')]
-    public function enableAction(string $themeName): RedirectResponse
+    public function enableAction(string $themeName, LogHandler $handler): RedirectResponse
     {
         try {
+            $handler->startSavingRecords();
             $this->dispatchCommand(new EnableThemeCommand(new ThemeName($themeName)));
             $this->addFlash('success', $this->trans('Successful update', [], 'Admin.Notifications.Success'));
         } catch (ThemeException $e) {
@@ -260,6 +263,15 @@ class ThemeController extends PrestaShopAdminController
             );
 
             return $this->redirectToRoute('admin_themes_index');
+        } finally {
+            $warnings = $handler->getSavedRecords(Logger::WARNING);
+            $handler->stopSavingRecords();
+            foreach ($warnings as $warning) {
+                $this->addFlash(
+                    'warning',
+                    $warning['message'],
+                );
+            }
         }
 
         return $this->redirectToRoute('admin_themes_index');

--- a/src/PrestaShopBundle/Install/AbstractInstall.php
+++ b/src/PrestaShopBundle/Install/AbstractInstall.php
@@ -45,6 +45,10 @@ abstract class AbstractInstall
      * @var array List of errors
      */
     protected $errors = [];
+    /**
+     * @var array List of warnings
+     */
+    protected $warnings = [];
 
     /**
      * @var PrestaShopLoggerInterface|null
@@ -73,6 +77,25 @@ abstract class AbstractInstall
     public function resetErrors(): void
     {
         $this->errors = [];
+    }
+
+    public function setWarning($warnings): void
+    {
+        if (!is_array($warnings)) {
+            $warnings = [$warnings];
+        }
+
+        $this->warnings = array_merge($this->warnings, $warnings);
+    }
+
+    public function getWarnings(): array
+    {
+        return $this->warnings;
+    }
+
+    public function resetWarnings(): void
+    {
+        $this->warnings = [];
     }
 
     public function setTranslator($translator)

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -68,6 +68,7 @@ use PrestaShopBundle\Cache\LocalizationWarmer;
 use PrestaShopException;
 use PrestashopInstallerException;
 use PrestaShopLoggerInterface;
+use Psr\Log\LogLevel;
 use PSRLoggerAdapter;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
@@ -1181,11 +1182,13 @@ class Install extends AbstractInstall
         $themeName = $themeName ?: _THEME_NAME_;
         $this->getLogger()->logInfo('Installing theme ' . $themeName);
 
+        $logger = new PSRLoggerAdapter($this->getLogger());
+        $logger->startSavingMessages();
         $builder = new ThemeManagerBuilder(
             Context::getContext(),
             Db::getInstance(),
             null,
-            new PSRLoggerAdapter($this->getLogger())
+            $logger,
         );
 
         $theme_manager = $builder->build();
@@ -1195,6 +1198,12 @@ class Install extends AbstractInstall
             $this->setError($theme_manager->getErrors($themeName));
 
             return false;
+        }
+
+        $warnings = $logger->getSavedMessages(LogLevel::WARNING);
+        $logger->stopSavingMessages();
+        if (!empty($warnings)) {
+            $this->setWarning($warnings);
         }
 
         /*

--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -69,10 +69,16 @@ services:
     class: PrestaShopBundle\Service\Hook\HookFinder
 
   # EVENT HANDLER
-  prestashop.handler.log:
-    class: PrestaShopBundle\Service\Log\LogHandler
+  PrestaShopBundle\Service\Log\LogHandler:
+    public: false
     arguments:
       - "@service_container"
+
+  prestashop.handler.log:
+    alias: PrestaShopBundle\Service\Log\LogHandler
+    deprecated:
+      package: PrestaShop\PrestaShop
+      version: 9.1
 
   # CSRF/XSS additional protection middleware
   PrestaShopBundle\Service\DataProvider\UserProvider:

--- a/src/PrestaShopBundle/Resources/config/services/legacy.yml
+++ b/src/PrestaShopBundle/Resources/config/services/legacy.yml
@@ -19,3 +19,5 @@ services:
     class: PrestaShop\PrestaShop\Core\Module\HookConfigurator
     arguments:
       - "@hook_repository"
+      - "@logger"
+      - "@prestashop.module.manager"

--- a/src/PrestaShopBundle/Service/Log/LogHandler.php
+++ b/src/PrestaShopBundle/Service/Log/LogHandler.php
@@ -37,10 +37,22 @@ use Symfony\Component\DependencyInjection\Container;
  * @phpstan-import-type Record from Logger
  *
  * @phpstan-type FormattedRecord array{message: string, context: mixed[], level: Level, level_name: LevelName, channel: string, datetime: \DateTimeImmutable, extra: mixed[], formatted: mixed}
+ *
+ * This handler is an interface between Monolog and the legacy logger.
+ *
+ * It also provides a feature that allows you saving log records, it is always disabled by default, but you can temporarily
+ * enable the saving of recors, which may be useful to get warning messages and then display them as flash messages in controllers.
  */
 class LogHandler extends AbstractProcessingHandler
 {
     protected $container;
+
+    /**
+     * @var array<int, array<int, array{level: int, message: string, context: array}>>
+     */
+    protected array $savedRecords = [];
+
+    protected bool $recordsSaved = false;
 
     public function __construct(Container $container, $level = Logger::DEBUG, $bubble = true)
     {
@@ -58,5 +70,40 @@ class LogHandler extends AbstractProcessingHandler
         /** @var LegacyLogger $logger */
         $logger = $this->container->get('prestashop.adapter.legacy.logger');
         $logger->log($record['level'], $record['message'], $record['context']);
+        if (!empty($record['level']) && $record['level'] > Logger::DEBUG && $this->recordsSaved) {
+            $this->savedRecords[$record['level']][] = $record;
+        }
+    }
+
+    public function isRecordsSaved(): bool
+    {
+        return $this->recordsSaved;
+    }
+
+    /**
+     * All messages logged after this method is called are stored in a class field.
+     */
+    public function startSavingRecords(): void
+    {
+        $this->recordsSaved = true;
+    }
+
+    /**
+     * Stop saving log records and clear the saved records.
+     */
+    public function stopSavingRecords(): void
+    {
+        $this->recordsSaved = false;
+        $this->savedRecords = [];
+    }
+
+    public function getSavedRecords(int $level): array
+    {
+        return $this->savedRecords[$level] ?? [];
+    }
+
+    public function getAllSavedRecords(): array
+    {
+        return $this->savedRecords;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | During the enabling of a theme some modules may have been removed, this is no longer blocking but we display a warning to explain the actions that were not performed
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/21031679856
| Fixed issue or discussion?     | Fixes #38835
| Related PRs       | ~
| Sponsor company   | ~

## How to test

Before testing these these three ways of enabling the theme you need to remove some modules from the disk:
- `ps_distributionapiclient` (or the module are re-installed via API)
- `ps_linklist`
- `blockwishlist`

### Install cli

Run this command (you probably need to adapt the DB settings to your environment:
```
php install-dev/index_cli.php  --language=en  --country=fr  --domain=localhost   --base_uri=/  --db_server=127.0.0.1 --db_user=root --db_name=prestashop --db_create=1 --firstname="John" --lastname="DOE" --name="Prestashop 91" --email=john.doe@prestashop.com --password="prestashop"
```
You should see some messages in the logs:
```
Installing database
Dropping database tables
Installing default data
Truncating database
Creating shop
Installing languages: en, fr
Populating database
Configuring shop
Installing modules on disk
Installing theme hummingbird
# These are the new extra warnings
Module blockwishlist was removed from disk, no need to disable it
Module ps_linklist was removed from disk, impossible to enable it
Module blockwishlist was removed from disk, impossible to reset it
Module ps_linklist was removed from disk, impossible to hook it
# TEnd of extra warnings
Installing fixtures
You can now access your backoffice at http://prestashop.91.localhost/admin-dev.
```

### Install from browser

Perform an install from the browser, a warning block should be displayed after the step that installs the theme, the warning stays visible when the installation succeeded.

<img width="697" height="550" alt="Capture d’écran 2026-01-15 à 11 54 23" src="https://github.com/user-attachments/assets/293c37a0-6aee-4988-a3a7-63d61ff0ac9c" />

### Enable from BO

Switch to classic theme by enabling it, then switch back to Hummingbird theme by enabling it you should see a warning:

<img width="1492" height="220" alt="Capture d’écran 2026-01-15 à 12 05 32" src="https://github.com/user-attachments/assets/fe4e9418-71eb-4763-8755-1b228adb9034" />
