### PR TITLE
Add builder form on add product inside a existing order

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataProvider/AddProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/AddProductFormDataProvider.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
+
+use PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderForViewing;
+use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderForViewing;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\QuerySorting;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
+
+class AddProductFormDataProvider implements FormDataProviderInterface
+{
+    public function __construct(
+        private CommandBusInterface $queryBus,
+        private CurrencyDataProvider $currencyDataProvider,
+        private FeatureFlagStateCheckerInterface $featureFlagStateChecker,
+    ) {
+    }
+
+    public function getData($orderId)
+    {
+        /** @var OrderForViewing $orderForViewing */
+        $orderForViewing = $this->queryBus->handle(new GetOrderForViewing($orderId, QuerySorting::DESC));
+        $currency = $this->currencyDataProvider->getCurrencyById($orderForViewing->getCurrencyId());
+        $multishipmentIsEnabled = $this->featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT);
+
+        return [
+            'order_id' => $orderId,
+            'currency' => $currency,
+            'is_multishipment_is_enabled' => $multishipmentIsEnabled,
+        ];
+    }
+
+    public function getDefaultData()
+    {
+        return [];
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -101,7 +101,6 @@ use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
 use PrestaShopBundle\Exception\InvalidModuleException;
 use PrestaShopBundle\Form\Admin\Sell\Customer\PrivateNoteType;
 use PrestaShopBundle\Form\Admin\Sell\Order\AddOrderCartRuleType;
-use PrestaShopBundle\Form\Admin\Sell\Order\AddProductRowType;
 use PrestaShopBundle\Form\Admin\Sell\Order\CartSummaryType;
 use PrestaShopBundle\Form\Admin\Sell\Order\ChangeOrderAddressType;
 use PrestaShopBundle\Form\Admin\Sell\Order\ChangeOrderCurrencyType;
@@ -435,6 +434,7 @@ class OrderController extends PrestaShopAdminController
         CurrencyDataProvider $currencyDataProvider,
         FeatureFlagStateCheckerInterface $featureFlagStateChecker,
         #[Autowire(service: 'PrestaShop\PrestaShop\Core\Grid\Factory\ShipmentFactory')] GridFactoryInterface $shipmentGridFactory,
+        #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.add_product_form_builder')] FormBuilderInterface $addProductFormBuilder,
         ShipmentFilters $filters,
         Tools $tools,
     ): Response {
@@ -505,10 +505,7 @@ class OrderController extends PrestaShopAdminController
         // @todo: Fix me. Should not rely on legacy object model - Currency
         $orderCurrency = $currencyDataProvider->getCurrencyById($orderForViewing->getCurrencyId());
 
-        $addProductRowForm = $this->createForm(AddProductRowType::class, [], [
-            'order_id' => $orderId,
-            'currency' => $orderCurrency,
-        ]);
+        $addProductForm = $addProductFormBuilder->getFormFor($orderId);
 
         $editProductRowForm = $this->createForm(EditProductRowType::class, [], [
             'order_id' => $orderId,
@@ -602,7 +599,7 @@ class OrderController extends PrestaShopAdminController
             'invoiceManagementIsEnabled' => $orderForViewing->isInvoiceManagementIsEnabled(),
             'changeOrderAddressForm' => $changeOrderAddressForm?->createView(),
             'orderMessageForm' => $orderMessageForm->createView(),
-            'addProductRowForm' => $addProductRowForm->createView(),
+            'addProductRowForm' => $addProductForm->createView(),
             'editProductRowForm' => $editProductRowForm->createView(),
             'backOfficeOrderButtons' => $backOfficeOrderButtons,
             'merchandiseReturnEnabled' => $merchandiseReturnEnabled,
@@ -641,17 +638,11 @@ class OrderController extends PrestaShopAdminController
     #[AdminSecurity("is_granted('update', 'AdminOrders')", redirectRoute: 'admin_orders_view', redirectQueryParamsToKeep: ['orderId'], message: 'You do not have permission to edit this.')]
     public function getAddProductForm(
         int $orderId,
-        CurrencyDataProvider $currencyDataProvider,
+        #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.add_product_form_builder')] FormBuilderInterface $addProductFormBuilder,
         FeatureFlagStateCheckerInterface $featureFlagStateChecker
     ): Response {
         $orderForViewing = $this->dispatchQuery(new GetOrderForViewing($orderId, QuerySorting::DESC));
-        $currency = $currencyDataProvider->getCurrencyById($orderForViewing->getCurrencyId());
-
-        $form = $this->createForm(AddProductRowType::class, [], [
-            'order_id' => $orderId,
-            'currency' => $currency,
-            'is_multishipment_is_enabled' => $featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT),
-        ]);
+        $form = $addProductFormBuilder->getFormFor($orderId);
 
         return $this->render('@PrestaShop/Admin/Sell/Order/Order/Blocks/View/add_product_form.html.twig', [
             'addProductForm' => $form->createView(),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/AddProductRowType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/AddProductRowType.php
@@ -51,14 +51,16 @@ class AddProductRowType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $invoices = $builder->getData()['order_id'] ?
+        $data = $builder->getData();
+
+        $invoices = $data['order_id'] ?
             $this->orderInvoiceByIdChoiceProvider->getChoices([
-                'id_order' => $builder->getData()['order_id'],
+                'id_order' => $data['order_id'],
                 'id_lang' => $this->contextLangId,
                 'display_total' => false,
             ]) : [];
 
-        if ($builder->getData()['is_multishipment_is_enabled'] === true) {
+        if ($data['is_multishipment_is_enabled'] === true) {
             $builder
                 ->add('addShipment', ChoiceType::class, [
                     'label' => $this->trans('Select a shipment', 'Admin.Orderscustomers.Feature'),
@@ -87,8 +89,8 @@ class AddProductRowType extends TranslatorAwareType
                     'class' => 'col-sm-12',
                     'autocomplete' => 'off',
                     'placeholder' => $this->trans('Search for a product', 'Admin.Orderscustomers.Feature'),
-                    'data-currency' => $builder->getData()['currency']->id,
-                    'data-order' => $builder->getData()['order_id'],
+                    'data-currency' => $data['currency']->id,
+                    'data-order' => $data['order_id'],
                 ],
             ])
             ->add('addProductCombinations', ChoiceType::class, [
@@ -98,11 +100,11 @@ class AddProductRowType extends TranslatorAwareType
             ])
             ->add('price_tax_excluded', MoneyType::class, [
                 'label' => $this->trans('tax excl.', 'Admin.Global'),
-                'currency' => $builder->getData()['currency']->iso_code,
+                'currency' => $data['currency']->iso_code,
             ])
             ->add('price_tax_included', MoneyType::class, [
                 'label' => $this->trans('tax incl.', 'Admin.Global'),
-                'currency' => $builder->getData()['currency']->iso_code,
+                'currency' => $data['currency']->iso_code,
             ])
             ->add('quantity', IntegerType::class, [
                 'label' => false,
@@ -141,7 +143,7 @@ class AddProductRowType extends TranslatorAwareType
                 'disabled' => true,
                 'attr' => [
                     'class' => 'btn btn-sm btn-primary js-product-add-action-btn mt-2 mb-2',
-                    'data-order-id' => $builder->getData()['order_id'],
+                    'data-order-id' => $data['order_id'],
                 ],
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/AddProductRowType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/AddProductRowType.php
@@ -51,14 +51,14 @@ class AddProductRowType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $invoices = $options['order_id'] ?
+        $invoices = $builder->getData()['order_id'] ?
             $this->orderInvoiceByIdChoiceProvider->getChoices([
-                'id_order' => $options['order_id'],
+                'id_order' => $builder->getData()['order_id'],
                 'id_lang' => $this->contextLangId,
                 'display_total' => false,
             ]) : [];
 
-        if ($options['is_multishipment_is_enabled'] === true) {
+        if ($builder->getData()['is_multishipment_is_enabled'] === true) {
             $builder
                 ->add('addShipment', ChoiceType::class, [
                     'label' => $this->trans('Select a shipment', 'Admin.Orderscustomers.Feature'),
@@ -87,8 +87,8 @@ class AddProductRowType extends TranslatorAwareType
                     'class' => 'col-sm-12',
                     'autocomplete' => 'off',
                     'placeholder' => $this->trans('Search for a product', 'Admin.Orderscustomers.Feature'),
-                    'data-currency' => $options['currency']->id,
-                    'data-order' => $options['order_id'],
+                    'data-currency' => $builder->getData()['currency']->id,
+                    'data-order' => $builder->getData()['order_id'],
                 ],
             ])
             ->add('addProductCombinations', ChoiceType::class, [
@@ -98,11 +98,11 @@ class AddProductRowType extends TranslatorAwareType
             ])
             ->add('price_tax_excluded', MoneyType::class, [
                 'label' => $this->trans('tax excl.', 'Admin.Global'),
-                'currency' => $options['currency']->iso_code,
+                'currency' => $builder->getData()['currency']->iso_code,
             ])
             ->add('price_tax_included', MoneyType::class, [
                 'label' => $this->trans('tax incl.', 'Admin.Global'),
-                'currency' => $options['currency']->iso_code,
+                'currency' => $builder->getData()['currency']->iso_code,
             ])
             ->add('quantity', IntegerType::class, [
                 'label' => false,
@@ -141,7 +141,7 @@ class AddProductRowType extends TranslatorAwareType
                 'disabled' => true,
                 'attr' => [
                     'class' => 'btn btn-sm btn-primary js-product-add-action-btn mt-2 mb-2',
-                    'data-order-id' => $options['order_id'],
+                    'data-order-id' => $builder->getData()['order_id'],
                 ],
             ])
         ;
@@ -152,16 +152,10 @@ class AddProductRowType extends TranslatorAwareType
      */
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver
-            ->setRequired([])
-            ->setDefaults([
-                'order_id' => null,
-                'currency' => [],
-                'is_multishipment_is_enabled' => false,
-            ])
-            ->setAllowedTypes('order_id', ['int', 'null'])
-            ->setAllowedTypes('currency', ['object'])
-            ->setAllowedTypes('is_multishipment_is_enabled', ['bool'])
-        ;
+        $resolver->setDefaults([
+            'order_id' => null,
+            'currency' => [],
+            'is_multishipment_is_enabled' => false,
+        ]);
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
@@ -365,3 +365,10 @@ services:
     arguments:
       - 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\Tag\TagType'
       - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\TagFormDataProvider'
+
+  prestashop.core.form.identifiable_object.builder.add_product_form_builder:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder'
+    factory: [ '@prestashop.core.form.builder.form_builder_factory', 'create' ]
+    arguments:
+      - 'PrestaShopBundle\Form\Admin\Sell\Order\AddProductRowType'
+      - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\AddProductFormDataProvider'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -269,3 +269,7 @@ services:
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\TagFormDataProvider:
     autowire: true
     public: false
+
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\AddProductFormDataProvider:
+    autowire: true
+    public: false

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/add_product_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/add_product_form.html.twig
@@ -94,7 +94,7 @@
     </div>
   </div>
 
-  {# to remove when the feature flag is released  #}
+  {# to remove when the feature flag is released #}
   {% do addProductForm.add.setRendered() %}
   {% do addProductForm.cancel.setRendered() %}
   {% do addProductForm.invoice.setRendered() %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/add_product_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/add_product_form.html.twig
@@ -93,6 +93,12 @@
       {{ form_row(addProductForm.confirm_new_invoice) }}
     </div>
   </div>
-</div>
 
-{{ form_end(addProductForm, {render_rest: false}) }}
+  {# to remove when the feature flag is released  #}
+  {% do addProductForm.add.setRendered() %}
+  {% do addProductForm.cancel.setRendered() %}
+  {% do addProductForm.invoice.setRendered() %}
+  {% do addProductForm.addProductCombinations.setRendered() %}
+
+  {{ form_end(addProductForm) }}
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -42,7 +42,7 @@
       class="table"
       id="orderProductsTable"
       data-currency-precision="{{ orderCurrency.precision }}"
-      data-multishipment-enabled="{{ isImprovedShipmentFeatureFlagEnabled }}"
+      data-multishipment-enabled="{{ isImprovedShipmentFeatureFlagEnabled and orderHasShipment == true }}"
     >
       <thead>
         <tr>
@@ -87,7 +87,7 @@
       </thead>
       <tbody>
         {{ include('@PrestaShop/Admin/Sell/Order/Order/Blocks/View/product_list.html.twig') }}
-        {% if isImprovedShipmentFeatureFlagEnabled is defined and isImprovedShipmentFeatureFlagEnabled == false %}
+        {% if orderHasShipment == false %}
           {{ include('@PrestaShop/Admin/Sell/Order/Order/Blocks/View/add_product_row.html.twig') }}
         {% endif %}
         {{ include('@PrestaShop/Admin/Sell/Order/Order/Blocks/View/edit_product_row.html.twig') }}
@@ -139,7 +139,7 @@
             type="button"
             class="btn btn-outline-secondary js-product-action-btn mr-3"
             id="addProductBtn"
-            {% if isImprovedShipmentFeatureFlagEnabled is defined and isImprovedShipmentFeatureFlagEnabled == true %}data-toggle="modal" data-target="#addOrderProductModal"{% endif %}
+            {% if isImprovedShipmentFeatureFlagEnabled is defined and isImprovedShipmentFeatureFlagEnabled == true and orderHasShipment == true %}data-toggle="modal" data-target="#addOrderProductModal"{% endif %}
           >
             <i class="material-icons">add_circle_outline</i>
             {{ 'Add a product'|trans({}, 'Admin.Orderscustomers.Feature') }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  The forms for add product did not use the form builder; this proposal now uses the builder, allowing the addition of hooks and splitting the retrieval into providers.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Indicate how to verify that this change works as expected.
| UI Tests          | [ui tests](https://github.com/PoulainMaxime/ga.tests.ui.pr/actions/runs/22221689067)
