### PR TITLE
Feat(OPC): introduce template feature flag for One-Page Checkout

### DIFF
--- a/classes/checkout/CheckoutProcess.php
+++ b/classes/checkout/CheckoutProcess.php
@@ -5,6 +5,9 @@
  */
 use PrestaShop\PrestaShop\Core\Foundation\Templating\RenderableInterface;
 use PrestaShop\PrestaShop\Core\Foundation\Templating\RenderableProxy;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
+use PrestaShop\PrestaShop\Adapter\ContainerFinder;
 
 class CheckoutProcessCore implements RenderableInterface
 {
@@ -160,6 +163,26 @@ class CheckoutProcessCore implements RenderableInterface
     public function hasErrors()
     {
         return $this->has_errors;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isOnePageCheckoutEnabled(): bool
+    {
+        $isConfigEnabled = (bool) Configuration::get('PS_ONE_PAGE_CHECKOUT_ENABLED');
+        if (!$isConfigEnabled) {
+            return false;
+        }
+
+        try {
+            $containerFinder = new ContainerFinder($this->context);
+            /** @var FeatureFlagStateCheckerInterface $featureFlagManager */
+            $featureFlagManager = $containerFinder->getContainer()->get(FeatureFlagStateCheckerInterface::class);
+            return $featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_ONE_PAGE_CHECKOUT);
+        } catch (Throwable $e) {
+            return false;
+        }
     }
 
     public function getDataToPersist()

--- a/classes/checkout/CheckoutProcess.php
+++ b/classes/checkout/CheckoutProcess.php
@@ -3,9 +3,7 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
-use PrestaShop\PrestaShop\Adapter\ContainerFinder;
-use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
-use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
+use PrestaShop\PrestaShop\Core\Checkout\OnePageCheckoutAvailabilityCheckerInterface;
 use PrestaShop\PrestaShop\Core\Foundation\Templating\RenderableInterface;
 use PrestaShop\PrestaShop\Core\Foundation\Templating\RenderableProxy;
 
@@ -26,6 +24,8 @@ class CheckoutProcessCore implements RenderableInterface
     private $template = 'checkout/checkout-process.tpl';
     /** @var Context */
     protected $context;
+    /** @var OnePageCheckoutAvailabilityCheckerInterface|null */
+    private $onePageCheckoutAvailabilityChecker;
 
     /**
      * @param Context $context
@@ -38,6 +38,16 @@ class CheckoutProcessCore implements RenderableInterface
         $this->context = $context;
         $this->smarty = $context->smarty;
         $this->checkoutSession = $checkoutSession;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setOnePageCheckoutAvailabilityChecker(OnePageCheckoutAvailabilityCheckerInterface $onePageCheckoutAvailabilityChecker)
+    {
+        $this->onePageCheckoutAvailabilityChecker = $onePageCheckoutAvailabilityChecker;
+
+        return $this;
     }
 
     /**
@@ -170,20 +180,11 @@ class CheckoutProcessCore implements RenderableInterface
      */
     public function isOnePageCheckoutEnabled(): bool
     {
-        $isConfigEnabled = (bool) Configuration::get('PS_ONE_PAGE_CHECKOUT_ENABLED');
-        if (!$isConfigEnabled) {
+        if (null === $this->onePageCheckoutAvailabilityChecker || !isset($this->context->shop->id)) {
             return false;
         }
 
-        try {
-            $containerFinder = new ContainerFinder($this->context);
-            /** @var FeatureFlagStateCheckerInterface $featureFlagManager */
-            $featureFlagManager = $containerFinder->getContainer()->get(FeatureFlagStateCheckerInterface::class);
-
-            return $featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_ONE_PAGE_CHECKOUT);
-        } catch (Throwable $e) {
-            return false;
-        }
+        return $this->onePageCheckoutAvailabilityChecker->isEnabledForShop((int) $this->context->shop->id);
     }
 
     public function getDataToPersist()

--- a/classes/checkout/CheckoutProcess.php
+++ b/classes/checkout/CheckoutProcess.php
@@ -3,11 +3,11 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
-use PrestaShop\PrestaShop\Core\Foundation\Templating\RenderableInterface;
-use PrestaShop\PrestaShop\Core\Foundation\Templating\RenderableProxy;
+use PrestaShop\PrestaShop\Adapter\ContainerFinder;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
-use PrestaShop\PrestaShop\Adapter\ContainerFinder;
+use PrestaShop\PrestaShop\Core\Foundation\Templating\RenderableInterface;
+use PrestaShop\PrestaShop\Core\Foundation\Templating\RenderableProxy;
 
 class CheckoutProcessCore implements RenderableInterface
 {
@@ -179,6 +179,7 @@ class CheckoutProcessCore implements RenderableInterface
             $containerFinder = new ContainerFinder($this->context);
             /** @var FeatureFlagStateCheckerInterface $featureFlagManager */
             $featureFlagManager = $containerFinder->getContainer()->get(FeatureFlagStateCheckerInterface::class);
+
             return $featureFlagManager->isEnabled(FeatureFlagSettings::FEATURE_FLAG_ONE_PAGE_CHECKOUT);
         } catch (Throwable $e) {
             return false;

--- a/config/services/common.yml
+++ b/config/services/common.yml
@@ -3,6 +3,7 @@ parameters:
 
 imports:
     - { resource: ../../src/PrestaShopBundle/Resources/config/services/core/cldr.yml }
+    - { resource: ../../src/PrestaShopBundle/Resources/config/services/core/checkout.yml }
     - { resource: ../../src/PrestaShopBundle/Resources/config/services/adapter/data_provider_common.yml }
     - { resource: ../../src/PrestaShopBundle/Resources/config/services/adapter/common.yml }
     - { resource: ../../src/PrestaShopBundle/Resources/config/services/core/common.yml }

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -301,6 +301,7 @@ class OrderControllerCore extends FrontController
             'checkout_process' => new RenderableProxy($this->checkoutProcess),
             'display_transaction_updated_info' => Tools::getIsset('updatedTransaction'),
             'tos_cms' => $this->getDefaultTermsAndConditions(),
+            'is_one_page_checkout_enabled' => $this->checkoutProcess->isOnePageCheckoutEnabled(),
         ]);
 
         parent::initContent();

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -6,6 +6,7 @@
 
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Shipment\DeliveryOptionsProvider;
+use PrestaShop\PrestaShop\Core\Checkout\OnePageCheckoutAvailabilityCheckerInterface;
 use PrestaShop\PrestaShop\Core\Checkout\TermsAndConditions;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
@@ -382,6 +383,9 @@ class OrderControllerCore extends FrontController
             $this->context,
             $session
         );
+        /** @var OnePageCheckoutAvailabilityCheckerInterface $onePageCheckoutAvailabilityChecker */
+        $onePageCheckoutAvailabilityChecker = $this->get(OnePageCheckoutAvailabilityCheckerInterface::class);
+        $checkoutProcess->setOnePageCheckoutAvailabilityChecker($onePageCheckoutAvailabilityChecker);
 
         $checkoutProcess
             ->addStep(new CheckoutPersonalInformationStep(

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -323,6 +323,9 @@
   <configuration id="PS_GUEST_CHECKOUT_ENABLED" name="PS_GUEST_CHECKOUT_ENABLED">
     <value>1</value>
   </configuration>
+  <configuration id="PS_ONE_PAGE_CHECKOUT_ENABLED" name="PS_ONE_PAGE_CHECKOUT_ENABLED">
+    <value>0</value>
+  </configuration>
   <configuration id="PS_DISPLAY_SUPPLIERS" name="PS_DISPLAY_SUPPLIERS">
     <value>0</value>
   </configuration>

--- a/src/Adapter/Order/Checkout/OnePageCheckoutAvailabilityChecker.php
+++ b/src/Adapter/Order/Checkout/OnePageCheckoutAvailabilityChecker.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Order\Checkout;
+
+use Exception;
+use PrestaShop\PrestaShop\Core\Checkout\OnePageCheckoutAvailabilityCheckerInterface;
+use PrestaShop\PrestaShop\Core\Checkout\OnePageCheckoutSettings;
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
+
+/**
+ * Determines if One Page Checkout can be used for the specified shop based on configuration and feature flag state.
+ */
+final class OnePageCheckoutAvailabilityChecker implements OnePageCheckoutAvailabilityCheckerInterface
+{
+    public function __construct(
+        private readonly ShopConfigurationInterface $configuration,
+        private readonly FeatureFlagStateCheckerInterface $featureFlagStateChecker,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEnabledForShop(int $shopId): bool
+    {
+        try {
+            $isConfigurationEnabled = (bool) $this->configuration->get(
+                OnePageCheckoutSettings::ONE_PAGE_CHECKOUT_ENABLED,
+                false,
+                ShopConstraint::shop($shopId)
+            );
+
+            if (!$isConfigurationEnabled) {
+                return false;
+            }
+
+            return $this->featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_ONE_PAGE_CHECKOUT);
+        } catch (Exception) {
+            return false;
+        }
+    }
+}

--- a/src/Core/Checkout/OnePageCheckoutAvailabilityCheckerInterface.php
+++ b/src/Core/Checkout/OnePageCheckoutAvailabilityCheckerInterface.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace PrestaShop\PrestaShop\Core\Checkout;
+
+/**
+ * Defines how to check One Page Checkout availability for a specific shop.
+ */
+interface OnePageCheckoutAvailabilityCheckerInterface
+{
+    /**
+     * Returns whether One Page Checkout is enabled for the given shop.
+     *
+     * @param int $shopId
+     *
+     * @return bool
+     */
+    public function isEnabledForShop(int $shopId): bool;
+}

--- a/src/Core/Checkout/OnePageCheckoutSettings.php
+++ b/src/Core/Checkout/OnePageCheckoutSettings.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace PrestaShop\PrestaShop\Core\Checkout;
+
+final class OnePageCheckoutSettings
+{
+    public const ONE_PAGE_CHECKOUT_ENABLED = 'PS_ONE_PAGE_CHECKOUT_ENABLED';
+}

--- a/src/Core/FeatureFlag/FeatureFlagSettings.php
+++ b/src/Core/FeatureFlag/FeatureFlagSettings.php
@@ -35,4 +35,5 @@ class FeatureFlagSettings
     public const FEATURE_FLAG_FRONT_CONTAINER_V2 = 'front_container_v2';
     public const FEATURE_FLAG_IMPROVED_SHIPMENT = 'improved_shipment';
     public const FEATURE_FLAG_DISCOUNT = 'discount';
+    public const FEATURE_FLAG_ONE_PAGE_CHECKOUT = 'one_page_checkout';
 }

--- a/src/PrestaShopBundle/Resources/config/services/core/checkout.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/checkout.yml
@@ -1,0 +1,12 @@
+services:
+  _defaults:
+    public: false
+
+  PrestaShop\PrestaShop\Adapter\Order\Checkout\OnePageCheckoutAvailabilityChecker:
+    arguments:
+      - '@PrestaShop\PrestaShop\Adapter\Configuration'
+      - '@PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface'
+
+  PrestaShop\PrestaShop\Core\Checkout\OnePageCheckoutAvailabilityCheckerInterface:
+    alias: PrestaShop\PrestaShop\Adapter\Order\Checkout\OnePageCheckoutAvailabilityChecker
+    public: true

--- a/tests/Integration/Adapter/Order/Checkout/OnePageCheckoutAvailabilityCheckerTest.php
+++ b/tests/Integration/Adapter/Order/Checkout/OnePageCheckoutAvailabilityCheckerTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Order\Checkout;
+
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\Shop\Context as ShopContext;
+use PrestaShop\PrestaShop\Core\Checkout\OnePageCheckoutAvailabilityCheckerInterface;
+use PrestaShop\PrestaShop\Core\Checkout\OnePageCheckoutSettings;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagManager;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+class OnePageCheckoutAvailabilityCheckerTest extends KernelTestCase
+{
+    private OnePageCheckoutAvailabilityCheckerInterface $onePageCheckoutAvailabilityChecker;
+    private FeatureFlagManager $featureFlagManager;
+    private Configuration $configuration;
+    private ShopContext $shopContext;
+
+    private int $shopId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::resetTables();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::resetTables();
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $container = self::getContainer();
+
+        $this->onePageCheckoutAvailabilityChecker = $container->get(OnePageCheckoutAvailabilityCheckerInterface::class);
+        $this->featureFlagManager = $container->get(FeatureFlagManager::class);
+        $this->configuration = $container->get(Configuration::class);
+        $this->shopContext = $container->get(ShopContext::class);
+
+        $this->shopId = $this->shopContext->getContextShopID();
+    }
+
+    protected static function resetTables(): void
+    {
+        DatabaseDump::restoreTables(['configuration', 'feature_flag']);
+    }
+
+    public function testItReturnsTrueWhenFeatureFlagAndShopConfigurationAreEnabled(): void
+    {
+        $this->configuration->set(OnePageCheckoutSettings::ONE_PAGE_CHECKOUT_ENABLED, true, ShopConstraint::shop($this->shopId));
+        $this->featureFlagManager->enable(FeatureFlagSettings::FEATURE_FLAG_ONE_PAGE_CHECKOUT);
+
+        $this->assertTrue($this->onePageCheckoutAvailabilityChecker->isEnabledForShop($this->shopId));
+    }
+
+    public function testItReturnsFalseWhenFeatureFlagIsDisabled(): void
+    {
+        $this->configuration->set(OnePageCheckoutSettings::ONE_PAGE_CHECKOUT_ENABLED, true, ShopConstraint::shop($this->shopId));
+        $this->featureFlagManager->disable(FeatureFlagSettings::FEATURE_FLAG_ONE_PAGE_CHECKOUT);
+
+        $this->assertFalse($this->onePageCheckoutAvailabilityChecker->isEnabledForShop($this->shopId));
+    }
+
+    public function testItReturnsFalseWhenConfigurationIsDisabled(): void
+    {
+        $this->configuration->set(OnePageCheckoutSettings::ONE_PAGE_CHECKOUT_ENABLED, false, ShopConstraint::shop($this->shopId));
+        $this->featureFlagManager->enable(FeatureFlagSettings::FEATURE_FLAG_ONE_PAGE_CHECKOUT);
+
+        $this->assertFalse($this->onePageCheckoutAvailabilityChecker->isEnabledForShop($this->shopId));
+    }
+
+    public function testItUsesGlobalFallbackWhenShopValueIsNotDefined(): void
+    {
+        $this->configuration->deleteFromContext(OnePageCheckoutSettings::ONE_PAGE_CHECKOUT_ENABLED, ShopConstraint::shop($this->shopId));
+        $this->configuration->set(OnePageCheckoutSettings::ONE_PAGE_CHECKOUT_ENABLED, true, ShopConstraint::allShops());
+        $this->featureFlagManager->enable(FeatureFlagSettings::FEATURE_FLAG_ONE_PAGE_CHECKOUT);
+
+        $this->assertTrue($this->onePageCheckoutAvailabilityChecker->isEnabledForShop($this->shopId));
+    }
+}

--- a/tests/Unit/Adapter/Order/Checkout/OnePageCheckoutAvailabilityCheckerTest.php
+++ b/tests/Unit/Adapter/Order/Checkout/OnePageCheckoutAvailabilityCheckerTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\Adapter\Order\Checkout;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Order\Checkout\OnePageCheckoutAvailabilityChecker;
+use PrestaShop\PrestaShop\Core\Checkout\OnePageCheckoutSettings;
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
+use RuntimeException;
+
+class OnePageCheckoutAvailabilityCheckerTest extends TestCase
+{
+    private const SHOP_ID = 42;
+
+    private ShopConfigurationInterface|MockObject $configuration;
+    private FeatureFlagStateCheckerInterface|MockObject $featureFlagStateChecker;
+
+    private OnePageCheckoutAvailabilityChecker $onePageCheckoutAvailabilityChecker;
+
+    protected function setUp(): void
+    {
+        $this->configuration = $this->createMock(ShopConfigurationInterface::class);
+        $this->featureFlagStateChecker = $this->createMock(FeatureFlagStateCheckerInterface::class);
+
+        $this->onePageCheckoutAvailabilityChecker = new OnePageCheckoutAvailabilityChecker(
+            $this->configuration,
+            $this->featureFlagStateChecker
+        );
+    }
+
+    /**
+     * @dataProvider provideAvailabilityCases
+     */
+    public function testItReturnsExpectedAvailability(
+        bool $isConfigurationEnabled,
+        bool $isFeatureFlagEnabled,
+        bool $expectedResult
+    ): void {
+        $this->configuration
+            ->expects($this->once())
+            ->method('get')
+            ->with(
+                OnePageCheckoutSettings::ONE_PAGE_CHECKOUT_ENABLED,
+                false,
+                $this->callback(fn (ShopConstraint $shopConstraint): bool => $shopConstraint->isEqual(ShopConstraint::shop(self::SHOP_ID)))
+            )
+            ->willReturn($isConfigurationEnabled)
+        ;
+
+        if ($isConfigurationEnabled) {
+            $this->featureFlagStateChecker
+                ->expects($this->once())
+                ->method('isEnabled')
+                ->with(FeatureFlagSettings::FEATURE_FLAG_ONE_PAGE_CHECKOUT)
+                ->willReturn($isFeatureFlagEnabled)
+            ;
+        } else {
+            $this->featureFlagStateChecker
+                ->expects($this->never())
+                ->method('isEnabled')
+            ;
+        }
+
+        $this->assertSame($expectedResult, $this->onePageCheckoutAvailabilityChecker->isEnabledForShop(self::SHOP_ID));
+    }
+
+    /**
+     * @return iterable<array{bool, bool, bool}>
+     */
+    public function provideAvailabilityCases(): iterable
+    {
+        yield 'configuration disabled' => [false, false, false];
+        yield 'configuration enabled and feature flag disabled' => [true, false, false];
+        yield 'configuration enabled and feature flag enabled' => [true, true, true];
+    }
+
+    public function testItReturnsFalseWhenConfigurationThrowsException(): void
+    {
+        $this->configuration
+            ->expects($this->once())
+            ->method('get')
+            ->willThrowException(new RuntimeException('Configuration read failed'))
+        ;
+
+        $this->featureFlagStateChecker
+            ->expects($this->never())
+            ->method('isEnabled')
+        ;
+
+        $this->assertFalse($this->onePageCheckoutAvailabilityChecker->isEnabledForShop(self::SHOP_ID));
+    }
+
+    public function testItReturnsFalseWhenFeatureFlagCheckerThrowsException(): void
+    {
+        $this->configuration
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn(true)
+        ;
+
+        $this->featureFlagStateChecker
+            ->expects($this->once())
+            ->method('isEnabled')
+            ->willThrowException(new RuntimeException('Feature flag check failed'))
+        ;
+
+        $this->assertFalse($this->onePageCheckoutAvailabilityChecker->isEnabledForShop(self::SHOP_ID));
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds `is_one_page_checkout_enabled` flag to FO templates. The flag is true only if feature flag `one_page_checkout` and config `PS_ONE_PAGE_CHECKOUT_ENABLED=1` are both enabled.
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable both flag and config → true. Disable either → false.
| UI Tests          | https://github.com/ThbPS/ga.tests.ui.pr/actions/runs/22481554491
| Fixed issue or discussion?     | N/A
| Related PRs       | None
| Sponsor company   | N/A

### Note

This pull request introduces the foundation required to enable One-page checkout (OPC), without changing the default checkout flow.
 - Adds a new feature flag ```one_page_checkout``` (beta, disabled by default).
- Adds a new shop configuration ```PS_ONE_PAGE_CHECKOUT_ENABLED``` (default: 0).
- Exposes a new Smarty variable ```is_one_page_checkout_enabled``` on the order page.
- Makes the OPC availability flag accessible from the back office, so themes and modules can rely on a single, consistent source.
- OPC is enabled only if the shop configuration and feature flag are enabled.
- Any error while reading configuration or feature flag results in OPC being disabled (fail-safe behavior).

By default, the checkout behavior remains unchanged. This PR only exposes the capability to enable OPC, it does not alter templates or the checkout UI.