### PR TITLE
Add support for .map files in themes .htaccess

### DIFF
--- a/themes/.htaccess
+++ b/themes/.htaccess
@@ -2,7 +2,7 @@
 <IfModule !mod_authz_core.c>
     Order deny,allow
     Deny from all
-    <Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp|woff|woff2|ttf|eot|otf|css|js|zip|avif)$">
+    <Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp|woff|woff2|ttf|eot|otf|css|js|map|zip|avif)$">
         Allow from all
     </Files>
 </IfModule>
@@ -10,7 +10,7 @@
 # Apache 2.4
 <IfModule mod_authz_core.c>
     Require all denied
-    <Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp|woff|woff2|ttf|eot|otf|css|js|zip|avif)$">
+    <Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp|woff|woff2|ttf|eot|otf|css|js|map|zip|avif)$">
         Require all granted
     </Files>
 </IfModule>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When developing a Prestashop theme, the browser needs to load .map files for the dev inspection tool, but as they are not whitelisted in themes/.htaccess, the .map files fail to load. This PR fixes the 403 errors and reenables .map files
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Work on a theme with source-maps enabled <br> 2. Go to Advanced parameters -> Performance and disable Smart cache for CSS and Smart cache for Javascript <br> 3. In the FO use "Inspect element" to bring up the browser's developer tools and inspect the properties of different CSS selectors. <br> 4. With this PR, you will see the source file (for example _reboot.scss:15); without this PR, you'll see the compiled file instead (for example theme.css:876 - which is not helpful in debugging).
