### PR TITLE
Fix email HTML previews for module emails

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -143,6 +143,11 @@ jobs:
     name: Admin Security Attribute Linter
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare docker prefix with repository name lower cased
+        run: |
+          REPOSITORY_NAME=${{ github.event.repository.name }}
+          echo "DOCKER_PREFIX=${REPOSITORY_NAME@L}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
 
       # First install the shop to that the modules controllers are also scanned (not the case without installation)
@@ -157,7 +162,7 @@ jobs:
       - name: Setup Environment failure
         uses: ./.github/actions/setup-env-export-logs
         with:
-          DOCKER_PREFIX: prestashop
+          DOCKER_PREFIX: ${{ env.DOCKER_PREFIX }}
           ARTIFACT_NAME: setup-symfony-console-${{ matrix.app-id }}
           ENABLE_SSL: 'true'
           INSTALL_AUTO: 'true'
@@ -166,4 +171,31 @@ jobs:
       - name: Run Admin Security Attribute Linter (inside the docker so installed modules are also scanned)
         run: |
           echo Searching for routes without security
-          docker exec prestashop-prestashop-git-1 php bin/console prestashop:linter:security-attribute find-missing
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php bin/console prestashop:linter:security-attribute find-missing
+
+  header-stamp:
+    name: Check license headers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Composer cache
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache Composer Directory
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Composer Install
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
+
+      # Run header stamp
+      - name: Header stamp dry run
+        run: composer header-stamp
+      # Little hint to help contributors fix their PRs
+      - name: Hint to fix
+        if: failure()
+        run: echo "::notice::Run composer header-stamp-fix at the root of the project to fix files, or update the .header-stamp-config.yml file to add exceptions"

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -19,30 +19,3 @@ jobs:
         uses: PrestaShop/.github/.github/actions/normalize-dependabot-pr@master
         with:
           default-branch: ${{ github.event.pull_request.base.ref }}
-
-  header-stamp:
-    name: Check license headers
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      # Composer cache
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - name: Cache Composer Directory
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-      - name: Composer Install
-        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
-
-      # Run header stamp
-      - name: Header stamp dry run
-        run: composer header-stamp
-      # Little hint to help contributors fix their PRs
-      - name: Hint to fix
-        if: failure()
-        run: echo "::notice::Run composer header-stamp-fix at the root of the project to fix files, or update the .header-stamp-config.yml file to add exceptions"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -27,8 +27,12 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.workflow_matrix_generator.outputs.dynamic_matrix) }}
       fail-fast: false
-
     steps:
+      - name: Prepare docker prefix with repository name lower cased
+        run: |
+          REPOSITORY_NAME=${{ github.event.repository.name }}
+          echo "DOCKER_PREFIX=${REPOSITORY_NAME@L}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
 
       - name: Setup Environment
@@ -43,7 +47,7 @@ jobs:
       - name: Setup Environment failure
         uses: ./.github/actions/setup-env-export-logs
         with:
-          DOCKER_PREFIX: prestashop
+          DOCKER_PREFIX: ${{ env.DOCKER_PREFIX }}
           ARTIFACT_NAME: setup-sanity-${{ matrix.php }}-${{ matrix.browser }}-${{ matrix.db }}
           DB_SERVER: ${{ matrix.db }}
           ENABLE_SSL: 'true'
@@ -62,7 +66,7 @@ jobs:
         run: |
           mkdir -p ./var/docker-logs
           docker logs prestashop-${{ matrix.db }}-1 > ./var/docker-logs/${{ matrix.db }}.log
-          docker logs prestashop-prestashop-git-1 > ./var/docker-logs/prestashop.log
+          docker logs ${{ inputs.DOCKER_PREFIX }}-prestashop-git-1 > ./var/docker-logs/prestashop.log
 
       - name: Upload Screenshots and logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/symfony-console.yml
+++ b/.github/workflows/symfony-console.yml
@@ -19,6 +19,11 @@ jobs:
     name: Symfony Console
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare docker prefix with repository name lower cased
+        run: |
+          REPOSITORY_NAME=${{ github.event.repository.name }}
+          echo "DOCKER_PREFIX=${REPOSITORY_NAME@L}" >> $GITHUB_ENV
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -102,7 +107,7 @@ jobs:
       - name: Setup Environment failure
         uses: ./.github/actions/setup-env-export-logs
         with:
-          DOCKER_PREFIX: prestashop
+          DOCKER_PREFIX: ${{ env.DOCKER_PREFIX }}
           ARTIFACT_NAME: setup-symfony-console-${{ matrix.app-id }}
           ENABLE_SSL: 'true'
           INSTALL_AUTO: 'false'
@@ -111,8 +116,8 @@ jobs:
       # Retest the console after shop install
       - name: Check bin/console and cache:clear can run after shop install
         run: |
-          docker exec prestashop-prestashop-git-1 php ./bin/console --app-id=${{ matrix.app-id }}
-          docker exec prestashop-prestashop-git-1 php -d memory_limit=-1 ./bin/console cache:clear --env=dev --app-id=${{ matrix.app-id }}
-          docker exec prestashop-prestashop-git-1 php -d memory_limit=-1 ./bin/console cache:clear --env=prod --app-id=${{ matrix.app-id }}
-          docker exec prestashop-prestashop-git-1 php ./bin/console cache:clear --env=dev --no-warmup --app-id=${{ matrix.app-id }}
-          docker exec prestashop-prestashop-git-1 php ./bin/console cache:clear --env=prod --no-warmup --app-id=${{ matrix.app-id }}
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php ./bin/console --app-id=${{ matrix.app-id }}
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php -d memory_limit=-1 ./bin/console cache:clear --env=dev --app-id=${{ matrix.app-id }}
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php -d memory_limit=-1 ./bin/console cache:clear --env=prod --app-id=${{ matrix.app-id }}
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php ./bin/console cache:clear --env=dev --no-warmup --app-id=${{ matrix.app-id }}
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php ./bin/console cache:clear --env=prod --no-warmup --app-id=${{ matrix.app-id }}

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -816,6 +816,6 @@ abstract class ControllerCore
 
     public function getControllerName(): string
     {
-        return Tools::toCamelCase($this->php_self, true);
+        return str_replace('Core', '', get_class($this));
     }
 }

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -813,4 +813,9 @@ abstract class ControllerCore
     {
         return $this->get(static::SERVICE_MULTISTORE_FEATURE)->isUsed();
     }
+
+    public function getControllerName(): string
+    {
+        return Tools::toCamelCase($this->php_self, true);
+    }
 }

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -816,6 +816,6 @@ abstract class ControllerCore
 
     public function getControllerName(): string
     {
-        return str_replace('Core', '', get_class($this));
+        return get_class($this);
     }
 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -225,6 +225,7 @@ class FrontControllerCore extends Controller
                 'controller' => $this,
             ]
         );
+        Hook::exec('actionFrontController' . $this->getControllerName() . 'InitBefore', ['controller' => $this]);
 
         /*
          * Globals are DEPRECATED as of version 1.5.0.1
@@ -492,6 +493,7 @@ class FrontControllerCore extends Controller
                 'controller' => $this,
             ]
         );
+        Hook::exec('actionFrontController' . $this->getControllerName() . 'InitAfter', ['controller' => $this]);
     }
 
     /**
@@ -506,6 +508,8 @@ class FrontControllerCore extends Controller
 
     /**
      * Initializes a set of commonly used variables, available for use in the template.
+     *
+     * @throws PrestaShopException
      */
     protected function assignGeneralPurposeVariables()
     {
@@ -514,6 +518,12 @@ class FrontControllerCore extends Controller
 
         Hook::exec(
             'actionFrontControllerSetVariablesBefore',
+            [
+                'templateVars' => &$templateVars,
+                'cart' => $cart,
+            ]
+        );
+        Hook::exec('actionFrontController' . $this->getControllerName() . 'SetVariablesBefore',
             [
                 'templateVars' => &$templateVars,
                 'cart' => $cart,
@@ -549,6 +559,16 @@ class FrontControllerCore extends Controller
             null,
             true
         );
+        $modulesVariables = array_merge(
+            $modulesVariables,
+            Hook::exec('actionFrontController' . $this->getControllerName() . 'SetVariables',
+                [
+                    'templateVars' => &$templateVars,
+                ],
+                null,
+                true
+            )
+        );
 
         if (is_array($modulesVariables)) {
             foreach ($modulesVariables as $moduleName => $variables) {
@@ -581,12 +601,17 @@ class FrontControllerCore extends Controller
         Hook::exec('actionBuildFrontEndObject', [
             'obj' => &$object,
         ]);
+        Hook::exec('actionBuildFront' . $this->getControllerName() . 'EndObject', [
+            'obj' => &$object,
+        ]);
 
         return $object;
     }
 
     /**
      * Initializes common front page content: header, footer and side columns.
+     *
+     * @throws PrestaShopException
      */
     public function initContent()
     {
@@ -594,7 +619,8 @@ class FrontControllerCore extends Controller
         $this->process();
 
         $this->context->smarty->assign([
-            'HOOK_HEADER' => Hook::exec('displayHeader'),
+            'HOOK_HEADER' => Hook::exec('displayHeader')
+                . Hook::exec('display' . $this->getControllerName() . 'Header'),
         ]);
     }
 
@@ -734,6 +760,7 @@ class FrontControllerCore extends Controller
         }
 
         Hook::exec('actionOutputHTMLBefore', ['html' => &$html]);
+        Hook::exec('actionOutput' . $this->getControllerName() . 'HTMLBefore', ['html' => &$html]);
         echo trim($html);
     }
 
@@ -783,7 +810,7 @@ class FrontControllerCore extends Controller
                 $this->context->smarty->assign([
                     'urls' => $this->getTemplateVarUrls(),
                     'shop' => $this->getTemplateVarShop(),
-                    'HOOK_MAINTENANCE' => Hook::exec('displayMaintenance', []),
+                    'HOOK_MAINTENANCE' => Hook::exec('displayMaintenance'),
                     'maintenance_text' => Configuration::get('PS_MAINTENANCE_TEXT', (int) $this->context->language->id),
                     'stylesheets' => $this->getStylesheets(),
                 ]);
@@ -935,6 +962,7 @@ class FrontControllerCore extends Controller
      * Sets controller CSS and JS files.
      *
      * @return bool
+     * @throws PrestaShopException
      */
     public function setMedia()
     {
@@ -962,7 +990,8 @@ class FrontControllerCore extends Controller
         }
 
         // Execute Hook FrontController SetMedia
-        Hook::exec('actionFrontControllerSetMedia', []);
+        Hook::exec('actionFrontControllerSetMedia');
+        Hook::exec('actionFrontController' . $this->getControllerName() . 'SetMedia');
 
         return true;
     }
