### PR TITLE
Dynamize docker names when using docker exec in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -143,6 +143,11 @@ jobs:
     name: Admin Security Attribute Linter
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare docker prefix with repository name lower cased
+        run: |
+          REPOSITORY_NAME=${{ github.event.repository.name }}
+          echo "DOCKER_PREFIX=${REPOSITORY_NAME@L}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
 
       # First install the shop to that the modules controllers are also scanned (not the case without installation)
@@ -157,7 +162,7 @@ jobs:
       - name: Setup Environment failure
         uses: ./.github/actions/setup-env-export-logs
         with:
-          DOCKER_PREFIX: prestashop
+          DOCKER_PREFIX: ${{ env.DOCKER_PREFIX }}
           ARTIFACT_NAME: setup-symfony-console-${{ matrix.app-id }}
           ENABLE_SSL: 'true'
           INSTALL_AUTO: 'true'
@@ -166,4 +171,31 @@ jobs:
       - name: Run Admin Security Attribute Linter (inside the docker so installed modules are also scanned)
         run: |
           echo Searching for routes without security
-          docker exec prestashop-prestashop-git-1 php bin/console prestashop:linter:security-attribute find-missing
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php bin/console prestashop:linter:security-attribute find-missing
+
+  header-stamp:
+    name: Check license headers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Composer cache
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache Composer Directory
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Composer Install
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
+
+      # Run header stamp
+      - name: Header stamp dry run
+        run: composer header-stamp
+      # Little hint to help contributors fix their PRs
+      - name: Hint to fix
+        if: failure()
+        run: echo "::notice::Run composer header-stamp-fix at the root of the project to fix files, or update the .header-stamp-config.yml file to add exceptions"

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -19,30 +19,3 @@ jobs:
         uses: PrestaShop/.github/.github/actions/normalize-dependabot-pr@master
         with:
           default-branch: ${{ github.event.pull_request.base.ref }}
-
-  header-stamp:
-    name: Check license headers
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      # Composer cache
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - name: Cache Composer Directory
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-      - name: Composer Install
-        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
-
-      # Run header stamp
-      - name: Header stamp dry run
-        run: composer header-stamp
-      # Little hint to help contributors fix their PRs
-      - name: Hint to fix
-        if: failure()
-        run: echo "::notice::Run composer header-stamp-fix at the root of the project to fix files, or update the .header-stamp-config.yml file to add exceptions"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -27,8 +27,12 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.workflow_matrix_generator.outputs.dynamic_matrix) }}
       fail-fast: false
-
     steps:
+      - name: Prepare docker prefix with repository name lower cased
+        run: |
+          REPOSITORY_NAME=${{ github.event.repository.name }}
+          echo "DOCKER_PREFIX=${REPOSITORY_NAME@L}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
 
       - name: Setup Environment
@@ -43,7 +47,7 @@ jobs:
       - name: Setup Environment failure
         uses: ./.github/actions/setup-env-export-logs
         with:
-          DOCKER_PREFIX: prestashop
+          DOCKER_PREFIX: ${{ env.DOCKER_PREFIX }}
           ARTIFACT_NAME: setup-sanity-${{ matrix.php }}-${{ matrix.browser }}-${{ matrix.db }}
           DB_SERVER: ${{ matrix.db }}
           ENABLE_SSL: 'true'
@@ -62,7 +66,7 @@ jobs:
         run: |
           mkdir -p ./var/docker-logs
           docker logs prestashop-${{ matrix.db }}-1 > ./var/docker-logs/${{ matrix.db }}.log
-          docker logs prestashop-prestashop-git-1 > ./var/docker-logs/prestashop.log
+          docker logs ${{ inputs.DOCKER_PREFIX }}-prestashop-git-1 > ./var/docker-logs/prestashop.log
 
       - name: Upload Screenshots and logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/symfony-console.yml
+++ b/.github/workflows/symfony-console.yml
@@ -19,6 +19,11 @@ jobs:
     name: Symfony Console
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare docker prefix with repository name lower cased
+        run: |
+          REPOSITORY_NAME=${{ github.event.repository.name }}
+          echo "DOCKER_PREFIX=${REPOSITORY_NAME@L}" >> $GITHUB_ENV
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -102,7 +107,7 @@ jobs:
       - name: Setup Environment failure
         uses: ./.github/actions/setup-env-export-logs
         with:
-          DOCKER_PREFIX: prestashop
+          DOCKER_PREFIX: ${{ env.DOCKER_PREFIX }}
           ARTIFACT_NAME: setup-symfony-console-${{ matrix.app-id }}
           ENABLE_SSL: 'true'
           INSTALL_AUTO: 'false'
@@ -111,8 +116,8 @@ jobs:
       # Retest the console after shop install
       - name: Check bin/console and cache:clear can run after shop install
         run: |
-          docker exec prestashop-prestashop-git-1 php ./bin/console --app-id=${{ matrix.app-id }}
-          docker exec prestashop-prestashop-git-1 php -d memory_limit=-1 ./bin/console cache:clear --env=dev --app-id=${{ matrix.app-id }}
-          docker exec prestashop-prestashop-git-1 php -d memory_limit=-1 ./bin/console cache:clear --env=prod --app-id=${{ matrix.app-id }}
-          docker exec prestashop-prestashop-git-1 php ./bin/console cache:clear --env=dev --no-warmup --app-id=${{ matrix.app-id }}
-          docker exec prestashop-prestashop-git-1 php ./bin/console cache:clear --env=prod --no-warmup --app-id=${{ matrix.app-id }}
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php ./bin/console --app-id=${{ matrix.app-id }}
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php -d memory_limit=-1 ./bin/console cache:clear --env=dev --app-id=${{ matrix.app-id }}
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php -d memory_limit=-1 ./bin/console cache:clear --env=prod --app-id=${{ matrix.app-id }}
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php ./bin/console cache:clear --env=dev --no-warmup --app-id=${{ matrix.app-id }}
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php ./bin/console cache:clear --env=prod --no-warmup --app-id=${{ matrix.app-id }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Dynamize docker names when using docker exec in CI, this way these CI can work on a forked repository even when the name is not strictly `prestashop` Also header stamp job was moved in the lint workflow because the original workflow requires write access which is not relevant for this linter (and may also not work on some forks)
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green
| UI Tests          | ~
| Fixed issue or discussion?     | ~
| Related PRs       | ~
| Sponsor company   | ~
