### PR TITLE
Always execute non display hooks in backoffice

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -174,7 +174,8 @@ class HookCore extends ObjectModel
     }
 
     /**
-     * Return true if the hook name starts with "display"
+     * Checks if a hook is a display or action one. This is used for filtering modules on module positions page,
+     * validating permissions and other things.
      *
      * @param string $hook_name The name of the hook to check
      *
@@ -184,12 +185,24 @@ class HookCore extends ObjectModel
     {
         $hook_name = strtolower(static::normalizeHookName($hook_name));
 
-        if ($hook_name === 'header' || $hook_name === 'displayheader') {
-            // this hook is to add resources to the <head> section of the page
-            // so it doesn't display anything by itself
+        // Exceptions that ARE display hooks
+        if (in_array($hook_name, [
+            'dashboarddata',
+            'dashboardzoneone',
+            'dashboardzonetwo',
+        ])) {
+            return true;
+        }
+
+        // Exceptions that ARE NOT display hooks
+        if (in_array($hook_name, [
+            'header',
+            'displayheader',
+        ])) {
             return false;
         }
 
+        // All other cases - we check if the hook name starts with "display" or not
         return strpos($hook_name, 'display') === 0;
     }
 

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1090,9 +1090,12 @@ class HookCore extends ObjectModel
                     continue;
                 }
 
-                // If we are in the backoffice, we check if the current employee has view rights for this module
-                if (
-                    Validate::isLoadedObject($context->employee)
+                /*
+                 * Next, we check employee permissions in backoffice - we check for 'view' permission on the given module.
+                 * We only do this for display hooks, other hooks are not concerned by this check and should be always executed.
+                 */
+                if (Hook::isDisplayHookName($registeredHookName)
+                    && Validate::isLoadedObject($context->employee)
                     && !Module::getPermissionStatic(
                         $hookRegistration['id_module'],
                         'view',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Improves permission check in backoffice to avoid blocking modules that do not generate any output. See more information below.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI + UI + dev test
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/21582148381
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.

### Problem
We have discovered a weird behavior on one of my client websites. Customer points in loyalty program were not added to orders.

I tracked the issue to `actionOrderStatusPostUpdate` not being executed, while it worked normally no matter what I did.

Then I found out that all issues happened only when an employee with limited rights worked on the order - a delivery driver.

The problem was that the hook was not executed because the role did not have the rights for the modules.

### Solution
The view rights should be only validated for display hooks, not action hooks. Hooks that do not have any output should be always executed no matter what, like in front office.