### PR TITLE
Update eligible carriers calculation for multi-shipment

### DIFF
--- a/src/Adapter/Carrier/QueryHandler/GetAvailableCarriersHandler.php
+++ b/src/Adapter/Carrier/QueryHandler/GetAvailableCarriersHandler.php
@@ -7,6 +7,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Carrier\QueryHandler;
 
 use Address;
+use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Address\Repository\AddressRepository;
 use PrestaShop\PrestaShop\Adapter\Carrier\Repository\CarrierRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
@@ -66,6 +67,7 @@ class GetAvailableCarriersHandler implements GetAvailableCarriersHandlerInterfac
 
         // Compute common carriers shared by all products
         $commonCarriers = $this->getCommonCarriers($carriersMapping);
+
         $carriersIndex = $this->indexCarriers($carriersMapping);
 
         $eligibleCarrierIds = [];
@@ -220,10 +222,14 @@ class GetAvailableCarriersHandler implements GetAvailableCarriersHandlerInterfac
 
         $limits = $this->carrierRepository->getCarrierConstraints(new CarrierId($carrier['id_carrier']));
 
-        return $totalWeight <= $limits->maxWeight
-            && $maxWidth <= $limits->maxWidth
-            && $maxHeight <= $limits->maxHeight
-            && $maxDepth <= $limits->maxDepth;
+        $check = fn ($value, $limit) => $limit === 0 || $value <= $limit;
+
+        $weightOk = $limits->maxWeight->equalsZero() || $limits->maxWeight->isGreaterOrEqualThan(new DecimalNumber((string) $totalWeight));
+        $widthOk = $check($maxWidth, $limits->maxWidth);
+        $heightOk = $check($maxHeight, $limits->maxHeight);
+        $depthOk = $check($maxDepth, $limits->maxDepth);
+
+        return $weightOk && $widthOk && $heightOk && $depthOk;
     }
 
     /**

--- a/src/Adapter/Carrier/Repository/CarrierRepository.php
+++ b/src/Adapter/Carrier/Repository/CarrierRepository.php
@@ -11,6 +11,7 @@ namespace PrestaShop\PrestaShop\Adapter\Carrier\Repository;
 use Carrier;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Shop\Repository\ShopRepository;
 use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\Attribute\Exception\AttributeNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CannotAddCarrierException;
@@ -364,10 +365,10 @@ class CarrierRepository extends AbstractMultiShopObjectModelRepository
         }
 
         return new CarrierConstraints(
-            (float) $result['max_weight'],
-            (float) $result['max_width'],
-            (float) $result['max_height'],
-            (float) $result['max_depth']
+            new DecimalNumber($result['max_weight']),
+            (int) $result['max_width'],
+            (int) $result['max_height'],
+            (int) $result['max_depth']
         );
     }
 

--- a/src/Core/Domain/Carrier/ValueObject/CarrierConstraints.php
+++ b/src/Core/Domain/Carrier/ValueObject/CarrierConstraints.php
@@ -8,13 +8,15 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject;
 
+use PrestaShop\Decimal\DecimalNumber;
+
 class CarrierConstraints
 {
     public function __construct(
-        public readonly float $maxWeight,
-        public readonly float $maxWidth,
-        public readonly float $maxHeight,
-        public readonly float $maxDepth,
+        public readonly DecimalNumber $maxWeight,
+        public readonly int $maxWidth,
+        public readonly int $maxHeight,
+        public readonly int $maxDepth,
     ) {
     }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_available.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_available.feature
@@ -193,6 +193,28 @@ Scenario: Carrier available when product fits all constraints
     | carrier         | state     | products     |
     | Perfect Carrier | available |              |
 
+Scenario: Carrier available when carrier constraints is not set
+  Given I add product "s81_fit_product" with following information:
+    | name[en-US] | Perfect Box |
+    | type        | standard    |
+  And I create carrier "s81_zero_carrier" with specified properties:
+    | name        | Zero Carrier |
+    | max_width   | 0            |
+    | max_height  | 0            |
+    | max_depth   | 0            |
+    | max_weight  | 0            |
+    | zones       | zone1        |
+  And I assign product "s81_fit_product" with following carriers:
+    | s81_zero_carrier |
+  And I update product "s81_fit_product" with following values:
+    | width  | 40 |
+    | height | 40 |
+    | depth  | 30 |
+    | weight | 10 |
+  Then the products "s81_fit_product" should have the following carriers with address "address1":
+    | carrier         | state     | products |
+    | Zero Carrier    | available |          |
+
 Scenario: Get available carrier when product constraints are equal to carrier limits
   Given I add product "s9_precise_product" with following information:
     | name[en-US] | precise product |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When retrieving eligible carriers as part of the split/edit for the multishipment feature, the constraint calculation was incorrect.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Test edit and split feature (carrier select)
| UI Tests          | https://github.com/M0rgan01/ga.tests.ui.pr/actions/runs/22392738214
| Fixed issue or discussion?     | -
| Related PRs       | -
| Sponsor company   | -