### PR TITLE
Fix precision of cart calculator

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -127,7 +127,7 @@ parameters:
 
 		-
 			message: "#^Namespace Tools is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
-			count: 3
+			count: 4
 			path: src/Core/Cart/Calculator.php
 
 		-

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -403,7 +403,7 @@ class Calculator
      *
      * @return AmountImmutable
      */
-    private function roundedTaxIncluded(AmountImmutable $amount, int $computePrecision)
+    private function roundedTaxIncluded(AmountImmutable $amount, int $computePrecision): AmountImmutable
     {
         return new AmountImmutable(
             Tools::ps_round($amount->getTaxIncluded(), $computePrecision),

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -156,12 +156,29 @@ class Calculator
             throw new Exception('Cart must be processed before getting its total');
         }
 
+        /*
+         * First, we get the total price of items in the cart with no discounts.
+         * We will round everything once again, because some prices in the sum may not be rounded
+         * to keep their precision.
+         */
         $amount = $this->rounded($this->getRowTotalWithoutDiscount(), $this->computePrecision);
+
+        /*
+         * Now, we subtract the amount of discounts from this sum.
+         */
         $amount = $amount->sub($this->rounded($this->getDiscountTotal(), $this->computePrecision));
+
+        /*
+         * Next thing, we add a rounded value for shipping fees.
+         */
         $shippingFees = $this->fees->getInitialShippingFees();
         if (null !== $shippingFees) {
             $amount = $amount->add($this->rounded($shippingFees, $this->computePrecision));
         }
+
+        /*
+         * And absolutely last, we add wrapping fees if they are present.
+         */
         $wrappingFees = $this->fees->getFinalWrappingFees();
         if (null !== $wrappingFees) {
             $amount = $amount->add($this->rounded($wrappingFees, $this->computePrecision));
@@ -186,6 +203,9 @@ class Calculator
     }
 
     /**
+     * This method returns sum of all cart lines - products.
+     * It returns the prices with their original price, without applying any cart rules on them.
+     *
      * @return AmountImmutable
      *
      * @throws Exception
@@ -194,7 +214,19 @@ class Calculator
     {
         $amount = new AmountImmutable();
         foreach ($this->cartRows as $cartRow) {
-            $amount = $amount->add($cartRow->getInitialTotalPrice());
+            /*
+             * We round the tax included price only, to keep the calculations using
+             * the displayed prices the user sees. If he sees 999 EUR, we will use this
+             * rounded values for calculations, no magic 999.5 EUR behind this.
+             *
+             * For tax excluded price however, we keep the non-rounded value, because we could
+             * have a big difference at the end of the calculation. We will round the tax
+             * excluded price as a last thing.
+             *
+             * If we decide one day to support using tax excluded price as the primary one, we
+             * can reverse this the other way around.
+             */
+            $amount = $amount->add($this->roundedTaxIncluded($cartRow->getInitialTotalPrice(), $this->computePrecision));
         }
 
         return $amount;
@@ -294,7 +326,7 @@ class Calculator
     }
 
     /**
-     * calculate only product rows.
+     * Calculate only product rows.
      */
     public function calculateRows()
     {
@@ -304,7 +336,7 @@ class Calculator
     }
 
     /**
-     * calculate only cart rules (rows and fees have to be calculated first).
+     * Calculate only cart rules (rows and fees have to be calculated first).
      */
     public function calculateCartRules()
     {
@@ -345,6 +377,9 @@ class Calculator
     }
 
     /**
+     * Rounds both values in the amount by given precision. Useful for total sums,
+     * where no additional precision is required and we want the final price.
+     *
      * @param AmountImmutable $amount
      * @param int $computePrecision
      *
@@ -355,6 +390,24 @@ class Calculator
         return new AmountImmutable(
             Tools::ps_round($amount->getTaxIncluded(), $computePrecision),
             Tools::ps_round($amount->getTaxExcluded(), $computePrecision)
+        );
+    }
+
+    /**
+     * Rounds only tax included price by given precision and leaves the tax
+     * excluded price with original precision. Useful for inter-calculations
+     * when we have one primary price to use.
+     *
+     * @param AmountImmutable $amount
+     * @param int $computePrecision
+     *
+     * @return AmountImmutable
+     */
+    private function roundedTaxIncluded(AmountImmutable $amount, int $computePrecision)
+    {
+        return new AmountImmutable(
+            Tools::ps_round($amount->getTaxIncluded(), $computePrecision),
+            $amount->getTaxExcluded()
         );
     }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Rounding/RoundingType/round_line.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Rounding/RoundingType/round_line.feature
@@ -27,7 +27,7 @@ Feature: Cart calculation with rounding type LINE
     When I add 2 items of product "product2" in my cart
     And I add 3 items of product "product1" in my cart
     And I add 1 items of product "product3" in my cart
-    Then my cart total should be precisely 162.4 tax included
+    Then my cart total should be precisely 162.41 tax included
     And my cart total shipping fees should be 7.0 tax included
 
   @restore-cart-rules-after-scenario

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Rounding/RoundingType/round_total.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Rounding/RoundingType/round_total.feature
@@ -27,7 +27,7 @@ Feature: Cart calculation with rounding type TOTAL
     When I add 2 items of product "product2" in my cart
     When I add 3 items of product "product1" in my cart
     When I add 1 items of product "product3" in my cart
-    Then my cart total should be precisely 162.4 tax included
+    Then my cart total should be precisely 162.41 tax included
     And my cart total shipping fees should be 7.0 tax included
 
   @restore-cart-rules-after-scenario


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Fixes a rounding issue in case of products with specific prices. This can sometimes result in a bug when order total is different than total products. Revival of PR https://github.com/PrestaShop/PrestaShop/pull/36493.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI + UI + specific cases
| UI Tests          | https://github.com/Hlavtox/ga.tests.ui.pr/actions/runs/30258224585
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/36369
| Related PRs       | 
| Sponsor company   | [TRENDO s.r.o.](https://www.trendo.cz/)

### How to test
Setup a currency with 0 decimal places. Setup some free carrier. A tax rule 21%.
Create three products.
- Product A
  - a) 825,619800 tax exc.
  - b) 998,999958 tax inc.
  - c) specific price discount 30 %
- Product B
  - a) 412,396700 tax exc.
  - b) 499,000007 tax inc.
  - c) specific price discount 30 %
- Product C
  - a) 990,909100 tax exc.
  - b) 1199,000011 tax inc.
  - c) specific price discount 20 %
- Order it in FO, with some free carrier.
- Check BO, see that product total is 2007, but order total is 2008.