### PR TITLE
Fix saving module settings when legacy profiler enabled

### DIFF
--- a/tools/profiling/Tools.php
+++ b/tools/profiling/Tools.php
@@ -86,21 +86,4 @@ class Tools extends ToolsCore
     {
         static::redirect($url);
     }
-
-    public static function redirectAdmin($url)
-    {
-        if (!is_object(Context::getContext()->controller)) {
-            try {
-                $controller = Controller::getController(static::getDefaultControllerClass());
-                $controller->setRedirectAfter($url);
-                $controller->run();
-                Context::getContext()->controller = $controller;
-                die;
-            } catch (PrestaShopException $e) {
-                $e->displayMessage();
-            }
-        } else {
-            Context::getContext()->controller->setRedirectAfter($url);
-        }
-    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Since BO is now rendered differently, I believe this method is no longer needed
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to save `contactform` module when legacy profiler is enabled
| UI Tests          | Not relevant.
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/37275
| Related PRs       | n/a
| Sponsor company   | PrestaShop
