### PR TITLE
Add ShopContext and LanguageContext to FeatureAttributeRepository

### DIFF
--- a/src/Adapter/Attribute/Repository/AttributeRepository.php
+++ b/src/Adapter/Attribute/Repository/AttributeRepository.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Attribute\Repository;
 
 use Attribute;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\Attribute\Exception\AttributeNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\Attribute\Exception\CannotAddAttributeException;
@@ -346,6 +347,69 @@ class AttributeRepository extends AbstractMultiShopObjectModelRepository
         }
 
         return $attributesInfoByAttributeId;
+    }
+
+    /**
+     * Retrieve attributes with values (id, name).
+     *
+     * @param int $languageId
+     * @param int[] $shopIds
+     *
+     * @return array<int, array{attribute_group_id: int, name: string, values: array<int, array{item_id: int, name: string}>}>
+     */
+    public function getAttributesWithValues(int $languageId, array $shopIds = []): array
+    {
+        $qb = $this->connection->createQueryBuilder()
+            ->select(
+                'DISTINCT a.id_attribute_group AS attribute_group_id',
+                'agl.name AS name',
+                'al.id_attribute AS value_id',
+                'al.name AS value_name'
+            )
+            ->from($this->dbPrefix . 'attribute', 'a')
+            ->leftJoin('a', $this->dbPrefix . 'attribute_lang', 'al',
+                'a.id_attribute = al.id_attribute AND al.id_lang = :language_id AND LENGTH(TRIM(al.name)) > 0'
+            )
+            ->leftJoin('a', $this->dbPrefix . 'attribute_group', 'ag',
+                'ag.id_attribute_group = a.id_attribute_group'
+            )
+            ->leftJoin('ag', $this->dbPrefix . 'attribute_group_lang', 'agl',
+                'ag.id_attribute_group = agl.id_attribute_group AND agl.id_lang = :language_id AND LENGTH(TRIM(agl.name)) > 0'
+            )
+            ->orderBy('a.id_attribute_group')
+            ->addOrderBy('al.id_attribute')
+            ->setParameter('language_id', $languageId);
+
+        if (!empty($shopIds)) {
+            $qb
+                ->join('a', $this->dbPrefix . 'attribute_shop', 'ats',
+                    'ats.id_attribute = a.id_attribute AND ats.id_shop IN (:shop_ids)'
+                )
+                ->join('a', $this->dbPrefix . 'attribute_group_shop', 'ags',
+                    'ags.id_attribute_group = a.id_attribute_group AND ags.id_shop IN (:shop_ids)'
+                )
+                ->setParameter('shop_ids', $shopIds, ArrayParameterType::INTEGER);
+        }
+
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        $attributeGroups = [];
+        foreach ($rows as $row) {
+            $groupId = (int) $row['attribute_group_id'];
+            if (!isset($attributeGroups[$groupId])) {
+                $attributeGroups[$groupId] = [
+                    'attribute_group_id' => (int) $groupId,
+                    'name' => (string) $row['name'],
+                    'values' => [],
+                ];
+            }
+            $attributeGroups[$groupId]['values'][] = [
+                'item_id' => (int) $row['value_id'],
+                'name' => (string) $row['value_name'],
+            ];
+        }
+
+        return array_values($attributeGroups);
     }
 
     /**

--- a/src/Adapter/Feature/Repository/FeatureRepository.php
+++ b/src/Adapter/Feature/Repository/FeatureRepository.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Feature\Repository;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Feature;
@@ -168,6 +169,7 @@ class FeatureRepository extends AbstractMultiShopObjectModelRepository
     {
         $qb = $this->getFeaturesQueryBuilder()
             ->select('f.*, fl.*')
+            ->leftJoin('f', $this->dbPrefix . 'feature_lang', 'fl', 'fl.id_feature = f.id_feature')
             ->setFirstResult($offset ?? 0)
             ->addOrderBy('f.position', 'ASC')
             ->setMaxResults($limit)
@@ -266,6 +268,66 @@ class FeatureRepository extends AbstractMultiShopObjectModelRepository
         return array_map(static function (array $result): ShopId {
             return new ShopId((int) $result['id_shop']);
         }, $qb->executeQuery()->fetchAllAssociative());
+    }
+
+    /**
+     * Retrieve features with values (id, name).
+     *
+     * @param int $languageId
+     * @param int[] $shopIds
+     *
+     * @return array<int, array{feature_id: int, name: string, values: array<int, array{item_id: int, name: string}>}>
+     */
+    public function getFeaturesWithValues(int $languageId, array $shopIds = []): array
+    {
+        $qb = $this->getFeaturesQueryBuilder()
+            ->select(
+                'DISTINCT f.id_feature AS feature_id',
+                'fl.name AS name',
+                'fvl.id_feature_value AS value_id',
+                'fvl.value AS value_name'
+            )
+            ->leftJoin('f', $this->dbPrefix . 'feature_lang', 'fl',
+                'f.id_feature = fl.id_feature AND fl.id_lang = :language_id'
+            )
+            ->leftJoin('f', $this->dbPrefix . 'feature_value', 'fv',
+                'f.id_feature = fv.id_feature'
+            )
+            ->leftJoin('fv', $this->dbPrefix . 'feature_value_lang', 'fvl',
+                'fvl.id_lang = :language_id AND fvl.id_feature_value = fv.id_feature_value'
+            )
+            ->where('fv.custom = 0')
+            ->orderBy('f.id_feature')
+            ->addOrderBy('fvl.id_feature_value')
+            ->setParameter('language_id', $languageId);
+
+        if (!empty($shopIds)) {
+            $qb
+                ->innerJoin('f', $this->dbPrefix . 'feature_shop', 'fs',
+                    'fs.id_feature = f.id_feature AND fs.id_shop IN (:shop_ids)'
+                )
+                ->setParameter('shop_ids', $shopIds, ArrayParameterType::INTEGER);
+        }
+
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        $features = [];
+        foreach ($rows as $row) {
+            $featureId = (int) $row['feature_id'];
+            if (!isset($features[$featureId])) {
+                $features[$featureId] = [
+                    'feature_id' => (int) $featureId,
+                    'name' => (string) $row['name'],
+                    'values' => [],
+                ];
+            }
+            $features[$featureId]['values'][] = [
+                'item_id' => (int) $row['value_id'],
+                'name' => (string) $row['value_name'],
+            ];
+        }
+
+        return array_values($features);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
@@ -10,6 +10,7 @@ namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 
 use Exception;
 use PrestaShop\PrestaShop\Adapter\Feature\FeatureFeature;
+use PrestaShop\PrestaShop\Adapter\Feature\Repository\FeatureRepository;
 use PrestaShop\PrestaShop\Core\Domain\Feature\Command\BulkDeleteFeatureCommand;
 use PrestaShop\PrestaShop\Core\Domain\Feature\Command\DeleteFeatureCommand;
 use PrestaShop\PrestaShop\Core\Domain\Feature\Exception\BulkFeatureException;
@@ -26,7 +27,6 @@ use PrestaShop\PrestaShop\Core\Search\Filters\FeatureFilters;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
 use PrestaShopBundle\Controller\BulkActionsTrait;
-use PrestaShopBundle\Entity\Repository\FeatureAttributeRepository;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -41,8 +41,7 @@ class FeatureController extends PrestaShopAdminController
     use BulkActionsTrait;
 
     public function __construct(
-        private readonly FeatureFeature $featureFeature,
-        private readonly FeatureAttributeRepository $featureAttributeRepository
+        private readonly FeatureFeature $featureFeature
     ) {
     }
 
@@ -275,9 +274,9 @@ class FeatureController extends PrestaShopAdminController
     }
 
     #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))")]
