### PR TITLE
Fix: Error when creating an attribute for a group in “All shops” context with multiple shops

### DIFF
--- a/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
@@ -27,6 +27,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceAttributeProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
@@ -54,12 +55,12 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
 
     /**
      * @param AttributeGroupRepository $attributeGroupRepository
-     * @param int $langId
+     * @param LanguageContext $languageContext
      * @param ShopContext $shopContext
      */
     public function __construct(
         private readonly AttributeGroupRepository $attributeGroupRepository,
-        private readonly int $langId,
+        private readonly LanguageContext $languageContext,
         private ShopContext $shopContext,
     ) {
     }
@@ -98,7 +99,7 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
         if (null === $this->attributeGroupsChoicesAttributes || null === $this->attributeGroupsChoices) {
             if (null === $this->attributeGroups) {
                 $this->attributeGroups = $this->attributeGroupRepository->findByLangForShops(
-                    $this->langId,
+                    $this->languageContext->getId(),
                     $this->shopContext->getAssociatedShopIds()
                 );
             }

--- a/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
@@ -97,14 +97,10 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
     {
         if (null === $this->attributeGroupsChoicesAttributes || null === $this->attributeGroupsChoices) {
             if (null === $this->attributeGroups) {
-                if ($this->shopContext->isSingleShopContext()) {
-                    $this->attributeGroups = $this->attributeGroupRepository->findByLangAndShop(
-                        $this->langId,
-                        $this->shopContext->getShopConstraint()->getShopId()->getValue()
-                    );
-                } else {
-                    $this->attributeGroups = $this->attributeGroupRepository->findByLangForAllShops($this->langId);
-                }
+                $this->attributeGroups = $this->attributeGroupRepository->findByLangForShops(
+                    $this->langId,
+                    $this->shopContext->getAssociatedShopIds()
+                );
             }
 
             $this->attributeGroupsChoices = [];

--- a/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
@@ -27,6 +27,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceAttributeProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Entity\Repository\AttributeGroupRepository;
@@ -54,12 +55,12 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
     /**
      * @param AttributeGroupRepository $attributeGroupRepository
      * @param int $langId
-     * @param int $shopId
+     * @param ShopContext $shopContext
      */
     public function __construct(
         private readonly AttributeGroupRepository $attributeGroupRepository,
         private readonly int $langId,
-        private readonly int $shopId,
+        private ShopContext $shopContext,
     ) {
     }
 
@@ -96,7 +97,14 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
     {
         if (null === $this->attributeGroupsChoicesAttributes || null === $this->attributeGroupsChoices) {
             if (null === $this->attributeGroups) {
-                $this->attributeGroups = $this->attributeGroupRepository->findByLangAndShop($this->langId, $this->shopId);
+                if ($this->shopContext->isSingleShopContext()) {
+                    $this->attributeGroups = $this->attributeGroupRepository->findByLangAndShop(
+                        $this->langId,
+                        $this->shopContext->getShopConstraint()->getShopId()->getValue()
+                    );
+                } else {
+                    $this->attributeGroups = $this->attributeGroupRepository->findByLangForAllShops($this->langId);
+                }
             }
 
             $this->attributeGroupsChoices = [];

--- a/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
@@ -59,22 +59,25 @@ class AttributeGroupRepository extends \Doctrine\ORM\EntityRepository
     }
 
     /**
-     * Finds attribute groups by language and shop.
+     * Finds attribute groups by language and shops.
      *
      * @param int $idLang Language ID
+     * @param int[] $idShops Shop IDs
      *
      * @return \PrestaShopBundle\Entity\AttributeGroup[]
      */
-    public function findByLangForAllShops(int $idLang): array
+    public function findByLangForShops(int $idLang, array $idShops): array
     {
         return $this->createQueryBuilder('ag')
             ->addSelect('agl')
             ->join('ag.shops', 'ags')
             ->join('ag.attributeGroupLangs', 'agl')
             ->andWhere('agl.lang = :idLang')
+            ->andWhere('ags.id IN (:idShops)')
             ->orderBy('ag.position', 'ASC')
             ->setParameters([
                 'idLang' => $idLang,
+                'idShops' => $idShops,
             ])->getQuery()->getResult();
     }
 }

--- a/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
@@ -57,4 +57,24 @@ class AttributeGroupRepository extends \Doctrine\ORM\EntityRepository
                 'idLang' => $idLang,
             ])->getQuery()->getResult();
     }
+
+    /**
+     * Finds attribute groups by language and shop.
+     *
+     * @param int $idLang Language ID
+     *
+     * @return \PrestaShopBundle\Entity\AttributeGroup[]
+     */
+    public function findByLangForAllShops(int $idLang): array
+    {
+        return $this->createQueryBuilder('ag')
+            ->addSelect('agl')
+            ->join('ag.shops', 'ags')
+            ->join('ag.attributeGroupLangs', 'agl')
+            ->andWhere('agl.lang = :idLang')
+            ->orderBy('ag.position', 'ASC')
+            ->setParameters([
+                'idLang' => $idLang,
+            ])->getQuery()->getResult();
+    }
 }

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -141,5 +141,3 @@ services:
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\AttributeGroupChoiceProvider:
     autowire: true
-    arguments:
-      $shopId: '@=service("prestashop.adapter.shop.context").getContextShopID()'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | This PR fixes an issue in AttributeGroupChoiceProvider where the service could receive a `null` shop ID in valid contexts (e.g. _All shops_ or back office initialization).<br/><br/>The service definition now resolves the shop ID by:<br/>- using the modern shop context when available<br/>- falling back to the legacy context when the shop context is `null`<br/>This prevents type errors and ensures consistent behavior across all shop contexts.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create 2 shops<br/>2. Go to **Attributes & Features > Attributes**<br/>3. Select an attribute group<br/>4. Select the **All stores** context<br/>5. You must be able to add the attribute without errors.
| UI Tests          |  🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/21871395698
| Fixed issue or discussion?     | Fixes #40705
| Related PRs       | 
| Sponsor company   | Codencode snc
