### PR TITLE
Add actionUpdateDefaultCombinationAfter hook when default combination is set

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -5665,8 +5665,8 @@
     </hook>
     <hook id="actionUpdateDefaultCombinationAfter">
       <name>actionUpdateDefaultCombinationAfter</name>
-      <title/>
-      <description/>
+      <title>After default combination update</title>
+      <description>Allows modules to react after the default combination of a product has been updated. This hook is triggered once the default combination has been successfully changed.</description>
     </hook>
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -5663,5 +5663,10 @@
       <title/>
       <description/>
     </hook>
+    <hook id="actionUpdateDefaultCombinationAfter">
+      <name>actionUpdateDefaultCombinationAfter</name>
+      <title/>
+      <description/>
+    </hook>
   </entities>
 </entity_hook>

--- a/src/Adapter/Product/Combination/Update/DefaultCombinationUpdater.php
+++ b/src/Adapter/Product/Combination/Update/DefaultCombinationUpdater.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 
 /**
  * Responsible for updating product default combination
@@ -40,22 +41,14 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 class DefaultCombinationUpdater
 {
     /**
-     * @var CombinationRepository
-     */
-    private $combinationRepository;
-
-    /**
-     * @var ProductRepository
-     */
-    private $productRepository;
-
-    /**
      * @param CombinationRepository $combinationRepository
      * @param ProductRepository $productRepository
+     * @param HookDispatcherInterface $hookDispatcher
      */
     public function __construct(
-        CombinationRepository $combinationRepository,
-        ProductRepository $productRepository
+        private CombinationRepository $combinationRepository,
+        private ProductRepository $productRepository,
+        private HookDispatcherInterface $hookDispatcher
     ) {
         $this->combinationRepository = $combinationRepository;
         $this->productRepository = $productRepository;
@@ -84,5 +77,10 @@ class DefaultCombinationUpdater
         );
 
         $this->productRepository->updateCachedDefaultCombination($productId, $shopConstraint);
+
+        $this->hookDispatcher->dispatchWithParameters(
+            'actionUpdateDefaultCombinationAfter',
+            ['id_product' => (int) $newDefaultCombination->id_product, 'id_product_attribute' => (int) $defaultCombinationId->getValue()]
+        );
     }
 }

--- a/src/Adapter/Product/Combination/Update/DefaultCombinationUpdater.php
+++ b/src/Adapter/Product/Combination/Update/DefaultCombinationUpdater.php
@@ -80,7 +80,11 @@ class DefaultCombinationUpdater
 
         $this->hookDispatcher->dispatchWithParameters(
             'actionUpdateDefaultCombinationAfter',
-            ['id_product' => (int) $newDefaultCombination->id_product, 'id_product_attribute' => (int) $defaultCombinationId->getValue()]
+            [
+                'id_product' => (int) $newDefaultCombination->id_product,
+                'id_product_attribute' => (int) $defaultCombinationId->getValue(),
+                'id_shop' => $shopConstraint->isSingleShopContext() ? $shopConstraint->getShopId()->getValue() : null,
+            ]
         );
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.1.x
| Description?      | This PR introduces the new `actionUpdateDefaultCombinationAfter` hook, dispatched when a product default combination is set.<br/> The hook exposes `id_product` and `id_product_attribute`, allowing modules to react to changes of the default combination.
| Type?             | improvement
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | 1. Install this module [pr40720.zip](https://github.com/user-attachments/files/25133390/pr40720.zip)<br/>  2. Modify an article that has combinations by specifying a new default combination<br/> 3. refresh the page and see the message: "Hook actionUpdateDefaultCombinationAfter executed".<br/>
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/21758466677
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/1644 <br/>https://github.com/PrestaShop/docs/pull/2100
| Sponsor company   | Codencode snc

---
### Video
[screen-capture.webm](https://github.com/user-attachments/assets/19d8a6f7-bcbe-45aa-ab47-4a6f93718b57)