### PR TITLE
Don't add "default" if "default" already in name for getFormattedName

### DIFF
--- a/classes/ImageType.php
+++ b/classes/ImageType.php
@@ -187,7 +187,12 @@ class ImageTypeCore extends ObjectModel
             return $themeName . '_' . $nameWithoutThemeName;
         }
 
-        return $nameWithoutThemeName . '_default';
+        // only if "default" isn't already in name, we return it with default
+        if (!strstr($name, 'default')) {
+            return $nameWithoutThemeName . '_default';
+        }
+
+        return $nameWithoutThemeName;
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Don't add "default" if "default" already in name in `ImageType::getFormattedName()` function.<br>We need to avoid this kind of return: `default_sm_default` if `default_sm` in args.<br>We keep retrocompat of the usecase of `sm` => `sm_default`.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #40331 (maybe here QA by dev!)
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/22134054061
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
