### PR TITLE
Fixed some depreciation in debug mode

### DIFF
--- a/src/Adapter/Admin/LegacyBlockHelperSubscriber.php
+++ b/src/Adapter/Admin/LegacyBlockHelperSubscriber.php
@@ -40,7 +40,7 @@ class LegacyBlockHelperSubscriber implements EventSubscriberInterface
      *
      * @return array The listeners array
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             'legacy_block_kpi' => ['renderKpi', 0],

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -79,7 +79,7 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function replace(array $parameters = [])
+    public function replace(array $parameters = []): void
     {
         $this->add($parameters);
     }
@@ -87,7 +87,7 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function add(array $parameters = [])
+    public function add(array $parameters = []): void
     {
         foreach ($parameters as $key => $value) {
             $this->set($key, $value);

--- a/src/Adapter/LegacyHookSubscriber.php
+++ b/src/Adapter/LegacyHookSubscriber.php
@@ -53,7 +53,7 @@ class LegacyHookSubscriber implements EventSubscriberInterface
      *
      * @return array The listeners array
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         $listeners = [];
 

--- a/src/Adapter/Module/Tab/ModuleTabManagementSubscriber.php
+++ b/src/Adapter/Module/Tab/ModuleTabManagementSubscriber.php
@@ -53,7 +53,7 @@ class ModuleTabManagementSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ModuleManagementEvent::INSTALL => 'onModuleInstall',

--- a/src/Adapter/QuickAccess/Repository/QuickAccessRepository.php
+++ b/src/Adapter/QuickAccess/Repository/QuickAccessRepository.php
@@ -61,6 +61,6 @@ class QuickAccessRepository extends AbstractObjectModelRepository implements Qui
             ->setParameter('languageId', $languageId->getValue())
         ;
 
-        return $qb->execute()->fetchAllAssociative();
+        return $qb->executeQuery()->fetchAllAssociative();
     }
 }

--- a/src/Core/ConstraintValidator/AddressDniRequiredValidator.php
+++ b/src/Core/ConstraintValidator/AddressDniRequiredValidator.php
@@ -55,7 +55,7 @@ class AddressDniRequiredValidator extends ConstraintValidator
     /**
      * {@inheritdoc}
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!($constraint instanceof AddressDniRequired)) {
             return;

--- a/src/Core/ConstraintValidator/AddressStateRequiredValidator.php
+++ b/src/Core/ConstraintValidator/AddressStateRequiredValidator.php
@@ -58,7 +58,7 @@ class AddressStateRequiredValidator extends ConstraintValidator
      *
      * @throws CountryConstraintException
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!($constraint instanceof AddressStateRequired)) {
             return;

--- a/src/Core/ConstraintValidator/AddressZipCodeValidator.php
+++ b/src/Core/ConstraintValidator/AddressZipCodeValidator.php
@@ -68,7 +68,7 @@ final class AddressZipCodeValidator extends ConstraintValidator
      *
      * @throws CountryConstraintException
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!($constraint instanceof AddressZipCode)) {
             return;

--- a/src/Core/ConstraintValidator/CartRuleValidator.php
+++ b/src/Core/ConstraintValidator/CartRuleValidator.php
@@ -37,7 +37,7 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 class CartRuleValidator extends ConstraintValidator
 {
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof CartRule) {
             throw new UnexpectedTypeException($constraint, CartRule::class);

--- a/src/Core/ConstraintValidator/CleanHtmlValidator.php
+++ b/src/Core/ConstraintValidator/CleanHtmlValidator.php
@@ -52,7 +52,7 @@ final class CleanHtmlValidator extends ConstraintValidator
     /**
      * {@inheritdoc}
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof CleanHtml) {
             throw new UnexpectedTypeException($constraint, CleanHtml::class);

--- a/src/Core/ConstraintValidator/CustomerNameValidator.php
+++ b/src/Core/ConstraintValidator/CustomerNameValidator.php
@@ -42,7 +42,7 @@ class CustomerNameValidator extends ConstraintValidator
     /**
      * {@inheritdoc}
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof CustomerName) {
             throw new UnexpectedTypeException($constraint, CustomerName::class);

--- a/src/Core/ConstraintValidator/DateRangeValidator.php
+++ b/src/Core/ConstraintValidator/DateRangeValidator.php
@@ -43,7 +43,7 @@ class DateRangeValidator extends ConstraintValidator
      *
      * @throws Exception
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof DateRange) {
             throw new UnexpectedTypeException($constraint, DateRange::class);

--- a/src/Core/ConstraintValidator/DefaultLanguageValidator.php
+++ b/src/Core/ConstraintValidator/DefaultLanguageValidator.php
@@ -46,7 +46,7 @@ class DefaultLanguageValidator extends ConstraintValidator
     /**
      * {@inheritdoc}
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof DefaultLanguage) {
             throw new UnexpectedTypeException($constraint, DefaultLanguage::class);

--- a/src/Core/ConstraintValidator/DiscountProductSegmentValidator.php
+++ b/src/Core/ConstraintValidator/DiscountProductSegmentValidator.php
@@ -39,7 +39,7 @@ class DiscountProductSegmentValidator extends ConstraintValidator
     {
     }
 
-    public function validate(mixed $value, Constraint $constraint)
+    public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof DiscountProductSegment) {
             throw new UnexpectedTypeException($constraint, DiscountProductSegment::class);

--- a/src/Core/ConstraintValidator/ExistingCustomerEmailValidator.php
+++ b/src/Core/ConstraintValidator/ExistingCustomerEmailValidator.php
@@ -53,7 +53,7 @@ final class ExistingCustomerEmailValidator extends ConstraintValidator
     /**
      * {@inheritdoc}
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof ExistingCustomerEmail) {
             throw new UnexpectedTypeException($constraint, ExistingCustomerEmail::class);

--- a/src/Core/ConstraintValidator/InstalledApiResourceScopeValidator.php
+++ b/src/Core/ConstraintValidator/InstalledApiResourceScopeValidator.php
@@ -45,7 +45,7 @@ class InstalledApiResourceScopeValidator extends ConstraintValidator
      * @param string[] $value
      * @param Constraint $constraint
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof InstalledApiResourceScope) {
             throw new UnexpectedTypeException($constraint, InstalledApiResourceScope::class);

--- a/src/Core/ConstraintValidator/IsUrlRewriteValidator.php
+++ b/src/Core/ConstraintValidator/IsUrlRewriteValidator.php
@@ -58,7 +58,7 @@ class IsUrlRewriteValidator extends ConstraintValidator
     /**
      * {@inheritdoc}
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof IsUrlRewrite) {
             throw new UnexpectedTypeException($constraint, IsUrlRewrite::class);

--- a/src/Core/ConstraintValidator/NotBlankWhenRequiredValidator.php
+++ b/src/Core/ConstraintValidator/NotBlankWhenRequiredValidator.php
@@ -32,7 +32,7 @@ use Symfony\Component\Validator\Constraints\NotBlankValidator;
 
 class NotBlankWhenRequiredValidator extends NotBlankValidator
 {
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if ($constraint instanceof NotBlankWhenRequired && true === $constraint->required) {
             parent::validate($value, $constraint);

--- a/src/Core/ConstraintValidator/NotCustomizableProductValidator.php
+++ b/src/Core/ConstraintValidator/NotCustomizableProductValidator.php
@@ -40,7 +40,7 @@ class NotCustomizableProductValidator extends ConstraintValidator
     ) {
     }
 
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof NotCustomizableProduct) {
             throw new UnexpectedTypeException($constraint, NotCustomizableProduct::class);

--- a/src/Core/ConstraintValidator/PositiveOrZeroValidator.php
+++ b/src/Core/ConstraintValidator/PositiveOrZeroValidator.php
@@ -42,7 +42,7 @@ class PositiveOrZeroValidator extends ConstraintValidator
     /**
      * {@inheritDoc}
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof PositiveOrZero) {
             throw new UnexpectedTypeException($constraint, PositiveOrZero::class);

--- a/src/Core/ConstraintValidator/ReductionValidator.php
+++ b/src/Core/ConstraintValidator/ReductionValidator.php
@@ -40,7 +40,7 @@ final class ReductionValidator extends ConstraintValidator
     /**
      * {@inheritdoc}
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof ReductionConstraint) {
             throw new UnexpectedTypeException($constraint, ReductionConstraint::class);

--- a/src/Core/ConstraintValidator/TypedRegexValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexValidator.php
@@ -71,7 +71,7 @@ class TypedRegexValidator extends ConstraintValidator
     /**
      * {@inheritdoc}
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof TypedRegex) {
             throw new UnexpectedTypeException($constraint, TypedRegex::class);

--- a/src/Core/ConstraintValidator/UniqueStateIsoCodeValidator.php
+++ b/src/Core/ConstraintValidator/UniqueStateIsoCodeValidator.php
@@ -41,7 +41,7 @@ class UniqueStateIsoCodeValidator extends ConstraintValidator
     /**
      * {@inheritdoc}
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!($constraint instanceof UniqueStateIsoCode)) {
             return;

--- a/src/Core/FeatureFlag/FeatureFlagManager.php
+++ b/src/Core/FeatureFlag/FeatureFlagManager.php
@@ -116,7 +116,7 @@ class FeatureFlagManager implements FeatureFlagStateCheckerInterface, ResetInter
         $this->getLayer($featureFlagName)->disable($featureFlagName);
     }
 
-    public function reset()
+    public function reset(): void
     {
         $this->featureFlagStates = [];
     }

--- a/src/Core/Form/FormHandler.php
+++ b/src/Core/Form/FormHandler.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Form;
 use Exception;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 
 /**
@@ -99,7 +100,7 @@ class FormHandler implements FormHandlerInterface
      *
      * @throws Exception
      */
