### PR TITLE
Fix regex in the getValidateFields function to filter out public properties in the Address class representing an identifier

### DIFF
--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -496,7 +496,7 @@ class AddressFormatCore extends ObjectModel
             foreach ($publicProperties as $property) {
                 $propertyName = $property->getName();
                 if ((!in_array($propertyName, AddressFormat::$forbiddenPropertyList))
-                        && (!preg_match('#id|id_\w#', $propertyName))) {
+                        && (!preg_match('#^id$|^id_.*$|^.*_id$#', $propertyName))) {
                     $propertyList[] = $propertyName;
                 }
             }


### PR DESCRIPTION
fix regex in the getValidateFields function to filter out public properties in the Address class representing an identifier

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | fixes #36281 
| Type?             | bug fix
| Category?         |  BO 
| BC breaks?        | no
| UI   | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/23591819582
| How to test?      | by installing this test module [testmodule.zip](https://github.com/user-attachments/files/25486353/testmodule.zip), make sure the "identification_code" property is present in each specific Country setting in the backoffice, here under the Address configuration, it must be shown in this list exactly like the "test" property:<img width="1452" height="305" alt="541198152-20bc493e-bbc4-437b-835b-8fa4538be978" src="https://github.com/user-attachments/assets/f1c65632-9159-4e0c-a9c6-b2087d954ebe" />
| Fixed issue or discussion?     | Fixes #36281 
