### PR TITLE
Fix: always display taxes total in order summary

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -215,14 +215,12 @@
           </div>
         </div>
 
-        {% if not orderForViewing.taxIncluded %}
-          <div class="col-sm text-center">
-            <p class="text-muted mb-0">
-              <strong>{{ 'Taxes'|trans({}, 'Admin.Global') }}</strong>
-            </p>
-            <strong id="orderTaxesTotal">{{ orderForViewing.prices.taxesAmountFormatted }}</strong>
-          </div>
-        {% endif %}
+        <div class="col-sm text-center">
+          <p class="text-muted mb-0">
+            <strong>{{ 'Taxes'|trans({}, 'Admin.Global') }}</strong>
+          </p>
+          <strong id="orderTaxesTotal">{{ orderForViewing.prices.taxesAmountFormatted }}</strong>
+        </div>
 
         <div class="col-sm text-center">
           <p class="text-muted mb-0">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR fixes an issue in the Back Office order view where the **tax/VAT total** was hidden when the customer group used “**Price display method = Tax included**”.<br>The tax summary is an important administrative value and should be visible regardless of how prices are displayed for the customer group.<br>With this change, the **Taxes** block is always displayed in the order totals summary.
| Type?             | bug fix
| Category?         |BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to **Shop parameters > Customer Settings > Groups**<br/>2. Edit the **Customer** group<br/>3. Set **Price display method** to **Tax included**<br/>4. Open **Order ID 1**<br/>5. You should see **Taxes** displayed as shown in the screenshot<br/>6. Go back to **Shop parameters > Customer Settings > Groups**<br/>7. Edit the **Customer** group again<br/>8. Set **Price display method** to **Tax excluded**<br/>9. Open **Order ID 1** again<br/>10. You should see **Taxes** displayed as shown in the screenshot<br/>
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/21165017220
| Fixed issue or discussion?     | Fixes #40553
| Related PRs       | 
| Sponsor company   | codencode snc


<img width="1107" height="450" alt="Screenshot 2026-01-19 at 15-29-33 Orders Order KHWLILZLL from John DOE • Codencode" src="https://github.com/user-attachments/assets/b7e6641c-370c-4b45-b383-4bfb9c074d7c" />

