### PR TITLE
Fix getimagesize() warning with SVG logos on PHP 8.5

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1668,7 +1668,7 @@ class FrontControllerCore extends Controller
 
         $imageSize = getimagesize($logoFileDir);
         $logoWidth = $imageSize[0] ?? null;
-        $logoHeight = $imageSize[1] ?? null;;
+        $logoHeight = $imageSize[1] ?? null;
 
         return [
             'src' => ($this->getTemplateVarUrls()['img_ps_url'] ?? _PS_IMG_) . $logoFileName,

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1666,7 +1666,9 @@ class FrontControllerCore extends Controller
             return [];
         }
 
-        list($logoWidth, $logoHeight) = getimagesize($logoFileDir);
+        $imageSize = getimagesize($logoFileDir);
+        $logoWidth = $imageSize[0] ?? null;
+        $logoHeight = $imageSize[1] ?? null;;
 
         return [
             'src' => ($this->getTemplateVarUrls()['img_ps_url'] ?? _PS_IMG_) . $logoFileName,


### PR DESCRIPTION
getimagesize() returns false for SVG files. Using list() on false triggers 'Cannot use bool as array' warning in PHP 8.5.

Replace list() with safe null coalescing access.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | `getimagesize()` returns `false` for SVG files. In PHP 8.5, using `list()` to destructure `false` triggers: `Cannot use bool as array` warning in `classes/controller/FrontController.php` line 1652.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Upload an SVG logo in BO > Design > Theme & Logo. 2. Use PHP 8.5. 3. Visit any front-office page. 4. Before fix: warning `Cannot use bool as array`. After fix: no warning, page loads normally.
| UI Tests          | n/a
| Fixed issue or discussion? | n/a
| Related PRs       | n/a
| Sponsor company   | n/a

## Description

`getimagesize()` does not support SVG files and returns `false`. In PHP 8.5, destructuring `false` with `list()` is no longer silently ignored and triggers a warning.

### Before (line 1652)
```php
list($logoWidth, $logoHeight) = getimagesize($logoFileDir);
```

### After
```php
$imageSize = getimagesize($logoFileDir);
$logoWidth = $imageSize[0] ?? null;
$logoHeight = $imageSize[1] ?? null;
```

This safely handles any file format not supported by `getimagesize()`, including SVG.