### PR TITLE
Fix/discount multishop support

### DIFF
--- a/src/Adapter/Discount/CommandHandler/AddDiscountHandler.php
+++ b/src/Adapter/Discount/CommandHandler/AddDiscountHandler.php
@@ -12,6 +12,7 @@ use PrestaShop\PrestaShop\Adapter\Discount\Update\DiscountBuilder;
 use PrestaShop\PrestaShop\Adapter\Discount\Update\DiscountConditionsUpdater;
 use PrestaShop\PrestaShop\Adapter\Discount\Validate\DiscountValidator;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierId;
 use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\ValueObject\GroupId;
@@ -30,6 +31,7 @@ class AddDiscountHandler implements AddDiscountHandlerInterface
         private readonly DiscountValidator $discountValidator,
         private readonly DiscountConditionsUpdater $discountConditionsUpdater,
         private readonly DiscountTypeRepository $discountTypeRepository,
+        private readonly ShopContext $shopContext,
     ) {
     }
 
@@ -56,12 +58,15 @@ class AddDiscountHandler implements AddDiscountHandlerInterface
         $discount = $this->discountRepository->add($builtCartRule);
         $newDiscountId = new DiscountId((int) $discount->id);
 
+        $shopIds = $this->shopContext->isAllShopContext() ? null : $this->shopContext->getAssociatedShopIds();
+
         $this->discountConditionsUpdater->update(
             $newDiscountId,
             $command->getProductConditions(),
             $command->getCarrierIds() ? array_map(fn (CarrierId $carrierId) => $carrierId->getValue(), $command->getCarrierIds()) : null,
             $command->getCountryIds() ? array_map(fn (CountryId $countryId) => $countryId->getValue(), $command->getCountryIds()) : null,
             $command->getCustomerGroupIds() ? array_map(fn (GroupId $groupId) => $groupId->getValue(), $command->getCustomerGroupIds()) : null,
+            $shopIds,
         );
         $this->discountTypeRepository->setCompatibleTypesForDiscount($newDiscountId->getValue(), $command->getCompatibleDiscountTypeIds() ?? []);
 

--- a/src/Adapter/Discount/CommandHandler/BulkDeleteDiscountsHandler.php
+++ b/src/Adapter/Discount/CommandHandler/BulkDeleteDiscountsHandler.php
@@ -7,7 +7,9 @@
 namespace PrestaShop\PrestaShop\Adapter\Discount\CommandHandler;
 
 use PrestaShop\PrestaShop\Adapter\Discount\Repository\DiscountRepository;
+use PrestaShop\PrestaShop\Adapter\Discount\Update\DiscountConditionsUpdater;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Domain\AbstractBulkCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\BulkDeleteDiscountsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\CommandHandler\BulkDeleteDiscountsHandlerInterface;
@@ -22,6 +24,8 @@ final class BulkDeleteDiscountsHandler extends AbstractBulkCommandHandler implem
 {
     public function __construct(
         private readonly DiscountRepository $discountRepository,
+        private readonly DiscountConditionsUpdater $discountConditionsUpdater,
+        private readonly ShopContext $shopContext,
     ) {
     }
 
@@ -43,7 +47,22 @@ final class BulkDeleteDiscountsHandler extends AbstractBulkCommandHandler implem
      */
     protected function handleSingleAction(mixed $id, mixed $command): void
     {
-        $this->discountRepository->delete($id);
+        if ($this->shopContext->isAllShopContext()) {
+            $this->discountRepository->delete($id);
+
+            return;
+        }
+
+        $existingShopIds = $this->discountRepository->getShopsIds($id);
+        $remainingShopIds = array_diff($existingShopIds, $this->shopContext->getAssociatedShopIds());
+
+        if (empty($existingShopIds) || empty($remainingShopIds)) {
+            $this->discountRepository->delete($id);
+
+            return;
+        }
+
+        $this->discountConditionsUpdater->update($id, shopIds: array_values($remainingShopIds));
     }
 
     /**

--- a/src/Adapter/Discount/CommandHandler/DeleteDiscountHandler.php
+++ b/src/Adapter/Discount/CommandHandler/DeleteDiscountHandler.php
@@ -7,20 +7,46 @@
 namespace PrestaShop\PrestaShop\Adapter\Discount\CommandHandler;
 
 use PrestaShop\PrestaShop\Adapter\Discount\Repository\DiscountRepository;
+use PrestaShop\PrestaShop\Adapter\Discount\Update\DiscountConditionsUpdater;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\DeleteDiscountCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\CommandHandler\DeleteDiscountHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Discount\ValueObject\DiscountId;
 
 #[AsCommandHandler]
 class DeleteDiscountHandler implements DeleteDiscountHandlerInterface
 {
     public function __construct(
         private readonly DiscountRepository $discountRepository,
+        private readonly DiscountConditionsUpdater $discountConditionsUpdater,
+        private readonly ShopContext $shopContext,
     ) {
     }
 
     public function handle(DeleteDiscountCommand $command): void
     {
-        $this->discountRepository->delete($command->getDiscountId());
+        $this->deleteDiscount($command->getDiscountId());
+    }
+
+    private function deleteDiscount(DiscountId $discountId): void
+    {
+        if ($this->shopContext->isAllShopContext()) {
+            $this->discountRepository->delete($discountId);
+
+            return;
+        }
+
+        $existingShopIds = $this->discountRepository->getShopsIds($discountId);
+        $remainingShopIds = array_diff($existingShopIds, $this->shopContext->getAssociatedShopIds());
+
+        if (empty($existingShopIds) || empty($remainingShopIds)) {
+            $this->discountRepository->delete($discountId);
+
+            return;
+        }
+
+        // Other shops still use this discount: dissociate from current shop(s) only.
+        $this->discountConditionsUpdater->update($discountId, shopIds: array_values($remainingShopIds));
     }
 }

--- a/src/Adapter/Discount/Update/DiscountConditionsUpdater.php
+++ b/src/Adapter/Discount/Update/DiscountConditionsUpdater.php
@@ -37,6 +37,7 @@ class DiscountConditionsUpdater
      * @param int[]|null $carrierIds
      * @param int[]|null $countryIds
      * @param int[]|null $customerGroupIds
+     * @param int[]|null $shopIds
      *
      * @return void
      */
@@ -46,12 +47,14 @@ class DiscountConditionsUpdater
         ?array $carrierIds = null,
         ?array $countryIds = null,
         ?array $customerGroupIds = null,
+        ?array $shopIds = null,
     ): void {
         // Nothing to modify we return immediately
         if ($productConditions === null
             && $carrierIds === null
             && $countryIds === null
-            && $customerGroupIds === null) {
+            && $customerGroupIds === null
+            && $shopIds === null) {
             return;
         }
 
@@ -69,6 +72,9 @@ class DiscountConditionsUpdater
         }
         if (null !== $customerGroupIds) {
             $updatableProperties = array_merge($updatableProperties, $this->applyCustomerGroups($discount, $customerGroupIds));
+        }
+        if (null !== $shopIds) {
+            $updatableProperties = array_merge($updatableProperties, $this->applyShopRestriction($discount, $shopIds));
         }
 
         $updatableProperties = array_unique($updatableProperties);
@@ -319,5 +325,50 @@ class DiscountConditionsUpdater
         ;
 
         return ['group_restriction'];
