### PR TITLE
Fix fuzzy search SQL when closest word contains apostrophe (#40847)

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -387,12 +387,18 @@ class SearchCore
                  */
                 $sql_param_search = self::getSearchParamFromWord($word);
                 while (!($result = $db->executeS($sql . "'" . $sql_param_search . "';", true, false))) {
-                    if (!$psFuzzySearch
-                        || $fuzzyLoop++ > $fuzzyMaxLoop
-                        || !($sql_param_search = static::findClosestWeightestWord($context, $word))
-                    ) {
+                    if (!$psFuzzySearch || $fuzzyLoop++ > $fuzzyMaxLoop) {
                         break;
                     }
+
+                    $closestWord = static::findClosestWeightestWord($context, $word);
+                    if (!$closestWord) {
+                        break;
+                    }
+
+                    // IMPORTANT: convert the closest matching word into the proper search parameter
+                    // (same normalization/escaping logic used for the original word)
+                    $sql_param_search = self::getSearchParamFromWord($closestWord);
                 }
 
                 // If nothing was found after X retries, skip this keyword


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.1.x
| Description?      |This PR fixes fuzzy search in `Search::find()`: the fallback “closest word” was previously used directly in the `LIKE` clause without applying the same normalization/escaping as the original query term, which could lead to SQL errors with special characters (e.g. apostrophes). The closest word is now passed through `getSearchParamFromWord()` before executing the query.
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | 1. Ensure fuzzy search is enabled by setting `PS_SEARCH_FUZZY = 1`.<br/>2. Edit any product name and include `s'u` in the name.<br/>3. In the Front Office, search for `shu` and verify that no errors are displayed.
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/22256472885
| Fixed issue or discussion?     | Fixes #40847
| Related PRs       | 
| Sponsor company   | Codencode snc
