### PR TITLE
Use Symfony Debug mode if needed, regardless of whether we use the front container

### DIFF
--- a/index.php
+++ b/index.php
@@ -44,13 +44,13 @@ define('_PS_APP_ID_', FrontKernel::APP_ID);
 // Load .env file from the root of project if present
 (new Dotenv(false))->loadEnv(_PS_FRONT_DIR_ . '/.env');
 
+// Activate Symfony's debug if we need it
+if (_PS_MODE_DEV_) {
+    Debug::enable();
+}
+
 // If we want to use new container access in front (Warning: Experimental feature from now!)
 if (isset($_ENV['PS_FF_FRONT_CONTAINER_V2']) && filter_var($_ENV['PS_FF_FRONT_CONTAINER_V2'], \FILTER_VALIDATE_BOOL)) {
-    // Activate Symfony's debug if we need it
-    if (_PS_MODE_DEV_) {
-        Debug::enable();
-    }
-
     // Block the process until the cache clear is in progress, this must be done before the kernel is created so it doesn't
     // try to use the old container
     CacheClearLocker::waitUntilUnlocked(_PS_ENV_, _PS_APP_ID_);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?   |   In PS 1.7, we used Debug::enable(), regardless of whether we were in a Symfony container context - this helped show Exceptions that are not PrestaShopException better.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Throw an exception in FrontController or somewhere else
| UI Tests          | Not needed.
| Fixed issue or discussion?     | I didn't create one.
| Related PRs       | n/a
| Sponsor company   | impSolutions

Before PR:

<img width="3808" height="486" alt="image" src="https://github.com/user-attachments/assets/0bc749aa-729d-4bec-995e-aa1696f1383e" />

After PR:

<img width="1125" height="771" alt="image" src="https://github.com/user-attachments/assets/45250ec9-bea8-4d71-b3b7-d0baeb2b52e5" />

