### PR TITLE
Fix "Free shipping" displayed on cart when a discount haven't free shipping enabled and with a reduction amount = 0

### DIFF
--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -493,9 +493,14 @@ class CartLazyArray extends AbstractLazyArray
 
     private function cartVoucherHasFreeShippingOnly(array $cartVoucher): bool
     {
+        /*
+         * Here, we cannot just use $cartVoucher['free_shipping'], because the rule can do multiple things.
+         * If it gives a money discount AND free shipping, we must still display a numeric value.
+         */
         return !$this->cartVoucherHasPercentReduction($cartVoucher)
             && !$this->cartVoucherHasAmountReduction($cartVoucher)
-            && !$this->cartVoucherHasGiftProductReduction($cartVoucher);
+            && !$this->cartVoucherHasGiftProductReduction($cartVoucher)
+            && $cartVoucher['free_shipping'];
     }
 
     private function cartVoucherHasPercentReduction(array $cartVoucher): bool

--- a/tests/UI/campaigns/functional/BO/03_catalog/07_discounts/01_cartRules/01_CRUDCartRule/03_actions/04_applyDiscountAmount.ts
+++ b/tests/UI/campaigns/functional/BO/03_catalog/07_discounts/01_cartRules/01_CRUDCartRule/03_actions/04_applyDiscountAmount.ts
@@ -313,9 +313,8 @@ describe('BO - Cart rules - Actions : Apply a discount Amount', async () => {
       const priceATI = await foHummingbirdCartPage.getATIPrice(page);
       expect(priceATI.toFixed(2)).to.eq((dataProducts.demo_6.combinations[0].price).toFixed(2));
 
-      // @todo : https://github.com/PrestaShop/PrestaShop/issues/39109
-      // const isCartRuleNameVisible = await foHummingbirdCartPage.isCartRuleNameVisible(page);
-      // expect(isCartRuleNameVisible).to.equals(false);
+      const isCartRuleNameVisible = await foHummingbirdCartPage.isCartRuleNameVisible(page);
+      expect(isCartRuleNameVisible).to.equals(true);
     });
   });
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fix "Free shipping" displayed on cart when a discount haven't free shipping enabled and with a reduction amount = 0
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #39109
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/21399305830
| Fixed issue or discussion?     | Fixes #39109
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
