### PR TITLE
Update split and merge forms for multi-shipment

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataProvider/MergeShipmentFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/MergeShipmentFormDataProvider.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetOrderShipments;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetShipmentProducts;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\QueryResult\OrderShipment;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\QueryResult\OrderShipmentProduct;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class MergeShipmentFormDataProvider extends ShipmentFormDataProvider
+{
+    public function __construct(
+        private CommandBusInterface $queryBus,
+        private RequestStack $requestStack
+    ) {
+        parent::__construct($queryBus);
+    }
+
+    public function getData($orderId)
+    {
+        $shipmentId = $this->requestStack->getMainRequest()->query->getInt('shipmentId');
+
+        /** @var OrderShipmentProduct[] $products */
+        $products = $this->queryBus->handle(new GetShipmentProducts($shipmentId));
+
+        /** @var OrderShipment[] $shipments */
+        $shipments = $this->queryBus->handle(new GetOrderShipments($orderId));
+
+        $shipments = array_filter($shipments, fn (OrderShipment $s) => $s->getId() !== $shipmentId);
+
+        foreach ($products as &$p) {
+            $p = $p->toArray();
+        }
+
+        return [
+            'products' => $products,
+            'shipments' => $shipments,
+            'is_shipped' => $this->isShipmentShipped($orderId, $shipmentId),
+        ];
+    }
+
+    public function getDefaultData()
+    {
+        return [];
+    }
+}

--- a/src/Core/Form/IdentifiableObject/DataProvider/ShipmentFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ShipmentFormDataProvider.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetShipmentForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\QueryResult\ShipmentForEditing;
+
+abstract class ShipmentFormDataProvider implements FormDataProviderInterface
+{
+    public function __construct(
+        private CommandBusInterface $queryBus,
+    ) {
+    }
+
+    protected function isShipmentShipped(int $orderId, int $shipmentId): bool
+    {
+        /** @var ShipmentForEditing $shipment */
+        $shipment = $this->queryBus->handle(new GetShipmentForEditing($orderId, $shipmentId));
+
+        return !empty($shipment->getTrackingNumber());
+    }
+}

