### PR TITLE
Fix: CsvFileReader service fails with "You have requested a non-existent service 'session'"

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -72,7 +72,7 @@ services:
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ImportEntityFieldChoiceProvider:
     arguments:
       - '@=service("prestashop.core.import.fields_provider_finder")'
-      - '@=service("session").get("entity")'
+      - '@=service("request_stack").getSession().get("entity")'
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ThemePageLayoutsChoiceProvider:
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/import.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/import.yml
@@ -59,7 +59,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Import\File\CsvFileReader'
     arguments:
       - '@prestashop.adapter.import.file_opener'
-      - '@=service("prestashop.core.import.normalizer.csv_value_separator").normalize(service("session").get("separator"))'
+      - '@=service("prestashop.core.import.normalizer.csv_value_separator").normalize(service("request_stack").getSession().get("separator"))'
 
   prestashop.core.import.data_row.presenter:
     class: 'PrestaShop\PrestaShop\Core\Import\File\DataRow\DataRowPresenter'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.0.x
| Description?      | This PR fixes an issue in the `prestashop.core.import.csv_file_reader` service definition where the `session` service was accessed directly, causing a `"You have requested a non-existent service 'session'"` error in certain contexts. <br/>The service definition has been updated to retrieve the session via `RequestStack`.<br/>This issue did not occur in PrestaShop 8 because the `session` service was still available. <br/> Starting from **Symfony 5.3**, the direct `session` service has been deprecated and later removed in favor of accessing the session through `RequestStack`. <br/>See: https://symfony.com/blog/new-in-symfony-5-3-session-service-deprecation
| Type?             | bug fix
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install the module [issue_csvfilereader.zip](https://github.com/user-attachments/files/24719955/issue_csvfilereader.zip)<br/> 2. Go to the module configuration page<br/>3. You should no longer see the error.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/21164990174
| Fixed issue or discussion?     | Fixes #40555
| Related PRs       | 
| Sponsor company   | @Codencode 
