### PR TITLE
Improve and clean some things in carrier calculation

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -692,7 +692,8 @@ class CarrierCore extends ObjectModel
     }
 
     /**
-     * Get available Carriers for given order (cart)
+     * Get available Carriers for given order (cart). This does only a basic filtering based on zones,
+     * groups and the order (cart) concerned.
      *
      * @param int $id_zone Zone ID
      * @param array|null $groups Group of the Customer
@@ -703,15 +704,19 @@ class CarrierCore extends ObjectModel
      */
     public static function getCarriersForOrder($id_zone, $groups = null, $cart = null, &$error = [])
     {
-        // First, initialize the context, language, currency
-        $context = Context::getContext();
-        $id_lang = $context->language->id;
+        // Get cart from context if not provided
         if (null === $cart) {
-            $cart = $context->cart;
+            $cart = Context::getContext()->cart;
         }
-        if (isset($context->currency)) {
-            $id_currency = $context->currency->id;
-        }
+
+        /*
+         * Get language from the context. It's probably a better option than using the cart language.
+         * If the cart is viewed in front office, the context language is the same as the cart language,
+         * so it doesn't change anything.
+         * If the cart is viewed in back office, the context language is the employee language, which
+         * is probably better than the one on the cart.
+         */
+        $id_lang = (int) Context::getContext()->language->id;
 
         // Use provided groups or a default group if none provided
         if (!is_array($groups) || empty($groups)) {
@@ -719,7 +724,7 @@ class CarrierCore extends ObjectModel
         }
 
         // And get all carriers available in the system
-        $result = Carrier::getCarriers($id_lang, true, false, (int) $id_zone, $groups, self::PS_CARRIERS_AND_CARRIER_MODULES_NEED_RANGE);
+        $result = Carrier::getCarriers((int) $id_lang, true, false, (int) $id_zone, $groups, self::PS_CARRIERS_AND_CARRIER_MODULES_NEED_RANGE);
         $results_array = [];
 
         foreach ($result as $k => $row) {
@@ -768,43 +773,26 @@ class CarrierCore extends ObjectModel
                     }
 
                     if ($shipping_method == Carrier::SHIPPING_METHOD_PRICE
-                        && (Carrier::checkDeliveryPriceByPrice($row['id_carrier'], $cart->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING), $id_zone, $id_currency ?? null) === false)) {
+                        && (Carrier::checkDeliveryPriceByPrice($row['id_carrier'], $cart->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING), $id_zone, $cart->id_currency) === false)) {
                         $error[$carrier->id] = Carrier::SHIPPING_PRICE_EXCEPTION;
                         unset($result[$k]);
 
                         continue;
                     }
                 }
+
+                /*
+                 * Third, remove this carrier if getPackageShippingCost method returns false, which means that the carrier is not available for the current cart.
+                 * This can happen with carrier modules that have their own logic to determine if they are available or not.
+                 */
+                if ($cart->getPackageShippingCost((int) $row['id_carrier'], true, null, null, $id_zone) === false) {
+                    unset($result[$k]);
+
+                    continue;
+                }
             }
-
-            // Calculate the price of the carrier
-            $row['price'] = (($shipping_method == Carrier::SHIPPING_METHOD_FREE) ? 0 : $cart->getPackageShippingCost((int) $row['id_carrier'], true, null, null, $id_zone));
-            $row['price_tax_exc'] = (($shipping_method == Carrier::SHIPPING_METHOD_FREE) ? 0 : $cart->getPackageShippingCost((int) $row['id_carrier'], false, null, null, $id_zone));
-
-            // If price is false, then the carrier is unavailable (carrier module)
-            if ($row['price'] === false) {
-                unset($result[$k]);
-
-                continue;
-            }
-
-            // Locate an image (original resolution, we should probably move to use a presenter and thumbnails here)
-            $row['img'] = file_exists(_PS_SHIP_IMG_DIR_ . (int) $row['id_carrier'] . '.jpg') ? _THEME_SHIP_DIR_ . (int) $row['id_carrier'] . '.jpg' : '';
 
             $results_array[] = $row;
