### PR TITLE
Fix: Features with the same name are shown only once when creating values and assigning to products

### DIFF
--- a/src/Adapter/Form/ChoiceProvider/FeaturesChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/FeaturesChoiceProvider.php
@@ -31,6 +31,7 @@ namespace PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider;
 use PrestaShop\PrestaShop\Adapter\Feature\Repository\FeatureRepository;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceFormatter;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 
 class FeaturesChoiceProvider implements FormChoiceProviderInterface
@@ -59,16 +60,20 @@ class FeaturesChoiceProvider implements FormChoiceProviderInterface
         }
 
         $contextLangId = (int) $this->legacyContext->getLanguage()->getId();
+        $contextShopId = (int) $this->legacyContext->getContext()->shop->id;
 
-        $features = $this->featureRepository->getFeaturesByLang(
-            $contextLangId,
-            $this->legacyContext->getContext()->shop->id
-        );
-        $this->cacheFeatureChoices = [];
-        foreach ($features as $feature) {
-            $this->cacheFeatureChoices[$feature['localized_names'][$contextLangId]] = $feature['id_feature'];
+        $features = [];
+        foreach ($this->featureRepository->getFeaturesByLang($contextLangId, $contextShopId) as $feature) {
+            $features[] = [
+                'id_feature' => $feature['id_feature'],
+                'name' => $feature['localized_names'][$contextLangId],
+            ];
         }
 
-        return $this->cacheFeatureChoices;
+        return $this->cacheFeatureChoices = FormChoiceFormatter::formatFormChoices(
+            $features,
+            'id_feature',
+            'name'
+        );
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.0.x
| Description?      | Fixes an ambiguity issue when multiple features share the same name by displaying the feature ID alongside the name in the feature value creation form.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create a feature with name X<br/>2. Create a second feature with the same name X <br/>3. create assign the feature to a product<br/> 4. Create a feature value for both created features <br/>5. Open a product in edit mode<br/> 6. Add the two created feature values<br/><br/>
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/22104649874 
| Fixed issue or discussion?     | Fixes #40703
| Related PRs       | 
| Sponsor company   | Codencode snc

---
### Note
This is a backport of https://github.com/PrestaShop/PrestaShop/pull/37882

---
 ### Attached videos:
 **feature creation** 
 
  [creazione.webm](https://github.com/user-attachments/assets/ec33f616-fdc2-4653-8daa-623dfcd330bb)
  
 **product edit** 
 
[modifica product.webm](https://github.com/user-attachments/assets/6645c6a4-abeb-444c-a528-11b0d460d438)