### PR TITLE
Update CACERT_LOCATION URL to new domain

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -43,7 +43,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class ToolsCore
 {
-    public const CACERT_LOCATION = 'https://curl.haxx.se/ca/cacert.pem';
+    public const CACERT_LOCATION = 'https://curl.se/ca/cacert.pem';
     public const SERVICE_LOCALE_REPOSITORY = 'prestashop.core.localization.locale.repository';
     public const CACHE_LIFETIME_SECONDS = 604800;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | the curl.haxx.se domain is deprecated (still active but redirects), so let's use the new curl.se domain instead
| Type?             | improvement 
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | It works exactly as before, but without a redirect from the old domain to the new
