### PR TITLE
Add feature during theme enabling to unhook specific modules

### DIFF
--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -181,6 +181,7 @@ class ThemeManager implements AddonManagerInterface
                 ->doEnableModules($theme->getModulesToEnable())
                 ->doResetModules($theme->get('global_settings.modules.to_reset', []))
                 ->doApplyImageTypes($theme->get('global_settings.image_types', []))
+                ->doUnhookModules($theme->get('global_settings.hooks.modules_to_unhook', []))
                 ->doHookModules($theme->get('global_settings.hooks.modules_to_hook', []));
 
             $theme->onEnable();
@@ -378,6 +379,18 @@ class ThemeManager implements AddonManagerInterface
     private function doHookModules(array $hooks): self
     {
         $this->hookConfigurator->setHooksConfiguration($hooks);
+
+        return $this;
+    }
+
+    /**
+     * @param array $hooks
+     *
+     * @return self
+     */
+    private function doUnhookModules(array $hooks): self
+    {
+        $this->hookConfigurator->unhookModules($hooks);
 
         return $this;
     }

--- a/src/Core/Module/HookConfigurator.php
+++ b/src/Core/Module/HookConfigurator.php
@@ -123,6 +123,30 @@ class HookConfigurator
         return $this;
     }
 
+    public function unhookModules(array $removedHooks): self
+    {
+        $cleanHooks = [];
+        foreach ($removedHooks as $hookName => $moduleNames) {
+            foreach ($moduleNames as $moduleName) {
+                if (null === $moduleName) {
+                    $cleanHooks[$hookName][] = $moduleName;
+                    continue;
+                }
+
+                if ($this->moduleManager && !$this->moduleManager->isOnDisk($moduleName)) {
+                    $this->logger?->warning(sprintf('Module %s was removed from disk, no need to unhook it', $moduleName));
+                    continue;
+                }
+                $cleanHooks[$hookName][] = $moduleName;
+            }
+        }
+        if (!empty($cleanHooks)) {
+            $this->hookRepository->unHookModules($cleanHooks);
+        }
+
+        return $this;
+    }
+
     private function getUniqueModuleToHookList(array $hooks)
     {
         $list = [];

--- a/src/Core/Module/HookRepository.php
+++ b/src/Core/Module/HookRepository.php
@@ -114,6 +114,32 @@ class HookRepository
         return $this;
     }
 
