### PR TITLE
Fix EntitySearchInput::setValues forEach callback argument order

### DIFF
--- a/admin-dev/themes/new-theme/js/components/entity-search-input.ts
+++ b/admin-dev/themes/new-theme/js/components/entity-search-input.ts
@@ -124,7 +124,7 @@ export default class EntitySearchInput {
       return;
     }
 
-    values.forEach((index: number, value: any) => {
+    values.forEach((value: any) => {
       this.appendSelectedItem(value);
     });
   }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.0.x
| Description?      | Fixed a bug in `EntitySearchInput::setValues()` where the `forEach` callback parameters were swapped, causing the numeric index to be passed instead of the entity object. The unused index was removed so selected items are rendered correctly when preloading values.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | 1. Intall this module: [pr_40640.zip](https://github.com/user-attachments/files/24961588/pr_40640.zip) <br/> 2. Go to configuration module <br/> 3. You display the search field with 3 random products. Click the reload button, you must display another 3 products correctly. **Note: clicking more than 2 times, the displayed products are always the same.**<br/>I am attaching a video with and without PR.
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/21486315786
| Fixed issue or discussion?     |  -
| Related PRs       |  -
| Sponsor company   | Codencode snc


## Summary

`EntitySearchInput::setValues()` was iterating the input array with a `forEach` callback that had its parameters swapped.  
In JavaScript/TypeScript, `forEach` passes `(value, index)`, but the code used `(index, value)`. As a consequence, the numeric
index (`0, 1, 2, ...`) could be forwarded to `appendSelectedItem()` instead of the entity object, preventing selected items
from being rendered correctly when values are preloaded.

Since the index is not needed in this method, it has been removed and the iteration now correctly forwards the entity object.

## Changes

**Before**

```ts
values.forEach((index: number, value: any) => {
  this.appendSelectedItem(value);
});
```

**After**

```ts
values.forEach((value: any) => {
  this.appendSelectedItem(value);
});
```
---

### Without PR (error)

[without-pr.webm](https://github.com/user-attachments/assets/eff6327b-680a-44ad-aafc-728593369f39)

### With PR

[with-pr.webm](https://github.com/user-attachments/assets/2a4e49fd-36b1-464f-bae4-c4c59f49749d)