@@ -2197,5 +2226,10 @@ class FrontControllerCore extends Controller
         }
 
         return Validate::isUrl($data);
+    }
+
+    protected function getControllerName(): string
+    {
+        return Tools::toCamelCase($this->php_self, true);
     }
 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -225,7 +225,7 @@ class FrontControllerCore extends Controller
                 'controller' => $this,
             ]
         );
-        Hook::exec('actionFrontController' . $this->getControllerName() . 'InitBefore', ['controller' => $this]);
+        Hook::exec('action' . $this->getControllerName() . 'InitBefore', ['controller' => $this]);
 
         /*
          * Globals are DEPRECATED as of version 1.5.0.1
@@ -493,7 +493,7 @@ class FrontControllerCore extends Controller
                 'controller' => $this,
             ]
         );
-        Hook::exec('actionFrontController' . $this->getControllerName() . 'InitAfter', ['controller' => $this]);
+        Hook::exec('action' . $this->getControllerName() . 'InitAfter', ['controller' => $this]);
     }
 
     /**
@@ -523,7 +523,7 @@ class FrontControllerCore extends Controller
                 'cart' => $cart,
             ]
         );
-        Hook::exec('actionFrontController' . $this->getControllerName() . 'SetVariablesBefore',
+        Hook::exec('action' . $this->getControllerName() . 'SetVariablesBefore',
             [
                 'templateVars' => &$templateVars,
                 'cart' => $cart,
@@ -561,7 +561,7 @@ class FrontControllerCore extends Controller
         );
         $modulesVariables = array_merge(
             $modulesVariables,
-            Hook::exec('actionFrontController' . $this->getControllerName() . 'SetVariables',
+            Hook::exec('action' . $this->getControllerName() . 'SetVariables',
                 [
                     'templateVars' => &$templateVars,
                 ],
@@ -601,7 +601,7 @@ class FrontControllerCore extends Controller
         Hook::exec('actionBuildFrontEndObject', [
             'obj' => &$object,
         ]);
-        Hook::exec('actionBuildFront' . $this->getControllerName() . 'EndObject', [
+        Hook::exec('actionBuild' . $this->getControllerName() . 'FrontEndObject', [
             'obj' => &$object,
         ]);
 
@@ -992,7 +992,7 @@ class FrontControllerCore extends Controller
 
         // Execute Hook FrontController SetMedia
         Hook::exec('actionFrontControllerSetMedia');
-        Hook::exec('actionFrontController' . $this->getControllerName() . 'SetMedia');
+        Hook::exec('action' . $this->getControllerName() . 'SetMedia');
 
         return true;
     }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -2228,9 +2228,4 @@ class FrontControllerCore extends Controller
 
         return Validate::isUrl($data);
     }
-
-    protected function getControllerName(): string
-    {
-        return Tools::toCamelCase($this->php_self, true);
-    }
 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -962,6 +962,7 @@ class FrontControllerCore extends Controller
      * Sets controller CSS and JS files.
      *
      * @return bool
+     *
      * @throws PrestaShopException
      */
     public function setMedia()

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1171,14 +1171,14 @@ class AdminImportControllerCore extends AdminController
         }
         AdminImportController::setDefaultValues($info);
 