+    public function unHookSpecificModuleFromHook(string $hookName, string $moduleName): self
+    {
+        $hookId = $this->getIdByName($hookName);
+        if (!$hookId) {
+            return $this;
+        }
+        $moduleId = $this->getIdModule($moduleName);
+        if (!$moduleId) {
+            return $this;
+        }
+        $shopId = (int) $this->shop->id;
+        if (!$shopId) {
+            return $this;
+        }
+
+        $this->db->execute("DELETE FROM {$this->db_prefix}hook_module
+             WHERE id_hook = $hookId AND id_shop = $shopId AND id_module = $moduleId
+        ");
+
+        $this->db->execute("DELETE FROM {$this->db_prefix}hook_module_exceptions
+            WHERE id_hook = $hookId AND id_shop = $shopId AND id_module = $moduleId
+        ");
+
+        return $this;
+    }
+
     /**
      * Saves hook settings for a list of hooks.
      * The $hooks array should have this format:
@@ -177,6 +203,27 @@ class HookRepository
                         $id_hook,
                         $extra_data['except_pages']
                     );
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    public function unHookModules(array $modulesToUnhook): self
+    {
+        foreach ($modulesToUnhook as $hookName => $moduleNames) {
+            $hookId = $this->getIdByName($hookName);
+            if (!$hookId) {
+                continue;
+            }
+
+            foreach ($moduleNames as $moduleName) {
+                // Null matches all hooked modules, so we remove all modules for this hook
+                if (null === $moduleName) {
+                    $this->unHookModulesFromHook($hookName);
+                } elseif (is_string($moduleName)) {
+                    $this->unHookSpecificModuleFromHook($hookName, $moduleName);
                 }
             }
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Add feature during theme enabling to unhook specific modules via the `global_settings.hooks.modules_to_unhook` configuration
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green, UI tests green Use a module and add the configuration `global_settings.hooks.modules_to_unhook configuration` to test removing one module from a hook, and test with the `~` value to remove all modules as well
| UI Tests          | 
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~

### Example of config to test

```yaml
name: hummingbird
display_name: Hummingbird
version: 2.0.0
author:
  name: "PrestaShop Team and Contributors"
  email: "pub@prestashop.com"
  url: "https://www.prestashop-project.org/"

meta:
  compatibility:
    from: 9.0.0
    to: ~
    framework: bootstrap-v5.3.3

  available_layouts:
    layout-full-width:
      name: Full Width
      description: No side columns, ideal for distraction-free pages such as product pages.
    layout-both-columns:
      name: Three Columns
      description: One large central column and 2 side columns.
    layout-left-column:
      name: Two Columns, small left column
      description: Two columns with a small left column
    layout-right-column:
      name: Two Columns, small right column
      description: Two columns with a small right column

global_settings:
  configuration:
    PS_IMAGE_QUALITY: png
    HOME_FEATURED_NBR: 4
    NEW_PRODUCTS_NBR: 4
    BLOCKSPECIALS_SPECIALS_NBR: 4
    PS_BLOCK_BESTSELLERS_TO_DISPLAY: 4
    PSR_ICON_COLOR: "#0b69f6"
    PSR_TEXT_COLOR: "#212529"
  modules:
    to_enable:
      - ps_linklist
    to_disable:
      - blockwishlist
  hooks:
    modules_to_unhook:
      displayHome:
        - ps_imageslider
        - module_not_found
      displayFooter:
        - ~
    modules_to_hook:
      displayCustomerAccount:
        - psgdpr
      displayNav1:
        - ps_contactinfo
      displayNav2:
        - ps_languageselector
        - ps_currencyselector
        - ps_customersignin
        - ps_shoppingcart
      displayTop:
        - ps_mainmenu
        - ps_searchbar
      displayHome:
        - ps_customtext
        - ps_featuredproducts
        - ps_banner
        - ps_newproducts
        - ps_bestsellers
      displayFooterBefore:
        - ps_socialfollow
        - ps_emailsubscription
      displayFooter:
        - ps_linklist
        - ps_customeraccountlinks
        - ps_contactinfo
      displayFooterProduct:
        - productcomments
      displayLeftColumn:
        - ps_categorytree
        - ps_facetedsearch
      displayContactLeftColumn:
        - ps_contactinfo
      displayContactRightColumn:
        - ps_contactinfo
      displayContactContent:
        - contactform
      displaySearch:
        - ps_searchbar
      displayProductAdditionalInfo:
        - ps_sharebuttons
        - productcomments
      displayProductListReviews:
        - productcomments
      displayOrderConfirmation2:
        - ps_featuredproducts
      displayCrossSellingShoppingCart:
        - ps_featuredproducts

  image_types:
    cart_default:
      width: 125
      height: 125
      scope: [products]
    small_default:
      width: 98
      height: 98
      scope: [products, categories, manufacturers, suppliers]
    medium_default:
      width: 452
      height: 452
      scope: [products, manufacturers, suppliers]
    large_default:
      width: 800
      height: 800
      scope: [products, manufacturers, suppliers]
    home_default:
      width: 250
      height: 250
      scope: [products]
    category_default:
      width: 141
      height: 180
      scope: [categories]
    stores_default:
      width: 287
      height: 160
      scope: [stores]
    default_xs:
      width: 160
      height: 160
      scope: [products, manufacturers, suppliers, categories]
    default_sm:
      width: 216
      height: 216
      scope: [categories, products]
    default_md:
      width: 261
      height: 261
      scope: [manufacturers, suppliers, products, categories]
    default_lg:
      width: 336
      height: 336
      scope: [categories, products]
    default_xl:
      width: 400
      height: 400
      scope: [products]
    product_main:
      width: 720
      height: 720
      scope: [products]
    category_cover:
      width: 1000
      height: 200
      scope: [categories]
    product_main_2x:
      width: 1440
      height: 1440
      scope: [products]
    category_cover_2x:
      width: 2000
      height: 400
      scope: [categories]

theme_settings:
  rtl_generation: false
  default_layout: layout-full-width
  layouts:
    category: layout-left-column
    best-sales: layout-left-column
    new-products: layout-left-column
    prices-drop: layout-left-column
    contact: layout-left-column
    manufacturer: layout-left-column
    supplier: layout-left-column
```