### PR TITLE
Fix Admin API Location header containing useless _token parameter

### DIFF
--- a/src/PrestaShopBundle/Service/Routing/Router.php
+++ b/src/PrestaShopBundle/Service/Routing/Router.php
@@ -4,6 +4,8 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace PrestaShopBundle\Service\Routing;
 
 use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
@@ -27,12 +29,20 @@ class Router extends BaseRouter
      */
     public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH): string
     {
-        $url = parent::generate($name, $parameters, $referenceType);
-        if (TokenInUrls::isDisabled() || $this->anonymousRouteProvider->isRouteAnonymous($name)) {
+        $url = $this->generateFromParent($name, $parameters, $referenceType);
+        if (TokenInUrls::isDisabled() || $this->anonymousRouteProvider->isRouteAnonymous($name) || str_starts_with($name, '_api')) {
             return $url;
         }
 
         return self::generateTokenizedUrl($url, $this->userTokenManager->getSymfonyToken());
+    }
+
+    /**
+     * Wraps the parent generate() call to allow overriding in tests.
+     */
+    protected function generateFromParent(string $name, array $parameters, int $referenceType): string
+    {
+        return parent::generate($name, $parameters, $referenceType);
     }
 
     public function setUserTokenManager(UserTokenManager $userTokenManager): void

--- a/tests/Unit/PrestaShopBundle/Service/Routing/RouterTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Routing/RouterTest.php
@@ -8,11 +8,21 @@ declare(strict_types=1);
 
 namespace Tests\Unit\PrestaShopBundle\Service\Routing;
 
+use Configuration;
 use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Routing\AnonymousRouteProvider;
+use PrestaShopBundle\Security\Admin\UserTokenManager;
 use PrestaShopBundle\Service\Routing\Router;
+use ReflectionClass;
 
 class RouterTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->resetConfigurationCache();
+    }
+
     public function testGenerateTokenizedUrlWithFragments(): void
     {
         $url = 'my-shop.com/product#routing-in-prestashop';
@@ -26,5 +36,101 @@ class RouterTest extends TestCase
         $url = 'localhost/shopp/product?delete=1&confirm=1#routing-in-prestashop/tokens?route';
         $route = Router::generateTokenizedUrl($url, 'token');
         static::assertEquals('localhost/shopp/product?delete=1&confirm=1&_token=token#routing-in-prestashop/tokens?route', $route);
+    }
+
+    public function testGenerateDoesNotAddTokenForApiPlatformRoutes(): void
+    {
+        $this->enableTokensInUrls();
+
+        $router = $this->buildTestableRouter('/admin-api/products/1');
+
+        // API Platform routes (prefixed with _api) must NOT get _token in the URL
+        static::assertEquals('/admin-api/products/1', $router->generate('_api_products_get_item'));
+        static::assertEquals('/admin-api/products/1', $router->generate('_api_products_post_collection'));
+        static::assertEquals('/admin-api/products/1', $router->generate('_api_languages_get_collection'));
+    }
+
+    public function testGenerateAddsTokenForRegularAdminRoutes(): void
+    {
+        $this->enableTokensInUrls();
+
+        $router = $this->buildTestableRouter('/admin/products/edit');
+
+        $url = $router->generate('admin_products_edit');
+        static::assertStringContainsString('_token=test-token', $url);
+    }
+
+    public function testGenerateDoesNotAddTokenForAnonymousRoutes(): void
+    {
+        $this->enableTokensInUrls();
+
+        $userTokenManagerMock = $this->createMock(UserTokenManager::class);
+        $userTokenManagerMock->method('getSymfonyToken')->willReturn('test-token');
+
+        $anonymousRouteProviderMock = $this->createMock(AnonymousRouteProvider::class);
+        $anonymousRouteProviderMock->method('isRouteAnonymous')->willReturn(true);
+
+        $router = $this->getMockBuilder(Router::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['generateFromParent'])
+            ->getMock();
+        $router->method('generateFromParent')->willReturn('/public/page');
+        $router->setUserTokenManager($userTokenManagerMock);
+        $router->setAnonymousRouteProvider($anonymousRouteProviderMock);
+
+        $url = $router->generate('some_public_route');
+        static::assertStringNotContainsString('_token', $url);
+    }
+
+    private function buildTestableRouter(string $fixedUrl): Router
+    {
+        $userTokenManagerMock = $this->createMock(UserTokenManager::class);
+        $userTokenManagerMock->method('getSymfonyToken')->willReturn('test-token');
+
+        $anonymousRouteProviderMock = $this->createMock(AnonymousRouteProvider::class);
+        $anonymousRouteProviderMock->method('isRouteAnonymous')->willReturn(false);
+
+        $router = $this->getMockBuilder(Router::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['generateFromParent'])
+            ->getMock();
+        $router->method('generateFromParent')->willReturn($fixedUrl);
+        $router->setUserTokenManager($userTokenManagerMock);
+        $router->setAnonymousRouteProvider($anonymousRouteProviderMock);
+
+        return $router;
+    }
+
+    /**
+     * Forces TokenInUrls::isDisabled() to return false by injecting a truthy
+     * PS_SECURITY_TOKEN value directly into the Configuration static cache,
+     * bypassing any database dependency.
+     */
+    private function enableTokensInUrls(): void
+    {
+        $reflection = new ReflectionClass(Configuration::class);
+
+        $initializedProp = $reflection->getProperty('_initialized');
+        $initializedProp->setAccessible(true);
+        $initializedProp->setValue(null, true);
+
+        $cacheProp = $reflection->getProperty('_new_cache_global');
+        $cacheProp->setAccessible(true);
+        $cache = $cacheProp->getValue() ?? [];
+        $cache['PS_SECURITY_TOKEN'][0] = true;
+        $cacheProp->setValue(null, $cache);
+    }
+
+    private function resetConfigurationCache(): void
+    {
+        $reflection = new ReflectionClass(Configuration::class);
+
+        $initializedProp = $reflection->getProperty('_initialized');
+        $initializedProp->setAccessible(true);
+        $initializedProp->setValue(null, false);
+
+        $cacheProp = $reflection->getProperty('_new_cache_global');
+        $cacheProp->setAccessible(true);
+        $cacheProp->setValue(null, null);
     }
 }


