### PR TITLE
EditStateHandler : Fixes if ZoneId or Country are null (partial update)

### DIFF
--- a/src/Adapter/State/CommandHandler/EditStateHandler.php
+++ b/src/Adapter/State/CommandHandler/EditStateHandler.php
@@ -38,11 +38,11 @@ class EditStateHandler implements EditStateHandlerInterface
         $state = $this->getState($command->getStateId());
 
         try {
-            if (null !== $command->getZoneId()->getValue()) {
+            if (null !== $command->getZoneId()) {
                 $state->id_zone = $command->getZoneId()->getValue();
             }
 
-            if (null !== $command->getCountryId()->getValue()) {
+            if (null !== $command->getCountryId()) {
                 $state->id_country = $command->getCountryId()->getValue();
             }
 

--- a/tests/Integration/Behaviour/Features/Scenario/State/state_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/State/state_management.feature
@@ -17,23 +17,53 @@ Feature: Zones management
     Then state "StateNormandy" zone should be "Europe"
     And state "StateNormandy" should be enabled
 
-  Scenario: Editing state
+  Scenario: Partial Editing state
+    ## Name
     When I edit state "StateNormandy" with following properties:
       | name    | Britain       |
-      | enabled | false         |
-      | country | Italy         |
-      | zone    | South America |
+    Then state "StateNormandy" name should be "Britain"
+    Then state "StateNormandy" country should be "United States"
+    Then state "StateNormandy" zone should be "Europe"
+    And state "StateNormandy" should be enabled
+    ## Enabled
+    When I edit state "StateNormandy" with following properties:
+      | enabled | false          |
+    Then state "StateNormandy" name should be "Britain"
+    Then state "StateNormandy" country should be "United States"
+    Then state "StateNormandy" zone should be "Europe"
+    And state "StateNormandy" should be disabled
+    ## Country
+    When I edit state "StateNormandy" with following properties:
+      | country | Italy          |
+    Then state "StateNormandy" name should be "Britain"
+    Then state "StateNormandy" country should be "Italy"
+    Then state "StateNormandy" zone should be "Europe"
+    And state "StateNormandy" should be disabled
+    ## Zone
+    When I edit state "StateNormandy" with following properties:
+      | zone | South America  |
     Then state "StateNormandy" name should be "Britain"
     Then state "StateNormandy" country should be "Italy"
     Then state "StateNormandy" zone should be "South America"
     And state "StateNormandy" should be disabled
 
+  Scenario: Editing state
+    When I edit state "StateNormandy" with following properties:
+      | name    | Tasmania      |
+      | enabled | true          |
+      | country | Australia     |
+      | zone    | Oceania       |
+    Then state "StateNormandy" name should be "Tasmania"
+    Then state "StateNormandy" country should be "Australia"
+    Then state "StateNormandy" zone should be "Oceania"
+    And state "StateNormandy" should be enabled
+
   Scenario: Enable and disable state status
-    Given state "StateNormandy" is disabled
-    When I toggle status of state "StateNormandy"
-    Then state "StateNormandy" should be enabled
+    Given state "StateNormandy" is enabled
     When I toggle status of state "StateNormandy"
     Then state "StateNormandy" should be disabled
+    When I toggle status of state "StateNormandy"
+    Then state "StateNormandy" should be enabled
 
   Scenario: Enabling and disabling multiple states in bulk action
     When I add new state "StateBrittany" with following properties:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | EditStateHandler : Fixes if ZoneId or Country are null (partial update)<br><br>The code is not testable with the interface in the BO. It is testable if you use the CQRS Command for a partial update. It's why I added Behat Tests.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: <br><br>**OR**<br><br>* Go to BO<br>* Edit any State (and change one field)<br>* Save : it's applied
| UI Tests          |  https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/22499948721
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | lefevre.dev