### PR TITLE
Dynamic pack quantity

### DIFF
--- a/src/Adapter/Product/Grid/Data/Factory/ProductGridDataFactoryDecorator.php
+++ b/src/Adapter/Product/Grid/Data/Factory/ProductGridDataFactoryDecorator.php
@@ -31,12 +31,14 @@ namespace PrestaShop\PrestaShop\Adapter\Product\Grid\Data\Factory;
 use Currency;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
+use PrestaShop\PrestaShop\Adapter\Product\Pack\Repository\ProductPackRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Adapter\Shop\Repository\ShopRepository;
 use PrestaShop\PrestaShop\Adapter\Tax\TaxComputer;
 use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\ValueObject\TaxRulesGroupId;
 use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
@@ -135,7 +137,8 @@ class ProductGridDataFactoryDecorator implements GridDataFactoryInterface
         bool $isEcotaxEnabled,
         int $ecoTaxGroupId,
         ShopRepository $shopRepository,
-        ProductRepository $productRepository
+        ProductRepository $productRepository,
+        private ProductPackRepository $productPackRepository,
     ) {
         $this->productGridDataFactory = $productGridDataFactory;
 
@@ -239,6 +242,23 @@ class ProductGridDataFactoryDecorator implements GridDataFactoryInterface
                 (string) $priceTaxIncluded,
                 $currency->iso_code
             );
+
+            $productType = $products[$i]['product_type'] ?? null;
+            // For pack products we dynamically update the quantity in the column so that it reflects its quantity based on
+            // its configuration and the quantity of its products. Since it's done in the decorator the dynamic quantity is not
+            // consistent with sorting and filtering Including this complexity in the query builder would cost too much in performance
+            // and would be too complex so it's a compromise
+            if ($productType === ProductType::TYPE_PACK) {
+                if ($searchCriteria->getShopConstraint()->getShopId() !== null) {
+                    $shopId = $searchCriteria->getShopConstraint()->getShopId();
+                } else {
+                    $shopId = new ShopId((int) $products[$i]['id_shop_default']);
+                }
+                $packQuantity = $this->productPackRepository->getDynamicPackQuantity(new ProductId($products[$i]['id_product']), $shopId);
+                if (null !== $packQuantity) {
+                    $products[$i]['quantity'] = $packQuantity;
+                }
+            }
         }
 
         return $this->applyShopModifications($products, $searchCriteria);

--- a/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
+++ b/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
@@ -30,15 +30,23 @@ namespace PrestaShop\PrestaShop\Adapter\Product\Pack\Repository;
 
 use Doctrine\DBAL\Connection;
 use Pack;
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\NoCombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Exception\ProductPackException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\QuantifiedProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\StockAvailableNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\InvalidShopConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
 use PrestaShopException;
