### PR TITLE
Handle no value objects, like NoStateId, NoCombinationId in ValueObje…

### DIFF
--- a/src/Core/Domain/Address/QueryResult/EditableCustomerAddress.php
+++ b/src/Core/Domain/Address/QueryResult/EditableCustomerAddress.php
@@ -10,7 +10,6 @@ namespace PrestaShop\PrestaShop\Core\Domain\Address\QueryResult;
 use PrestaShop\PrestaShop\Core\Domain\Address\ValueObject\AddressId;
 use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
-use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\StateId;
 use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\StateIdInterface;
 
 /**
@@ -128,7 +127,7 @@ class EditableCustomerAddress
      * @param string $company
      * @param string $vatNumber
      * @param string $address2
-     * @param StateId $stateId
+     * @param StateIdInterface $stateId
      * @param string $homePhone
      * @param string $mobilePhone
      * @param string $other

--- a/src/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizer.php
+++ b/src/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizer.php
@@ -65,6 +65,15 @@ class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterfac
      */
     protected array $constructorParameter = [];
 
+    /**
+     * The key is the initial class of the NoValueObject (example NoStateId)
+     * The value is the deduced short name of the associated ValueObject with the No part removed (example StateId)
+     * If the array doesn't contain the VO class it means it's not a NoValueObject
+     *
+     * @var array<string, string>
+     */
+    protected array $noValueClasses = [];
+
     public function __construct(
         protected readonly ClassMetadataFactoryInterface $classMetadataFactory
     ) {
@@ -137,9 +146,15 @@ class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterfac
         }
 
         $metadata = $this->classMetadataFactory->getMetadataFor($object);
+        $className = $metadata->getReflectionClass()->getName();
+        if ($this->isNoValueClass($object) && !empty($this->noValueClasses[$className])) {
+            $valueId = lcfirst($this->noValueClasses[$className]);
+        } else {
+            $valueId = lcfirst($metadata->getReflectionClass()->getShortName());
+        }
 
         return [
-            lcfirst($metadata->getReflectionClass()->getShortName()) => $object->getValue(),
+            $valueId => $object->getValue(),
         ];
     }
 
@@ -162,7 +177,10 @@ class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterfac
             && method_exists($data, 'getValue')
             // Check that ValueObject is part of the namespace
             && str_contains(get_class($data), 'ValueObject')
-            && $this->getConstructorParameter($data);
+            && (
+                $this->getConstructorParameter($data)
+                || $this->isNoValueClass($data)
+            );
     }
 
     protected function isValueObjectType(string $type): bool
@@ -171,7 +189,10 @@ class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterfac
             && method_exists($type, 'getValue')
             // Check that ValueObject is part of the namespace
             && str_contains($type, 'ValueObject')
-            && $this->getConstructorParameter($type);
+            && (
+                $this->getConstructorParameter($type)
+                || $this->isNoValueClass($type)
+            );
     }
 
     protected function matchesConstructorParameter(mixed $value, string $type): bool
@@ -238,5 +259,28 @@ class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterfac
         }
 
         return $this->constructorParameter[$objectType] ?? null;
+    }
+
+    /**
+     * Is the class used for "no values" like NoStateId, NoCombination that always carry the
+     * 0 value.
+     */
+    protected function isNoValueClass(object|string $type): bool
+    {
+        $objectType = is_object($type) ? get_class($type) : $type;
+        if (!array_key_exists($objectType, $this->noValueClasses)) {
+            $metadata = $this->classMetadataFactory->getMetadataFor($objectType);
+            $shortName = $metadata->getReflectionClass()->getShortName();
+            $matches = [];
+            // Check that the class name starts with No, the following part should be the expected ShortName
+            // when value is set
+            if (!preg_match('/No(.+)/', $shortName, $matches)) {
+                $this->noValueClasses[$objectType] = null;
+            } else {
+                $this->noValueClasses[$objectType] = $matches[1];
+            }
+        }
+
+        return !empty($this->noValueClasses[$objectType]);
     }
 }

--- a/tests/Integration/ApiPlatform/Serializer/CQRSApiSerializerTest.php
+++ b/tests/Integration/ApiPlatform/Serializer/CQRSApiSerializerTest.php
@@ -17,12 +17,16 @@ use PrestaShop\Module\APIResources\ApiPlatform\Resources\Product\Product;
 use PrestaShop\PrestaShop\Core\Context\CurrencyContextBuilder;
 use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
 use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Address\QueryResult\EditableCustomerAddress;
