### PR TITLE
Add cart product presenter and cart availability

### DIFF
--- a/src/Adapter/Presenter/Cart/CartLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartLazyArray.php
@@ -38,7 +38,6 @@ use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\LazyArrayAttribute;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingLazyArray;
-use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -87,6 +86,8 @@ class CartLazyArray extends AbstractLazyArray
 
     private ImageRetriever $imageRetriever;
 
+    private CartProductPresenter $cartProductPresenter;
+
     public function __construct(Cart $cart, CartPresenter $cartPresenter, bool $shouldSeparateGifts = false)
     {
         $this->shouldSeparateGifts = $shouldSeparateGifts;
@@ -97,6 +98,13 @@ class CartLazyArray extends AbstractLazyArray
         $this->link = $context->link;
         $this->imageRetriever = new ImageRetriever($this->link);
         $this->priceFormatter = new PriceFormatter();
+        $this->cartProductPresenter = new CartProductPresenter(
+            $this->imageRetriever,
+            $this->link,
+            $this->priceFormatter,
+            new ProductColorsRetriever(),
+            $this->translator
+        );
         parent::__construct();
     }
 
@@ -576,15 +584,7 @@ class CartLazyArray extends AbstractLazyArray
 
         $rawProduct['quantity_wanted'] = $rawProduct['cart_quantity'];
 
