### PR TITLE
Fix help sidebar not displaying on Aliases index page

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/SearchAliasController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/SearchAliasController.php
@@ -45,6 +45,7 @@ class SearchAliasController extends PrestaShopAdminController
         return $this->render('@PrestaShop/Admin/Configure/ShopParameters/Search/index.html.twig', [
             'aliasGrid' => $this->presentGrid($aliasGrid),
             'help_link' => $this->generateSidebarLink('AdminSearchConf'),
+            'enableSidebar' => true,
             'layoutHeaderToolbarBtn' => [
                 'add' => [
                     'desc' => $this->trans('Add new alias', [], 'Admin.Shopparameters.Feature'),

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/SearchAliasControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/SearchAliasControllerTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Integration\Utility\ContextMockerTrait;
+use Tests\Integration\Utility\LoginTrait;
+
+class SearchAliasControllerTest extends WebTestCase
+{
+    use ContextMockerTrait;
+    use LoginTrait;
+
+    /**
+     * @var KernelBrowser
+     */
+    protected $client;
+
+    /**
+     * @var Router
+     */
+    protected $router;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::mockContext();
+
+        $this->client = self::createClient();
+        $this->loginUser($this->client);
+        $this->router = self::$kernel->getContainer()->get('router');
+    }
+
+    public function testIndexActionReturnsSuccessResponse(): void
+    {
+        $this->client->request('GET', $this->router->generate('admin_search_alias_index'));
+
+        $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testIndexActionRendersSidebarHelpButton(): void
+    {
+        $crawler = $this->client->request('GET', $this->router->generate('admin_search_alias_index'));
+
+        $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+
+        // The help button must open the right sidebar (btn-sidebar), not a new window.
+        // This was broken because enableSidebar was not passed to the template.
+        // See: https://github.com/PrestaShop/PrestaShop/issues/40932
+        $this->assertGreaterThan(
+            0,
+            $crawler->filter('.btn-sidebar')->count(),
+            'The help button on the Aliases index page must use the sidebar (btn-sidebar class), not a plain link.'
+        );
+    }
+
+    public function testCreateActionReturnsSuccessResponse(): void
+    {
+        $this->client->request('GET', $this->router->generate('admin_search_alias_create'));
+
+        $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testCreateActionRendersSidebarHelpButton(): void
+    {
+        $crawler = $this->client->request('GET', $this->router->generate('admin_search_alias_create'));
+
+        $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+
+        $this->assertGreaterThan(
+            0,
+            $crawler->filter('.btn-sidebar')->count(),
+            'The help button on the Aliases create page must use the sidebar (btn-sidebar class).'
+        );
+    }
+}


### PR DESCRIPTION
| Questions                  | Answers
| -------------------------- | -------------------------------------------------------
| Branch?                    | 9.1.x
| Description?               | Details are below,
| Type?                      | bug fix
| Category?                  | BO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | 1. Go to BO > Shop Parameters > Search > Aliases tab. 2. Click the "Help" button in the toolbar. 3. Verify the right sidebar panel opens correctly and can be closed. Before this fix: the panel content renders broken and cannot be dismissed. After this fix: the sidebar opens and closes as expected, consistently with every other page in the Shop Parameters section.
| UI Tests          | https://github.com/alexsarti/ga.tests.ui.pr/actions/runs/22955229467
| Fixed issue or discussion? | Fixes #40932
| Related PRs                | none
| Sponsor company            | PrestaShop

Details:

On BO > Shop Parameters > Search > Aliases, clicking the "Help" button was failing to display the help panel correctly, and it was impossible to close it afterwards. The root cause is a missing enableSidebar parameter in `SearchAliasController::indexAction()`. Without it, the toolbar renders a plain link instead of a sidebar-toggling button, causing the documentation URL to load in an unexpected context. Both `createAction()` and `editAction()` in the same controller already correctly set' enableSidebar to true — the index action was the only inconsistency.