@@ -58,7 +66,10 @@ class ProductPackRepository extends AbstractObjectModelRepository
 
     public function __construct(
         Connection $connection,
-        string $dbPrefix
+        string $dbPrefix,
+        private ProductRepository $productRepository,
+        private ConfigurationInterface $configuration,
+        private StockAvailableRepository $stockAvailableRepository,
     ) {
         $this->connection = $connection;
         $this->dbPrefix = $dbPrefix;
@@ -204,6 +215,78 @@ class ProductPackRepository extends AbstractObjectModelRepository
         return array_map(function (array $packData) {
             return new PackId((int) $packData['id_product_pack']);
         }, $packs);
+    }
+
+    public function getDynamicPackQuantity(ProductId $productId, ShopId $shopId): ?int
+    {
+        $product = $this->productRepository->get($productId, $shopId);
+        if ($product->getProductType() !== ProductType::TYPE_PACK) {
+            return null;
+        }
+
+        $packQuantity = null;
+
+        // First, get pack stock type
+        $packStockType = (int) $product->pack_stock_type;
+        if ($packStockType === PackStockType::STOCK_TYPE_DEFAULT) {
+            $packStockType = (int) $this->configuration->get('PS_PACK_STOCK_TYPE');
+        }
+
+        // Now get quantity based on the pack stock type
+        if ($packStockType === PackStockType::STOCK_TYPE_PACK_ONLY) {
+            try {
+                $stockAvailable = $this->stockAvailableRepository->getForProduct($productId, $shopId);
+                $packQuantity = $stockAvailable->quantity;
+            } catch (StockAvailableNotFoundException) {
+                $packQuantity = 0;
+            }
+        } elseif ($packStockType === PackStockType::STOCK_TYPE_PRODUCTS_ONLY || $packStockType === PackStockType::STOCK_TYPE_BOTH) {
+            $packedItems = $this->getPackedProducts(
+                new PackId((int) $product->id),
+                new LanguageId((int) $this->configuration->get('PS_LANG_DEFAULT')),
+                ShopConstraint::shop($shopId->getValue())
+            );
+
+            // Compute minimum quantity based on products
+            $productsMinQuantity = null;
+            foreach ($packedItems as $packedItem) {
+                $packedItemProductId = (int) $packedItem['id_product_item'];
+                $packedItemCombinationId = (int) $packedItem['id_product_attribute_item'];
+                $packedItemQuantity = (int) $packedItem['quantity'];
+                try {
+                    if (empty($packedItemCombinationId)) {
+                        $packedItemStockAvailable = $this->stockAvailableRepository->getForProduct(new ProductId($packedItemProductId), $shopId);
+                    } else {
+                        $packedItemStockAvailable = $this->stockAvailableRepository->getForCombination(new CombinationId($packedItemCombinationId), $shopId);
+                    }
+
+                    $packedItemStock = $packedItemStockAvailable->quantity;
+                } catch (StockAvailableNotFoundException) {
+                    $packedItemStock = 0;
+                }
+
+                // Depending on the quantity required in the packs the amount of possible pack is impacted
+                $availablePackUnits = (int) floor($packedItemStock / $packedItemQuantity);
+                if ($productsMinQuantity === null) {
+                    $productsMinQuantity = $availablePackUnits;
+                } else {
+                    $productsMinQuantity = min($productsMinQuantity, $availablePackUnits);
+                }
+            }
+
+            if ($packStockType === PackStockType::STOCK_TYPE_PRODUCTS_ONLY) {
+                $packQuantity = $productsMinQuantity;
+            } else {
+                try {
+                    $stockAvailable = $this->stockAvailableRepository->getForProduct($productId, $shopId);
+                    $packQuantity = min($productsMinQuantity, (int) $stockAvailable->quantity);
+                } catch (StockAvailableNotFoundException) {
+                    $packQuantity = 0;
+                }
+            }
+        }
+
+        return $packQuantity;
     }
 
     /**

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Adapter\Category\Repository\CategoryRepository;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
 use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Pack\Repository\ProductPackRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Adapter\Product\SpecificPrice\Repository\SpecificPriceRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository;
@@ -182,7 +183,8 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
         ProductImagePathFactory $productImageUrlFactory,
         SpecificPriceRepository $specificPriceRepository,
         Configuration $configuration,
-        CategoryDisplayNameBuilder $categoryDisplayNameBuilder
+        CategoryDisplayNameBuilder $categoryDisplayNameBuilder,
+        private ProductPackRepository $packRepository,
     ) {
         $this->numberExtractor = $numberExtractor;
         $this->productRepository = $productRepository;
@@ -209,10 +211,11 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
             $query->getProductId(),
             $query->getShopConstraint()
         );
+        $productType = $product->getProductType();
 
         return new ProductForEditing(
             (int) $product->id,
-            $product->getProductType(),
+            $productType,
             (bool) $product->active,
             $this->getCustomizationOptions($product),
             $this->getBasicInformation($product),
@@ -223,7 +226,7 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
             $this->getShippingInformation($product),
             $this->getSeoOptions($product),
             $this->getAttachments($query->getProductId()),
-            $this->getProductStockInformation($product),
+            $this->getProductStockInformation($product, $query->getShopConstraint()),
             $this->getVirtualProductFile($product),
             $this->getCover($query->getProductId(), $product->getShopId()),
             array_map(fn (ShopId $shopId) => $shopId->getValue(), $this->productRepository->getAssociatedShopIds($query->getProductId()))
@@ -508,16 +511,21 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
      * Returns the product stock infos, it's important that the Product is fetched with stock data
      *
      * @param Product $product
+     * @param ShopConstraint $shopConstraint
      *
      * @return ProductStockInformation
      */
-    private function getProductStockInformation(Product $product): ProductStockInformation
+    private function getProductStockInformation(Product $product, ShopConstraint $shopConstraint): ProductStockInformation
     {
         try {
             $stockAvailable = $this->stockAvailableRepository->getForProduct(new ProductId($product->id), new ShopId($product->getShopId()));
         } catch (StockAvailableNotFoundException) {
             $stockAvailable = $this->stockAvailableRepository->createStockAvailable(new ProductId($product->id), new ShopId($product->getShopId()));
         }
+
+        // Compute pack quantity based on its configuration
+        $shopId = $shopConstraint->getShopId() !== null ? $shopConstraint->getShopId() : new ShopId($product->getShopId());
+        $packQuantity = $this->packRepository->getDynamicPackQuantity(new ProductId((int) $product->id), $shopId);
 
         return new ProductStockInformation(
             (int) $product->pack_stock_type,
@@ -529,7 +537,8 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
             $product->available_now,
             $product->available_later,
             $stockAvailable->location,
-            DateTimeUtil::buildDateTimeOrNull($product->available_date)
+            DateTimeUtil::buildDateTimeOrNull($product->available_date),
+            $packQuantity,
         );
     }
 

--- a/src/Core/Domain/Product/QueryResult/ProductStockInformation.php
+++ b/src/Core/Domain/Product/QueryResult/ProductStockInformation.php
@@ -85,6 +85,8 @@ class ProductStockInformation
      */
     private $availableDate;
 
+    private ?int $packQuantity;
+
     /**
      * @param int $packStockType
      * @param int $outOfStockType
@@ -96,6 +98,7 @@ class ProductStockInformation
      * @param array $localizedAvailableLaterLabels
      * @param string $location
      * @param DateTimeInterface|null $availableDate
+     * @param int|null $packQuantity
      */
     public function __construct(
         int $packStockType,
@@ -107,7 +110,8 @@ class ProductStockInformation
         array $localizedAvailableNowLabels,
         array $localizedAvailableLaterLabels,
         string $location,
-        ?DateTimeInterface $availableDate
+        ?DateTimeInterface $availableDate,
+        ?int $packQuantity = null,
     ) {
         $this->packStockType = $packStockType;
         $this->outOfStockType = $outOfStockType;
@@ -119,6 +123,7 @@ class ProductStockInformation
         $this->localizedAvailableNowLabels = $localizedAvailableNowLabels;
         $this->localizedAvailableLaterLabels = $localizedAvailableLaterLabels;
         $this->availableDate = $availableDate;
+        $this->packQuantity = $packQuantity;
     }
 
     /**
@@ -199,5 +204,15 @@ class ProductStockInformation
     public function getAvailableDate(): ?DateTimeInterface
     {
         return $this->availableDate;
+    }
+
+    /**
+     * Dynamic quantity of the pack based on its config and the quantity of its products
+     *
+     * @return int|null
+     */
+    public function getPackQuantity(): ?int
+    {
+        return $this->packQuantity;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -409,6 +409,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
                     $productForEditing->getProductId(),
                     $shopConstraint
                 ),
