### PR TITLE
Prevent accidental usage of quantity_wanted from request

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5466,8 +5466,14 @@ class ProductCore extends ObjectModel
             return array_merge($row, self::$productPropertiesCache[$cache_key]);
         }
 
+        /*
+         * Now, to get proper prices, we need to calculate them for a specific quantity, because
+         * there can be quantity discount. The variable to use is different for different contexts.
+         * If a specific quantity_wanted is set, we use it. Usually a product page.
+         * If cart_quantity is defined, we use it. Usually cart context.
+         * Otherwise, we use minimal_quantity, if nothing was passed - on listings.
+         */
         if (isset($row['quantity_wanted'])) {
-            // 'quantity_wanted' may very well be zero even if set
             $quantityToUseForPriceCalculations = max((int) $row['minimal_quantity'], (int) $row['quantity_wanted']);
         } elseif (isset($row['cart_quantity'])) {
             $quantityToUseForPriceCalculations = max((int) $row['minimal_quantity'], (int) $row['cart_quantity']);

--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -574,6 +574,7 @@ class CartLazyArray extends AbstractLazyArray
                 $rawProduct['total']
         );
 
+        // Pass the cart quantity as quantity wanted for proper price calculation
         $rawProduct['quantity_wanted'] = $rawProduct['cart_quantity'];
 
         $presenter = new ProductListingPresenter(

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -439,14 +439,11 @@ class ProductLazyArray extends AbstractLazyArray
     public function getReferenceToDisplay()
     {
         $combinationData = $this->getCombinationSpecificData();
-        if (
-            isset($combinationData['reference'])
-            && !empty($combinationData['reference'])
-        ) {
+        if (!empty($combinationData['reference'])) {
             return $combinationData['reference'];
         }
 
-        if ('' !== $this->product['reference']) {
+        if (!empty($this->product['reference'])) {
             return $this->product['reference'];
         }
 
@@ -1332,10 +1329,6 @@ class ProductLazyArray extends AbstractLazyArray
         $show_availability = $show_price && $settings->stock_management_enabled;
         $this->product['show_availability'] = $show_availability;
 
-        if (!isset($product['quantity_wanted'])) {
-            $product['quantity_wanted'] = $this->getQuantityWanted();
-        }
-
         // Validate and format availability date
         $product['available_date'] = $this->prepareAvailabilityDate($product);
 
@@ -1362,12 +1355,14 @@ class ProductLazyArray extends AbstractLazyArray
             return;
         }
 
-        // Quantity available we will display is reduced by amount we want to add to cart
-        $availableQuantity = $product['quantity'] - $product['quantity_wanted'];
-        if (isset($product['stock_quantity'])) {
-            $availableQuantity =
-                $product['stock_quantity'] - $product['quantity_wanted'];
-        }
+        /*
+         * To define availabiity, we will subtract the stock quantity by the quantity the customer
+         * wants to add to cart. Since this class can be instantiated from multiple places, we need
+         * to make sure we use proper quantity key. Normally, it's 'quantity', but on cart page,
+         * it's 'stock_quantity'.
+         */
+        $stockQuantity = isset($product['stock_quantity']) ? $product['stock_quantity'] : $product['quantity'];
+        $availableQuantity = $stockQuantity - $this->getQuantityWanted();
 
         // Combination labels
         $combinationData = $this->getCombinationSpecificData();

--- a/src/Adapter/Presenter/Product/ProductListingLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductListingLazyArray.php
@@ -65,4 +65,21 @@ class ProductListingLazyArray extends ProductLazyArray
 
         return parent::shouldEnableAddToCartButton($product, $settings);
     }
+
+    /**
+     * Returns the quantity wanted value for products in listings. We have this specific implementation
+     * because in listings, the quantity wanted is not to be taken from the request directly.
+     * If a specific value was already provided, we use it. For example, in cart context.
+     *
+     * @return int Quantity wanted, usually 1, altered if needed, always a positive integer
+     */
+    #[LazyArrayAttribute(arrayAccess: true)]
+    public function getQuantityWanted()
+    {
+        if (empty($this->product['quantity_wanted'])) {
+            $this->product['quantity_wanted'] = $this->getQuantityRequired();
+        }
+
+        return $this->product['quantity_wanted'];
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Adds some last code to prevents accidental usage of `quantity_wanted` in the request for other products on the product page. Added some stabilization fixes and comments to ProductLazyArray also. `if (!isset($product['quantity_wanted'])) {` is not needed - `getQuantityWanted` does it. `$this->getQuantityWanted()` is a better source of truth.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Just automatic test, not sure if there is anything to test.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/21320348611 🟢 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/40561
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### How to reproduce a potential problem
- Use current 9.0.x branch and hummingbird.
- Create product `Krystian A`, 5 in stock, OOSP disabled, price 100
- Create product `Krystian B`, 5 in stock, OOSP disabled, price 100
- Assign `Krystian B` as accessory to `Krystian A`
- Go to `Krystian A` in FO.
- See in related products, you have add to cart button on the miniature of `Krystian B`.
- Add `?quantity_wanted=10` to the end of the URL. If something, it should affect only the product page, but it affects all products, even all the miniatures. 🔴 
- If you move the accessories block into any live theme block, for example, into `<div class="product__additional-info js-product-additional-info">`, you can also reproduce it just by clicking on +- arrows on the main product. 🔴
- With this PR, it doesn't happen. 🟢 

<img width="969" height="546" alt="buggggg" src="https://github.com/user-attachments/assets/8123066c-a6da-491c-97da-5054cc6def94" />