-        $presenter = new ProductListingPresenter(
-            $this->imageRetriever,
-            $this->link,
-            $this->priceFormatter,
-            new ProductColorsRetriever(),
-            $this->translator
-        );
-
-        return $presenter->present(
+        return $this->cartProductPresenter->present(
             $this->cartPresenter->getSettings(),
             $rawProduct,
             Context::getContext()->language

--- a/src/Adapter/Presenter/Cart/CartProductLazyArray.php
+++ b/src/Adapter/Presenter/Cart/CartProductLazyArray.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Presenter\Cart;
+
+use Language;
+use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingLazyArray;
+use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
+
+class CartProductLazyArray extends ProductListingLazyArray
+{
+    /**
+     * Custom implementation of quantity information for cart products. In cart, we use the data
+     * a bit differently than in product listing. We also have edge cases when some of the ordered
+     * items are in stock, and some are not.
+     *
+     * @param ProductPresentationSettings $settings
+     * @param array $product
+     * @param Language $language
+     */
+    public function addQuantityInformation(
+        ProductPresentationSettings $settings,
+        array $product,
+        Language $language
+    ) {
+        // Define if we should show availability
+        $show_price = $this->shouldShowPrice($settings, $product);
+        $show_availability = $show_price && $settings->stock_management_enabled;
+        $this->product['show_availability'] = $show_availability;
+
+        // Default data
+        $this->product['availability_message'] = null;
+        $this->product['availability_submessage'] = null;
+        $this->product['availability_date'] = null;
+        $this->product['availability'] = null;
+
+        // If we don't want to show availability, we return immediately
+        if (!$show_availability) {
+            return;
+        }
+
+        // If the product is disabled, but still displayed, we display a proper message
+        if ($this->product['active'] != 1) {
+            $this->product['availability'] = 'discontinued';
+            $this->product['availability_message'] = $this->translator->trans('This product is no longer available for sale.', [], 'Shop.Notifications.Error');
+
+            return;
+        }
+
+        // Get combination labels
+        $combinationData = $this->getCombinationSpecificData();
+
+        // All ordered items are in stock
+        if ($product['stock_quantity'] >= $product['quantity']) {
+            $this->product['availability'] = 'in_stock';
+            if (!empty($combinationData['available_later'])) {
+                $this->product['availability_message'] = $combinationData['available_now'];
+            } elseif (!empty($product['available_later'])) {
+                $this->product['availability_message'] = $product['available_now'];
+            } else {
+                $this->product['availability_message'] = $this->configuration->get('PS_LABEL_IN_STOCK_PRODUCTS')[$language->id] ?? null;
+            }
+        // Ordered items are partially in stock
+        } elseif ($product['stock_quantity'] > 0) {
+            // Define both parts of the message
+            if (!empty($combinationData['available_later'])) {
+                $messageForInStockProducts = $combinationData['available_now'];
+            } elseif (!empty($product['available_later'])) {
+                $messageForInStockProducts = $product['available_now'];
+            } else {
+                $messageForInStockProducts = $this->configuration->get('PS_LABEL_IN_STOCK_PRODUCTS')[$language->id] ?? null;
+            }
+
+            if ($product['allow_oosp']) {
+                $this->product['availability'] = 'available';
+                if (!empty($combinationData['available_later'])) {
+                    $messageForOutOfStockProducts = $combinationData['available_later'];
+                } elseif (!empty($product['available_later'])) {
+                    $messageForOutOfStockProducts = $product['available_later'];
+                } else {
+                    $messageForOutOfStockProducts = $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOA')[$language->id] ?? null;
+                }
+            } else {
+                $this->product['availability'] = 'unavailable';
+                if (!empty($combinationData['available_later'])) {
+                    $messageForOutOfStockProducts = $combinationData['available_later'];
+                } elseif (!empty($product['available_later'])) {
+                    $messageForOutOfStockProducts = $product['available_later'];
+                } else {
+                    $messageForOutOfStockProducts = $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOD')[$language->id] ?? null;
+                }
+            }
+
+            // And construct the final message
+            if (!empty($messageForInStockProducts) && !empty($messageForOutOfStockProducts)) {
+                $this->product['availability_message'] = $this->translator->trans(
+                    '%quantityInStock% - %messageForInStockProducts%, the rest - %messageForOutOfStockProducts%',
+                    [
+                        '%quantityInStock%' => $product['stock_quantity'],
+                        '%messageForInStockProducts%' => $messageForInStockProducts,
+                        '%messageForOutOfStockProducts%' => $messageForOutOfStockProducts,
+                    ],
+                    'Shop.Theme.Checkout'
+                );
+            }
+
+        // None of the ordered items are in stock
+        } else {
+            if ($product['allow_oosp']) {
+                $this->product['availability'] = 'available';
+                if (!empty($combinationData['available_later'])) {
+                    $this->product['availability_message'] = $combinationData['available_later'];
+                } elseif (!empty($product['available_later'])) {
+                    $this->product['availability_message'] = $product['available_later'];
+                } else {
+                    $this->product['availability_message'] = $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOA')[$language->id] ?? null;
+                }
+            } else {
+                $this->product['availability'] = 'unavailable';
+                if (!empty($combinationData['available_later'])) {
+                    $this->product['availability_message'] = $combinationData['available_later'];
+                } elseif (!empty($product['available_later'])) {
+                    $this->product['availability_message'] = $product['available_later'];
+                } else {
+                    $this->product['availability_message'] = $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOD')[$language->id] ?? null;
+                }
+            }
+        }
+    }
+}

--- a/src/Adapter/Presenter/Cart/CartProductPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartProductPresenter.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Presenter\Cart;
+
+use Hook;
+use Language;
+use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductPresenter;
+use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
+use ReflectionException;
+
+class CartProductPresenter extends ProductPresenter
+{
+    /**
+     * @param ProductPresentationSettings $settings
+     * @param array $product
+     * @param Language $language
+     *
+     * @return CartProductLazyArray
+     *
+     * @throws ReflectionException
+     */
+    public function present(
+        ProductPresentationSettings $settings,
+        array $product,
+        Language $language
+    ) {
+        $cartProductLazyArray = new CartProductLazyArray(
+            $settings,
+            $product,
+            $language,
+            $this->imageRetriever,
+            $this->link,
+            $this->priceFormatter,
+            $this->productColorsRetriever,
+            $this->translator
+        );
+
+        /*
+         * @deprecated since 9.1.0 - please use actionPresentCartProduct instead. This hook is here so
+         * that modules using the old hook do not break.
+         */
+        Hook::exec('actionPresentProductListing',
+            ['presentedProduct' => &$cartProductLazyArray]
+        );
+        Hook::exec('actionPresentCartProduct',
+            ['presentedProduct' => &$cartProductLazyArray]
+        );
+
+        return $cartProductLazyArray;
+    }
+}

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -63,27 +63,27 @@ class ProductLazyArray extends AbstractLazyArray
     /**
      * @var ImageRetriever
      */
-    private $imageRetriever;
+    protected $imageRetriever;
 
     /**
      * @var Link
      */
-    private $link;
+    protected $link;
 
     /**
      * @var PriceFormatter
      */
-    private $priceFormatter;
+    protected $priceFormatter;
 
     /**
      * @var ProductColorsRetriever
      */
-    private $productColorsRetriever;
+    protected $productColorsRetriever;
 
     /**
      * @var TranslatorInterface
      */
-    private $translator;
+    protected $translator;
 
     /**
      * @var ProductPresentationSettings
@@ -98,17 +98,17 @@ class ProductLazyArray extends AbstractLazyArray
     /**
      * @var Language
      */
-    private $language;
+    protected $language;
 
     /**
      * @var HookManager
      */
-    private $hookManager;
+    protected $hookManager;
 
     /**
      * @var Configuration
      */
-    private $configuration;
+    protected $configuration;
 
     public function __construct(
         ProductPresentationSettings $settings,
@@ -875,7 +875,7 @@ class ProductLazyArray extends AbstractLazyArray
      *
      * @return bool
      */
-    private function shouldShowPrice(
+    protected function shouldShowPrice(
         ProductPresentationSettings $settings,
         array $product
     ): bool {
@@ -887,7 +887,7 @@ class ProductLazyArray extends AbstractLazyArray
      *
      * @return bool
      */
-    private function shouldShowOutOfStockLabel(
+    protected function shouldShowOutOfStockLabel(
         ProductPresentationSettings $settings,
         array $product
     ): bool {
@@ -935,7 +935,7 @@ class ProductLazyArray extends AbstractLazyArray
      * @param array $product
      * @param Language $language
      */
-    private function fillImages(array $product, Language $language): void
+    protected function fillImages(array $product, Language $language): void
     {
         // Get all product images assigned to this product.
         $productImages = $this->imageRetriever->getAllProductImages(
@@ -991,7 +991,7 @@ class ProductLazyArray extends AbstractLazyArray
      *
      * @return array
      */
-    private function filterImagesForCombination(
+    protected function filterImagesForCombination(
         array $images,
         int $productAttributeId
     ) {
@@ -1010,7 +1010,7 @@ class ProductLazyArray extends AbstractLazyArray
      * @param ProductPresentationSettings $settings
      * @param array $product
      */
-    private function addPriceInformation(
+    protected function addPriceInformation(
         ProductPresentationSettings $settings,
         array $product
     ): void {
@@ -1240,7 +1240,7 @@ class ProductLazyArray extends AbstractLazyArray
      *
      * @return string
      */
-    private function getProductURL(
+    protected function getProductURL(
         array $product,
         Language $language,
         $canonical = false
@@ -1452,7 +1452,7 @@ class ProductLazyArray extends AbstractLazyArray
      *
      * @return string|null
      */
-    private function prepareAvailabilityDate($product)
+    protected function prepareAvailabilityDate($product)
     {
         // Check if the date is valid
         if (
@@ -1477,7 +1477,7 @@ class ProductLazyArray extends AbstractLazyArray
      *
      * @return string
      */
-    private function getTranslatedKey($key)
+    protected function getTranslatedKey($key)
     {
         switch ($key) {
             case 'ean13':

--- a/src/Adapter/Presenter/Product/ProductListingLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductListingLazyArray.php
@@ -33,6 +33,11 @@ use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
 class ProductListingLazyArray extends ProductLazyArray
 {
     /**
+     * Custom implementation of add to cart URL for product listing. In product listing, we have a bit stricter
+     * rules to allow adding to cart a product. Specifically, we do not want to allow adding to cart of product
+     * combinations if the setting is disabled. Also, we do not want to allow adding to cart of products that
+     * require customization, because it's not possible to do so from the listing page.
+     *
      * @return string|null
      */
     #[LazyArrayAttribute(arrayAccess: true)]


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Implements CartProductLazyArray to have more control over data being displayed in cart, without the risk of breaking other parts of the shop. As the first part, implements availability data for cart. The changes in ProductLazyArray are just changing attributes to protected.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Apply https://github.com/PrestaShop/hummingbird/pull/919 and see the new availability in the cart.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/21625853831🟢
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/hummingbird/pull/919
| Sponsor company   | TRENDO s.r.o.

### Screenshot
<img width="1458" height="674" alt="Snímek obrazovky 2026-01-31 122031" src="https://github.com/user-attachments/assets/f94d2842-5617-4763-b20b-42deff29c74f" />

### Other languages
I think the case with combined availability should work fairly well in all languages.

@Touxten - %quantityInStock% – %messageForInStockProducts%, le reste – %messageForOutOfStockProducts%
@Codencode - %quantityInStock% – %messageForInStockProducts%, il resto – %messageForOutOfStockProducts%
@kpodemski - %quantityInStock% – %messageForInStockProducts%, pozostała część – %messageForOutOfStockProducts%

all good?