### PR TITLE
Fix quantity input, add to cart button and availability labels when items are added in a cart

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1188,6 +1188,16 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
         // Assign several product properties to the array
         $product['description'] = $this->transformDescriptionWithImg($this->product->description);
+
+        /*
+         * This property is not a product property, but value from stock_available table. It must be here because on this page,
+         * it's not initialized in any other way. On listings, it goes through ProductAssembler and the property is included.
+         * In cart, it's also in the selected fields. But not here.
+         *
+         * We could centralize it right now, but the call StockAvailable::outOfStock($this->id) would still be called
+         * when constructing a Product object, so, let's just migrate it all at once later.
+         */
+        $product['out_of_stock'] = (int) $this->product->out_of_stock;
         $product['id_product_attribute'] = $this->getIdProductAttributeByGroupOrRequestOrDefault();
 
         // @todo These three properties should be migrated into the lazy array, so they are available also in listings
@@ -1198,9 +1208,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product['cart_quantity'] = $this->context->cart->getProductQuantity((int) $this->product->id, $product['id_product_attribute'])['quantity'];
 
         // Quantity requested by the customer by the quantity input on product page - may be force-altered by us
+        // @todo - a centralized version of this method is implemented in ProductLazyArray - migrate to it when migrating this code
         $product['quantity_wanted'] = $this->getWantedQuantity($product);
 
         // Required quantity to add to cart to reach minimal quantity
+        // @todo - a centralized version of this method is implemented in ProductLazyArray - migrate to it when migrating this code
         $product['quantity_required'] = $this->getRequiredQuantity($product);
 
         // Render hook displayProductExtraContent
@@ -1247,22 +1259,26 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      *
      * @param array $product
      *
