### PR TITLE
Remove misleading "Invalid characters" hints from form fields

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
@@ -81,7 +81,6 @@ abstract class AbstractCategoryType extends TranslatorAwareType
         $builder
             ->add('name', TranslatableType::class, [
                 'label' => $this->trans('Name', 'Admin.Global'),
-                'help' => $genericCharactersHint,
                 'type' => TextType::class,
                 'constraints' => [
                     new DefaultLanguage(),
@@ -161,7 +160,6 @@ abstract class AbstractCategoryType extends TranslatorAwareType
             )
             ->add('meta_title', TranslatableType::class, [
                 'label' => $this->trans('Meta title', 'Admin.Global'),
-                'help' => $genericCharactersHint,
                 'type' => TextWithRecommendedLengthType::class,
                 'required' => false,
                 'options' => [
@@ -192,7 +190,6 @@ abstract class AbstractCategoryType extends TranslatorAwareType
             ])
             ->add('meta_description', TranslatableType::class, [
                 'label' => $this->trans('Meta description', 'Admin.Global'),
-                'help' => $genericCharactersHint,
                 'required' => false,
                 'type' => TextWithRecommendedLengthType::class,
                 'options' => [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -8,7 +8,6 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Tax;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
-use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
@@ -29,18 +28,10 @@ class TaxType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $invalidCharsText = sprintf(
-            '%s ' . TypedRegexValidator::GENERIC_NAME_CHARS,
-            $this->trans('Invalid characters:', 'Admin.Notifications.Info')
+        $nameHintText = $this->trans(
+            'Tax name to display in carts and on invoices (e.g. "VAT").',
+            'Admin.International.Help'
         );
-
-        $nameHintText =
-            $this->trans(
-                'Tax name to display in carts and on invoices (e.g. "VAT").',
-                'Admin.International.Help'
-            )
-            . PHP_EOL
-            . $invalidCharsText;
 
         $builder
             ->add('name', TranslatableType::class, [
@@ -57,7 +48,7 @@ class TaxType extends TranslatorAwareType
                             ),
                         ]),
                         new TypedRegex([
-                            'type' => 'generic_name',
+                            'type' => TypedRegex::TYPE_GENERIC_NAME,
                         ]),
                     ],
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
@@ -11,7 +11,6 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\AddressZipCode;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\ExistingCustomerEmail;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
-use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator;
 use PrestaShop\PrestaShop\Core\Domain\Address\Configuration\AddressConstraint;
 use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\CountryChoiceType;
@@ -81,10 +80,6 @@ class CustomerAddressType extends TranslatorAwareType
     {
         $data = $builder->getData();
         $countryId = 0 !== $data['id_country'] ? $data['id_country'] : $this->contextCountryId;
-        $genericInvalidCharsMessage = $this->trans(
-            'Invalid characters:',
-            'Admin.Notifications.Info'
-        ) . ' ' . TypedRegexValidator::GENERIC_NAME_CHARS;
         $stateChoices = $this->stateChoiceProvider->getChoices(['id_country' => $countryId]);
         $showStates = !empty($stateChoices);
         $requiredFields = $options['requiredFields'];
@@ -138,7 +133,6 @@ class CustomerAddressType extends TranslatorAwareType
         ])
             ->add('alias', TextType::class, [
                 'label' => $this->trans('Address alias', 'Admin.Orderscustomers.Feature'),
-                'help' => $genericInvalidCharsMessage,
                 'required' => true,
                 'constraints' => [
                     new NotBlank([
@@ -162,10 +156,6 @@ class CustomerAddressType extends TranslatorAwareType
             ])
             ->add('first_name', TextType::class, [
                 'label' => $this->trans('First name', 'Admin.Global'),
-                'help' => $this->trans(
-                    'Invalid characters:',
-                    'Admin.Notifications.Info'
-                ) . ' ' . TypedRegexValidator::NAME_CHARS,
                 'required' => true,
                 'constraints' => [
                     new NotBlank([
@@ -189,10 +179,6 @@ class CustomerAddressType extends TranslatorAwareType
             ])
             ->add('last_name', TextType::class, [
                 'label' => $this->trans('Last name', 'Admin.Global'),
-                'help' => $this->trans(
-                    'Invalid characters:',
-                    'Admin.Notifications.Info'
-                ) . ' ' . TypedRegexValidator::NAME_CHARS,
                 'required' => true,
                 'constraints' => [
                     new NotBlank([
@@ -216,7 +202,6 @@ class CustomerAddressType extends TranslatorAwareType
             ])
             ->add('company', TextType::class, [
                 'label' => $this->trans('Company', 'Admin.Global'),
-                'help' => $genericInvalidCharsMessage,
                 'required' => in_array('company', $requiredFields, true),
                 'empty_data' => '',
                 'constraints' => [
@@ -414,10 +399,6 @@ class CustomerAddressType extends TranslatorAwareType
             ->add('other', TextareaType::class, [
                 'required' => in_array('other', $requiredFields, true),
                 'label' => $this->trans('Other', 'Admin.Global'),
-                'help' => $this->trans(
-                    'Invalid characters:',
-                    'Admin.Notifications.Info'
-                ) . ' ' . TypedRegexValidator::MESSAGE_CHARS,
                 'empty_data' => '',
                 'constraints' => [
                     new CleanHtml(),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
@@ -74,11 +74,9 @@ class ManufacturerAddressType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $nameHint = $this->trans('Invalid characters:', 'Admin.Global') . ' 0-9!<>,;?=+()@#"�{}_$%:';
         $data = $builder->getData();
         $countryId = 0 !== $data['id_country'] ? $data['id_country'] : $this->contextCountryId;
         $stateChoices = $this->statesChoiceProvider->getChoices(['id_country' => $countryId]);
-        $otherHint = $this->trans('Invalid characters:', 'Admin.Global') . ' <>{}';
 
         $builder
             ->add('id_manufacturer', ChoiceType::class, [
@@ -90,7 +88,6 @@ class ManufacturerAddressType extends TranslatorAwareType
             ])
             ->add('last_name', TextType::class, [
                 'label' => $this->trans('Last name', 'Admin.Global'),
-                'help' => $nameHint,
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->trans(
@@ -98,7 +95,7 @@ class ManufacturerAddressType extends TranslatorAwareType
                         ),
                     ]),
                     new TypedRegex([
-                        'type' => 'name',
+                        'type' => TypedRegex::TYPE_NAME,
                     ]),
                     new Length([
                         'max' => AddressSettings::MAX_NAME_LENGTH,
@@ -112,7 +109,6 @@ class ManufacturerAddressType extends TranslatorAwareType
             ])
             ->add('first_name', TextType::class, [
                 'label' => $this->trans('First name', 'Admin.Global'),
-                'help' => $nameHint,
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->trans(
@@ -120,7 +116,7 @@ class ManufacturerAddressType extends TranslatorAwareType
                         ),
                     ]),
                     new TypedRegex([
-                        'type' => 'name',
+                        'type' => TypedRegex::TYPE_NAME,
                     ]),
                     new Length([
                         'max' => AddressSettings::MAX_NAME_LENGTH,
@@ -136,7 +132,7 @@ class ManufacturerAddressType extends TranslatorAwareType
                 'label' => $this->trans('Address', 'Admin.Global'),
                 'constraints' => [
                     new TypedRegex([
-                        'type' => 'address',
+                        'type' => TypedRegex::TYPE_ADDRESS,
                     ]),
                     new Length([
                         'max' => AddressSettings::MAX_ADDRESS_LENGTH,
@@ -154,7 +150,7 @@ class ManufacturerAddressType extends TranslatorAwareType
                 'empty_data' => '',
                 'constraints' => [
                     new TypedRegex([
-                        'type' => 'address',
+                        'type' => TypedRegex::TYPE_ADDRESS,
                     ]),
                     new Length([
                         'max' => AddressSettings::MAX_ADDRESS_LENGTH,
@@ -172,7 +168,7 @@ class ManufacturerAddressType extends TranslatorAwareType
                 'empty_data' => '',
                 'constraints' => [
                     new TypedRegex([
-                        'type' => 'post_code',
+                        'type' => TypedRegex::TYPE_POST_CODE,
                     ]),
                     new Length([
                         'max' => AddressSettings::MAX_POST_CODE_LENGTH,
@@ -193,7 +189,7 @@ class ManufacturerAddressType extends TranslatorAwareType
                         ),
                     ]),
                     new TypedRegex([
-                        'type' => 'city_name',
+                        'type' => TypedRegex::TYPE_CITY_NAME,
                     ]),
                     new Length([
                         'max' => AddressSettings::MAX_CITY_NAME_LENGTH,
@@ -243,7 +239,7 @@ class ManufacturerAddressType extends TranslatorAwareType
                         'id_country' => $countryId,
                     ]),
                     new TypedRegex([
-                        'type' => 'dni_lite',
+                        'type' => TypedRegex::TYPE_DNI_LITE,
                     ]),
                     new Length([
                         'max' => 16,
@@ -261,7 +257,7 @@ class ManufacturerAddressType extends TranslatorAwareType
                 'empty_data' => '',
                 'constraints' => [
                     new TypedRegex([
-                        'type' => 'phone_number',
+                        'type' => TypedRegex::TYPE_PHONE_NUMBER,
                     ]),
                     new Length([
                         'max' => AddressSettings::MAX_PHONE_LENGTH,
@@ -279,7 +275,7 @@ class ManufacturerAddressType extends TranslatorAwareType
                 'empty_data' => '',
                 'constraints' => [
                     new TypedRegex([
-                        'type' => 'phone_number',
+                        'type' => TypedRegex::TYPE_PHONE_NUMBER,
                     ]),
                     new Length([
                         'max' => AddressSettings::MAX_PHONE_LENGTH,
@@ -294,11 +290,10 @@ class ManufacturerAddressType extends TranslatorAwareType
             ->add('other', TextType::class, [
                 'label' => $this->trans('Other', 'Admin.Global'),
                 'required' => false,
-                'help' => $otherHint,
                 'empty_data' => '',
                 'constraints' => [
                     new TypedRegex([
-                        'type' => 'message',
+                        'type' => TypedRegex::TYPE_MESSAGE,
                     ]),
                     new Length([
                         'max' => AddressSettings::MAX_OTHER_LENGTH,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Manufacturer/ManufacturerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Manufacturer/ManufacturerType.php
@@ -51,13 +51,9 @@ class ManufacturerType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $invalidCharactersForCatalogLabel = $this->trans('Invalid characters:', 'Admin.Global') . '<>{}';
-        $invalidCharactersForNameLabel = $this->trans('Invalid characters:', 'Admin.Global') . '<>{}';
-
         $builder
             ->add('name', TextType::class, [
                 'label' => $this->trans('Name', 'Admin.Global'),
-                'help' => $invalidCharactersForCatalogLabel,
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->trans(
@@ -116,7 +112,6 @@ class ManufacturerType extends TranslatorAwareType
             ])
             ->add('meta_title', TranslatableType::class, [
                 'label' => $this->trans('Meta title', 'Admin.Catalog.Feature'),
-                'help' => $invalidCharactersForNameLabel,
                 'type' => TextType::class,
                 'required' => false,
                 'options' => [
@@ -137,7 +132,6 @@ class ManufacturerType extends TranslatorAwareType
             ])
             ->add('meta_description', TranslatableType::class, [
                 'label' => $this->trans('Meta description', 'Admin.Catalog.Feature'),
-                'help' => $invalidCharactersForNameLabel,
                 'type' => TextareaType::class,
                 'required' => false,
                 'options' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -10,7 +10,6 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\AddressDniRequire
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\AddressStateRequired;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
-use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator;
 use PrestaShop\PrestaShop\Core\Domain\Address\AddressSettings;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\SupplierSettings;
 use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
@@ -84,28 +83,10 @@ class SupplierType extends TranslatorAwareType
         $data = $builder->getData();
         $countryId = 0 !== $data['id_country'] ? $data['id_country'] : $this->contextCountryId;
 
-        $invalidCharsText = sprintf(
-            '%s ' . TypedRegexValidator::CATALOG_CHARS,
-            $this->trans('Invalid characters:', 'Admin.Global')
-        );
-
-        $invalidGenericNameHint = sprintf(
-            '%s ' . TypedRegexValidator::GENERIC_NAME_CHARS,
-            $this->trans('Invalid characters:', 'Admin.Global')
-        );
-
-        $keywordHint = sprintf(
-            '%s ' . PHP_EOL . $invalidGenericNameHint,
-            $this->trans(
-                'To add tags, click in the field, write something, and then press the "Enter" key.',
-                'Admin.Shopparameters.Help'
-            ));
-
         $builder
             ->add('name', TextType::class, [
                 'label' => $this->trans('Name', 'Admin.Global'),
                 'required' => true,
-                'help' => $invalidCharsText,
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->trans(
@@ -256,7 +237,6 @@ class SupplierType extends TranslatorAwareType
             ])
             ->add('meta_title', TranslatableType::class, [
                 'label' => $this->trans('Meta title', 'Admin.Global'),
-                'help' => $invalidGenericNameHint,
                 'type' => TextType::class,
                 'required' => false,
                 'options' => [
@@ -277,7 +257,6 @@ class SupplierType extends TranslatorAwareType
             ])
             ->add('meta_description', TranslatableType::class, [
                 'label' => $this->trans('Meta description', 'Admin.Global'),
-                'help' => $invalidGenericNameHint,
                 'type' => TextareaType::class,
                 'required' => false,
                 'options' => [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Remove misleading "Invalid characters" help texts from several BO form fields.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| UI Tests        | https://github.com/kseghair/ga.tests.ui.pr/actions/runs/22961190476
| Fixed issue or discussion?     | Fixes #27782

## Context

Several Back Office form fields displayed a `help` text listing invalid characters (e.g. angle brackets, braces, semicolons) that was either:

- **Inaccurate** — the listed characters did not always match what the underlying `TypedRegex` constraint actually blocks, misleading merchants and developers.
- **Redundant** — the constraint already surfaces a clear validation error on form submit; the hint added noise without actionable UX value.

Affected pages:
- **Sell > Catalog > Brands & Suppliers > Brands** — Add/Edit brand (`name`, `meta_title`, `meta_description`)
- **Sell > Catalog > Brands & Suppliers > Suppliers** — Add/Edit supplier (`name`, `meta_title`, `meta_description`)
- **Sell > Catalog > Categories** — Add/Edit category (`name`, `meta_title`, `meta_description`)
- **Improve > International > Taxes** — Add/Edit tax (`name`, invalid chars line only)
- **Sell > Customers > Addresses** — Add/Edit customer address (`alias`, `first_name`, `last_name`, `company`, `other`)
- **Sell > Catalog > Brands & Suppliers > Brand addresses** — Add/Edit brand address (`last_name`, `first_name`, `other`)

## Proposed solution

Remove the `'help'` option (or the appended invalid-chars fragment) from the listed fields in the following form types:

- `ManufacturerType.php`
- `SupplierType.php`
- `AbstractCategoryType.php`
- `TaxType.php` (kept the descriptive hint `"Tax name to display in carts and on invoices (e.g. VAT)."`)
- `CustomerAddressType.php`
- `ManufacturerAddressType.php`

Also replaces raw string literals passed to `TypedRegex` with their class constants (`TypedRegex::TYPE_NAME`, `TypedRegex::TYPE_ADDRESS`, etc.) in `ManufacturerAddressType` and `TaxType`, for consistency with the rest of the codebase.

**All `TypedRegex` and `Length` constraints are left untouched** — server-side validation continues to fire and display an error message on submit.

## How to test

1. Go to **Sell > Catalog > Brands & Suppliers > Brands > Add new brand**.
   - Confirm no "Invalid characters" hint is visible on the Name, Meta title, or Meta description fields.
   - Enter an invalid name and click Save — confirm a validation error is still shown.
2. Repeat for **Suppliers**, **Categories**, **Taxes**, **Customer Addresses**, and **Brand Addresses**.
3. Confirm all create/edit operations for valid data still work correctly.