### PR DESCRIPTION
| Questions | Answers |
| --------- | ------- |
| Branch? | 9.1.x |
| Description? | The Admin API \`Location\` response header on POST endpoints includes a \`_token\` CSRF query parameter, which is meaningless in an OAuth2 API context. This fix prevents the custom Router from appending \`_token\` to URLs generated for API Platform routes (\`_api_*\`). |
| Type? | bug fix |
| Category? | CO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | See testing instructions below |
| Fixed issue or discussion? | Fixes #39496 |
| Related PRs | N/A |
| Sponsor company | PrestaShop |

## Context

PrestaShop's Admin API authenticates requests via OAuth2 Bearer tokens. However, POST endpoints return a `Location` header containing a `_token` CSRF query parameter:

```
HTTP/1.1 201 Created
Location: /admin-api/products/42?_token=abc123xyz…
```

This parameter is injected by a custom `Router` service (`PrestaShopBundle\Service\Routing\Router`) that overrides Symfony's URL generator to append `_token` to every generated URL as a CSRF protection mechanism for the Back Office. This protection is irrelevant in an API context where authentication is handled by OAuth2.

## Root Cause

`Router::generate()` appends `_token` to all URLs unless:
- `TokenInUrls::isDisabled()` returns `true` (global feature flag), or
- the route is registered as anonymous via `AnonymousRouteProvider`

Neither condition applies to API Platform routes. The `TokenizedUrlsListener` — which handles the *validation* side — already skips CSRF checks for all routes whose name starts with `_` (line 46: `str_starts_with($route, '_')`), which covers API Platform routes (`_api_*`). The *generation* side in `Router::generate()` had no equivalent guard.

## Solution

Added `str_starts_with($name, '_api')` to the early-return condition in `Router::generate()`:

```php
// Before
if (TokenInUrls::isDisabled() || $this->anonymousRouteProvider->isRouteAnonymous($name)) {
    return $url;
}

// After
if (TokenInUrls::isDisabled() || $this->anonymousRouteProvider->isRouteAnonymous($name) || str_starts_with($name, '_api')) {
    return $url;
}
```

API Platform generates route names with the `_api` prefix by convention (e.g. `_api_products_post_collection`, `_api_products_get_item`). The guard is intentionally scoped to `_api` rather than all `_`-prefixed routes (as `TokenizedUrlsListener` does) to stay conservative and avoid accidentally skipping tokenization for unrelated internal Symfony routes.

A `generateFromParent()` protected method was also extracted to wrap `parent::generate()`, enabling proper unit testing of the `generate()` logic without bootstrapping the full Symfony routing infrastructure.

## Alternatives Considered

**Option B — Inject `RequestStack` into the Router and check the firewall context**

Would detect the API context at the HTTP request level rather than by route name. Rejected because:
- Risk of circular dependency (Router is instantiated early in the kernel lifecycle)
- More complex for the same outcome
- The route name prefix is a stable API Platform convention, not a fragile heuristic

**Option C — New `ApiRouteProvider` service (mirror of `AnonymousRouteProvider`)**

Would enumerate API routes from the route collection and cache them. Rejected because:
- Over-engineered for a naming convention that is already an established constant
- `AnonymousRouteProvider` exists because anonymous routes have no consistent naming pattern and require an explicit opt-in attribute; `_api_*` routes have a reliable, framework-enforced prefix

## Changes

### `src/PrestaShopBundle/Service/Routing/Router.php`
- Added `declare(strict_types=1)` (missing from original file, required by coding standards)
- Added `str_starts_with($name, '_api')` guard in `generate()`
- Extracted `generateFromParent()` protected method

### `tests/Unit/PrestaShopBundle/Service/Routing/RouterTest.php`
- `testGenerateDoesNotAddTokenForApiPlatformRoutes` — verifies that routes prefixed with `_api` do not receive `_token`
- `testGenerateAddsTokenForRegularAdminRoutes` — non-regression: regular admin routes still receive `_token`
- `testGenerateDoesNotAddTokenForAnonymousRoutes` — non-regression: anonymous routes still bypass tokenization

## How to Test

**Manual verification:**

1. Set up a local PrestaShop instance with the Admin API enabled (`PS_ENABLE_ADMIN_API=1`)
2. Obtain an OAuth2 access token:
```bash
curl -X POST https://your-shop/admin-api/access_token \
  -d "client_id=YOUR_CLIENT&client_secret=YOUR_SECRET&grant_type=client_credentials"
```
3. Create a resource via the API (e.g. a product) and inspect the response headers:
```
HTTP/1.1 201 Created
Location: /admin-api/products/42       ✅  (no _token)
```

**Before this fix**, the `Location` header would look like:
```
Location: /admin-api/products/42?_token=abc123xyz  ❌
```

**Automated tests:**
```bash
php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit \
  -c tests/Unit/phpunit.xml \
  tests/Unit/PrestaShopBundle/Service/Routing/RouterTest.php
```