### PR TITLE
Fix the collision when we create / delete product customization in the same action

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/manager/customizations-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/manager/customizations-manager.ts
@@ -61,14 +61,17 @@ export default class CustomizationsManager {
   }
 
   private addCustomizationField(): void {
-    const index = this.getIndex();
-    const newItem = this.prototypeTemplate.replace(new RegExp(this.prototypeName, 'g'), this.getIndex());
+    // The container keeps track of the next index to use, we increment it right away
+    const rowIndex = this.$customizationFieldsList.data('rowIndex');
+    this.$customizationFieldsList.data('rowIndex', rowIndex + 1);
+
+    const newItem = this.prototypeTemplate.replace(new RegExp(this.prototypeName, 'g'), rowIndex);
 
     this.$customizationFieldsList.append(newItem);
     window.prestaShopUiKit.initToolTips();
     const {translatableInput} = window.prestashop.instance;
     translatableInput.refreshFormInputs(this.$customizationsContainer.closest('form'));
-    this.eventEmitter.emit(ProductEventMap.customizations.rowAdded, {index});
+    this.eventEmitter.emit(ProductEventMap.customizations.rowAdded, {index: rowIndex});
   }
 
   private removeCustomizationField(event: JQuery.ClickEvent): void {
@@ -91,9 +94,5 @@ export default class CustomizationsManager {
       },
     );
     modal.show();
-  }
-
-  private getIndex(): string {
-    return this.$customizationFieldsList.find(ProductMap.customizations.customizationFieldRow).length.toString();
   }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/customizations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/customizations.html.twig
@@ -47,7 +47,7 @@
 {%- block collection_row -%}
   {%- set attr = attr|merge({'data-prototype': form_row(prototype), 'data-prototype-name': prototype.vars.name}) -%}
   {%- set attr = attr|merge({class: (attr.class|default('') ~ ' list-unstyled')|trim}) -%}
-  <ul {{ block('widget_attributes') }}>
+  <ul {{ block('widget_attributes') }} data-row-index="{{ form.children|length }}">
     {{- block('form_rows') -}}
   </ul>
 {%- endblock collection_row -%}