+                'pack_quantity' => $productForEditing->getStockInformation()->getPackQuantity(),
                 'minimal_quantity' => $stockInformation->getMinimalQuantity(),
             ],
             'options' => [

--- a/src/Core/Grid/Query/ProductQueryBuilder.php
+++ b/src/Core/Grid/Query/ProductQueryBuilder.php
@@ -94,7 +94,7 @@ class ProductQueryBuilder extends AbstractDoctrineQueryBuilder
     {
         $qb = $this->getQueryBuilder($searchCriteria);
         $qb
-            ->addSelect('p.`id_product`, p.`reference`, p.`id_shop_default`')
+            ->addSelect('p.`id_product`, p.`reference`, p.`id_shop_default`, p.`product_type`')
             ->addSelect('ps.`price` AS `price_tax_excluded`, ps.`ecotax` AS `ecotax_tax_excluded`, ps.`id_tax_rules_group`, ps.`active`')
             ->addSelect('pl.`name`, pl.`link_rewrite`')
             ->addSelect('cl.`name` AS `category`')

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
@@ -31,6 +31,7 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product\Stock;
 use PrestaShopBundle\Form\Admin\Type\DeltaQuantityType;
 use PrestaShopBundle\Form\Admin\Type\EntitySearchInputType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -105,6 +106,7 @@ class QuantityType extends TranslatorAwareType
                         'class' => 'stock-movement-list',
                     ],
                 ])
+                ->add('pack_quantity', HiddenType::class)
             ;
         }
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -27,6 +27,7 @@ services:
     autoconfigure: true
 
   PrestaShop\PrestaShop\Adapter\Product\Grid\Data\Factory\ProductGridDataFactoryDecorator:
+    autowire: true
     arguments:
       - '@prestashop.core.grid.data.factory.product'
       - '@PrestaShop\PrestaShop\Core\Localization\Locale\Repository'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_pack.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_pack.yml
@@ -3,6 +3,7 @@ services:
     public: true
 
   PrestaShop\PrestaShop\Adapter\Product\Pack\Repository\ProductPackRepository:
+    autowire: true
     arguments:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/header-details.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/header-details.html.twig
@@ -68,7 +68,12 @@
 
     {# Only display stock when Stock management is enabled #}
     {% if stockEnabled %}
-      {% set quantityData = productData.stock.quantities.delta_quantity.quantity %}
+      {% if productData.header.type == 'pack' and productData.stock.quantities.pack_quantity is not null %}
+        {% set quantityData = productData.stock.quantities.pack_quantity %}
+      {% else %}
+        {% set quantityData = productData.stock.quantities.delta_quantity.quantity %}
+      {% endif %}
+
       {% if productData.header.type != 'combinations' %}
         {% set lowStock = productData.stock.options.low_stock_threshold %}
       {% else %}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/StockAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/StockAssertionFeatureContext.php
@@ -422,6 +422,15 @@ class StockAssertionFeatureContext extends AbstractProductFeatureContext
         $this->assertBoolProperty($productForEditing, $data, 'low_stock_alert', $shopErrorMessage);
         $this->assertDateTimeProperty($productForEditing, $data, 'available_date', $shopErrorMessage);
 
+        if (isset($data['pack_quantity'])) {
+            if ($data['pack_quantity'] === '') {
+                Assert::assertNull($productForEditing->getStockInformation()->getPackQuantity(), 'invalid pack quantity, null expected');
+            } else {
+                Assert::assertEquals((int) $data['pack_quantity'], $productForEditing->getStockInformation()->getPackQuantity(), 'invalid pack quantity');
+            }
+            unset($data['pack_quantity']);
+        }
+
         // Assertions checking isset() can hide some errors if it doesn't find array key,
         // to make sure all provided fields were checked we need to unset every asserted field
         // and finally, if provided data is not empty, it means there are some unnasserted values left

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_stock.feature
@@ -41,36 +41,86 @@ Feature: Update product stock from Back Office (BO)
       | low_stock_alert     | false     |
       | available_date      |           |
 
-  Scenario: I update product pack stock type
+  Scenario: I update product pack stock type and check its quantity
     Given I add product "productPack1" with following information:
       | name[en-US] | weird sunglasses box |
       | type        | pack                 |
     And product "productPack1" type should be pack
-    And I add product "product2" with following information:
+    And I update product "productPack1" stock with following information:
+      | delta_quantity | 100 |
+      | location       | dtc |
+    And I add product "shady_sunglasses" with following information:
       | name[en-US] | shady sunglasses |
       | type        | standard         |
-    And product "product2" type should be standard
+    And I update product "shady_sunglasses" stock with following information:
+      | delta_quantity | 50  |
+      | location       | dtc |
+    And product "shady_sunglasses" type should be standard
+    And I add product "stylish_hat" with following information:
+      | name[en-US] | stylish hat |
+      | type        | standard    |
+    And product "stylish_hat" type should be standard
+    And I update product "stylish_hat" stock with following information:
+      | delta_quantity | 20  |
+      | location       | dtc |
     When I update pack "productPack1" with following product quantities:
-      | product  | quantity |
-      | product2 | 5        |
+      | product          | quantity |
+      | shady_sunglasses | 5        |
+      | stylish_hat      | 1        |
     Then product "productPack1" type should be pack
     And pack "productPack1" should contain products with following details:
-      | product  | combination | quantity | name             | image url                                              |
-      | product2 |             | 5        | shady sunglasses | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | product          | combination | quantity | name             | image url                                              |
+      | shady_sunglasses |             | 5        | shady sunglasses | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | stylish_hat      |             | 1        | stylish hat      | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+    # With default configuration, use pack only
     And product "productPack1" should have following stock information:
       | pack_stock_type | default |
+      | quantity        | 100     |
+      | pack_quantity   | 100     |
     When I update product "productPack1" with following values:
       | pack_stock_type | pack_only |
+    # With pack only same behaviour
     Then product "productPack1" should have following stock information:
       | pack_stock_type | pack_only |
+      | quantity        | 100       |
+      | pack_quantity   | 100       |
     When I update product "productPack1" with following values:
       | pack_stock_type | products_only |
+    # Use products only, stylish hat minimum is 20, sunglasses minimum is 10 (stock available / quantity in pack = 50 / 5), so 10 is the minimum
     Then product "productPack1" should have following stock information:
       | pack_stock_type | products_only |
+      | quantity        | 100           |
+      | pack_quantity   | 10            |
+    And I update product "productPack1" stock with following information:
+      | delta_quantity | -95 |
+      | location       | dtc |
+    Then product "productPack1" should have following stock information:
+      | pack_stock_type | products_only |
+      | quantity        | 5             |
+      | pack_quantity   | 10            |
+    # Now both are used but pack quantity is only 5 now, so this minimum is used
     When I update product "productPack1" with following values:
       | pack_stock_type | both |
     Then product "productPack1" should have following stock information:
       | pack_stock_type | both |
+      | quantity        | 5    |
+      | pack_quantity   | 5    |
+    And I update product "productPack1" stock with following information:
+      | delta_quantity | 10  |
+      | location       | dtc |
+    Then product "productPack1" should have following stock information:
+      | pack_stock_type | both |
+      | quantity        | 15   |
+      | pack_quantity   | 10   |
+    # Update the required quantity, stylish hat is now the one with minimum quantity (20 / 10)
+    When I update pack "productPack1" with following product quantities:
+      | product          | quantity |
+      | shady_sunglasses | 5        |
+      | stylish_hat      | 10       |
+    Then product "productPack1" should have following stock information:
+      | pack_stock_type | both |
+      | quantity        | 15   |
+      | pack_quantity   | 2    |
     When I update product "productPack1" with following values:
       | pack_stock_type | invalid |
     Then I should get error that pack stock type is invalid
@@ -120,7 +170,7 @@ Feature: Update product stock from Back Office (BO)
       | quantity | 51  |
       | location | dtc |
     And product "product1" last stock movements should be:
-      | employee   | delta_quantity |
+      | employee     | delta_quantity |
       | Puffin Mummy | 51             |
     And product "product1" last stock movement increased by 51
     When I update product "product1" stock with following information:
@@ -130,7 +180,7 @@ Feature: Update product stock from Back Office (BO)
       | quantity | 42 |
       | location |    |
     And product "product1" last stock movements should be:
-      | employee   | delta_quantity |
+      | employee     | delta_quantity |
       | Puffin Mummy | -9             |
       | Puffin Mummy | 51             |
     And product "product1" last stock movement decreased by 9
@@ -140,7 +190,7 @@ Feature: Update product stock from Back Office (BO)
     Then product "product1" should have following stock information:
       | quantity | 42 |
     And product "product1" last stock movements should be:
-      | employee   | delta_quantity |
+      | employee     | delta_quantity |
       | Puffin Mummy | -9             |
       | Puffin Mummy | 51             |
     And product "product1" last stock movement decreased by 9
@@ -281,7 +331,7 @@ Feature: Update product stock from Back Office (BO)
       | delta_quantity | -1 |
     Then I should get error that stock available quantity is invalid
     And product "product2" last stock movements should be:
-      | employee   | delta_quantity |
+      | employee     | delta_quantity |
       | Puffin Mummy | -4294967295    |
       | Puffin Mummy | 4294967295     |
       | Puffin Mummy | -2147483648    |

--- a/tests/UI/campaigns/functional/BO/13_shopParameters/03_productSettings/03_productsStock/02_defaultPackStockManagement.ts
+++ b/tests/UI/campaigns/functional/BO/13_shopParameters/03_productSettings/03_productsStock/02_defaultPackStockManagement.ts
@@ -126,7 +126,10 @@ describe('BO - Shop Parameters - Product Settings : Default pack stock managemen
       {
         args: {
           option: 'Use quantity of products in the pack',
-          packQuantity: productPackData.quantity - 1,
+          // The lower quantity is defined by the first product based on the quantity required in the pack
+          packQuantity: Math.floor(
+            (firstProductData.quantity - productPackData.pack[0].quantity) / productPackData.pack[0].quantity,
+          ),
           firstProductQuantity: firstProductData.quantity - productPackData.pack[0].quantity,
           secondProductQuantity: secondProductData.quantity - productPackData.pack[1].quantity,
         },
@@ -134,7 +137,10 @@ describe('BO - Shop Parameters - Product Settings : Default pack stock managemen
       {
         args: {
           option: 'Use both, whatever is lower',
-          packQuantity: productPackData.quantity - 2,
+          // The lower quantity is defined by the first product based on the quantity required in the pack
+          packQuantity: Math.floor(
+            (firstProductData.quantity - 2 * productPackData.pack[0].quantity) / productPackData.pack[0].quantity,
+          ),
           firstProductQuantity: firstProductData.quantity - 2 * productPackData.pack[0].quantity,
           secondProductQuantity: secondProductData.quantity - 2 * productPackData.pack[1].quantity,
         },

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -1627,6 +1627,7 @@ class ProductFormDataProviderTest extends TestCase
                         'delta' => 0,
                     ],
                     'stock_movements' => [],
+                    'pack_quantity' => null,
                     'minimal_quantity' => 0,
                 ],
                 'options' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Compute pack quantity dynamically absed on its config and contained products' stocks in CQRS, integrate this dynamic quantity in the form header and in the product grid
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green UI tests green, see issue
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/21220936427
| Fixed issue or discussion?     | Fixes #36825
| Related PRs       | ~
| Sponsor company   | ~
