### PR TITLE
Make .env relocatable as per symfony standard

### DIFF
--- a/admin-api/index.php
+++ b/admin-api/index.php
@@ -35,11 +35,10 @@ if (_PS_MODE_DEV_) {
 require_once __DIR__ . '/../autoload.php';
 
 // Loads .env file from the root of project
-$dotEnvFile = dirname(__FILE__, 2) . '/.env';
 (new Dotenv())
     // DO NOT use putEnv
     ->usePutenv(false)
-    ->loadEnv($dotEnvFile)
+    ->loadEnv(_PS_ENV_FILE_PATH_)
 ;
 
 // Block the process until the cache clear is in progress, this must be done before the kernel is created so it doesn't

--- a/admin-dev/index.php
+++ b/admin-dev/index.php
@@ -43,11 +43,10 @@ if (_PS_MODE_DEV_) {
 require_once __DIR__ . '/../autoload.php';
 
 // Loads .env file from the root of project
-$dotEnvFile = dirname(__FILE__, 2) . '/.env';
 (new Dotenv())
     // DO NOT use putEnv
     ->usePutenv(false)
-    ->loadEnv($dotEnvFile)
+    ->loadEnv(_PS_ENV_FILE_PATH_)
 ;
 
 // Block the process until the cache clear is in progress, this must be done before the kernel is created so it doesn't

--- a/autoload.php
+++ b/autoload.php
@@ -8,5 +8,8 @@
  * Allow call of Legacy classes from classes in /src and /tests
  * @see composer.json "files" property for custom autoloading
  */
+if (is_file(__DIR__ . '/config/defines_custom.inc.php')) {
+    include_once __DIR__ . '/config/defines_custom.inc.php';
+}
 require_once __DIR__.'/config/defines.inc.php';
 require_once __DIR__.'/config/autoload.php';

--- a/bin/console
+++ b/bin/console
@@ -18,11 +18,10 @@ set_time_limit(0);
 require_once __DIR__ . '/../autoload.php';
 
 // Loads .env file from the root of project
-$dotEnvFile = dirname(__FILE__, 2) . '/.env';
 (new Dotenv())
   // DO NOT use putEnv
   ->usePutenv(false)
-  ->loadEnv($dotEnvFile)
+  ->loadEnv(_PS_ENV_FILE_PATH_)
 ;
 
 try {

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -85,6 +85,8 @@ if (!defined('_PS_ENV_FILE_PATH_')) {
             ? $_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path']
             : _PS_ROOT_DIR_.'/.env',
     );
+} else {
+    $_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path'] = _PS_ENV_FILE_PATH_;
 }
 
 // Find if we are running under a Symfony command

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -81,9 +81,10 @@ if (defined('_PS_ADMIN_DIR_')) {
 if (!defined('_PS_ENV_FILE_PATH_')) {
     define(
         '_PS_ENV_FILE_PATH_',
-        !empty($_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path'])
-            ? $_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path']
-            : _PS_ROOT_DIR_.'/.env',
+        getenv('PS_ENV_FILE_PATH', true)
+            ?: getenv('PS_ENV_FILE_PATH')
+            ?: ($_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path'] ?? null)
+            ?: _PS_ROOT_DIR_.'/.env',
     );
 }
 

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -85,8 +85,11 @@ if (!defined('_PS_ENV_FILE_PATH_')) {
             ? $_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path']
             : _PS_ROOT_DIR_.'/.env',
     );
-} else {
-    $_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path'] = _PS_ENV_FILE_PATH_;
+}
+
+if (_PS_ENV_FILE_PATH_ !== _PS_ROOT_DIR_.'/.env') {
+    // SYMFONY_DOTENV_PATH only introduced in Sf 7.1 but needed for console debug:dotenv
+    $_SERVER['SYMFONY_DOTENV_PATH'] = $_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path'] = _PS_ENV_FILE_PATH_;
 }
 
 // Find if we are running under a Symfony command

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -77,6 +77,16 @@ if (defined('_PS_ADMIN_DIR_')) {
     define('_PS_BO_ALL_THEMES_DIR_', _PS_ADMIN_DIR_.'/themes/');
 }
 
+// Define .env file path
+if (!defined('_PS_ENV_FILE_PATH_')) {
+    define(
+        '_PS_ENV_FILE_PATH_',
+        !empty($_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path'])
+            ? $_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path']
+            : _PS_ROOT_DIR_.'/.env',
+    );
+}
+
 // Find if we are running under a Symfony command
 $cliEnvValue = null;
 if (isset($argv) && is_array($argv)) {

--- a/index.php
+++ b/index.php
@@ -22,7 +22,11 @@ require_once _PS_FRONT_DIR_ . '/vendor/autoload.php';
 define('_PS_APP_ID_', FrontKernel::APP_ID);
 
 // Load .env file from the root of project if present
-(new Dotenv(false))->loadEnv(_PS_ENV_FILE_PATH_);
+(new Dotenv())
+    // DO NOT use putEnv
+    ->usePutenv(false)
+    ->loadEnv(_PS_ENV_FILE_PATH_)
+;
 
 // If we want to use new container access in front (Warning: Experimental feature from now!)
 if (isset($_ENV['PS_FF_FRONT_CONTAINER_V2']) && filter_var($_ENV['PS_FF_FRONT_CONTAINER_V2'], \FILTER_VALIDATE_BOOL)) {

--- a/index.php
+++ b/index.php
@@ -22,7 +22,7 @@ require_once _PS_FRONT_DIR_ . '/vendor/autoload.php';
 define('_PS_APP_ID_', FrontKernel::APP_ID);
 
 // Load .env file from the root of project if present
-(new Dotenv(false))->loadEnv(_PS_FRONT_DIR_ . '/.env');
+(new Dotenv(false))->loadEnv(_PS_ENV_FILE_PATH_);
 
 // If we want to use new container access in front (Warning: Experimental feature from now!)
 if (isset($_ENV['PS_FF_FRONT_CONTAINER_V2']) && filter_var($_ENV['PS_FF_FRONT_CONTAINER_V2'], \FILTER_VALIDATE_BOOL)) {

--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -5,6 +5,7 @@
  */
 
 use PrestaShop\PrestaShop\Adapter\ContainerBuilder;
+use Symfony\Component\Dotenv\Dotenv;
 
 ob_start();
 
@@ -13,6 +14,8 @@ if (!defined('_PS_API_IN_USE_')) {
 }
 
 require_once dirname(__FILE__) . '/../config/config.inc.php';
+
+(new Dotenv(false))->loadEnv(_PS_ENV_FILE_PATH_);
 
 // Cart is needed for some requests
 Context::getContext()->cart = new Cart();

--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -15,7 +15,11 @@ if (!defined('_PS_API_IN_USE_')) {
 
 require_once dirname(__FILE__) . '/../config/config.inc.php';
 
-(new Dotenv(false))->loadEnv(_PS_ENV_FILE_PATH_);
+(new Dotenv())
+    // DO NOT use putEnv
+    ->usePutenv(false)
+    ->loadEnv(_PS_ENV_FILE_PATH_)
+;
 
 // Cart is needed for some requests
 Context::getContext()->cart = new Cart();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allow to move the .env to a custom path<br>See: https://symfony.com/doc/6.4/configuration/override_dir_structure.html#override-the-environment-dotenv-files-directory<br>New .env path can be set by defining `$_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path']` or `_PS_ENV_FILE_PATH_`
| Type?             | improvement
| Category?         | CO
| BC breaks?        | No
| Deprecations?     | No
| How to test?      | Override `$_SERVER['APP_RUNTIME_OPTIONS']['dotenv_path']` or `_PS_ENV_FILE_PATH_` using `defines_custom.inc.php` to move the `.env` in another place
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | Novius