-        }
-
-        // Sort carriers by price if needed
-        $prices = [];
-        if (Configuration::get('PS_CARRIER_DEFAULT_SORT') == Carrier::SORT_BY_PRICE) {
-            foreach ($results_array as $r) {
-                $prices[] = $r['price'];
-            }
-            if (Configuration::get('PS_CARRIER_DEFAULT_ORDER') == Carrier::SORT_BY_ASC) {
-                array_multisort($prices, SORT_ASC, SORT_NUMERIC, $results_array);
-            } else {
-                array_multisort($prices, SORT_DESC, SORT_NUMERIC, $results_array);
-            }
         }
 
         return $results_array;
@@ -1516,7 +1504,11 @@ class CarrierCore extends ObjectModel
     }
 
     /**
-     * For a given product, gets the carrier available.
+     * For a given product, gets the carrier available. It takes a basic-filtered list from getCarriersForOrder and applies
+     * some more rules to it. Size and weight restrictions, product-carrier associations, and so on.
+     *
+     * Watch out - this method is a bit weird in a sense that while it calculates some restrictions based on product scope,
+     * the weight is calculated based on the whole cart.
      *
      * @param Product $product The id of the product, or an array with at least the package size and weight
      * @param int|null $id_warehouse Warehouse ID - not used anymore
@@ -1590,9 +1582,8 @@ class CarrierCore extends ObjectModel
         $available_carrier_list = [];
         $cache_id = 'Carrier::getAvailableCarrierList_getCarriersForOrder_' . (int) $id_zone . '-' . (int) $cart->id;
         if (!Cache::isStored($cache_id)) {
-            $customer = new Customer($cart->id_customer);
             $carrier_error = [];
-            $carriers = Carrier::getCarriersForOrder($id_zone, $customer->getGroups(), $cart, $carrier_error);
+            $carriers = Carrier::getCarriersForOrder($id_zone, Customer::getGroupsStatic((int) $cart->id_customer), $cart, $carrier_error);
             Cache::store($cache_id, [$carriers, $carrier_error]);
         } else {
             list($carriers, $carrier_error) = Cache::retrieve($cache_id);
@@ -1613,10 +1604,12 @@ class CarrierCore extends ObjectModel
         $cart_quantity = 0;
         $cart_weight = 0;
 
-        foreach ($cart->getProducts(false, false) as $cart_product) {
+        foreach ($cart->getProducts() as $cart_product) {
             if ($cart_product['id_product'] == $product->id) {
                 $cart_quantity += $cart_product['cart_quantity'];
             }
+
+            // The weight property already contains customization weight
             if (isset($cart_product['weight_attribute']) && $cart_product['weight_attribute'] > 0) {
                 $cart_weight += ($cart_product['weight_attribute'] * $cart_product['cart_quantity']);
             } else {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2999,6 +2999,11 @@ class CartCore extends ObjectModel
                         $carriers_instance[$id_carrier] = new Carrier($id_carrier);
                     }
 
+                    /*
+                     * getPackageShippingCost can return false in some cases, which means the carrier is not available. If it did for
+                     * some carriers, they SHOULD be filtered out earlier in the process. Right now, we have a final list of packages
+                     * and their carriers, so we should not have to deal with false here.
+                     */
                     $price_with_tax = $this->getPackageShippingCost((int) $id_carrier, true, $country, $package['product_list']);
                     $price_without_tax = $this->getPackageShippingCost((int) $id_carrier, false, $country, $package['product_list']);
                     if (null === $best_price || $price_with_tax < $best_price) {
@@ -3586,9 +3591,12 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * Return package shipping cost.
+     * Returns calculated shipping cost for a given carrier, for given zone and a list of products.
+     * If you do not pass a list of products, the shipping cost will be calculated with all the products of the cart.
+     * The zone will be determined first by the delivery address of the cart, then by the default country passed as
+     * a parameter and finally by the default country of the shop.
      *
-     * @param int $id_carrier Carrier ID (default : current carrier)
+     * @param int $id_carrier Carrier ID
      * @param bool $use_tax
      * @param Country|null $default_country
      * @param array|null $product_list list of product concerned by the shipping.
@@ -3606,6 +3614,10 @@ class CartCore extends ObjectModel
         $id_zone = null,
         bool $keepOrderPrices = false
     ) {
+        if ($id_carrier === null) {
+            throw new PrestaShopException('This method no longer accepts null as a carrier ID. Please provide a valid carrier ID to calculate cost for.');
+        }
+
         $shippingCost = $this->getPackageShippingCostValue(
             $id_carrier,
             $use_tax,
@@ -3635,7 +3647,7 @@ class CartCore extends ObjectModel
     /**
      * Return calculated package shipping cost.
      *
-     * @param int $id_carrier Carrier ID (default : current carrier)
+     * @param int $id_carrier Carrier ID
      * @param bool $use_tax
      * @param Country|null $default_country
      * @param array|null $product_list list of product concerned by the shipping.
@@ -3684,11 +3696,6 @@ class CartCore extends ObjectModel
             $address_id = null;
         }
 
-        // If no carrier ID was passed and we have a carrier on this cart, we use it
-        if (null === $id_carrier && !empty($this->id_carrier)) {
-            $id_carrier = (int) $this->id_carrier;
-        }
-
         // Initialize a unique cache ID for the shipping cost and retrieve it if it exists
         $cache_id = 'getPackageShippingCost_' . (int) $this->id . '_' . (int) $address_id . '_' . (int) $id_carrier . '_' . (int) $use_tax . '_' . (int) $default_country->id . '_' . (int) $id_zone;
         if ($products) {
@@ -3700,9 +3707,6 @@ class CartCore extends ObjectModel
         if (Cache::isStored($cache_id)) {
             return Cache::retrieve($cache_id);
         }
-
-        // Order total in default currency without fees
-        $order_total = $this->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING, $product_list, $id_carrier, false, $keepOrderPrices);
 
         // Start with shipping cost at 0
         $shipping_cost = 0;
@@ -3739,89 +3743,11 @@ class CartCore extends ObjectModel
             }
         }
 
-        // If we have a specific carrier ID, check if it is in range for the given zone, if not, reset it
-        if ($id_carrier && !$this->isCarrierInRange((int) $id_carrier, (int) $id_zone)) {
-            $id_carrier = '';
-        }
+        // If it's not in range for the given zone, we return false and store it in cache
+        if (!$this->isCarrierInRange((int) $id_carrier, (int) $id_zone)) {
+            Cache::store($cache_id, false);
 
-        // If we have no carrier ID, we try to use the default one first, if it's in range for the given zone
-        if (empty($id_carrier) && $this->isCarrierInRange((int) Configuration::get('PS_CARRIER_DEFAULT'), (int) $id_zone)) {
-            $id_carrier = (int) Configuration::get('PS_CARRIER_DEFAULT');
-        }
-
-        // If we still have no carrier ID, we try to find the cheapest one for the given zone
-        if (empty($id_carrier)) {
-            if ((int) $this->id_customer) {
-                $customer = new Customer((int) $this->id_customer);
-                $result = Carrier::getCarriers((int) Configuration::get('PS_LANG_DEFAULT'), true, false, (int) $id_zone, $customer->getGroups());
-                unset($customer);
-            } else {
-                $result = Carrier::getCarriers((int) Configuration::get('PS_LANG_DEFAULT'), true, false, (int) $id_zone);
-            }
-
-            foreach ($result as $k => $row) {
-                if ($row['id_carrier'] == Configuration::get('PS_CARRIER_DEFAULT')) {
-                    continue;
-                }
-
-                if (!isset(self::$_carriers[$row['id_carrier']])) {
-                    self::$_carriers[$row['id_carrier']] = new Carrier((int) $row['id_carrier']);
-                }
-
-                /** @var Carrier $carrier */
-                $carrier = self::$_carriers[$row['id_carrier']];
-
-                /*
-                 * Get shipping method of this carrier, it can either be by weight or by price.
-                 * If the shipping method is not compatible with the current zone, we skip this carrier.
-                 */
-                $shipping_method = $carrier->getShippingMethod();
-                if (($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT && $carrier->getMaxDeliveryPriceByWeight((int) $id_zone) === false)
-                    || ($shipping_method == Carrier::SHIPPING_METHOD_PRICE && $carrier->getMaxDeliveryPriceByPrice((int) $id_zone) === false)) {
-                    unset($result[$k]);
-
-                    continue;
-                }
-
-                // If out-of-range behavior carrier is set to "Deactivate the carrier", we skip this carrier
-                if ($row['range_behavior'] == OutOfRangeBehavior::DISABLED) {
-                    // If the carrier has weight based shipping, remove the carrier if it does not have a compatible range
-                    if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT
-                        && Carrier::checkDeliveryPriceByWeight($row['id_carrier'], $this->getTotalWeight(), (int) $id_zone) === false) {
-                        unset($result[$k]);
-
-                        continue;
-                    }
-
-                    // If the carrier has price based shipping, remove the carrier if it does not have a compatible range
-                    if ($shipping_method == Carrier::SHIPPING_METHOD_PRICE
-                        && Carrier::checkDeliveryPriceByPrice($row['id_carrier'], $order_total, (int) $id_zone, (int) $this->id_currency) === false) {
-                        continue;
-                    }
-                }
-
-                // Get the shipping cost for this carrier
-                if ($shipping_method == Carrier::SHIPPING_METHOD_WEIGHT) {
-                    $shipping = $carrier->getDeliveryPriceByWeight($this->getTotalWeight($product_list), (int) $id_zone);
-                } else {
-                    $shipping = $carrier->getDeliveryPriceByPrice($order_total, (int) $id_zone, (int) $this->id_currency);
-                }
-
-                // And if it's the first carrier we check OR it's cheaper, we use the ID
-                if (!isset($min_shipping_price)) {
-                    $min_shipping_price = $shipping;
-                }
-
-                if ($shipping <= $min_shipping_price) {
-                    $id_carrier = (int) $row['id_carrier'];
-                    $min_shipping_price = $shipping;
-                }
-            }
-        }
-
-        // And again, one more fallback to the default carrier if we still have no carrier ID
-        if (empty($id_carrier)) {
-            $id_carrier = Configuration::get('PS_CARRIER_DEFAULT');
+            return false;
         }
 
         // Initialize the instance of the Carrier object and store it in the cache
