### PR TITLE
Login form: change `autocomplete="email"` to `autocomplete="username"`

### DIFF
--- a/classes/form/CustomerLoginFormatter.php
+++ b/classes/form/CustomerLoginFormatter.php
@@ -23,7 +23,7 @@ class CustomerLoginFormatterCore implements FormFormatterInterface
             'email' => (new FormField())
                 ->setName('email')
                 ->setType('email')
-                ->setAutocompleteAttribute('email')
+                ->setAutocompleteAttribute('username')
                 ->setRequired(true)
                 ->setLabel($this->translator->trans(
                     'Email',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Follow best practices to autocomplete the "username" field (even if like here it's an email).
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to login form and inspect the "email" field.
| UI Tests          | -
| Fixed issue or discussion?     | https://github.com/PrestaShop/hummingbird/pull/936#discussion_r2831988567
| Related PRs       | https://github.com/PrestaShop/hummingbird/pull/936
| Sponsor company   | N/A
