### PR TITLE
Turkey updated its tax rates on July 10, 2023.

### DIFF
--- a/localization/tr.xml
+++ b/localization/tr.xml
@@ -7,15 +7,15 @@
 		<language iso_code="tr" />
 	</languages>
 	<taxes>
-		<tax id="1" name="KDV TR 18%" rate="18" />
-		<tax id="2" name="KDV TR 8%" rate="8" />
+		<tax id="1" name="KDV TR 20%" rate="20" />
+		<tax id="2" name="KDV TR 10%" rate="10" />
 		<tax id="3" name="KDV TR 1%" rate="1" />
 
-		<taxRulesGroup name="TR Standard Rate (18%)">
+		<taxRulesGroup name="TR Standard Rate (20%)">
 			<taxRule iso_code_country="tr" id_tax="1" />
 		</taxRulesGroup>
 
-		<taxRulesGroup name="TR Reduced Rate (8%)">
+		<taxRulesGroup name="TR Reduced Rate (10%)">
 			<taxRule iso_code_country="tr" id_tax="2" />
 		</taxRulesGroup>
 


### PR DESCRIPTION
Tax rates for Turkey have been changed from 18% to 20% and from 8% to 10% as of July 10, 2023. The 1% tax rate remains unchanged.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Tax rates for Turkey have been changed from 18% to 20% and from 8% to 10% as of July 10, 2023. The 1% tax rate remains unchanged.
| Type?             | improvement
| Category?         | LO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | For The relevant presidential decree : https://www.resmigazete.gov.tr/eskiler/2023/07/20230707-11.pdf
| UI Tests          | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/23047876272
| Fixed issue or discussion?     | Fixes #40941
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Metin EREN
