### PR TITLE
Add shipping helptexts

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
@@ -67,7 +67,7 @@ class CarrierOptionsType extends TranslatorAwareType
                     'Admin.Shipping.Feature'
                 ),
                 'help' => $this->trans(
-                    'Your shop\'s default carrier.',
+                    'Default carrier that will be pre-selected for customers in the checkout process.',
                     'Admin.Shipping.Help'
                 ),
                 'multistore_configuration_key' => 'PS_CARRIER_DEFAULT',
@@ -81,7 +81,7 @@ class CarrierOptionsType extends TranslatorAwareType
                     'Admin.Actions'
                 ),
                 'help' => $this->trans(
-                    'This will only be visible in the front office.',
+                    'Determines how carriers are sorted in the checkout.',
                     'Admin.Shipping.Help'
                 ),
                 'multistore_configuration_key' => 'PS_CARRIER_DEFAULT_SORT',
@@ -94,7 +94,7 @@ class CarrierOptionsType extends TranslatorAwareType
                     'Admin.Actions'
                 ),
                 'help' => $this->trans(
-                    'This will only be visible in the front office.',
+                    'Sets the sorting direction of carriers in the checkout.',
                     'Admin.Shipping.Help'
                 ),
                 'multistore_configuration_key' => 'PS_CARRIER_DEFAULT_ORDER',

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
@@ -67,6 +67,10 @@ class HandlingType extends TranslatorAwareType
                     'Handling charges',
                     'Admin.Shipping.Feature'
                 ),
+                'help' => $this->trans(
+                    'Optional additional fee added to carriers with handling charges enabled. This fee is not applied when shipping is free due to options below.',
+                    'Admin.Shipping.Help'
+                ),
                 'multistore_configuration_key' => 'PS_SHIPPING_HANDLING',
             ])
             ->add('free_shipping_price', MoneyType::class, [
@@ -80,6 +84,10 @@ class HandlingType extends TranslatorAwareType
                 'label' => $this->trans(
                     'Free shipping starts at',
                     'Admin.Shipping.Feature'
+                ),
+                'help' => $this->trans(
+                    'Shipping is free for all zones when the cart total reaches or exceeds this amount.',
+                    'Admin.Shipping.Help'
                 ),
                 'multistore_configuration_key' => 'PS_SHIPPING_FREE_PRICE',
             ])
@@ -95,6 +103,10 @@ class HandlingType extends TranslatorAwareType
                     new GreaterThanOrEqual(['value' => 0]),
                     new Type(['type' => 'numeric']),
                 ],
+                'help' => $this->trans(
+                    'Shipping is free for all zones when the total cart weight reaches or exceeds this value.',
+                    'Admin.Shipping.Help'
+                ),
                 'multistore_configuration_key' => 'PS_SHIPPING_FREE_WEIGHT',
             ]);
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/ShippingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/ShippingType.php
@@ -81,7 +81,7 @@ class ShippingType extends TranslatorAwareType
                 'label' => $this->trans('Shipping fees', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h3',
                 'label_subtitle' => $this->trans('Additional shipping costs', 'Admin.Catalog.Feature'),
-                'label_help_box' => $this->trans('If a carrier has a tax, it will be added to the shipping fees. Does not apply to free shipping.', 'Admin.Catalog.Help'),
+                'label_help_box' => $this->trans('Optional additional fee added to the shipping cost for each purchased item. Applies only if shipping is not free.', 'Admin.Catalog.Help'),
                 'currency' => $this->currencyIsoCode,
                 'constraints' => [
                     new NotBlank(),


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Improves the help text related to shipping fees. On product page, it was a total nonsense.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI + UI
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/22137004479
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | TRENDO s.r.o.
