### PR TITLE
Hide expiration field when "period never expires" is checked

### DIFF
--- a/admin-dev/themes/new-theme/js/components/form/form-field-toggler.ts
+++ b/admin-dev/themes/new-theme/js/components/form/form-field-toggler.ts
@@ -113,7 +113,7 @@ export default class FormFieldToggler {
     this.toggle(targetSelector, disabledState, switchEvent);
   }
 
-  private getInputValue(inputElement: HTMLInputElement): string | undefined {
+  private getInputValue(inputElement: HTMLInputElement): string | false | undefined {
     switch (inputElement.type) {
       case 'radio': {
         const checkedRadios = document.querySelectorAll<HTMLInputElement>(`[name="${inputElement.name}"]`);
@@ -127,7 +127,7 @@ export default class FormFieldToggler {
         return checkedValue;
       }
       case 'checkbox':
-        return inputElement.checked ? inputElement.value : undefined;
+        return inputElement.checked ? inputElement.value : false;
       default:
         return inputElement.value;
     }

--- a/admin-dev/themes/new-theme/js/pages/discount/discount-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/discount/discount-map.ts
@@ -28,4 +28,6 @@ export default {
   productSegmentFeatures: '#discount_conditions_product_product_segment_features',
   quantityPerCustomerInput: '#discount_usability_quantity_per_customer',
   customerEligibilityInput: '#discount_customer_eligibility_eligibility',
+  periodNeverExpiresCheckbox: 'input[name*="[period_never_expires]"]',
+  periodExpiryDateFormGroup: '.date-range.row .col:has(.date-range-end-date)',
 };

--- a/admin-dev/themes/new-theme/js/pages/discount/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/discount/form/index.ts
@@ -3,6 +3,7 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 
+import FormFieldToggler, {ToggleType} from '@components/form/form-field-toggler';
 import PriceReductionManager from '@components/form/price-reduction-manager';
 import DiscountMap from '@pages/discount/discount-map';
 import CreateFreeGiftDiscount from '@pages/discount/form/create-free-gift-discount';
@@ -74,6 +75,14 @@ $(() => {
   } else {
     $(DiscountMap.quantityPerCustomerInput).parents('.form-group').show();
   }
+
+  new FormFieldToggler({
+    disablingInputSelector: DiscountMap.periodNeverExpiresCheckbox,
+    matchingValue: '1',
+    disableOnMatch: true,
+    targetSelector: DiscountMap.periodExpiryDateFormGroup,
+    toggleType: ToggleType.visibility,
+  });
 
   $(DiscountMap.countriesSelect).select2({
     templateResult: formatOption,

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -10,6 +10,7 @@ use PrestaShop\PrestaShop\Core\Domain\Discount\DiscountSettings;
 use PrestaShop\PrestaShop\Core\Domain\Discount\ValueObject\DiscountType;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 
 /**
  * Class CartRuleCore.
@@ -46,7 +47,7 @@ class CartRuleCore extends ObjectModel
     /**
      * @var string|null
      */
-    public $date_to;
+    public $date_to = null;
     public $description;
     public $quantity = 1;
     public ?int $total_quantity = null;
@@ -111,7 +112,7 @@ class CartRuleCore extends ObjectModel
         'fields' => [
             'id_customer' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
             'date_from' => ['type' => self::TYPE_DATE, 'validate' => 'isDate', 'required' => true],
-            'date_to' => ['type' => self::TYPE_DATE, 'validate' => 'isDate', 'required' => true],
+            'date_to' => ['type' => self::TYPE_DATE, 'validate' => 'isDateOrNull', 'required' => false, 'allow_null' => true],
             'description' => ['type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'size' => DiscountSettings::MAX_DESCRIPTION_LENGTH],
             'quantity' => ['type' => self::TYPE_INT, 'allow_null' => true, 'validate' => 'isUnsignedInt'],
             'total_quantity' => ['type' => self::TYPE_INT, 'allow_null' => true, 'validate' => 'isUnsignedInt'],
@@ -377,8 +378,9 @@ class CartRuleCore extends ObjectModel
                 '") OR (date_from >= "' . $start_date .
                 '" AND date_from <= "' . $end_date .
                 '") OR (date_from < "' . $start_date .
-                '" AND date_to > "' . $end_date .
-                '")) AND `id_customer` IN (0,' . (int) $idCustomer . ')';
+                '" AND (date_to > "' . $end_date .
+                '" OR date_to IS NULL)' .
+                ')) AND `id_customer` IN (0,' . (int) $idCustomer . ')';
 
             $haveCartRuleToday[$idCustomer] = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
         }
@@ -432,7 +434,7 @@ class CartRuleCore extends ObjectModel
         $sql .= ')';
 
         // Then, conditions for date, voucher active property and total amount of vouchers in stock
-        $sql .= ' AND NOW() BETWEEN cr.date_from AND cr.date_to
+        $sql .= ' AND ((cr.date_from <= NOW() AND cr.date_to IS NULL) OR (NOW() BETWEEN cr.date_from AND cr.date_to))
             ' . ($active ? 'AND cr.`active` = 1' : '') . '
             ' . ($inStock ? 'AND (cr.`quantity` > 0 OR cr.`quantity` is null)' : '');
 
@@ -789,7 +791,7 @@ class CartRuleCore extends ObjectModel
             if (strtotime($this->date_from) > time()) {
                 return (!$display_error) ? false : $this->trans('This voucher is not valid yet', [], 'Shop.Notifications.Error');
             }
-            if (strtotime($this->date_to) < time()) {
+            if (!DateTimeUtil::isNull($this->date_to ?? null) && strtotime($this->date_to) < time()) {
                 return (!$display_error) ? false : $this->trans('This voucher has expired', [], 'Shop.Notifications.Error');
             }
 
@@ -1995,7 +1997,7 @@ class CartRuleCore extends ObjectModel
 		WHERE cr.active = 1
 		AND cr.code = ""
 		AND (cr.quantity > 0 OR cr.quantity is null)
-        AND NOW() BETWEEN cr.date_from AND cr.date_to
+		AND ((cr.date_from <= NOW() AND cr.date_to IS NULL) OR (NOW() BETWEEN cr.date_from AND cr.date_to))
 		AND (
 			cr.id_customer = 0
 			' . (Validate::isLoadedObject($context->customer) ? 'OR cr.id_customer = ' . (int) $context->cart->id_customer : '') . '

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "prestashop/hummingbird": "^2.0",
         "prestashop/pagesnotfound": "^3",
         "prestashop/productcomments": "^8.0",
-        "prestashop/ps_apiresources": "0.5.0",
+        "prestashop/ps_apiresources": "dev-change-validto",
         "prestashop/ps_banner": "^2",
         "prestashop/ps_bestsellers": "^1.0",
         "prestashop/ps_brandlist": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d093436d510292d38939f8f83b18d79d",
+    "content-hash": "e84fc033e547231cc577e5f8ceb7ec1d",
     "packages": [
         {
             "name": "api-platform/core",
@@ -5208,16 +5208,16 @@
         },
         {
             "name": "prestashop/ps_apiresources",
-            "version": "v0.5.0",
+            "version": "dev-change-validto",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_apiresources.git",
-                "reference": "9521020fbdbc3b8791b077f1af148e007a99dce1"
+                "reference": "c74a019fc74aa0df82b5b5a8187ca17c1fbfe9bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_apiresources/zipball/9521020fbdbc3b8791b077f1af148e007a99dce1",
-                "reference": "9521020fbdbc3b8791b077f1af148e007a99dce1",
+                "url": "https://api.github.com/repos/PrestaShop/ps_apiresources/zipball/c74a019fc74aa0df82b5b5a8187ca17c1fbfe9bc",
+                "reference": "c74a019fc74aa0df82b5b5a8187ca17c1fbfe9bc",
                 "shasum": ""
             },
             "require": {
@@ -5281,10 +5281,10 @@
             "description": "PrestaShop - API Resources",
             "homepage": "https://github.com/PrestaShop/ps_apiresources",
             "support": {
-                "source": "https://github.com/PrestaShop/ps_apiresources/tree/v0.5.0",
+                "source": "https://github.com/PrestaShop/ps_apiresources/tree/change-validto",
                 "issues": "https://github.com/PrestaShop/ps_apiresources/issues"
             },
-            "time": "2026-02-18T13:38:08+00:00"
+            "time": "2026-02-24T15:00:54+00:00"
         },
         {
             "name": "prestashop/ps_banner",
@@ -18303,7 +18303,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "prestashop/ps_apiresources": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -167,7 +167,7 @@ CREATE TABLE `PREFIX_cart_rule` (
   `id_cart_rule` int(10) unsigned NOT NULL auto_increment,
   `id_customer` int unsigned NOT NULL DEFAULT '0',
   `date_from` datetime NOT NULL,
-  `date_to` datetime NOT NULL,
+  `date_to` datetime DEFAULT NULL,
   `description` MEDIUMTEXT,
   `quantity` int(10) unsigned DEFAULT '0',
   `quantity_per_user` int(10) unsigned DEFAULT '0',

--- a/src/Adapter/Discount/QueryHandler/GetDiscountForEditingHandler.php
+++ b/src/Adapter/Discount/QueryHandler/GetDiscountForEditingHandler.php
@@ -16,6 +16,7 @@ use PrestaShop\PrestaShop\Core\Domain\Discount\DiscountSettings;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Query\GetDiscountForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Discount\QueryHandler\GetDiscountForEditingHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Discount\QueryResult\DiscountForEditing;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 
 #[AsQueryHandler]
 class GetDiscountForEditingHandler implements GetDiscountForEditingHandlerInterface
@@ -45,7 +46,7 @@ class GetDiscountForEditingHandler implements GetDiscountForEditingHandlerInterf
             $cartRule->priority,
             $cartRule->active,
             new DateTimeImmutable($cartRule->date_from),
-            new DateTimeImmutable($cartRule->date_to),
+            DateTimeUtil::buildDateTimeOrNull($cartRule->date_to),
             $cartRule->total_quantity,
             $cartRule->quantity,
             $quantityUsedInOrders,

--- a/src/Adapter/Discount/Update/DiscountBuilder.php
+++ b/src/Adapter/Discount/Update/DiscountBuilder.php
@@ -25,7 +25,7 @@ class DiscountBuilder
     {
         $cartRule = new CartRule();
         $validFrom = $command->getValidFrom() ?: new DateTimeImmutable();
-        $validTo = $command->getValidTo() ?: $validFrom->modify('+1 month');
+        $validTo = $command->getValidTo();
 
         $cartRule->name = $command->getLocalizedNames();
         $cartRule->description = $command->getDescription();
@@ -36,7 +36,7 @@ class DiscountBuilder
         $cartRule->active = $command->isActive();
         $cartRule->id_customer = $command->getCustomerId()?->getValue();
         $cartRule->date_from = $validFrom->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT);
-        $cartRule->date_to = $validTo->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT);
+        $cartRule->date_to = $validTo !== null ? $validTo->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT) : null;
         // We are initializing the discount so the remaining quantity and the total quantity are the same thing
         $cartRule->total_quantity = $command->getTotalQuantity();
         $cartRule->quantity = $command->getTotalQuantity();

--- a/src/Adapter/Discount/Update/Filler/DiscountFiller.php
+++ b/src/Adapter/Discount/Update/Filler/DiscountFiller.php
@@ -32,7 +32,8 @@ class DiscountFiller
             $updatableProperties[] = 'date_from';
         }
         if ($command->isDirty('validTo')) {
-            $cartRule->date_to = $command->getValidTo()->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT);
+            $validTo = $command->getValidTo();
+            $cartRule->date_to = $validTo !== null ? $validTo->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT) : null;
             $updatableProperties[] = 'date_to';
         }
         if ($command->isDirty('localizedNames')) {

--- a/src/Adapter/Discount/Validate/DiscountValidator.php
+++ b/src/Adapter/Discount/Validate/DiscountValidator.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 use PrestaShopException;
 
 /**
@@ -296,6 +297,10 @@ class DiscountValidator extends AbstractObjectModelValidator
 
     private function assertDateRangeIsCorrect(CartRule $cartrule): void
     {
+        if (DateTimeUtil::isNull($cartrule->date_to)) {
+            return;
+        }
+
         if ($cartrule->date_from > $cartrule->date_to) {
             throw new DiscountConstraintException('Date from cannot be greater than date to.', DiscountConstraintException::DATE_FROM_GREATER_THAN_DATE_TO);
         }

--- a/src/Core/Domain/Discount/Command/AddDiscountCommand.php
+++ b/src/Core/Domain/Discount/Command/AddDiscountCommand.php
@@ -124,9 +124,11 @@ class AddDiscountCommand
     /**
      * @throws DiscountConstraintException
      */
-    public function setValidityDateRange(DateTimeImmutable $from, DateTimeImmutable $to): self
+    public function setValidityDateRange(DateTimeImmutable $from, ?DateTimeImmutable $to = null): self
     {
-        $this->assertDateRangeIsValid($from, $to);
+        if ($to !== null) {
+            $this->assertDateRangeIsValid($from, $to);
+        }
         $this->validFrom = $from;
         $this->validTo = $to;
 

--- a/src/Core/Domain/Discount/Command/UpdateDiscountCommand.php
+++ b/src/Core/Domain/Discount/Command/UpdateDiscountCommand.php
@@ -136,7 +136,7 @@ class UpdateDiscountCommand
         return $this;
     }
 
-    public function setValidTo(DateTimeImmutable $validTo): self
+    public function setValidTo(?DateTimeImmutable $validTo): self
     {
         $this->validTo = $validTo;
         $this->markDirty('validTo');
@@ -147,9 +147,9 @@ class UpdateDiscountCommand
     /**
      * @throws DiscountConstraintException
      */
-    public function setValidityDateRange(DateTimeImmutable $from, DateTimeImmutable $to): self
+    public function setValidityDateRange(DateTimeImmutable $from, ?DateTimeImmutable $to = null): self
     {
-        if ($from > $to) {
+        if ($to !== null && $from > $to) {
             throw new DiscountConstraintException('Date from cannot be greater than date to.', DiscountConstraintException::DATE_FROM_GREATER_THAN_DATE_TO);
         }
 

--- a/src/Core/Form/IdentifiableObject/DataHandler/DiscountFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/DiscountFormDataHandler.php
@@ -128,13 +128,12 @@ class DiscountFormDataHandler implements FormDataHandlerInterface
 
             $neverExpires = !empty($data['period']['period_never_expires']);
             if ($neverExpires) {
-                $validTo = (new DateTime())->modify('+100 years')->setTime(23, 59, 59);
-                $validTo = DateTimeImmutable::createFromMutable($validTo);
+                $validTo = null;
             } else {
                 $validTo = $this->parseDateWithDefaultTime($dateRange['to'] ?? null, '23:59');
             }
 
-            if ($validFrom && $validTo) {
+            if ($validFrom) {
                 $command->setValidityDateRange($validFrom, $validTo);
             }
         }

--- a/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
@@ -7,7 +7,6 @@
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
 
 use DateTime;
-use DateTimeInterface;
 use PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository;
 use PrestaShop\PrestaShop\Adapter\Customer\Repository\CustomerRepository;
 use PrestaShop\PrestaShop\Adapter\Feature\Repository\FeatureValueRepository;
@@ -212,7 +211,7 @@ class DiscountFormDataProvider implements FormDataProviderInterface
                     'from' => $discountForEditing->getValidFrom() ? $discountForEditing->getValidFrom()->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT) : null,
                     'to' => $discountForEditing->getValidTo() ? $discountForEditing->getValidTo()->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT) : null,
                 ],
-                'period_never_expires' => $this->isPeriodNeverExpires($discountForEditing->getValidFrom(), $discountForEditing->getValidTo()),
+                'period_never_expires' => null === $discountForEditing->getValidTo(),
             ],
             'customer_eligibility' => [
                 'eligibility' => $this->getCustomerEligibilityData($discountForEditing),
@@ -464,20 +463,5 @@ class DiscountFormDataProvider implements FormDataProviderInterface
         }
 
         return $data;
-    }
-
-    /**
-     * Check if the discount period is set to "never expires" (>= 100 years duration).
-     */
-    private function isPeriodNeverExpires(?DateTimeInterface $validFrom, ?DateTimeInterface $validTo): bool
-    {
-        if ($validFrom === null || $validTo === null) {
-            return false;
-        }
-
-        $diff = $validFrom->diff($validTo);
-        $years = $diff->y + ($diff->m / 12) + ($diff->d / 365);
-
-        return $years >= 100;
     }
 }

--- a/src/Core/Grid/Data/Factory/DiscountGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/DiscountGridDataFactoryDecorator.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Grid\Data\GridDataInterface;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
+
+/**
+ * Decorates discount grid data to display a fallback when expiration date is null
+ */
+final class DiscountGridDataFactoryDecorator implements GridDataFactoryInterface
+{
+    private const EMPTY_DATE_FALLBACK = '—';
+
+    public function __construct(
+        private readonly GridDataFactoryInterface $discountGridDataFactory,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(SearchCriteriaInterface $searchCriteria): GridDataInterface
+    {
+        $data = $this->discountGridDataFactory->getData($searchCriteria);
+        $records = $data->getRecords()->all();
+
+        foreach ($records as &$record) {
+            if (DateTimeUtil::isNull($record['date_to'] ?? null)) {
+                $record['date_to'] = self::EMPTY_DATE_FALLBACK;
+            }
+        }
+
+        return new GridData(
+            new RecordCollection($records),
+            $data->getRecordsTotal(),
+            $data->getQuery()
+        );
+    }
+}

--- a/src/Core/Grid/Data/Factory/DiscountGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/DiscountGridDataFactoryDecorator.php
@@ -13,16 +13,16 @@ use PrestaShop\PrestaShop\Core\Grid\Data\GridDataInterface;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Decorates discount grid data to display a fallback when expiration date is null
  */
 final class DiscountGridDataFactoryDecorator implements GridDataFactoryInterface
 {
-    private const EMPTY_DATE_FALLBACK = '—';
-
     public function __construct(
         private readonly GridDataFactoryInterface $discountGridDataFactory,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 
@@ -36,7 +36,7 @@ final class DiscountGridDataFactoryDecorator implements GridDataFactoryInterface
 
         foreach ($records as &$record) {
             if (DateTimeUtil::isNull($record['date_to'] ?? null)) {
-                $record['date_to'] = self::EMPTY_DATE_FALLBACK;
+                $record['date_to'] = $this->translator->trans('No end date', [], 'Admin.Catalog.Feature');
             }
         }
 

--- a/src/PrestaShopBundle/ApiPlatform/Normalizer/DateTimeImmutableNormalizer.php
+++ b/src/PrestaShopBundle/ApiPlatform/Normalizer/DateTimeImmutableNormalizer.php
@@ -23,6 +23,10 @@ class DateTimeImmutableNormalizer implements DenormalizerInterface, NormalizerIn
 {
     public function denormalize($data, string $type, ?string $format = null, array $context = [])
     {
+        if (DateTimeUtil::isNull($data)) {
+            return null;
+        }
+
         return new DateTimeImmutable($data);
     }
 

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -342,6 +342,11 @@ services:
       - '@prestashop.core.grid.query.doctrine_query_parser'
       - 'discount'
 
+  prestashop.core.grid.data.factory.discount_decorator:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\DiscountGridDataFactoryDecorator'
+    arguments:
+      - '@prestashop.core.grid.data.factory.discount'
+
   prestashop.core.grid.data.factory.catalog_price_rule:
     class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -346,6 +346,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\DiscountGridDataFactoryDecorator'
     arguments:
       - '@prestashop.core.grid.data.factory.discount'
+      - '@translator'
 
   prestashop.core.grid.data.factory.catalog_price_rule:
     class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
@@ -276,7 +276,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
     arguments:
       - '@prestashop.core.grid.definition.factory.discount'
-      - '@prestashop.core.grid.data.factory.discount'
+      - '@prestashop.core.grid.data.factory.discount_decorator'
       - '@prestashop.core.grid.filter.form_factory'
       - '@prestashop.core.hook.dispatcher'
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Discount/DiscountFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Discount/DiscountFeatureContext.php
@@ -9,9 +9,7 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Discount;
 use Behat\Gherkin\Node\TableNode;
 use Cart;
 use CartRule;
-use DateTime;
 use DateTimeImmutable;
-use DateTimeInterface;
 use Exception;
 use PHPUnit\Framework\Assert;
 use PrestaShop\Decimal\DecimalNumber;
@@ -202,11 +200,8 @@ class DiscountFeatureContext extends AbstractDomainFeatureContext
         if (isset($data['valid_from'])) {
             $validFrom = new DateTimeImmutable($data['valid_from']);
 
-            // Check if "never expires" is set
             if (isset($data['period_never_expires']) && PrimitiveUtils::castStringBooleanIntoBoolean($data['period_never_expires'])) {
-                // Set expiration date to 100 years in the future
-                $validTo = (new DateTime())->modify('+100 years')->setTime(23, 59, 59);
-                $validTo = DateTimeImmutable::createFromMutable($validTo);
+                $validTo = null;
             } elseif (!empty($data['valid_to'])) {
                 $validTo = new DateTimeImmutable($data['valid_to']);
             } else {
@@ -380,17 +375,14 @@ class DiscountFeatureContext extends AbstractDomainFeatureContext
             $command->setActive(PrimitiveUtils::castStringBooleanIntoBoolean($data['active']));
         }
         if (isset($data['period_never_expires']) && PrimitiveUtils::castStringBooleanIntoBoolean($data['period_never_expires'])) {
-            // When "never expires" is set, use 100 years in the future
             if (isset($data['valid_from'])) {
                 $validFrom = new DateTimeImmutable($data['valid_from']);
             } else {
                 $validFrom = new DateTimeImmutable();
             }
-            $validTo = (new DateTime())->modify('+100 years')->setTime(23, 59, 59);
-            $validTo = DateTimeImmutable::createFromMutable($validTo);
 
             try {
-                $command->setValidityDateRange($validFrom, $validTo);
+                $command->setValidityDateRange($validFrom, null);
             } catch (DiscountConstraintException $e) {
                 $this->setLastException($e);
             }
@@ -718,7 +710,7 @@ class DiscountFeatureContext extends AbstractDomainFeatureContext
             Assert::assertSame($this->referencesToIds($expectedData['countries']), $discountForEditing->getCountryIds(), 'Unexpected countries');
         }
         if (isset($expectedData['period_never_expires'])) {
-            $neverExpires = $this->isPeriodNeverExpires($discountForEditing->getValidTo());
+            $neverExpires = $discountForEditing->getValidTo() === null;
             Assert::assertSame(
                 PrimitiveUtils::castStringBooleanIntoBoolean($expectedData['period_never_expires']),
                 $neverExpires,
@@ -731,40 +723,15 @@ class DiscountFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then discount :discountReference expiration date should be more than :years years in the future
+     * @Then discount :discountReference should have no expiration date
      */
-    public function assertExpirationDateIsFarInFuture(string $discountReference, int $years = 50): void
+    public function assertDiscountHasNoExpirationDate(string $discountReference): void
     {
         $discountForEditing = $this->getDiscountForEditing($discountReference);
-        $validTo = $discountForEditing->getValidTo();
-
-        Assert::assertNotNull($validTo, 'Expiration date should not be null');
-
-        $now = new DateTime();
-        $threshold = $now->modify('+' . $years . ' years');
-
-        Assert::assertGreaterThan(
-            $threshold,
-            $validTo,
-            sprintf('Expiration date should be more than %d years in the future', $years)
+        Assert::assertNull(
+            $discountForEditing->getValidTo(),
+            'Discount should have no expiration date (period never expires)'
         );
-    }
-
-    /**
-     * Check if the discount period is set to "never expires" (100 years in the future).
-     */
-    private function isPeriodNeverExpires(?DateTimeInterface $validTo): bool
-    {
-        if ($validTo === null) {
-            return false;
-        }
-
-        // Check if the expiration date is more than 50 years in the future
-        // (we use 50 years as a threshold to detect "never expires" dates set to 100 years)
-        $now = new DateTime();
-        $threshold = $now->modify('+50 years');
-
-        return $validTo > $threshold;
     }
 
     protected function getDiscountForEditing(string $discountReference): DiscountForEditing

--- a/tests/Integration/Behaviour/Features/Scenario/Discount/BO/update_discount_validity_dates.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Discount/BO/update_discount_validity_dates.feature
@@ -200,7 +200,7 @@ Feature: Update discount validity dates
       | period_never_expires | false               |
       | reduction_percent    | 15.0                |
 
-  Scenario: Verify never-expiring discount has expiration far in the future
+  Scenario: Verify never-expiring discount has no expiration date
     When I create a "cart_level" discount "verify_never_expires" with following properties:
       | name[en-US]          | Long Term Discount  |
       | valid_from           | 2024-01-01 00:00:00 |
@@ -208,5 +208,5 @@ Feature: Update discount validity dates
       | reduction_percent    | 20.0                |
     Then discount "verify_never_expires" should have the following properties:
       | period_never_expires | true |
-    And discount "verify_never_expires" expiration date should be more than 50 years in the future
+    And discount "verify_never_expires" should have no expiration date
 

--- a/tests/Integration/Behaviour/Features/Scenario/Discount/FO/discount_validity_date_range.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Discount/FO/discount_validity_date_range.feature
@@ -1,0 +1,74 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s discount --tags discount-validity-date-range
+@restore-all-tables-before-feature
+@discount-validity-date-range
+Feature: Discount validity date range in FO
+  Check that discount validity is enforced by valid_from and valid_to:
+  - if current date is in the range, the discount can be used
+  - if valid_to is in the past, the discount can't be used
+  - if valid_to is null, the discount can be used
+
+  Background:
+    Given there is a customer named "testCustomer" whose email is "customer@prestashop.com"
+    Given language with iso code "en" is the default one
+    Given shop "shop1" with name "test_shop" exists
+    And there is a currency named "usd" with iso code "USD" and exchange rate of 0.92
+    And currency "usd" is the default one
+    And I enable feature flag "discount"
+    And there is a product in the catalog named "product1" with a price of 100.0 and 1000 items in stock
+
+  Scenario: Discount with validTo in the future
+    When I create a "cart_level" discount "VALID_TO_FUTURE" with following properties:
+      | name[en-US]       | validTo in future |
+      | active            | true                    |
+      | valid_from        | 2026-02-24 00:00:00    |
+      | valid_to          | 2028-12-31 23:59:59    |
+      | code              | VALID_TO_FUTURE         |
+      | reduction_percent | 10.0                   |
+    Given I create an empty cart "cart_order" for customer "testCustomer"
+    When I add 1 product "product1" to the cart "cart_order"
+    And I use a voucher "VALID_TO_FUTURE" on the cart "cart_order"
+    Then discount "VALID_TO_FUTURE" is applied to my cart
+    And cart "cart_order" total with tax included should be '$97.00'
+    And my cart "cart_order" should have the following details:
+      | total_products | $100.00 |
+      | shipping       | $7.00   |
+      | total_discount | -$10.00 |
+      | total          | $97.00  |
+
+  Scenario: Discount with validTo in the past
+    When I create a "cart_level" discount "VALID_TO_PAST" with following properties:
+      | name[en-US]       | validTo in past |
+      | active            | true             |
+      | valid_from        | 2026-01-01 00:00:00 |
+      | valid_to          | 2026-01-31 00:00:00 |
+      | code              | VALID_TO_PAST     |
+      | reduction_percent | 15.0             |
+    Given I create an empty cart "cart_order" for customer "testCustomer"
+    When I add 1 product "product1" to the cart "cart_order"
+    When I use a voucher "VALID_TO_PAST" on the cart "cart_order"
+    Then I should get cart rule validation error
+    And cart "cart_order" total with tax included should be '$107.00'
+    And my cart "cart_order" should have the following details:
+      | total_products | $100.00 |
+      | shipping       | $7.00   |
+      | total_discount | $0.00   |
+      | total          | $107.00 |
+
+  Scenario: Discount where validTo is null 
+    When I create a "cart_level" discount "VALID_TO_NULL" with following properties:
+      | name[en-US]        | validTo is null |
+      | active             | true                   |
+      | valid_from         | 2026-01-01 00:00:00   |
+      | period_never_expires | true                 |
+      | code               | VALID_TO_NULL         |
+      | reduction_percent  | 20.0                  |
+    Given I create an empty cart "cart_order" for customer "testCustomer"
+    When I add 1 product "product1" to the cart "cart_order"
+    And I use a voucher "VALID_TO_NULL" on the cart "cart_order"
+    Then discount "VALID_TO_NULL" is applied to my cart
+    And cart "cart_order" total with tax included should be '$87.00'
+    And my cart "cart_order" should have the following details:
+      | total_products | $100.00 |
+      | shipping       | $7.00   |
+      | total_discount | -$20.00 |
+      | total          | $87.00  |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Hide expiration date field when the 'period never expires' option is checked
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Steps to reproduce are here https://github.com/PrestaShop/PrestaShop/issues/40801
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/22674629116
| Fixed issue or discussion?     | #40801
| Related PRs       | https://github.com/PrestaShop/ps_apiresources/pull/142 and https://github.com/PrestaShop/autoupgrade/pull/1671
| Sponsor company   | PrestaShop SA 