### PR TITLE
Fix getting specific price for a given customer group

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -828,10 +828,21 @@ class CartCore extends ObjectModel
         $pa_ids = [];
         $cart_base_product_quantity = [];
         if (is_iterable($products)) {
+            $customerGroupId = (int) (new Customer((int) $this->id_customer))->id_default_group;
             foreach ($products as $key => $product) {
                 $products_ids[] = $product['id_product'];
                 $pa_ids[] = $product['id_product_attribute'];
-                $specific_price = SpecificPrice::getSpecificPrice($product['id_product'], $this->id_shop, $this->id_currency, $id_country, $this->id_shop_group, $product['cart_quantity'], $product['id_product_attribute'], $this->id_customer, $this->id);
+                $specific_price = SpecificPrice::getSpecificPrice(
+                    $product['id_product'],
+                    $this->id_shop,
+                    $this->id_currency,
+                    $id_country,
+                    $customerGroupId,
+                    $product['cart_quantity'],
+                    $product['id_product_attribute'],
+                    $this->id_customer,
+                    $this->id
+                );
                 if ($specific_price) {
                     $reduction_type_row = ['reduction_type' => $specific_price['reduction_type']];
                 } else {

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -712,13 +712,13 @@ class OrderCore extends ObjectModel
     {
         $address = Address::initialize($this->id_address_delivery, true);
         $id_country = (int) $address->id_country;
-
+        $customerGroupId = (int) (new Customer($this->id_customer))->id_default_group;
         $specific_price = SpecificPrice::getSpecificPrice(
             $product['product_id'],
             $product['id_shop'],
             $this->id_currency,
             $id_country,
-            $this->id_shop_group,
+            $customerGroupId,
             $product['product_quantity'],
             $product['product_attribute_id']
         );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Straightforward fix, the parameter used was wrong because we used shop group instead of customer' group, for some reason previous PR never went through
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow instructions from the issue
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/21546062212
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/13705
| Related PRs       | n/a
| Sponsor company   | impSolutions
