### PR TITLE
Fix: Bug: reserved_quantity not updated when "Share available quantities for sale" is enabled (Multishop)

### DIFF
--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -17,6 +17,8 @@ use StockAvailable;
  */
 class StockManager
 {
+    private $cachedStockContext = [];
+
     /**
      * Gets available stock for a given product / combination / shop.
      *
@@ -101,12 +103,12 @@ class StockManager
             ';
         }
 
-        $stockShopId = $this->getStockShopId((int) $shopId);
+        $stockContext = $this->getStockContext((int) $shopId);
 
         $updatePhysicalQuantityQuery .= '
             SET sa.physical_quantity = sa.quantity + sa.reserved_quantity
-            WHERE sa.id_shop = ' . (int) $stockShopId . '
-        ';
+            WHERE sa.id_shop = ' . (int) $stockContext['shopId'] . ' AND sa.id_shop_group = ' . (int) $stockContext['shopGroupId']
+        ;
 
         if ($idProduct) {
             $updatePhysicalQuantityQuery .= ' AND sa.id_product = ' . (int) $idProduct;
@@ -157,13 +159,18 @@ class StockManager
                 sa.id_product_attribute = od.product_attribute_id
                 GROUP BY od.product_id, od.product_attribute_id
             )
-            WHERE sa.id_shop = :stock_shop_id
+            WHERE
+                sa.id_shop = :stock_shop_id AND 
+                sa.id_shop_group = :stock_shop_group_id 
         ';
+
+        $stockContext = $this->getStockContext((int) $shopId);
 
         $strParams = [
             '{table_prefix}' => _DB_PREFIX_,
             ':shop_id' => (int) $shopId,
-            ':stock_shop_id' => (int) $this->getStockShopId((int) $shopId),
+            ':stock_shop_id' => (int) $stockContext['shopId'],
+            ':stock_shop_group_id' => (int) $stockContext['shopGroupId'],
             ':error_state' => (int) $errorState,
             ':cancellation_state' => (int) $cancellationState,
         ];
@@ -182,24 +189,32 @@ class StockManager
         return Db::getInstance()->execute($updateReservedQuantityQuery);
     }
 
-    private function getStockShopId(int $shopId)
+    /**
+     * Returns the stock context for the given shop.
+     *
+     * Note: when stock is shared at shop group level (share_stock = true),
+     * PrestaShop uses id_shop = 0 as a “virtual shop id” to read/write the shared stock
+     * in stock_available.
+     *
+     * @return array{shopGroupId:int, shopId:int} shopId is 0 when stock is shared, otherwise it's the given $shopId
+     */
+    private function getStockContext(int $shopId)
     {
-        static $stockShopId = null;
-
-        if ($stockShopId !== null) {
-            return $stockShopId;
+        if (isset($this->cachedStockContext[$shopId])) {
+            return $this->cachedStockContext[$shopId];
         }
 
         $shopAdapter = new ShopAdapter();
-        $shop_group = $shopAdapter->ShopGroup((int) $shopAdapter->getGroupFromShop((int) $shopId));
+        $shopGroup = $shopAdapter->ShopGroup((int) $shopAdapter->getGroupFromShop((int) $shopId));
 
-        if ($shop_group->share_stock) {
-            $stockShopId = 0;
-        } else {
-            $stockShopId = $shopId;
-        }
-
-        return $stockShopId;
+        return $this->cachedStockContext[$shopId] = [
+            // When stock is shared at group level, we scope the stock to the shop group.
+            // Otherwise we use 0 as a sentinel value meaning "not group-scoped".
+            'shopGroupId' => $shopGroup->share_stock ? $shopGroup->id : 0,
+            // When stock is shared at group level, PrestaShop uses id_shop = 0 to store/read the shared stock.
+            // Otherwise the stock is scoped to the current shop id.
+            'shopId' => $shopGroup->share_stock ? 0 : $shopId,
+        ];
     }
 
     /**

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -146,8 +146,8 @@ class StockManager
         $stockContext = $this->getStockContext((int) $shopId);
 
         $orderScopeCondition = $stockContext['shopGroupId'] > 0
-            ? 'o.id_shop_group = :order_shop_group_id'
-            : 'o.id_shop = :shop_id';
+            ? 'o.id_shop_group = :stock_shop_group_id'
+            : 'o.id_shop = :stock_shop_id';
 
         $updateReservedQuantityQuery .= '
             SET sa.reserved_quantity = (
@@ -177,12 +177,6 @@ class StockManager
             ':error_state' => (int) $errorState,
             ':cancellation_state' => (int) $cancellationState,
         ];
-
-        if ($stockContext['shopGroupId'] > 0) {
-            $strParams[':order_shop_group_id'] = (int) $stockContext['shopGroupId'];
-        } else {
-            $strParams[':shop_id'] = (int) $shopId;
-        }
 
         if ($idProduct) {
             $updateReservedQuantityQuery .= ' AND sa.id_product = :product_id';

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -143,13 +143,19 @@ class StockManager
             ';
         }
 
+        $stockContext = $this->getStockContext((int) $shopId);
+
+        $orderScopeCondition = $stockContext['shopGroupId'] > 0
+            ? 'o.id_shop_group = :order_shop_group_id'
+            : 'o.id_shop = :shop_id';
+
         $updateReservedQuantityQuery .= '
             SET sa.reserved_quantity = (
                 SELECT SUM(od.product_quantity - od.product_quantity_refunded)
                 FROM {table_prefix}orders o
                 INNER JOIN {table_prefix}order_detail od ON od.id_order = o.id_order
                 INNER JOIN {table_prefix}order_state os ON os.id_order_state = o.current_state
-                WHERE o.id_shop = :shop_id AND
+                WHERE ' . $orderScopeCondition . ' AND
                 os.shipped != 1 AND (
                     o.valid = 1 OR (
                         os.id_order_state != :error_state AND
@@ -164,16 +170,19 @@ class StockManager
                 sa.id_shop_group = :stock_shop_group_id 
         ';
 
-        $stockContext = $this->getStockContext((int) $shopId);
-
         $strParams = [
             '{table_prefix}' => _DB_PREFIX_,
-            ':shop_id' => (int) $shopId,
             ':stock_shop_id' => (int) $stockContext['shopId'],
             ':stock_shop_group_id' => (int) $stockContext['shopGroupId'],
             ':error_state' => (int) $errorState,
             ':cancellation_state' => (int) $cancellationState,
         ];
+
+        if ($stockContext['shopGroupId'] > 0) {
+            $strParams[':order_shop_group_id'] = (int) $stockContext['shopGroupId'];
+        } else {
+            $strParams[':shop_id'] = (int) $shopId;
+        }
 
         if ($idProduct) {
             $updateReservedQuantityQuery .= ' AND sa.id_product = :product_id';

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -101,9 +101,11 @@ class StockManager
             ';
         }
 
+        $stockShopId = $this->getStockShopId((int) $shopId);
+
         $updatePhysicalQuantityQuery .= '
             SET sa.physical_quantity = sa.quantity + sa.reserved_quantity
-            WHERE sa.id_shop = ' . (int) $shopId . '
+            WHERE sa.id_shop = ' . (int) $stockShopId . '
         ';
 
         if ($idProduct) {
@@ -155,12 +157,13 @@ class StockManager
                 sa.id_product_attribute = od.product_attribute_id
                 GROUP BY od.product_id, od.product_attribute_id
             )
-            WHERE sa.id_shop = :shop_id
+            WHERE sa.id_shop = :stock_shop_id
         ';
 
         $strParams = [
             '{table_prefix}' => _DB_PREFIX_,
             ':shop_id' => (int) $shopId,
+            ':stock_shop_id' => (int) $this->getStockShopId((int) $shopId),
             ':error_state' => (int) $errorState,
             ':cancellation_state' => (int) $cancellationState,
         ];
@@ -177,6 +180,26 @@ class StockManager
         $updateReservedQuantityQuery = strtr($updateReservedQuantityQuery, $strParams);
 
         return Db::getInstance()->execute($updateReservedQuantityQuery);
+    }
+
+    private function getStockShopId(int $shopId)
+    {
+        static $stockShopId = null;
+
+        if ($stockShopId !== null) {
+            return $stockShopId;
+        }
+
+        $shopAdapter = new ShopAdapter();
+        $shop_group = $shopAdapter->ShopGroup((int) $shopAdapter->getGroupFromShop((int) $shopId));
+
+        if ($shop_group->share_stock) {
+            $stockShopId = 0;
+        } else {
+            $stockShopId = $shopId;
+        }
+
+        return $stockShopId;
     }
 
     /**


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.1.x 
| Description?      | When multishop is enabled and "Share available quantities for sale" is set to true, the stock_available row is stored with id_shop = 0.<br/><br/>However, `updateReservedProductQuantity()` was using the current shop ID, causing the UPDATE query to not match any row.<br/>This resulted in reserved_quantity not being updated and `physical_quantity` never being recalculated properly.<br/>This fix resolves the correct stock shop ID (0 when `share_stock `is enabled) before executing the update query.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | <strong>TEST 1</strong> <br/>- Enable multishop.<br/>- Create a shop group with: 2 shops and shop group with field **Share available quantities for sale** = true<br/>- Create a product with stock.<br/>- Place an order in one shop.<br/>- Check the `stock_available` table and verify that the `reserved_quantity` field has been updated with the purchased quantity.<br/>- Change the order status to "Shipped" and verify that the `physical_quantity` field has been updated accordingly.<br/><br/><strong>TEST 2</strong> <br/>- Create 2 shop groups, each with 2 shops and with field **Share available quantities for sale** = true.<br/>- Create a product with stock assigned to both shop groups.<br/>- Place an order in one shop of the first group and verify that `reserved_quantity` is updated only for that shop group (id_shop = 0 within the group scope).<br/>- Ensure that stock values of the second shop group remain unchanged.
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/26216755396
| Fixed issue or discussion?     | Fixes #40896
| Related PRs       | 
| Sponsor company   | Codencode snc
