### PR TITLE
Fix SQL escaping in fuzzy search to prevent syntax errors with apostrophes

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -389,10 +389,11 @@ class SearchCore
                 while (!($result = $db->executeS($sql . "'" . $sql_param_search . "';", true, false))) {
                     if (!$psFuzzySearch
                         || $fuzzyLoop++ > $fuzzyMaxLoop
-                        || !($sql_param_search = static::findClosestWeightestWord($context, $word))
+                        || !($closestWord = static::findClosestWeightestWord($context, $word))
                     ) {
                         break;
                     }
+                    $sql_param_search = self::getSearchParamFromWord($closestWord);
                 }
 
                 // If nothing was found after X retries, skip this keyword


### PR DESCRIPTION
Fixes #40847. The fuzzy search feature was returning closest words from the database without proper SQL escaping through getSearchParamFromWord(). When a word contains an apostrophe (e.g., "s'u"), it generated malformed SQL like "LIKE 's'u'" causing syntax error 1064. The fix wraps the closest word with getSearchParamFromWord() to properly escape special characters.