### PR TITLE
Disable sub-directory usage for Smarty #40714

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -36,7 +36,7 @@ if (Configuration::get('PS_SMARTY_LOCAL')) {
 $smarty->setConfigDir([]);
 $smarty->setCompileDir(_PS_CACHE_DIR_ . 'smarty/compile');
 $smarty->setCacheDir(_PS_CACHE_DIR_ . 'smarty/cache');
-$smarty->use_sub_dirs = true;
+$smarty->use_sub_dirs = false;
 $smarty->caching = Smarty::CACHING_OFF;
 $smarty->force_compile = Configuration::get('PS_SMARTY_FORCE_COMPILE') == _PS_SMARTY_FORCE_COMPILE_;
 $smarty->compile_check = (Configuration::get('PS_SMARTY_FORCE_COMPILE') >= _PS_SMARTY_CHECK_COMPILE_) ? Smarty::COMPILECHECK_ON : Smarty::COMPILECHECK_OFF;


### PR DESCRIPTION
<div class="comment-body markdown-body js-comment-body soft-wrap user-select-contain d-block">
      
<markdown-accessiblity-table data-catalyst=""><table role="table">
<thead>
<tr>
<th>Questions</th>
<th>Answers</th>
</tr>
</thead>
<tbody>
<tr>
<td>Branch</td>
<td>develop</td>
</tr>
<tr>
<td>Description</td>
<td>Since Smarty-2.6.2 use_sub_dirs is set to false by default, keeping it in false reduces syscalls when the clearSmartyCache() function is executed.

https://www.smarty.net/docsv2/es/variable.use.sub.dirs.tpl

Even though higher versions of Smarty are used in PS, in all versions "use_sub_dirs" is always true.</td>
</tr>
<tr>
<td>Type</td>
<td>bug fix</td>
</tr>
<tr>
<td>Category</td>
<td>CO</td>
</tr>
<tr>
<td>How to test</td>
<td>In a PrestaShop installation with a large /var/cache/prod/smarty directory (many generated directories and files), if you access, for example, index.php?controller=AdminSpecificPriceRule (Related to this issue https://github.com/PrestaShop/PrestaShop/issues/29298 ), the controller executes the clearSmartyCache() function, completely blocking the page from loading until the smarty directory is emptied. By changing use_sub_dirs to false, the loading is instantaneous, and the clearing is quick and effective.</td>
</tr>
<tr>
<td>Issue</td>
<td>#40714</td>
</tr>
</tbody>
</table></markdown-accessiblity-table>
    </div>