### PR TITLE
Resolve problem on split shipment on carrier select

### DIFF
--- a/src/Adapter/Form/ChoiceProvider/AvailableCarriersForShipmentChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/AvailableCarriersForShipmentChoiceProvider.php
@@ -35,6 +35,7 @@ final class AvailableCarriersForShipmentChoiceProvider implements ConfigurableFo
     {
         $options = $this->resolveOptions($options);
         $shipmentId = $options['shipment_id'];
+        $useCurrentCarrierId = $options['useCurrentCarrierId'];
         $shipment = $this->shipmentRepository->findById($shipmentId);
 
         if ($shipment === null) {
@@ -59,7 +60,7 @@ final class AvailableCarriersForShipmentChoiceProvider implements ConfigurableFo
         $carriers = $this->commandBus->handle(new GetAvailableCarriers(
             $productQuantities,
             new AddressId($shipment->getAddressId()),
-            $shipment->getCarrierId()
+            $useCurrentCarrierId === true ? $shipment->getCarrierId() : null
         ));
 
         return FormChoiceFormatter::formatFormChoices(
@@ -80,6 +81,7 @@ final class AvailableCarriersForShipmentChoiceProvider implements ConfigurableFo
         $resolver->setRequired([
             'shipment_id',
             'selectedProducts',
+            'useCurrentCarrierId',
         ]);
         $resolver->setAllowedTypes('selectedProducts', 'array');
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Shipment/EditShipmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Shipment/EditShipmentType.php
@@ -30,6 +30,7 @@ class EditShipmentType extends AbstractType
                 'choices' => $this->availableCarriersForShipmentChoiceProvider->getChoices([
                     'selectedProducts' => $options['data']['selectedProducts'],
                     'shipment_id' => $options['data']['shipment_id'],
+                    'useCurrentCarrierId' => true,
                 ]),
                 'placeholder' => $this->translator->trans('Select a carrier', [], 'Admin.Orderscustomers.Feature'),
                 'required' => true,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Shipment/SplitShipmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Shipment/SplitShipmentType.php
@@ -68,6 +68,7 @@ class SplitShipmentType extends AbstractType
             return $this->availableCarriersForShipmentChoiceProvider->getChoices([
                 'shipment_id' => $options['data']['shipment_id'],
                 'selectedProducts' => $selectedProductsId,
+                'useCurrentCarrierId' => false,
             ]);
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | When you select a product for split a shipment, a default carrier is always there, we need to get it only for edit a shipment, not for split
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see description
| UI Tests          | https://github.com/Poulinhoo/ga.tests.ui.pr/actions/runs/22390786510