@@ -3830,18 +3756,18 @@ class CartCore extends ObjectModel
         }
         $carrier = self::$_carriers[$id_carrier];
 
-        // Validate the carrier object and return 0 if not valid
+        // Validate the carrier object and return false if not valid
         if (!Validate::isLoadedObject($carrier)) {
-            Cache::store($cache_id, $shipping_cost);
+            Cache::store($cache_id, false);
 
-            return $shipping_cost;
+            return false;
         }
 
-        // Check if the carrier is active and return 0 if not valid
+        // Check if the carrier is active and return false if not valid
         if (!$carrier->active) {
-            Cache::store($cache_id, $shipping_cost);
+            Cache::store($cache_id, false);
 
-            return $shipping_cost;
+            return false;
         }
 
         // If the carrier is free, we return 0 and store it in cache
@@ -3951,6 +3877,9 @@ class CartCore extends ObjectModel
 
             return $shipping_cost;
         }
+
+        // Order total in default currency without fees
+        $order_total = $this->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING, $product_list, $id_carrier, false, $keepOrderPrices);
 
         // Get shipping cost using correct method
         $shipping_method = $carrier->getShippingMethod();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Improves several things in carrier calculations. More info below.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI and UI tests should reveal issues.
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/22663450796
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | 

Changes
- Adds comments
- Improves some minor things like changing `context->currency->id` to `cart->id_currency`.
- Removes one `getPackageShippingCost` that is not needed in `getCarriersForOrder`.
- Removes unused sorting logic from `getCarriersForOrder`.
- Removes on extra Customer object construct, fetches groups directly anyway with the same call.
- Removes historic logic where getPackageShippingCost was called with no id carrier.
- Returns false from getPackageShippingCost if the carrier cannot be used, like specifications say and module carriers do.