+    }
+
+    /**
+     * @param CartRule $discount
+     * @param int[] $shopIds
+     *
+     * @return array List of updated properties
+     */
+    private function applyShopRestriction(CartRule $discount, array $shopIds): array
+    {
+        $updatableProperties = $this->cleanShopRestriction($discount);
+        if (empty($shopIds)) {
+            return $updatableProperties;
+        }
+
+        $discount->shop_restriction = true;
+        foreach ($shopIds as $shopId) {
+            $this->connection->createQueryBuilder()
+                ->insert($this->dbPrefix . 'cart_rule_shop')
+                ->values([
+                    'id_cart_rule' => (int) $discount->id,
+                    'id_shop' => $shopId,
+                ])
+                ->executeStatement()
+            ;
+        }
+
+        return ['shop_restriction'];
+    }
+
+    /**
+     * @return array List of updated properties
+     */
+    private function cleanShopRestriction(CartRule $discount): array
+    {
+        $discount->shop_restriction = false;
+
+        $this->connection->createQueryBuilder()
+            ->delete($this->dbPrefix . 'cart_rule_shop')
+            ->where('id_cart_rule = :discountId')
+            ->setParameter('discountId', (int) $discount->id)
+            ->executeStatement()
+        ;
+
+        return ['shop_restriction'];
     }
 }

--- a/src/Core/Grid/Query/DiscountQueryBuilder.php
+++ b/src/Core/Grid/Query/DiscountQueryBuilder.php
@@ -14,7 +14,9 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Domain\Discount\DiscountSettings;
+use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShop\PrestaShop\Core\Grid\Search\ShopSearchCriteriaInterface;
 
 /**
  * Builds query for discount list
@@ -49,7 +51,7 @@ class DiscountQueryBuilder extends AbstractDoctrineQueryBuilder
             (int) $this->configuration->get('PS_OS_ERROR')
         );
 
-        $qb = $this->getQueryBuilder($searchCriteria->getFilters())
+        $qb = $this->getQueryBuilder($searchCriteria)
             ->select(
                 'cr.id_cart_rule AS id_discount,
                 crl.name,
@@ -75,7 +77,7 @@ class DiscountQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
-        $qb = $this->getQueryBuilder($searchCriteria->getFilters())
+        $qb = $this->getQueryBuilder($searchCriteria)
             ->select('COUNT(DISTINCT cr.`id_cart_rule`)')
         ;
 
@@ -85,12 +87,14 @@ class DiscountQueryBuilder extends AbstractDoctrineQueryBuilder
     /**
      * Gets query builder with the common sql for discounts listing.
      *
-     * @param array $filters
-     *
-     * @return QueryBuilder
+     * @throws InvalidArgumentException
      */
-    private function getQueryBuilder(array $filters): QueryBuilder
+    private function getQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
+        if (!$searchCriteria instanceof ShopSearchCriteriaInterface) {
+            throw new InvalidArgumentException(sprintf('Invalid search criteria, expected a %s', ShopSearchCriteriaInterface::class));
+        }
+
         $qb = $this->connection
             ->createQueryBuilder()
             ->from($this->dbPrefix . 'cart_rule', 'cr')
@@ -118,9 +122,58 @@ class DiscountQueryBuilder extends AbstractDoctrineQueryBuilder
             ->setParameter('contextLangId', $this->languageContext->getId())
         ;
 
-        $this->applyFilters($qb, $filters);
+        $this->applyShopConstraint($qb, $searchCriteria);
+        $this->applyFilters($qb, $searchCriteria->getFilters());
 
         return $qb;
