### PR TITLE
Fix: Bug: when invoicing is disabled, changing order status to "paid=1" does not register any payment on the order

### DIFF
--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -719,10 +719,6 @@ class OrderInvoiceCore extends ObjectModel
      */
     public function getRestPaid()
     {
-        if (!$this->number) {
-            return 0;
-        }
-
         return round($this->total_paid_tax_incl + (float) $this->getSiblingTotal() - $this->getTotalPaid(), 2);
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | When invoices are disabled, changing an order status to a state with `paid = 1` does not create the corresponding payment entry.<br/>This PR removes the `$this->number` check in `OrderInvoice::getRestPaid()` so that the remaining paid amount is correctly calculated even when no invoice number exists, ensuring the payment is properly recorded.
| Type?             | bug fix
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to **Orders > Invoices**<br/>2. Set **"Enable invoices" = NO**<br/>3. Create an order selecting **Bank wire** as the payment method<br/>4. Open the order and change its status to **"Payment accepted"**<br/>5. In the Payments section of the order, you must display the payment correctly.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/21897489539
| Fixed issue or discussion?     | Fixes #40741
| Related PRs       | 
| Sponsor company   | Codencode snc
