### PR TITLE
Add support for ServiceEntityRepository in FrontContainer

### DIFF
--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -6,6 +6,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter;
 
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\ORM\Tools\Setup;
 use Exception;
@@ -167,6 +168,7 @@ class ContainerBuilder
 
         $container->addCompilerPass(new LoadServicesFromModulesPass($this->containerName), PassConfig::TYPE_BEFORE_OPTIMIZATION, PrestaShopBundle::LOAD_MODULE_SERVICES_PASS_PRIORITY);
         $container->addCompilerPass(new LegacyCompilerPass());
+        $container->addCompilerPass(new ServiceRepositoryCompilerPass());
 
         // Build extensions
         $builderExtensions = [

--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter;
 
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\ORM\Tools\Setup;
 use Exception;
@@ -186,6 +187,7 @@ class ContainerBuilder
 
         $container->addCompilerPass(new LoadServicesFromModulesPass($this->containerName), PassConfig::TYPE_BEFORE_OPTIMIZATION, PrestaShopBundle::LOAD_MODULE_SERVICES_PASS_PRIORITY);
         $container->addCompilerPass(new LegacyCompilerPass());
+        $container->addCompilerPass(new ServiceRepositoryCompilerPass());
 
         // Build extensions
         $builderExtensions = [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allow ServiceEntityRepository to be used in front. Adds the ServiceRepositoryCompilerPass to the FrontContainer builder.
| Type?             | bug fix 
| Category?         | CO 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Install the module 'test_servicerepo' provided with this PR 
| UI Tests          | No UI changes
| Fixed issue or discussion?     | Fixes #40551
| Related PRs       | None
| Sponsor company   | Novius

[test_servicerepo.zip](https://github.com/user-attachments/files/24716805/test_servicerepo.zip)