-        if ($force_ids && isset($info['id']) && (int) $info['id']) {
+        if (!$force_ids) {
+            unset($info['id']);
+        }
+
+        if ($force_ids && isset($info['id']) && (int) $info['id'] && Category::existsInDatabase((int) $info['id'], 'category')) {
             $category = new Category((int) $info['id']);
         } else {
-            if (isset($info['id']) && (int) $info['id'] && Category::existsInDatabase((int) $info['id'], 'category')) {
-                $category = new Category((int) $info['id']);
-            } else {
-                $category = new Category();
-            }
+            $category = new Category();
         }
 
         AdminImportController::arrayWalk($info, ['AdminImportController', 'fillInfo'], $category);
@@ -2661,14 +2661,14 @@ class AdminImportControllerCore extends AdminController
     {
         AdminImportController::setDefaultValues($info);
 
-        if ($force_ids && isset($info['id']) && (int) $info['id']) {
+        if (!$force_ids) {
+            unset($info['id']);
+        }
+
+        if ($force_ids && isset($info['id']) && (int) $info['id'] && Customer::customerIdExistsStatic((int) $info['id'])) {
             $customer = new Customer((int) $info['id']);
         } else {
-            if (array_key_exists('id', $info) && (int) $info['id'] && Customer::customerIdExistsStatic((int) $info['id'])) {
-                $customer = new Customer((int) $info['id']);
-            } else {
-                $customer = new Customer();
-            }
+            $customer = new Customer();
         }
 
         $customer_exist = false;
@@ -2920,14 +2920,13 @@ class AdminImportControllerCore extends AdminController
     {
         AdminImportController::setDefaultValues($info);
 
-        if ($force_ids && isset($info['id']) && (int) $info['id']) {
+        if (!$force_ids) {
+            unset($info['id']);
+        }
+        if ($force_ids && isset($info['id']) && (int) $info['id'] && Address::addressExists((int) $info['id'])) {
             $address = new Address((int) $info['id']);
         } else {
-            if (array_key_exists('id', $info) && (int) $info['id'] && Address::addressExists((int) $info['id'])) {
-                $address = new Address((int) $info['id']);
-            } else {
-                $address = new Address();
-            }
+            $address = new Address();
         }
 
         AdminImportController::arrayWalk($info, ['AdminImportController', 'fillInfo'], $address);
@@ -3240,14 +3239,13 @@ class AdminImportControllerCore extends AdminController
     {
         AdminImportController::setDefaultValues($info);
 
-        if ($force_ids && isset($info['id']) && (int) $info['id']) {
+        if (!$force_ids) {
+            unset($info['id']);
+        }
+        if ($force_ids && isset($info['id']) && (int) $info['id'] && Manufacturer::existsInDatabase((int) $info['id'], 'manufacturer')) {
             $manufacturer = new Manufacturer((int) $info['id']);
         } else {
-            if (array_key_exists('id', $info) && (int) $info['id'] && Manufacturer::existsInDatabase((int) $info['id'], 'manufacturer')) {
-                $manufacturer = new Manufacturer((int) $info['id']);
-            } else {
-                $manufacturer = new Manufacturer();
-            }
+            $manufacturer = new Manufacturer();
         }
 
         AdminImportController::arrayWalk($info, ['AdminImportController', 'fillInfo'], $manufacturer);
@@ -3355,14 +3353,13 @@ class AdminImportControllerCore extends AdminController
     {
         AdminImportController::setDefaultValues($info);
 
-        if ($force_ids && isset($info['id']) && (int) $info['id']) {
+        if (!$force_ids) {
+            unset($info['id']);
+        }
+        if ($force_ids && isset($info['id']) && (int) $info['id'] && Supplier::existsInDatabase((int) $info['id'], 'supplier')) {
             $supplier = new Supplier((int) $info['id']);
         } else {
-            if (array_key_exists('id', $info) && (int) $info['id'] && Supplier::existsInDatabase((int) $info['id'], 'supplier')) {
-                $supplier = new Supplier((int) $info['id']);
-            } else {
-                $supplier = new Supplier();
-            }
+            $supplier = new Supplier();
         }
 
         AdminImportController::arrayWalk($info, ['AdminImportController', 'fillInfo'], $supplier);
@@ -3461,14 +3458,13 @@ class AdminImportControllerCore extends AdminController
     {
         AdminImportController::setDefaultValues($info);
 
-        if ($force_ids && isset($info['id']) && (int) $info['id']) {
+        if (!$force_ids) {
+            unset($info['id']);
+        }
+        if ($force_ids && isset($info['id']) && (int) $info['id'] && Alias::existsInDatabase((int) $info['id'], 'alias')) {
             $alias = new Alias((int) $info['id']);
         } else {
-            if (array_key_exists('id', $info) && (int) $info['id'] && Alias::existsInDatabase((int) $info['id'], 'alias')) {
-                $alias = new Alias((int) $info['id']);
-            } else {
-                $alias = new Alias();
-            }
+            $alias = new Alias();
         }
 
         AdminImportController::arrayWalk($info, ['AdminImportController', 'fillInfo'], $alias);
@@ -3541,14 +3537,13 @@ class AdminImportControllerCore extends AdminController
     {
         AdminImportController::setDefaultValues($info);
 
-        if ($force_ids && isset($info['id']) && (int) $info['id']) {
+        if (!$force_ids) {
+            unset($info['id']);
+        }
+        if ($force_ids && isset($info['id']) && (int) $info['id'] && Store::existsInDatabase((int) $info['id'], 'store')) {
             $store = new Store((int) $info['id']);
         } else {
-            if (array_key_exists('id', $info) && (int) $info['id'] && Store::existsInDatabase((int) $info['id'], 'store')) {
-                $store = new Store((int) $info['id']);
-            } else {
-                $store = new Store();
-            }
+            $store = new Store();
         }
 
         AdminImportController::arrayWalk($info, ['AdminImportController', 'fillInfo'], $store);

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -3036,10 +3036,24 @@ class AdminTranslationsControllerCore extends AdminController
             $email_file = _PS_ROOT_DIR_ . $email;
         }
 
-        if (strpos(realpath($email_file), _PS_MAIL_DIR_) === 0 && file_exists($email_file)) {
+        if (!file_exists($email_file)) {
+            return '';
+        }
+
+        $realEmailPath = realpath($email_file);
+
+        if (!$realEmailPath) {
+            return '';
+        }
+
+        $isCoreMail = strpos($realEmailPath, _PS_MAIL_DIR_) === 0;
+        $isModuleMail = strpos($realEmailPath, _PS_MODULE_DIR_) === 0
+            && str_contains($realEmailPath, '/mails/');
+
+        $email_html = '';
+
+        if ($isCoreMail || $isModuleMail) {
             $email_html = file_get_contents($email_file);
-        } else {
-            $email_html = '';
         }
 
         return $email_html;

--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -137,6 +137,10 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
             $customer->active = $command->isEnabled();
         }
 
+        if (null !== $command->isNewsletterSubscribed()) {
+            $customer->newsletter = $command->isNewsletterSubscribed();
+        }
+
         if (null !== $command->isPartnerOffersSubscribed()) {
             $customer->optin = $command->isPartnerOffersSubscribed();
         }

--- a/src/Adapter/State/CommandHandler/EditStateHandler.php
+++ b/src/Adapter/State/CommandHandler/EditStateHandler.php
@@ -38,11 +38,11 @@ class EditStateHandler implements EditStateHandlerInterface
         $state = $this->getState($command->getStateId());
 
         try {
-            if (null !== $command->getZoneId()->getValue()) {
+            if (null !== $command->getZoneId()) {
                 $state->id_zone = $command->getZoneId()->getValue();
             }
 
-            if (null !== $command->getCountryId()->getValue()) {
+            if (null !== $command->getCountryId()) {
                 $state->id_country = $command->getCountryId()->getValue();
             }
 

--- a/src/Core/Domain/Address/QueryResult/EditableCustomerAddress.php
+++ b/src/Core/Domain/Address/QueryResult/EditableCustomerAddress.php
@@ -10,7 +10,6 @@ namespace PrestaShop\PrestaShop\Core\Domain\Address\QueryResult;
 use PrestaShop\PrestaShop\Core\Domain\Address\ValueObject\AddressId;
 use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
-use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\StateId;
 use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\StateIdInterface;
 
 /**
@@ -128,7 +127,7 @@ class EditableCustomerAddress
      * @param string $company
      * @param string $vatNumber
      * @param string $address2
-     * @param StateId $stateId
+     * @param StateIdInterface $stateId
      * @param string $homePhone
      * @param string $mobilePhone
      * @param string $other

--- a/src/Core/Domain/Customer/Command/EditCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/EditCustomerCommand.php
@@ -285,10 +285,14 @@ class EditCustomerCommand
 
     /**
      * @param bool $isNewsletterSubscribed
+     *
+     * @return self
      */
     public function setNewsletterSubscribed($isNewsletterSubscribed)
     {
         $this->isNewsletterSubscribed = $isNewsletterSubscribed;
+
+        return $this;
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
@@ -162,6 +162,7 @@ final class CustomerFormDataHandler implements FormDataHandlerInterface
             ->setFirstName($data['first_name'])
             ->setLastName($data['last_name'])
             ->setIsEnabled($data['is_enabled'])
+            ->setNewsletterSubscribed($data['is_newsletter_subscribed'])
             ->setIsPartnerOffersSubscribed($data['is_partner_offers_subscribed'])
             ->setDefaultGroupId((int) $data['default_group_id'])
             ->setGroupIds($groupIds)

--- a/src/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProvider.php
@@ -71,6 +71,7 @@ final class CustomerFormDataProvider implements FormDataProviderInterface
             'email' => $editableCustomer->getEmail()->getValue(),
             'birthday' => $birthday->isEmpty() ? null : $birthday->getValue(),
             'is_enabled' => $editableCustomer->isEnabled(),
+            'is_newsletter_subscribed' => $editableCustomer->isNewsletterSubscribed(),
             'is_partner_offers_subscribed' => $editableCustomer->isPartnerOffersSubscribed(),
             'group_ids' => $editableCustomer->getGroupIds(),
             'default_group_id' => $editableCustomer->getDefaultGroupId(),

--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -147,7 +147,7 @@ class LogoUploader
                 }
             }
 
-            $idShop = $this->shop->id;
+            $idShop = null;
             $idShopGroup = null;
 
             // on updating PS_LOGO if the new file is an svg, copy old logo for mail and invoice
@@ -195,7 +195,7 @@ class LogoUploader
             $logoAll = Configuration::get($fieldName);
             Shop::setContext(Shop::CONTEXT_GROUP);
             $logoGroup = Configuration::get($fieldName);
-            Shop::setContext(Shop::CONTEXT_SHOP);
+            Shop::setContext(Shop::CONTEXT_SHOP, $idShop);
             $logoShop = Configuration::get($fieldName);
             if ($logoAll != $logoShop && $logoGroup != $logoShop && $logoShop != false) {
                 @unlink($this->imageDirection . Configuration::get($fieldName));

--- a/src/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizer.php
+++ b/src/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizer.php
@@ -65,6 +65,15 @@ class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterfac
      */
     protected array $constructorParameter = [];
 
+    /**
+     * The key is the initial class of the NoValueObject (example NoStateId)
+     * The value is the deduced short name of the associated ValueObject with the No part removed (example StateId)
+     * If the array doesn't contain the VO class it means it's not a NoValueObject
+     *
+     * @var array<string, string>
+     */
+    protected array $noValueClasses = [];
+
     public function __construct(
         protected readonly ClassMetadataFactoryInterface $classMetadataFactory
     ) {
@@ -137,9 +146,15 @@ class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterfac
         }
 
         $metadata = $this->classMetadataFactory->getMetadataFor($object);
+        $className = $metadata->getReflectionClass()->getName();
+        if ($this->isNoValueClass($object) && !empty($this->noValueClasses[$className])) {
+            $valueId = lcfirst($this->noValueClasses[$className]);
+        } else {
+            $valueId = lcfirst($metadata->getReflectionClass()->getShortName());
+        }
 
         return [
-            lcfirst($metadata->getReflectionClass()->getShortName()) => $object->getValue(),
+            $valueId => $object->getValue(),
         ];
     }
 
@@ -162,7 +177,10 @@ class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterfac
             && method_exists($data, 'getValue')
             // Check that ValueObject is part of the namespace
             && str_contains(get_class($data), 'ValueObject')
-            && $this->getConstructorParameter($data);
+            && (
+                $this->getConstructorParameter($data)
+                || $this->isNoValueClass($data)
+            );
     }
 
     protected function isValueObjectType(string $type): bool
@@ -171,7 +189,10 @@ class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterfac
             && method_exists($type, 'getValue')
             // Check that ValueObject is part of the namespace
             && str_contains($type, 'ValueObject')
-            && $this->getConstructorParameter($type);
+            && (
+                $this->getConstructorParameter($type)
+                || $this->isNoValueClass($type)
+            );
     }
 
     protected function matchesConstructorParameter(mixed $value, string $type): bool
@@ -238,5 +259,28 @@ class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterfac
         }
 
         return $this->constructorParameter[$objectType] ?? null;
+    }
+
+    /**
+     * Is the class used for "no values" like NoStateId, NoCombination that always carry the
+     * 0 value.
+     */
+    protected function isNoValueClass(object|string $type): bool
+    {
+        $objectType = is_object($type) ? get_class($type) : $type;
+        if (!array_key_exists($objectType, $this->noValueClasses)) {
+            $metadata = $this->classMetadataFactory->getMetadataFor($objectType);
+            $shortName = $metadata->getReflectionClass()->getShortName();
+            $matches = [];
+            // Check that the class name starts with No, the following part should be the expected ShortName
+            // when value is set
+            if (!preg_match('/No(.+)/', $shortName, $matches)) {
+                $this->noValueClasses[$objectType] = null;
+            } else {
+                $this->noValueClasses[$objectType] = $matches[1];
+            }
+        }
+
+        return !empty($this->noValueClasses[$objectType]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -260,6 +260,11 @@ class CustomerType extends TranslatorAwareType
                 ),
                 'required' => false,
             ])
+            ->add('is_newsletter_subscribed', SwitchType::class, [
+                'label' => $this->trans('Newsletter', 'Admin.Orderscustomers.Feature'),
+                'help' => '',
+                'required' => false,
+            ])
             ->add('is_partner_offers_subscribed', SwitchType::class, [
                 'label' => $this->trans('Partner offers', 'Admin.Orderscustomers.Feature'),
                 'help' => $this->trans(

--- a/tests/Integration/ApiPlatform/Serializer/CQRSApiSerializerTest.php
+++ b/tests/Integration/ApiPlatform/Serializer/CQRSApiSerializerTest.php
@@ -17,12 +17,16 @@ use PrestaShop\Module\APIResources\ApiPlatform\Resources\Product\Product;
 use PrestaShop\PrestaShop\Core\Context\CurrencyContextBuilder;
 use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
 use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Address\QueryResult\EditableCustomerAddress;
+use PrestaShop\PrestaShop\Core\Domain\Address\ValueObject\AddressId;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\ValueObject\CreatedApiClient;
+use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Command\AddCustomerGroupCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Command\EditCustomerGroupCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Query\GetCustomerGroupForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\QueryResult\EditableCustomerGroup;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\ValueObject\GroupId;
+use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\AddDiscountCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\UpdateDiscountCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\ProductRule;
@@ -40,6 +44,8 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\QueryResult\VirtualProductFileForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopCollection;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\NoStateId;
+use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\StateId;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 use PrestaShopBundle\ApiPlatform\NormalizationMapper;
@@ -688,6 +694,96 @@ class CQRSApiSerializerTest extends KernelTestCase
             $productId,
             [
                 'productId' => 42,
+            ],
+        ];
+
+        yield 'normalize EditableCustomerAddress with no state ID' => [
+            new EditableCustomerAddress(
+                new AddressId(1),
+                new CustomerId(42),
+                'pub@prestashop.com',
+                'Order Test Address',
+                'John',
+                'Doe',
+                '1 street Example',
+                'Orleans',
+                new CountryId(8),
+                '45000',
+                'dni',
+                'company',
+                'vatNumber',
+                'address2',
+                new NoStateId(),
+                '',
+                '',
+                '',
+                []
+            ),
+            [
+                'addressId' => 1,
+                'customerId' => 42,
+                'customerEmail' => 'pub@prestashop.com',
+                'addressAlias' => 'Order Test Address',
+                'firstName' => 'John',
+                'lastName' => 'Doe',
+                'address' => '1 street Example',
+                'city' => 'Orleans',
+                'countryId' => 8,
+                'postCode' => '45000',
+                'dni' => 'dni',
+                'company' => 'company',
+                'vatNumber' => 'vatNumber',
+                'address2' => 'address2',
+                'stateId' => 0,
+                'homePhone' => '',
+                'mobilePhone' => '',
+                'other' => '',
+                'requiredFields' => [],
+            ],
+        ];
+
+        yield 'normalize EditableCustomerAddress with StateID' => [
+            new EditableCustomerAddress(
+                new AddressId(1),
+                new CustomerId(42),
+                'pub@prestashop.com',
+                'Order Test Address',
+                'John',
+                'Doe',
+                '1 street Example',
+                'Orleans',
+                new CountryId(8),
+                '45000',
+                'dni',
+                'company',
+                'vatNumber',
+                'address2',
+                new StateId(4),
+                '',
+                '',
+                '',
+                []
+            ),
+            [
+                'addressId' => 1,
+                'customerId' => 42,
+                'customerEmail' => 'pub@prestashop.com',
+                'addressAlias' => 'Order Test Address',
+                'firstName' => 'John',
+                'lastName' => 'Doe',
+                'address' => '1 street Example',
+                'city' => 'Orleans',
+                'countryId' => 8,
+                'postCode' => '45000',
+                'dni' => 'dni',
+                'company' => 'company',
+                'vatNumber' => 'vatNumber',
+                'address2' => 'address2',
+                'stateId' => 4,
+                'homePhone' => '',
+                'mobilePhone' => '',
+                'other' => '',
+                'requiredFields' => [],
             ],
         ];
 

--- a/tests/Integration/Behaviour/Features/Scenario/State/state_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/State/state_management.feature
@@ -17,23 +17,53 @@ Feature: Zones management
     Then state "StateNormandy" zone should be "Europe"
     And state "StateNormandy" should be enabled
 
-  Scenario: Editing state
+  Scenario: Partial Editing state
+    ## Name
     When I edit state "StateNormandy" with following properties:
       | name    | Britain       |
-      | enabled | false         |
-      | country | Italy         |
-      | zone    | South America |
+    Then state "StateNormandy" name should be "Britain"
+    Then state "StateNormandy" country should be "United States"
+    Then state "StateNormandy" zone should be "Europe"
+    And state "StateNormandy" should be enabled
+    ## Enabled
+    When I edit state "StateNormandy" with following properties:
+      | enabled | false          |
+    Then state "StateNormandy" name should be "Britain"
+    Then state "StateNormandy" country should be "United States"
+    Then state "StateNormandy" zone should be "Europe"
+    And state "StateNormandy" should be disabled
+    ## Country
+    When I edit state "StateNormandy" with following properties:
+      | country | Italy          |
+    Then state "StateNormandy" name should be "Britain"
+    Then state "StateNormandy" country should be "Italy"
+    Then state "StateNormandy" zone should be "Europe"
+    And state "StateNormandy" should be disabled
+    ## Zone
+    When I edit state "StateNormandy" with following properties:
+      | zone | South America  |
     Then state "StateNormandy" name should be "Britain"
     Then state "StateNormandy" country should be "Italy"
     Then state "StateNormandy" zone should be "South America"
     And state "StateNormandy" should be disabled
 
+  Scenario: Editing state
+    When I edit state "StateNormandy" with following properties:
+      | name    | Tasmania      |
+      | enabled | true          |
+      | country | Australia     |
+      | zone    | Oceania       |
+    Then state "StateNormandy" name should be "Tasmania"
+    Then state "StateNormandy" country should be "Australia"
+    Then state "StateNormandy" zone should be "Oceania"
+    And state "StateNormandy" should be enabled
+
   Scenario: Enable and disable state status
-    Given state "StateNormandy" is disabled
-    When I toggle status of state "StateNormandy"
-    Then state "StateNormandy" should be enabled
+    Given state "StateNormandy" is enabled
     When I toggle status of state "StateNormandy"
     Then state "StateNormandy" should be disabled
+    When I toggle status of state "StateNormandy"
+    Then state "StateNormandy" should be enabled
 
   Scenario: Enabling and disabling multiple states in bulk action
     When I add new state "StateBrittany" with following properties:

--- a/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/04_documentsTab.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/04_documentsTab.ts
@@ -355,7 +355,7 @@ describe('BO - Orders - View and edit order : Check order documents tab', async 
     it('should check if \'Delivery slip\' document is created', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkDeliverySlipDocument', baseContext);
 
-      const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 3);
+      const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 2);
       expect(documentType).to.be.equal('Delivery slip');
     });
 
@@ -382,7 +382,7 @@ describe('BO - Orders - View and edit order : Check order documents tab', async 
       await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocument', baseContext);
 
       // Get document name
-      const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 4);
+      const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 3);
       expect(documentType).to.be.equal('Credit slip');
     });
 

--- a/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/12_checkMultiInvoice.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/12_checkMultiInvoice.ts
@@ -232,7 +232,7 @@ describe('BO - Orders - View and edit order: Check multi invoice', async () => {
     it('should get the second invoice file name', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'getSecondInvoiceNumber', baseContext);
 
-      secondFileName = await boOrdersViewBlockTabListPage.getFileName(page, 3);
+      secondFileName = await boOrdersViewBlockTabListPage.getFileName(page, 2);
       expect(filePath).is.not.equal('');
     });
   });

--- a/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/01_createFilterCreditSlips.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/01_createFilterCreditSlips.ts
@@ -137,12 +137,10 @@ describe('BO - Orders - Credit slips : Create, filter and check credit slips fil
         .and.to.contain('Delivery slip');
     });
 
-    const tests = [
-      {args: {productID: 1, quantity: 1, documentRow: 4}},
-      {args: {productID: 1, quantity: 2, documentRow: 5}},
-    ];
-
-    tests.forEach((test, index: number) => {
+    [
+      {productID: 1, quantity: 1, documentRow: 4},
+      {productID: 1, quantity: 2, documentRow: 5},
+    ].forEach((arg, index: number) => {
       it(`should create the partial refund n°${index + 1}`, async function () {
         await testContext.addContextItem(this, 'testIdentifier', `addPartialRefund${index + 1}`, baseContext);
 
@@ -150,8 +148,8 @@ describe('BO - Orders - Credit slips : Create, filter and check credit slips fil
 
         const textMessage = await boOrdersViewBlockProductsPage.addPartialRefundProduct(
           page,
-          test.args.productID,
-          test.args.quantity,
+          arg.productID,
+          arg.quantity,
         );
         expect(textMessage).to.contains(boOrdersViewBlockProductsPage.partialRefundValidationMessage);
       });
@@ -205,35 +203,27 @@ describe('BO - Orders - Credit slips : Create, filter and check credit slips fil
       expect(numberOfCreditSlips).to.be.above(0);
     });
 
-    const tests = [
+    [
       {
-        args:
-          {
-            testIdentifier: 'filterIdCreditSlip',
-            filterBy: 'id_credit_slip',
-            filterValue: '1',
-            columnName: 'id_order_slip',
-          },
+        testIdentifier: 'filterIdCreditSlip',
+        filterBy: 'id_credit_slip',
+        filterValue: '1',
+        columnName: 'id_order_slip',
       },
       {
-        args:
-          {
-            testIdentifier: 'filterIdOrder',
-            filterBy: 'id_order',
-            filterValue: '4',
-            columnName: 'id_order',
-          },
+        testIdentifier: 'filterIdOrder',
+        filterBy: 'id_order',
+        filterValue: '4',
+        columnName: 'id_order',
       },
-    ];
-
-    tests.forEach((test) => {
-      it(`should filter by ${test.args.filterBy} '${test.args.filterValue}'`, async function () {
-        await testContext.addContextItem(this, 'testIdentifier', test.args.testIdentifier, baseContext);
+    ].forEach((arg) => {
+      it(`should filter by ${arg.filterBy} '${arg.filterValue}'`, async function () {
+        await testContext.addContextItem(this, 'testIdentifier', arg.testIdentifier, baseContext);
 
         await boCreditSlipsPage.filterCreditSlips(
           page,
-          test.args.filterBy,
-          test.args.filterValue,
+          arg.filterBy,
+          arg.filterValue,
         );
 
         // Get number of credit slips
@@ -244,14 +234,14 @@ describe('BO - Orders - Credit slips : Create, filter and check credit slips fil
           const textColumn = await boCreditSlipsPage.getTextColumnFromTableCreditSlips(
             page,
             i,
-            test.args.columnName,
+            arg.columnName,
           );
-          expect(textColumn).to.contains(test.args.filterValue);
+          expect(textColumn).to.contains(arg.filterValue);
         }
       });
 
       it('should reset all filters', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', `${test.args.testIdentifier}Reset`, baseContext);
+        await testContext.addContextItem(this, 'testIdentifier', `${arg.testIdentifier}Reset`, baseContext);
 
         const numberOfCreditSlipsAfterReset = await boCreditSlipsPage.resetAndGetNumberOfLines(page);
         expect(numberOfCreditSlipsAfterReset).to.be.equal(numberOfCreditSlips);

--- a/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/02_sortAndPaginationCreditSlips.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/02_sortAndPaginationCreditSlips.ts
@@ -146,7 +146,7 @@ describe('BO - Orders - Credit slips : Sort (by ID, Date and OrderID) and Pagina
           `${baseContext}_preTest_${i}`,
         );
 
-        const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 4);
+        const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 3);
         expect(documentType).to.be.equal(creditSlipDocumentName);
       });
     });

--- a/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/03_generateCreditSlipsByDate.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/03_generateCreditSlipsByDate.ts
@@ -39,7 +39,6 @@ describe('BO - Orders - Credit slips : Generate Credit slip file by date', async
   let page: Page;
 
   const futureDate: string = utilsDate.getDateFormat('yyyy-mm-dd', 'future');
-  const creditSlipDocumentName: string = 'Credit slip';
   const orderByCustomerData: FakerOrder = new FakerOrder({
     customer: dataCustomers.johnDoe,
     products: [
@@ -54,7 +53,6 @@ describe('BO - Orders - Credit slips : Generate Credit slip file by date', async
   // Pre-condition: Create order in FO
   createOrderByCustomerTest(orderByCustomerData, baseContext);
 
-  // before and after functions
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
     page = await utilsPlaywright.newTab(browserContext);
@@ -97,6 +95,20 @@ describe('BO - Orders - Credit slips : Generate Credit slip file by date', async
       expect(pageTitle).to.contains(boOrdersViewBlockTabListPage.pageTitle);
     });
 
+    it('should check documents', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocumentNameBefore', baseContext);
+
+      const numDocuments = await boOrdersViewBlockTabListPage.getNumberOfDocuments(page);
+      expect(numDocuments).to.be.equals(0);
+
+      const countDocuments = await boOrdersViewBlockTabListPage.countDocumentsType(page);
+      expect(countDocuments).to.be.deep.equal({
+        creditSlips: 0,
+        deliverySlips: 0,
+        invoices: 0,
+      });
+    });
+
     it(`should change the order status to '${dataOrderStatuses.shipped.name}' and check it`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'updateCreatedOrderStatus', baseContext);
 
@@ -114,10 +126,17 @@ describe('BO - Orders - Credit slips : Generate Credit slip file by date', async
     });
 
     it('should check the existence of the Credit slip document', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocumentName', baseContext);
+      await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocumentNameAfter', baseContext);
 
-      const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 4);
-      expect(documentType).to.be.equal(creditSlipDocumentName);
+      const numDocuments = await boOrdersViewBlockTabListPage.getNumberOfDocuments(page);
+      expect(numDocuments).to.be.equals(3);
+
+      const countDocuments = await boOrdersViewBlockTabListPage.countDocumentsType(page);
+      expect(countDocuments).to.be.deep.equal({
+        creditSlips: 1,
+        deliverySlips: 1,
+        invoices: 1,
+      });
     });
   });
 

--- a/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/04_creditSlipOptions.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/04_creditSlipOptions.ts
@@ -138,6 +138,20 @@ describe('BO - Orders - Credit slips: Credit slip options', async () => {
       expect(pageTitle).to.contains(boOrdersViewBlockTabListPage.pageTitle);
     });
 
+    it('should check documents', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocumentNameBefore', baseContext);
+
+      const numDocuments = await boOrdersViewBlockTabListPage.getNumberOfDocuments(page);
+      expect(numDocuments).to.be.equals(0);
+
+      const countDocuments = await boOrdersViewBlockTabListPage.countDocumentsType(page);
+      expect(countDocuments).to.be.deep.equal({
+        creditSlips: 0,
+        deliverySlips: 0,
+        invoices: 0,
+      });
+    });
+
     it(`should change the order status to '${dataOrderStatuses.shipped.name}' and check it`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'updateOrderStatus', baseContext);
 
@@ -155,18 +169,24 @@ describe('BO - Orders - Credit slips: Credit slip options', async () => {
     });
 
     it('should check the existence of the Credit slip document', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocument', baseContext);
+      await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocumentNameAfter', baseContext);
 
-      // Get document name
-      const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 4);
-      expect(documentType).to.be.equal('Credit slip');
+      const numDocuments = await boOrdersViewBlockTabListPage.getNumberOfDocuments(page);
+      expect(numDocuments).to.be.equals(3);
+
+      const countDocuments = await boOrdersViewBlockTabListPage.countDocumentsType(page);
+      expect(countDocuments).to.be.deep.equal({
+        creditSlips: 1,
+        deliverySlips: 1,
+        invoices: 1,
+      });
     });
 
     it(`should check that the credit slip file name contain the prefix '${prefixToEdit}'`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkUpdatedPrefixOnFileName', baseContext);
 
       // Get file name
-      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 4);
+      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 3);
       expect(fileName).to.contains(prefixToEdit);
     });
   });
@@ -221,7 +241,7 @@ describe('BO - Orders - Credit slips: Credit slip options', async () => {
     it('should check the credit slip file name', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkDeletedPrefix', baseContext);
 
-      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 4);
+      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 3);
       expect(fileName, 'Credit slip file name is not changed to default!').to.not.contains(prefixToEdit);
     });
   });

--- a/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/01_generateDeliverySlipByDate.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/01_generateDeliverySlipByDate.ts
@@ -28,7 +28,6 @@ describe('BO - Orders - Delivery slips : Generate Delivery slip file by date', a
 
   const futureDate: string = utilsDate.getDateFormat('yyyy-mm-dd', 'future');
 
-  // before and after functions
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
     page = await utilsPlaywright.newTab(browserContext);
@@ -72,6 +71,20 @@ describe('BO - Orders - Delivery slips : Generate Delivery slip file by date', a
       expect(pageTitle).to.contains(boOrdersViewBlockTabListPage.pageTitle);
     });
 
+    it('should check documents', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkDocumentsBefore', baseContext);
+
+      const numDocuments = await boOrdersViewBlockTabListPage.getNumberOfDocuments(page);
+      expect(numDocuments).to.be.equals(3);
+
+      const countDocuments = await boOrdersViewBlockTabListPage.countDocumentsType(page);
+      expect(countDocuments).to.be.deep.equal({
+        creditSlips: 1,
+        deliverySlips: 1,
+        invoices: 1,
+      });
+    });
+
     it(`should change the order status to '${dataOrderStatuses.shipped.name}' and check it`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'updateOrderStatus', baseContext);
 
@@ -80,10 +93,17 @@ describe('BO - Orders - Delivery slips : Generate Delivery slip file by date', a
     });
 
     it('should check the delivery slip document name', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkDocumentName', baseContext);
+      await testContext.addContextItem(this, 'testIdentifier', 'checkDocumentsAfter', baseContext);
 
-      const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 3);
-      expect(documentType).to.be.equal('Delivery slip');
+      const numDocuments = await boOrdersViewBlockTabListPage.getNumberOfDocuments(page);
+      expect(numDocuments).to.be.equals(3);
+
+      const countDocuments = await boOrdersViewBlockTabListPage.countDocumentsType(page);
+      expect(countDocuments).to.be.deep.equal({
+        creditSlips: 1,
+        deliverySlips: 1,
+        invoices: 1,
+      });
     });
   });
 

--- a/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/02_deliverySlipOptions/01_deliverySlipPrefix.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/02_deliverySlipOptions/01_deliverySlipPrefix.ts
@@ -109,7 +109,7 @@ describe('BO - Orders - Delivery slips : Update delivery slip prefix and check t
       await testContext.addContextItem(this, 'testIdentifier', 'checkDocumentNamePrefix', baseContext);
 
       // Get delivery slips filename
-      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 3);
+      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 2);
       expect(fileName).to.contains(deliverySlipData.prefix.replace('#', '').trim());
     });
   });

--- a/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/02_deliverySlipOptions/02_deliverySlipNumber.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/02_deliverySlipOptions/02_deliverySlipNumber.ts
@@ -133,7 +133,7 @@ describe('BO - Orders - Delivery slips : Update \'Delivery slip number\'', async
       await testContext.addContextItem(this, 'testIdentifier', 'checkDeliverySlipsDocumentName', baseContext);
 
       // Get delivery slips filename
-      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 3);
+      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 2);
       expect(fileName).to.contains(deliverySlipData.number);
     });
   });

--- a/tests/UI/campaigns/functional/BO/03_catalog/07_discounts/discountV2/01_minimumPurchaseAmount.ts
+++ b/tests/UI/campaigns/functional/BO/03_catalog/07_discounts/discountV2/01_minimumPurchaseAmount.ts
@@ -1,0 +1,448 @@
+import testContext from '@utils/testContext';
+import {expect} from 'chai';
+
+import setFeatureFlag from '@commonTests/BO/advancedParameters/newFeatures';
+
+import {
+  // BO pages
+  boDiscountsPage,
+  boDiscountsCreatePage,
+  boDashboardPage,
+  boLoginPage,
+  boFeatureFlagPage,
+  // FO pages
+  foHummingbirdHomePage,
+  foHummingbirdSearchResultsPage,
+  foHummingbirdModalQuickViewPage,
+  foHummingbirdModalBlockCartPage,
+  foHummingbirdCartPage,
+  // Data
+  dataProducts,
+  FakerDiscount,
+  type BrowserContext,
+  type Page,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_BO_catalog_discounts_discountV2_minimumPurchaseAmount';
+
+/*
+Pre-condition:
+- Enable discount
+Scenario:
+- Create discount in BO and check it in FO
+- Edit discount in BO and check it in FO
+- Delete discount
+Post-condition:
+- Disable discount
+ */
+describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+
+  const discountWithoutName: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: ' ',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: 20,
+    minimumAmountTax: 'Tax included',
+    discountValue: 10,
+    discountReductionType: '€',
+    discountTax: 'Tax included',
+  });
+
+  const discountPurchaseAmountZero: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: 'Test',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: '0',
+    minimumAmountTax: 'Tax included',
+    discountValue: 10,
+    discountReductionType: '€',
+    discountTax: 'Tax included',
+  });
+  const discountPurchaseAmountNegative: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: 'Test',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: -50,
+    minimumAmountTax: 'Tax included',
+    discountValue: 10,
+    discountReductionType: '€',
+    discountTax: 'Tax included',
+  });
+  const discountPurchaseAmountText: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: 'Test',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: 'asefr',
+    minimumAmountTax: 'Tax included',
+    discountValue: 10,
+    discountReductionType: '€',
+    discountTax: 'Tax included',
+  });
+
+  const discountValueNegative: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: 'Test',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: 50,
+    minimumAmountTax: 'Tax included',
+    discountValue: -20,
+    discountReductionType: '€',
+    discountTax: 'Tax included',
+  });
+
+  const discountValueZero: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: 'Test',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: 50,
+    minimumAmountTax: 'Tax included',
+    discountValue: '0',
+    discountReductionType: '€',
+    discountTax: 'Tax included',
+  });
+
+  const discountData: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: 'Test',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: 50,
+    minimumAmountTax: 'Tax included',
+    discountValue: 10,
+    discountReductionType: '€',
+    discountTax: 'Tax included',
+    generateDiscountCode: true,
+    discountCode: 'test',
+  });
+  const editDiscountData: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: 'Test',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: 50,
+    minimumAmountTax: 'Tax excluded',
+    discountValue: 10,
+    discountReductionType: '€',
+    discountTax: 'Tax excluded',
+    generateDiscountCode: false,
+  });
+
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+  });
+
+  // 1 - Pre-condition: Enable discount
+  setFeatureFlag(boFeatureFlagPage.featureFlagDiscount, true, `${baseContext}_preTest`);
+
+  describe('Create discount and check it in FO', async () => {
+    it('should login in BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+      await boLoginPage.goTo(page, global.BO.URL);
+      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+      const pageTitle = await boDashboardPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+    });
+
+    it('should go to \'Catalog > Discounts\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToDiscountsPage', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.catalogParentLink,
+        boDashboardPage.discountsLink,
+      );
+
+      const pageTitle = await boDiscountsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDiscountsPage.pageTitle);
+    });
+
+    it('should click on create discount button and choose the type \'On cart amount\'', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'chooseDiscountType', baseContext);
+
+      await boDiscountsPage.clickOnCreateDiscountButton(page);
+      await boDiscountsPage.selectDiscountType(page, discountWithoutName.discountType!);
+
+      const pageTitle = await boDiscountsCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDiscountsCreatePage.pageTitle);
+    });
+
+    it('should create a discount without name and check the error', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createDiscount_1', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, discountWithoutName);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.errorMessageNameRequired);
+    });
+
+    it('should create a discount with a minimum purchase value = 0 euro and check the error', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createDiscount_2', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, discountPurchaseAmountZero);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.errorMessageMinPurchaseAmount);
+    });
+
+    it('should create a discount with a minimum purchase value < 0 and check the error', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createDiscount_3', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, discountPurchaseAmountNegative);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.errorMessageMinPurchaseAmount);
+    });
+
+    it('should create a discount with a minimum purchase value = asefr and check the error', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createDiscount_4', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, discountPurchaseAmountText);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.errorMessageMinPurchaseAmountNotnumber);
+    });
+
+    it('should create a discount with a discount value < 0 and check the error', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createDiscount_5', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, discountValueNegative);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.errorMessageDiscountValue(
+        discountValueNegative.discountValue.toString()));
+    });
+
+    it('should create a discount with a discount value = 0 and check the error', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createDiscount_6', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, discountValueZero);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.errorMessageDiscountValue('0'));
+    });
+
+    it('should create a discount with code', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createDiscountWithCode', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, discountData);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.successfulCreationMessage);
+    });
+
+    it('should view my shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'viewMyShop', baseContext);
+
+      page = await boDiscountsCreatePage.viewMyShop(page);
+      await foHummingbirdHomePage.changeLanguage(page, 'en');
+
+      const isHomePage = await foHummingbirdHomePage.isHomePage(page);
+      expect(isHomePage, 'Home page is not displayed').to.equal(true);
+    });
+
+    it(`should search for the product '${dataProducts.demo_3.name}'`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'searchProduct_1', baseContext);
+
+      await foHummingbirdHomePage.searchProduct(page, dataProducts.demo_3.name);
+
+      const pageTitle = await foHummingbirdSearchResultsPage.getPageTitle(page);
+      expect(pageTitle).to.equal(foHummingbirdSearchResultsPage.pageTitle);
+    });
+
+    it(`should add the product '${dataProducts.demo_3.name}' to the cart`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'addProductToCart_1', baseContext);
+
+      await foHummingbirdSearchResultsPage.quickViewProduct(page, 1);
+      await foHummingbirdModalQuickViewPage.addToCartByQuickView(page);
+      await foHummingbirdModalBlockCartPage.proceedToCheckout(page);
+
+      const shoppingCarts = await foHummingbirdCartPage.getCartNotificationsNumber(page);
+      expect(shoppingCarts).to.equal(1);
+    });
+
+    it('should add the promo code and check the error message', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'addPromoCode_1', baseContext);
+
+      await foHummingbirdCartPage.addPromoCode(page, discountData.discountCode);
+
+      const voucherErrorText = await foHummingbirdCartPage.getCartRuleErrorMessage(page);
+      expect(voucherErrorText).to.equal(`${foHummingbirdCartPage.minimumAmountErrorMessage
+      } €${parseFloat(discountData.minimumAmountValue.toString()).toFixed(2)}.`);
+    });
+
+    it('should go to home page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToHomePage', baseContext);
+
+      await foHummingbirdCartPage.goToHomePage(page);
+
+      const result = await foHummingbirdHomePage.isHomePage(page);
+      expect(result).to.equal(true);
+    });
+
+    it(`should search for the product '${dataProducts.demo_5.name}'`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'searchProduct_2', baseContext);
+
+      await foHummingbirdHomePage.searchProduct(page, dataProducts.demo_5.name);
+
+      const pageTitle = await foHummingbirdSearchResultsPage.getPageTitle(page);
+      expect(pageTitle).to.equal(foHummingbirdSearchResultsPage.pageTitle);
+    });
+
+    it(`should add the product '${dataProducts.demo_5.name}' to cart`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'addProductToCart_2', baseContext);
+
+      await foHummingbirdSearchResultsPage.quickViewProduct(page, 1);
+      await foHummingbirdModalQuickViewPage.addToCartByQuickView(page);
+      await foHummingbirdModalBlockCartPage.proceedToCheckout(page);
+
+      const shoppingCarts = await foHummingbirdCartPage.getCartNotificationsNumber(page);
+      expect(shoppingCarts).to.equal(2);
+    });
+
+    it('should add the promo code and check the discount name', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'addPromoCode_2', baseContext);
+
+      await foHummingbirdCartPage.addPromoCode(page, discountData.discountCode);
+
+      const cartRuleName = await foHummingbirdCartPage.getCartRuleName(page, 1);
+      expect(cartRuleName).to.contains(discountData.name);
+    });
+
+    it('should check the discount value', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkDiscountValue1', baseContext);
+
+      const discount = parseFloat(discountData.discountValue.toString()).toFixed(2);
+
+      const discountValue = await foHummingbirdCartPage.getCartRuleValue(page);
+      expect(discountValue).to.contains(`-€${discount}`);
+
+      const subTotalDiscount = await foHummingbirdCartPage.getSubtotalDiscountValue(page);
+      expect(subTotalDiscount.toString()).to.equal(`-${discountData.discountValue}`);
+    });
+
+    it('should check the shipping cost', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkShippingCost_2', baseContext);
+
+      const subTotalShipping = await foHummingbirdCartPage.getSubtotalShippingValue(page);
+      expect(subTotalShipping).to.equal('Free');
+    });
+
+    it('should check the Total (tax incl.) after the discount', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkTotalAfterDiscount1', baseContext);
+
+      const discount = parseFloat(discountData.discountValue.toString());
+
+      const totalBeforeDiscount = dataProducts.demo_3.finalPrice + dataProducts.demo_5.finalPrice;
+
+      const totalAfterDiscount = await foHummingbirdCartPage.getATIPrice(page);
+      expect(totalAfterDiscount.toString()).to.equal((totalBeforeDiscount - discount).toFixed(2));
+    });
+  });
+
+  describe('Edit discount in BO and check it in FO', async () => {
+    it('should go back to BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goBackToBO', baseContext);
+
+      page = await foHummingbirdCartPage.changePage(browserContext, 0);
+
+      const pageTitle = await boDiscountsCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDiscountsCreatePage.pageTitle);
+    });
+
+    it('should edit the discount', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'editDiscount', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, editDiscountData);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.successfulUpdateMessage);
+    });
+
+    it('should go back to FO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goBackToFO', baseContext);
+
+      page = await boDiscountsCreatePage.changePage(browserContext, 1);
+
+      const pageTitle = await foHummingbirdCartPage.getPageTitle(page);
+      expect(pageTitle).to.contains(foHummingbirdCartPage.pageTitle);
+    });
+
+    it('should check the discount value', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkDiscountValue_2', baseContext);
+
+      await foHummingbirdCartPage.reloadPage(page);
+      const discountValue = await foHummingbirdCartPage.getCartRuleValue(page);
+      expect(discountValue).to.contains('-€12.00');
+
+      const subTotalDiscount = await foHummingbirdCartPage.getSubtotalDiscountValue(page);
+      expect(subTotalDiscount.toString()).to.equal('-12');
+    });
+
+    it('should check the shipping cost', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkShippingCost_3', baseContext);
+
+      const subTotalShipping = await foHummingbirdCartPage.getSubtotalShippingValue(page);
+      expect(subTotalShipping).to.eq('Free');
+    });
+
+    it('should check the Total (tax incl.) after the discount', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkTotalAfterDiscount_2', baseContext);
+
+      const totalAfterDiscount = await foHummingbirdCartPage.getATIPrice(page);
+      expect(totalAfterDiscount.toString()).to.equal('57.26');
+    });
+  });
+
+  describe('Delete discount', async () => {
+    it('should go back to BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goBackToBO_2', baseContext);
+
+      page = await foHummingbirdCartPage.changePage(browserContext, 0);
+
+      const pageTitle = await boDiscountsCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDiscountsCreatePage.pageTitle);
+    });
+
+    it('should go to \'Catalog > Discounts\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToDiscountsPage2', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.catalogParentLink,
+        boDashboardPage.discountsLink,
+      );
+
+      const pageTitle = await boDiscountsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDiscountsPage.pageTitle);
+    });
+
+    it('should delete the create discount', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'deleteDiscount', baseContext);
+
+      const validationMessage = await boDiscountsPage.deleteDiscount(page, 1);
+      expect(validationMessage).to.contains(boDiscountsPage.successfulDeleteMessage);
+    });
+
+    it('should go back to FO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goBackToFO_3', baseContext);
+
+      page = await boDiscountsCreatePage.changePage(browserContext, 1);
+
+      const pageTitle = await foHummingbirdCartPage.getPageTitle(page);
+      expect(pageTitle).to.contains(foHummingbirdCartPage.pageTitle);
+    });
+
+    it('should check the Total (tax incl.) after the discount', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkTotalAfterDiscount_3', baseContext);
+
+      await foHummingbirdCartPage.reloadPage(page);
+      const total = dataProducts.demo_3.finalPrice + dataProducts.demo_5.finalPrice;
+
+      const totalAfterDiscount = await foHummingbirdCartPage.getATIPrice(page);
+      expect(totalAfterDiscount.toString()).to.equal(total.toFixed(2));
+    });
+  });
+
+  // 1 - Post-condition: Disable discount
+  setFeatureFlag(boFeatureFlagPage.featureFlagDiscount, false, `${baseContext}_postTest`);
+});

--- a/tests/UI/campaigns/functional/BO/03_catalog/07_discounts/discountV2/01_minimumPurchaseAmount.ts
+++ b/tests/UI/campaigns/functional/BO/03_catalog/07_discounts/discountV2/01_minimumPurchaseAmount.ts
@@ -370,14 +370,14 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
 
       await foHummingbirdCartPage.reloadPage(page);
 
-      const discountTaxExcluded = utilsCore.percentage(parseFloat(editDiscountData.discountValue.toString()),
-        20) + editDiscountData.discountValue;
+      const discount = utilsCore.percentage(parseFloat(editDiscountData.discountValue.toString()),
+        20) + parseFloat(editDiscountData.discountValue.toString());
 
       const discountValue = await foHummingbirdCartPage.getCartRuleValue(page);
-      expect(discountValue).to.contains(`-€${discountTaxExcluded.toFixed(2)}`);
+      expect(discountValue).to.contains(`-€${discount.toFixed(2)}`);
 
       const subTotalDiscount = await foHummingbirdCartPage.getSubtotalDiscountValue(page);
-      expect(subTotalDiscount.toString()).to.equal(`-${discountTaxExcluded}`);
+      expect(subTotalDiscount.toString()).to.equal(`-${discount}`);
     });
 
     it('should check the shipping cost', async function () {
@@ -392,7 +392,7 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
 
       const total = dataProducts.demo_3.finalPrice + dataProducts.demo_5.price;
       const discount = utilsCore.percentage(parseFloat(editDiscountData.discountValue.toString()),
-        20) + editDiscountData.discountValue;
+        20) + parseFloat(editDiscountData.discountValue.toString());
 
       const totalAfterDiscount = await foHummingbirdCartPage.getATIPrice(page);
       expect(totalAfterDiscount.toString()).to.equal((total - discount).toFixed(2));

--- a/tests/UI/campaigns/functional/BO/03_catalog/07_discounts/discountV2/01_minimumPurchaseAmount.ts
+++ b/tests/UI/campaigns/functional/BO/03_catalog/07_discounts/discountV2/01_minimumPurchaseAmount.ts
@@ -19,6 +19,7 @@ import {
   // Data
   dataProducts,
   FakerDiscount,
+  utilsCore,
   type BrowserContext,
   type Page,
   utilsPlaywright,
@@ -51,7 +52,6 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
     discountReductionType: '€',
     discountTax: 'Tax included',
   });
-
   const discountPurchaseAmountZero: FakerDiscount = new FakerDiscount({
     discountType: 'On cart amount',
     name: 'Test',
@@ -85,7 +85,6 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
     discountReductionType: '€',
     discountTax: 'Tax included',
   });
-
   const discountValueNegative: FakerDiscount = new FakerDiscount({
     discountType: 'On cart amount',
     name: 'Test',
@@ -97,7 +96,6 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
     discountReductionType: '€',
     discountTax: 'Tax included',
   });
-
   const discountValueZero: FakerDiscount = new FakerDiscount({
     discountType: 'On cart amount',
     name: 'Test',
@@ -172,7 +170,7 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
       expect(pageTitle).to.contains(boDiscountsPage.pageTitle);
     });
 
-    it('should click on create discount button and choose the type \'On cart amount\'', async function () {
+    it(`should click on create discount button and choose the type '${discountData.discountType}'`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'chooseDiscountType', baseContext);
 
       await boDiscountsPage.clickOnCreateDiscountButton(page);
@@ -371,11 +369,15 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
       await testContext.addContextItem(this, 'testIdentifier', 'checkDiscountValue_2', baseContext);
 
       await foHummingbirdCartPage.reloadPage(page);
+
+      const discountTaxExcluded = utilsCore.percentage(parseFloat(editDiscountData.discountValue.toString()),
+        20) + editDiscountData.discountValue;
+
       const discountValue = await foHummingbirdCartPage.getCartRuleValue(page);
-      expect(discountValue).to.contains('-€12.00');
+      expect(discountValue).to.contains(`-€${discountTaxExcluded.toFixed(2)}`);
 
       const subTotalDiscount = await foHummingbirdCartPage.getSubtotalDiscountValue(page);
-      expect(subTotalDiscount.toString()).to.equal('-12');
+      expect(subTotalDiscount.toString()).to.equal(`-${discountTaxExcluded}`);
     });
 
     it('should check the shipping cost', async function () {
@@ -388,8 +390,12 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
     it('should check the Total (tax incl.) after the discount', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkTotalAfterDiscount_2', baseContext);
 
+      const total = dataProducts.demo_3.finalPrice + dataProducts.demo_5.price;
+      const discount = utilsCore.percentage(parseFloat(editDiscountData.discountValue.toString()),
+        20) + editDiscountData.discountValue;
+
       const totalAfterDiscount = await foHummingbirdCartPage.getATIPrice(page);
-      expect(totalAfterDiscount.toString()).to.equal('57.26');
+      expect(totalAfterDiscount.toString()).to.equal((total - discount).toFixed(2));
     });
   });
 

