### PR TITLE
fix(AdminLoginController): Check that ID is null instead of false

### DIFF
--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -177,7 +177,7 @@ class AdminLoginControllerCore extends AdminController
         parent::initContent();
         $this->initFooter();
 
-        //force to disable modals
+        // force to disable modals
         $this->context->smarty->assign('modals', null);
     }
 
@@ -322,7 +322,7 @@ class AdminLoginControllerCore extends AdminController
             $this->errors[] = $this->trans('Invalid email address.', [], 'Admin.Notifications.Error');
         } else {
             $employee = new Employee();
-            if (!$employee->getByEmail($email)) {
+            if ($employee->getByEmail($email)->id === null) {
                 die(json_encode([
                     'hasErrors' => false,
                     'confirm' => $this->trans(


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      | The 8.0.3 version introcued a fix to prevent time-based email enumeration attacks introduced a regression in the admin password reset flow. Employee::getByEmail() now returns a fake/stub Employee instance instead of false when the provided email address does not match any existing employee. As a result, the check in AdminLoginController that gates the early return no longer works, the controller proceeds as if a real employee was found, eventually calling $employee->update() on an object with unset mandatory properties (e.g. lastname), causing a 500 error.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See Issue Steps to reproduce
| UI Tests          | NA
| Fixed issue or discussion?     | Fixes [#{40876}](https://github.com/PrestaShop/PrestaShop/issues/40876)
| Related PRs       | NA
| Sponsor company   | Evolutive
