### PR TITLE
Allow category tree selector to open when no default category

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/category/category-tree-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/category/category-tree-selector.ts
@@ -71,12 +71,6 @@ export default class CategoryTreeSelector {
   }
 
   public showModal(selectedCategories: Array<Category>, defaultCategoryId: number): void {
-    if (!defaultCategoryId) {
-      console.error('Default category id is invalid.');
-
-      return;
-    }
-
     this.selectedCategories = selectedCategories;
     this.defaultCategoryId = defaultCategoryId;
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | When a product is created without a default category, it makes it impossible to further assign it categories from the category selector in product edit page. Its default category is 0, and is interpreted as false, preventing the modal from opening.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set a product id_default_category to 0. Edit the product from BO, and try clicking the button to add new categories to the product. See the modal is opening.
| UI Tests          |  🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/22714450606
| Fixed issue or discussion?     | NA
| Related PRs       | NA
| Sponsor company   | Evolutive