-     * @return int
+     * @return int Minimal quantity of product from it's settings, always a positive integer
      */
     protected function getProductMinimalQuantity(ProductLazyArray|array $product)
     {
-        $minimal_quantity = 1;
+        $minimalQuantity = 1;
 
         if ($product['id_product_attribute']) {
             $combination = $this->findProductCombinationById($product['id_product_attribute']);
             if ($combination['minimal_quantity']) {
-                $minimal_quantity = $combination['minimal_quantity'];
+                $minimalQuantity = (int) $combination['minimal_quantity'];
             }
         } else {
-            $minimal_quantity = $this->product->minimal_quantity;
+            $minimalQuantity = (int) $this->product->minimal_quantity;
         }
 
-        return $minimal_quantity;
+        if ($minimalQuantity < 1) {
+            $minimalQuantity = 1;
+        }
+
+        return $minimalQuantity;
     }
 
     /**
@@ -1317,15 +1333,16 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      * if the minimal quantity is higher. Also, we adjust it by the quantity already in cart.
      *
      * @todo This method should be migrated to ProductLazyArray, so it's available also in listings.
+     *       It's already implemented there.
      *
      * @param array $product
      *
-     * @return int
+     * @return int Minimal quantity of product the customer buy right now, always a positive integer
      */
     protected function getRequiredQuantity(ProductLazyArray|array $product)
     {
         // For the required quantity, we will need to limit it by the minimal quantity on the low side.
-        $minimalRequiredQuantityForPurchase = $this->getProductMinimalQuantity($product);
+        $requiredQuantityForPurchase = $this->getProductMinimalQuantity($product);
 
         /*
          * We reduce it by the quantity we already have in cart. If the user already has a sufficient
@@ -1334,19 +1351,25 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
          * may not be the correct one.
          */
         if (!empty($product['cart_quantity'])) {
-            $minimalRequiredQuantityForPurchase -= $product['cart_quantity'];
+            $requiredQuantityForPurchase -= $product['cart_quantity'];
+            if ($requiredQuantityForPurchase < 1) {
+                $requiredQuantityForPurchase = 1;
+            }
         }
 
-        return $minimalRequiredQuantityForPurchase;
+        return $requiredQuantityForPurchase;
     }
 
     /**
      * Gets the quantity wanted by the customer for the product. We will take his request,
      * but we will adjust it if it's lower than the required quantity.
      *
+     * @todo This method should be migrated to ProductLazyArray, so it's available also in listings.
+     *       It's already implemented there.
+     *
      * @param array $product
      *
-     * @return int
+     * @return int Quantity of product requested by the customer, altered if needed, always a positive integer
      */
     public function getWantedQuantity(ProductLazyArray|array $product): int
     {
@@ -1354,10 +1377,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $quantityWantedByTheCustomer = (int) Tools::getValue('quantity_wanted', 1);
 
         // Get minimal required quantity for purchase
-        $minimalRequiredQuantityForPurchase = $this->getRequiredQuantity($product);
+        $requiredQuantityForPurchase = $this->getRequiredQuantity($product);
 
-        if ($quantityWantedByTheCustomer < $minimalRequiredQuantityForPurchase) {
-            $quantityWantedByTheCustomer = $minimalRequiredQuantityForPurchase;
+        // If the wanted quantity is lower than the required, we adjust it
+        if ($quantityWantedByTheCustomer < $requiredQuantityForPurchase) {
+            $quantityWantedByTheCustomer = $requiredQuantityForPurchase;
         }
 
         return $quantityWantedByTheCustomer;

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -454,6 +454,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function displayAjaxRefresh(): void
     {
         $product = $this->getTemplateVarProduct();
+
+        // After refresh, we will show the customer a new quantity he has to use
         $minimalProductQuantity = $this->getProductMinimalQuantity($product);
 
         // If the product is already in the cart, we can set the minimal quantity to 1
@@ -1182,33 +1184,37 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
     public function getTemplateVarProduct(): ProductLazyArray
     {
-        $productSettings = $this->getProductPresentationSettings();
-        // Hook displayProductExtraContent
-        $extraContentFinder = new ProductExtraContentFinder();
-
+        // Convert product object into array
         $product = $this->objectPresenter->present($this->product);
+
+        // Assign several product properties to the array
         $product['description'] = $this->transformDescriptionWithImg($this->product->description);
-        $product['out_of_stock'] = (int) $this->product->out_of_stock;
         $product['id_product_attribute'] = $this->getIdProductAttributeByGroupOrRequestOrDefault();
+
+        // @todo These three properties should be migrated into the lazy array, so they are available also in listings
         $product['minimal_quantity'] = $this->getProductMinimalQuantity($product);
         $product['cart_quantity'] = $this->context->cart->getProductQuantity((int) $this->product->id, $product['id_product_attribute'])['quantity'];
         $product['quantity_wanted'] = $this->getRequiredQuantity($product);
-        $product['extraContent'] = $extraContentFinder->addParams(['product' => $this->product])->present();
+
+        // Render hook displayProductExtraContent
+        $product['extraContent'] = (new ProductExtraContentFinder())->addParams(['product' => $this->product])->present();
         $product['ecotax_tax_inc'] = $this->product->getEcotax(null, true, true);
         $product['ecotax'] = Tools::convertPrice($this->getProductEcotax($product), $this->context->currency, true, $this->context);
 
+        // Enrich the product array
         $product_full = Product::getProductProperties($this->context->language->id, $product, $this->context);
 
+        // Add possible customizations
         $product_full = $this->addProductCustomizationData($product_full);
 
         $product_full['show_quantities'] = (bool) (
             Configuration::get('PS_DISPLAY_QTIES')
             && Configuration::get('PS_STOCK_MANAGEMENT')
-            && $this->product->quantity > 0
+            && $product_full['quantity'] > 0
             && $this->product->available_for_order
             && !Configuration::isCatalogMode()
         );
-        $product_full['quantity_label'] = ($this->product->quantity > 1) ? $this->trans('Items', [], 'Shop.Theme.Catalog') : $this->trans('Item', [], 'Shop.Theme.Catalog');
+        $product_full['quantity_label'] = ($product_full['quantity'] > 1) ? $this->trans('Items', [], 'Shop.Theme.Catalog') : $this->trans('Item', [], 'Shop.Theme.Catalog');
         $product_full['quantity_discounts'] = $this->quantity_discounts;
 
         $group_reduction = GroupReduction::getValueForProduct($this->product->id, (int) Group::getCurrent()->id);
@@ -1218,14 +1224,19 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product_full['customer_group_discount'] = $group_reduction;
         $product_full['title'] = $this->getProductPageTitle();
 
+        // And finally, present it in the modern way
         return $this->getProductPresenter()->present(
-            $productSettings,
+            $this->getProductPresentationSettings(),
             $product_full,
             $this->context->language
         );
     }
 
     /**
+     * Gets the minimal quantity allowed for the product or its combination.
+     *
+     * @todo This method should be migrated to ProductLazyArray, so it's available also in listings.
+     *
      * @param array $product
      *
      * @return int
@@ -1294,19 +1305,41 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     }
 
     /**
+     * Gets the minimal quantity the customer has to purchase. We cannot just let him buy 1 piece
+     * if the minimal quantity is higher. Also, we adjust it by the quantity already in cart.
+     *
+     * @todo This method should be migrated to ProductLazyArray, so it's available also in listings.
+     *
      * @param array $product
      *
      * @return int
      */
     protected function getRequiredQuantity(array $product)
     {
-        $requiredQuantity = (int) Tools::getValue('quantity_wanted', $this->getProductMinimalQuantity($product));
-        if ($requiredQuantity < $product['minimal_quantity']) {
-            $requiredQuantity = $product['minimal_quantity'];
+        // For the required quantity, we will need to limit it by the minimal quantity on the low side.
+        $minimalProductQuantity = $this->getProductMinimalQuantity($product);
+
+        /*
+         * We reduce it by the quantity we already have in cart. If the user already has a sufficient
+         * quantity in the cart, we don't need to add more. Although it may seem that we can just reset
+         * the minimal quantity to one in that case, we must not do that, because the quantity in the cart
+         * may not be the correct one.
+         */
+        if (!empty($product['cart_quantity'])) {
+            $minimalProductQuantity -= $product['cart_quantity'];
         }
 
-        if ($product['cart_quantity'] >= $requiredQuantity) {
-            return 0;
+        // Get the quantity wanted from the request
+        $requiredQuantity = (int) Tools::getValue('quantity_wanted');
+
+        // Safety check to fall back on one, if some nonsense was passed
+        if (empty($requiredQuantity)) {
+            $requiredQuantity = 1;
+        }
+
+        // And adjust the lower boundary depending on the minimal quantity
+        if ($requiredQuantity < $minimalProductQuantity) {
+            $requiredQuantity = $minimalProductQuantity;
         }
 
         return $requiredQuantity;

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -456,11 +456,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product = $this->getTemplateVarProduct();
 
         // After refresh, we will show the customer a new quantity he has to use
-        $minimalProductQuantity = $this->getProductMinimalQuantity($product);
-
-        // If the product is already in the cart, we can set the minimal quantity to 1
-        if ($product['cart_quantity'] >= $minimalProductQuantity) {
-            $minimalProductQuantity = 1;
+        $newMinimalQuantity = $product['quantity_required'];
+        if (empty($newMinimalQuantity)) {
+            $newMinimalQuantity = 1;
         }
 
         ob_end_clean();
@@ -498,7 +496,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                     'adtoken' => Tools::getValue('adtoken'),
                 ] : []
             ),
-            'product_minimal_quantity' => $minimalProductQuantity,
+            // A new minimal quantity to use on the input after refresh
+            'product_minimal_quantity' => $newMinimalQuantity,
             'product_has_combinations' => !empty($this->combinations),
             'id_product_attribute' => $product['id_product_attribute'],
             'id_customization' => $product['id_customization'],
@@ -1192,9 +1191,17 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product['id_product_attribute'] = $this->getIdProductAttributeByGroupOrRequestOrDefault();
 
         // @todo These three properties should be migrated into the lazy array, so they are available also in listings
+        // Minimal quantity setting of this product or combination
         $product['minimal_quantity'] = $this->getProductMinimalQuantity($product);
+
+        // Quantity of this product in the current cart
         $product['cart_quantity'] = $this->context->cart->getProductQuantity((int) $this->product->id, $product['id_product_attribute'])['quantity'];
-        $product['quantity_wanted'] = $this->getRequiredQuantity($product);
+
+        // Quantity requested by the customer by the quantity input on product page - may be force-altered by us
+        $product['quantity_wanted'] = $this->getWantedQuantity($product);
+
+        // Required quantity to add to cart to reach minimal quantity
+        $product['quantity_required'] = $this->getRequiredQuantity($product);
 
         // Render hook displayProductExtraContent
         $product['extraContent'] = (new ProductExtraContentFinder())->addParams(['product' => $this->product])->present();
@@ -1233,7 +1240,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     }
 
     /**
-     * Gets the minimal quantity allowed for the product or its combination.
+     * Gets the minimal quantity allowed for the product or its combination. With no adjustments
+     * by the current context.
      *
      * @todo This method should be migrated to ProductLazyArray, so it's available also in listings.
      *
@@ -1314,10 +1322,10 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      *
      * @return int
      */
-    protected function getRequiredQuantity(array $product)
+    protected function getRequiredQuantity(ProductLazyArray|array $product)
     {
         // For the required quantity, we will need to limit it by the minimal quantity on the low side.
-        $minimalProductQuantity = $this->getProductMinimalQuantity($product);
+        $minimalRequiredQuantityForPurchase = $this->getProductMinimalQuantity($product);
 
         /*
          * We reduce it by the quantity we already have in cart. If the user already has a sufficient
@@ -1326,23 +1334,33 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
          * may not be the correct one.
          */
         if (!empty($product['cart_quantity'])) {
-            $minimalProductQuantity -= $product['cart_quantity'];
+            $minimalRequiredQuantityForPurchase -= $product['cart_quantity'];
         }
 
+        return $minimalRequiredQuantityForPurchase;
+    }
+
+    /**
+     * Gets the quantity wanted by the customer for the product. We will take his request,
+     * but we will adjust it if it's lower than the required quantity.
+     *
+     * @param array $product
+     *
+     * @return int
+     */
+    public function getWantedQuantity(ProductLazyArray|array $product): int
+    {
         // Get the quantity wanted from the request
-        $requiredQuantity = (int) Tools::getValue('quantity_wanted');
+        $quantityWantedByTheCustomer = (int) Tools::getValue('quantity_wanted', 1);
 
-        // Safety check to fall back on one, if some nonsense was passed
-        if (empty($requiredQuantity)) {
-            $requiredQuantity = 1;
+        // Get minimal required quantity for purchase
+        $minimalRequiredQuantityForPurchase = $this->getRequiredQuantity($product);
+
+        if ($quantityWantedByTheCustomer < $minimalRequiredQuantityForPurchase) {
+            $quantityWantedByTheCustomer = $minimalRequiredQuantityForPurchase;
         }
 
-        // And adjust the lower boundary depending on the minimal quantity
-        if ($requiredQuantity < $minimalProductQuantity) {
-            $requiredQuantity = $minimalProductQuantity;
-        }
-
-        return $requiredQuantity;
+        return $quantityWantedByTheCustomer;
     }
 
     /**

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -1214,14 +1214,15 @@ class ProductLazyArray extends AbstractLazyArray
      *
      * @return int Quantity of product requested by the customer, altered if needed, always a positive integer
      */
-    private function getQuantityWanted()
+    #[LazyArrayAttribute(arrayAccess: true)]
+    public function getQuantityWanted()
     {
         if (empty($this->product['quantity_wanted'])) {
             // Get the quantity wanted from the request
             $quantityWantedByTheCustomer = (int) Tools::getValue('quantity_wanted', 1);
 
             // Get minimal required quantity for purchase
-            $requiredQuantityForPurchase = $this->getRequiredQuantity();
+            $requiredQuantityForPurchase = $this->getQuantityRequired();
 
             if ($quantityWantedByTheCustomer < $requiredQuantityForPurchase) {
                 $quantityWantedByTheCustomer = $requiredQuantityForPurchase;
@@ -1239,7 +1240,8 @@ class ProductLazyArray extends AbstractLazyArray
      *
      * @return int Minimal quantity of product the customer buy right now, always a positive integer
      */
-    protected function getRequiredQuantity()
+    #[LazyArrayAttribute(arrayAccess: true)]
+    public function getQuantityRequired()
     {
         // For the required quantity, we will need to limit it by the minimal quantity on the low side.
         $requiredQuantityForPurchase = $this->getMinimalQuantity();
@@ -1267,7 +1269,8 @@ class ProductLazyArray extends AbstractLazyArray
      *
      * @return int Minimal quantity of product from it's settings, always a positive integer
      */
-    private function getMinimalQuantity()
+    #[LazyArrayAttribute(arrayAccess: true)]
+    public function getMinimalQuantity()
     {
         $minimalQuantity = (int) $this->product['minimal_quantity'];
 

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -1199,12 +1199,8 @@ class ProductLazyArray extends AbstractLazyArray
         }
 
         // Disable because of stock management
-        if (
-            $settings->stock_management_enabled
-            && !$product['allow_oosp']
-            && ($product['quantity'] <= 0
-                || $product['quantity'] - $this->getQuantityWanted() < 0
-                || $product['quantity'] - $this->getMinimalQuantity() < 0)
+        if ($settings->stock_management_enabled && !$product['allow_oosp']
+            && ($product['quantity'] <= 0 || $product['quantity'] - $this->getQuantityWanted() < 0)
         ) {
             $shouldEnable = false;
         }
@@ -1213,22 +1209,74 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * @return int Quantity of product requested by the customer
+     * Gets the quantity wanted by the customer for the product. We will take his request,
+     * but we will adjust it if it's lower than the required quantity.
+     *
+     * @return int Quantity of product requested by the customer, altered if needed, always a positive integer
      */
     private function getQuantityWanted()
     {
-        return (int) Tools::getValue(
-            'quantity_wanted',
-            $this->product['quantity_wanted'] ?? 1
-        );
+        if (empty($this->product['quantity_wanted'])) {
+            // Get the quantity wanted from the request
+            $quantityWantedByTheCustomer = (int) Tools::getValue('quantity_wanted', 1);
+
+            // Get minimal required quantity for purchase
+            $requiredQuantityForPurchase = $this->getRequiredQuantity();
+
+            if ($quantityWantedByTheCustomer < $requiredQuantityForPurchase) {
+                $quantityWantedByTheCustomer = $requiredQuantityForPurchase;
+            }
+
+            $this->product['quantity_wanted'] = $quantityWantedByTheCustomer;
+        }
+
+        return $this->product['quantity_wanted'];
     }
 
     /**
-     * @return int Minimal quantity of product requested by the customer
+     * Gets the minimal quantity the customer has to purchase. We cannot just let him buy 1 piece
+     * if the minimal quantity is higher. Also, we adjust it by the quantity already in cart.
+     *
+     * @return int Minimal quantity of product the customer buy right now, always a positive integer
+     */
+    protected function getRequiredQuantity()
+    {
+        // For the required quantity, we will need to limit it by the minimal quantity on the low side.
+        $requiredQuantityForPurchase = $this->getMinimalQuantity();
+
+        /*
+         * We reduce it by the quantity we already have in cart. If the user already has a sufficient
+         * quantity in the cart, we don't need to add more. Although it may seem that we can just reset
+         * the minimal quantity to one in that case, we must not do that, because the quantity in the cart
+         * may not be the correct one.
+         */
+        if (!empty($this->product['cart_quantity'])) {
+            $requiredQuantityForPurchase -= $this->product['cart_quantity'];
+            if ($requiredQuantityForPurchase < 1) {
+                $requiredQuantityForPurchase = 1;
+            }
+        }
+
+        return $requiredQuantityForPurchase;
+    }
+
+    /**
+     * Gets the minimal quantity allowed for the product or its combination. With no adjustments
+     * by the current context. The builder of this object is responsible for passing the correct
+     * minimal quantity depending on the combination selected.
+     *
+     * @return int Minimal quantity of product from it's settings, always a positive integer
      */
     private function getMinimalQuantity()
     {
-        return (int) $this->product['minimal_quantity'];
+        $minimalQuantity = (int) $this->product['minimal_quantity'];
+
+        // If we received faulty data, we correct it to 1
+        if ($minimalQuantity < 1) {
+            $minimalQuantity = 1;
+        }
+
+        return $minimalQuantity;
     }
 
     /**

--- a/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
+++ b/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
@@ -94,6 +94,7 @@ class ProductLazyArrayTest extends TestCase
         'out_of_stock' => OutOfStockType::OUT_OF_STOCK_DEFAULT,
         'customizable' => 0,
         'active' => 1,
+        'minimal_quantity' => 1,
     ];
 
     private const PRODUCT_DISCONTINUED = 'This product is no longer available for sale.';


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Completely fixes all issues with availability, quantities, quantity inputs, add to cart buttons, especially in case of products with minimal quantities. It should be a bulletproof solution, I tried to break it in all kinds of ways imaginable.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Use scenarios below.
| UI Tests          |  ✅https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/21133027941
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/40531, Fixes https://github.com/PrestaShop/PrestaShop/issues/40539, Fixes https://github.com/PrestaShop/PrestaShop/issues/40541, Fixes https://github.com/PrestaShop/PrestaShop/issues/40495
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### Basic information
- First, it fixes label issue when products are in the cart here - https://github.com/PrestaShop/PrestaShop/issues/40531. This problem was caused by `quantity_wanted` being reset to zero [from some previous PRs in 8.1.7](https://github.com/PrestaShop/PrestaShop/pull/35902). It caused issues with label calculation down the line. This value MUST contain the quantity the user wants, for many reasons.
- Then, I discovered that by removing this hacky code, quantity input broke again, so I put my focus on it. So I discovered its even more broken, if the product is partially in cart. So I described it here in https://github.com/PrestaShop/PrestaShop/issues/40541 and also fixed it.
- When I was changing to proper quantity value from deprecated `$product->quantity` to `$product['quantity']`, I acccidentaly discovered and fixed https://github.com/PrestaShop/PrestaShop/issues/40539. The deprecated value on the product object does not contain proper stock for packs.
- Then, I also fixed the issue with the add to cart button status - https://github.com/PrestaShop/PrestaShop/issues/40495. I added all of these fixes to lazy array, prepared it there, used it and the issue fixed itself.

### Information to establish before reviewing this PR
- You need 4 different amounts if you want to properly distinguish everything. We partially had them, but as an intermediate calculations.
  - `quantity` or `stock_quantity` - what you have in stock, after reducing the amount of products in cart
  - `minimal_quantity` - minimal quantity the customer can buy, configured on the product
  - `quantity_required` - minimal quantity the customer can buy, after adjusting for amount currently in cart, can be as well 1
  - `quantity_wanted` - quantity the customer wants to buy, adjusted for `quantity_required`

### Theme changes required for full functionality
- https://github.com/PrestaShop/classic-theme/pull/189
- https://github.com/PrestaShop/hummingbird/pull/902
- The change does two things:
  - It unifies both themes to use a proper value. Hummingbird used `minimal_quantity` for the current value, which is not correct. Set it to `quantity_wanted` like it should be.
  - Then, it changes the value used for minimal value. There was no proper value to be used, so I now pass `quantity_required`.
    - You cannot use 1, because you need to account for minimal quantity.
    - You cannot use minimal quantity, because you need to alter this boundary if the product is already in the cart.
    - You cannot just switch between minimal quantity and 1, because there could be a state when the product is in cart, but not in sufficient amount.
    - You cannot use minimal quantity and alter it, because you would break the value for other places on the page, like the information message.

# How to test https://github.com/PrestaShop/PrestaShop/issues/40531 + https://github.com/PrestaShop/PrestaShop/issues/40495
- Use classic theme.
- BO > Shop settings > Product settings > Products stock > Display remaining quantities when the quantity is lower than - 3
- BO > Shop settings > Product settings > Products stock > Label of in-stock products, out of stock products - filled in.
- BO > Shop settings > Product settings > Products stock > Allow ordering out of stock products - false.
- Create products:
  - Product normal, min quantity 1:
    - in stock 5
    - min quantity 1
  - Product normal, minimum quantity 3:
    - in stock 5
    - min quantity 3
  - Product combination:
    - Combination One
      -  in stock 5
      - min quantity 1
    - Combination Three
      -  in stock 5
      - min quantity 3
- Add following to cart, everything 3 times.
    - 3x Product normal, min quantity 1
    - 3x Product normal, minimum quantity 3
    - 3x Product combination, Combination One
    - 3x Product combination, Combination Three

### Before
| Product                                | Quantity | Label | Button status |
|----------------------------------------|-----------------|-------|---------------|
| Product normal, min quantity 1         | 1               |  Last quantities in stock ✅ | Allowed ✅ |
| Product normal, min quantity 1         | 2               |  Last quantities in stock ✅ | Allowed ✅ |
| Product normal, min quantity 1         | 3               |  Last quantities in stock 🔴  |  Blocked ✅ |
| Product normal, min quantity 1         | 4               |  Not enough products in stock ✅ | Blocked ✅ |
| Product normal, minimum quantity 3     | 1               |  Last quantities in stock ✅ | Blocked 🔴 |
| Product normal, minimum quantity 3     | 2               |  Last quantities in stock ✅ |  Blocked 🔴 |
| Product normal, minimum quantity 3     | 3               |  Last quantities in stock 🔴 | Blocked ✅ |
| Product normal, minimum quantity 3     | 4               |  Not enough products in stock ✅ | Blocked ✅ |
| Product combination, Combination One   | 1               |  Last quantities in stock ✅ | Allowed ✅ |
| Product combination, Combination One   | 2              |  Last quantities in stock ✅ | Allowed ✅ |
| Product combination, Combination One   | 3               |  Last quantities in stock 🔴 | Blocked ✅ |
| Product combination, Combination One   | 4               |  Not enough products in stock ✅ | Blocked ✅ |
| Product combination, Combination Three | 1              |  Last quantities in stock ✅ | Blocked 🔴 |
| Product combination, Combination Three | 2              |  Last quantities in stock ✅ | Blocked 🔴 |
| Product combination, Combination Three | 3              |  Last quantities in stock 🔴 | Blocked ✅ |
| Product combination, Combination Three | 4              |  Not enough products in stock ✅ | Blocked ✅ |

### After
| Product                                | Quantity | Label | Button status |
|----------------------------------------|-----------------|-------|---------------|
| Product normal, min quantity 1         | 1               |  Last quantities in stock ✅ | Allowed ✅ |
| Product normal, min quantity 1         | 2               |  Last quantities in stock ✅ | Allowed ✅ |
| Product normal, min quantity 1         | 3               |  Not enough products in stock ✅ | Blocked ✅ |
| Product normal, min quantity 1         | 4               |  Not enough products in stock ✅ | Blocked ✅ |
| Product normal, minimum quantity 3     | 1               |  Last quantities in stock ✅ |  Allowed ✅ |
| Product normal, minimum quantity 3     | 2               |  Last quantities in stock ✅ |   Allowed ✅ |
| Product normal, minimum quantity 3     | 3               |  Not enough products in stock ✅ |  Blocked ✅ |
| Product normal, minimum quantity 3     | 4               |  Not enough products in stock ✅ |  Blocked ✅ |
| Product combination, Combination One   | 1               |  Last quantities in stock ✅ |  Allowed ✅ |
| Product combination, Combination One   | 2              |  Last quantities in stock ✅ |  Allowed ✅ |
| Product combination, Combination One   | 3               |  Not enough products in stock ✅ |  Blocked ✅ |
| Product combination, Combination One   | 4               |  Not enough products in stock ✅ |  Blocked ✅ |
| Product combination, Combination Three | 1              |  Last quantities in stock ✅ | Allowed ✅ |
| Product combination, Combination Three | 2              |  Last quantities in stock ✅ |  Allowed ✅ |
| Product combination, Combination Three | 3              |  Not enough products in stock ✅ |  Blocked ✅ |
| Product combination, Combination Three | 4              |  Not enough products in stock ✅ |  Blocked ✅ |

# How to test https://github.com/PrestaShop/PrestaShop/issues/40539
- Create product A, quantity in stock 1.
- Create product B, quantity in stock 1.
- Create pack A, composed of product A and product B, pack has it's own quantity 1.
- Create pack B, composed of product A and product B, pack depends on products inside - it's own quantity is 0.
- Enable "display quantity on product page" in prestashop settings.

Before
- See that Product A shows 1 piece, Product B shows 1 piece, Pack A shows 1 piece, but Pack B doesn't show anything. 🔴

After
- See that both Pack A and Pack B show 1 Item in stock on product page. ✅

# How to test https://github.com/PrestaShop/PrestaShop/issues/40541

- Create Product A, min quantity 1, in stock 5.
- Go to FO to this product, add it to cart.
- Change minimum quantity of this product to 3.
- Go back to FO to this product

Before
- See that quantity input now shows 3. 🔴

After
- See that quantity input now shows 2. ✅ 
