### PR TITLE
Fix "Free shipping" displayed for discounts with free shipping off an…

### DIFF
--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -495,7 +495,8 @@ class CartLazyArray extends AbstractLazyArray
     {
         return !$this->cartVoucherHasPercentReduction($cartVoucher)
             && !$this->cartVoucherHasAmountReduction($cartVoucher)
-            && !$this->cartVoucherHasGiftProductReduction($cartVoucher);
+            && !$this->cartVoucherHasGiftProductReduction($cartVoucher)
+            && $cartVoucher['free_shipping'];
     }
 
     private function cartVoucherHasPercentReduction(array $cartVoucher): bool


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Fix "Free shipping" displayed on cart when a discount haven't free shipping enabled and with a reduction amount = 0
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #39109
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/21438283932 🟢 
| Fixed issue or discussion?     | Fixes #39109
| Related PRs       | ~
| Sponsor company   | TRENDO s.r.o.

original PR by @boherm 