### PR TITLE
Fix: Fatal error in hookActionCartSave when switching language and calling Product::getPriceStatic() or Cart::getProducts()

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -419,6 +419,7 @@ class FrontControllerCore extends Controller
                 }
                 $cart->id_lang = (int) $this->context->language->id;
                 $cart->id_currency = (int) $this->context->currency->id;
+                $this->context->cart = $cart;
                 $cart->update();
             }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fixes a fatal error occurring on language switch when modules use `Cart::getProducts()` or `Product::getPriceStatic()` inside `hookActionCartSave`.<br/>The cart is now assigned to the context before calling `Cart::update()` in `FrontController::init()`, ensuring it is properly available during hook execution.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Make sure you have at least 2 languages installed<br/>2. Install this module [issue40794.zip](https://github.com/user-attachments/files/25342589/issue40794.zip)<br/>3. Add a product to the cart<br/>4. Switch the language in the front office. <br/> 5. You should not see any errors.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/22066895836
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/40794
| Related PRs       | 
| Sponsor company   | Codencode snc