### PR TITLE
[test] Make install more resilient offline

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1278,11 +1278,14 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
         // 3 attempts to download the language pack
         for ($i = 1; $i <= 3; ++$i) {
-            $content = Tools::file_get_contents($url, false, null, static::PACK_DOWNLOAD_TIMEOUT);
-
-            // If we managed to download the pack successfully and it's a valid zip file, we stop
-            if (!empty($content) && strpos($content, "\x50\x4b\x03\x04") !== false) {
-                break;
+            try {
+                $content = Tools::file_get_contents($url, false, null, static::PACK_DOWNLOAD_TIMEOUT);
+                // If we managed to download the pack successfully and it's a valid zip file, we stop
+                if (!empty($content) && strpos($content, "\x50\x4b\x03\x04") !== false) {
+                    break;
+                }
+            } catch (Exception) {
+                // Let the check below exit the loop
             }
 
             // If not, we will give it another try, unless we are on our last attempt
@@ -1717,6 +1720,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     public static function translationPackIsInCache(string $locale, string $type = self::PACK_TYPE_SYMFONY): bool
     {
+        $cachePath = self::getPathToCachedTranslationPack($locale, $type);
         return file_exists(self::getPathToCachedTranslationPack($locale, $type));
     }
 

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -642,26 +642,18 @@ class Install extends AbstractInstall
                 'locale' => (string) $xml->locale,
             ];
 
-            if (file_exists(_PS_TRANSLATIONS_DIR_ . (string) $iso . '.gzip') == false) {
-                $language = EntityLanguage::downloadLanguagePack($iso, _PS_INSTALL_VERSION_);
-
-                if ($language == false) {
-                    throw new PrestashopInstallerException($this->translator->trans('Cannot download language pack "%iso%"', ['%iso%' => $iso], 'Install'));
-                }
-            }
-
-            $errors = [];
             $locale = $params_lang['locale'];
 
-            /* @todo check if a newer pack is available */
+            // Try and update the language page all the time, but if it's in the cache this is not blocking
+            $downloaded = EntityLanguage::downloadLanguagePack($iso, _PS_INSTALL_VERSION_);
+            // Calling downloadLanguagePack with $iso is equivalent internally to download file for $locale
             if (!EntityLanguage::translationPackIsInCache($locale)) {
-                EntityLanguage::downloadXLFLanguagePack($locale, $errors);
-
-                if (!empty($errors)) {
-                    throw new PrestashopInstallerException($this->translator->trans('Cannot download language pack "%iso%"', ['%iso%' => $iso], 'Install'));
-                }
+                throw new PrestashopInstallerException($this->translator->trans('Cannot download language pack "%iso%"', ['%iso%' => $iso], 'Install'));
             }
-
+            if (!$downloaded) {
+                $this->getLogger()->logWarning(sprintf('Could not download language %s but found in cache', $locale));
+            }
+            $errors = [];
             $this->callWithUnityAutoincrement(function () use ($iso, $params_lang, &$errors) {
                 EntityLanguage::installFirstLanguagePack($iso, $params_lang, $errors);
             });


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Make installation more resilient to unreachable API for languages when the files are already present
| Type?             | improvement
| Category?         | installation
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install the shop once (so language packs are downloaded), then go offline and do another install The installation should fallback using previously downloaded files, warnings are displayed
| UI Tests          | ~
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
