### PR TITLE
Fix: Error when creating an attribute for a group in “All shops” context with multiple shops

### DIFF
--- a/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
@@ -59,7 +59,7 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
     public function __construct(
         private readonly AttributeGroupRepository $attributeGroupRepository,
         private readonly int $langId,
-        private readonly int $shopId,
+        private readonly ?int $shopId,
     ) {
     }
 

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -142,4 +142,4 @@ services:
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\AttributeGroupChoiceProvider:
     autowire: true
     arguments:
-      $shopId: '@=service("prestashop.adapter.shop.context").getContextShopID()'
+      $shopId: '@=service("prestashop.adapter.shop.context").getContextShopID() !== null ? service("prestashop.adapter.shop.context").getContextShopID() : service("prestashop.adapter.legacy.context").getContext().shop.id'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR fixes an issue in AttributeGroupChoiceProvider where the service could receive a `null` shop ID in valid contexts (e.g. _All shops_ or back office initialization).<br/><br/>The service definition now resolves the shop ID by:<br/>- using the modern shop context when available<br/>- falling back to the legacy context when the shop context is `null`<br/>This prevents type errors and ensures consistent behavior across all shop contexts.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create 2 shops<br/>2. Go to **Attributes & Features > Attributes**<br/>3. Select an attribute group<br/>4. Select the **All stores** context<br/>5. You must be able to add the attribute without errors.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/21714179059
| Fixed issue or discussion?     | Fixes #40705
| Related PRs       | 
| Sponsor company   | Codencode snc
