### PR TITLE
Remove unnecessary force refresh in checkout

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4696,7 +4696,7 @@ class CartCore extends ObjectModel
      */
     public function checkAllProductsHaveMinimalQuantities()
     {
-        $productList = $this->getProducts(true);
+        $productList = $this->getProducts();
         foreach ($productList as $product) {
             if ($product['minimal_quantity'] > $product['cart_quantity']) {
                 return false;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Probably a last PR from my cart optimization series now. Since we are responsibly clearing cart cache now and I removed a force refresh from all other places, this is one more spot I missed. It will gain few ms of load time in checkout - it's used only there.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Automatic test
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/21131958598
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

Before
<img width="630" height="290" alt="before" src="https://github.com/user-attachments/assets/9945df2a-e379-49cf-888b-8d2401505c3d" />

After
<img width="630" height="288" alt="after" src="https://github.com/user-attachments/assets/45f91e91-5e27-4b75-97fd-b746ba17a180" />

