### PR TITLE
Add a feature flag relation to the Tab entity / ObjectModel to conditionally hide tabs

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -63,6 +63,9 @@ class TabCore extends ObjectModel
     /** @var string|null Wording domain to use for the display name */
     public $wording_domain;
 
+    /** @var int Associated feature flag ID */
+    public $id_feature_flag;
+
     /**
      * @see ObjectModel::$definition
      */
@@ -81,6 +84,7 @@ class TabCore extends ObjectModel
             'icon' => ['type' => self::TYPE_STRING, 'size' => 64],
             'wording' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'allow_null' => true, 'size' => 255],
             'wording_domain' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'allow_null' => true, 'size' => 255],
+            'id_feature_flag' => ['type' => self::TYPE_INT, 'validate' => 'isInt', 'allow_null' => true],
             /* Lang fields */
             'name' => ['type' => self::TYPE_STRING, 'lang' => true, 'required' => true, 'validate' => 'isTabName', 'size' => 128],
         ],

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -2923,17 +2923,18 @@ CREATE TABLE `PREFIX_attribute_shop` (
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 
 CREATE TABLE `PREFIX_tab` (
-  `id_tab`         INT AUTO_INCREMENT NOT NULL,
-  `id_parent`      INT         NOT NULL,
-  `position`       INT         NOT NULL,
-  `module`         VARCHAR(64)  DEFAULT NULL,
-  `class_name`     VARCHAR(64) NOT NULL,
-  `route_name`     VARCHAR(256) DEFAULT NULL,
-  `active`         TINYINT(1) NOT NULL,
-  `enabled`        TINYINT(1) NOT NULL,
-  `icon`           VARCHAR(32)  DEFAULT NULL,
-  `wording`        VARCHAR(255) DEFAULT NULL,
-  `wording_domain` VARCHAR(255) DEFAULT NULL,
+  `id_tab`          INT AUTO_INCREMENT NOT NULL,
+  `id_parent`       INT         NOT NULL,
+  `position`        INT         NOT NULL,
+  `module`          VARCHAR(64)  DEFAULT NULL,
+  `class_name`      VARCHAR(64) NOT NULL,
+  `route_name`      VARCHAR(256) DEFAULT NULL,
+  `active`          TINYINT(1) NOT NULL,
+  `enabled`         TINYINT(1) NOT NULL,
+  `icon`            VARCHAR(32)  DEFAULT NULL,
+  `wording`         VARCHAR(255) DEFAULT NULL,
+  `wording_domain`  VARCHAR(255) DEFAULT NULL,
+  `id_feature_flag` INT          DEFAULT NULL,
   PRIMARY KEY (`id_tab`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 CREATE TABLE `PREFIX_tab_lang` (

--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -367,6 +367,7 @@ class ModuleTabRegister
         $tab->id_parent = $this->findParentId($tabDetails);
         $tab->wording = $tabDetails->get('wording');
         $tab->wording_domain = $tabDetails->get('wording_domain');
+        $tab->id_feature_flag = $tabDetails->get('id_feature_flag');
 
         if (!$tab->save()) {
             throw new Exception($this->translator->trans('Failed to install admin tab "%name%".', ['%name%' => $tab->name], 'Admin.Modules.Notification'));

--- a/src/PrestaShopBundle/Entity/Tab.php
+++ b/src/PrestaShopBundle/Entity/Tab.php
@@ -99,6 +99,13 @@ class Tab
     private ?string $wordingDomain;
 
     /**
+     * @ORM\ManyToOne(targetEntity="PrestaShopBundle\Entity\FeatureFlag")
+     *
+     * @ORM\JoinColumn(name="id_feature_flag", referencedColumnName="id_feature_flag", nullable=true)
+     */
+    private ?FeatureFlag $featureFlag;
+
+    /**
      * @var Collection<TabLang>
      *
      * @ORM\OneToMany(targetEntity="PrestaShopBundle\Entity\TabLang", mappedBy="tab")
@@ -253,6 +260,18 @@ class Tab
     public function setRouteName(?string $routeName): static
     {
         $this->routeName = $routeName;
+
+        return $this;
+    }
+
+    public function getFeatureFlag(): ?FeatureFlag
+    {
+        return $this->featureFlag;
+    }
+
+    public function setFeatureFlag(FeatureFlag $featureFlag): self
+    {
+        $this->featureFlag = $featureFlag;
 
         return $this;
     }

--- a/src/PrestaShopBundle/Twig/Component/NavBar.php
+++ b/src/PrestaShopBundle/Twig/Component/NavBar.php
@@ -29,6 +29,8 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Twig\Component;
 
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShopBundle\Entity\FeatureFlag;
+use PrestaShopBundle\Entity\Repository\FeatureFlagRepository;
 use PrestaShopBundle\Twig\Layout\MenuBuilder;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -45,6 +47,7 @@ class NavBar
         protected readonly LoggerInterface $logger,
         protected readonly MenuBuilder $menuBuilder,
         protected readonly string $psVersion,
+        protected readonly FeatureFlagRepository $featureFlagRepository,
     ) {
     }
 
@@ -92,9 +95,23 @@ class NavBar
 
     protected function isValidTab(array $tab): bool
     {
+        $featureFlag = $this->retrieveFeatureFlagTab($tab);
+
         return Tab::checkTabRights($tab['id_tab'])
             && $tab['enabled']
-            && $tab['class_name'] !== 'AdminCarrierWizard';
+            && $tab['class_name'] !== 'AdminCarrierWizard'
+            && ($featureFlag?->isEnabled() ?? true);
+    }
+
+    private function retrieveFeatureFlagTab(array $tab): ?FeatureFlag
+    {
+        $featureFlagId = $tab['id_feature_flag'];
+
+        if (empty($featureFlagId)) {
+            return null;
+        }
+
+        return $this->featureFlagRepository->find($featureFlagId);
     }
 
     protected function processTab(array $tab, int $currentId, int $level, ?string $controllerName): array


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Currently, it's not possible to hide a tab if it's subject to a feature flag. This could be useful, particularly for B2B contributions, or for other feature in the future.
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create or modify a tab by specifying a feature flag id, enable/disable the feature flag and see the tab appear or not.
| UI Tests          | 
| Fixed issue or discussion?     | [40763](https://github.com/PrestaShop/PrestaShop/discussions/40763)
| Related PRs       | 
| Sponsor company   | Soledis