--- a/tests/UI/campaigns/functional/BO/03_catalog/01_products/14_detailsTab.ts
+++ b/tests/UI/campaigns/functional/BO/03_catalog/01_products/14_detailsTab.ts
@@ -491,18 +491,10 @@ describe('BO - Catalog - Products : Details tab', async () => {
       await testContext.addContextItem(this, 'testIdentifier', 'removeAndAddCustomizations', baseContext);
 
       // Remove the first one (same bug scenario as features: delete then add causes index collision)
-      await boProductsCreateTabDetailsPage.deleteCustomizations(page, {
-        ...editProductData,
-        customizations: [editProductData.customizations[0]],
-      });
+      await boProductsCreateTabDetailsPage.deleteCustomizationNth(page, 1);
       // Add 2 new customizations
-      await boProductsCreateTabDetailsPage.addNewCustomizations(page, {
-        ...editProductData,
-        customizations: [
-          {label: 'NewField1', type: 'Text', required: false},
-          {label: 'NewField2', type: 'Text', required: false},
-        ],
-      });
+      await boProductsCreateTabDetailsPage.addNewCustomization(page, {label: 'NewField1', type: 'Text', required: false});
+      await boProductsCreateTabDetailsPage.addNewCustomization(page, {label: 'NewField2', type: 'Text', required: false});
 
       const message = await boProductsCreatePage.saveProduct(page);
       expect(message).to.eq(boProductsCreatePage.successfulUpdateMessage);
@@ -541,15 +533,7 @@ describe('BO - Catalog - Products : Details tab', async () => {
       await testContext.addContextItem(this, 'testIdentifier', 'deleteCustomizations', baseContext);
 
       // 5 customizations to delete: 3 remaining original + 2 newly added
-      const customizationsToDelete = [
-        ...editProductData.customizations.slice(1),
-        {label: 'NewField1', type: 'Text' as const, required: false},
-        {label: 'NewField2', type: 'Text' as const, required: false},
-      ];
-      await boProductsCreateTabDetailsPage.deleteCustomizations(page, {
-        ...editProductData,
-        customizations: customizationsToDelete,
-      });
+      await boProductsCreateTabDetailsPage.deleteCustomizations(page);
 
       const message = await boProductsCreatePage.saveProduct(page);
       expect(message).to.eq(boProductsCreatePage.successfulUpdateMessage);

--- a/tests/UI/campaigns/functional/BO/03_catalog/01_products/14_detailsTab.ts
+++ b/tests/UI/campaigns/functional/BO/03_catalog/01_products/14_detailsTab.ts
@@ -487,10 +487,69 @@ describe('BO - Catalog - Products : Details tab', async () => {
       expect(pageTitle).to.contains(boProductsCreatePage.pageTitle);
     });
 
-    it('should delete the 4 customizations', async function () {
+    it('should remove 1 customization and add two new customizations', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'removeAndAddCustomizations', baseContext);
+
+      // Remove the first one (same bug scenario as features: delete then add causes index collision)
+      await boProductsCreateTabDetailsPage.deleteCustomizations(page, {
+        ...editProductData,
+        customizations: [editProductData.customizations[0]],
+      });
+      // Add 2 new customizations
+      await boProductsCreateTabDetailsPage.addNewCustomizations(page, {
+        ...editProductData,
+        customizations: [
+          {label: 'NewField1', type: 'Text', required: false},
+          {label: 'NewField2', type: 'Text', required: false},
+        ],
+      });
+
+      const message = await boProductsCreatePage.saveProduct(page);
+      expect(message).to.eq(boProductsCreatePage.successfulUpdateMessage);
+    });
+
+    it('should preview updated product with customizations', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'previewUpdatedProductCustomizations', baseContext);
+
+      // Click on preview button
+      page = await boProductsCreatePage.previewProduct(page);
+
+      await foHummingbirdProductPage.changeLanguage(page, 'en');
+
+      const pageTitle = await foHummingbirdProductPage.getPageTitle(page);
+      expect(pageTitle).to.contains(newProductData.name);
+    });
+
+    it('should check the updated product customizations', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkUpdatedProductCustomizations', baseContext);
+
+      const isCustomizationVisible = await foHummingbirdProductPage.isCustomizationBlockVisible(page);
+      expect(isCustomizationVisible).to.eq(true);
+    });
+
+    it('should go back to BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goBackToBO6', baseContext);
+
+      // Go back to BO
+      page = await foHummingbirdProductPage.closePage(browserContext, page, 0);
+
+      const pageTitle = await boProductsCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boProductsCreatePage.pageTitle);
+    });
+
+    it('should delete the 5 customizations', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'deleteCustomizations', baseContext);
 
-      await boProductsCreateTabDetailsPage.deleteCustomizations(page, editProductData);
+      // 5 customizations to delete: 3 remaining original + 2 newly added
+      const customizationsToDelete = [
+        ...editProductData.customizations.slice(1),
+        {label: 'NewField1', type: 'Text' as const, required: false},
+        {label: 'NewField2', type: 'Text' as const, required: false},
+      ];
+      await boProductsCreateTabDetailsPage.deleteCustomizations(page, {
+        ...editProductData,
+        customizations: customizationsToDelete,
+      });
 
       const message = await boProductsCreatePage.saveProduct(page);
       expect(message).to.eq(boProductsCreatePage.successfulUpdateMessage);

--- a/tests/UI/package.json
+++ b/tests/UI/package.json
@@ -111,7 +111,7 @@
   "homepage": "https://github.com/PrestaShop/PrestaShop/tree/develop/tests/UI#readme",
   "dependencies": {
     "@faker-js/faker": "^10.1.0",
-    "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main",
+    "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#pull/814/head",
     "chai": "^4.5.0",
     "chai-string": "^1.6.0",
     "dotenv": "^17.2.3",

--- a/tests/UI/package.json
+++ b/tests/UI/package.json
@@ -111,7 +111,7 @@
   "homepage": "https://github.com/PrestaShop/PrestaShop/tree/develop/tests/UI#readme",
   "dependencies": {
     "@faker-js/faker": "^10.1.0",
-    "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#pull/814/head",
+    "@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main",
     "chai": "^4.5.0",
     "chai-string": "^1.6.0",
     "dotenv": "^17.2.3",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x 
| Description?      | Fix the collision when we create / delete product customization in the same action
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | edit a product > details tab > create a new customization and remove an old one in the same action. We had the same issue for features here https://github.com/PrestaShop/PrestaShop/issues/40131
| UI Tests          | https://github.com/nicosomb/ga.tests.ui.pr/actions/runs/22064507670
| Fixed issue or discussion?     | N/A
| Related PRs       | #40532
| Sponsor company   | PrestaShop SA 
