### PR TITLE
Fix: in the customer form from admin side, it is missing the newsletter option as Partner Offers

### DIFF
--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -137,6 +137,10 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
             $customer->active = $command->isEnabled();
         }
 
+        if (null !== $command->isNewsletterSubscribed()) {
+            $customer->newsletter = $command->isNewsletterSubscribed();
+        }
+
         if (null !== $command->isPartnerOffersSubscribed()) {
             $customer->optin = $command->isPartnerOffersSubscribed();
         }

--- a/src/Core/Domain/Customer/Command/EditCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/EditCustomerCommand.php
@@ -285,10 +285,14 @@ class EditCustomerCommand
 
     /**
      * @param bool $isNewsletterSubscribed
+     *
+     * @return self
      */
     public function setNewsletterSubscribed($isNewsletterSubscribed)
     {
         $this->isNewsletterSubscribed = $isNewsletterSubscribed;
+
+        return $this;
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
@@ -162,6 +162,7 @@ final class CustomerFormDataHandler implements FormDataHandlerInterface
             ->setFirstName($data['first_name'])
             ->setLastName($data['last_name'])
             ->setIsEnabled($data['is_enabled'])
+            ->setNewsletterSubscribed($data['is_newsletter_subscribed'])
             ->setIsPartnerOffersSubscribed($data['is_partner_offers_subscribed'])
             ->setDefaultGroupId((int) $data['default_group_id'])
             ->setGroupIds($groupIds)

--- a/src/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProvider.php
@@ -71,6 +71,7 @@ final class CustomerFormDataProvider implements FormDataProviderInterface
             'email' => $editableCustomer->getEmail()->getValue(),
             'birthday' => $birthday->isEmpty() ? null : $birthday->getValue(),
             'is_enabled' => $editableCustomer->isEnabled(),
+            'is_newsletter_subscribed' => $editableCustomer->isNewsletterSubscribed(),
             'is_partner_offers_subscribed' => $editableCustomer->isPartnerOffersSubscribed(),
             'group_ids' => $editableCustomer->getGroupIds(),
             'default_group_id' => $editableCustomer->getDefaultGroupId(),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -260,6 +260,11 @@ class CustomerType extends TranslatorAwareType
                 ),
                 'required' => false,
             ])
+            ->add('is_newsletter_subscribed', SwitchType::class, [
+                'label' => $this->trans('Newsletter', 'Admin.Orderscustomers.Feature'),
+                'help' => '',
+                'required' => false,
+            ])
             ->add('is_partner_offers_subscribed', SwitchType::class, [
                 'label' => $this->trans('Partner offers', 'Admin.Orderscustomers.Feature'),
                 'help' => $this->trans(

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
@@ -115,6 +115,7 @@ class CustomerFormDataProviderTest extends TestCase
             'group_ids' => [1, 2, 3],
             'default_group_id' => 3,
             'is_guest' => false,
+            'is_newsletter_subscribed' => true,
         ], $customerFormDataProvider->getData(1));
     }
 
@@ -145,6 +146,7 @@ class CustomerFormDataProviderTest extends TestCase
             'max_payment_days' => 10,
             'risk_id' => 1,
             'is_guest' => false,
+            'is_newsletter_subscribed' => true,
         ], $customerFormDataProvider->getData(1));
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR adds handling for the newsletter field in the admin Customer form.
| Type?             | improvement
| Category?         | BO 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | 1. go to Customers > Customers<br>2. edit a customer<br>3. change the **Newsletter** field<br>4. verify that the field has been updated correctly
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/22297904886
| Fixed issue or discussion?     | Fixes #40856
| Related PRs       |
| Sponsor company   | Codencode snc
