### PR TITLE
Fix: [BO][Multishop] Design > Theme & Logo: when updating the logo in the “All shops” context, only shop ID 1 gets updated

### DIFF
--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -147,7 +147,7 @@ class LogoUploader
                 }
             }
 
-            $idShop = $this->shop->id;
+            $idShop = null;
             $idShopGroup = null;
 
             // on updating PS_LOGO if the new file is an svg, copy old logo for mail and invoice
@@ -195,7 +195,7 @@ class LogoUploader
             $logoAll = Configuration::get($fieldName);
             Shop::setContext(Shop::CONTEXT_GROUP);
             $logoGroup = Configuration::get($fieldName);
-            Shop::setContext(Shop::CONTEXT_SHOP);
+            Shop::setContext(Shop::CONTEXT_SHOP, $idShop);
             $logoShop = Configuration::get($fieldName);
             if ($logoAll != $logoShop && $logoGroup != $logoShop && $logoShop != false) {
                 @unlink($this->imageDirection . Configuration::get($fieldName));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | With multishop enabled, when I go to Back Office > Design > Theme & Logo and update the logo while in the “All shops” context, the system applies the change only to the shop with ID = 1 (the first shop).
| Type?             | bug fix
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | 1. Enable **Multishop**.<br/> 2. Create at least **2 shops** (e.g., Shop ID 1 and Shop ID 2).<br/> 3. Go to **Design > Theme & Logo**.<br/> 4. Select “**All shops**” and upload a new logo.<br/> 5. Now, in all contexts—both “All shops” and individual shop contexts—you should see the uploaded logo displayed.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/21748635757
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/issues/40692
| Related PRs       | In this PR, I also included the fix from PR #40642, originally implemented by @Yaniis.
| Sponsor company   | Codencode snc
