### PR TITLE
Fix Windows CRLF line endings in shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure shell scripts always use LF line endings (fixes Windows CRLF issue)
+*.sh text eol=lf


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | On Windows, Git with `core.autocrlf=true` checks out shell scripts with CRLF line endings, causing Docker to fail with `/usr/bin/env: 'bash\r': No such file or directory`. Added a `.gitattributes` rule to enforce LF line endings for all `.sh` files, overriding `core.autocrlf` on Windows and preventing this issue for all contributors.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On Windows with `core.autocrlf=true`, clone the repository and verify `.sh` files have LF endings (`file .docker/wait-for-it.sh` should not show `CRLF line terminators`). Then run `docker compose up` — it should no longer fail with `/usr/bin/env: 'bash\r': No such file or directory`.
| UI Tests          | N/A
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | PrestaShop