### PR TITLE
Use proper delivery times

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -29,6 +29,7 @@ use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ProductSettings;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Gtin;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
@@ -345,7 +346,7 @@ class ProductCore extends ObjectModel
      *
      * @var int
      */
-    public $additional_delivery_times = 1;
+    public $additional_delivery_times = DeliveryTimeNoteType::TYPE_DEFAULT;
 
     /**
      * Delivery in-stock information.

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -47,6 +47,7 @@ use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Core\Domain\Product\ProductCustomizabilitySettings;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
 use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
 use Product;
 use ReflectionException;
@@ -321,24 +322,38 @@ class ProductLazyArray extends AbstractLazyArray
     #[LazyArrayAttribute(arrayAccess: true)]
     public function getDeliveryInformation()
     {
-        $productQuantity =
-            $this->product['stock_quantity'] ?? $this->product['quantity'];
+        // If the product is virtual, we don't show delivery information
+        if ($this->getVirtual()) {
+            return null;
+        }
 
-        if ($productQuantity >= $this->getQuantityWanted()) {
-            $config = $this->configuration->get(
-                'PS_LABEL_DELIVERY_TIME_AVAILABLE'
-            );
+        // If the product cannot be ordered, we don't show delivery information
+        if (!$this->shouldEnableAddToCartButton($this->product, $this->settings)) {
+            return null;
+        }
 
-            return $config[$this->language->id] ?? null;
-        } elseif (
-            $this->shouldEnableAddToCartButton($this->product, $this->settings)
-        ) {
-            $config = $this->configuration->get(
-                'PS_LABEL_DELIVERY_TIME_OOSBOA',
-                []
-            );
+        // Get proper quantity available value
+        $productQuantity = $this->product['stock_quantity'] ?? $this->product['quantity'];
 
-            return $config[$this->language->id] ?? null;
+        // Type 0 - no delivery information
+        if ($this->product['additional_delivery_times'] == DeliveryTimeNoteType::TYPE_NONE) {
+            return null;
+
+        // Type 1 - use default information
+        } elseif ($this->product['additional_delivery_times'] == DeliveryTimeNoteType::TYPE_DEFAULT) {
+            if ($productQuantity >= $this->getQuantityWanted()) {
+                return $this->configuration->get('PS_LABEL_DELIVERY_TIME_AVAILABLE')[$this->language->id] ?? null;
+            } else {
+                return $this->configuration->get('PS_LABEL_DELIVERY_TIME_OOSBOA')[$this->language->id] ?? null;
+            }
+
+        // Type 2 - use product information
+        } elseif ($this->product['additional_delivery_times'] == DeliveryTimeNoteType::TYPE_SPECIFIC) {
+            if ($productQuantity >= $this->getQuantityWanted()) {
+                return $this->product['delivery_in_stock'] ?? null;
+            } else {
+                return $this->product['delivery_out_stock'] ?? null;
+            }
         }
 
         return null;

--- a/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
+++ b/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
@@ -346,7 +346,7 @@ class ProductLazyArrayTest extends TestCase
 
         /*
          * If the product is out of stock and backorders are allowed, we should see delivery information
-         */    
+         */
         yield [
             array_merge(
                 $product,

--- a/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
+++ b/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductLazyArray;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
 use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -95,6 +96,8 @@ class ProductLazyArrayTest extends TestCase
         'customizable' => 0,
         'active' => 1,
         'minimal_quantity' => 1,
+        'is_virtual' => 0,
+        'additional_delivery_times' => DeliveryTimeNoteType::TYPE_DEFAULT,
     ];
 
     private const PRODUCT_DISCONTINUED = 'This product is no longer available for sale.';
@@ -252,6 +255,10 @@ class ProductLazyArrayTest extends TestCase
     ): void {
         $language = $this->mockLanguage;
 
+        $this->mockProductPresentationSettings
+            ->method('shouldShowPrice')
+            ->willReturn(true);
+
         $this->mockConfiguration
             ->method('get')
             ->willReturnCallback(function (string $key) use ($language) {
@@ -299,10 +306,13 @@ class ProductLazyArrayTest extends TestCase
                 'show_availability' => 1,
                 'available_date' => false,
                 'available_for_order' => 1,
+                'show_price' => 1,
             ]
         );
 
-        // Product page: in stock && out of stock not available
+        /*
+         * If the product is in stock, we should see the delivery information for available products
+         */
         yield [
             array_merge(
                 $product,
@@ -317,7 +327,9 @@ class ProductLazyArrayTest extends TestCase
             self::PRODUCT_DELIVERY_TIME_AVAILABLE,
         ];
 
-        // not enough stock, not allowed to order when out of stock, we should not see any delivery information
+        /*
+         * If the product is out of stock and backorders are not allowed, we should not see any delivery information
+         */
         yield [
             array_merge(
                 $product,
@@ -332,7 +344,9 @@ class ProductLazyArrayTest extends TestCase
             null,
         ];
 
-        // not enough stock, allowed to order when out of stock
+        /*
+         * If the product is out of stock and backorders are allowed, we should see delivery information
+         */    
         yield [
             array_merge(
                 $product,
@@ -344,7 +358,75 @@ class ProductLazyArrayTest extends TestCase
                     'allow_oosp' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
                 ]
             ),
+            self::PRODUCT_DELIVERY_TIME_OOSBOA,
+        ];
+
+        /*
+         * In case of virtual products, we should not display delivery information
+         */
+        yield [
+            array_merge(
+                $product,
+                [
+                    'cache_default_attribute' => 0,
+                    'quantity_wanted' => 11,
+                    'stock_quantity' => 10,
+                    'quantity' => 10,
+                    'allow_oosp' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
+                    'is_virtual' => 1,
+                ]
+            ),
             null,
+        ];
+
+        /*
+         * Test that we get different delivery information depending on additional_delivery_times.
+         * If it's 0, we should not get any delivery information.
+         * If it's 1, we should get the default delivery information.
+         * If it's 2, we should get the product delivery information.
+         */
+        yield [
+            array_merge(
+                $product,
+                [
+                    'cache_default_attribute' => 0,
+                    'quantity_wanted' => 1,
+                    'stock_quantity' => 10,
+                    'quantity' => 10,
+                    'allow_oosp' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
+                    'additional_delivery_times' => DeliveryTimeNoteType::TYPE_NONE,
+                ]
+            ),
+            null,
+        ];
+        yield [
+            array_merge(
+                $product,
+                [
+                    'cache_default_attribute' => 0,
+                    'quantity_wanted' => 1,
+                    'stock_quantity' => 10,
+                    'quantity' => 10,
+                    'allow_oosp' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
+                    'additional_delivery_times' => DeliveryTimeNoteType::TYPE_DEFAULT,
+                ]
+            ),
+            self::PRODUCT_DELIVERY_TIME_AVAILABLE,
+        ];
+        yield [
+            array_merge(
+                $product,
+                [
+                    'cache_default_attribute' => 0,
+                    'quantity_wanted' => 1,
+                    'stock_quantity' => 10,
+                    'quantity' => 10,
+                    'allow_oosp' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
+                    'additional_delivery_times' => DeliveryTimeNoteType::TYPE_SPECIFIC,
+                    'delivery_in_stock' => 'Delivered in next century',
+                ]
+            ),
+            'Delivered in next century',
         ];
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Delivery times in ProductLazyArray do not account for custom data, and all of the complicated handling is done in the theme. See below. The code will work just fine everywhere, on product page and in cart.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Dev test with theme change.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/21625867464 🟢 
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/hummingbird/pull/919
| Sponsor company   | TRENDO s.r.o.

This code:

```tpl
        {if $product.is_virtual	== 0}
          {if $product.additional_delivery_times == 1}
            {if $product.delivery_information}
              <span class="product__delivery__information">{$product.delivery_information}</span>
            {/if}
          {elseif $product.additional_delivery_times == 2}
            {if $product.quantity> 0}
              <span class="product__delivery__information">{$product.delivery_in_stock}</span>
            {* Out of stock message should not be displayed if customer can't order the product. *}
            {elseif $product.quantity <= 0 && $product.add_to_cart_url}
              <span class="product__delivery__information">{$product.delivery_out_stock}</span>
            {/if}
          {/if}
        {/if}
```

Can be simplified to:

```tpl
            {if !empty($product.delivery_information)}
              <span class="product__delivery__information">{$product.delivery_information}</span>
            {/if}
```