+    }
+
+    /**
+     * Filters discounts by shop context.
+     *
+     * Discounts with shop_restriction = 0 are always visible regardless of the current shop.
+     * Discounts with shop_restriction = 1 are only visible if explicitly associated to the
+     * current shop (or a shop in the current group) via the cart_rule_shop table.
+     * In the "all shops" context no filter is applied.
+     */
+    private function applyShopConstraint(QueryBuilder $qb, ShopSearchCriteriaInterface $searchCriteria): void
+    {
+        $shopConstraint = $searchCriteria->getShopConstraint();
+
+        if ($shopConstraint === null || $shopConstraint->isAllShopContext()) {
+            return;
+        }
+
+        if ($shopConstraint->getShopId() !== null) {
+            $qb
+                ->leftJoin(
+                    'cr',
+                    $this->dbPrefix . 'cart_rule_shop',
+                    'crs',
+                    'crs.id_cart_rule = cr.id_cart_rule AND crs.id_shop = :shopId'
+                )
+                ->andWhere('cr.shop_restriction = 0 OR crs.id_cart_rule IS NOT NULL')
+                ->setParameter('shopId', $shopConstraint->getShopId()->getValue())
+            ;
+
+            return;
+        }
+
+        // Shop group context: use EXISTS to avoid duplicate rows when multiple shops
+        // of the group are linked to the same discount.
+        $qb
+            ->andWhere(
+                'cr.shop_restriction = 0 OR EXISTS (
+                    SELECT 1
+                    FROM ' . $this->dbPrefix . 'cart_rule_shop crs_sub
+                    INNER JOIN ' . $this->dbPrefix . 'shop crs_shop
+                        ON crs_shop.id_shop = crs_sub.id_shop
+                        AND crs_shop.id_shop_group = :shopGroupId
+                    WHERE crs_sub.id_cart_rule = cr.id_cart_rule
+                )'
+            )
+            ->setParameter('shopGroupId', $shopConstraint->getShopGroupId()->getValue())
+        ;
     }
 
     /**

--- a/src/Core/Search/Filters/DiscountFilters.php
+++ b/src/Core/Search/Filters/DiscountFilters.php
@@ -9,12 +9,12 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Search\Filters;
 
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\DiscountGridDefinitionFactory;
-use PrestaShop\PrestaShop\Core\Search\Filters;
+use PrestaShop\PrestaShop\Core\Search\ShopFilters;
 
 /**
  * Responsible for providing default filters for discount grid.
  */
-final class DiscountFilters extends Filters
+final class DiscountFilters extends ShopFilters
 {
     /** @var string */
     protected $filterId = DiscountGridDefinitionFactory::GRID_ID;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | With the `discount` feature flag enabled, multishop is completely broken:
  discounts created on shop A are visible on shop B, and deleting from shop B removes the discount globally.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Manually tested end-to-end (see How to test below). No automated UI tests added in this PR.
| Fixed issue or discussion?     | Fixes #40862
| Sponsor company            | axel-paillaud

## What was wrong

The new discount system (CQRS) ignored multishop entirely:
- `DiscountQueryBuilder` had no filter on `cart_rule_shop`, listing all discounts regardless of the current
 shop context
- `AddDiscountHandler` never populated `cart_rule_shop` or set `shop_restriction`
- `DeleteDiscountHandler` and `BulkDeleteDiscountsHandler` always deleted globally

## What was changed

**Phase 1 — Listing**
- `DiscountFilters` now extends `ShopFilters` to carry the `ShopConstraint` from the request
- `DiscountQueryBuilder` filters by shop context: LEFT JOIN on `cart_rule_shop` for single shop, EXISTS
subquery for shop group, no filter in all-shops context. Discounts with `shop_restriction = 0` remain
visible everywhere.

**Phase 2 — Creation**
- `AddDiscountHandler` resolves shop IDs from `ShopContext` and passes them to `DiscountConditionsUpdater`
- `DiscountConditionsUpdater` gains `applyShopRestriction` / `cleanShopRestriction`, following the same
pattern as existing carrier/country/group restrictions

**Phase 3 & 5 — Deletion (single and bulk)**
- Both delete handlers now check the shop context before acting:
  - All-shops context → global delete
  - Unrestricted discount (`shop_restriction = 0`) → global delete
  - Restricted discount, no remaining shops after removal → global delete
  - Restricted discount, other shops still associated → dissociate current shop(s) only

## How to test

Prerequisites: multishop enabled, at least two shops (shop A and shop B), `discount` feature flag enabled.

1. Select shop A, create a discount. Verify it appears in shop A's listing.
2. Switch to shop B. Verify the discount does **not** appear.
3. Switch to "all shops". Verify the discount appears.
4. Select shop A, delete the discount. Verify it disappears from shop A and from "all shops".

Repeat step 1, then from step 4 delete from "all shops" context — discount should be removed globally.

All scenarios above have been tested manually end-to-end and behave as expected, including single shop,
shop group, and all-shops contexts.