### PR TITLE
Fix duplicated front container and side effect

### DIFF
--- a/index.php
+++ b/index.php
@@ -58,6 +58,9 @@ if (isset($_ENV['PS_FF_FRONT_CONTAINER_V2']) && filter_var($_ENV['PS_FF_FRONT_CO
         if (!headers_sent()) {
             header('Content-Type: text/html; charset=utf-8');
         }
+
+        // Restore request to stack for legacy context
+        $kernel->getContainer()->get('request_stack')->push($request);
     }
 }
 

--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -33,6 +33,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 class ContainerBuilder
 {
@@ -40,6 +41,11 @@ class ContainerBuilder
      * @var ContainerInterface
      */
     private static $containers;
+
+    /**
+     * @var KernelInterface[]
+     */
+    private static array $kernels = [];
 
     /**
      * @var EnvironmentInterface
@@ -76,23 +82,31 @@ class ContainerBuilder
      */
     public static function getContainer($containerName, $isDebug)
     {
-        if ($containerName === 'admin') {
+        if (!in_array($containerName, ['front', 'webservice'])) {
             throw new ServiceContainerException(
-                'You should use `SymfonyContainer::getInstance()` instead of `ContainerBuilder::getContainer(\'admin\')`'
+                'You should use `SymfonyContainer::getInstance()` instead of `ContainerBuilder::getContainer(\''.$containerName.'\')`'
             );
         }
 
-        if (!isset(self::$containers[$containerName])) {
+        if (!isset(self::$kernels[$containerName])) {
             if (isset($_ENV['PS_FF_FRONT_CONTAINER_V2']) && filter_var($_ENV['PS_FF_FRONT_CONTAINER_V2'], \FILTER_VALIDATE_BOOL)) {
                 global $kernel;
 
                 if ($kernel instanceof FrontKernel) {
-                    self::$containers[$containerName] = $kernel->getContainer();
+                    $frontKernel = $kernel;
                 } else {
-                    $frontKernel = (new FrontKernel(_PS_ENV_, _PS_MODE_DEV_));
-                    $frontKernel->boot();
-                    self::$containers[$containerName] = $frontKernel->getContainer();
+                    if (empty(self::$kernels[$containerName])) {
+                        $frontKernel = new FrontKernel(_PS_ENV_, _PS_MODE_DEV_);
+                        // Must cache kernel reference *BEFORE* calling boot()
+                        // Booting the kernel will call the ContainerBuilder when compiling and try to boot it again, creating a lock hell.
+                        self::$kernels[$containerName] = $frontKernel;
+                        $frontKernel->boot();
+                    }  else {
+                        $frontKernel = self::$kernels[$containerName];
+                    }
                 }
+
+                self::$containers[$containerName] = $frontKernel->getContainer();
             } else {
                 // Container builder is only used for FO now, so we hard code the Environment to use the front appId so that
                 // it uses the cache dir from FrontKernel (in var/cache/{dev|prod}/front)

--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -82,13 +82,13 @@ class ContainerBuilder
      */
     public static function getContainer($containerName, $isDebug)
     {
-        if (!in_array($containerName, ['front', 'webservice'])) {
+        if (!in_array($containerName, [FrontKernel::APP_ID, 'webservice'])) {
             throw new ServiceContainerException(
                 'You should use `SymfonyContainer::getInstance()` instead of `ContainerBuilder::getContainer(\''.$containerName.'\')`'
             );
         }
 
-        if (!isset(self::$kernels[$containerName])) {
+        if (!isset(self::$containers[$containerName])) {
             if (isset($_ENV['PS_FF_FRONT_CONTAINER_V2']) && filter_var($_ENV['PS_FF_FRONT_CONTAINER_V2'], \FILTER_VALIDATE_BOOL)) {
                 global $kernel;
 
@@ -101,7 +101,7 @@ class ContainerBuilder
                         // Booting the kernel will call the ContainerBuilder when compiling and try to boot it again, creating a lock hell.
                         self::$kernels[$containerName] = $frontKernel;
                         $frontKernel->boot();
-                    }  else {
+                    } else {
                         $frontKernel = self::$kernels[$containerName];
                     }
                 }

--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -9,6 +9,7 @@ namespace PrestaShop\PrestaShop\Adapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\ORM\Tools\Setup;
 use Exception;
+use FrontKernel;
 use LegacyCompilerPass;
 use PrestaShop\PrestaShop\Adapter\Container\ContainerBuilderExtensionInterface;
 use PrestaShop\PrestaShop\Adapter\Container\ContainerParametersExtension;
@@ -80,11 +81,24 @@ class ContainerBuilder
                 'You should use `SymfonyContainer::getInstance()` instead of `ContainerBuilder::getContainer(\'admin\')`'
             );
         }
+
         if (!isset(self::$containers[$containerName])) {
-            // Container builder is only used for FO now, so we hard code the Environment to use the front appId so that
-            // it uses the cache dir from FrontKernel (in var/cache/{dev|prod}/front)
-            $builder = new ContainerBuilder(new Environment($isDebug, $isDebug ? 'dev' : 'prod', 'front'));
-            self::$containers[$containerName] = $builder->buildContainer($containerName);
+            if (isset($_ENV['PS_FF_FRONT_CONTAINER_V2']) && filter_var($_ENV['PS_FF_FRONT_CONTAINER_V2'], \FILTER_VALIDATE_BOOL)) {
+                global $kernel;
+
+                if ($kernel instanceof FrontKernel) {
+                    self::$containers[$containerName] = $kernel->getContainer();
+                } else {
+                    $frontKernel = (new FrontKernel(_PS_ENV_, _PS_MODE_DEV_));
+                    $frontKernel->boot();
+                    self::$containers[$containerName] = $frontKernel->getContainer();
+                }
+            } else {
+                // Container builder is only used for FO now, so we hard code the Environment to use the front appId so that
+                // it uses the cache dir from FrontKernel (in var/cache/{dev|prod}/front)
+                $builder = new ContainerBuilder(new Environment($isDebug, $isDebug ? 'dev' : 'prod', 'front'));
+                self::$containers[$containerName] = $builder->buildContainer($containerName);
+            }
         }
 
         return self::$containers[$containerName];

--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -84,7 +84,7 @@ class ContainerBuilder
     {
         if (!in_array($containerName, [FrontKernel::APP_ID, 'webservice'])) {
             throw new ServiceContainerException(
-                'You should use `SymfonyContainer::getInstance()` instead of `ContainerBuilder::getContainer(\''.$containerName.'\')`'
+                'You should use `SymfonyContainer::getInstance()` instead of `ContainerBuilder::getContainer(\'' . $containerName . '\')`'
             );
         }
 

--- a/src/Adapter/HookManager.php
+++ b/src/Adapter/HookManager.php
@@ -7,6 +7,7 @@
 namespace PrestaShop\PrestaShop\Adapter;
 
 use Exception;
+use FrontKernel;
 use Hook;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -47,7 +48,7 @@ class HookManager
             $request = $sfContainer->get('request_stack')->getCurrentRequest();
         }
 
-        if (null !== $request) {
+        if (null !== $request && !in_array($sfContainer->getParameter('kernel.app_id'), [FrontKernel::APP_ID, 'webservice'])) {
             $hook_args = array_merge(['request' => $request], $hook_args);
 
             // If Symfony application is booted, we use it to dispatch Hooks

--- a/src/Adapter/LegacyHookSubscriber.php
+++ b/src/Adapter/LegacyHookSubscriber.php
@@ -8,9 +8,7 @@ namespace PrestaShop\PrestaShop\Adapter;
 
 use BadMethodCallException;
 use Context;
-use FrontKernel;
 use Hook;
-use PrestaShopBundle\Service\Hook\HookEvent;
 use PrestaShopBundle\Service\Hook\RenderingHookEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 

--- a/src/Adapter/LegacyHookSubscriber.php
+++ b/src/Adapter/LegacyHookSubscriber.php
@@ -8,6 +8,7 @@ namespace PrestaShop\PrestaShop\Adapter;
 
 use BadMethodCallException;
 use Context;
+use FrontKernel;
 use Hook;
 use PrestaShopBundle\Service\Hook\HookEvent;
 use PrestaShopBundle\Service\Hook\RenderingHookEvent;
@@ -39,7 +40,8 @@ class LegacyHookSubscriber implements EventSubscriberInterface
 
         // Hack Symfony cache clear : if context not mounted, bypass legacy call
         $legacyContext = Context::getContext();
-        if (!$legacyContext || empty($legacyContext->shop) || empty($legacyContext->employee)) {
+        global $kernel;
+        if (!($kernel instanceof FrontKernel) && (!$legacyContext || empty($legacyContext->shop) || empty($legacyContext->employee))) {
             return $listeners;
         }
 

--- a/src/Adapter/LegacyHookSubscriber.php
+++ b/src/Adapter/LegacyHookSubscriber.php
@@ -40,8 +40,7 @@ class LegacyHookSubscriber implements EventSubscriberInterface
 
         // Hack Symfony cache clear : if context not mounted, bypass legacy call
         $legacyContext = Context::getContext();
-        global $kernel;
-        if (!($kernel instanceof FrontKernel) && (!$legacyContext || empty($legacyContext->shop) || empty($legacyContext->employee))) {
+        if (!$legacyContext || empty($legacyContext->shop) || empty($legacyContext->employee)) {
             return $listeners;
         }
 

--- a/src/PrestaShopBundle/Resources/config/services/front_legacy.yml
+++ b/src/PrestaShopBundle/Resources/config/services/front_legacy.yml
@@ -55,3 +55,19 @@ services:
     class: PrestaShopBundle\Translation\TranslatorLanguageLoader
     arguments:
       - '@prestashop.adapter.module.repository.module_repository'
+
+  # Special definition for legacy environments since they don't initialize the request stack, which is a dependency for the feature flag checker
+  Symfony\Component\HttpFoundation\RequestStack:
+    factory: [ 'PrestaShopBundle\Http\RequestStackFactory', 'buildRequestStack' ]
+    lazy: true
+
+  request_stack:
+    alias: Symfony\Component\HttpFoundation\RequestStack
+
+  # Special validator to validate tokens from admin in the front environment
+  PrestaShopBundle\Security\Admin\LegacyAdminTokenValidator:
+    public: true
+    lazy: true
+    arguments:
+      $employeeRepository: '@PrestaShop\PrestaShop\Adapter\Employee\EmployeeRepository'
+      $requestStack: '@request_stack'

--- a/src/PrestaShopBundle/Resources/config/services/front_legacy.yml
+++ b/src/PrestaShopBundle/Resources/config/services/front_legacy.yml
@@ -55,3 +55,9 @@ services:
     class: PrestaShopBundle\Translation\TranslatorLanguageLoader
     arguments:
       - '@prestashop.adapter.module.repository.module_repository'
+
+  # Special validator to validate tokens from admin in the front environment
+  PrestaShopBundle\Security\Admin\LegacyAdminTokenValidator:
+    public: true
+    lazy: true
+    autowire: true

--- a/src/PrestaShopBundle/Resources/config/services/front_legacy.yml
+++ b/src/PrestaShopBundle/Resources/config/services/front_legacy.yml
@@ -55,19 +55,3 @@ services:
     class: PrestaShopBundle\Translation\TranslatorLanguageLoader
     arguments:
       - '@prestashop.adapter.module.repository.module_repository'
-
-  # Special definition for legacy environments since they don't initialize the request stack, which is a dependency for the feature flag checker
-  Symfony\Component\HttpFoundation\RequestStack:
-    factory: [ 'PrestaShopBundle\Http\RequestStackFactory', 'buildRequestStack' ]
-    lazy: true
-
-  request_stack:
-    alias: Symfony\Component\HttpFoundation\RequestStack
-
-  # Special validator to validate tokens from admin in the front environment
-  PrestaShopBundle\Security\Admin\LegacyAdminTokenValidator:
-    public: true
-    lazy: true
-    arguments:
-      $employeeRepository: '@PrestaShop\PrestaShop\Adapter\Employee\EmployeeRepository'
-      $requestStack: '@request_stack'

--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -15,10 +15,10 @@ if (!defined('_PS_API_IN_USE_')) {
 
 require_once dirname(__FILE__) . '/../config/config.inc.php';
 
-define('_PS_APP_ID_', FrontKernel::APP_ID);
+define('_PS_APP_ID_', AdminAPIKernel::APP_ID);
 
 // Load .env file from the root of project if present
-(new Dotenv(false))->loadEnv(dirname(__FILE__, 2) . '/.env');
+(new Dotenv())->loadEnv(dirname(__FILE__, 2) . '/.env');
 
 // Cart is needed for some requests
 Context::getContext()->cart = new Cart();

--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -5,6 +5,7 @@
  */
 
 use PrestaShop\PrestaShop\Adapter\ContainerBuilder;
+use Symfony\Component\Dotenv\Dotenv;
 
 ob_start();
 
@@ -13,6 +14,11 @@ if (!defined('_PS_API_IN_USE_')) {
 }
 
 require_once dirname(__FILE__) . '/../config/config.inc.php';
+
+define('_PS_APP_ID_', FrontKernel::APP_ID);
+
+// Load .env file from the root of project if present
+(new Dotenv(false))->loadEnv(dirname(__FILE__, 2) . '/.env');
 
 // Cart is needed for some requests
 Context::getContext()->cart = new Cart();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | If  `PS_FF_FRONT_CONTAINER_V2` is set to `true` in `.env` file the front container will be duplicated creating unexpected results.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | unsure
| Deprecations?     | no
| How to test?      | Under redaction
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #40571 
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Novius

If  `PS_FF_FRONT_CONTAINER_V2` is set to `true` in `.env` file the front container will be duplicated, one will the old reduced front container built by the custom container builder, the other one will be the new.
Since the old container is still built, the use of non-available services in the old one will trigger an exception despite having the new container building properly.

This PR is a draft to address this issue and side effects related to the fix. Your feedback is more than welcome as the proposed fixes feels quirky.

Identified side effects when the old container is removed:

- Missing services definitions in `src/PrestaShopBundle/Resources/config/services/front_legacy.yml`, copied from `config/services/front/services_prod.yml`
- When `displayPaymentEU`, `advancedPaymentOptions` and `paymentOptions` fail to execute as `LegacyHookSubscriber::getSubscribedEvents` acts like it's called from admin

Probably few part of the code will consider that if a kernel is booted we are into the BO and may trigger other side effects