### PR TITLE
BO: Hide raw exception on state delete failure

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/StateController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/StateController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
@@ -17,6 +18,7 @@ use PrestaShop\PrestaShop\Core\Domain\State\Command\DeleteStateCommand;
 use PrestaShop\PrestaShop\Core\Domain\State\Command\ToggleStateStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\State\Exception\CannotAddStateException;
 use PrestaShop\PrestaShop\Core\Domain\State\Exception\CannotUpdateStateException;
+use PrestaShop\PrestaShop\Core\Domain\State\Exception\DeleteStateException;
 use PrestaShop\PrestaShop\Core\Domain\State\Exception\StateConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\State\Exception\StateException;
 use PrestaShop\PrestaShop\Core\Domain\State\Exception\StateNotFoundException;
@@ -491,6 +493,13 @@ class StateController extends PrestaShopAdminController
             CountryConstraintException::class => [
                 CountryConstraintException::INVALID_ID => $this->trans(
                     'The object cannot be loaded (the identifier is missing or invalid)',
+                    [],
+                    'Admin.Notifications.Error'
+                ),
+            ],
+            DeleteStateException::class => [
+                DeleteStateException::FAILED_DELETE => $this->trans(
+                    'An error occurred while deleting the object.',
                     [],
                     'Admin.Notifications.Error'
                 ),

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/International/StateControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/International/StateControllerTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Controller\Admin\Improve\International;
+
+use PrestaShop\PrestaShop\Core\Domain\State\Command\DeleteStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\State\CommandHandler\DeleteStateHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\State\Exception\DeleteStateException;
+use State;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Tests\Integration\Utility\LoginTrait;
+
+class StateControllerTest extends WebTestCase
+{
+    use LoginTrait;
+
+    /**
+     * @var KernelBrowser
+     */
+    private $client;
+
+    /**
+     * @var Router
+     */
+    private $router;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = self::createClient();
+        $this->loginUser($this->client);
+
+        $this->router = self::$kernel->getContainer()->get('router');
+    }
+
+    public function testDeleteActionAddsErrorFlashWhenDeleteStateExceptionIsThrown(): void
+    {
+        $this->client->disableReboot();
+
+        $deleteStateHandler = $this->createMock(DeleteStateHandlerInterface::class);
+        $deleteStateHandler
+            ->method('handle')
+            ->willReturnCallback(function (DeleteStateCommand $command) {
+                throw new DeleteStateException(
+                    'Delete failed',
+                    DeleteStateException::FAILED_DELETE
+                );
+            });
+
+        self::$kernel->getContainer()->set(DeleteStateHandlerInterface::class, $deleteStateHandler);
+
+        $stateId = State::getIdByIso('FL');
+
+        $this->client->request(
+            'DELETE',
+            $this->router->generate('admin_states_delete', ['stateId' => $stateId])
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
+
+        /** @var Session $session */
+        $session = $this->client->getRequest()->getSession();
+        $messages = $session->getFlashBag()->all();
+
+        $this->assertArrayHasKey('error', $messages);
+        $this->assertContains(
+            'An error occurred while deleting the object.',
+            $messages['error'],
+            print_r($messages['error'], true)
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Handle `DeleteStateException::FAILED_DELETE` in the State BO controller to avoid exposing raw exception messages. Add an integration test ensuring an error flash is shown when delete fails.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1) In BO go to International > Locations > States, try to delete a state linked to an address, and verify the flash error is `An error occurred while deleting the object.` (no raw exception message)  2) Run `php vendor/bin/phpunit tests/Integration/PrestaShopBundle/Controller/Admin/Improve/International/StateControllerTest.php`
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/28653811757
| Fixed issue or discussion?     | Resolve #39761
| Related PRs       | N/A
| Sponsor company   | N/A