### PR TITLE
Replace github action that sets up mysql in CI

### DIFF
--- a/.github/workflows/api-module.yml
+++ b/.github/workflows/api-module.yml
@@ -27,11 +27,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup MySQL
-        uses: mirromutth/mysql-action@v1.1
+        uses: shogo82148/actions-setup-mysql@v1
         with:
-          mysql version: '8.0'
-          mysql database: 'prestashop'
-          mysql root password: 'password'
+          mysql-version: "8.0"
+          root-password: 'password'
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -69,9 +68,6 @@ jobs:
       # because some built files (like preload.html.twig) are included and cause errors when absent
       - name: Build all assets
         run: make assets
-
-      - name: Change MySQL authentication method
-        run: mysql -h127.0.0.1 -uroot -ppassword -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'password'; FLUSH PRIVILEGES;"
 
       - name: Run integration-tests
         run: composer run-script api-module-tests --timeout=0

--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -27,11 +27,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup MySQL
-        uses: mirromutth/mysql-action@v1.1
+        uses: shogo82148/actions-setup-mysql@v1
         with:
-          mysql version: '8.0'
-          mysql database: 'prestashop'
-          mysql root password: 'password'
+          mysql-version: "8.0"
+          root-password: 'password'
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -67,9 +66,6 @@ jobs:
 
       - name: Build theme assets
         run: make front-classic
-
-      - name: Change MySQL authentication method
-        run: mysql -h127.0.0.1 -uroot -ppassword -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'password'; FLUSH PRIVILEGES;"
 
       - name: Install maildev
         run: |

--- a/.github/workflows/cron_js_routing.yml
+++ b/.github/workflows/cron_js_routing.yml
@@ -18,12 +18,15 @@ jobs:
       matrix:
         BRANCH:
           - develop
+          - 9.1.x
           - 9.0.x
           - 8.2.x
           - 8.1.x
           - 8.0.x
         include:
           - BRANCH: develop
+            node: 20
+          - BRANCH: 9.1.x
             node: 20
           - BRANCH: 9.0.x
             node: 20
@@ -45,11 +48,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup MySQL
-        uses: mirromutth/mysql-action@v1.1
+        uses: shogo82148/actions-setup-mysql@v1
         with:
-          mysql version: '5.7'
-          mysql database: 'prestashop'
-          mysql root password: 'password'
+          mysql-version: "8.0"
+          root-password: 'password'
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,11 +27,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup MySQL
-        uses: mirromutth/mysql-action@v1.1
+        uses: shogo82148/actions-setup-mysql@v1
         with:
-          mysql version: '8.0'
-          mysql database: 'prestashop'
-          mysql root password: 'password'
+          mysql-version: "8.0"
+          root-password: 'password'
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -69,9 +68,6 @@ jobs:
       # because some built files (like preload.html.twig) are included and cause errors when absent
       - name: Build all assets
         run: make assets
-
-      - name: Change MySQL authentication method
-        run: mysql -h127.0.0.1 -uroot -ppassword -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'password'; FLUSH PRIVILEGES;"
 
       - name: Run integration-tests
         run: composer run-script integration-tests --timeout=0


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | Change the github action to install mysql because the old one is not compatible with Github runners anymore
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: 
| UI Tests          | No need (impact on CI)
| Fixed issue or discussion?     | N/A
| Related PRs       | #40762 by @Touxten & #40759 by @jolelievre 
| Sponsor company   | @PrestaShopCorp