### PR TITLE
B2B Contribution - Add "default" flag to business entity address

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -3164,6 +3164,7 @@ CREATE TABLE `PREFIX_business_entity_address`
   `id_business_entity` INT UNSIGNED                       NOT NULL,
   `id_address`         INT UNSIGNED                       NOT NULL,
   `address_type`       ENUM ('both','invoice','delivery') NOT NULL DEFAULT 'both',
+  `default`            TINYINT(1)                         NOT NULL DEFAULT 0,
   PRIMARY KEY (`id_business_entity`, `id_address`),
   INDEX                `business_entity_address_address_idx` (`id_address`)
 ) ENGINE = ENGINE_TYPE

--- a/src/PrestaShopBundle/Entity/B2B/BusinessEntityAddress.php
+++ b/src/PrestaShopBundle/Entity/B2B/BusinessEntityAddress.php
@@ -37,6 +37,13 @@ class BusinessEntityAddress
     private int $idAddress;
 
     /**
+     * @ORM\Id
+     *
+     * @ORM\Column(name="default", type="boolean", options={"default"=false})
+     */
+    private bool $default = false;
+
+    /**
      * @ORM\Column(name="address_type", enumType=AddressTypeEnum::class, length=50)
      */
     private AddressTypeEnum $addressType = AddressTypeEnum::BOTH;
@@ -74,6 +81,17 @@ class BusinessEntityAddress
     {
         $this->addressType = $addressType;
 
+        return $this;
+    }
+
+    public function isDefault(): bool
+    {
+        return $this->default;
+    }
+
+    public function setDefault(bool $default): self
+    {
+        $this->default = $default;
         return $this;
     }
 }

--- a/src/PrestaShopBundle/Entity/B2B/BusinessEntityAddress.php
+++ b/src/PrestaShopBundle/Entity/B2B/BusinessEntityAddress.php
@@ -92,6 +92,7 @@ class BusinessEntityAddress
     public function setDefault(bool $default): self
     {
         $this->default = $default;
+
         return $this;
     }
 }

--- a/src/PrestaShopBundle/Entity/B2B/BusinessEntityAddress.php
+++ b/src/PrestaShopBundle/Entity/B2B/BusinessEntityAddress.php
@@ -37,9 +37,7 @@ class BusinessEntityAddress
     private int $idAddress;
 
     /**
-     * @ORM\Id
-     *
-     * @ORM\Column(name="default", type="boolean", options={"default"=false})
+     * @ORM\Column(name="`default`", type="boolean", options={"default"=false})
      */
     private bool $default = false;
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Added a "default" flag for addresses, to manage the "same billing address as shipping address" option.
| Type?             | improvement 
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install a fresh database et check that the new column "default" is in the table PREFIX_business_entity_address
| UI Tests          | https://github.com/soledis-contributeur/ga.tests.ui.pr/actions/runs/22479278427
| Fixed issue or discussion?     | https://github.com/orgs/PrestaShop/projects/38/views/1?pane=issue&itemId=152000713&issue=PrestaShop%7CPrestaShop%7C40605
| Related PRs       | 
| Sponsor company   | Soledis
