### PR TITLE
fix(ProductController): FormAction is checking permissions one by one…

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -458,10 +458,8 @@ class ProductController extends FrameworkBundleAdminController
 
         gc_disable();
 
-        foreach ([PageVoter::READ, PageVoter::UPDATE, PageVoter::CREATE] as $permission) {
-            if (!$this->isGranted($permission, self::PRODUCT_OBJECT)) {
-                return $this->redirect('admin_dashboard');
-            }
+        if (!$this->isGranted([PageVoter::READ, PageVoter::UPDATE, PageVoter::CREATE], self::PRODUCT_OBJECT)) {
+            return $this->redirect('admin_dashboard');
         }
 
         $productAdapter = $this->get('prestashop.adapter.data_provider.product');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | During the Symfony migration, this part of code has been changed but has created a regression. When an employee only has READ permission on the Product tab, he should be able to read the product details, with disabled inputs. With the edited code, the employee now needs to have READ/UPDATE/CREATE to be able to view the page. If you check the before, and PRESTASHOP v9, you'll see that a OR operator is the correct way.
| Type?             | bug fix
| Category?         | CO
| Deprecations?     | no
| How to test?      | Log in as an employee with only READ permission on Catalog/product. Edit a product and check you can view the details without editing it.
| UI Tests          | NA
| Fixed issue or discussion?     | NA
| Related PRs       | NA
| Sponsor company   | Evolutive
