### PR TITLE
Use sticky positioning for module selection panel in Positions page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/improve/design_positions/positions-list-handler.ts
+++ b/admin-dev/themes/new-theme/js/pages/improve/design_positions/positions-list-handler.ts
@@ -12,8 +12,6 @@ class PositionsListHandler {
 
   $panelSelectionMultipleSelection: JQuery;
 
-  $panelSelectionOriginalY: number;
-
   $showModules: JQuery;
 
   $modulesList: JQuery;
@@ -40,12 +38,6 @@ class PositionsListHandler {
     this.$panelSelectionMultipleSelection = $(
       '#modules-position-multiple-selection',
     );
-    const $alertMessage = $('#content-message-box + .alert');
-
-    this.$panelSelectionOriginalY = <number> this.$panelSelection.offset()?.top;
-    if ($alertMessage.length > 0) {
-      this.$panelSelectionOriginalY += <number> $alertMessage.outerHeight();
-    }
     this.$showModules = $('#show-modules');
     this.$modulesList = $('.modules-position-checkbox');
     this.$hookPosition = $('#hook-position');
@@ -74,14 +66,6 @@ class PositionsListHandler {
    */
   handleList(): void {
     const self = this;
-
-    $(window).on('scroll', () => {
-      const $scrollTop = <number>$(window).scrollTop();
-      self.$panelSelection.css(
-        'top',
-        $scrollTop < 20 ? 0 : $scrollTop - self.$panelSelectionOriginalY,
-      );
-    });
 
     self.$modulesList.on('change', () => {
       const $checkedCount = self.$modulesList.filter(':checked').length;

--- a/admin-dev/themes/new-theme/scss/pages/_modules.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_modules.scss
@@ -632,9 +632,17 @@ form#importDropzone {
 
 #modules-position-selection-panel {
   position: sticky;
-  top: 0;
+  top: calc(var(--#{$cdk}header-height) + #{$size-header-toolbar-height});
   z-index: 1;
   display: none;
+
+  @include media-breakpoint-down(sm) {
+    position: fixed;
+    top: calc(var(--#{$cdk}header-height) + #{$size-header-toolbar-height});
+    left: 0;
+    right: 0;
+    width: 100%;
+  }
 
   .btn {
     white-space: normal;

--- a/admin-dev/themes/new-theme/scss/pages/_modules.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_modules.scss
@@ -639,8 +639,8 @@ form#importDropzone {
   @include media-breakpoint-down(sm) {
     position: fixed;
     top: calc(var(--#{$cdk}header-height) + #{$size-header-toolbar-height});
-    left: 0;
     right: 0;
+    left: 0;
     width: 100%;
   }
 

--- a/admin-dev/themes/new-theme/scss/pages/_modules.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_modules.scss
@@ -631,7 +631,8 @@ form#importDropzone {
  */
 
 #modules-position-selection-panel {
-  position: relative;
+  position: sticky;
+  top: 0;
   z-index: 1;
   display: none;
 

--- a/js/admin/modules-position.js
+++ b/js/admin/modules-position.js
@@ -34,20 +34,7 @@ $(function(){
 		var panel_selection_single_selection = panel_selection.find("#modules-position-single-selection");
 		var panel_selection_multiple_selection = panel_selection.find("#modules-position-multiple-selection");
 
-		var panel_selection_original_y = panel_selection.offset().top;
-		var panel_selection_original_y_top_margin = 111;
-
-		panel_selection.css("position", "relative").hide();
-
-		$(window).on("scroll", function (event) {
-			var scroll_top = $(window).scrollTop();
-			panel_selection.css(
-				"top",
-				scroll_top < panel_selection_original_y_top_margin
-					? 0
-					: scroll_top - panel_selection_original_y + panel_selection_original_y_top_margin
-			);
-		});
+		panel_selection.hide();
 
 		var modules_list = $(".modules-position-checkbox");
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | The selection card panel on the Design > Positions page was not staying visible when scrolling down. It used `position: relative` combined with a manual JS scroll handler that recalculated the `top` offset on every scroll event — a fragile approach that broke in various contexts. The fix replaces this with a simple `position: sticky; top: 0` CSS rule, and removes the now-unnecessary scroll handler and related JS code.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to BO > Design > Positions<br>2. Check any module checkbox — the "Sélection" panel appears<br>3. Scroll down → the panel should stay fixed at the top of the viewport
| UI Tests          | MySQL: https://github.com/intraordinaire/ga.tests.ui.pr/actions/runs/22995070200 <br> MariaDB: https://github.com/intraordinaire/ga.tests.ui.pr/actions/runs/22995077784
| Fixed issue or discussion?     | Fixes #28428
| Related PRs       | N/A
| Sponsor company   | PrestaShop