### PR TITLE
Fix translation catalogue filename corruption during export

### DIFF
--- a/src/Core/Translation/Export/TranslationCatalogueExporter.php
+++ b/src/Core/Translation/Export/TranslationCatalogueExporter.php
@@ -217,7 +217,7 @@ class TranslationCatalogueExporter
         $finder = Finder::create();
         foreach ($finder->in($path . DIRECTORY_SEPARATOR . $locale)->files() as $file) {
             $currentName = $file->getPathname();
-            $newName = rtrim($currentName, '.xlf') . '.' . $locale . '.xlf';
+            $newName = preg_replace('/\.xlf$/', '.' . $locale . '.xlf', $currentName);
             $this->filesystem->rename($currentName, $newName);
         }
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Replace rtrim() with preg_replace() when renaming exported translation files to prevent character removal from domain names.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Export theme translations from the admin, ShopThemeGlobal file should now have the correct name (ShopThemeGlobal.fr-FR.xlf instead of ShopThemeGloba.fr-FR.xlf)

Replace rtrim() with preg_replace() when renaming exported translation files to prevent character removal from domain names.

The issue occurred because rtrim() treats its second parameter as a character mask, not a literal string. When removing '.xlf' extension, it was removing any occurrence of '.', 'x', 'l', or 'f' characters from the right side of the filename.

This caused domain names ending with these characters to be truncated:
- ShopThemeGlobal.xlf → ShopThemeGloba.fr-FR.xlf (missing 'l')

Using preg_replace() with the pattern '/\.xlf$/' ensures only the literal '.xlf' extension at the end of the filename is replaced, preserving the complete domain name:
- ShopThemeGlobal.xlf → ShopThemeGlobal.fr-FR.xlf