-    public function getForm()
+    public function getForm(): FormInterface
     {
         foreach ($this->formTypes as $formName => $formType) {
             $this->formBuilder->add($formName, $formType);
@@ -122,7 +123,7 @@ class FormHandler implements FormHandlerInterface
      * @throws Exception
      * @throws UndefinedOptionsException
      */
-    public function save(array $data)
+    public function save(array $data): array
     {
         $errors = $this->formDataProvider->setData($data);
 

--- a/src/Core/Form/FormHandlerInterface.php
+++ b/src/Core/Form/FormHandlerInterface.php
@@ -37,7 +37,7 @@ interface FormHandlerInterface
     /**
      * @return FormInterface
      */
-    public function getForm();
+    public function getForm(): FormInterface;
 
     /**
      * Describe what need to be done on saving the form: mostly persists the data
@@ -49,5 +49,5 @@ interface FormHandlerInterface
      *
      * @throws Exception if the data can't be handled
      */
-    public function save(array $data);
+    public function save(array $data): array;
 }

--- a/src/Core/Form/Handler.php
+++ b/src/Core/Form/Handler.php
@@ -30,6 +30,7 @@ namespace PrestaShop\PrestaShop\Core\Form;
 use Exception;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 
 /**
@@ -98,7 +99,7 @@ class Handler implements FormHandlerInterface
      *
      * @throws Exception
      */
-    public function getForm()
+    public function getForm(): FormInterface
     {
         $formBuilder = $this->formFactory->createNamedBuilder($this->formName, $this->form);
 
@@ -120,7 +121,7 @@ class Handler implements FormHandlerInterface
      * @throws Exception
      * @throws UndefinedOptionsException
      */
-    public function save(array $data)
+    public function save(array $data): array
     {
         $errors = $this->formDataProvider->setData($data);
 

--- a/src/Core/Grid/Action/Bulk/Type/Customer/DeleteCustomersBulkAction.php
+++ b/src/Core/Grid/Action/Bulk/Type/Customer/DeleteCustomersBulkAction.php
@@ -45,7 +45,7 @@ final class DeleteCustomersBulkAction extends AbstractBulkAction
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([

--- a/src/Core/Grid/Action/Row/Type/SubmitRowAction.php
+++ b/src/Core/Grid/Action/Row/Type/SubmitRowAction.php
@@ -49,7 +49,7 @@ final class SubmitRowAction extends AbstractRowAction
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/Core/Grid/Column/Type/Common/ImageColumn.php
+++ b/src/Core/Grid/Column/Type/Common/ImageColumn.php
@@ -45,7 +45,7 @@ final class ImageColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([

--- a/src/Core/Grid/Data/Factory/ProfileGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/ProfileGridDataFactoryDecorator.php
@@ -33,7 +33,7 @@ use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShopBundle\Entity\Employee\Employee;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Bundle\SecurityBundle\Security;
 
 /**
  * Class ProfileGridDataFactory decorates data from profile doctrine data factory.

--- a/src/Core/Module/EventSubscriber.php
+++ b/src/Core/Module/EventSubscriber.php
@@ -50,7 +50,7 @@ class EventSubscriber implements EventSubscriberInterface
         $this->cacheClearer = $cacheClearer;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ModuleManagementEvent::PRE_ACTION => 'onModuleStateChanged',

--- a/src/PrestaShopBundle/ApiPlatform/Processor/UpdatePositionProcessor.php
+++ b/src/PrestaShopBundle/ApiPlatform/Processor/UpdatePositionProcessor.php
@@ -50,7 +50,7 @@ class UpdatePositionProcessor implements ProcessorInterface
     ) {
     }
 
-    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = [])
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
     {
         $positionDefinitionName = $operation->getExtraProperties()['positionDefinition'] ?? null;
         if (null === $positionDefinitionName) {
@@ -77,6 +77,8 @@ class UpdatePositionProcessor implements ProcessorInterface
             // We catch and force the API Platform exception to have a 400 bad request code
             throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
         }
+
+        return null;
     }
 
     protected function getPositionsData(array $data, PositionDefinition $positionDefinition, string $parentIdField): ?array

--- a/src/PrestaShopBundle/Cache/CacheWarmer.php
+++ b/src/PrestaShopBundle/Cache/CacheWarmer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -31,14 +34,12 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
 class CacheWarmer implements CacheWarmerInterface
 {
-    private $fileSystem;
-
-    public function __construct(Filesystem $fileSystem)
-    {
-        $this->fileSystem = $fileSystem;
+    public function __construct(
+        private readonly Filesystem $fileSystem,
+    ) {
     }
 
-    public function warmUp($cacheDir)
+    public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
         $legacyDirs = [
             $cacheDir . DIRECTORY_SEPARATOR . 'cachefs',
@@ -53,7 +54,7 @@ class CacheWarmer implements CacheWarmerInterface
         return [];
     }
 
-    public function isOptional()
+    public function isOptional(): bool
     {
         return false;
     }

--- a/src/PrestaShopBundle/Cache/LegacyCacheClearer.php
+++ b/src/PrestaShopBundle/Cache/LegacyCacheClearer.php
@@ -68,7 +68,7 @@ class LegacyCacheClearer implements CacheClearerInterface
     ) {
     }
 
-    public function clear(string $cacheDir)
+    public function clear(string $cacheDir): void
     {
         if (!is_dir($this->legacyCacheDir)) {
             return;

--- a/src/PrestaShopBundle/Command/AppendConfigurationFileHooksListCommand.php
+++ b/src/PrestaShopBundle/Command/AppendConfigurationFileHooksListCommand.php
@@ -64,7 +64,7 @@ class AppendConfigurationFileHooksListCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('prestashop:update:configuration-file-hooks-listing')

--- a/src/PrestaShopBundle/Command/AppendHooksListForSqlUpgradeFileCommand.php
+++ b/src/PrestaShopBundle/Command/AppendHooksListForSqlUpgradeFileCommand.php
@@ -68,7 +68,7 @@ class AppendHooksListForSqlUpgradeFileCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('prestashop:update:sql-upgrade-file-hooks-listing')

--- a/src/PrestaShopBundle/Command/CheckTranslationDuplicatesCommand.php
+++ b/src/PrestaShopBundle/Command/CheckTranslationDuplicatesCommand.php
@@ -46,7 +46,7 @@ class CheckTranslationDuplicatesCommand extends Command
         $this->translator = $translator;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('prestashop:translation:find-duplicates')

--- a/src/PrestaShopBundle/Command/CheckTranslationFixtures.php
+++ b/src/PrestaShopBundle/Command/CheckTranslationFixtures.php
@@ -45,7 +45,7 @@ class CheckTranslationFixtures extends Command
 
     protected const OBJECT_FILE = 'classes/%s.php';
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('prestashop:translation:check-fixtures')

--- a/src/PrestaShopBundle/Command/DebugCommand.php
+++ b/src/PrestaShopBundle/Command/DebugCommand.php
@@ -67,7 +67,7 @@ class DebugCommand extends Command
         $this->debugConfiguration = $debugConfiguration;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('prestashop:debug')

--- a/src/PrestaShopBundle/Command/ExportThemeCommand.php
+++ b/src/PrestaShopBundle/Command/ExportThemeCommand.php
@@ -66,7 +66,7 @@ class ExportThemeCommand extends Command
         $this->translator = $translator;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('prestashop:theme:export')

--- a/src/PrestaShopBundle/Command/FeatureFlagCommand.php
+++ b/src/PrestaShopBundle/Command/FeatureFlagCommand.php
@@ -31,6 +31,7 @@ namespace PrestaShopBundle\Command;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagManager;
 use PrestaShopBundle\Entity\FeatureFlag;
 use PrestaShopBundle\Entity\Repository\FeatureFlagRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
@@ -40,12 +41,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * This CLI command allows to enable/disable a feature flag or to list all of them.
  */
+#[AsCommand(name: 'prestashop:feature-flag', description: 'Manage feature flags via command line')]
 class FeatureFlagCommand extends Command
 {
     private const SUCCESS_RETURN_CODE = 0;
     private const INVALID_ARGUMENTS_RETURN_CODE = 1;
-
-    protected static $defaultName = 'prestashop:feature-flag';
 
     /**
      * @var string[]
@@ -63,7 +63,7 @@ class FeatureFlagCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Manage feature flags via command line')

--- a/src/PrestaShopBundle/Command/GenerateMailTemplatesCommand.php
+++ b/src/PrestaShopBundle/Command/GenerateMailTemplatesCommand.php
@@ -55,7 +55,7 @@ class GenerateMailTemplatesCommand extends Command
         $this->legacyContext = $legacyContext;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('prestashop:mail:generate')

--- a/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
+++ b/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
@@ -192,7 +192,7 @@ class LegacyLinkLinterCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('prestashop:linter:legacy-link')

--- a/src/PrestaShopBundle/Command/ListCommandsAndQueriesCommand.php
+++ b/src/PrestaShopBundle/Command/ListCommandsAndQueriesCommand.php
@@ -67,7 +67,7 @@ class ListCommandsAndQueriesCommand extends Command
     /**
      * {@inheritdoc}
      */
-    public function configure()
+    public function configure(): void
     {
         $this
             ->setName('prestashop:list:commands-and-queries')

--- a/src/PrestaShopBundle/Command/ModuleCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleCommand.php
@@ -74,7 +74,7 @@ class ModuleCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('prestashop:module')

--- a/src/PrestaShopBundle/Command/NamingConventionLinterCommand.php
+++ b/src/PrestaShopBundle/Command/NamingConventionLinterCommand.php
@@ -62,7 +62,7 @@ final class NamingConventionLinterCommand extends Command
     /**
      * {@inheritdoc}
      */
-    public function configure()
+    public function configure(): void
     {
         $this
             ->setName('prestashop:linter:naming-convention')

--- a/src/PrestaShopBundle/Command/RegenerateThumbnailsCommand.php
+++ b/src/PrestaShopBundle/Command/RegenerateThumbnailsCommand.php
@@ -58,7 +58,7 @@ class RegenerateThumbnailsCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addArgument(

--- a/src/PrestaShopBundle/Command/SecurityAttributeLinterCommand.php
+++ b/src/PrestaShopBundle/Command/SecurityAttributeLinterCommand.php
@@ -137,7 +137,7 @@ final class SecurityAttributeLinterCommand extends Command
     /**
      * {@inheritdoc}
      */
-    public function configure()
+    public function configure(): void
     {
         $description = 'Checks if Back Office route controllers has configured Security annotations.';
         $actionDescription = sprintf(

--- a/src/PrestaShopBundle/Command/ThemeEnablerCommand.php
+++ b/src/PrestaShopBundle/Command/ThemeEnablerCommand.php
@@ -59,7 +59,7 @@ final class ThemeEnablerCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('prestashop:theme:enable')

--- a/src/PrestaShopBundle/Command/UpdateEUTaxruleGroupsCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateEUTaxruleGroupsCommand.php
@@ -79,7 +79,7 @@ class UpdateEUTaxruleGroupsCommand extends Command
         $this->localizationPath = $localizationPath;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('prestashop:taxes:update-eu-tax-rule-groups')

--- a/src/PrestaShopBundle/Command/UpdateLicensesCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateLicensesCommand.php
@@ -76,7 +76,7 @@ class UpdateLicensesCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('prestashop:licenses:update')

--- a/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
@@ -62,7 +62,7 @@ class UpdateSchemaCommand extends Command
         $this->em = $manager;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('prestashop:schema:update-without-foreign')

--- a/src/PrestaShopBundle/Controller/ArgumentResolver/FiltersBuilderResolver.php
+++ b/src/PrestaShopBundle/Controller/ArgumentResolver/FiltersBuilderResolver.php
@@ -30,14 +30,14 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Search\Builder\FiltersBuilderInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
 /**
  * This argument resolver uses the FiltersBuilderInterface service to automatically
  * instantiate and inject parameters in controllers.
  */
-class FiltersBuilderResolver implements ArgumentValueResolverInterface
+class FiltersBuilderResolver implements ValueResolverInterface
 {
     /** @var FiltersBuilderInterface */
     private $builder;
@@ -53,16 +53,12 @@ class FiltersBuilderResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument): bool
-    {
-        return is_subclass_of($argument->getType(), Filters::class);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
+        if (!is_subclass_of($argument->getType() ?? '', Filters::class)) {
+            return [];
+        }
+
         // The shop constraint should be added in the request attributes by another listener (@see ShopConstraintListener)
         $shopConstraint = null;
         if ($request->attributes->has('shopConstraint') && $request->attributes->get('shopConstraint') instanceof ShopConstraint) {

--- a/src/PrestaShopBundle/DataCollector/CommandsAndQueriesDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/CommandsAndQueriesDataCollector.php
@@ -53,7 +53,7 @@ final class CommandsAndQueriesDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, ?Throwable $exception = null)
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void
     {
         $this->data = [
             'executed_commands' => $this->executedCommandRegistry->getExecutedCommands(),
@@ -64,7 +64,7 @@ final class CommandsAndQueriesDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'ps.commands_and_queries_collector';
     }
@@ -72,7 +72,7 @@ final class CommandsAndQueriesDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function reset()
+    public function reset(): void
     {
         $this->data = [];
     }

--- a/src/PrestaShopBundle/DataCollector/HookDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/HookDataCollector.php
@@ -50,7 +50,7 @@ final class HookDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, ?Throwable $exception = null)
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void
     {
         $hooks = $this->registry->getHooks();
         $calledHooks = $this->registry->getCalledHooks();
@@ -107,7 +107,7 @@ final class HookDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function reset()
+    public function reset(): void
     {
         $this->data = [];
     }
@@ -115,7 +115,7 @@ final class HookDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'ps.hooks_collector';
     }

--- a/src/PrestaShopBundle/DataCollector/LegacyCollector.php
+++ b/src/PrestaShopBundle/DataCollector/LegacyCollector.php
@@ -40,7 +40,7 @@ final class LegacyCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, ?Throwable $exception = null)
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void
     {
         $this->data = [
             'isProfilerEnabled' => false,
@@ -78,7 +78,7 @@ final class LegacyCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'ps.legacy_collector';
     }
@@ -86,7 +86,7 @@ final class LegacyCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function reset()
+    public function reset(): void
     {
         $this->data = [];
     }

--- a/src/PrestaShopBundle/DependencyInjection/AddOnsConfiguration.php
+++ b/src/PrestaShopBundle/DependencyInjection/AddOnsConfiguration.php
@@ -32,7 +32,7 @@ use Tools;
 
 class AddOnsConfiguration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('prestashop');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/DynamicRolePass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/DynamicRolePass.php
@@ -40,7 +40,7 @@ class DynamicRolePass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         /*
          * @see Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension:createRoleHierarchy

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/GridDefinitionServiceIdsCollectorPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/GridDefinitionServiceIdsCollectorPass.php
@@ -40,7 +40,7 @@ final class GridDefinitionServiceIdsCollectorPass implements CompilerPassInterfa
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!in_array($container->getParameter('kernel.environment'), ['dev', 'test'])) {
             return;

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/IdentifiableObjectFormTypesCollectorPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/IdentifiableObjectFormTypesCollectorPass.php
@@ -44,7 +44,7 @@ class IdentifiableObjectFormTypesCollectorPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!in_array($container->getParameter('kernel.environment'), ['dev', 'test'])) {
             return;

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
@@ -58,7 +58,7 @@ class LoadServicesFromModulesPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $installedModules = $container->getParameter('prestashop.installed_modules');
         $moduleDir = $container->getParameter('prestashop.module_dir');

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/ModulesDoctrineCompilerPass.php
@@ -45,7 +45,7 @@ class ModulesDoctrineCompilerPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $installedModules = $container->getParameter('prestashop.installed_modules');
         $compilerPassList = $this->getCompilerPassList($installedModules);

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/OptionsFormHookNameCollectorPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/OptionsFormHookNameCollectorPass.php
@@ -56,7 +56,7 @@ final class OptionsFormHookNameCollectorPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!in_array($container->getParameter('kernel.environment'), ['dev', 'test'])) {
             return;

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/OverrideTranslatorServiceCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/OverrideTranslatorServiceCompilerPass.php
@@ -36,7 +36,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class OverrideTranslatorServiceCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $definition = $container->getDefinition('translator.default');
         $definition->setClass($container->getParameter('translator.class'));

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/PopulateTranslationProvidersPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/PopulateTranslationProvidersPass.php
@@ -40,7 +40,7 @@ class PopulateTranslationProvidersPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has(self::DEFINITION)) {
             return;

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/RemoveXmlCompiledContainerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/RemoveXmlCompiledContainerPass.php
@@ -39,7 +39,7 @@ class RemoveXmlCompiledContainerPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->getParameter('kernel.debug')) {
             $filename = $container->getParameter('debug.container.dump');

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/RouterPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/RouterPass.php
@@ -41,7 +41,7 @@ class RouterPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $container->setAlias('router', 'prestashop.router')->setPublic(true);
     }

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/TestEnvironmentPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/TestEnvironmentPass.php
@@ -37,7 +37,7 @@ class TestEnvironmentPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $env = $container->getParameter('kernel.environment');
 

--- a/src/PrestaShopBundle/DependencyInjection/Config/ConfigYamlLoader.php
+++ b/src/PrestaShopBundle/DependencyInjection/Config/ConfigYamlLoader.php
@@ -41,7 +41,7 @@ class ConfigYamlLoader extends FileLoader
     /**
      * {@inheritdoc}
      */
-    public function load($resource, $type = null)
+    public function load($resource, $type = null): mixed
     {
         $path = $this->locator->locate($resource);
         $configValues = Yaml::parse(file_get_contents($path), Yaml::PARSE_CONSTANT);
@@ -50,12 +50,14 @@ class ConfigYamlLoader extends FileLoader
         unset($configValues['imports']);
 
         $this->configValues = array_merge_recursive($this->configValues, $configValues);
+
+        return null;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function supports($resource, $type = null)
+    public function supports($resource, $type = null): bool
     {
         return is_string($resource) && 'yml' === pathinfo(
             $resource,

--- a/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
+++ b/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Http\CookieOptions;
 use PrestaShop\PrestaShop\Core\Security\OAuth2\AuthorisationServerInterface;
+use Symfony\Component\Config\Definition\ConfigurationInterface as ConfigConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -46,7 +47,7 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader($container, new FileLocator(dirname(__DIR__) . '/Resources/config'));
         $env = $container->getParameter('kernel.environment');
@@ -61,7 +62,7 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigConfigurationInterface
     {
         return new AddOnsConfiguration();
     }
@@ -74,7 +75,7 @@ class PrestaShopExtension extends Extension implements PrependExtensionInterface
         return 'prestashop';
     }
 
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         $container->setParameter('prestashop.admin_cookie_lifetime', $this->getAdminCookieLifetime());
         $this->preprendApiConfig($container);

--- a/src/PrestaShopBundle/Doctrine/DatabaseConnection.php
+++ b/src/PrestaShopBundle/Doctrine/DatabaseConnection.php
@@ -30,6 +30,7 @@ namespace PrestaShopBundle\Doctrine;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Exception;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 
 /**
@@ -54,7 +55,7 @@ class DatabaseConnection extends Connection
 {
     private const PARAMETERS_FILE = __DIR__ . '/../../../app/config/parameters.php';
 
-    public function getDatabasePlatform()
+    public function getDatabasePlatform(): AbstractPlatform
     {
         try {
             $detectedVersion = parent::getDatabasePlatform();

--- a/src/PrestaShopBundle/EventListener/ActionDispatcherLegacyHooksSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/ActionDispatcherLegacyHooksSubscriber.php
@@ -60,7 +60,7 @@ class ActionDispatcherLegacyHooksSubscriber implements EventSubscriberInterface
         $this->hookDispatcher = $hookDispatcher;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER => [

--- a/src/PrestaShopBundle/EventListener/Admin/Context/CountryContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/CountryContextSubscriber.php
@@ -50,7 +50,7 @@ class CountryContextSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => [

--- a/src/PrestaShopBundle/EventListener/Admin/Context/CurrencyContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/CurrencyContextSubscriber.php
@@ -50,7 +50,7 @@ class CurrencyContextSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => [

--- a/src/PrestaShopBundle/EventListener/Admin/Context/EmployeeContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/EmployeeContextSubscriber.php
@@ -53,7 +53,7 @@ class EmployeeContextSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => [

--- a/src/PrestaShopBundle/EventListener/Admin/Context/LanguageContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/LanguageContextSubscriber.php
@@ -57,7 +57,7 @@ class LanguageContextSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => [

--- a/src/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/LegacyControllerContextSubscriber.php
@@ -48,7 +48,7 @@ class LegacyControllerContextSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => ['onKernelRequest'],

--- a/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
+++ b/src/PrestaShopBundle/EventListener/Admin/Context/ShopContextSubscriber.php
@@ -80,7 +80,7 @@ class ShopContextSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => [

--- a/src/PrestaShopBundle/EventListener/ModuleGuardListener.php
+++ b/src/PrestaShopBundle/EventListener/ModuleGuardListener.php
@@ -72,7 +72,7 @@ class ModuleGuardListener implements EventSubscriberInterface
     /**
      * @return array
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ModuleManagementEvent::INSTALL => 'protectModule',

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/ApiClientType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/ApiClientType.php
@@ -43,7 +43,7 @@ use Symfony\Component\Validator\Constraints\Positive;
 
 class ApiClientType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // If an external issuer is specified most of the form is not editable or relevant
         $formData = $builder->getData();
@@ -144,7 +144,7 @@ class ApiClientType extends TranslatorAwareType
         }
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/ConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/ConfigurationType.php
@@ -44,7 +44,7 @@ class ConfigurationType extends TranslatorAwareType
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $enableAdminAPIHelp = $this->trans(
             'Before enabling the Admin API, you must be sure to:',
@@ -94,7 +94,7 @@ class ConfigurationType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/ResourceScopesType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/ResourceScopesType.php
@@ -55,7 +55,7 @@ class ResourceScopesType extends TranslatorAwareType implements DataMapperInterf
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $resourceScopes = $this->resourceScopeExtractor->getAllApiResourceScopes();
         foreach ($resourceScopes as $resourceScope) {
@@ -68,7 +68,7 @@ class ResourceScopesType extends TranslatorAwareType implements DataMapperInterf
         $builder->setDataMapper($this);
     }
 
-    public function mapDataToForms($viewData, Traversable $forms)
+    public function mapDataToForms(mixed $viewData, Traversable $forms): void
     {
         /** @var FormInterface[] $forms */
         $forms = iterator_to_array($forms);
@@ -87,7 +87,7 @@ class ResourceScopesType extends TranslatorAwareType implements DataMapperInterf
         }
     }
 
-    public function mapFormsToData(Traversable $forms, &$viewData)
+    public function mapFormsToData(Traversable $forms, mixed &$viewData): void
     {
         $associatedScopes = [];
         /** @var FormInterface $collection */
@@ -101,7 +101,7 @@ class ResourceScopesType extends TranslatorAwareType implements DataMapperInterf
         $viewData = $associatedScopes;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([
@@ -110,7 +110,7 @@ class ResourceScopesType extends TranslatorAwareType implements DataMapperInterf
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return AccordionType::class;
     }
@@ -118,7 +118,7 @@ class ResourceScopesType extends TranslatorAwareType implements DataMapperInterf
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $scopes = 0;
 

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/SwitchScopeType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/AdminAPI/SwitchScopeType.php
@@ -38,7 +38,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class SwitchScopeType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('scope', TextPreviewType::class, [
@@ -54,7 +54,7 @@ class SwitchScopeType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([
@@ -68,7 +68,7 @@ class SwitchScopeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
 

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CachingType.php
@@ -46,7 +46,7 @@ class CachingType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('use_cache', SwitchType::class, [
@@ -99,7 +99,7 @@ class CachingType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'performance_caching_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CombineCompressCacheType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/CombineCompressCacheType.php
@@ -38,7 +38,7 @@ class CombineCompressCacheType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('smart_cache_css', SwitchType::class, [
@@ -56,7 +56,7 @@ class CombineCompressCacheType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'performance_ccc_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
@@ -39,7 +39,7 @@ class DebugModeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('disable_overrides', SwitchType::class, [
@@ -80,7 +80,7 @@ class DebugModeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'performance_debug_mode_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MediaServersType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MediaServersType.php
@@ -38,7 +38,7 @@ class MediaServersType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('media_server_one', TextType::class, [
@@ -64,7 +64,7 @@ class MediaServersType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'performance_media_servers_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MemcacheServerType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/MemcacheServerType.php
@@ -38,7 +38,7 @@ class MemcacheServerType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('memcache_ip', TextType::class, [
@@ -61,7 +61,7 @@ class MemcacheServerType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'performance_memcache_server_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/OptionalFeaturesType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/OptionalFeaturesType.php
@@ -56,7 +56,7 @@ class OptionalFeaturesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('combinations', SwitchType::class, [
@@ -81,7 +81,7 @@ class OptionalFeaturesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'performance_optional_features_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/PerformanceFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/PerformanceFormDataProvider.php
@@ -49,7 +49,7 @@ final class PerformanceFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->dataConfiguration->getConfiguration();
     }
@@ -57,7 +57,7 @@ final class PerformanceFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->dataConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/SmartyType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/SmartyType.php
@@ -39,7 +39,7 @@ class SmartyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('template_compilation', ChoiceType::class, [
@@ -84,7 +84,7 @@ class SmartyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'performance_smarty_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
@@ -94,7 +94,7 @@ abstract class AbstractCategoryType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $genericCharactersHint = $this->trans('Invalid characters: %s', 'Admin.Notifications.Info', [TypedRegexValidator::CATALOG_CHARS]);
         /* @var EditableCategory $editableCategory */

--- a/src/PrestaShopBundle/Form/Admin/Catalog/Category/CategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Catalog/Category/CategoryType.php
@@ -38,7 +38,7 @@ class CategoryType extends AbstractCategoryType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
 
@@ -67,7 +67,7 @@ class CategoryType extends AbstractCategoryType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/AdminAPI/FormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/AdminAPI/FormDataProvider.php
@@ -41,7 +41,7 @@ class FormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->dataConfiguration->getConfiguration();
     }
@@ -49,7 +49,7 @@ class FormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->dataConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/FormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/FormDataProvider.php
@@ -54,7 +54,7 @@ final class FormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->dataConfiguration->getConfiguration();
     }
@@ -62,7 +62,7 @@ final class FormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->dataConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralDataProvider.php
@@ -72,7 +72,7 @@ final class GeneralDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->dataConfiguration->getConfiguration();
     }
@@ -80,7 +80,7 @@ final class GeneralDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         $this->validate($data);
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
@@ -43,7 +43,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('check_ip_address', SwitchType::class, [
@@ -70,7 +70,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',
@@ -80,7 +80,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'administration_general_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/NotificationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/NotificationsType.php
@@ -36,7 +36,7 @@ class NotificationsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('show_notifs_new_orders', SwitchType::class, [
@@ -53,7 +53,7 @@ class NotificationsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',
@@ -63,7 +63,7 @@ class NotificationsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'administration_notification_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaDataProvider.php
@@ -58,7 +58,7 @@ final class UploadQuotaDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->dataConfiguration->getConfiguration();
     }
@@ -66,7 +66,7 @@ final class UploadQuotaDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         $this->validate($data);
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
@@ -62,7 +62,7 @@ class UploadQuotaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $configuration = $this->configuration;
         $builder
@@ -167,7 +167,7 @@ class UploadQuotaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',
@@ -177,7 +177,7 @@ class UploadQuotaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'administration_upload_quota_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Backup/BackupDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Backup/BackupDataProvider.php
@@ -50,7 +50,7 @@ final class BackupDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->backupOptionsConfigurator->getConfiguration();
     }
@@ -58,7 +58,7 @@ final class BackupDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->backupOptionsConfigurator->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Backup/BackupOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Backup/BackupOptionsType.php
@@ -61,7 +61,7 @@ class BackupOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $backupAllHelp = $this->trans(
             'Drop existing tables during import.',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/DkimConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/DkimConfigurationType.php
@@ -41,7 +41,7 @@ class DkimConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('domain', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationFormDataProvider.php
@@ -52,7 +52,7 @@ final class EmailConfigurationFormDataProvider implements FormDataProviderInterf
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->emailDataConfigurator->getConfiguration();
     }
@@ -60,7 +60,7 @@ final class EmailConfigurationFormDataProvider implements FormDataProviderInterf
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         $errors = $this->checkSmtpConfiguration($data);
         if (!empty($errors)) {

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
@@ -70,7 +70,7 @@ class EmailConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('send_emails_to', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/SmtpConfigurationType.php
@@ -40,7 +40,7 @@ class SmtpConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('domain', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/TestEmailSendingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/TestEmailSendingType.php
@@ -39,7 +39,7 @@ class TestEmailSendingType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('send_email_to', EmailType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsFormDataProvider.php
@@ -50,7 +50,7 @@ final class EmployeeOptionsFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->employeeOptionsConfiguration->getConfiguration();
     }
@@ -58,7 +58,7 @@ final class EmployeeOptionsFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->employeeOptionsConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
@@ -60,7 +60,7 @@ class EmployeeOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $optionsLock = [];
         if (!$this->canOptionsBeChanged) {

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -119,7 +119,7 @@ final class EmployeeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $minScore = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_SCORE);
         $maxLength = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH);
@@ -261,7 +261,7 @@ final class EmployeeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagListType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagListType.php
@@ -40,7 +40,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class FeatureFlagListType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('feature_flags', CollectionType::class, [
@@ -56,7 +56,7 @@ class FeatureFlagListType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagType.php
@@ -53,7 +53,7 @@ class FeatureFlagType extends TranslatorAwareType
         $this->formCloner = $formCloner;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('enabled', FeatureFlagSwitchType::class, [
@@ -81,7 +81,7 @@ class FeatureFlagType extends TranslatorAwareType
         ]));
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagsFormDataProvider.php
@@ -54,7 +54,7 @@ class FeatureFlagsFormDataProvider implements FormDataProviderInterface
     ) {
     }
 
-    public function getData()
+    public function getData(): array
     {
         $featureFlags = $this->doctrineEntityManager->getRepository(FeatureFlag::class)->findBy(['stability' => $this->stability]);
 
@@ -80,7 +80,7 @@ class FeatureFlagsFormDataProvider implements FormDataProviderInterface
         return ['feature_flags' => $featureFlagsData];
     }
 
-    public function setData(array $flagsData)
+    public function setData(array $flagsData): array
     {
         $featureFlags = $flagsData['feature_flags'];
         if (!$this->validateFlagsData($featureFlags)) {

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportDataConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportDataConfigurationType.php
@@ -72,7 +72,7 @@ class ImportDataConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('matches', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportFormHandler.php
@@ -95,7 +95,7 @@ class ImportFormHandler implements ImportFormHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function save(array $data)
+    public function save(array $data): array
     {
         $errors = $this->formDataProvider->setData($data);
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportFormHandlerInterface.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportFormHandlerInterface.php
@@ -49,5 +49,5 @@ interface ImportFormHandlerInterface
      *
      * @return array of errors
      */
-    public function save(array $data);
+    public function save(array $data): array;
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Import/ImportType.php
@@ -47,7 +47,7 @@ class ImportType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('csv', HiddenType::class)
@@ -146,7 +146,7 @@ class ImportType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/DatabaseLogsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/DatabaseLogsFormDataProvider.php
@@ -43,7 +43,7 @@ final class DatabaseLogsFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->databaseLogsConfiguration->getConfiguration();
     }
@@ -51,7 +51,7 @@ final class DatabaseLogsFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->databaseLogsConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/DatabaseLogsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/DatabaseLogsType.php
@@ -39,7 +39,7 @@ final class DatabaseLogsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('database_min_logger_level', LogSeverityChoiceType::class, [
@@ -59,7 +59,7 @@ final class DatabaseLogsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',
@@ -69,7 +69,7 @@ final class DatabaseLogsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'database_logs_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
@@ -40,7 +40,7 @@ final class LogsByEmailType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('logs_by_email', LogSeverityChoiceType::class, [
@@ -72,7 +72,7 @@ final class LogsByEmailType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',
@@ -82,7 +82,7 @@ final class LogsByEmailType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'logs_by_email_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsFormDataProvider.php
@@ -48,7 +48,7 @@ final class LogsFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->logsConfiguration->getConfiguration();
     }
@@ -56,7 +56,7 @@ final class LogsFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->logsConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
@@ -53,7 +53,7 @@ class ProfileType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestSettingsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestSettingsFormDataProvider.php
@@ -50,7 +50,7 @@ final class SqlRequestSettingsFormDataProvider implements FormDataProviderInterf
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->dataConfiguration->getConfiguration();
     }
@@ -58,7 +58,7 @@ final class SqlRequestSettingsFormDataProvider implements FormDataProviderInterf
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->dataConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestType.php
@@ -40,7 +40,7 @@ class SqlRequestType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/FormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/FormDataProvider.php
@@ -51,7 +51,7 @@ final class FormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->dataConfiguration->getConfiguration();
     }
@@ -59,7 +59,7 @@ final class FormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->dataConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/GeneralType.php
@@ -38,7 +38,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add(
             'token',
@@ -54,7 +54,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',
@@ -64,7 +64,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'security_general_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/PasswordPolicyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/PasswordPolicyType.php
@@ -40,7 +40,7 @@ class PasswordPolicyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(
@@ -88,7 +88,7 @@ class PasswordPolicyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',
@@ -98,7 +98,7 @@ class PasswordPolicyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'security_password_policy_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceConfigurationType.php
@@ -41,7 +41,7 @@ class WebserviceConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $enableWebservicesHelp = $this->trans(
             'Before activating the webservice, you must be sure to: ',
@@ -85,7 +85,7 @@ class WebserviceConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Advparameters.Feature',
@@ -95,7 +95,7 @@ class WebserviceConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'webservice_configuration';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceFormDataProvider.php
@@ -51,7 +51,7 @@ final class WebserviceFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->webserviceConfiguration->getConfiguration();
     }
@@ -59,7 +59,7 @@ final class WebserviceFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->webserviceConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -83,7 +83,7 @@ class WebserviceKeyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('key', GeneratableTextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
@@ -79,7 +79,7 @@ class ContactType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('title', TranslatableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/CustomerPreferencesDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/CustomerPreferencesDataProvider.php
@@ -48,7 +48,7 @@ final class CustomerPreferencesDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->generalDataConfiguration->getConfiguration();
     }
@@ -56,7 +56,7 @@ final class CustomerPreferencesDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->generalDataConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/CustomerPreferencesFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/CustomerPreferencesFormHandler.php
@@ -44,7 +44,7 @@ final class CustomerPreferencesFormHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function save(array $data)
+    public function save(array $data): array
     {
         $errors = parent::save($data);
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
@@ -42,7 +42,7 @@ use Symfony\Component\Validator\Constraints\Type;
  */
 class GeneralType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('redisplay_cart_at_login', SwitchType::class, [
@@ -131,7 +131,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',
@@ -141,7 +141,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'customer_preferences_general_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/TitleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/TitleType.php
@@ -43,7 +43,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class TitleType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceFormDataProvider.php
@@ -48,7 +48,7 @@ final class MaintenanceFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->maintenanceConfiguration->getConfiguration();
     }
@@ -56,7 +56,7 @@ final class MaintenanceFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->maintenanceConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
@@ -67,7 +67,7 @@ class MaintenanceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(
@@ -138,7 +138,7 @@ class MaintenanceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',
@@ -148,7 +148,7 @@ class MaintenanceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'maintenance_general_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesFormDataProvider.php
@@ -48,7 +48,7 @@ final class PreferencesFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->preferencesConfiguration->getConfiguration();
     }
@@ -56,7 +56,7 @@ final class PreferencesFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->preferencesConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesFormHandler.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\General;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 
 /**
  * This class manages the data manipulated using forms
@@ -64,7 +65,7 @@ final class PreferencesFormHandler implements FormHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function getForm()
+    public function getForm(): FormInterface
     {
         return $this->formFactory->createBuilder()
             ->add('general', PreferencesType::class, [
@@ -77,7 +78,7 @@ final class PreferencesFormHandler implements FormHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function save(array $data)
+    public function save(array $data): array
     {
         return $this->formDataProvider->setData($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -95,7 +95,7 @@ class PreferencesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $configuration = $this->configuration;
 
@@ -209,7 +209,7 @@ class PreferencesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',
@@ -219,7 +219,7 @@ class PreferencesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'preferences';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -75,7 +75,7 @@ class GeneralType extends TranslatorAwareType
         $this->currencyDataProvider = $currencyDataProvider;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $configuration = $this->configuration;
         $currencyIsoCode = $this->currencyDataProvider->getDefaultCurrencyIsoCode();
@@ -147,7 +147,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',
@@ -157,7 +157,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'order_preferences_general_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
@@ -91,7 +91,7 @@ class GiftOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $atcpShipWrap = (bool) $this->configuration->get('PS_ATCP_SHIPWRAP');
         $currencyIsoCode = $this->defaultCurrencyIsoCode;
@@ -140,7 +140,7 @@ class GiftOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',
@@ -150,7 +150,7 @@ class GiftOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'order_preferences_gift_options_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/OrderPreferencesGeneralFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/OrderPreferencesGeneralFormDataProvider.php
@@ -66,7 +66,7 @@ class OrderPreferencesGeneralFormDataProvider implements FormDataProviderInterfa
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->generalConfiguration->getConfiguration();
     }
@@ -74,7 +74,7 @@ class OrderPreferencesGeneralFormDataProvider implements FormDataProviderInterfa
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         // If TOS option is disabled - reset the cms id as well
         if (!$data['enable_tos']) {

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/OrderPreferencesGiftOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/OrderPreferencesGiftOptionsFormDataProvider.php
@@ -58,7 +58,7 @@ class OrderPreferencesGiftOptionsFormDataProvider implements FormDataProviderInt
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->giftOptionsConfiguration->getConfiguration();
     }
@@ -66,7 +66,7 @@ class OrderPreferencesGiftOptionsFormDataProvider implements FormDataProviderInt
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         // If gift wrapping tax rules group was not submitted - reset it to 0
         if (!isset($data['gift_wrapping_tax_rules_group'])) {

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
@@ -48,7 +48,7 @@ class OrderReturnStateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [
@@ -92,7 +92,7 @@ class OrderReturnStateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
@@ -133,7 +133,7 @@ class OrderStateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [
@@ -273,7 +273,7 @@ class OrderStateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralFormDataProvider.php
@@ -58,7 +58,7 @@ class GeneralFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->configuration->getConfiguration();
     }
@@ -66,7 +66,7 @@ class GeneralFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         if ($errors = $this->validate($data)) {
             return $errors;

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -65,7 +65,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('catalog_mode', SwitchType::class, [
@@ -205,7 +205,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',
@@ -215,7 +215,7 @@ class GeneralType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_preferences_general_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageFormDataProvider.php
@@ -50,7 +50,7 @@ class PageFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->configuration->getConfiguration();
     }
@@ -58,7 +58,7 @@ class PageFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->configuration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -41,7 +41,7 @@ class PageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('display_quantities', SwitchType::class, [
@@ -137,7 +137,7 @@ class PageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',
@@ -147,7 +147,7 @@ class PageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_preferences_page_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationFormDataProvider.php
@@ -58,7 +58,7 @@ class PaginationFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->configuration->getConfiguration();
     }
@@ -66,7 +66,7 @@ class PaginationFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         if ($errors = $this->validate($data)) {
             return $errors;

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
@@ -41,7 +41,7 @@ class PaginationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('products_per_page', IntegerType::class, [
@@ -93,7 +93,7 @@ class PaginationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',
@@ -103,7 +103,7 @@ class PaginationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_preferences_pagination_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/ProductPreferencesFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/ProductPreferencesFormHandler.php
@@ -43,7 +43,7 @@ class ProductPreferencesFormHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function save(array $data)
+    public function save(array $data): array
     {
         $errors = $this->formDataProvider->setData($data);
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockFormDataProvider.php
@@ -58,7 +58,7 @@ class StockFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->configuration->getConfiguration();
     }
@@ -66,7 +66,7 @@ class StockFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         if ($errors = $this->validate($data)) {
             return $errors;

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
@@ -45,7 +45,7 @@ class StockType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('stock_management', SwitchType::class, [
@@ -215,7 +215,7 @@ class StockType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shopparameters.Feature',
@@ -225,7 +225,7 @@ class StockType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product_preferences_stock_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Search/AliasType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Search/AliasType.php
@@ -43,7 +43,7 @@ class AliasType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('alias', TextType::class, [
@@ -68,7 +68,7 @@ class AliasType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'alias_type';
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Tag/TagType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Tag/TagType.php
@@ -60,7 +60,7 @@ class TagType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsSeoOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsSeoOptionsFormDataProvider.php
@@ -55,7 +55,7 @@ final class MetaSettingsSeoOptionsFormDataProvider implements FormDataProviderIn
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->seoOptionsDataConfiguration->getConfiguration();
     }
@@ -63,7 +63,7 @@ final class MetaSettingsSeoOptionsFormDataProvider implements FormDataProviderIn
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->seoOptionsDataConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsSetUpUrlsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsSetUpUrlsFormDataProvider.php
@@ -55,7 +55,7 @@ final class MetaSettingsSetUpUrlsFormDataProvider implements FormDataProviderInt
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->setUpUrlDataConfiguration->getConfiguration();
     }
@@ -63,7 +63,7 @@ final class MetaSettingsSetUpUrlsFormDataProvider implements FormDataProviderInt
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->setUpUrlDataConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsShopUrlsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsShopUrlsFormDataProvider.php
@@ -74,7 +74,7 @@ final class MetaSettingsShopUrlsFormDataProvider implements FormDataProviderInte
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->shopUrlsDataConfiguration->getConfiguration();
     }
@@ -82,7 +82,7 @@ final class MetaSettingsShopUrlsFormDataProvider implements FormDataProviderInte
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         $errors = $this->validateData($data);
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsUrlSchemaFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsUrlSchemaFormDataProvider.php
@@ -74,7 +74,7 @@ final class MetaSettingsUrlSchemaFormDataProvider implements FormDataProviderInt
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->urlSchemaDataConfiguration->getConfiguration();
     }
@@ -82,7 +82,7 @@ final class MetaSettingsUrlSchemaFormDataProvider implements FormDataProviderInt
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         $errors = $this->validateData($data);
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaType.php
@@ -81,7 +81,7 @@ class MetaType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('page_name', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SEOOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SEOOptionsType.php
@@ -40,7 +40,7 @@ class SEOOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('product_attributes_in_title', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
@@ -87,7 +87,7 @@ class SetUpUrlType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $friendlyUrlHelp = $this->trans(
             'Enable this option only if your server allows URL rewriting (recommended).',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/ShopUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/ShopUrlType.php
@@ -70,7 +70,7 @@ class ShopUrlType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if (!$this->isShopFeatureActive && $this->doesMainShopUrlExist) {
             $builder
@@ -98,7 +98,7 @@ class ShopUrlType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => false,

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
@@ -59,7 +59,7 @@ class UrlSchemaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('product_rule', TextType::class, [
@@ -123,7 +123,7 @@ class UrlSchemaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => false,

--- a/src/PrestaShopBundle/Form/Admin/CustomerService/CustomerThread/ForwardCustomerThreadType.php
+++ b/src/PrestaShopBundle/Form/Admin/CustomerService/CustomerThread/ForwardCustomerThreadType.php
@@ -63,7 +63,7 @@ class ForwardCustomerThreadType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $employeeChoices = $this->employeeChoiceProvider->getChoices();
         $employeeChoices[$this->translator->trans('Someone else', [], 'Admin.Orderscustomers.Feature')] = 0;

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/DeleteImageTypeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/DeleteImageTypeType.php
@@ -34,7 +34,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class DeleteImageTypeType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('delete_images_files_too', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageSettingsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageSettingsFormDataProvider.php
@@ -67,7 +67,7 @@ final class ImageSettingsFormDataProvider implements FormDataProviderInterface
         ];
     }
 
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         $command = new EditImageSettingsCommand();
         $command->setFormats($data['formats']);

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageSettingsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageSettingsType.php
@@ -47,7 +47,7 @@ class ImageSettingsType extends TranslatorAwareType
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // Check if AVIF is enabled on the server
         $avifEnabled = $this->avifExtensionChecker->isAvailable();

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageTypeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/ImageTypeType.php
@@ -45,7 +45,7 @@ class ImageTypeType extends TranslatorAwareType
     /** Maximum size for width and height in pixels for the image type */
     private const MAX_PX_SIZE = 9999;
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/RegenerateThumbnailsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/ImageSettings/RegenerateThumbnailsType.php
@@ -46,7 +46,7 @@ class RegenerateThumbnailsType extends TranslatorAwareType
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('image', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/GenerateMailsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/GenerateMailsType.php
@@ -73,7 +73,7 @@ class GenerateMailsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $noTheme = $this->trans('Core (no theme selected)', 'Admin.International.Feature');
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/MailThemeConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/MailThemeConfigurationType.php
@@ -50,7 +50,7 @@ class MailThemeConfigurationType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('defaultTheme', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/MailThemeFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/MailThemeFormDataProvider.php
@@ -46,7 +46,7 @@ class MailThemeFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->mailThemeConfiguration->getConfiguration();
     }
@@ -54,7 +54,7 @@ class MailThemeFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->mailThemeConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/TranslateMailsBodyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/TranslateMailsBodyType.php
@@ -39,7 +39,7 @@ class TranslateMailsBodyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('language', LocaleChoiceType::class)

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
@@ -77,7 +77,7 @@ class CmsPageCategoryType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $invalidCharactersForCatalogLabel = $this->trans('Invalid characters:', 'Admin.Global') . TypedRegexValidator::CATALOG_CHARS;
         $invalidCharactersForNameLabel = $this->trans('Invalid characters:', 'Admin.Global') . TypedRegexValidator::GENERIC_NAME_CHARS;

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -86,7 +86,7 @@ class CmsPageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $invalidCharsText = sprintf('%s <>{}', $this->trans('Invalid characters:', 'Admin.Notifications.Info'));
 
@@ -285,7 +285,7 @@ class CmsPageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/AdaptThemeToRTLLanguagesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/AdaptThemeToRTLLanguagesType.php
@@ -52,7 +52,7 @@ class AdaptThemeToRTLLanguagesType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('theme_to_adapt', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ImportThemeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ImportThemeType.php
@@ -62,7 +62,7 @@ class ImportThemeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('import_from_computer', FileType::class, [
@@ -102,7 +102,7 @@ class ImportThemeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'post_max_size_message' => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutsCustomizationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/PageLayoutsCustomizationType.php
@@ -52,7 +52,7 @@ class PageLayoutsCustomizationType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('layouts', CollectionType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ShopLogosFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ShopLogosFormDataProvider.php
@@ -62,7 +62,7 @@ final class ShopLogosFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->themeMultiStoreSettingsFormDataProvider->getData();
     }
@@ -72,7 +72,7 @@ final class ShopLogosFormDataProvider implements FormDataProviderInterface
      *
      * @return array
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         $data = $this->geFilteredFieldsByShopRestriction($data);
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ShopLogosType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ShopLogosType.php
@@ -77,7 +77,7 @@ class ShopLogosType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $shopLogoSettings = new ShopLogoSettings();
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyExchangeRateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyExchangeRateType.php
@@ -26,18 +26,18 @@
 
 namespace PrestaShopBundle\Form\Admin\Improve\International\Currencies;
 
-use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * Class CurrencyExchangeRateType
  */
-class CurrencyExchangeRateType extends CommonAbstractType
+class CurrencyExchangeRateType extends AbstractType
 {
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyFormDataProvider.php
@@ -36,7 +36,7 @@ final class CurrencyFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return [
             'exchange_rates' => [
@@ -47,7 +47,7 @@ final class CurrencyFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return [];
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
@@ -82,7 +82,7 @@ class CurrencyType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $newCurrency = !isset($options['data']['id']);
         $unofficialCurrency = isset($options['data']['unofficial']) ? (bool) $options['data']['unofficial'] : false;

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationByIpAddressFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationByIpAddressFormDataProvider.php
@@ -61,7 +61,7 @@ final class GeolocationByIpAddressFormDataProvider implements FormDataProviderIn
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->dataConfiguration->getConfiguration();
     }
@@ -69,7 +69,7 @@ final class GeolocationByIpAddressFormDataProvider implements FormDataProviderIn
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         $errors = [];
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationByIpAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationByIpAddressType.php
@@ -39,7 +39,7 @@ class GeolocationByIpAddressType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('geolocation_enabled', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationIpAddressWhitelistType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationIpAddressWhitelistType.php
@@ -40,7 +40,7 @@ class GeolocationIpAddressWhitelistType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('geolocation_whitelist', TextareaType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsFormDataProvider.php
@@ -51,7 +51,7 @@ final class GeolocationOptionsFormDataProvider implements FormDataProviderInterf
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         $configuration = $this->dataConfiguration->getConfiguration();
 
@@ -67,7 +67,7 @@ final class GeolocationOptionsFormDataProvider implements FormDataProviderInterf
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         $errors = [];
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php
@@ -70,7 +70,7 @@ class GeolocationOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('geolocation_behaviour', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationWhitelistFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationWhitelistFormDataProvider.php
@@ -61,7 +61,7 @@ final class GeolocationWhitelistFormDataProvider implements FormDataProviderInte
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->dataConfiguration->getConfiguration();
     }
@@ -69,7 +69,7 @@ final class GeolocationWhitelistFormDataProvider implements FormDataProviderInte
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         $errors = [];
         if (!$this->validator->isCleanHtml($data['geolocation_whitelist'])) {

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
@@ -68,7 +68,7 @@ class LanguageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextType::class, [
@@ -205,7 +205,7 @@ class LanguageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/AdvancedConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/AdvancedConfigurationType.php
@@ -39,7 +39,7 @@ class AdvancedConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('language_identifier', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php
@@ -62,7 +62,7 @@ class ImportLocalizationPackType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('iso_localization_pack', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalUnitsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalUnitsType.php
@@ -39,7 +39,7 @@ class LocalUnitsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('weight_unit', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
@@ -68,7 +68,7 @@ class LocalizationConfigurationType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('default_language', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationFormDataProvider.php
@@ -52,7 +52,7 @@ class LocalizationFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->dataConfiguration->getConfiguration();
     }
@@ -60,7 +60,7 @@ class LocalizationFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->dataConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/ChangeStatesZoneType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/ChangeStatesZoneType.php
@@ -43,7 +43,7 @@ class ChangeStatesZoneType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('new_zone_id', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryType.php
@@ -75,7 +75,7 @@ class CountryType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/StateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/StateType.php
@@ -79,7 +79,7 @@ class StateType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $stateIdValue = isset($builder->getData()['id_state']) && $builder->getData()['id_state'] instanceof StateId ?
             $builder->getData()['id_state']->getValue() :

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/ZoneType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/ZoneType.php
@@ -65,7 +65,7 @@ class ZoneType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsFormDataProvider.php
@@ -50,7 +50,7 @@ final class TaxOptionsFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->taxOptionsDataConfiguration->getConfiguration();
     }
@@ -58,7 +58,7 @@ final class TaxOptionsFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->taxOptionsDataConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
@@ -82,7 +82,7 @@ class TaxOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxRulesGroupType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxRulesGroupType.php
@@ -66,7 +66,7 @@ class TaxRulesGroupType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -47,7 +47,7 @@ class TaxType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $invalidCharsText = sprintf(
             '%s ' . TypedRegexValidator::GENERIC_NAME_CHARS,

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/AddUpdateLanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/AddUpdateLanguageType.php
@@ -59,7 +59,7 @@ class AddUpdateLanguageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('iso_localization_pack', ChoiceType::class, [
             'label' => $this->trans('Please select the language you want to add or update', 'Admin.International.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/CopyLanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/CopyLanguageType.php
@@ -60,7 +60,7 @@ class CopyLanguageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('from_language', LocaleChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportThemeLanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportThemeLanguageType.php
@@ -60,7 +60,7 @@ class ExportThemeLanguageType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('iso_code', LocaleChoiceType::class)

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
@@ -86,7 +86,7 @@ class ModifyTranslationsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $noTheme = $this->trans('Core (no theme selected)', 'Admin.International.Feature');
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/TranslationsSettingsFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/TranslationsSettingsFormHandler.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Translations;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 
 final class TranslationsSettingsFormHandler implements FormHandlerInterface
 {
@@ -73,7 +74,7 @@ final class TranslationsSettingsFormHandler implements FormHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function getForm()
+    public function getForm(): FormInterface
     {
         $formBuilder = $this->formFactory->createNamedBuilder('form', $this->form);
 
@@ -90,7 +91,7 @@ final class TranslationsSettingsFormHandler implements FormHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function save(array $data)
+    public function save(array $data): array
     {
         // Translations forms do not save data
         return [];

--- a/src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentModulePreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentModulePreferencesType.php
@@ -100,7 +100,7 @@ class PaymentModulePreferencesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('currency_restrictions', MaterialMultipleChoiceTableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentPreferencesFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentPreferencesFormDataProvider.php
@@ -51,7 +51,7 @@ final class PaymentPreferencesFormDataProvider implements FormDataProviderInterf
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->paymentModulePreferencesConfiguration->getConfiguration();
     }
@@ -59,7 +59,7 @@ final class PaymentPreferencesFormDataProvider implements FormDataProviderInterf
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->paymentModulePreferencesConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/CarrierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/CarrierType.php
@@ -45,7 +45,7 @@ class CarrierType extends TranslatorAwareType
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder
@@ -61,12 +61,12 @@ class CarrierType extends TranslatorAwareType
         ;
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return NavigationTabType::class;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/GeneralSettings.php
@@ -55,7 +55,7 @@ class GeneralSettings extends TranslatorAwareType
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $maximumFileSize = (int) str_replace('M', '', strval(self::MAX_IMAGE_SIZE_IN_BYTES));
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/ShippingLocationsAndCostsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/ShippingLocationsAndCostsType.php
@@ -54,7 +54,7 @@ class ShippingLocationsAndCostsType extends TranslatorAwareType
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/SizeWeightSettings.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/SizeWeightSettings.php
@@ -53,7 +53,7 @@ class SizeWeightSettings extends TranslatorAwareType
         parent::__construct($translator, $locales);
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder
@@ -131,7 +131,7 @@ class SizeWeightSettings extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CarrierRangesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CarrierRangesType.php
@@ -48,7 +48,7 @@ class CarrierRangesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('data', HiddenType::class)
@@ -76,7 +76,7 @@ class CarrierRangesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => $this->trans('Ranges', 'Admin.Shipping.Feature'),
@@ -87,7 +87,7 @@ class CarrierRangesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'carrier_ranges';
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsRangeType.php
@@ -41,7 +41,7 @@ class CostsRangeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('range', TextPreviewType::class, [
@@ -70,7 +70,7 @@ class CostsRangeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => false,
@@ -81,7 +81,7 @@ class CostsRangeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'carrier_ranges_costs_zone_range';
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsZoneType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Carrier/Type/CostsZoneType.php
@@ -41,7 +41,7 @@ class CostsZoneType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('zoneId', HiddenType::class)
@@ -73,7 +73,7 @@ class CostsZoneType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => false,
@@ -84,7 +84,7 @@ class CostsZoneType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'carrier_ranges_costs_zone';
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
@@ -72,7 +72,7 @@ class CarrierOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $carrierChoices = array_merge([
             'Best price' => (int) -1,
@@ -124,7 +124,7 @@ class CarrierOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shipping.Feature',
@@ -134,7 +134,7 @@ class CarrierOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'shipping_preferences_carrier_options_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
@@ -68,7 +68,7 @@ class HandlingType extends TranslatorAwareType
         $this->configuration = $configuration;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $defaultCurrencyIsoCode = $this->currencyDataProvider->getDefaultCurrencyIsoCode();
         $weightUnit = $this->configuration->get('PS_WEIGHT_UNIT');
@@ -122,7 +122,7 @@ class HandlingType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Shipping.Feature',
@@ -132,7 +132,7 @@ class HandlingType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'shipping_preferences_handling_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/PreferencesCarrierOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/PreferencesCarrierOptionsFormDataProvider.php
@@ -50,7 +50,7 @@ class PreferencesCarrierOptionsFormDataProvider implements FormDataProviderInter
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->dataConfiguration->getConfiguration();
     }
@@ -58,7 +58,7 @@ class PreferencesCarrierOptionsFormDataProvider implements FormDataProviderInter
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->dataConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/PreferencesHandlingFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/PreferencesHandlingFormDataProvider.php
@@ -49,7 +49,7 @@ class PreferencesHandlingFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->dataConfiguration->getConfiguration();
     }
@@ -57,7 +57,7 @@ class PreferencesHandlingFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->dataConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Login/LoginFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Login/LoginFormDataProvider.php
@@ -36,14 +36,14 @@ class LoginFormDataProvider implements FormDataProviderInterface
     ) {
     }
 
-    public function getData()
+    public function getData(): array
     {
         return [
             'email' => $this->authenticationUtils->getLastUsername(),
         ];
     }
 
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         // Nothing to do the login mechanism is handled by the Symfony framework
         return [];

--- a/src/PrestaShopBundle/Form/Admin/Login/LoginType.php
+++ b/src/PrestaShopBundle/Form/Admin/Login/LoginType.php
@@ -55,7 +55,7 @@ class LoginType extends AbstractType
         $this->isDemoModeEnabled = $shopConfiguration->getBoolean('_PS_MODE_DEMO_');
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('email', EmailType::class, [
@@ -95,7 +95,7 @@ class LoginType extends AbstractType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([
@@ -108,7 +108,7 @@ class LoginType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return '';
     }

--- a/src/PrestaShopBundle/Form/Admin/Login/RequestPasswordResetFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Login/RequestPasswordResetFormDataProvider.php
@@ -37,12 +37,12 @@ class RequestPasswordResetFormDataProvider implements FormDataProviderInterface
     ) {
     }
 
-    public function getData()
+    public function getData(): array
     {
         return [];
     }
 
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         $this->commandBus->handle(new SendEmployeePasswordResetEmailCommand($data['email_forgot']));
 

--- a/src/PrestaShopBundle/Form/Admin/Login/RequestPasswordResetType.php
+++ b/src/PrestaShopBundle/Form/Admin/Login/RequestPasswordResetType.php
@@ -43,7 +43,7 @@ class RequestPasswordResetType extends AbstractType
     ) {
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('email_forgot', EmailType::class, [
@@ -73,7 +73,7 @@ class RequestPasswordResetType extends AbstractType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Login/ResetPasswordFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Login/ResetPasswordFormDataProvider.php
@@ -37,12 +37,12 @@ class ResetPasswordFormDataProvider implements FormDataProviderInterface
     ) {
     }
 
-    public function getData()
+    public function getData(): array
     {
         return [];
     }
 
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         $this->commandBus->handle(new ResetEmployeePasswordCommand(
             $data['resetToken'],

--- a/src/PrestaShopBundle/Form/Admin/Login/ResetPasswordType.php
+++ b/src/PrestaShopBundle/Form/Admin/Login/ResetPasswordType.php
@@ -46,7 +46,7 @@ class ResetPasswordType extends AbstractType
     ) {
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $maxLength = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH);
@@ -96,7 +96,7 @@ class ResetPasswordType extends AbstractType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
@@ -97,7 +97,7 @@ class CustomerAddressType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $data = $builder->getData();
         $countryId = 0 !== $data['id_country'] ? $data['id_country'] : $this->contextCountryId;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
@@ -92,7 +92,7 @@ class ManufacturerAddressType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $nameHint = $this->trans('Invalid characters:', 'Admin.Global') . ' 0-9!<>,;?=+()@#"�{}_$%:';
         $data = $builder->getData();

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/RequiredFieldsAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/RequiredFieldsAddressType.php
@@ -52,7 +52,7 @@ class RequiredFieldsAddressType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('required_fields', MaterialChoiceTableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
@@ -47,7 +47,7 @@ class AttachmentType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $required = true;
         if (isset($options['data']['file_name']) && $options['data']['file_name']) {

--- a/src/PrestaShopBundle/Form/Admin/Sell/CartRule/ActionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CartRule/ActionsType.php
@@ -37,7 +37,7 @@ class ActionsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('free_shipping', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/CartRule/CartRuleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CartRule/CartRuleType.php
@@ -38,7 +38,7 @@ class CartRuleType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('information', InformationType::class, [
@@ -62,7 +62,7 @@ class CartRuleType extends TranslatorAwareType
         return NavigationTabType::class;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/CartRule/ConditionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CartRule/ConditionsType.php
@@ -35,7 +35,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class ConditionsType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('customer', CustomerSearchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/CartRule/DiscountType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CartRule/DiscountType.php
@@ -65,7 +65,7 @@ class DiscountType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('reduction', PriceReductionType::class, [
@@ -105,7 +105,7 @@ class DiscountType extends TranslatorAwareType
         ]);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/CartRule/InformationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CartRule/InformationType.php
@@ -46,7 +46,7 @@ class InformationType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/CartRule/MinimumAmountType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CartRule/MinimumAmountType.php
@@ -40,7 +40,7 @@ class MinimumAmountType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('amount', NumberType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Catalog/AttributeGroupType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Catalog/AttributeGroupType.php
@@ -59,7 +59,7 @@ class AttributeGroupType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Catalog/AttributeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Catalog/AttributeType.php
@@ -62,7 +62,7 @@ class AttributeType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $attributeGroupId = (is_int($options['attribute_group']) && $options['attribute_group'] > 0) ? $options['attribute_group'] : '';
 
@@ -121,7 +121,7 @@ class AttributeType extends TranslatorAwareType
         }
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setRequired('attribute_group');
         parent::configureOptions($resolver);

--- a/src/PrestaShopBundle/Form/Admin/Sell/Catalog/FeatureType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Catalog/FeatureType.php
@@ -43,7 +43,7 @@ class FeatureType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TranslatableType::class, [
@@ -67,7 +67,7 @@ class FeatureType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Catalog/FeatureValueType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Catalog/FeatureValueType.php
@@ -44,7 +44,7 @@ class FeatureValueType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('feature_value_id', HiddenType::class)
@@ -72,7 +72,7 @@ class FeatureValueType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'form_theme' => '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig',

--- a/src/PrestaShopBundle/Form/Admin/Sell/CatalogPriceRule/CatalogPriceRuleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CatalogPriceRule/CatalogPriceRuleType.php
@@ -89,7 +89,7 @@ class CatalogPriceRuleType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Category/DeleteCategoriesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Category/DeleteCategoriesType.php
@@ -54,7 +54,7 @@ class DeleteCategoriesType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('delete_mode', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -122,7 +122,7 @@ class CustomerType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // Initialize password strength configuration set in Security section of backoffice
         $minScore = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_SCORE);
@@ -402,7 +402,7 @@ class CustomerType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/DeleteCustomersType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/DeleteCustomersType.php
@@ -54,7 +54,7 @@ class DeleteCustomersType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('delete_method', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/PrivateNoteType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/PrivateNoteType.php
@@ -54,7 +54,7 @@ class PrivateNoteType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('note', TextareaType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/RequiredFieldsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/RequiredFieldsType.php
@@ -51,7 +51,7 @@ class RequiredFieldsType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('required_fields', MaterialChoiceTableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/SearchedCustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/SearchedCustomerType.php
@@ -27,17 +27,17 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Customer;
 
-use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\TextPreviewType;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class SearchedCustomerType extends CommonAbstractType
+class SearchedCustomerType extends AbstractType
 {
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('id_customer', HiddenType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/TransferGuestAccountType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/TransferGuestAccountType.php
@@ -40,7 +40,7 @@ class TransferGuestAccountType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('id_customer', HiddenType::class)

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/MerchandiseReturn/MerchandiseReturnOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/MerchandiseReturn/MerchandiseReturnOptionsFormDataProvider.php
@@ -50,7 +50,7 @@ final class MerchandiseReturnOptionsFormDataProvider implements FormDataProvider
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->optionsDataConfiguration->getConfiguration();
     }
@@ -58,7 +58,7 @@ final class MerchandiseReturnOptionsFormDataProvider implements FormDataProvider
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->optionsDataConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/MerchandiseReturn/MerchandiseReturnOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/MerchandiseReturn/MerchandiseReturnOptionsType.php
@@ -47,7 +47,7 @@ class MerchandiseReturnOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(static::FIELD_ENABLE_ORDER_RETURN, SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/MerchandiseReturn/OrderReturnType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/MerchandiseReturn/OrderReturnType.php
@@ -64,7 +64,7 @@ class OrderReturnType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('customer_name', TextPreviewType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/ReplyToCustomerThreadType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/ReplyToCustomerThreadType.php
@@ -51,7 +51,7 @@ class ReplyToCustomerThreadType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('reply_message', TextareaType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/CartConditionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/CartConditionsType.php
@@ -41,7 +41,7 @@ class CartConditionsType extends TranslatorAwareType
     public const MINIMUM_AMOUNT = 'minimum_amount';
     public const MINIMUM_PRODUCT_QUANTITY = 'minimum_product_quantity';
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder
@@ -85,7 +85,7 @@ class CartConditionsType extends TranslatorAwareType
         ;
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return ToggleChildrenChoiceType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DeliveryConditionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DeliveryConditionsType.php
@@ -42,7 +42,7 @@ class DeliveryConditionsType extends TranslatorAwareType
     public const CARRIERS = 'carriers';
     public const COUNTRY = 'country';
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(self::NONE, HiddenType::class, [
@@ -85,7 +85,7 @@ class DeliveryConditionsType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([
@@ -93,7 +93,7 @@ class DeliveryConditionsType extends TranslatorAwareType
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return ToggleChildrenChoiceType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountConditionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountConditionsType.php
@@ -38,7 +38,7 @@ class DiscountConditionsType extends TranslatorAwareType
     public const CART_CONDITIONS = 'cart';
     public const DELIVERY_CONDITIONS = 'delivery';
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $discountType = $options['discount_type'];
         $builder
@@ -88,7 +88,7 @@ class DiscountConditionsType extends TranslatorAwareType
         $resolver->setAllowedTypes('discount_type', ['string']);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return CardType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountCustomerEligibilityChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountCustomerEligibilityChoiceType.php
@@ -57,7 +57,7 @@ class DiscountCustomerEligibilityChoiceType extends TranslatorAwareType
         $this->groupByIdChoiceProvider = $groupByIdChoiceProvider;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(self::ALL_CUSTOMERS, HiddenType::class, [
@@ -120,7 +120,7 @@ class DiscountCustomerEligibilityChoiceType extends TranslatorAwareType
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return ToggleChildrenChoiceType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountCustomerEligibilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountCustomerEligibilityType.php
@@ -33,7 +33,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DiscountCustomerEligibilityType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('eligibility', DiscountCustomerEligibilityChoiceType::class)
@@ -49,7 +49,7 @@ class DiscountCustomerEligibilityType extends TranslatorAwareType
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return CardType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountInformationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountInformationType.php
@@ -41,7 +41,7 @@ use Symfony\Component\Validator\Constraints\Length;
 
 class DiscountInformationType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $discountType = $options['discount_type'];
         $builder
@@ -98,7 +98,7 @@ class DiscountInformationType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setRequired([
@@ -110,7 +110,7 @@ class DiscountInformationType extends TranslatorAwareType
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return CardType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountPeriodType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountPeriodType.php
@@ -38,7 +38,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DiscountPeriodType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('valid_date_range', DateRangeType::class, [
@@ -80,7 +80,7 @@ class DiscountPeriodType extends TranslatorAwareType
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return CardType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountProductSegmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountProductSegmentType.php
@@ -47,7 +47,7 @@ class DiscountProductSegmentType extends TranslatorAwareType
     public const SUPPLIER = 'supplier';
     public const ATTRIBUTES = 'attributes';
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(self::MANUFACTURER, ManufacturerType::class, [
@@ -109,7 +109,7 @@ class DiscountProductSegmentType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountType.php
@@ -44,7 +44,7 @@ class DiscountType extends TranslatorAwareType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
 
@@ -101,7 +101,7 @@ class DiscountType extends TranslatorAwareType
             ]);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountTypeSelectorType.php
@@ -34,7 +34,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DiscountTypeSelectorType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder
@@ -78,7 +78,7 @@ class DiscountTypeSelectorType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountUsabilityModeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountUsabilityModeType.php
@@ -43,7 +43,7 @@ class DiscountUsabilityModeType extends TranslatorAwareType
     public const CODE_MODE = 'code';
     protected const GENERATED_CODE_LENGTH = 8;
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(self::AUTO_MODE, HiddenType::class, [
@@ -78,7 +78,7 @@ class DiscountUsabilityModeType extends TranslatorAwareType
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return ToggleChildrenChoiceType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountUsabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountUsabilityType.php
@@ -39,7 +39,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class DiscountUsabilityType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $cartRuleTypeChoices = [];
         foreach ($options['available_cart_rule_types'] as $cartRuleType) {
@@ -140,7 +140,7 @@ class DiscountUsabilityType extends TranslatorAwareType
         $resolver->setAllowedTypes('available_cart_rule_types', ['array']);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return CardType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountValueType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountValueType.php
@@ -33,7 +33,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class DiscountValueType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('reduction', PriceReductionType::class, [
@@ -48,7 +48,7 @@ class DiscountValueType extends TranslatorAwareType
         ;
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return CardType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/MinimumAmountType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/MinimumAmountType.php
@@ -68,7 +68,7 @@ class MinimumAmountType extends TranslatorAwareType implements EventSubscriberIn
         ];
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('value', MoneyType::class, [
@@ -92,7 +92,7 @@ class MinimumAmountType extends TranslatorAwareType implements EventSubscriberIn
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/ProductConditionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/ProductConditionsType.php
@@ -46,7 +46,7 @@ class ProductConditionsType extends TranslatorAwareType
     public const SPECIFIC_PRODUCTS = 'specific_products';
     public const PRODUCT_SEGMENT = 'product_segment';
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $discountType = $options['discount_type'];
@@ -120,7 +120,7 @@ class ProductConditionsType extends TranslatorAwareType
         $resolver->setAllowedTypes('discount_type', ['string']);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return ToggleChildrenChoiceType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/SpecificProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/SpecificProductType.php
@@ -69,7 +69,7 @@ class SpecificProductType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('id', HiddenType::class, [
@@ -186,7 +186,7 @@ class SpecificProductType extends TranslatorAwareType
         return 'entity_item';
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Manufacturer/ManufacturerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Manufacturer/ManufacturerType.php
@@ -69,7 +69,7 @@ class ManufacturerType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $invalidCharactersForCatalogLabel = $this->trans('Invalid characters:', 'Admin.Global') . '<>{}';
         $invalidCharactersForNameLabel = $this->trans('Invalid characters:', 'Admin.Global') . '<>{}';

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CartSummaryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CartSummaryType.php
@@ -72,7 +72,7 @@ class CartSummaryType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('cart_id', HiddenType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/ChangeOrdersStatusType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/ChangeOrdersStatusType.php
@@ -52,7 +52,7 @@ class ChangeOrdersStatusType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('new_order_status_id', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsFormDataProvider.php
@@ -50,7 +50,7 @@ final class CreditSlipOptionsFormDataProvider implements FormDataProviderInterfa
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->creditSlipOptionsConfiguration->getConfiguration();
     }
@@ -58,7 +58,7 @@ final class CreditSlipOptionsFormDataProvider implements FormDataProviderInterfa
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->creditSlipOptionsConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
@@ -41,7 +41,7 @@ final class CreditSlipOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('slip_prefix', TranslatableType::class, [
             'label' => $this->trans('Credit slip prefix', 'Admin.Orderscustomers.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
@@ -44,7 +44,7 @@ final class GeneratePdfByDateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $dateFormat = 'Y-m-d';
         $nowDate = (new \DateTime())->format($dateFormat);
@@ -87,7 +87,7 @@ final class GeneratePdfByDateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsFormDataProvider.php
@@ -48,7 +48,7 @@ final class SlipOptionsFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->configuration->getConfiguration();
     }
@@ -56,7 +56,7 @@ final class SlipOptionsFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->configuration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
@@ -41,7 +41,7 @@ class SlipOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(
@@ -80,7 +80,7 @@ class SlipOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'order_delivery_slip_options';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipPdfFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipPdfFormDataProvider.php
@@ -48,7 +48,7 @@ final class SlipPdfFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return [];
     }
@@ -56,7 +56,7 @@ final class SlipPdfFormDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         return $this->configuration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipPdfType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipPdfType.php
@@ -39,7 +39,7 @@ class SlipPdfType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $now = (new DateTime())->format('Y-m-d');
         $builder
@@ -80,7 +80,7 @@ class SlipPdfType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'order_delivery_slip_options';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/InternalNoteType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/InternalNoteType.php
@@ -56,7 +56,7 @@ class InternalNoteType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('note', TextareaType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByDateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByDateType.php
@@ -40,7 +40,7 @@ class GenerateByDateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('date_from', DatePickerType::class, [
@@ -56,7 +56,7 @@ class GenerateByDateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Orderscustomers.Feature',
@@ -66,7 +66,7 @@ class GenerateByDateType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'orders_invoices_by_date_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByStatusType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/GenerateByStatusType.php
@@ -70,7 +70,7 @@ class GenerateByStatusType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('order_states', ChoiceType::class, [
@@ -85,7 +85,7 @@ class GenerateByStatusType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function finishView(FormView $view, FormInterface $form, array $options)
+    public function finishView(FormView $view, FormInterface $form, array $options): void
     {
         /** @var FormView $child */
         foreach ($view->children['order_states'] as $child) {
@@ -100,7 +100,7 @@ class GenerateByStatusType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Orderscustomers.Feature',
@@ -110,7 +110,7 @@ class GenerateByStatusType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'orders_invoices_by_status_block';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceByDateFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceByDateFormHandler.php
@@ -76,7 +76,7 @@ final class InvoiceByDateFormHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function save(array $data)
+    public function save(array $data): array
     {
         if ($errors = parent::save($data)) {
             return $errors;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceByStatusFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceByStatusFormHandler.php
@@ -75,7 +75,7 @@ final class InvoiceByStatusFormHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function save(array $data)
+    public function save(array $data): array
     {
         if ($errors = parent::save($data)) {
             return $errors;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsDataProvider.php
@@ -60,7 +60,7 @@ final class InvoiceOptionsDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->invoiceOptionsConfiguration->getConfiguration();
     }
@@ -68,7 +68,7 @@ final class InvoiceOptionsDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         if ($errors = $this->validate($data)) {
             return $errors;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsType.php
@@ -79,7 +79,7 @@ class InvoiceOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(
@@ -241,7 +241,7 @@ class InvoiceOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['next_invoice_number'] = $this->nextInvoiceNumber;
     }
@@ -249,7 +249,7 @@ class InvoiceOptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Orderscustomers.Feature',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoicesByDateDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoicesByDateDataProvider.php
@@ -49,7 +49,7 @@ final class InvoicesByDateDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         $date = (new DateTime())->format('Y-m-d');
 
@@ -62,7 +62,7 @@ final class InvoicesByDateDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         // This form doesn't need to save any data, so it only validates the data
         return $this->validate($data);

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoicesByStatusDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoicesByStatusDataProvider.php
@@ -37,7 +37,7 @@ final class InvoicesByStatusDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getData()
+    public function getData(): array
     {
         return [];
     }
@@ -45,7 +45,7 @@ final class InvoicesByStatusDataProvider implements FormDataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setData(array $data)
+    public function setData(array $data): array
     {
         // This form doesn't need to save any data, so it only validates the data
         return $this->validate($data);

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageType.php
@@ -69,7 +69,7 @@ class OrderMessageType extends AbstractType
         $this->translator = $translator;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('order_message', ChoiceType::class, [
@@ -113,7 +113,7 @@ class OrderMessageType extends AbstractType
         ;
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['messages'] = $this->orderMessageChoiceProvider->getChoices([
             'lang_id' => $options['data']['lang_id'] ?? null,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderStatusType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderStatusType.php
@@ -55,7 +55,7 @@ class UpdateOrderStatusType extends AbstractType
         $this->statusChoiceAttributes = $statusChoiceAttributes;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $choiceProviderParams = [];
         if (!empty($options['data']['new_order_status_id'])) {

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
@@ -69,7 +69,7 @@ class CategoriesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('product_categories', CategoryTagsCollectionType::class)
@@ -94,7 +94,7 @@ class CategoriesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryFilterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryFilterType.php
@@ -74,7 +74,7 @@ class CategoryFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
         $view->vars['nested_tree'] = $options['nested_tree'];
@@ -83,7 +83,7 @@ class CategoryFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $nestedTree = $this->categoryProvider->getNestedCategories(null, $this->contextLangId, false);
@@ -105,7 +105,7 @@ class CategoryFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }
@@ -113,7 +113,7 @@ class CategoryFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'category_filter';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryTagsCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryTagsCollectionType.php
@@ -50,7 +50,7 @@ class CategoryTagsCollectionType extends CollectionType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryTreeSelectorType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoryTreeSelectorType.php
@@ -56,7 +56,7 @@ class CategoryTreeSelectorType extends CollectionType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('product_categories', CategoryTagsCollectionType::class)
@@ -94,7 +94,7 @@ class CategoryTreeSelectorType extends CollectionType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/ProductCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/ProductCategoryType.php
@@ -35,7 +35,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class ProductCategoryType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('display_name', TextPreviewType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationImagesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationImagesType.php
@@ -36,7 +36,7 @@ class BulkCombinationImagesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('images', CombinationImagesChoiceType::class, [
             'product_id' => $options['product_id'],
@@ -47,7 +47,7 @@ class BulkCombinationImagesType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationReferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationReferencesType.php
@@ -42,7 +42,7 @@ use Symfony\Component\Validator\Constraints\Length;
 
 class BulkCombinationReferencesType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('reference', TextType::class, [
@@ -102,7 +102,7 @@ class BulkCombinationReferencesType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
@@ -65,7 +65,7 @@ class BulkCombinationStockType extends TranslatorAwareType
         $this->stockManagementEnabled = $stockManagementEnabled;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if ($this->stockManagementEnabled) {
             $builder
@@ -169,7 +169,7 @@ class BulkCombinationStockType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationType.php
@@ -57,7 +57,7 @@ class BulkCombinationType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver
@@ -83,7 +83,7 @@ class BulkCombinationType extends TranslatorAwareType
         ;
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return AccordionType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
@@ -67,7 +67,7 @@ class CombinationAvailabilityType extends TranslatorAwareType
         $this->router = $router;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('out_of_stock_type', ChoiceType::class, [
@@ -110,7 +110,7 @@ class CombinationAvailabilityType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationFormType.php
@@ -66,7 +66,7 @@ class CombinationFormType extends TranslatorAwareType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('cover_thumbnail_url', ImagePreviewType::class, [
@@ -103,7 +103,7 @@ class CombinationFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationHeaderType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationHeaderType.php
@@ -39,7 +39,7 @@ class CombinationHeaderType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder
@@ -63,7 +63,7 @@ class CombinationHeaderType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationImagesChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationImagesChoiceType.php
@@ -57,7 +57,7 @@ class CombinationImagesChoiceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationItemType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationItemType.php
@@ -245,7 +245,7 @@ class CombinationItemType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
         $view->vars['placeholder_data'] = $this->getPlaceholderData($form->all());

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationListType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationListType.php
@@ -38,7 +38,7 @@ class CombinationListType extends CollectionType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationManagerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationManagerType.php
@@ -61,13 +61,13 @@ class CombinationManagerType extends TranslatorAwareType
         $this->multiStoreFeature = $multiStoreFeature;
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['productId'] = $options['product_id'];
         $view->vars['isMultiStoreActive'] = $this->multiStoreFeature->isActive();
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationPriceImpactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationPriceImpactType.php
@@ -115,7 +115,7 @@ class CombinationPriceImpactType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('price_tax_excluded', MoneyType::class, [
@@ -287,7 +287,7 @@ class CombinationPriceImpactType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
@@ -46,7 +46,7 @@ class CombinationStockType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('quantities', QuantityType::class, [
@@ -111,7 +111,7 @@ class CombinationStockType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationsType.php
@@ -34,7 +34,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CombinationsType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('combination_manager', CombinationManagerType::class, [
@@ -44,7 +44,7 @@ class CombinationsType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/LowStockThresholdType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/LowStockThresholdType.php
@@ -51,7 +51,7 @@ class LowStockThresholdType extends TranslatorAwareType
         $this->router = $router;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('low_stock_alert', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/CreateProductFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/CreateProductFormType.php
@@ -42,7 +42,7 @@ class CreateProductFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('type', ProductTypeType::class)
@@ -70,7 +70,7 @@ class CreateProductFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'required' => false,
@@ -86,7 +86,7 @@ class CreateProductFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'create_product';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/DataTransformer/RedirectionTargetTransformer.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/DataTransformer/RedirectionTargetTransformer.php
@@ -40,7 +40,7 @@ class RedirectionTargetTransformer implements DataTransformerInterface
     /**
      * {@inheritDoc}
      */
-    public function transform($redirectionData)
+    public function transform(mixed $redirectionData): mixed
     {
         if (isset($redirectionData['target'])) {
             $redirectionData['target'] = [
@@ -54,7 +54,7 @@ class RedirectionTargetTransformer implements DataTransformerInterface
     /**
      * {@inheritDoc}
      */
-    public function reverseTransform($redirectionData)
+    public function reverseTransform(mixed $redirectionData): mixed
     {
         // EntitySearchInputType contains a collection of hidden inputs, for redirection only one target is selected
         // and we just want to retrieve the first (and only) selected ID

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/DataTransformer/SpecificPriceFixedPriceTransformer.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/DataTransformer/SpecificPriceFixedPriceTransformer.php
@@ -50,7 +50,7 @@ class SpecificPriceFixedPriceTransformer implements DataTransformerInterface
         $this->numberTransformer = new NumberToLocalizedStringTransformer($scale, $grouping, $roundingMode);
     }
 
-    public function transform($fixedPriceLocalizedValue)
+    public function transform(mixed $fixedPriceLocalizedValue): mixed
     {
         $floatValue = $this->numberTransformer->reverseTransform((string) $fixedPriceLocalizedValue);
         if (InitialPrice::isInitialPriceValue((string) $floatValue)) {
@@ -60,7 +60,7 @@ class SpecificPriceFixedPriceTransformer implements DataTransformerInterface
         return $fixedPriceLocalizedValue;
     }
 
-    public function reverseTransform($fixedPriceViewValue)
+    public function reverseTransform(mixed $fixedPriceViewValue): mixed
     {
         if ($fixedPriceViewValue === '') {
             return InitialPrice::INITIAL_PRICE_VALUE;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/DescriptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/DescriptionType.php
@@ -81,7 +81,7 @@ class DescriptionType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $productId = $options['product_id'];
         $shopId = $options['shop_id'];
@@ -151,7 +151,7 @@ class DescriptionType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/CustomizationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/CustomizationsType.php
@@ -36,7 +36,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CustomizationsType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('customization_fields', CollectionType::class, [
@@ -58,7 +58,7 @@ class CustomizationsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/DetailsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/DetailsType.php
@@ -69,7 +69,7 @@ class DetailsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('references', ReferencesType::class);
 
@@ -105,7 +105,7 @@ class DetailsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeatureCollectionItemType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeatureCollectionItemType.php
@@ -36,7 +36,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 
 class FeatureCollectionItemType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('feature_id', HiddenType::class, [
@@ -71,7 +71,7 @@ class FeatureCollectionItemType extends TranslatorAwareType
      *
      * @return string
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'feature_collection_item';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeatureCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeatureCollectionType.php
@@ -33,7 +33,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FeatureCollectionType extends CollectionType
 {
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeatureValueType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeatureValueType.php
@@ -45,7 +45,7 @@ class FeatureValueType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('feature_value_id', HiddenType::class, [
@@ -118,7 +118,7 @@ class FeatureValueType extends TranslatorAwareType
         ]);
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
         $formData = $form->getData();

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeaturesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/FeaturesType.php
@@ -65,7 +65,7 @@ class FeaturesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $features = array_merge([
             $this->trans('Choose a feature', 'Admin.Catalog.Feature') => 0,
@@ -119,7 +119,7 @@ class FeaturesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/ReferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Details/ReferencesType.php
@@ -45,7 +45,7 @@ class ReferencesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('reference', TextType::class, [
@@ -103,7 +103,7 @@ class ReferencesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EditProductFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EditProductFormType.php
@@ -82,7 +82,7 @@ class EditProductFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $productId = $options['product_id'];
         $shopId = $options['shop_id'];
@@ -134,7 +134,7 @@ class EditProductFormType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $formVars = [
             'product_type' => $options['product_type'],
@@ -149,7 +149,7 @@ class EditProductFormType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 
@@ -190,7 +190,7 @@ class EditProductFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return NavigationTabType::class;
     }
@@ -198,7 +198,7 @@ class EditProductFormType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'product';
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/VirtualProductFileListener.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/VirtualProductFileListener.php
@@ -48,7 +48,7 @@ class VirtualProductFileListener implements EventSubscriberInterface
     /**
      * {@inheritDoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FormEvents::PRE_SUBMIT => 'adaptFormConstraints',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ExtraModulesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ExtraModulesType.php
@@ -76,7 +76,7 @@ class ExtraModulesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
 
@@ -87,7 +87,7 @@ class ExtraModulesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
@@ -96,7 +96,7 @@ class FooterType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $productId = $options['product_id'];
 
@@ -220,7 +220,7 @@ class FooterType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
@@ -84,7 +84,7 @@ class HeaderType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('cover_thumbnail', ImagePreviewType::class, [
@@ -157,7 +157,7 @@ class HeaderType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Image/ImageDropzoneType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Image/ImageDropzoneType.php
@@ -64,7 +64,7 @@ class ImageDropzoneType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
 
@@ -95,7 +95,7 @@ class ImageDropzoneType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([
@@ -167,7 +167,7 @@ class ImageDropzoneType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
         $view->vars['locales'] = $this->locales;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Image/ProductImageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Image/ProductImageType.php
@@ -28,23 +28,22 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Image;
 
-use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class ProductImageType extends CommonAbstractType
+class ProductImageType extends AbstractType
 {
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        parent::buildForm($builder, $options);
         $builder
             ->add('product_id', HiddenType::class)
             ->add('shop_id', HiddenType::class)

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/AttachedFileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/AttachedFileType.php
@@ -34,7 +34,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class AttachedFileType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->remove('name')

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/CustomizationFieldType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/CustomizationFieldType.php
@@ -59,7 +59,7 @@ class CustomizationFieldType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('id', HiddenType::class)

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/OptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/OptionsType.php
@@ -39,7 +39,7 @@ class OptionsType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('visibility', VisibilityType::class)
@@ -51,7 +51,7 @@ class OptionsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductAttachmentsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductAttachmentsType.php
@@ -60,7 +60,7 @@ class ProductAttachmentsType extends TranslatorAwareType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('attached_files', EntitySearchInputType::class, [
@@ -96,7 +96,7 @@ class ProductAttachmentsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductSupplierCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductSupplierCollectionType.php
@@ -44,7 +44,7 @@ class ProductSupplierCollectionType extends CollectionType
         $this->translator = $translator;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductSupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductSupplierType.php
@@ -89,7 +89,7 @@ class ProductSupplierType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('supplier_id', HiddenType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/SuppliersType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/SuppliersType.php
@@ -59,7 +59,7 @@ class SuppliersType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $suppliers = $this->supplierNameByIdChoiceProvider->getChoices();
 
@@ -92,7 +92,7 @@ class SuppliersType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/VisibilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/VisibilityType.php
@@ -61,7 +61,7 @@ class VisibilityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('visibility', ChoiceType::class, [
@@ -101,7 +101,7 @@ class VisibilityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/ApplicableGroupsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/ApplicableGroupsType.php
@@ -129,7 +129,7 @@ class ApplicableGroupsType extends TranslatorAwareType
         return $choices;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/CatalogPriceRulesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/CatalogPriceRulesType.php
@@ -64,7 +64,7 @@ class CatalogPriceRulesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PriceSummaryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PriceSummaryType.php
@@ -33,7 +33,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PriceSummaryType extends TranslatorAwareType
 {
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => $this->trans('Summary', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
@@ -68,7 +68,7 @@ class PricingType extends TranslatorAwareType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('retail_price', RetailPriceType::class, [
@@ -123,7 +123,7 @@ class PricingType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
@@ -124,7 +124,7 @@ class RetailPriceType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if ($this->isTaxEnabled) {
             $ecotaxRate = $this->taxComputer->getTaxRate(new TaxRulesGroupId($this->ecoTaxGroupId), new CountryId($this->contextCountryId));
@@ -264,7 +264,7 @@ class RetailPriceType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceImpactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceImpactType.php
@@ -66,7 +66,7 @@ class SpecificPriceImpactType extends TranslatorAwareType
         $this->defaultCurrencyIsoCode = $defaultCurrencyIsoCode;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('reduction', PriceReductionType::class, [
@@ -116,7 +116,7 @@ class SpecificPriceImpactType extends TranslatorAwareType
         $builder->get('fixed_price_tax_excluded')->addViewTransformer(new SpecificPriceFixedPriceTransformer());
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPricePriorityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPricePriorityType.php
@@ -48,7 +48,7 @@ class SpecificPricePriorityType extends CollectionType
         $this->priorityChoiceProvider = $priorityChoiceProvider;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
@@ -170,7 +170,7 @@ class SpecificPriceType extends TranslatorAwareType
         $builder->addEventSubscriber($this->specificPriceCombinationListener);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPricesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPricesType.php
@@ -37,7 +37,7 @@ class SpecificPricesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('add_specific_price_btn', IconButtonType::class, [
@@ -56,7 +56,7 @@ class SpecificPricesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/UnitPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/UnitPriceType.php
@@ -66,7 +66,7 @@ class UnitPriceType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('price_tax_excluded', MoneyType::class, [
@@ -113,7 +113,7 @@ class UnitPriceType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductSearchAndResetType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductSearchAndResetType.php
@@ -36,7 +36,7 @@ use Symfony\Component\Form\FormView;
  */
 class ProductSearchAndResetType extends SearchAndResetType
 {
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
         if (null !== $form->getParent()) {

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductShopsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductShopsType.php
@@ -45,7 +45,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ProductShopsType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('source_shop_id', HiddenType::class)
@@ -81,7 +81,7 @@ class ProductShopsType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/RedirectOptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/RedirectOptionType.php
@@ -96,7 +96,7 @@ class RedirectOptionType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $entityAttributes = [
             'product' => [
@@ -178,7 +178,7 @@ class RedirectOptionType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
@@ -99,7 +99,7 @@ class SEOType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // Automatic update is only enabled when product is offline and the configuration is enabled
         $automaticUrlUpdate = false;
@@ -256,7 +256,7 @@ class SEOType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SerpType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SerpType.php
@@ -36,7 +36,7 @@ class SerpType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SearchedProductItemType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SearchedProductItemType.php
@@ -27,17 +27,17 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product;
 
-use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\EntityItemType;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class SearchedProductItemType extends CommonAbstractType
+class SearchedProductItemType extends AbstractType
 {
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('unique_identifier', HiddenType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DeliveryTimeNotesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DeliveryTimeNotesType.php
@@ -39,7 +39,7 @@ class DeliveryTimeNotesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('in_stock', TranslatableType::class, [
@@ -73,7 +73,7 @@ class DeliveryTimeNotesType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DimensionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DimensionsType.php
@@ -69,7 +69,7 @@ class DimensionsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('width', NumberType::class, [
@@ -146,7 +146,7 @@ class DimensionsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/ShippingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/ShippingType.php
@@ -81,7 +81,7 @@ class ShippingType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('dimensions', DimensionsType::class)
@@ -136,7 +136,7 @@ class ShippingType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
@@ -74,7 +74,7 @@ class AvailabilityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('out_of_stock_type', ChoiceType::class, [
@@ -157,7 +157,7 @@ class AvailabilityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/PackedProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/PackedProductType.php
@@ -42,7 +42,7 @@ class PackedProductType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('reference', TextPreviewType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
@@ -71,7 +71,7 @@ class QuantityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if ($this->stockManagementEnabled) {
             $stockMovementsUrl = $this->router->generate('admin_stock_movements_overview', ['productId' => $options['product_id']]);
@@ -134,7 +134,7 @@ class QuantityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockMovementType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockMovementType.php
@@ -42,7 +42,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class StockMovementType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('date', TextPreviewType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockOptionsType.php
@@ -40,7 +40,7 @@ class StockOptionsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('stock_location', TextType::class, [
@@ -80,7 +80,7 @@ class StockOptionsType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
@@ -77,7 +77,7 @@ class StockType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('packed_products', ProductSearchType::class, [
@@ -125,7 +125,7 @@ class StockType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/VirtualProductFileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/VirtualProductFileType.php
@@ -84,7 +84,7 @@ class VirtualProductFileType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $virtualProductFileDownloadUrl = null;
         if (!empty($options['virtual_product_file_id'])) {
@@ -181,7 +181,7 @@ class VirtualProductFileType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'virtual_product_file_id' => null,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -99,7 +99,7 @@ class SupplierType extends TranslatorAwareType
         $this->router = $router;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $data = $builder->getData();
         $countryId = 0 !== $data['id_country'] ? $data['id_country'] : $this->contextCountryId;

--- a/src/PrestaShopBundle/Form/Admin/Type/AccordionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/AccordionType.php
@@ -38,7 +38,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class AccordionType extends AbstractType
 {
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['expand_first'] = $options['expand_first'];
         $view->vars['expand_all'] = $options['expand_all'];
@@ -46,7 +46,7 @@ class AccordionType extends AbstractType
         $view->vars['display_one'] = $options['display_one'];
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'expand_first' => true,

--- a/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ApeType.php
@@ -41,12 +41,12 @@ class ApeType extends AbstractType implements DataTransformerInterface
 {
     use TranslatorAwareTrait;
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addModelTransformer($this);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'constraints' => [
@@ -58,17 +58,17 @@ class ApeType extends AbstractType implements DataTransformerInterface
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return TextType::class;
     }
 
-    public function transform($value)
+    public function transform(mixed $value): mixed
     {
         return $value;
     }
 
-    public function reverseTransform($value)
+    public function reverseTransform(mixed $value): mixed
     {
         return $value;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/ButtonCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ButtonCollectionType.php
@@ -57,14 +57,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ButtonCollectionType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         foreach ($options['buttons'] as $buttonOptions) {
             $builder->add($buttonOptions['name'], $buttonOptions['type'], $buttonOptions['options']);
         }
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
 
@@ -80,7 +80,7 @@ class ButtonCollectionType extends AbstractType
         $view->vars['use_button_groups'] = $options['use_button_groups'];
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/CategoryChoiceTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CategoryChoiceTreeType.php
@@ -51,7 +51,7 @@ class CategoryChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices_tree' => $this->categoryTreeChoices,
@@ -63,7 +63,7 @@ class CategoryChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return MaterialChoiceTreeType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/CategorySeoPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CategorySeoPreviewType.php
@@ -39,7 +39,7 @@ class CategorySeoPreviewType extends AbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'category_seo_preview';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
@@ -63,7 +63,7 @@ class ChangePasswordType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $maxLength = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH);
         $minLength = $this->configuration->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH);

--- a/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChoiceCategoriesTreeType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -35,14 +36,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * This form class is responsible to create a category selector using Nested sets.
  */
-class ChoiceCategoriesTreeType extends CommonAbstractType
+class ChoiceCategoriesTreeType extends AbstractType
 {
     /**
      * {@inheritdoc}
      *
      * Add the var choices to the view
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['choices'] = $options['list'];
         $view->vars['multiple'] = $options['multiple'];
@@ -59,7 +60,7 @@ class ChoiceCategoriesTreeType extends CommonAbstractType
      *
      * Builds the form.
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('tree', ChoiceType::class, [
             'label' => false,
@@ -74,7 +75,7 @@ class ChoiceCategoriesTreeType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => '',
@@ -90,7 +91,7 @@ class ChoiceCategoriesTreeType extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'choice_tree';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/ColorPickerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ColorPickerType.php
@@ -38,7 +38,7 @@ class ColorPickerType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return TextType::class;
     }
@@ -48,7 +48,7 @@ class ColorPickerType extends AbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'color_picker';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/Common/Team/ProfileChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Common/Team/ProfileChoiceType.php
@@ -51,7 +51,7 @@ class ProfileChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -65,7 +65,7 @@ class ProfileChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/CommonAbstractType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CommonAbstractType.php
@@ -55,7 +55,7 @@ abstract class CommonAbstractType extends AbstractType
      *
      * @return array
      */
-    protected function formatDataChoicesList($list, $mapping_value = 'id', $mapping_name = 'name')
+    protected function formatDataChoicesList($list, $mapping_value = 'id', $mapping_name = 'name'): array
     {
         @trigger_error(
             sprintf(
@@ -79,7 +79,7 @@ abstract class CommonAbstractType extends AbstractType
      *
      * @return array
      */
-    protected function formatDataDuplicateChoicesList($list, $mapping_value = 'id', $mapping_name = 'name')
+    protected function formatDataDuplicateChoicesList($list, $mapping_value = 'id', $mapping_name = 'name'): array
     {
         @trigger_error(
             sprintf(

--- a/src/PrestaShopBundle/Form/Admin/Type/ConfigurableCountryChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ConfigurableCountryChoiceType.php
@@ -55,7 +55,7 @@ class ConfigurableCountryChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         // Set normalizer enables to use closure for choice generation with options
         $resolver->setNormalizer(
@@ -79,7 +79,7 @@ class ConfigurableCountryChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomContentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomContentType.php
@@ -39,7 +39,7 @@ final class CustomContentType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['data'] = $options['data'];
         $view->vars['template'] = $options['template'];
@@ -48,7 +48,7 @@ final class CustomContentType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomerSearchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomerSearchType.php
@@ -47,7 +47,7 @@ class CustomerSearchType extends EntitySearchInputType
         $this->router = $router;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DatePickerType.php
@@ -52,12 +52,12 @@ class DatePickerType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return TextType::class;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addViewTransformer($this->arabicToLatinDigitDataTransformer);
     }
@@ -65,7 +65,7 @@ class DatePickerType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['date_format'] = $options['date_format'];
     }
@@ -73,7 +73,7 @@ class DatePickerType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'widget' => 'single_text',
@@ -88,7 +88,7 @@ class DatePickerType extends AbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'date_picker';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/DateRangeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DateRangeType.php
@@ -71,7 +71,7 @@ class DateRangeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('from', DatePickerType::class, [
@@ -132,7 +132,7 @@ class DateRangeType extends AbstractType
         }
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'date_format' => self::DEFAULT_DATE_FORMAT,
@@ -153,7 +153,7 @@ class DateRangeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'date_range';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/DeltaQuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DeltaQuantityType.php
@@ -52,7 +52,7 @@ class DeltaQuantityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('quantity', TextPreviewType::class, [
@@ -100,7 +100,7 @@ class DeltaQuantityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
 
@@ -114,7 +114,7 @@ class DeltaQuantityType extends TranslatorAwareType
         $view->vars['initialQuantity'] = $initialQuantity;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver
@@ -130,7 +130,7 @@ class DeltaQuantityType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'delta_quantity';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/DisablingSwitchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DisablingSwitchType.php
@@ -42,7 +42,7 @@ class DisablingSwitchType extends SwitchType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 
@@ -71,7 +71,7 @@ class DisablingSwitchType extends SwitchType
     /**
      * {@inheritDoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
         $view->vars['attr']['data-target-selector'] = $options['target_selector'];

--- a/src/PrestaShopBundle/Form/Admin/Type/EmailType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/EmailType.php
@@ -41,12 +41,12 @@ class EmailType extends BaseEmailType
     ) {
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addViewTransformer($this->IDNConverterDataTransformer);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/EnrichedChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/EnrichedChoiceType.php
@@ -44,13 +44,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class EnrichedChoiceType extends ChoiceType
 {
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
         $view->vars['flex_direction'] = $options['flex_direction'];
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/EntityItemType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/EntityItemType.php
@@ -28,18 +28,19 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * Default entry type used by @see EntitySearchInputType
  */
-class EntityItemType extends CommonAbstractType
+class EntityItemType extends AbstractType
 {
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('id', HiddenType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Type/EntitySearchInputType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/EntitySearchInputType.php
@@ -70,7 +70,7 @@ class EntitySearchInputType extends CollectionType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 
@@ -146,7 +146,7 @@ class EntitySearchInputType extends CollectionType
     /**
      * {@inheritDoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         // If no mapping has been defined it is built based on the prototype field names
         /** @var FormInterface $prototype */

--- a/src/PrestaShopBundle/Form/Admin/Type/FeatureFlagSwitchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/FeatureFlagSwitchType.php
@@ -43,7 +43,7 @@ class FeatureFlagSwitchType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'block_prefix' => 'feature_flag',
@@ -60,7 +60,7 @@ class FeatureFlagSwitchType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['types'] = $options['types'];
         $view->vars['used_type'] = $options['used_type'];
@@ -70,7 +70,7 @@ class FeatureFlagSwitchType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return SwitchType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/FormattedTextareaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/FormattedTextareaType.php
@@ -69,7 +69,7 @@ class FormattedTextareaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefined(['message'])
@@ -110,7 +110,7 @@ class FormattedTextareaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
         if (!isset($view->vars['attr']['class'])) {
@@ -126,7 +126,7 @@ class FormattedTextareaType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return TextareaType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/GeneratableTextType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/GeneratableTextType.php
@@ -42,7 +42,7 @@ class GeneratableTextType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -55,7 +55,7 @@ class GeneratableTextType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['generated_value_length'] = $options['generated_value_length'];
     }
@@ -63,7 +63,7 @@ class GeneratableTextType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return TextType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/GroupedItemCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/GroupedItemCollectionType.php
@@ -74,7 +74,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class GroupedItemCollectionType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('groups', CollectionType::class, [
@@ -108,7 +108,7 @@ class GroupedItemCollectionType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/GroupedItemType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/GroupedItemType.php
@@ -36,7 +36,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class GroupedItemType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('id', HiddenType::class, [
@@ -56,7 +56,7 @@ class GroupedItemType extends TranslatorAwareType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/IconButtonType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/IconButtonType.php
@@ -41,7 +41,7 @@ class IconButtonType extends ButtonType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver
@@ -58,7 +58,7 @@ class IconButtonType extends ButtonType
     /**
      * {@inheritDoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
         $view->vars['button_icon'] = $options['icon'];

--- a/src/PrestaShopBundle/Form/Admin/Type/ImagePreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ImagePreviewType.php
@@ -43,7 +43,7 @@ class ImagePreviewType extends HiddenType
     /**
      * {@inheritDoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
         $view->vars['type'] = 'hidden';
@@ -53,7 +53,7 @@ class ImagePreviewType extends HiddenType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/ImageWithPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ImageWithPreviewType.php
@@ -38,7 +38,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ImageWithPreviewType extends FileType
 {
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
         $view->vars['download_url'] = $options['download_url'];
@@ -55,7 +55,7 @@ class ImageWithPreviewType extends FileType
         $view->vars['warning_message'] = $options['warning_message'];
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/IntegerMinMaxFilterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/IntegerMinMaxFilterType.php
@@ -50,7 +50,7 @@ final class IntegerMinMaxFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'min_field_options' => [],
@@ -80,7 +80,7 @@ final class IntegerMinMaxFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if (!isset($options['min_field_options']['attr']['placeholder'])) {
             $options['min_field_options']['attr']['placeholder'] = $this->trans('Min', [], 'Admin.Global');

--- a/src/PrestaShopBundle/Form/Admin/Type/IpAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/IpAddressType.php
@@ -56,7 +56,7 @@ class IpAddressType extends TextType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([
@@ -67,7 +67,7 @@ class IpAddressType extends TextType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
         $view->vars['currentIp'] = $options['current_ip'];

--- a/src/PrestaShopBundle/Form/Admin/Type/LinkPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/LinkPreviewType.php
@@ -43,7 +43,7 @@ class LinkPreviewType extends HiddenType
     /**
      * {@inheritDoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
         $view->vars['type'] = 'hidden';
@@ -61,7 +61,7 @@ class LinkPreviewType extends HiddenType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/LogSeverityChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/LogSeverityChoiceType.php
@@ -40,7 +40,7 @@ class LogSeverityChoiceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices' => $this->getSeveritysChoices(),
@@ -52,7 +52,7 @@ class LogSeverityChoiceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTableType.php
@@ -40,7 +40,7 @@ class MaterialChoiceTableType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'expanded' => true,
@@ -52,7 +52,7 @@ class MaterialChoiceTableType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }
@@ -69,7 +69,7 @@ class MaterialChoiceTableType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'material_choice_table';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialChoiceTreeType.php
@@ -36,7 +36,7 @@ class MaterialChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $selectedData = [];
         if (null !== $form->getData()) {
@@ -55,7 +55,7 @@ class MaterialChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -81,7 +81,7 @@ class MaterialChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'material_choice_tree';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialMultipleChoiceTableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialMultipleChoiceTableType.php
@@ -39,7 +39,7 @@ class MaterialMultipleChoiceTableType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         foreach ($options['multiple_choices'] as $choices) {
             $builder->add($choices['name'], ChoiceType::class, [
@@ -69,7 +69,7 @@ class MaterialMultipleChoiceTableType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['choices'] = $options['choices'];
         $view->vars['scrollable'] = $options['scrollable'];
@@ -81,7 +81,7 @@ class MaterialMultipleChoiceTableType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function finishView(FormView $view, FormInterface $form, array $options)
+    public function finishView(FormView $view, FormInterface $form, array $options): void
     {
         $entryIndexMapping = [];
 
@@ -97,7 +97,7 @@ class MaterialMultipleChoiceTableType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([
@@ -126,7 +126,7 @@ class MaterialMultipleChoiceTableType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'material_multiple_choice_table';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/MoneyWithSuffixType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/MoneyWithSuffixType.php
@@ -40,7 +40,7 @@ class MoneyWithSuffixType extends MoneyType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $pattern = self::getPattern($options['currency']);
 
@@ -59,7 +59,7 @@ class MoneyWithSuffixType extends MoneyType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/MultipleZoneChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/MultipleZoneChoiceType.php
@@ -42,7 +42,7 @@ class MultipleZoneChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         // Set normalizer enables to use closure for choice generation with options
         $resolver->setNormalizer(
@@ -64,7 +64,7 @@ class MultipleZoneChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/NavigationTabType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/NavigationTabType.php
@@ -66,7 +66,7 @@ class NavigationTabType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         if (!empty($options['toolbar_buttons'])) {
@@ -95,7 +95,7 @@ class NavigationTabType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver

--- a/src/PrestaShopBundle/Form/Admin/Type/NumberMinMaxFilterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/NumberMinMaxFilterType.php
@@ -50,7 +50,7 @@ final class NumberMinMaxFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'min_field_options' => [],
@@ -80,7 +80,7 @@ final class NumberMinMaxFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if (!isset($options['min_field_options']['attr']['placeholder'])) {
             $options['min_field_options']['attr']['placeholder'] = $this->trans('Min', [], 'Admin.Global');

--- a/src/PrestaShopBundle/Form/Admin/Type/PriceReductionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/PriceReductionType.php
@@ -70,7 +70,7 @@ class PriceReductionType extends TranslatorAwareType
         $this->currencyDataProvider = $currencyDataProvider;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('value', MoneyType::class, [
@@ -107,7 +107,7 @@ class PriceReductionType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/ReorderPositionsButtonType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ReorderPositionsButtonType.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\ButtonType;
@@ -37,7 +39,7 @@ class ReorderPositionsButtonType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('position', ButtonType::class, [
             'label' => $this->trans('Rearrange', 'Admin.Actions'),

--- a/src/PrestaShopBundle/Form/Admin/Type/SearchAndResetType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SearchAndResetType.php
@@ -54,7 +54,7 @@ class SearchAndResetType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $showResetButton = false;
 
@@ -97,7 +97,7 @@ class SearchAndResetType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -116,7 +116,7 @@ class SearchAndResetType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'search_and_reset';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/ShopChoiceTreeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ShopChoiceTreeType.php
@@ -81,7 +81,7 @@ class ShopChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addModelTransformer($this->stringArrayToIntegerArrayDataTransformer);
 
@@ -91,7 +91,7 @@ class ShopChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 
@@ -111,7 +111,7 @@ class ShopChoiceTreeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return MaterialChoiceTreeType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/ShopRestrictionCheckboxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ShopRestrictionCheckboxType.php
@@ -40,7 +40,7 @@ class ShopRestrictionCheckboxType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $isChecked = $form->getData();
 
@@ -54,7 +54,7 @@ class ShopRestrictionCheckboxType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'required' => false,
@@ -64,7 +64,7 @@ class ShopRestrictionCheckboxType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return CheckboxType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/SubmittableDeltaQuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SubmittableDeltaQuantityType.php
@@ -41,7 +41,7 @@ use Symfony\Component\Validator\Constraints\Type;
  */
 class SubmittableDeltaQuantityType extends DeltaQuantityType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder->add('delta', IntegerType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Type/SubmittableInputType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SubmittableInputType.php
@@ -44,7 +44,7 @@ class SubmittableInputType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('value', $options['type'], $options['type_options']);
     }
@@ -52,7 +52,7 @@ class SubmittableInputType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['type_attr'] = $options['type_options']['attr'] ?? [];
     }
@@ -60,7 +60,7 @@ class SubmittableInputType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefault('type', NumberType::class)

--- a/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
@@ -42,7 +42,7 @@ class SwitchType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices' => [
@@ -63,7 +63,7 @@ class SwitchType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         if (true === $options['disabled']) {
             $view->vars['disabled'] = true;
@@ -89,7 +89,7 @@ class SwitchType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TaggedItemCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TaggedItemCollectionType.php
@@ -47,7 +47,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class TaggedItemCollectionType extends CollectionType
 {
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/TaggedItemType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TaggedItemType.php
@@ -34,7 +34,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class TaggedItemType extends TranslatorAwareType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextPreviewType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Type/TaxGroupChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TaxGroupChoiceType.php
@@ -42,7 +42,7 @@ class TaxGroupChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         // Set normalizer enables to use closure for choice generation with options
         $resolver->setNormalizer(
@@ -61,7 +61,7 @@ class TaxGroupChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TextPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextPreviewType.php
@@ -43,7 +43,7 @@ class TextPreviewType extends TextType
     /**
      * {@inheritDoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
         $view->vars['type'] = 'hidden';
@@ -68,7 +68,7 @@ class TextPreviewType extends TextType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/TextWithLengthCounterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextWithLengthCounterType.php
@@ -39,7 +39,7 @@ class TextWithLengthCounterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['max_length'] = $options['max_length'];
         $view->vars['position'] = $options['position'];
@@ -50,7 +50,7 @@ class TextWithLengthCounterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired([
@@ -72,7 +72,7 @@ class TextWithLengthCounterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'text_with_length_counter';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TextWithRecommendedLengthType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextWithRecommendedLengthType.php
@@ -41,7 +41,7 @@ class TextWithRecommendedLengthType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['recommended_length'] = $options['recommended_length'];
         $view->vars['input_type'] = $options['input_type'];
@@ -50,7 +50,7 @@ class TextWithRecommendedLengthType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/ToggleChildrenChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ToggleChildrenChoiceType.php
@@ -60,7 +60,7 @@ class ToggleChildrenChoiceType extends AbstractType
     ) {
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($options) {
@@ -90,7 +90,7 @@ class ToggleChildrenChoiceType extends AbstractType
         $form->add('children_selector', $options['choice_type'], $options['choice_options'] + $defaultChoiceOptions);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableChoiceType.php
@@ -36,7 +36,7 @@ class TranslatableChoiceType extends TranslatableType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
 
@@ -48,7 +48,7 @@ class TranslatableChoiceType extends TranslatableType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'button' => [],
@@ -66,7 +66,7 @@ class TranslatableChoiceType extends TranslatableType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'translatable_choice';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -120,7 +120,7 @@ class TranslatableType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $errors = iterator_to_array($view->vars['errors']);
 
@@ -166,7 +166,7 @@ class TranslatableType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'type' => TextType::class,
@@ -196,7 +196,7 @@ class TranslatableType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'translatable';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslateType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -36,7 +37,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  * This form class is responsible to create a translatable form.
  * Language selection uses tabs.
  */
-class TranslateType extends CommonAbstractType
+class TranslateType extends AbstractType
 {
     /**
      * @var UrlGeneratorInterface
@@ -81,7 +82,7 @@ class TranslateType extends CommonAbstractType
      *
      * Builds form fields for each locales
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $i = 0;
         foreach ($options['locales'] as $locale) {
@@ -103,7 +104,7 @@ class TranslateType extends CommonAbstractType
      *
      * Add the var locales and defaultLocale to the view
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['locales'] = $options['locales'];
         $view->vars['defaultLocale'] = $this->getDefaultLocale($options['locales']);
@@ -119,7 +120,7 @@ class TranslateType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'type' => null,
@@ -134,7 +135,7 @@ class TranslateType extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'translatefields';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
+use Symfony\Component\Form\AbstractType;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -33,7 +34,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  * This feature is not available in Symfony so we need to inject the translator
  * for constraints messages only.
  */
-abstract class TranslatorAwareType extends CommonAbstractType
+abstract class TranslatorAwareType extends AbstractType
 {
     /**
      * @var TranslatorInterface

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadCustomerCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadCustomerCollectionType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -34,7 +35,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * This form class is responsible to create a customer.
  */
-class TypeaheadCustomerCollectionType extends CommonAbstractType
+class TypeaheadCustomerCollectionType extends AbstractType
 {
     protected $customerAdapter;
 
@@ -54,7 +55,7 @@ class TypeaheadCustomerCollectionType extends CommonAbstractType
      * Add the vars to the view
      * Inject collection customer
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['placeholder'] = $options['placeholder'];
         $view->vars['remote_url'] = $options['remote_url'];
@@ -93,7 +94,7 @@ class TypeaheadCustomerCollectionType extends CommonAbstractType
      *
      * Builds the form.
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('data', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', [
             'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\HiddenType',
@@ -108,7 +109,7 @@ class TypeaheadCustomerCollectionType extends CommonAbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'remote_url' => '',
@@ -125,7 +126,7 @@ class TypeaheadCustomerCollectionType extends CommonAbstractType
      *
      * @return string The prefix name
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'typeahead_customer_collection';
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/UnavailableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/UnavailableType.php
@@ -38,7 +38,7 @@ class UnavailableType extends TranslatorAwareType
     /**
      * {@inheritDoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([

--- a/src/PrestaShopBundle/Form/Admin/Type/YesAndNoChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/YesAndNoChoiceType.php
@@ -37,7 +37,7 @@ class YesAndNoChoiceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices' => [
@@ -53,7 +53,7 @@ class YesAndNoChoiceType extends TranslatorAwareType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/ZoneChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ZoneChoiceType.php
@@ -55,7 +55,7 @@ class ZoneChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         // Set normalizer enables to use closure for choice generation with options
         $resolver->setNormalizer(
@@ -77,7 +77,7 @@ class ZoneChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }

--- a/src/PrestaShopBundle/Form/DataTransformer/ArabicToLatinDigitDataTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/ArabicToLatinDigitDataTransformer.php
@@ -52,7 +52,7 @@ final class ArabicToLatinDigitDataTransformer implements DataTransformerInterfac
      *
      * {@inheritdoc}
      */
-    public function transform($value)
+    public function transform($value): mixed
     {
         return $value;
     }
@@ -60,7 +60,7 @@ final class ArabicToLatinDigitDataTransformer implements DataTransformerInterfac
     /**
      * {@inheritdoc}
      */
-    public function reverseTransform($value)
+    public function reverseTransform($value): mixed
     {
         if (null === $value || '' === $value) {
             return null;

--- a/src/PrestaShopBundle/Form/DataTransformer/DefaultEmptyDataTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/DefaultEmptyDataTransformer.php
@@ -94,7 +94,7 @@ class DefaultEmptyDataTransformer implements DataTransformerInterface
     /**
      * {@inheritDoc}
      */
-    public function transform($value)
+    public function transform($value): mixed
     {
         return empty($value) ? $this->viewEmptyData : $value;
     }
@@ -102,7 +102,7 @@ class DefaultEmptyDataTransformer implements DataTransformerInterface
     /**
      * {@inheritDoc}
      */
-    public function reverseTransform($value)
+    public function reverseTransform($value): mixed
     {
         return empty($value) ? $this->emptyData : $value;
     }

--- a/src/PrestaShopBundle/Form/DataTransformer/DefaultLanguageToFilledArrayDataTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/DefaultLanguageToFilledArrayDataTransformer.php
@@ -50,7 +50,7 @@ final class DefaultLanguageToFilledArrayDataTransformer implements DataTransform
     /**
      * {@inheritdoc}
      */
-    public function transform($value)
+    public function transform($value): mixed
     {
         // No transformation is required here due to this data is being sent to template
         return $value;
@@ -61,7 +61,7 @@ final class DefaultLanguageToFilledArrayDataTransformer implements DataTransform
      *
      * @param array $values
      */
-    public function reverseTransform($values)
+    public function reverseTransform($values): mixed
     {
         if (!$this->assertIsValidForDataTransforming($values)) {
             return $values;

--- a/src/PrestaShopBundle/Form/DataTransformer/IDNConverterDataTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/IDNConverterDataTransformer.php
@@ -51,7 +51,7 @@ final class IDNConverterDataTransformer implements DataTransformerInterface
      *
      * Do not convert utf8 to punycode, should be done on the client side
      */
-    public function transform($value)
+    public function transform($value): mixed
     {
         return $value;
     }
@@ -61,7 +61,7 @@ final class IDNConverterDataTransformer implements DataTransformerInterface
      *
      * Convert punycode to utf8 (prestashop@xn--80aswg.xn--p1ai -> prestashop@сайт.рф)
      */
-    public function reverseTransform($value)
+    public function reverseTransform($value): mixed
     {
         return is_string($value) ? $this->converter->emailToUtf8($value) : $value;
     }

--- a/src/PrestaShopBundle/Form/DataTransformer/StringArrayToIntegerArrayDataTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/StringArrayToIntegerArrayDataTransformer.php
@@ -37,7 +37,7 @@ final class StringArrayToIntegerArrayDataTransformer implements DataTransformerI
     /**
      * {@inheritdoc}
      */
-    public function transform($value)
+    public function transform($value): mixed
     {
         // No transformation is required here due to this data is being sent to template
         return $value;
@@ -46,7 +46,7 @@ final class StringArrayToIntegerArrayDataTransformer implements DataTransformerI
     /**
      * {@inheritdoc}
      */
-    public function reverseTransform($value)
+    public function reverseTransform($value): mixed
     {
         if (!is_array($value)) {
             return $value;

--- a/src/PrestaShopBundle/Form/Extension/AlertExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/AlertExtension.php
@@ -44,7 +44,7 @@ class AlertExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -64,7 +64,7 @@ class AlertExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         if (!empty($options['alert_message'])) {
             $view->vars['alert_message'] = is_string($options['alert_message']) ? [$options['alert_message']] : $options['alert_message'];

--- a/src/PrestaShopBundle/Form/Extension/AlertsTrackingExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/AlertsTrackingExtension.php
@@ -54,7 +54,7 @@ class AlertsTrackingExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         // We dont want to add alerts on every single child form, just the parent one.
         if ($form->getParent()) {

--- a/src/PrestaShopBundle/Form/Extension/ColumnsNumberExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/ColumnsNumberExtension.php
@@ -49,7 +49,7 @@ class ColumnsNumberExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -64,7 +64,7 @@ class ColumnsNumberExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         if (!empty($options['columns_number'])) {
             $view->vars['columns_number'] = $options['columns_number'];

--- a/src/PrestaShopBundle/Form/Extension/CustomMoneyTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/CustomMoneyTypeExtension.php
@@ -67,7 +67,7 @@ class CustomMoneyTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'precision' => null,
@@ -84,7 +84,7 @@ class CustomMoneyTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritDoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
 
@@ -94,7 +94,7 @@ class CustomMoneyTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // We only want to adapt the MoneyToLocalizedStringTransformer, so we save the current transformers
         // to restore them after replacing the new MoneyToLocalizedStringTransformer.

--- a/src/PrestaShopBundle/Form/Extension/DefaultEmptyDataExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/DefaultEmptyDataExtension.php
@@ -67,7 +67,7 @@ class DefaultEmptyDataExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
         if (!isset($options['default_empty_data'])) {

--- a/src/PrestaShopBundle/Form/Extension/ExternalLinkExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/ExternalLinkExtension.php
@@ -52,7 +52,7 @@ class ExternalLinkExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -74,7 +74,7 @@ class ExternalLinkExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         if (!empty($options['external_link'])) {
             $view->vars['external_link'] = $options['external_link'];

--- a/src/PrestaShopBundle/Form/Extension/FormThemeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/FormThemeExtension.php
@@ -101,7 +101,7 @@ class FormThemeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -118,7 +118,7 @@ class FormThemeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         if (!empty($options['form_theme'])) {
             $formThemes = is_array($options['form_theme']) ? $options['form_theme'] : [$options['form_theme']];

--- a/src/PrestaShopBundle/Form/Extension/HelpTextExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/HelpTextExtension.php
@@ -40,7 +40,7 @@ class HelpTextExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -53,7 +53,7 @@ class HelpTextExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['help'] = $options['help'] ?? null;
     }

--- a/src/PrestaShopBundle/Form/Extension/HintTextExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/HintTextExtension.php
@@ -41,7 +41,7 @@ class HintTextExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -54,7 +54,7 @@ class HintTextExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['hint'] = isset($options['hint']) ? $options['hint'] : null;
     }

--- a/src/PrestaShopBundle/Form/Extension/IntegerTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/IntegerTypeExtension.php
@@ -55,7 +55,7 @@ class IntegerTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // We only want to replace/adapt the IntegerToLocalizedStringTransformer, so we save the current transformers
         // to restore them after replacing the new IntegerToLocalizedStringTransformer.

--- a/src/PrestaShopBundle/Form/Extension/LabelOptionsExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/LabelOptionsExtension.php
@@ -46,7 +46,7 @@ class LabelOptionsExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -69,7 +69,7 @@ class LabelOptionsExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         if (!empty($options['label_tag_name'])) {
             $view->vars['label_tag_name'] = $options['label_tag_name'];

--- a/src/PrestaShopBundle/Form/Extension/NumberTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/NumberTypeExtension.php
@@ -55,7 +55,7 @@ class NumberTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // We only want to replace/adapt the NumberToLocalizedStringTransformer, so we save the current transformers
         // to restore them after replacing the new NumberToLocalizedStringTransformer.

--- a/src/PrestaShopBundle/Form/Extension/ResizableTextTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/ResizableTextTypeExtension.php
@@ -48,7 +48,7 @@ class ResizableTextTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefined('size')
@@ -64,7 +64,7 @@ class ResizableTextTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         if (isset($options['size'])) {
             $sizeClass = 'size-' . $options['size'];

--- a/src/PrestaShopBundle/Form/Extension/RowAttributesExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/RowAttributesExtension.php
@@ -48,7 +48,7 @@ class RowAttributesExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -61,7 +61,7 @@ class RowAttributesExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['row_attr'] = $options['row_attr'] ?? [];
     }

--- a/src/PrestaShopBundle/Form/Extension/UnitTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Extension/UnitTypeExtension.php
@@ -43,7 +43,7 @@ class UnitTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefined('unit')
@@ -56,7 +56,7 @@ class UnitTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         if (isset($options['unit'])) {
             $view->vars['unit'] = $options['unit'];

--- a/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
+++ b/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
@@ -64,7 +64,7 @@ class TinyMceMaxLengthValidator extends ConstraintValidator
      * @param mixed $value
      * @param TinyMceMaxLength $constraint
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof TinyMceMaxLength) {
             throw new UnexpectedTypeException($constraint, TinyMceMaxLength::class);

--- a/src/PrestaShopBundle/Routing/AnonymousRouteProvider.php
+++ b/src/PrestaShopBundle/Routing/AnonymousRouteProvider.php
@@ -64,7 +64,7 @@ class AnonymousRouteProvider implements CacheWarmerInterface
         return array_key_exists($routeName, $this->getAnonymousRoutes());
     }
 
-    public function warmUp(string $cacheDir): array
+    public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
         // Simply call the method so that its result is put in the cache
         $this->getAnonymousRoutes();

--- a/src/PrestaShopBundle/Routing/YamlModuleLoader.php
+++ b/src/PrestaShopBundle/Routing/YamlModuleLoader.php
@@ -54,7 +54,7 @@ class YamlModuleLoader extends Loader
     /**
      * {@inheritdoc}
      */
-    public function load($resource, $type = null)
+    public function load($resource, $type = null): mixed
     {
         if (true === $this->isLoaded) {
             throw new RuntimeException('Do not add the "module" loader twice.');
@@ -78,7 +78,7 @@ class YamlModuleLoader extends Loader
     /**
      * {@inheritdoc}
      */
-    public function supports($resource, $type = null)
+    public function supports($resource, $type = null): bool
     {
         return 'module' === $type;
     }
@@ -86,7 +86,7 @@ class YamlModuleLoader extends Loader
     /**
      * {@inheritdoc}
      */
-    public function import($resource, $type = null)
+    public function import($resource, $type = null): mixed
     {
         $loadedRoutes = parent::import($resource, $type);
 

--- a/src/PrestaShopBundle/Service/Database/DoctrineNamingStrategy.php
+++ b/src/PrestaShopBundle/Service/Database/DoctrineNamingStrategy.php
@@ -55,7 +55,7 @@ class DoctrineNamingStrategy extends UnderscoreNamingStrategy
      *
      * This override adds a prefix to the underscored table name.
      */
-    public function classToTableName($className)
+    public function classToTableName($className): string
     {
         $underscored = parent::classToTableName($className);
 
@@ -67,7 +67,7 @@ class DoctrineNamingStrategy extends UnderscoreNamingStrategy
      *
      * This override adds a prefix to the underscored table name.
      */
-    public function joinTableName($sourceEntity, $targetEntity, $propertyName = null)
+    public function joinTableName($sourceEntity, $targetEntity, $propertyName = null): string
     {
         $prestashopTable = $this->getPrestashopTable($sourceEntity, $propertyName);
         if (!empty($prestashopTable)) {

--- a/src/PrestaShopBundle/Translation/Constraints/PassVsprintfValidator.php
+++ b/src/PrestaShopBundle/Translation/Constraints/PassVsprintfValidator.php
@@ -35,7 +35,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class PassVsprintfValidator extends ConstraintValidator
 {
-    public function validate($translation, Constraint $constraint)
+    public function validate($translation, Constraint $constraint): void
     {
         if (!$constraint instanceof PassVsprintf) {
             throw new UnexpectedTypeException($constraint, 'PrestaShopBundle\Translation\Constraints\PassVsprintf');

--- a/src/PrestaShopBundle/Twig/ContextIsoCodeProviderExtension.php
+++ b/src/PrestaShopBundle/Twig/ContextIsoCodeProviderExtension.php
@@ -50,7 +50,7 @@ class ContextIsoCodeProviderExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('get_context_iso_code', [$this, 'getIsoCode']),

--- a/src/PrestaShopBundle/Twig/DataFormatterExtension.php
+++ b/src/PrestaShopBundle/Twig/DataFormatterExtension.php
@@ -40,7 +40,7 @@ class DataFormatterExtension extends AbstractExtension
      *
      * @return array Twig_SimpleFilter
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('arrayCast', [$this, 'arrayCast']),
@@ -55,7 +55,7 @@ class DataFormatterExtension extends AbstractExtension
      *
      * @return array Twig_SimpleFunction
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('arrayCast', [$this, 'arrayCast']),

--- a/src/PrestaShopBundle/Twig/Extension/ColorBrightnessCalculatorExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/ColorBrightnessCalculatorExtension.php
@@ -51,7 +51,7 @@ class ColorBrightnessCalculatorExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction(

--- a/src/PrestaShopBundle/Twig/Extension/DocumentationLinkExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/DocumentationLinkExtension.php
@@ -51,7 +51,7 @@ class DocumentationLinkExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction(

--- a/src/PrestaShopBundle/Twig/Extension/EntitySearchExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/EntitySearchExtension.php
@@ -39,7 +39,7 @@ use Twig\TwigFilter;
  */
 class EntitySearchExtension extends AbstractExtension
 {
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('entity_field', [$this, 'getEntityField']),

--- a/src/PrestaShopBundle/Twig/Extension/GridExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/GridExtension.php
@@ -69,7 +69,7 @@ class GridExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('column_content', [$this, 'renderColumnContent'], [
@@ -87,7 +87,7 @@ class GridExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getTests()
+    public function getTests(): array
     {
         return [
             new TwigTest('formview', static function ($value) {

--- a/src/PrestaShopBundle/Twig/Extension/LocalizationExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/LocalizationExtension.php
@@ -53,7 +53,7 @@ class LocalizationExtension extends AbstractExtension
         ];
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction(

--- a/src/PrestaShopBundle/Twig/Extension/NumberExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/NumberExtension.php
@@ -40,7 +40,7 @@ class NumberExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [new TwigFunction('number', [$this, 'createNumber'])];
     }

--- a/src/PrestaShopBundle/Twig/HookExtension.php
+++ b/src/PrestaShopBundle/Twig/HookExtension.php
@@ -75,7 +75,7 @@ class HookExtension extends AbstractExtension
      *
      * @return array Twig_SimpleFilter
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('renderhook', [$this, 'renderHook'], ['is_safe' => ['html']]),
@@ -89,7 +89,7 @@ class HookExtension extends AbstractExtension
      *
      * @return array Twig_SimpleFilter
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('renderhook', [$this, 'renderHook'], ['is_safe' => ['html']]),

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -96,7 +96,7 @@ class LayoutExtension extends AbstractExtension implements GlobalsInterface
      *
      * @return array Twig_SimpleFilter
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('configuration', [$this, 'getConfiguration'], ['deprecated' => true]),
@@ -108,7 +108,7 @@ class LayoutExtension extends AbstractExtension implements GlobalsInterface
      *
      * @return array An array of functions
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('getAdminLink', [$this, 'getAdminLink']),

--- a/src/PrestaShopBundle/Twig/TranslationsExtension.php
+++ b/src/PrestaShopBundle/Twig/TranslationsExtension.php
@@ -69,7 +69,7 @@ class TranslationsExtension extends AbstractExtension
      *
      * @return array An array of functions
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('getTranslationsTree', [$this, 'getTranslationsTree']),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Reduces Symfony Profiler deprecations (Symfony 6.4 / 7.0 readiness).<br><br>**Changes:**<br>• **AppKernel:** use `.container.dumper.inline_class_loader` parameter (replaces deprecated `container.dumper.inline_class_loader`)<br>• **CacheWarmer:** add `warmUp($cacheDir, ?$buildDir): array`, `isOptional(): bool`, strict types<br>• **LegacyCacheClearer:** add `clear($cacheDir): void`<br>• **FrameworkBundleAdminController:** replace `@required` with `#[Required]` attribute
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Clear cache, load BO (e.g. admin-dev/) <br> 2. Open Symfony Profiler > Logs: deprecation count should be lower; no new errors
| UI Tests          |https://github.com/tleon/ga.tests.ui.pr/actions/runs/21684984619
| Fixed issue or discussion?     | #38985 
| Sponsor company   | PrestaShop SA