+use PrestaShop\PrestaShop\Core\Domain\Address\ValueObject\AddressId;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\ValueObject\CreatedApiClient;
+use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Command\AddCustomerGroupCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Command\EditCustomerGroupCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Query\GetCustomerGroupForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\QueryResult\EditableCustomerGroup;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\ValueObject\GroupId;
+use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\AddDiscountCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\UpdateDiscountCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\ProductRule;
@@ -40,6 +44,8 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\QueryResult\VirtualProductFileForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopCollection;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\NoStateId;
+use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\StateId;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 use PrestaShopBundle\ApiPlatform\NormalizationMapper;
@@ -688,6 +694,96 @@ class CQRSApiSerializerTest extends KernelTestCase
             $productId,
             [
                 'productId' => 42,
+            ],
+        ];
+
+        yield 'normalize EditableCustomerAddress with no state ID' => [
+            new EditableCustomerAddress(
+                new AddressId(1),
+                new CustomerId(42),
+                'pub@prestashop.com',
+                'Order Test Address',
+                'John',
+                'Doe',
+                '1 street Example',
+                'Orleans',
+                new CountryId(8),
+                '45000',
+                'dni',
+                'company',
+                'vatNumber',
+                'address2',
+                new NoStateId(),
+                '',
+                '',
+                '',
+                []
+            ),
+            [
+                'addressId' => 1,
+                'customerId' => 42,
+                'customerEmail' => 'pub@prestashop.com',
+                'addressAlias' => 'Order Test Address',
+                'firstName' => 'John',
+                'lastName' => 'Doe',
+                'address' => '1 street Example',
+                'city' => 'Orleans',
+                'countryId' => 8,
+                'postCode' => '45000',
+                'dni' => 'dni',
+                'company' => 'company',
+                'vatNumber' => 'vatNumber',
+                'address2' => 'address2',
+                'stateId' => 0,
+                'homePhone' => '',
+                'mobilePhone' => '',
+                'other' => '',
+                'requiredFields' => [],
+            ],
+        ];
+
+        yield 'normalize EditableCustomerAddress with StateID' => [
+            new EditableCustomerAddress(
+                new AddressId(1),
+                new CustomerId(42),
+                'pub@prestashop.com',
+                'Order Test Address',
+                'John',
+                'Doe',
+                '1 street Example',
+                'Orleans',
+                new CountryId(8),
+                '45000',
+                'dni',
+                'company',
+                'vatNumber',
+                'address2',
+                new StateId(4),
+                '',
+                '',
+                '',
+                []
+            ),
+            [
+                'addressId' => 1,
+                'customerId' => 42,
+                'customerEmail' => 'pub@prestashop.com',
+                'addressAlias' => 'Order Test Address',
+                'firstName' => 'John',
+                'lastName' => 'Doe',
+                'address' => '1 street Example',
+                'city' => 'Orleans',
+                'countryId' => 8,
+                'postCode' => '45000',
+                'dni' => 'dni',
+                'company' => 'company',
+                'vatNumber' => 'vatNumber',
+                'address2' => 'address2',
+                'stateId' => 4,
+                'homePhone' => '',
+                'mobilePhone' => '',
+                'other' => '',
+                'requiredFields' => [],
             ],
         ];
 

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizerTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizerTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\EditApiClientCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\NoStateId;
 use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
@@ -37,6 +38,7 @@ class ValueObjectNormalizerTest extends TestCase
         yield 'real value object based on string' => [new ProductType(ProductType::TYPE_STANDARD), true];
         yield 'object with getValue but not ValueObject namespace' => [new DbMySQLi('localhost', 'root', 'root', 'prestashop', false), false];
         yield 'object without getValue method' => [new ContactTypeChoiceProvider(1), false];
+        yield 'no state id' => [new NoStateId(), true];
     }
 
     /**
@@ -61,6 +63,9 @@ class ValueObjectNormalizerTest extends TestCase
 
         yield 'VO integer as scalar' => [new ProductId(1), 1, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
         yield 'VO string as scalar' => [new ProductType(ProductType::TYPE_STANDARD), ProductType::TYPE_STANDARD, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+
+        yield 'no state id' => [new NoStateId(), ['stateId' => NoStateId::NO_STATE_ID_VALUE]];
+        yield 'no state id as scalar' => [new NoStateId(), NoStateId::NO_STATE_ID_VALUE, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
     }
 
     /**
@@ -92,6 +97,13 @@ class ValueObjectNormalizerTest extends TestCase
         yield 'product type value' => [['value' => ProductType::TYPE_COMBINATIONS], ProductType::class, true];
         yield 'product type string' => [ProductType::TYPE_COMBINATIONS, ProductType::class, true];
         yield 'product type integer' => [42, ProductType::class, false];
+
+        yield 'no state id, stateId' => [['stateId' => 0], NoStateId::class, true];
+        yield 'no state id, noStateId' => [['noStateId' => 0], NoStateId::class, true];
+        yield 'no state id, state_id' => [['state_id' => 0], NoStateId::class, true];
+        yield 'no state id, value' => [['value' => 0], NoStateId::class, true];
+        yield 'no state id, integer' => [0, NoStateId::class, true];
+        yield 'no state id, string' => ['0', NoStateId::class, true];
     }
 
     /**
@@ -131,5 +143,11 @@ class ValueObjectNormalizerTest extends TestCase
         yield 'product type snake case as scalar' => [['product_type' => ProductType::TYPE_COMBINATIONS], ProductType::class, ProductType::TYPE_COMBINATIONS, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
         yield 'product type value as scalar' => [['value' => ProductType::TYPE_COMBINATIONS], ProductType::class, ProductType::TYPE_COMBINATIONS, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
         yield 'product type string as scalar' => [ProductType::TYPE_COMBINATIONS, ProductType::class, ProductType::TYPE_COMBINATIONS, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+
+        yield 'no state id, stateId' => [['stateId' => 0], NoStateId::class, new NoStateId()];
+        yield 'no state id, noStateId' => [['noStateId' => 0], NoStateId::class, new NoStateId()];
+        yield 'no state id, state_id' => [['state_id' => 0], NoStateId::class, new NoStateId()];
+        yield 'no state id, value' => [['value' => 0], NoStateId::class, new NoStateId()];
+        yield 'no state id, integer' => [0, NoStateId::class, new NoStateId()];
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Handle no value objects, like NoStateId, NoCombinationId in ValueObjectNormalizer
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and UI tests green
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/22623264391
| Fixed issue or discussion?     | ~
| Related PRs       | Bug found via https://github.com/PrestaShop/ps_apiresources/pull/144 But the PR uses a workaround to keep compatibility with 9.0 for now
| Sponsor company   | ~