--- a/src/Core/Form/IdentifiableObject/DataProvider/SplitShipmentFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/SplitShipmentFormDataProvider.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
+
+use PrestaShop\PrestaShop\Adapter\Order\Repository\OrderDetailRepository;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\ShipmentException;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetShipmentProducts;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\QueryResult\OrderShipmentProduct;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\ValueObject\OrderDetailId;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class SplitShipmentFormDataProvider extends ShipmentFormDataProvider
+{
+    public function __construct(
+        private OrderDetailRepository $orderDetailRepository,
+        private CommandBusInterface $queryBus,
+        private RequestStack $requestStack
+    ) {
+        parent::__construct($queryBus);
+    }
+
+    public function getData($orderId)
+    {
+        $shipmentId = $this->requestStack->getMainRequest()->query->getInt('shipmentId');
+        $productsFromQuery = $this->requestStack->getMainRequest()->get('products', []);
+        $selectedCarrier = $this->requestStack->getMainRequest()->query->getInt('carrier');
+        $orderShipmentProducts = $this->mergeProductsFromQueries($shipmentId, $productsFromQuery);
+
+        return [
+            'products' => $orderShipmentProducts,
+            'carrier' => $selectedCarrier,
+            'shipment_id' => $shipmentId,
+            'order_id' => $orderId,
+            'form_is_valid' => $this->checkFormValidity($orderShipmentProducts),
+            'is_shipped' => $this->isShipmentShipped($orderId, $shipmentId),
+        ];
+    }
+
+    public function getDefaultData()
+    {
+        return [];
+    }
+
+    /**
+     * @param int $shipmentId
+     * @param array<array{selected: string, selected_quantity: string, order_detail_id: string}> $productsFromQuery
+     *
+     * @return array<array{
+     *     selected?: bool,
+     *     selected_quantity?: int,
+     *     order_detail_id: int,
+     *     quantity: int,
+     *     product_name: string,
+     *     product_reference: string,
+     *     product_image_path: string
+     * }>
+     *
+     * @throws ShipmentException
+     */
+    private function mergeProductsFromQueries(
+        int $shipmentId,
+        array $productsFromQuery,
+    ): array {
+        foreach ($productsFromQuery as &$product) {
+            if (isset($product['selected_quantity'])) {
+                $product['selected_quantity'] = (int) $product['selected_quantity'];
+            }
+            if (isset($product['selected'])) {
+                $product['selected'] = (bool) filter_var((int) $product['selected'], FILTER_VALIDATE_BOOLEAN);
+            }
+        }
+
+        $productsQueryMap = array_column(
+            $productsFromQuery,
+            null,
+            'order_detail_id'
+        );
+
+        /** @var OrderShipmentProduct[] $orderShipmentProducts */
+        $orderShipmentProducts = $this->queryBus->handle(new GetShipmentProducts($shipmentId));
+
+        $mergedProducts = [];
+
+        foreach ($orderShipmentProducts as $product) {
+            $productArray = $product->toArray();
+            $id = $productArray['order_detail_id'] ?? null;
+            if ($id !== null && isset($productsQueryMap[$id])) {
+                $productArray['product_id'] = $this->orderDetailRepository
+                    ->get(new OrderDetailId($productArray['order_detail_id']))
+                    ->product_id;
+                $productArray = array_merge($productsQueryMap[$id], $productArray);
+            }
+
+            $mergedProducts[] = $productArray;
+        }
+
+        return $mergedProducts;
+    }
+
+    /**
+     * @param array<array{
+     *      selected?: bool,
+     *      selected_quantity?: int,
+     *      order_detail_id: int,
+     *      quantity: int,
+     *      product_name: string,
+     *      product_reference: string,
+     *      product_image_path: string
+     *  }> $products
+     *
+     * @return bool
+     */
+    private function checkFormValidity(array $products): bool
+    {
+        $allSelected = array_reduce($products, fn ($carry, $product) => $carry && ($product['selected'] ?? false), true);
+        $allQuantitiesMatch = array_reduce($products, fn ($carry, $product) => $carry && (($product['selected_quantity'] ?? 0) === $product['quantity']), true);
+
+        return !($allSelected && $allQuantitiesMatch);
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -11,7 +11,6 @@ use Exception;
 use InvalidArgumentException;
 use PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
-use PrestaShop\PrestaShop\Adapter\Order\Repository\OrderDetailRepository;
 use PrestaShop\PrestaShop\Adapter\PDF\OrderInvoicePdfGenerator;
 use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Action\ActionsBarButtonsCollection;
@@ -72,15 +71,10 @@ use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\EditShipment;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\MergeProductsToShipment;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\SplitShipment;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\CannotEditShipmentShippedException;
-use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\ShipmentException;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetOrderShipments;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetShipmentForEditing;
-use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetShipmentProducts;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\ListAvailableShipmentsForProduct;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\QueryResult\OrderShipment;
-use PrestaShop\PrestaShop\Core\Domain\Shipment\QueryResult\OrderShipmentProduct;
-use PrestaShop\PrestaShop\Core\Domain\Shipment\QueryResult\ShipmentForEditing;
-use PrestaShop\PrestaShop\Core\Domain\Shipment\ValueObject\OrderDetailId;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\QuerySorting;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
@@ -112,8 +106,6 @@ use PrestaShopBundle\Form\Admin\Sell\Order\InternalNoteType;
 use PrestaShopBundle\Form\Admin\Sell\Order\OrderMessageType;
 use PrestaShopBundle\Form\Admin\Sell\Order\OrderPaymentType;
 use PrestaShopBundle\Form\Admin\Sell\Order\Shipment\EditShipmentType;
-use PrestaShopBundle\Form\Admin\Sell\Order\Shipment\MergeShipmentType;
-use PrestaShopBundle\Form\Admin\Sell\Order\Shipment\SplitShipmentType;
 use PrestaShopBundle\Form\Admin\Sell\Order\UpdateOrderShippingType;
 use PrestaShopBundle\Form\Admin\Sell\Order\UpdateOrderStatusType;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
@@ -621,19 +613,18 @@ class OrderController extends PrestaShopAdminController
     }
 
     #[AdminSecurity("is_granted('update', 'AdminOrders')", redirectRoute: 'admin_orders_view', redirectQueryParamsToKeep: ['orderId'], message: 'You do not have permission to edit this.')]
-    public function getMergeShipmentForm(int $orderId, Request $request): Response
+    public function getMergeShipmentForm(int $orderId, Request $request, #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.merge_shipment_form_builder')] FormBuilderInterface $formBuilder): Response
     {
         $shipmentId = (int) $request->query->get('shipmentId');
-        $formData = $this->getMergeFormData($orderId, $shipmentId);
-        $form = $this->createForm(MergeShipmentType::class, null, $formData);
-        $isShipped = $this->isShipmentShipped($orderId, $shipmentId);
+        $form = $formBuilder->getFormFor($orderId);
+        $data = $form->getData();
 
         return $this->render('@PrestaShop/Admin/Sell/Order/Order/Blocks/View/merge_shipment_form.html.twig', [
             'mergeShipmentForm' => $form->createView(),
             'orderId' => $orderId,
             'shipmentId' => $shipmentId,
-            'products' => $formData['products'],
-            'isShipped' => $isShipped,
+            'products' => $data['products'],
+            'isShipped' => $data['is_shipped'],
         ]);
     }
 
@@ -678,13 +669,11 @@ class OrderController extends PrestaShopAdminController
      * @return RedirectResponse
      */
     #[AdminSecurity("is_granted('update', 'AdminOrders')", redirectRoute: 'admin_orders_view', redirectQueryParamsToKeep: ['orderId'], message: 'You do not have permission to edit this.')]
-    public function mergeShipmentAction(int $orderId, Request $request): RedirectResponse
+    public function mergeShipmentAction(int $orderId, Request $request, #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.merge_shipment_form_builder')] FormBuilderInterface $formBuilder): RedirectResponse
     {
         try {
             $shipmentId = (int) $request->query->get('shipmentId');
-            $formData = $this->getMergeFormData($orderId, $shipmentId);
-
-            $form = $this->createForm(MergeShipmentType::class, null, $formData);
+            $form = $formBuilder->getFormFor($orderId);
             $form->handleRequest($request);
 
             if (!$form->isSubmitted() || !$form->isValid()) {
@@ -692,12 +681,13 @@ class OrderController extends PrestaShopAdminController
 
                 return $this->redirectToRoute('admin_orders_view', ['orderId' => $orderId]);
             }
+            $data = $form->getData();
 
             /** @var OrderShipment $targetShipment */
             $targetShipment = $form->get('merge_to_shipment')->getData();
             $targetShipmentId = $targetShipment->getId();
 
-            if ($this->isShipmentShipped($orderId, $targetShipmentId)) {
+            if ($data['is_shipped']) {
                 $this->addFlash('error', $this->trans('This shipment can\'t be merged because a tracking number has already been assigned, indicating that it has already been shipped.', [], 'Admin.Orderscustomers.Notification'));
 
                 return $this->redirectToRoute('admin_orders_view', ['orderId' => $orderId]);
@@ -772,26 +762,6 @@ class OrderController extends PrestaShopAdminController
         ]);
     }
 
-    private function getMergeFormData(int $orderId, int $shipmentId): array
-    {
-        /** @var OrderShipmentProduct[] $products */
-        $products = $this->dispatchQuery(new GetShipmentProducts($shipmentId));
-
-        /** @var OrderShipment[] $shipments */
-        $shipments = $this->dispatchQuery(new GetOrderShipments($orderId));
-
-        $shipments = array_filter($shipments, fn (OrderShipment $s) => $s->getId() !== $shipmentId);
-
-        foreach ($products as &$p) {
-            $p = $p->toArray();
-        }
-
-        return [
-            'products' => $products,
-            'shipments' => $shipments,
-        ];
-    }
-
     #[AdminSecurity("is_granted('update', 'AdminOrders')", redirectRoute: 'admin_orders_view', redirectQueryParamsToKeep: ['orderId'], message: 'You do not have permission to edit this.')]
     public function splitShipmentAction(int $orderId, int $shipmentId, Request $request): RedirectResponse
     {
@@ -833,52 +803,18 @@ class OrderController extends PrestaShopAdminController
     #[AdminSecurity("is_granted('update', 'AdminOrders')", message: 'You do not have permission to show this.')]
     public function getSplitShipmentForm(
         int $orderId,
-        Request $request,
-        #[Autowire(service: 'PrestaShop\PrestaShop\Adapter\Order\Repository\OrderDetailRepository')] OrderDetailRepository $orderDetailRepository,
+        #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.split_shipment_form_builder')] FormBuilderInterface $formBuilder,
     ): Response {
-        $shipmentId = $request->query->getInt('shipmentId');
-        $productsFromQuery = $request->get('products', []);
-        $selectedCarrier = $request->query->getInt('carrier');
-        $orderShipmentProducts = $this->mergeProductsFromQueries($shipmentId, $productsFromQuery, $orderDetailRepository);
-        $canSplitShipment = $this->isShipmentShipped($orderId, $shipmentId);
-
-        $formIsValid = $this->checkFormValidity($orderShipmentProducts);
-
-        $splitShipmentTypeForm = $this->createForm(SplitShipmentType::class, [
-            'products' => $orderShipmentProducts,
-            'carrier' => $selectedCarrier,
-            'shipment_id' => $shipmentId,
-            'order_id' => $orderId,
-        ]);
+        $form = $formBuilder->getFormFor($orderId);
+        $data = $form->getData();
 
         return $this->render('@PrestaShop/Admin/Sell/Order/Order/Blocks/View/split_shipment_form.html.twig', [
-            'splitShipmentForm' => $splitShipmentTypeForm->createView(),
+            'splitShipmentForm' => $form->createView(),
             'orderId' => $orderId,
-            'shipmentId' => $shipmentId,
-            'formIsValid' => $formIsValid,
-            'isShipped' => $canSplitShipment,
+            'shipmentId' => $data['shipment_id'],
+            'formIsValid' => $data['form_is_valid'],
+            'isShipped' => $data['is_shipped'],
         ]);
-    }
-
-    /**
-     * @param array<array{
-     *      selected?: bool,
-     *      selected_quantity?: int,
-     *      order_detail_id: int,
-     *      quantity: int,
-     *      product_name: string,
-     *      product_reference: string,
-     *      product_image_path: string
-     *  }> $products
-     *
-     * @return bool
-     */
-    private function checkFormValidity(array $products): bool
-    {
-        $allSelected = array_reduce($products, fn ($carry, $product) => $carry && ($product['selected'] ?? false), true);
-        $allQuantitiesMatch = array_reduce($products, fn ($carry, $product) => $carry && (($product['selected_quantity'] ?? 0) === $product['quantity']), true);
-
-        return !($allSelected && $allQuantitiesMatch);
     }
 
     #[AdminSecurity("is_granted('update', 'AdminOrders')", message: 'You do not have permission to show this.')]
@@ -914,73 +850,6 @@ class OrderController extends PrestaShopAdminController
             ['carriers' => $carriers],
             Response::HTTP_OK
         );
-    }
-
-    private function isShipmentShipped(int $orderId, int $shipmentId): bool
-    {
-        /** @var ShipmentForEditing $shipment */
-        $shipment = $this->dispatchQuery(new GetShipmentForEditing($orderId, $shipmentId));
-
-        return !empty($shipment->getTrackingNumber());
-    }
-
-    /**
-     * @param int $shipmentId
-     * @param array<array{selected: string, selected_quantity: string, order_detail_id: string}> $productsFromQuery
-     * @param OrderDetailRepository $orderDetailRepository
-     *
-     * @return array<array{
-     *     selected?: bool,
-     *     selected_quantity?: int,
-     *     order_detail_id: int,
-     *     quantity: int,
-     *     product_name: string,
-     *     product_reference: string,
-     *     product_image_path: string
-     * }>
-     *
-     * @throws CoreException
-     * @throws ShipmentException
-     */
-    private function mergeProductsFromQueries(
-        int $shipmentId,
-        array $productsFromQuery,
-        OrderDetailRepository $orderDetailRepository,
-    ): array {
-        foreach ($productsFromQuery as &$product) {
-            if (isset($product['selected_quantity'])) {
-                $product['selected_quantity'] = (int) $product['selected_quantity'];
-            }
-            if (isset($product['selected'])) {
-                $product['selected'] = (bool) filter_var((int) $product['selected'], FILTER_VALIDATE_BOOLEAN);
-            }
-        }
-
-        $productsQueryMap = array_column(
-            $productsFromQuery,
-            null,
-            'order_detail_id'
-        );
-
-        /** @var OrderShipmentProduct[] $orderShipmentProducts */
-        $orderShipmentProducts = $this->dispatchQuery(new GetShipmentProducts($shipmentId));
-
-        $mergedProducts = [];
-
-        foreach ($orderShipmentProducts as $product) {
-            $productArray = $product->toArray();
-            $id = $productArray['order_detail_id'] ?? null;
-            if ($id !== null && isset($productsQueryMap[$id])) {
-                $productArray['product_id'] = $orderDetailRepository
-                    ->get(new OrderDetailId($productArray['order_detail_id']))
-                    ->product_id;
-                $productArray = array_merge($productsQueryMap[$id], $productArray);
-            }
-
-            $mergedProducts[] = $productArray;
-        }
-
-        return $mergedProducts;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Shipment/MergeShipmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Shipment/MergeShipmentType.php
@@ -23,7 +23,9 @@ class MergeShipmentType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        foreach ($options['products'] as $product) {
+        $datas = $builder->getData();
+
+        foreach ($datas['products'] as $product) {
             $builder->add('product_' . $product['order_detail_id'], CheckboxType::class, [
                 'label' => $product['order_detail_id'],
                 'required' => false,
@@ -43,7 +45,7 @@ class MergeShipmentType extends AbstractType
 
         $builder->add('merge_to_shipment', ChoiceType::class, [
             'label' => $this->translator->trans('Select shipment to merge to', [], 'Admin.Orderscustomers.Feature'),
-            'choices' => $options['shipments'],
+            'choices' => $datas['shipments'],
             'choice_label' => function ($shipment) {
                 return $this->translator->trans(
                     'Shipment %shipment_id% - carrier %carrier_name%',

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
@@ -372,3 +372,17 @@ services:
     arguments:
       - 'PrestaShopBundle\Form\Admin\Sell\Order\AddProductRowType'
       - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\AddProductFormDataProvider'
+
+  prestashop.core.form.identifiable_object.builder.merge_shipment_form_builder:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder'
+    factory: [ '@prestashop.core.form.builder.form_builder_factory', 'create' ]
+    arguments:
+      - 'PrestaShopBundle\Form\Admin\Sell\Order\Shipment\MergeShipmentType'
+      - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\MergeShipmentFormDataProvider'
+
+  prestashop.core.form.identifiable_object.builder.split_shipment_form_builder:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder'
+    factory: [ '@prestashop.core.form.builder.form_builder_factory', 'create' ]
+    arguments:
+      - 'PrestaShopBundle\Form\Admin\Sell\Order\Shipment\SplitShipmentType'
+      - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\SplitShipmentFormDataProvider'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -273,3 +273,11 @@ services:
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\AddProductFormDataProvider:
     autowire: true
     public: false
+
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\MergeShipmentFormDataProvider:
+    autowire: true
+    public: false
+
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\SplitShipmentFormDataProvider:
+    autowire: true
+    public: false


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The forms for splitting and merging shipments did not use the form builder; this proposal now uses the builder, allowing the addition of hooks and splitting the retrieval into providers.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | full tests for split and merge shipment forms
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/22392764957
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -
