### PR TITLE
Fix configuration of Dev mode and Debug profiling in the back office

### DIFF
--- a/src/Adapter/Debug/DebugMode.php
+++ b/src/Adapter/Debug/DebugMode.php
@@ -221,7 +221,11 @@ class DebugMode
     {
         // Check custom defines file first
         if ($this->isCustomDefinesReadable()) {
-            return $this->updateDebugModeValueInCustomFile($value);
+            $result = $this->updateDebugModeValueInCustomFile($value);
+            // If the constant is not found in custom file, fallback to main file
+            if ($result !== self::DEBUG_MODE_ERROR_NO_DEFINITION_FOUND) {
+                return $result;
+            }
         }
 
         if ($this->isMainDefinesReadable()) {

--- a/src/Adapter/Debug/DebugProfiling.php
+++ b/src/Adapter/Debug/DebugProfiling.php
@@ -175,7 +175,11 @@ class DebugProfiling
     {
         // Check custom defines file first
         if ($this->isCustomDefinesReadable()) {
-            return $this->updateProfilingValueInCustomFile($value);
+            $result = $this->updateProfilingValueInCustomFile($value);
+            // If the constant is not found in custom file, fallback to main file
+            if ($result !== self::DEBUG_PROFILING_ERROR_NO_DEFINITION_FOUND) {
+                return $result;
+            }
         }
 
         if ($this->isMainDefinesReadable()) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR fixes annoying bug when you want to enable/disable dev mode or profiler and you still have `defines_custom.inc.php`.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | All the details in the issue.
| UI Tests          | Not relevant.
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/36487
| Related PRs       | n/a
| Sponsor company   | impSolutions
