### PR TITLE
Fix BO breadcrumb alignment in header toolbar

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
@@ -63,6 +63,11 @@
 
     > ol {
       padding-left: 0;
+
+      .breadcrumb-item {
+        display: inline-flex;
+        align-items: center;
+      }
     }
   }
   // toolbar buttons

--- a/tests/UI/campaigns/functional/BO/15_header/04_breadcrumb.ts
+++ b/tests/UI/campaigns/functional/BO/15_header/04_breadcrumb.ts
@@ -1,0 +1,126 @@
+// Import utils
+import testContext from '@utils/testContext';
+
+import {expect} from 'chai';
+import {
+  boDashboardPage,
+  boLoginPage,
+  boOrdersPage,
+  boCustomersPage,
+  type BrowserContext,
+  type Page,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_BO_header_breadcrumb';
+
+describe('BO - Header : Breadcrumb', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+
+  // before and after functions
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+  });
+
+  it('should login in BO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+    await boLoginPage.goTo(page, global.BO.URL);
+    await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+    const pageTitle = await boDashboardPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+  });
+
+  describe('Breadcrumb on Orders page', async () => {
+    it('should go to the Orders page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToOrdersPage', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.ordersParentLink,
+        boDashboardPage.ordersLink,
+      );
+      await boOrdersPage.closeSfToolBar(page);
+
+      const pageTitle = await boOrdersPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boOrdersPage.pageTitle);
+    });
+
+    it('should check that the breadcrumb is visible', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkBreadcrumbVisibleOrders', baseContext);
+
+      const isBreadcrumbVisible = await boOrdersPage.elementVisible(page, 'nav[aria-label="Breadcrumb"]');
+      expect(isBreadcrumbVisible).to.eq(true);
+    });
+
+    it('should check the breadcrumb container item', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkBreadcrumbContainerOrders', baseContext);
+
+      const breadcrumbContainerText = await boOrdersPage.getTextContent(
+        page,
+        '.header-toolbar nav .breadcrumb-item:first-child',
+      );
+      expect(breadcrumbContainerText).to.contains('Sell');
+    });
+
+    it('should check the breadcrumb tab item', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkBreadcrumbTabOrders', baseContext);
+
+      const breadcrumbTabText = await boOrdersPage.getTextContent(
+        page,
+        '.header-toolbar nav .breadcrumb-item.active',
+      );
+      expect(breadcrumbTabText).to.contains(boOrdersPage.pageTitle);
+    });
+  });
+
+  describe('Breadcrumb on Customers page', async () => {
+    it('should go to the Customers page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToCustomersPage', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.customersParentLink,
+        boDashboardPage.customersLink,
+      );
+      await boCustomersPage.closeSfToolBar(page);
+
+      const pageTitle = await boCustomersPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boCustomersPage.pageTitle);
+    });
+
+    it('should check that the breadcrumb is visible', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkBreadcrumbVisibleCustomers', baseContext);
+
+      const isBreadcrumbVisible = await boCustomersPage.elementVisible(page, 'nav[aria-label="Breadcrumb"]');
+      expect(isBreadcrumbVisible).to.eq(true);
+    });
+
+    it('should check the breadcrumb container item', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkBreadcrumbContainerCustomers', baseContext);
+
+      const breadcrumbContainerText = await boCustomersPage.getTextContent(
+        page,
+        '.header-toolbar nav .breadcrumb-item:first-child',
+      );
+      expect(breadcrumbContainerText).to.contains('Sell');
+    });
+
+    it('should check the breadcrumb tab item', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkBreadcrumbTabCustomers', baseContext);
+
+      const breadcrumbTabText = await boCustomersPage.getTextContent(
+        page,
+        '.header-toolbar nav .breadcrumb-item.active',
+      );
+      expect(breadcrumbTabText).to.contains(boCustomersPage.pageTitle);
+    });
+  });
+});


### PR DESCRIPTION
## Context / Problem

Fixes #37999

The breadcrumb in the Back Office header toolbar was not aligned correctly on many pages (Dashboard, Design, etc.). When a breadcrumb item contains a Material Icons icon alongside text, the icon and the text were not vertically centered, causing a visual misalignment.

**Root cause:** The \ elements lacked a flex display context, so the inline \ icon (24px tall) and the adjacent text had no common vertical alignment axis.

## Proposed solution

Add \ and \ to \ in \:

\
This is the established pattern already used across the codebase for icon+text alignment (e.g., \ in \, logout link in \).

## Alternatives considered

- **\ on \**: Targeted but brittle — depends on the icon being an inline element and does not account for all browsers rendering Material Icons at the same baseline.
- **Setting a fixed \**: Would affect text rendering globally inside breadcrumb items and is not consistent with the rest of the codebase.
- **Changing \ on the parent \ (Bootstrap)**: Would affect all flex items in the \ including Bootstrap's \ separator pseudo-elements, with broader side effects.

## Changes

| File | Change |
|------|--------|
| \ | Add \ to \ |
| \ | New UI test covering breadcrumb visibility and content on Orders and Customers pages |

## Tests added

**New test file:** 
Run with:
\
Covers:
- Breadcrumb \ is visible on the Orders page
- First breadcrumb item contains the container name ("Sell")
- Active breadcrumb item contains the page title ("Orders")
- Same checks on the Customers page

## Contribution checklist

- [x] I read the [contribution guidelines](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/)
- [x] I wrote/updated tests to cover the fix
- [x] The fix targets the \ branch
- [x] No breaking change introduced
- [x] The SCSS change follows existing codebase patterns (\)