### PR TITLE
Hide expiration field when "period never expires" is checked

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/discount/discount-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/discount/discount-map.ts
@@ -28,4 +28,6 @@ export default {
   productSegmentFeatures: '#discount_conditions_product_product_segment_features',
   quantityPerCustomerInput: '#discount_usability_quantity_per_customer',
   customerEligibilityInput: '#discount_customer_eligibility_eligibility',
+  periodNeverExpiresCheckbox: 'input[name*="[period_never_expires]"]',
+  periodExpiryDateField: '.date-range-end-date',
 };

--- a/admin-dev/themes/new-theme/js/pages/discount/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/discount/form/index.ts
@@ -75,6 +75,18 @@ $(() => {
     $(DiscountMap.quantityPerCustomerInput).parents('.form-group').show();
   }
 
+  const toggleExpiryDateVisibility = () => {
+    const isNeverExpires = (document.querySelector(DiscountMap.periodNeverExpiresCheckbox) as HTMLInputElement).checked;
+    const expiryDateFormGroup = document.querySelector(DiscountMap.periodExpiryDateField)!.closest('.form-group');
+
+    if (expiryDateFormGroup instanceof HTMLElement) {
+      expiryDateFormGroup.style.display = isNeverExpires ? 'none' : '';
+    }
+  };
+
+  toggleExpiryDateVisibility();
+  document.querySelector(DiscountMap.periodNeverExpiresCheckbox)!.addEventListener('change', toggleExpiryDateVisibility);
+
   $(DiscountMap.countriesSelect).select2({
     templateResult: formatOption,
     templateSelection: formatOption,

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -110,7 +110,7 @@ class CartRuleCore extends ObjectModel
         'fields' => [
             'id_customer' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
             'date_from' => ['type' => self::TYPE_DATE, 'validate' => 'isDate', 'required' => true],
-            'date_to' => ['type' => self::TYPE_DATE, 'validate' => 'isDate', 'required' => true],
+            'date_to' => ['type' => self::TYPE_DATE, 'validate' => 'isDateOrNull', 'required' => false],
             'description' => ['type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'size' => DiscountSettings::MAX_DESCRIPTION_LENGTH],
             'quantity' => ['type' => self::TYPE_INT, 'allow_null' => true, 'validate' => 'isUnsignedInt'],
             'quantity_per_user' => ['type' => self::TYPE_INT, 'allow_null' => true, 'validate' => 'isUnsignedInt'],
@@ -369,13 +369,13 @@ class CartRuleCore extends ObjectModel
             $start_date = date('Y-m-d 00:00:00');
             $end_date = date('Y-m-d 23:59:59');
             $sql = 'SELECT 1 FROM `' . _DB_PREFIX_ . 'cart_rule` ' .
-                'WHERE ((date_to >= "' . $start_date .
+                'WHERE (((date_to >= "' . $start_date .
                 '" AND date_to <= "' . $end_date .
                 '") OR (date_from >= "' . $start_date .
                 '" AND date_from <= "' . $end_date .
                 '") OR (date_from < "' . $start_date .
                 '" AND date_to > "' . $end_date .
-                '")) AND `id_customer` IN (0,' . (int) $idCustomer . ')';
+                '") OR (date_to IS NULL AND date_from <= "' . $end_date . '"))) AND `id_customer` IN (0,' . (int) $idCustomer . ')';
 
             $haveCartRuleToday[$idCustomer] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
         }
@@ -429,7 +429,7 @@ class CartRuleCore extends ObjectModel
         $sql .= ')';
 
         // Then, conditions for date, voucher active property and total amount of vouchers in stock
-        $sql .= ' AND NOW() BETWEEN cr.date_from AND cr.date_to
+        $sql .= ' AND (cr.date_to IS NULL OR (NOW() BETWEEN cr.date_from AND cr.date_to))
             ' . ($active ? 'AND cr.`active` = 1' : '') . '
             ' . ($inStock ? 'AND (cr.`quantity` > 0 OR cr.`quantity` is null)' : '');
 
@@ -786,7 +786,7 @@ class CartRuleCore extends ObjectModel
             if (strtotime($this->date_from) > time()) {
                 return (!$display_error) ? false : $this->trans('This voucher is not valid yet', [], 'Shop.Notifications.Error');
             }
-            if (strtotime($this->date_to) < time()) {
+            if ($this->date_to !== null && $this->date_to !== '' && strtotime($this->date_to) < time()) {
                 return (!$display_error) ? false : $this->trans('This voucher has expired', [], 'Shop.Notifications.Error');
             }
 
@@ -1992,7 +1992,7 @@ class CartRuleCore extends ObjectModel
 		WHERE cr.active = 1
 		AND cr.code = ""
 		AND (cr.quantity > 0 OR cr.quantity is null)
-		AND NOW() BETWEEN cr.date_from AND cr.date_to
+		AND (cr.date_to IS NULL OR (NOW() BETWEEN cr.date_from AND cr.date_to))
 		AND (
 			cr.id_customer = 0
 			' . (Validate::isLoadedObject($context->customer) ? 'OR cr.id_customer = ' . (int) $context->cart->id_customer : '') . '

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -167,7 +167,7 @@ CREATE TABLE `PREFIX_cart_rule` (
   `id_cart_rule` int(10) unsigned NOT NULL auto_increment,
   `id_customer` int unsigned NOT NULL DEFAULT '0',
   `date_from` datetime NOT NULL,
-  `date_to` datetime NOT NULL,
+  `date_to` datetime DEFAULT NULL,
   `description` MEDIUMTEXT,
   `quantity` int(10) unsigned DEFAULT '0',
   `quantity_per_user` int(10) unsigned DEFAULT '0',

--- a/src/Adapter/Discount/QueryHandler/GetDiscountForEditingHandler.php
+++ b/src/Adapter/Discount/QueryHandler/GetDiscountForEditingHandler.php
@@ -16,6 +16,7 @@ use PrestaShop\PrestaShop\Core\Domain\Discount\DiscountSettings;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Query\GetDiscountForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Discount\QueryHandler\GetDiscountForEditingHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Discount\QueryResult\DiscountForEditing;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 
 #[AsQueryHandler]
 class GetDiscountForEditingHandler implements GetDiscountForEditingHandlerInterface
@@ -44,7 +45,7 @@ class GetDiscountForEditingHandler implements GetDiscountForEditingHandlerInterf
             $cartRule->priority,
             $cartRule->active,
             new DateTimeImmutable($cartRule->date_from),
-            new DateTimeImmutable($cartRule->date_to),
+            DateTimeUtil::buildDateTimeOrNull($cartRule->date_to),
             $cartRule->quantity,
             $cartRule->quantity_per_user,
             $cartRule->description,

--- a/src/Adapter/Discount/Update/DiscountBuilder.php
+++ b/src/Adapter/Discount/Update/DiscountBuilder.php
@@ -36,7 +36,7 @@ class DiscountBuilder
         $cartRule->active = $command->isActive();
         $cartRule->id_customer = $command->getCustomerId()?->getValue();
         $cartRule->date_from = $validFrom->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT);
-        $cartRule->date_to = $validTo->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT);
+        $cartRule->date_to = $command->isPeriodNeverExpires() ? null : $validTo->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT);
         $cartRule->quantity = $command->getTotalQuantity();
         $cartRule->quantity_per_user = $command->getQuantityPerUser();
         $cartRule->reduction_amount = 0;

--- a/src/Adapter/Discount/Update/Filler/DiscountFiller.php
+++ b/src/Adapter/Discount/Update/Filler/DiscountFiller.php
@@ -26,7 +26,8 @@ class DiscountFiller
             $updatableProperties[] = 'date_from';
         }
         if ($command->isDirty('validTo')) {
-            $cartRule->date_to = $command->getValidTo()->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT);
+            $validTo = $command->getValidTo();
+            $cartRule->date_to = $validTo !== null ? $validTo->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT) : null;
             $updatableProperties[] = 'date_to';
         }
         if ($command->isDirty('localizedNames')) {

--- a/src/Adapter/Discount/Validate/DiscountValidator.php
+++ b/src/Adapter/Discount/Validate/DiscountValidator.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 use PrestaShopException;
 
 /**
@@ -296,6 +297,10 @@ class DiscountValidator extends AbstractObjectModelValidator
 
     private function assertDateRangeIsCorrect(CartRule $cartrule): void
     {
+        if (DateTimeUtil::isNull($cartrule->date_to)) {
+            return;
+        }
+
         if ($cartrule->date_from > $cartrule->date_to) {
             throw new DiscountConstraintException('Date from cannot be greater than date to.', DiscountConstraintException::DATE_FROM_GREATER_THAN_DATE_TO);
         }

--- a/src/Core/Domain/Discount/Command/AddDiscountCommand.php
+++ b/src/Core/Domain/Discount/Command/AddDiscountCommand.php
@@ -33,6 +33,7 @@ class AddDiscountCommand
     private bool $active = false;
     private ?DateTimeImmutable $validFrom = null;
     private ?DateTimeImmutable $validTo = null;
+    private bool $periodNeverExpires = false;
     private ?int $totalQuantity = null;
     private ?int $quantityPerUser = null;
     private string $description = '';
@@ -124,13 +125,27 @@ class AddDiscountCommand
     /**
      * @throws DiscountConstraintException
      */
-    public function setValidityDateRange(DateTimeImmutable $from, DateTimeImmutable $to): self
+    public function setValidityDateRange(DateTimeImmutable $from, ?DateTimeImmutable $to = null): self
     {
-        $this->assertDateRangeIsValid($from, $to);
+        if ($to !== null) {
+            $this->assertDateRangeIsValid($from, $to);
+        }
         $this->validFrom = $from;
         $this->validTo = $to;
 
         return $this;
+    }
+
+    public function setPeriodNeverExpires(bool $periodNeverExpires): self
+    {
+        $this->periodNeverExpires = $periodNeverExpires;
+
+        return $this;
+    }
+
+    public function isPeriodNeverExpires(): bool
+    {
+        return $this->periodNeverExpires;
     }
 
     public function getPriority(): int

--- a/src/Core/Domain/Discount/Command/UpdateDiscountCommand.php
+++ b/src/Core/Domain/Discount/Command/UpdateDiscountCommand.php
@@ -36,6 +36,7 @@ class UpdateDiscountCommand
     private ?bool $active = null;
     private ?DateTimeImmutable $validFrom = null;
     private ?DateTimeImmutable $validTo = null;
+    private bool $periodNeverExpires = false;
     private ?int $totalQuantity = null;
     private ?int $quantityPerUser = null;
     private ?string $description = null;
@@ -136,7 +137,7 @@ class UpdateDiscountCommand
         return $this;
     }
 
-    public function setValidTo(DateTimeImmutable $validTo): self
+    public function setValidTo(?DateTimeImmutable $validTo): self
     {
         $this->validTo = $validTo;
         $this->markDirty('validTo');
@@ -147,9 +148,9 @@ class UpdateDiscountCommand
     /**
      * @throws DiscountConstraintException
      */
-    public function setValidityDateRange(DateTimeImmutable $from, DateTimeImmutable $to): self
+    public function setValidityDateRange(DateTimeImmutable $from, ?DateTimeImmutable $to = null): self
     {
-        if ($from > $to) {
+        if ($to !== null && $from > $to) {
             throw new DiscountConstraintException('Date from cannot be greater than date to.', DiscountConstraintException::DATE_FROM_GREATER_THAN_DATE_TO);
         }
 
@@ -159,6 +160,18 @@ class UpdateDiscountCommand
         $this->markDirty('validTo');
 
         return $this;
+    }
+
+    public function setPeriodNeverExpires(bool $periodNeverExpires): self
+    {
+        $this->periodNeverExpires = $periodNeverExpires;
+
+        return $this;
+    }
+
+    public function isPeriodNeverExpires(): bool
+    {
+        return $this->periodNeverExpires;
     }
 
     public function getPriority(): ?int

--- a/src/Core/Form/IdentifiableObject/DataHandler/DiscountFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/DiscountFormDataHandler.php
@@ -128,14 +128,16 @@ class DiscountFormDataHandler implements FormDataHandlerInterface
 
             $neverExpires = !empty($data['period']['period_never_expires']);
             if ($neverExpires) {
-                $validTo = (new DateTime())->modify('+100 years')->setTime(23, 59, 59);
-                $validTo = DateTimeImmutable::createFromMutable($validTo);
+                $validTo = null;
             } else {
                 $validTo = $this->parseDateWithDefaultTime($dateRange['to'] ?? null, '23:59');
             }
 
-            if ($validFrom && $validTo) {
+            if ($validFrom) {
                 $command->setValidityDateRange($validFrom, $validTo);
+                if ($neverExpires) {
+                    $command->setPeriodNeverExpires(true);
+                }
             }
         }
 

--- a/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
@@ -207,7 +207,7 @@ class DiscountFormDataProvider implements FormDataProviderInterface
                     'from' => $discountForEditing->getValidFrom() ? $discountForEditing->getValidFrom()->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT) : null,
                     'to' => $discountForEditing->getValidTo() ? $discountForEditing->getValidTo()->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT) : null,
                 ],
