### PR TITLE
Fix creating orders for guests

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -895,14 +895,17 @@ class CustomerCore extends ObjectModel
      *
      * @throws PrestaShopDatabaseException
      */
-    public static function searchByName($query, $limit = null, ?ShopConstraint $shopConstraint = null)
+    public static function searchByName($query, $limit = null, ?ShopConstraint $shopConstraint = null, $ignoreGuest = false)
     {
         $sql = 'SELECT c.*,
                 GROUP_CONCAT(cg.id_group SEPARATOR \',\') AS group_ids
                 FROM `' . _DB_PREFIX_ . 'customer` c
                 LEFT JOIN `' . _DB_PREFIX_ . 'customer_group` cg ON c.id_customer = cg.id_customer
-                WHERE 1
-                AND c.is_guest = 0';
+                WHERE 1';
+
+        if ($ignoreGuest) {
+            $sql .= ' AND c.is_guest = 0';
+        }
 
         if ($shopConstraint) {
             if ($shopConstraint->getShopGroupId()) {

--- a/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
+++ b/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
@@ -81,7 +81,8 @@ final class SearchCustomersHandler implements SearchCustomersHandlerInterface
             $customersResult = Customer::searchByName(
                 $searchPhrase,
                 $limit,
-                $query->getShopConstraint()
+                $query->getShopConstraint(),
+                $query->getExcludeGuests()
             );
             if (!is_array($customersResult)) {
                 continue;

--- a/src/Core/Domain/Customer/Query/SearchCustomers.php
+++ b/src/Core/Domain/Customer/Query/SearchCustomers.php
@@ -46,16 +46,25 @@ class SearchCustomers
     private $shopConstraint;
 
     /**
+     * @var bool
+     */
+    private $excludeGuests;
+
+    /**
      * @param string[] $phrases
+     * @param ShopConstraint|null $shopConstraint
+     * @param bool $excludeGuests
      */
     public function __construct(
         array $phrases,
-        ?ShopConstraint $shopConstraint = null
+        ?ShopConstraint $shopConstraint = null,
+        bool $excludeGuests = false
     ) {
         $this->assertPhrasesAreNotEmpty($phrases);
         $this->assertShopConstraintIsSupported($shopConstraint);
         $this->phrases = $phrases;
         $this->shopConstraint = $shopConstraint;
+        $this->excludeGuests = $excludeGuests;
     }
 
     /**
@@ -72,6 +81,14 @@ class SearchCustomers
     public function getShopConstraint(): ?ShopConstraint
     {
         return $this->shopConstraint;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getExcludeGuests(): bool
+    {
+        return $this->excludeGuests;
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -504,10 +504,13 @@ class CustomerController extends PrestaShopAdminController
             $shopConstraint = $shopId ? ShopConstraint::shop($shopId) : ShopConstraint::allShops();
         }
 
+        $excludeGuests = $request->query->getBoolean('exclude_guests', false);
+
         try {
             $customers = $this->dispatchQuery(new SearchCustomers(
                 $phrases,
-                $shopConstraint
+                $shopConstraint,
+                $excludeGuests
             ));
         } catch (Exception $e) {
             return $this->json(

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountCustomerEligibilityChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountCustomerEligibilityChoiceType.php
@@ -91,6 +91,7 @@ class DiscountCustomerEligibilityChoiceType extends TranslatorAwareType
                 'layout' => EntitySearchInputType::LIST_LAYOUT,
                 'required' => false,
                 'disabling_switch' => false,
+                'exclude_guests' => true,
                 'constraints' => [
                     new When(
                         expression: sprintf(

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomerSearchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomerSearchType.php
@@ -63,10 +63,26 @@ class CustomerSearchType extends EntitySearchInputType
             'disabled_value' => function ($data) {
                 return empty($data[0]['id_customer']);
             },
-            'remote_url' => $this->router->generate('admin_customers_search', ['customer_search' => '__QUERY__']),
             'placeholder' => $this->trans('Search customer', 'Admin.Actions'),
             'suggestion_field' => 'fullname_and_email',
             'required' => false,
+            'exclude_guests' => false,
         ]);
+
+        $resolver->setAllowedTypes('exclude_guests', 'bool');
+
+        $resolver->setNormalizer('remote_url', function ($options) {
+            return $this->buildSearchUrl($options['exclude_guests']);
+        });
+    }
+
+    private function buildSearchUrl(bool $excludeGuests): string
+    {
+        $params = [
+            'customer_search' => '__QUERY__',
+            'exclude_guests' => (int) $excludeGuests,
+        ];
+
+        return $this->router->generate('admin_customers_search', $params);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fix regression from https://github.com/PrestaShop/PrestaShop/pull/39789 that prevents creating orders for guests
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to create an order for guest account before and after this PR. When you select customer eligible for a discount guest accounts should not be visible.
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/21258602444
| Fixed issue or discussion?     | n/a
| Related PRs       | n/a
| Sponsor company   | impSolutions
