### PR TITLE
Fix: Feature values count is duplicated when using “All shops” with multiple shops

### DIFF
--- a/src/Core/Grid/Query/FeatureQueryBuilder.php
+++ b/src/Core/Grid/Query/FeatureQueryBuilder.php
@@ -78,7 +78,7 @@ class FeatureQueryBuilder extends AbstractDoctrineQueryBuilder
         $qb = $this->getQueryBuilder($searchCriteria);
         $qb
             ->select('f.id_feature, fl.name, f.position')
-            ->addSelect('COUNT(fv.id_feature_value) AS values_count')
+            ->addSelect('COUNT(DISTINCT(fv.id_feature_value)) AS values_count')
             ->leftJoin(
                 'f',
                 $this->dbPrefix . 'feature_value',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR updates the feature query to count **distinct** feature values instead of all occurrences.<br/>By adding `DISTINCT `to the `COUNT `expression, the query now returns an accurate number of feature values per feature, avoiding duplicated counts caused by joins.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create 2 shops<br/>2. Create a feature in Attributes & Features > Features<br/>3. Create a value for the new feature<br/> 4. Go back to the feature list and select the All shops context<br/>5. The count of values (Values column) must be 1 and not 2
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/21720543744
| Fixed issue or discussion?     | Fixes #40704
| Related PRs       | 
| Sponsor company   | Codencode snc