-    public function getAllFeatureGroupsAction(?int $shopId): JsonResponse
+    public function getAllFeatureGroupsAction(FeatureRepository $featureRepository): JsonResponse
     {
-        $features = $this->featureAttributeRepository->getFeatures();
+        $features = $featureRepository->getFeaturesWithValues($this->getLanguageContext()->getId(), $this->getShopContext()->getAssociatedShopIds());
 
         return $this->json($this->formatFeatureGroupsForPresentation($features));
     }

--- a/src/PrestaShopBundle/Entity/Repository/FeatureAttributeRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/FeatureAttributeRepository.php
@@ -6,73 +6,29 @@
 
 namespace PrestaShopBundle\Entity\Repository;
 
-use Doctrine\DBAL\Connection;
-use Employee;
-use PrestaShop\PrestaShop\Adapter\LegacyContext as ContextAdapter;
-use PrestaShopBundle\Exception\NotImplementedException;
-use RuntimeException;
-use Shop;
+use PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository;
+use PrestaShop\PrestaShop\Adapter\Feature\Repository\FeatureRepository;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
 
+/**
+ * FeatureAttributeRepository
+ *
+ * @deprecated since 9.1 and will be removed in 10.0, this repository don't have to be used anymore. Use instead FeaturesRepository or AttributesRepository directly.
+ */
 class FeatureAttributeRepository
 {
     use NormalizeFieldTrait;
 
     /**
-     * @var Connection
-     */
-    private $connection;
-
-    /**
-     * @var string
-     */
-    private $tablePrefix;
-
-    /**
-     * @var int
-     */
-    private $languageId;
-
-    /**
-     * @var int
-     */
-    private $shopId;
-
-    /**
      * FeatureAttributeRepository constructor.
-     *
-     * @param Connection $connection
-     * @param ContextAdapter $contextAdapter
-     * @param string $tablePrefix
-     *
-     * @throws NotImplementedException
      */
     public function __construct(
-        Connection $connection,
-        ContextAdapter $contextAdapter,
-        $tablePrefix
+        private readonly ShopContext $shopContext,
+        private readonly LanguageContext $languageContext,
+        private readonly FeatureRepository $featureRepository,
+        private readonly AttributeRepository $attributeRepository
     ) {
-        $this->connection = $connection;
-        $this->tablePrefix = $tablePrefix;
-
-        $context = $contextAdapter->getContext();
-
-        if (!$context->employee instanceof Employee) {
-            throw new RuntimeException('Determining the active language requires a contextual employee instance.');
-        }
-
-        $languageId = $context->employee->id_lang;
-        $this->languageId = (int) $languageId;
-
-        if (!$context->shop instanceof Shop) {
-            throw new RuntimeException('Determining the active shop requires a contextual shop instance.');
-        }
-
-        $shop = $context->shop;
-        if ($shop->getContextType() !== $shop::CONTEXT_SHOP) {
-            throw new NotImplementedException('Shop context types other than "single shop" are not supported');
-        }
-
-        $this->shopId = $shop->getContextualShopId();
     }
 
     /**
@@ -80,53 +36,7 @@ class FeatureAttributeRepository
      */
     public function getAttributes()
     {
-        $query = str_replace(
-            '{table_prefix}',
-            $this->tablePrefix,
-            'SELECT
-            a.id_attribute_group AS attribute_group_id,
-            agl.name AS name,
-            GROUP_CONCAT(
-              CONCAT(al.id_attribute, ":", al.name)
-              ORDER BY al.id_attribute
-            ) AS "values"
-            FROM {table_prefix}attribute a
-            LEFT JOIN {table_prefix}attribute_shop ats ON (
-                ats.id_attribute = a.id_attribute AND
-                ats.id_shop = :shop_id
-            )
-            LEFT JOIN {table_prefix}attribute_lang al ON (
-                a.id_attribute = al.id_attribute
-                AND al.id_lang = :language_id
-                AND LENGTH(TRIM(al.name)) > 0
-            )
-            LEFT JOIN {table_prefix}attribute_group ag ON (
-                ag.id_attribute_group = a.id_attribute_group
-            )
-            LEFT JOIN {table_prefix}attribute_group_shop ags ON (
-                ags.id_attribute_group = a.id_attribute_group AND
-                ags.id_shop = :shop_id
-            )
-            LEFT JOIN {table_prefix}attribute_group_lang agl ON (
-                ag.id_attribute_group = agl.id_attribute_group
-                AND agl.id_lang = :language_id
-                AND LENGTH(TRIM(agl.name)) > 0
-            )
-            GROUP BY ag.id_attribute_group
-        '
-        );
-
-        $statement = $this->connection->prepare($query);
-
-        $statement->bindValue('language_id', $this->languageId);
-        $statement->bindValue('shop_id', $this->shopId);
-
-        $result = $statement->executeQuery();
-
-        $rows = $result->fetchAllAssociative();
-        $rows = $this->explodeCollections($rows);
-
-        return $this->castNumericToInt($rows);
+        return $this->attributeRepository->getAttributesWithValues($this->languageContext->getId(), $this->shopContext->getAssociatedShopIds());
     }
 
     /**
@@ -134,77 +44,6 @@ class FeatureAttributeRepository
      */
     public function getFeatures()
     {
-        $query = str_replace(
-            '{table_prefix}',
-            $this->tablePrefix,
-            'SELECT
-            f.id_feature AS feature_id,
-            fl.name AS name,
-            GROUP_CONCAT(
-              CONCAT(fvl.id_feature_value, ":", fvl.value)
-              ORDER BY fvl.id_feature_value
-            ) AS "values"
-            FROM {table_prefix}feature f
-            LEFT JOIN {table_prefix}feature_lang fl ON (
-                f.id_feature = fl.id_feature AND
-                fl.id_lang = :language_id
-            )
-            LEFT JOIN {table_prefix}feature_shop fs ON (
-                fs.id_shop = :shop_id AND
-                fs.id_feature = f.id_feature
-            )
-            LEFT JOIN {table_prefix}feature_value fv ON (
-                f.id_feature = fv.id_feature
-            )
-            LEFT JOIN {table_prefix}feature_value_lang fvl ON (
-                fvl.id_lang = :language_id AND
-                fvl.id_feature_value = fv.id_feature_value
-            )
-            WHERE fv.custom = 0
-            GROUP BY fv.id_feature
-            ORDER BY f.id_feature
-        '
-        );
-
-        $statement = $this->connection->prepare($query);
-
-        $statement->bindValue('language_id', $this->languageId);
-        $statement->bindValue('shop_id', $this->shopId);
-
-        $result = $statement->executeQuery();
-
-        $rows = $result->fetchAllAssociative();
-        $rows = $this->explodeCollections($rows);
-
-        return $this->castNumericToInt($rows);
-    }
-
-    /**
-     * @param array $rows
-     *
-     * @return array
-     */
-    private function explodeCollections($rows)
-    {
-        return array_map(function ($row) {
-            $row['values'] = explode(',', $row['values']);
-
-            $row['values'] = array_map(function ($value) {
-                if (!str_contains($value, ':')) {
-                    return $value;
-                }
-
-                $parts = explode(':', $value);
-
-                return [
-                    'item_id' => $parts[0],
-                    'name' => $parts[1],
-                ];
-            }, $row['values']);
-
-            $row['values'] = $this->castNumericToInt($row['values']);
-
-            return $row;
-        }, $rows);
+        return $this->featureRepository->getFeaturesWithValues($this->languageContext->getId(), $this->shopContext->getAssociatedShopIds());
     }
 }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/features.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/features.yml
@@ -179,7 +179,7 @@ admin_feature_get_feature_values:
     expose: true
 
 admin_all_feature_groups:
-  path: /all-feature-groups/{shopId}
+  path: /all-feature-groups
   methods: [ GET ]
   options:
     expose: true
@@ -188,5 +188,3 @@ admin_all_feature_groups:
     _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\FeatureController::getAllFeatureGroupsAction
     _legacy_controller: AdminFeatures
     _legacy_link: AdminFeatures:getAllFeatureGroups
-  requirements:
-    shopId: \d+

--- a/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
@@ -104,7 +104,6 @@ services:
   PrestaShopBundle\Controller\Admin\Sell\Catalog\FeatureController:
     arguments:
       $featureFeature: "@prestashop.adapter.feature.feature"
-      $featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
     public: false
     autowire: true
     autoconfigure: true

--- a/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
@@ -97,10 +97,10 @@ services:
 
   prestashop.core.api.feature_attribute.repository:
     class: PrestaShopBundle\Entity\Repository\FeatureAttributeRepository
-    arguments:
-      - "@doctrine.dbal.default_connection"
-      - "@prestashop.adapter.legacy.context"
-      - "%database_prefix%"
+    deprecated:
+      package: PrestaShop\PrestaShop
+      version: 9.1
+    autowire: true
 
   prestashop.core.admin.timezone.repository:
     class: PrestaShopBundle\Entity\Repository\TimezoneRepository


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Avoid 500 error by adding ShopContext and LanguageContext to FeatureAttributeRepository.<br>**Bonus:** improve repository queries in multistore context + deprecate FeatureAttributeRepository and add new functions in dedicated repositories.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #40861
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/22666178293
| Fixed issue or discussion?     | Fixes #40861
| Related PRs       | ~
| Sponsor company   | PrestaShop SA
