### PR TITLE
Fix incorrect discount flag when SpecificPrice has CartId

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -831,13 +831,13 @@ class CartCore extends ObjectModel
             foreach ($products as $key => $product) {
                 $products_ids[] = $product['id_product'];
                 $pa_ids[] = $product['id_product_attribute'];
-$cartPrices = $this->getCartPrices($product,$product['cart_quantity'], $product['id_customization'], Context::getContext(), $specific_price);
-if ($specific_price) {
-$reduction_type_row = ['reduction_type' => $specific_price['reduction_type']];
-                                        // set product reduction based on cart so it wont be overwritten by value from getProductProperties
+                $cartPrices = $this->getCartPrices($product,$product['cart_quantity'], $product['id_customization'], Context::getContext(), $specific_price);
+                if ($specific_price) {
+                    $reduction_type_row = ['reduction_type' => $specific_price['reduction_type']];
+                    // set product reduction based on cart so it wont be overwritten by value from getProductProperties
                     $product['specific_prices'] = $specific_price;
                     $product['reduction'] = $cartPrices['price_with_reduction'];
-                    $product['reduction_without_tax'] = $cartPrices['price_with_reduction_without_tax'];    
+                    $product['reduction_without_tax'] = $cartPrices['price_with_reduction_without_tax'];
                 } else {
                     $reduction_type_row = ['reduction_type' => 0];
                 }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -831,7 +831,15 @@ class CartCore extends ObjectModel
             foreach ($products as $key => $product) {
                 $products_ids[] = $product['id_product'];
                 $pa_ids[] = $product['id_product_attribute'];
-                $cartPrices = $this->getCartPrices($product, $product['cart_quantity'], $product['id_customization'], Context::getContext(), $specific_price);
+                if (Configuration::get('PS_TAX_ADDRESS_TYPE') == 'id_address_invoice') {
+                    $address_id = (int) $this->id_address_invoice;
+                } else {
+                    $address_id = (int) $product['id_address_delivery'];
+                }
+                if (!Address::addressExists($address_id, true)) {
+                    $address_id = null;
+                }                
+                $cartPrices = $this->getCartPrices($product,$product['cart_quantity'], $address_id, Context::getContext(), $specific_price);
                 if ($specific_price) {
                     $reduction_type_row = ['reduction_type' => $specific_price['reduction_type']];
                     // set product reduction based on cart so it wont be overwritten by value from getProductProperties

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -833,8 +833,37 @@ class CartCore extends ObjectModel
                 $pa_ids[] = $product['id_product_attribute'];
                 $specific_price = SpecificPrice::getSpecificPrice($product['id_product'], $this->id_shop, $this->id_currency, $id_country, $this->id_shop_group, $product['cart_quantity'], $product['id_product_attribute'], $this->id_customer, $this->id);
                 if ($specific_price) {
-                    $product['specific_prices'] = $specific_price;
                     $reduction_type_row = ['reduction_type' => $specific_price['reduction_type']];
+                    // set product reduction based on cart so it wont be overwritten by value from getProductProperties
+                    $product['specific_prices'] = $specific_price;
+                    
+                    $product['reduction'] = Product::getPriceStatic(
+                    (int) $product['id_product'],
+                    !Tax::excludeTaxeOption(),
+                    $product['id_product_attribute'],
+                    6,
+                    null,
+                    true,
+                    true,
+                    $product['cart_quantity'],
+                    true,
+                    $this->id_customer,
+                    $this->id,
+                    );
+
+                    $product['reduction_without_tax'] = Product::getPriceStatic(
+                    (int) $product['id_product'],
+                    false,
+                    $product['id_product_attribute'],
+                    6,
+                    null,
+                    true,
+                    true,
+                    $product['cart_quantity'],
+                    true,
+                    $this->id_customer,
+                    $this->id,
+                    );
                 } else {
                     $reduction_type_row = ['reduction_type' => 0];
                 }
@@ -923,7 +952,11 @@ class CartCore extends ObjectModel
                 $product['reduction'] = $props['reduction'];
                 $product['reduction_without_tax'] = $props['reduction_without_tax'];
                 $product['price_without_reduction'] = $props['price_without_reduction'];
-                if(!isset($product['specific_prices'])){
+                //if there is specific_prices with cart id provided, we dont want to overwrite it by getProductProperties as it get reduction without cart context
+                if (!isset($product['specific_prices'])) {
+                    $product['reduction'] = $props['reduction'];
+                    $product['reduction_without_tax'] = $props['reduction_without_tax'];
+                    $product['price_without_reduction'] = $props['price_without_reduction'];
                     $product['specific_prices'] = $props['specific_prices'];
                 }
                 $product['specific_prices'] = $props['specific_prices'];

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -930,13 +930,10 @@ class CartCore extends ObjectModel
                 }
 
                 $props = Product::getProductProperties((int) $this->id_lang, $product);
-                // if there is specific_prices with cart id provided, we dont want to overwrite it by getProductProperties as it get reduction without cart context
-                if (!isset($product['specific_prices'])) {
-                    $product['reduction'] = $props['reduction'];
-                    $product['reduction_without_tax'] = $props['reduction_without_tax'];
-                    $product['price_without_reduction'] = $props['price_without_reduction'];
-                    $product['specific_prices'] = $props['specific_prices'];
-                }
+                $product['reduction'] = $props['reduction'];
+                $product['reduction_without_tax'] = $props['reduction_without_tax'];
+                $product['price_without_reduction'] = $props['price_without_reduction'];
+                $product['specific_prices'] = $props['specific_prices'];
                 $product['unit_price'] = $props['unit_price_tax_excluded'];
                 $product['unit_price_ratio'] = $props['unit_price_ratio'];
                 $product['unit_price_tax_excluded'] = $props['unit_price_tax_excluded'];

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -831,39 +831,13 @@ class CartCore extends ObjectModel
             foreach ($products as $key => $product) {
                 $products_ids[] = $product['id_product'];
                 $pa_ids[] = $product['id_product_attribute'];
-                $specific_price = SpecificPrice::getSpecificPrice($product['id_product'], $this->id_shop, $this->id_currency, $id_country, $this->id_shop_group, $product['cart_quantity'], $product['id_product_attribute'], $this->id_customer, $this->id);
-                if ($specific_price) {
-                    $reduction_type_row = ['reduction_type' => $specific_price['reduction_type']];
-                    // set product reduction based on cart so it wont be overwritten by value from getProductProperties
+$cartPrices = $this->getCartPrices($product,$product['cart_quantity'], $product['id_customization'], Context::getContext(), $specific_price);
+if ($specific_price) {
+$reduction_type_row = ['reduction_type' => $specific_price['reduction_type']];
+                                        // set product reduction based on cart so it wont be overwritten by value from getProductProperties
                     $product['specific_prices'] = $specific_price;
-
-                    $product['reduction'] = Product::getPriceStatic(
-                        (int) $product['id_product'],
-                        !Tax::excludeTaxeOption(),
-                        $product['id_product_attribute'],
-                        6,
-                        null,
-                        true,
-                        true,
-                        $product['cart_quantity'],
-                        true,
-                        $this->id_customer,
-                        $this->id,
-                    );
-
-                    $product['reduction_without_tax'] = Product::getPriceStatic(
-                        (int) $product['id_product'],
-                        false,
-                        $product['id_product_attribute'],
-                        6,
-                        null,
-                        true,
-                        true,
-                        $product['cart_quantity'],
-                        true,
-                        $this->id_customer,
-                        $this->id,
-                    );
+                    $product['reduction'] = $cartPrices['price_with_reduction'];
+                    $product['reduction_without_tax'] = $cartPrices['price_with_reduction_without_tax'];    
                 } else {
                     $reduction_type_row = ['reduction_type' => 0];
                 }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -838,7 +838,7 @@ class CartCore extends ObjectModel
             }
             foreach ($products as $key => $product) {
                 $products_ids[] = $product['id_product'];
-                $pa_ids[] = $product['id_product_attribute'];        
+                $pa_ids[] = $product['id_product_attribute'];
                 $cartPrices = $this->getCartPrices($product, $product['cart_quantity'], $address_id, Context::getContext(), $specific_price);
                 if ($specific_price) {
                     $reduction_type_row = ['reduction_type' => $specific_price['reduction_type']];

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -828,18 +828,18 @@ class CartCore extends ObjectModel
         $pa_ids = [];
         $cart_base_product_quantity = [];
         if (is_iterable($products)) {
+            if (Configuration::get('PS_TAX_ADDRESS_TYPE') == 'id_address_invoice') {
+                $address_id = (int) $this->id_address_invoice;
+            } else {
+                $address_id = (int) $this->id_address_delivery;
+            }
+            if (!Address::addressExists($address_id, true)) {
+                $address_id = null;
+            }
             foreach ($products as $key => $product) {
                 $products_ids[] = $product['id_product'];
-                $pa_ids[] = $product['id_product_attribute'];
-                if (Configuration::get('PS_TAX_ADDRESS_TYPE') == 'id_address_invoice') {
-                    $address_id = (int) $this->id_address_invoice;
-                } else {
-                    $address_id = (int) $product['id_address_delivery'];
-                }
-                if (!Address::addressExists($address_id, true)) {
-                    $address_id = null;
-                }                
-                $cartPrices = $this->getCartPrices($product,$product['cart_quantity'], $address_id, Context::getContext(), $specific_price);
+                $pa_ids[] = $product['id_product_attribute'];        
+                $cartPrices = $this->getCartPrices($product, $product['cart_quantity'], $address_id, Context::getContext(), $specific_price);
                 if ($specific_price) {
                     $reduction_type_row = ['reduction_type' => $specific_price['reduction_type']];
                     // set product reduction based on cart so it wont be overwritten by value from getProductProperties

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -831,7 +831,7 @@ class CartCore extends ObjectModel
             foreach ($products as $key => $product) {
                 $products_ids[] = $product['id_product'];
                 $pa_ids[] = $product['id_product_attribute'];
-                $cartPrices = $this->getCartPrices($product,$product['cart_quantity'], $product['id_customization'], Context::getContext(), $specific_price);
+                $cartPrices = $this->getCartPrices($product, $product['cart_quantity'], $product['id_customization'], Context::getContext(), $specific_price);
                 if ($specific_price) {
                     $reduction_type_row = ['reduction_type' => $specific_price['reduction_type']];
                     // set product reduction based on cart so it wont be overwritten by value from getProductProperties

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -863,7 +863,6 @@ class CartCore extends ObjectModel
                         true,
                         $this->id_customer,
                         $this->id,
-                        
                     );
                 } else {
                     $reduction_type_row = ['reduction_type' => 0];

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -836,33 +836,34 @@ class CartCore extends ObjectModel
                     $reduction_type_row = ['reduction_type' => $specific_price['reduction_type']];
                     // set product reduction based on cart so it wont be overwritten by value from getProductProperties
                     $product['specific_prices'] = $specific_price;
-                    
+
                     $product['reduction'] = Product::getPriceStatic(
-                    (int) $product['id_product'],
-                    !Tax::excludeTaxeOption(),
-                    $product['id_product_attribute'],
-                    6,
-                    null,
-                    true,
-                    true,
-                    $product['cart_quantity'],
-                    true,
-                    $this->id_customer,
-                    $this->id,
+                        (int) $product['id_product'],
+                        !Tax::excludeTaxeOption(),
+                        $product['id_product_attribute'],
+                        6,
+                        null,
+                        true,
+                        true,
+                        $product['cart_quantity'],
+                        true,
+                        $this->id_customer,
+                        $this->id,
                     );
 
                     $product['reduction_without_tax'] = Product::getPriceStatic(
-                    (int) $product['id_product'],
-                    false,
-                    $product['id_product_attribute'],
-                    6,
-                    null,
-                    true,
-                    true,
-                    $product['cart_quantity'],
-                    true,
-                    $this->id_customer,
-                    $this->id,
+                        (int) $product['id_product'],
+                        false,
+                        $product['id_product_attribute'],
+                        6,
+                        null,
+                        true,
+                        true,
+                        $product['cart_quantity'],
+                        true,
+                        $this->id_customer,
+                        $this->id,
+                        
                     );
                 } else {
                     $reduction_type_row = ['reduction_type' => 0];
@@ -949,10 +950,7 @@ class CartCore extends ObjectModel
                 }
 
                 $props = Product::getProductProperties((int) $this->id_lang, $product);
-                $product['reduction'] = $props['reduction'];
-                $product['reduction_without_tax'] = $props['reduction_without_tax'];
-                $product['price_without_reduction'] = $props['price_without_reduction'];
-                //if there is specific_prices with cart id provided, we dont want to overwrite it by getProductProperties as it get reduction without cart context
+                // if there is specific_prices with cart id provided, we dont want to overwrite it by getProductProperties as it get reduction without cart context
                 if (!isset($product['specific_prices'])) {
                     $product['reduction'] = $props['reduction'];
                     $product['reduction_without_tax'] = $props['reduction_without_tax'];

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -833,6 +833,7 @@ class CartCore extends ObjectModel
                 $pa_ids[] = $product['id_product_attribute'];
                 $specific_price = SpecificPrice::getSpecificPrice($product['id_product'], $this->id_shop, $this->id_currency, $id_country, $this->id_shop_group, $product['cart_quantity'], $product['id_product_attribute'], $this->id_customer, $this->id);
                 if ($specific_price) {
+                    $product['specific_prices'] = $specific_price;
                     $reduction_type_row = ['reduction_type' => $specific_price['reduction_type']];
                 } else {
                     $reduction_type_row = ['reduction_type' => 0];
@@ -922,6 +923,9 @@ class CartCore extends ObjectModel
                 $product['reduction'] = $props['reduction'];
                 $product['reduction_without_tax'] = $props['reduction_without_tax'];
                 $product['price_without_reduction'] = $props['price_without_reduction'];
+                if(!isset($product['specific_prices'])){
+                    $product['specific_prices'] = $props['specific_prices'];
+                }
                 $product['specific_prices'] = $props['specific_prices'];
                 $product['unit_price'] = $props['unit_price_tax_excluded'];
                 $product['unit_price_ratio'] = $props['unit_price_ratio'];

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -956,7 +956,6 @@ class CartCore extends ObjectModel
                     $product['price_without_reduction'] = $props['price_without_reduction'];
                     $product['specific_prices'] = $props['specific_prices'];
                 }
-                $product['specific_prices'] = $props['specific_prices'];
                 $product['unit_price'] = $props['unit_price_tax_excluded'];
                 $product['unit_price_ratio'] = $props['unit_price_ratio'];
                 $product['unit_price_tax_excluded'] = $props['unit_price_tax_excluded'];

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5470,9 +5470,11 @@ class ProductCore extends ObjectModel
          * If cart_quantity is defined, we use it. Usually cart context.
          * Otherwise, we use minimal_quantity, if nothing was passed - on listings.
          */
+        $id_cart = null;
         if (isset($row['quantity_wanted'])) {
             $quantityToUseForPriceCalculations = max((int) $row['minimal_quantity'], (int) $row['quantity_wanted']);
         } elseif (isset($row['cart_quantity'])) {
+            $id_cart = $context->cart->id;
             $quantityToUseForPriceCalculations = max((int) $row['minimal_quantity'], (int) $row['cart_quantity']);
         } else {
             $quantityToUseForPriceCalculations = (int) $row['minimal_quantity'];
@@ -5557,7 +5559,7 @@ class ProductCore extends ObjectModel
             $quantityToUseForPriceCalculations,
             true,
             null,
-            null,
+            $id_cart,
             null,
             $specific_prices
         );
@@ -5573,7 +5575,7 @@ class ProductCore extends ObjectModel
             $quantityToUseForPriceCalculations,
             true,
             null,
-            null,
+            $id_cart,
             null,
             $specific_prices
         );

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5489,7 +5489,10 @@ class ProductCore extends ObjectModel
             null,
             false,
             true,
-            $quantityToUseForPriceCalculations
+            $quantityToUseForPriceCalculations,
+            false,
+            null,
+            $id_cart
         );
 
         if (self::$_taxCalculationMethod == PS_TAX_EXC) {
@@ -5502,7 +5505,10 @@ class ProductCore extends ObjectModel
                 null,
                 false,
                 true,
-                $quantityToUseForPriceCalculations
+                $quantityToUseForPriceCalculations,
+                false,
+                null,
+                $id_cart
             );
             $row['price_without_reduction'] = $row['price_without_reduction_without_tax'] = Product::getPriceStatic(
                 (int) $row['id_product'],
@@ -5512,7 +5518,10 @@ class ProductCore extends ObjectModel
                 null,
                 false,
                 false,
-                $quantityToUseForPriceCalculations
+                $quantityToUseForPriceCalculations,
+                false,
+                null,
+                $id_cart
             );
         } else {
             $priceTaxIncluded = Product::getPriceStatic(
@@ -5523,7 +5532,10 @@ class ProductCore extends ObjectModel
                 null,
                 false,
                 true,
-                $quantityToUseForPriceCalculations
+                $quantityToUseForPriceCalculations,
+                false,
+                null,
+                $id_cart
             );
             $row['price'] = Tools::ps_round($priceTaxIncluded, Context::getContext()->getComputingPrecision());
             $row['price_without_reduction'] = Product::getPriceStatic(
@@ -5534,7 +5546,10 @@ class ProductCore extends ObjectModel
                 null,
                 false,
                 false,
-                $quantityToUseForPriceCalculations
+                $quantityToUseForPriceCalculations,
+                false,
+                null,
+                $id_cart
             );
             $row['price_without_reduction_without_tax'] = Product::getPriceStatic(
                 (int) $row['id_product'],
@@ -5544,7 +5559,10 @@ class ProductCore extends ObjectModel
                 null,
                 false,
                 false,
-                $quantityToUseForPriceCalculations
+                $quantityToUseForPriceCalculations,
+                false,
+                null,
+                $id_cart
             );
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix discount flag inside cart when SpecificPrice has cart id provided.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Explained in #40773 
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #40773
| Related PRs       | 
| Sponsor company   | 
