### PR TITLE
Fix Category::searchByPath losing context during recursion

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1537,8 +1537,10 @@ class CategoryCore extends ObjectModel
     {
         $categories = explode('/', trim($path));
         $idParentCategory = false;
+        $selfPath = '';
 
         foreach ($categories as $categoryName) {
+            $selfPath = $selfPath ? ($selfPath . '/' . $categoryName) : $categoryName;
             if ($idParentCategory) {
                 $category = Category::searchByNameAndParentCategoryId($idLang, $categoryName, $idParentCategory);
             } else {
@@ -1547,7 +1549,7 @@ class CategoryCore extends ObjectModel
 
             if (!$category && $objectToCreate && $methodToCreate) {
                 call_user_func_array([$objectToCreate, $methodToCreate], [$idLang, $categoryName, $idParentCategory]);
-                $category = Category::searchByPath($idLang, $categoryName);
+                $category = Category::searchByPath($idLang, $selfPath);
             }
             if (isset($category['id_category']) && $category['id_category']) {
                 $idParentCategory = (int) $category['id_category'];


### PR DESCRIPTION
| Questions | Answers |
| ----------------- | ------------------------------------------------------- |
| Branch? | develop |
| Description? | Fixes loss of parent context in `Category::searchByPath()` when creating missing path segments. The method recurses using only the segment name, which discards the accumulated path and can resolve incorrect parents when category names are duplicated. This change preserves recursion semantics by recursing with the accumulated path. |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | 1) Create categories: `A` (root) and `Other/A`. 2) Call `Category::searchByPath($idLang, 'Other/A/NewChild', $creator, $method)` where `NewChild` does not exist. 3) Verify `NewChild` is created under `Other/A` and returned correctly. |
| UI Tests | https://github.com/paulnoelcholot/ga.tests.ui.pr/actions/runs/23497785974 |
| Fixed issue or discussion? | Fixes #40643 |
| Related PRs | N/A |
| Sponsor company | N/A |
