### PR TITLE
Add feature flag for One-page checkout

### DIFF
--- a/classes/lang/KeysReference/FeatureFlagLang.php
+++ b/classes/lang/KeysReference/FeatureFlagLang.php
@@ -76,3 +76,7 @@ trans('Enable / Disable the new discount system.', 'Admin.Advparameters.Help');
 
 trans('Tag', 'Admin.Advparameters.Feature');
 trans('Enable / Disable the tag page.', 'Admin.Advparameters.Help');
+
+// One-Page Checkout feature flag
+trans('One-page checkout', 'Admin.Advparameters.Feature');
+trans('Enable / Disable one page checkout flow. All checkout steps (address, delivery, payment) are grouped on a single page to reduce friction and improve conversion rate.', 'Admin.Advparameters.Help');

--- a/install-dev/data/xml/feature_flag.xml
+++ b/install-dev/data/xml/feature_flag.xml
@@ -29,5 +29,6 @@
     <feature_flag id="discount" name="discount" type="env,dotenv,db" label_wording="Discount" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the new discount system." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
     <feature_flag id="tag" name="tag" type="env,dotenv,db" label_wording="Tag" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the tag page." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
     <feature_flag id="improved_b2b" name="improved_b2b" type="env,dotenv,db" label_wording="Improved B2B" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable the improved B2B mode. To use the feature activate the B2B mode in General Settings." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
+    <feature_flag id="one_page_checkout" name="one_page_checkout" type="env,dotenv,db" label_wording="One-page checkout" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable one-page checkout flow. All checkout steps (address, delivery, payment) are grouped on a single page to reduce friction and improve conversion rate." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
   </entities>
 </entity_feature_flag>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Introduce a new feature flag to toggle One Page Checkout.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run `make install-prestashop`. Go to the BO in "Advanced Parameters" > "New & Experimentail Features", and see a new feature flag "One-Page Checkout"
| UI Tests          | https://github.com/kevin-carangeot/ga.tests.ui.pr/actions/runs/22184085699
| Fixed issue or discussion?     | N/A
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/1666
| Sponsor company   | PrestaShop
