### PR TITLE
Added multi-shipment support to emails

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -23,8 +23,10 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 use PrestaShop\PrestaShop\Adapter\MailTemplate\MailPartialTemplateRenderer;
 use PrestaShop\PrestaShop\Adapter\Shipment\OrderShipmentCreator;
+use PrestaShop\PrestaShop\Adapter\Shipment\OrderShipmentService;
 use PrestaShop\PrestaShop\Adapter\StockManager;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
@@ -231,6 +233,7 @@ abstract class PaymentModuleCore extends Module
             'id_order_state' => &$id_order_state,
             'payment_method' => $payment_method,
         ]);
+        $orderShipmentService = $this->get(OrderShipmentService::class);
 
         $this->context->cart = new Cart((int) $id_cart);
         $this->context->customer = new Customer((int) $this->context->cart->id_customer);
@@ -489,11 +492,22 @@ abstract class PaymentModuleCore extends Module
 
                 $product_price = Product::getTaxCalculationMethod() == PS_TAX_EXC ? Tools::ps_round($price, Context::getContext()->getComputingPrecision()) : $price_wt;
 
+                $carrierName = null;
+                if ($orderShipmentService->orderHasShipment($order->id)) {
+                    $carrierName = $orderShipmentService->getCarrierForProduct($order->id, (int) $product['id_product'])->name;
+                }
+
                 $product_var_tpl = [
                     'id_product' => $product['id_product'],
                     'id_product_attribute' => $product['id_product_attribute'],
                     'reference' => $product['reference'],
-                    'name' => $product['name'] . (!empty($product['attributes']) ? ' - ' . $product['attributes'] : ''),
+                    'name' => $this->trans(
+                        '%name%%attributes%%carrier%',
+                        [
+                            '%name%' => $product['name'],
+                            '%attributes%' => !empty($product['attributes']) ? $this->trans(' - %attributes%', ['%attributes%' => $product['attributes']], 'Emails.Body') : '',
+                            '%carrier%' => $carrierName ? $this->trans(' - Carrier: %carrier_name%', ['%carrier_name%' => $carrierName], 'Emails.Body') : '',
+                        ], 'Emails.Body'),
                     'price' => Tools::getContextLocale($this->context)->formatPrice($product_price * $product['quantity'], $this->context->currency->iso_code),
                     'quantity' => $product['quantity'],
                     'customization' => [],
@@ -682,6 +696,15 @@ abstract class PaymentModuleCore extends Module
                 }
 
                 if (Validate::isEmail($this->context->customer->email)) {
+                    if ($orderShipmentService->orderHasShipment($order->id)) {
+                        $carriers = $orderShipmentService->getAllCarriersForOrder($order->id);
+                        $carrierNames = array_map(fn ($carrier) => $carrier->name, $carriers);
+                        $carrierNames = implode(', ', $carrierNames);
+                    } else {
+                        $carrier = new Carrier($order->id_carrier);
+                        $carrierNames = $carrier->name;
+                    }
+
                     $data = [
                         '{firstname}' => $this->context->customer->firstname,
                         '{lastname}' => $this->context->customer->lastname,
@@ -722,7 +745,7 @@ abstract class PaymentModuleCore extends Module
                         '{order_name}' => $order->getUniqReference(),
                         '{id_order}' => $order->id,
                         '{date}' => Tools::displayDate(date('Y-m-d H:i:s'), true),
-                        '{carrier}' => ($virtual_product || !isset($carrier->name)) ? $this->trans('No carrier', [], 'Admin.Payment.Notification') : $carrier->name,
+                        '{carrier}' => ($virtual_product || !isset($carrierNames)) ? $this->trans('No carrier', [], 'Admin.Payment.Notification') : $carrierNames,
                         '{payment}' => $order->payment,
                         '{products}' => $product_list_html,
                         '{products_txt}' => $product_list_txt,

--- a/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
+++ b/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
@@ -33,6 +33,7 @@ use Cart;
 use Context;
 use Order;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Adapter\Shipment\OrderShipmentService;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Employee\ContextEmployeeProviderInterface;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
@@ -82,6 +83,11 @@ final class MailPreviewVariablesBuilder
     private $translator;
 
     /**
+     * @var OrderShipmentService
+     */
+    private $orderShipmentService;
+
+    /**
      * MailPreviewVariablesBuilder constructor.
      *
      * @param ConfigurationInterface $configuration
@@ -97,8 +103,10 @@ final class MailPreviewVariablesBuilder
         ContextEmployeeProviderInterface $employeeProvider,
         MailPartialTemplateRenderer $mailPartialTemplateRenderer,
         Locale $locale,
-        TranslatorInterface $translatorComponent
+        TranslatorInterface $translatorComponent,
+        OrderShipmentService $orderShipmentService
     ) {
+        $this->orderShipmentService = $orderShipmentService;
         $this->configuration = $configuration;
         $this->legacyContext = $legacyContext;
         $this->context = $this->legacyContext->getContext();
@@ -216,12 +224,20 @@ final class MailPreviewVariablesBuilder
             return [];
         }
 
-        $carrier = new Carrier($order->id_carrier);
         $delivery = new Address($order->id_address_delivery);
         $invoice = new Address($order->id_address_invoice);
 
+        if ($this->orderShipmentService->orderHasShipment($order->id)) {
+            $carriers = $this->orderShipmentService->getAllCarriersForOrder($order->id);
+            $carrierNames = array_map(fn ($carrier) => $carrier->name, $carriers);
+            $carrierNames = implode(', ', $carrierNames);
+        } else {
+            $carrier = new Carrier($order->id_carrier);
+            $carrierNames = $carrier->name;
+        }
+
         return array_merge($productVariables, [
-            '{carrier}' => $carrier->name,
+            '{carrier}' => $carrierNames,
             '{delivery_block_txt}' => $this->getFormatedAddress($delivery, "\n"),
             '{invoice_block_txt}' => $this->getFormatedAddress($invoice, "\n"),
             '{delivery_block_html}' => $this->getFormatedAddress($delivery, '<br />', [
@@ -364,11 +380,25 @@ final class MailPreviewVariablesBuilder
 
             $productPrice = Product::getTaxCalculationMethod() == PS_TAX_EXC ? Tools::ps_round($price, 2) : $priceWithTax;
 
+            $carrierName = null;
+            if ($this->orderShipmentService->orderHasShipment($order->id)) {
+                $carrier = $this->orderShipmentService->getCarrierForProduct($order->id, (int) $product['id_product']);
+                if ($carrier) {
+                    $carrierName = $carrier->name;
+                }
+            }
+
             $productTemplate = [
                 'id_product' => $product['id_product'],
                 'id_product_attribute' => $product['id_product_attribute'],
                 'reference' => $product['reference'],
-                'name' => $product['name'] . (isset($product['attributes']) ? ' - ' . $product['attributes'] : ''),
+                'name' => $this->trans(
+                    '%name%%attributes%%carrier%',
+                    [
+                        '%name%' => $product['name'],
+                        '%attributes%' => !empty($product['attributes']) ? $this->trans(' - %attributes%', ['%attributes%' => $product['attributes']], 'Emails.Body') : '',
+                        '%carrier%' => $carrierName ? $this->trans(' - Carrier: %carrier_name%', ['%carrier_name%' => $carrierName], 'Emails.Body') : '',
+                    ], 'Emails.Body'),
                 'price' => $this->locale->formatPrice($productPrice * $product['quantity'], $this->context->currency->iso_code),
                 'quantity' => $product['quantity'],
                 'customization' => [],

--- a/src/Adapter/Shipment/OrderShipmentService.php
+++ b/src/Adapter/Shipment/OrderShipmentService.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Shipment;
+
+use Carrier;
+use PrestaShop\PrestaShop\Adapter\Carrier\Repository\CarrierRepository;
+use PrestaShop\PrestaShop\Adapter\Order\Repository\OrderRepository;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierId;
+use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
+use PrestaShopBundle\Entity\Repository\ShipmentRepository;
+
+class OrderShipmentService
+{
+    /**
+     * @var ShipmentRepository
+     */
+    private $shipmentRepository;
+
+    /**
+     * @var OrderRepository
+     */
+    private $orderRepository;
+
+    /**
+     * @var CarrierRepository
+     */
+    private $carrierRepository;
+
+    public function __construct(ShipmentRepository $shipmentRepository, OrderRepository $orderRepository, CarrierRepository $carrierRepository)
+    {
+        $this->orderRepository = $orderRepository;
+        $this->shipmentRepository = $shipmentRepository;
+        $this->carrierRepository = $carrierRepository;
+    }
+
+    /**
+     * Returns the carrier used to ship a specific product within a given order.
+     */
+    public function getCarrierForProduct(int $orderId, int $productId): ?Carrier
+    {
+        $order = $this->orderRepository->get(new OrderId($orderId));
+        $shipments = $this->shipmentRepository->findByOrderId($order->id);
+
+        $orderDetails = $order->getOrderDetailList();
+        $orderDetailId = null;
+
+        foreach ($orderDetails as $orderDetail) {
+            if ((int) $orderDetail['product_id'] === $productId) {
+                $orderDetailId = (int) $orderDetail['id_order_detail'];
+                break;
+            }
+        }
+
+        foreach ($shipments as $shipment) {
+            foreach ($shipment->getProducts() as $shipmentProduct) {
+                if ($shipmentProduct->getOrderDetailId() === $orderDetailId) {
+                    $carrierId = new CarrierId($shipment->getCarrierId());
+                    $carrier = $this->carrierRepository->get($carrierId);
+
+                    return $carrier;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns all distinct carriers used to ship an order.
+     *
+     * @return Carrier[]
+     */
+    public function getAllCarriersForOrder(int $orderId): array
+    {
+        $shipments = $this->shipmentRepository->findByOrderId($orderId);
+
+        $carriers = [];
+
+        foreach ($shipments as $shipment) {
+            if (!isset($carriers[$shipment->getCarrierId()])) {
+                $carrierId = new CarrierId($shipment->getCarrierId());
+                $carrier = $this->carrierRepository->get($carrierId);
+                $carriers[$carrierId->getValue()] = $carrier;
+            }
+        }
+
+        return $carriers;
+    }
+
+    public function orderHasShipment(int $orderId): bool
+    {
+        $shipments = $this->shipmentRepository->findByOrderId($orderId);
+
+        return !empty($shipments);
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
@@ -35,6 +35,7 @@ services:
       - "@prestashop.adapter.mail_template.partial_template_renderer"
       - "@prestashop.core.localization.locale.context_locale"
       - "@translator"
+      - '@PrestaShop\PrestaShop\Adapter\Shipment\OrderShipmentService'
 
   prestashop.adapter.mail_template.preview_variables_builder:
     alias: 'PrestaShop\PrestaShop\Adapter\MailTemplate\MailPreviewVariablesBuilder'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/common.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/common.yml
@@ -35,7 +35,25 @@ services:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
 
+  PrestaShop\PrestaShop\Adapter\Shop\Repository\ShopRepository:
+    arguments:
+      - '@doctrine.dbal.default_connection'
+      - '%database_prefix%'
+
+  PrestaShop\PrestaShop\Adapter\Carrier\Repository\CarrierRepository:
+    arguments:
+      - '@PrestaShop\PrestaShop\Adapter\Shop\Repository\ShopRepository'
+      - '@doctrine.dbal.default_connection'
+      - '%database_prefix%'
+
   PrestaShop\PrestaShop\Adapter\Order\Repository\OrderDetailRepository:
     arguments:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
+
+  PrestaShop\PrestaShop\Adapter\Shipment\OrderShipmentService:
+    public: true
+    arguments:
+      - '@PrestaShopBundle\Entity\Repository\ShipmentRepository'
+      - '@PrestaShop\PrestaShop\Adapter\Order\Repository\OrderRepository'
+      - '@PrestaShop\PrestaShop\Adapter\Carrier\Repository\CarrierRepository'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The purpose of this modification is to allow the display of the carriers delivering each product in the order, and to show all the carriers involved. This only applies to multi-shipments; the default behavior remains unchanged.
| Type?             | improvement
| Category?         | BO
| BC breaks?        |no
| Deprecations?     | no
| How to test?      | -
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/21754973981
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -

<img width="615" height="1154" alt="image" src="https://github.com/user-attachments/assets/8e1d2edc-4dd7-423b-8cc2-dded7d20231b" />