--- a/tests/UI/campaigns/functional/BO/13_shopParameters/07_search/02_tags/01_CRUDTag.ts
+++ b/tests/UI/campaigns/functional/BO/13_shopParameters/07_search/02_tags/01_CRUDTag.ts
@@ -102,7 +102,7 @@ describe('BO - Shop Parameters - Search : Create, update and delete tag in BO', 
       await boTagsPage.gotoEditTagPage(page, 1);
 
       const pageTitle = await boTagsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.contains(boTagsCreatePage.pageTitleEdit);
+      expect(pageTitle).to.contains(boTagsCreatePage.pageTitleEdit(createTagData.name));
     });
 
     it('should update tag', async function () {

--- a/tests/UI/campaigns/functional/FO/classic/03_userAccount/01_creditSlips/01_consultCreditSlip.ts
+++ b/tests/UI/campaigns/functional/FO/classic/03_userAccount/01_creditSlips/01_consultCreditSlip.ts
@@ -230,7 +230,7 @@ describe('FO - Consult credit slip list & View PDF Credit slip & View order', as
         await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocument', baseContext);
 
         // Get document name
-        const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 3);
+        const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 2);
         expect(documentType).to.be.equal('Credit slip');
       });
 
@@ -246,11 +246,11 @@ describe('FO - Consult credit slip list & View PDF Credit slip & View order', as
         await testContext.addContextItem(this, 'testIdentifier', 'getIdentifierDateIssued', baseContext);
 
         // Get Credit Slip ID
-        creditSlipID = await boOrdersViewBlockTabListPage.getFileName(page, 3);
+        creditSlipID = await boOrdersViewBlockTabListPage.getFileName(page, 2);
         expect(creditSlipID).is.not.equal('');
 
         // Get Date Issued
-        dateIssued = await boOrdersViewBlockTabListPage.getDocumentDate(page, 3);
+        dateIssued = await boOrdersViewBlockTabListPage.getDocumentDate(page, 2);
         expect(dateIssued).is.not.equal('');
       });
     });

--- a/tests/UI/campaigns/functional/FO/hummingbird/03_userAccount/01_creditSlips/01_consultCreditSlip.ts
+++ b/tests/UI/campaigns/functional/FO/hummingbird/03_userAccount/01_creditSlips/01_consultCreditSlip.ts
@@ -235,7 +235,7 @@ describe('FO - Consult credit slip list & View PDF Credit slip & View order', as
         await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocument', baseContext);
 
         // Get document name
-        const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 3);
+        const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 2);
         expect(documentType).to.be.equal('Credit slip');
       });
 
@@ -251,11 +251,11 @@ describe('FO - Consult credit slip list & View PDF Credit slip & View order', as
         await testContext.addContextItem(this, 'testIdentifier', 'getIdentifierDateIssued', baseContext);
 
         // Get Credit Slip ID
-        creditSlipID = await boOrdersViewBlockTabListPage.getFileName(page, 3);
+        creditSlipID = await boOrdersViewBlockTabListPage.getFileName(page, 2);
         expect(creditSlipID).is.not.equal('');
 
         // Get Date Issued
-        dateIssued = await boOrdersViewBlockTabListPage.getDocumentDate(page, 3);
+        dateIssued = await boOrdersViewBlockTabListPage.getDocumentDate(page, 2);
         expect(dateIssued).is.not.equal('');
       });
     });

--- a/tests/UI/commonTests/BO/advancedParameters/newFeatures.ts
+++ b/tests/UI/commonTests/BO/advancedParameters/newFeatures.ts
@@ -26,6 +26,9 @@ function setFeatureFlag(featureFlag: string, expectedStatus: boolean, baseContex
     case boFeatureFlagPage.featureFlagImprovedShipment:
       title = 'Improved shipment';
       break;
+    case boFeatureFlagPage.featureFlagDiscount:
+      title = 'Discount';
+      break;
     default:
       throw new Error(`The feature flag ${featureFlag} is not defined`);
   }

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -418,7 +418,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#6c83be94ce863e3515307e939d666344076d352d",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#bc1cc93405133e86673432b82994bbd33f2cc20e",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -7779,7 +7779,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#6c83be94ce863e3515307e939d666344076d352d",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#bc1cc93405133e86673432b82994bbd33f2cc20e",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^10.1.0",

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -534,7 +534,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#6c83be94ce863e3515307e939d666344076d352d",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#fdcd24f0c875e089691637e7a4ce935feed63842",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -8710,7 +8710,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#6c83be94ce863e3515307e939d666344076d352d",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#fdcd24f0c875e089691637e7a4ce935feed63842",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^10.1.0",

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -418,7 +418,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#bc1cc93405133e86673432b82994bbd33f2cc20e",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#ac440421950d8dedfc22b38ba9003cfdf0b90344",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -7779,7 +7779,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#bc1cc93405133e86673432b82994bbd33f2cc20e",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#ac440421950d8dedfc22b38ba9003cfdf0b90344",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^10.1.0",

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
@@ -115,6 +115,7 @@ class CustomerFormDataProviderTest extends TestCase
             'group_ids' => [1, 2, 3],
             'default_group_id' => 3,
             'is_guest' => false,
+            'is_newsletter_subscribed' => true,
         ], $customerFormDataProvider->getData(1));
     }
 
@@ -145,6 +146,7 @@ class CustomerFormDataProviderTest extends TestCase
             'max_payment_days' => 10,
             'risk_id' => 1,
             'is_guest' => false,
+            'is_newsletter_subscribed' => true,
         ], $customerFormDataProvider->getData(1));
     }
 

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizerTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizerTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\EditApiClientCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\NoStateId;
 use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
@@ -37,6 +38,7 @@ class ValueObjectNormalizerTest extends TestCase
         yield 'real value object based on string' => [new ProductType(ProductType::TYPE_STANDARD), true];
         yield 'object with getValue but not ValueObject namespace' => [new DbMySQLi('localhost', 'root', 'root', 'prestashop', false), false];
         yield 'object without getValue method' => [new ContactTypeChoiceProvider(1), false];
+        yield 'no state id' => [new NoStateId(), true];
     }
 
     /**
@@ -61,6 +63,9 @@ class ValueObjectNormalizerTest extends TestCase
 
         yield 'VO integer as scalar' => [new ProductId(1), 1, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
         yield 'VO string as scalar' => [new ProductType(ProductType::TYPE_STANDARD), ProductType::TYPE_STANDARD, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+
+        yield 'no state id' => [new NoStateId(), ['stateId' => NoStateId::NO_STATE_ID_VALUE]];
+        yield 'no state id as scalar' => [new NoStateId(), NoStateId::NO_STATE_ID_VALUE, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
     }
 
     /**
@@ -92,6 +97,13 @@ class ValueObjectNormalizerTest extends TestCase
         yield 'product type value' => [['value' => ProductType::TYPE_COMBINATIONS], ProductType::class, true];
         yield 'product type string' => [ProductType::TYPE_COMBINATIONS, ProductType::class, true];
         yield 'product type integer' => [42, ProductType::class, false];
+
+        yield 'no state id, stateId' => [['stateId' => 0], NoStateId::class, true];
+        yield 'no state id, noStateId' => [['noStateId' => 0], NoStateId::class, true];
+        yield 'no state id, state_id' => [['state_id' => 0], NoStateId::class, true];
+        yield 'no state id, value' => [['value' => 0], NoStateId::class, true];
+        yield 'no state id, integer' => [0, NoStateId::class, true];
+        yield 'no state id, string' => ['0', NoStateId::class, true];
     }
 
     /**
@@ -131,5 +143,11 @@ class ValueObjectNormalizerTest extends TestCase
         yield 'product type snake case as scalar' => [['product_type' => ProductType::TYPE_COMBINATIONS], ProductType::class, ProductType::TYPE_COMBINATIONS, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
         yield 'product type value as scalar' => [['value' => ProductType::TYPE_COMBINATIONS], ProductType::class, ProductType::TYPE_COMBINATIONS, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
         yield 'product type string as scalar' => [ProductType::TYPE_COMBINATIONS, ProductType::class, ProductType::TYPE_COMBINATIONS, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+
+        yield 'no state id, stateId' => [['stateId' => 0], NoStateId::class, new NoStateId()];
+        yield 'no state id, noStateId' => [['noStateId' => 0], NoStateId::class, new NoStateId()];
+        yield 'no state id, state_id' => [['state_id' => 0], NoStateId::class, new NoStateId()];
+        yield 'no state id, value' => [['value' => 0], NoStateId::class, new NoStateId()];
+        yield 'no state id, integer' => [0, NoStateId::class, new NoStateId()];
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fix email HTML preview for module mail templates in International > Translations by extending the path security check to also allow paths under _PS_MODULE_DIR_/mails/, in addition to the existing _PS_MAIL_DIR_
  check.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to International > Translations, in **Modify Translations** select "Email Translations" - Body - Any theme or language. HTML Preview for module emails should work
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #40855

Before: `getEmailHTML()` only handle Core Emails path `mails/`, for example `/var/www/html/mails/`

But for Emails Modules, path is: `modules/mymodule/mails`, for example `/var/www/html/modules/ps_emailalerts/mails/`

This proposal takes both paths into account, with early returns if the conditions are not met to avoid overly nested else/if statements.

Should work on any branch, code is here for 15+ years.

Generated 90% with my brain and 10% with Claude's.

Before fix:

<img width="1313" height="905" alt="555771691-5b0aee74-b58e-481b-9731-e5a855090833" src="https://github.com/user-attachments/assets/243ecdc9-db89-419c-af44-68c51e6fb664" />

After fix:

<img width="1655" height="848" alt="Screenshot_2026-03-04_05-31-56" src="https://github.com/user-attachments/assets/1156ca6d-65c5-403b-8cce-ab843f745854" />

(The logo still needs to be corrected; this will be the subject of another PR)