-                'period_never_expires' => $this->isPeriodNeverExpires($discountForEditing->getValidFrom(), $discountForEditing->getValidTo()),
+                'period_never_expires' => $this->isPeriodNeverExpires($discountForEditing->getValidTo()),
             ],
             'customer_eligibility' => [
                 'eligibility' => $this->getCustomerEligibilityData($discountForEditing),
@@ -457,17 +457,10 @@ class DiscountFormDataProvider implements FormDataProviderInterface
     }
 
     /**
-     * Check if the discount period is set to "never expires" (>= 100 years duration).
+     * Check if the discount period is set to "never expires"
      */
-    private function isPeriodNeverExpires(?DateTimeInterface $validFrom, ?DateTimeInterface $validTo): bool
+    private function isPeriodNeverExpires(?DateTimeInterface $validTo): bool
     {
-        if ($validFrom === null || $validTo === null) {
-            return false;
-        }
-
-        $diff = $validFrom->diff($validTo);
-        $years = $diff->y + ($diff->m / 12) + ($diff->d / 365);
-
-        return $years >= 100;
+        return $validTo === null;
     }
 }

--- a/src/Core/Grid/Data/Factory/DiscountGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/DiscountGridDataFactoryDecorator.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Grid\Data\GridDataInterface;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
+
+/**
+ * Decorates discount grid data to display a fallback when expiration date is null
+ */
+final class DiscountGridDataFactoryDecorator implements GridDataFactoryInterface
+{
+    private const EMPTY_DATE_FALLBACK = '—';
+
+    public function __construct(
+        private readonly GridDataFactoryInterface $discountGridDataFactory,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(SearchCriteriaInterface $searchCriteria): GridDataInterface
+    {
+        $data = $this->discountGridDataFactory->getData($searchCriteria);
+        $records = $data->getRecords()->all();
+
+        foreach ($records as &$record) {
+            if (DateTimeUtil::isNull($record['date_to'] ?? null)) {
+                $record['date_to'] = self::EMPTY_DATE_FALLBACK;
+            }
+        }
+
+        return new GridData(
+            new RecordCollection($records),
+            $data->getRecordsTotal(),
+            $data->getQuery()
+        );
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -342,6 +342,11 @@ services:
       - '@prestashop.core.grid.query.doctrine_query_parser'
       - 'discount'
 
+  prestashop.core.grid.data.factory.discount_decorator:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\DiscountGridDataFactoryDecorator'
+    arguments:
+      - '@prestashop.core.grid.data.factory.discount'
+
   prestashop.core.grid.data.factory.catalog_price_rule:
     class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
@@ -276,7 +276,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
     arguments:
       - '@prestashop.core.grid.definition.factory.discount'
-      - '@prestashop.core.grid.data.factory.discount'
+      - '@prestashop.core.grid.data.factory.discount_decorator'
       - '@prestashop.core.grid.filter.form_factory'
       - '@prestashop.core.hook.dispatcher'
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Discount/DiscountFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Discount/DiscountFeatureContext.php
@@ -9,7 +9,6 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Discount;
 use Behat\Gherkin\Node\TableNode;
 use Cart;
 use CartRule;
-use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Exception;
@@ -202,11 +201,8 @@ class DiscountFeatureContext extends AbstractDomainFeatureContext
         if (isset($data['valid_from'])) {
             $validFrom = new DateTimeImmutable($data['valid_from']);
 
-            // Check if "never expires" is set
             if (isset($data['period_never_expires']) && PrimitiveUtils::castStringBooleanIntoBoolean($data['period_never_expires'])) {
-                // Set expiration date to 100 years in the future
-                $validTo = (new DateTime())->modify('+100 years')->setTime(23, 59, 59);
-                $validTo = DateTimeImmutable::createFromMutable($validTo);
+                $validTo = null;
             } elseif (!empty($data['valid_to'])) {
                 $validTo = new DateTimeImmutable($data['valid_to']);
             } else {
@@ -215,6 +211,9 @@ class DiscountFeatureContext extends AbstractDomainFeatureContext
 
             try {
                 $command->setValidityDateRange($validFrom, $validTo);
+                if ($validTo === null) {
+                    $command->setPeriodNeverExpires(true);
+                }
             } catch (DiscountConstraintException $e) {
                 $this->setLastException($e);
             }
@@ -380,17 +379,15 @@ class DiscountFeatureContext extends AbstractDomainFeatureContext
             $command->setActive(PrimitiveUtils::castStringBooleanIntoBoolean($data['active']));
         }
         if (isset($data['period_never_expires']) && PrimitiveUtils::castStringBooleanIntoBoolean($data['period_never_expires'])) {
-            // When "never expires" is set, use 100 years in the future
             if (isset($data['valid_from'])) {
                 $validFrom = new DateTimeImmutable($data['valid_from']);
             } else {
                 $validFrom = new DateTimeImmutable();
             }
-            $validTo = (new DateTime())->modify('+100 years')->setTime(23, 59, 59);
-            $validTo = DateTimeImmutable::createFromMutable($validTo);
 
             try {
-                $command->setValidityDateRange($validFrom, $validTo);
+                $command->setValidityDateRange($validFrom, null);
+                $command->setPeriodNeverExpires(true);
             } catch (DiscountConstraintException $e) {
                 $this->setLastException($e);
             }
@@ -721,40 +718,23 @@ class DiscountFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then discount :discountReference expiration date should be more than :years years in the future
+     * @Then discount :discountReference should have no expiration date
      */
-    public function assertExpirationDateIsFarInFuture(string $discountReference, int $years = 50): void
+    public function assertDiscountHasNoExpirationDate(string $discountReference): void
     {
         $discountForEditing = $this->getDiscountForEditing($discountReference);
-        $validTo = $discountForEditing->getValidTo();
-
-        Assert::assertNotNull($validTo, 'Expiration date should not be null');
-
-        $now = new DateTime();
-        $threshold = $now->modify('+' . $years . ' years');
-
-        Assert::assertGreaterThan(
-            $threshold,
-            $validTo,
-            sprintf('Expiration date should be more than %d years in the future', $years)
+        Assert::assertNull(
+            $discountForEditing->getValidTo(),
+            'Discount should have no expiration date (period never expires)'
         );
     }
 
     /**
-     * Check if the discount period is set to "never expires" (100 years in the future).
+     * Check if the discount period is set to "never expires" (null expiration date).
      */
     private function isPeriodNeverExpires(?DateTimeInterface $validTo): bool
     {
-        if ($validTo === null) {
-            return false;
-        }
-
-        // Check if the expiration date is more than 50 years in the future
-        // (we use 50 years as a threshold to detect "never expires" dates set to 100 years)
-        $now = new DateTime();
-        $threshold = $now->modify('+50 years');
-
-        return $validTo > $threshold;
+        return $validTo === null;
     }
 
     protected function getDiscountForEditing(string $discountReference): DiscountForEditing

--- a/tests/Integration/Behaviour/Features/Scenario/Discount/BO/update_discount_validity_dates.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Discount/BO/update_discount_validity_dates.feature
@@ -200,7 +200,7 @@ Feature: Update discount validity dates
       | period_never_expires | false               |
       | reduction_percent    | 15.0                |
 
-  Scenario: Verify never-expiring discount has expiration far in the future
+  Scenario: Verify never-expiring discount has no expiration date
     When I create a "cart_level" discount "verify_never_expires" with following properties:
       | name[en-US]          | Long Term Discount  |
       | valid_from           | 2024-01-01 00:00:00 |
@@ -208,5 +208,5 @@ Feature: Update discount validity dates
       | reduction_percent    | 20.0                |
     Then discount "verify_never_expires" should have the following properties:
       | period_never_expires | true |
-    And discount "verify_never_expires" expiration date should be more than 50 years in the future
+    And discount "verify_never_expires" should have no expiration date
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x 
| Description?      | Hide expiration date field when the 'period never expires' option is checked
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Steps to reproduce are here https://github.com/PrestaShop/PrestaShop/issues/40801
| UI Tests          | https://github.com/nicosomb/ga.tests.ui.pr/actions/runs/22102909816
| Fixed issue or discussion?     | #40801
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA 