### PR TITLE
Multi-shipment - Fix split shipment carrier choice

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Shipment/SplitShipmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Shipment/SplitShipmentType.php
@@ -65,10 +65,7 @@ class SplitShipmentType extends AbstractType
         $selectedProductsId = array_column($selectedProducts, 'quantity', 'product_id');
 
         $builder->add('carrier', ChoiceType::class, [
-            'choices' => $this->availableCarriersForShipmentChoiceProvider->getChoices([
-                'shipment_id' => $options['data']['shipment_id'],
-                'selectedProducts' => $selectedProductsId,
-            ]),
+            'choices' => $this->getCarrierChoices($options, $selectedProductsId),
             'placeholder' => $this->translator->trans('Select a carrier', [], 'Admin.Orderscustomers.Feature'),
             'required' => true,
         ]);
@@ -80,5 +77,20 @@ class SplitShipmentType extends AbstractType
             'products' => [],
             'carrier' => 0,
         ]);
+    }
+
+    /**
+     * @param array<int, string> $selectedProductsId
+     */
+    private function getCarrierChoices(array $options, array $selectedProductsId): array
+    {
+        if (count($selectedProductsId) > 0) {
+            return $this->availableCarriersForShipmentChoiceProvider->getChoices([
+                'shipment_id' => $options['data']['shipment_id'],
+                'selectedProducts' => $selectedProductsId,
+            ]);
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Choosing a carrier should only be possible once we have selected a product.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |no
| How to test?      | Use split shipment form
| UI Tests          | -
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -