### PR TITLE
Add hooks that enable to control free shipping price

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3859,10 +3859,10 @@ class CartCore extends ObjectModel
         }
 
         /*
-         * Allow modules to override the free shipping price and return their custom value, for example
-         * to specify it by zone or other criteria.
+         * Allow modules to override the free shipping price and return their custom value, for example to specify
+         * it by zone or other criteria. Make sure to convert it to the currency of the cart if needed.
          */
-        Hook::exec('actionOverrideShippingFreePrice', ['shippingFreePrice' => &$shippingFreePrice, 'id_zone' => $id_zone]);
+        Hook::exec('actionOverrideShippingFreePrice', ['shippingFreePrice' => &$shippingFreePrice, 'id_zone' => $id_zone, 'id_currency' => $this->id_currency]);
 
         $orderTotalwithDiscounts = $this->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING, null, null, false);
         if ($orderTotalwithDiscounts >= (float) $shippingFreePrice && (float) $shippingFreePrice > 0) {
@@ -3896,10 +3896,10 @@ class CartCore extends ObjectModel
         $shippingFreeWeight = (float) Configuration::get('PS_SHIPPING_FREE_WEIGHT');
 
         /*
-         * Allow modules to override the free shipping weight and return their custom value, for example
-         * to specify it by zone or other criteria.
+         * Allow modules to override the free shipping weight and return their custom value, for example to specify
+         * it by zone or other criteria. Make sure to convert it to the currency of the cart if needed.
          */
-        Hook::exec('actionOverrideShippingFreeWeight', ['shippingFreeWeight' => &$shippingFreeWeight, 'id_zone' => $id_zone]);
+        Hook::exec('actionOverrideShippingFreeWeight', ['shippingFreeWeight' => &$shippingFreeWeight, 'id_zone' => $id_zone, 'id_currency' => $this->id_currency]);
 
         if (!empty($shippingFreeWeight)
             && $this->getTotalWeight() >= (float) $shippingFreeWeight

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3840,10 +3840,8 @@ class CartCore extends ObjectModel
         }
 
         $configuration = Configuration::getMultiple([
-            'PS_SHIPPING_FREE_PRICE',
             'PS_SHIPPING_HANDLING',
             'PS_SHIPPING_METHOD',
-            'PS_SHIPPING_FREE_WEIGHT',
         ]);
 
         /*
@@ -3854,12 +3852,20 @@ class CartCore extends ObjectModel
          *
          * Watch out, this is different from the other calculations which use the order total WITH discounts.
          */
-        $free_fees_price = 0;
-        if (isset($configuration['PS_SHIPPING_FREE_PRICE'])) {
-            $free_fees_price = Tools::convertPrice((float) $configuration['PS_SHIPPING_FREE_PRICE'], Currency::getCurrencyInstance((int) $this->id_currency));
+        // Get the configuration value and convert it to the current currency
+        $shippingFreePrice = (float) Configuration::get('PS_SHIPPING_FREE_PRICE');
+        if (!empty(($shippingFreePrice))) {
+            $shippingFreePrice = Tools::convertPrice((float) $shippingFreePrice, Currency::getCurrencyInstance((int) $this->id_currency));
         }
+
+        /*
+         * Allow modules to override the free shipping price and return their custom value, for example
+         * to specify it by zone or other criteria.
+         */
+        Hook::exec('actionOverrideShippingFreePrice', ['shippingFreePrice' => &$shippingFreePrice, 'id_zone' => $id_zone]);
+
         $orderTotalwithDiscounts = $this->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING, null, null, false);
-        if ($orderTotalwithDiscounts >= (float) $free_fees_price && (float) $free_fees_price > 0) {
+        if ($orderTotalwithDiscounts >= (float) $shippingFreePrice && (float) $shippingFreePrice > 0) {
             // Allow module to override the shipping cost and return their custom value
             $shipping_cost = $this->getPackageShippingCostFromModule($carrier, $shipping_cost, $products);
 
@@ -3887,9 +3893,17 @@ class CartCore extends ObjectModel
          * is greater than or equal to the free shipping weight.
          * If it is, we return 0.
          */
-        if (isset($configuration['PS_SHIPPING_FREE_WEIGHT'])
-            && $this->getTotalWeight() >= (float) $configuration['PS_SHIPPING_FREE_WEIGHT']
-            && (float) $configuration['PS_SHIPPING_FREE_WEIGHT'] > 0) {
+        $shippingFreeWeight = (float) Configuration::get('PS_SHIPPING_FREE_WEIGHT');
+
+        /*
+         * Allow modules to override the free shipping weight and return their custom value, for example
+         * to specify it by zone or other criteria.
+         */
+        Hook::exec('actionOverrideShippingFreeWeight', ['shippingFreeWeight' => &$shippingFreeWeight, 'id_zone' => $id_zone]);
+
+        if (!empty($shippingFreeWeight)
+            && $this->getTotalWeight() >= (float) $shippingFreeWeight
+            && (float) $shippingFreeWeight > 0) {
             // Allow module to override the shipping cost and return their custom value
             $shipping_cost = $this->getPackageShippingCostFromModule($carrier, $shipping_cost, $products);
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3854,7 +3854,7 @@ class CartCore extends ObjectModel
          */
         // Get the configuration value and convert it to the current currency
         $shippingFreePrice = (float) Configuration::get('PS_SHIPPING_FREE_PRICE');
-        if (!empty(($shippingFreePrice))) {
+        if (!empty($shippingFreePrice)) {
             $shippingFreePrice = Tools::convertPrice((float) $shippingFreePrice, Currency::getCurrencyInstance((int) $this->id_currency));
         }
 

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -5668,5 +5668,15 @@
       <title>After default combination update</title>
       <description>Allows modules to react after the default combination of a product has been updated. This hook is triggered once the default combination has been successfully changed.</description>
     </hook>
+    <hook id="actionOverrideShippingFreePrice">
+      <name>actionOverrideShippingFreePrice</name>
+      <title>Override price that determines free shipping</title>
+      <description>Allows modules to override the free shipping price and return their custom value, for example to specify it by zone or other criteria.</description>
+    </hook>
+    <hook id="actionOverrideShippingFreeWeight">
+      <name>actionOverrideShippingFreeWeight</name>
+      <title>Override weight that determines free shipping</title>
+      <description>Allows modules to override the free shipping weight and return their custom value, for example to specify it by zone or other criteria.</description>
+    </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Adds a new hooks to enable overriding free shipping values.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Dev test
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/1650
| Sponsor company   | TRENDO s.r.o.

### The problem
PrestaShop allows to set free shipping price only generally. A value that is valid for all countries/zones.
That works usually only for one country shops, if you have more, you are in trouble. We want free shipping only in CZ, not the whole Europe.
If you are using only price-based ranges, you can get around it just by configuring the ranges to be zero in some zones, non-zero in others.
But, that doesn't work if you have to use weight-based ranges. Then you have to use the value in Shipping settings, which doesn't work in many cases.

### Solution
Adds hooks that allows easy hooking into the logic.
One can add simple form into the Prestashop administration and then just alter the value for some zones via these hooks.