### PR TITLE
Fix/issue 40627

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -13,15 +13,21 @@ ARG GROUP_ID
 ARG USER_ID
 ARG NODE_VERSION
 ARG INSTALL_XDEBUG
+ARG TIMEZONE
 
+ENV TZ=$TIMEZONE
+ENV NODE_VERSION=$NODE_VERSION
 
 RUN groupmod -g $GROUP_ID www-data \
   && usermod -u $USER_ID -g $GROUP_ID www-data
 
 # Install mailutils to make sendmail work
-RUN apt update && apt install -y mailutils
+# Install tzdata to define the timezone
+RUN apt update && apt install -y mailutils tzdata
 
-ENV NODE_VERSION       $NODE_VERSION
+## Define timezone
+RUN ln -sf /usr/share/zoneinfo/$TIMEZONE /etc/localtime \
+  && echo $TZ > /etc/timezone
 
 RUN php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');" && php /tmp/composer-setup.php --no-ansi --install-dir=/usr/local/bin --filename=composer && rm -rf /tmp/composer-setup.php
 

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -89,6 +89,7 @@ runs:
         DB_PASSWD: 'prestashop'
         PS_LANGUAGE: 'en'
         ADMIN_PASSWD: 'Correct Horse Battery Staple'
+        TIMEZONE: 'Europe/Paris'
       run: |
         cd ${{ inputs.PRESTASHOP_DIR }}
         if [[ "${{ inputs.DOCKER_DAEMON }}" = "true" ]]; then

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -143,6 +143,11 @@ jobs:
     name: Admin Security Attribute Linter
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare docker prefix with repository name lower cased
+        run: |
+          REPOSITORY_NAME=${{ github.event.repository.name }}
+          echo "DOCKER_PREFIX=${REPOSITORY_NAME@L}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
 
       # First install the shop to that the modules controllers are also scanned (not the case without installation)
@@ -157,7 +162,7 @@ jobs:
       - name: Setup Environment failure
         uses: ./.github/actions/setup-env-export-logs
         with:
-          DOCKER_PREFIX: prestashop
+          DOCKER_PREFIX: ${{ env.DOCKER_PREFIX }}
           ARTIFACT_NAME: setup-symfony-console-${{ matrix.app-id }}
           ENABLE_SSL: 'true'
           INSTALL_AUTO: 'true'
@@ -166,4 +171,31 @@ jobs:
       - name: Run Admin Security Attribute Linter (inside the docker so installed modules are also scanned)
         run: |
           echo Searching for routes without security
-          docker exec prestashop-prestashop-git-1 php bin/console prestashop:linter:security-attribute find-missing
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php bin/console prestashop:linter:security-attribute find-missing
+
+  header-stamp:
+    name: Check license headers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Composer cache
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache Composer Directory
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Composer Install
+        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
+
+      # Run header stamp
+      - name: Header stamp dry run
+        run: composer header-stamp
+      # Little hint to help contributors fix their PRs
+      - name: Hint to fix
+        if: failure()
+        run: echo "::notice::Run composer header-stamp-fix at the root of the project to fix files, or update the .header-stamp-config.yml file to add exceptions"

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -19,30 +19,3 @@ jobs:
         uses: PrestaShop/.github/.github/actions/normalize-dependabot-pr@master
         with:
           default-branch: ${{ github.event.pull_request.base.ref }}
-
-  header-stamp:
-    name: Check license headers
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      # Composer cache
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - name: Cache Composer Directory
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-      - name: Composer Install
-        run: COMPOSER_PROCESS_TIMEOUT=600 composer install --ansi --prefer-dist --no-interaction --no-progress
-
-      # Run header stamp
-      - name: Header stamp dry run
-        run: composer header-stamp
-      # Little hint to help contributors fix their PRs
-      - name: Hint to fix
-        if: failure()
-        run: echo "::notice::Run composer header-stamp-fix at the root of the project to fix files, or update the .header-stamp-config.yml file to add exceptions"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -27,8 +27,12 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.workflow_matrix_generator.outputs.dynamic_matrix) }}
       fail-fast: false
-
     steps:
+      - name: Prepare docker prefix with repository name lower cased
+        run: |
+          REPOSITORY_NAME=${{ github.event.repository.name }}
+          echo "DOCKER_PREFIX=${REPOSITORY_NAME@L}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
 
       - name: Setup Environment
@@ -43,7 +47,7 @@ jobs:
       - name: Setup Environment failure
         uses: ./.github/actions/setup-env-export-logs
         with:
-          DOCKER_PREFIX: prestashop
+          DOCKER_PREFIX: ${{ env.DOCKER_PREFIX }}
           ARTIFACT_NAME: setup-sanity-${{ matrix.php }}-${{ matrix.browser }}-${{ matrix.db }}
           DB_SERVER: ${{ matrix.db }}
           ENABLE_SSL: 'true'
@@ -62,7 +66,7 @@ jobs:
         run: |
           mkdir -p ./var/docker-logs
           docker logs prestashop-${{ matrix.db }}-1 > ./var/docker-logs/${{ matrix.db }}.log
-          docker logs prestashop-prestashop-git-1 > ./var/docker-logs/prestashop.log
+          docker logs ${{ inputs.DOCKER_PREFIX }}-prestashop-git-1 > ./var/docker-logs/prestashop.log
 
       - name: Upload Screenshots and logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/symfony-console.yml
+++ b/.github/workflows/symfony-console.yml
@@ -19,6 +19,11 @@ jobs:
     name: Symfony Console
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare docker prefix with repository name lower cased
+        run: |
+          REPOSITORY_NAME=${{ github.event.repository.name }}
+          echo "DOCKER_PREFIX=${REPOSITORY_NAME@L}" >> $GITHUB_ENV
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -102,7 +107,7 @@ jobs:
       - name: Setup Environment failure
         uses: ./.github/actions/setup-env-export-logs
         with:
-          DOCKER_PREFIX: prestashop
+          DOCKER_PREFIX: ${{ env.DOCKER_PREFIX }}
           ARTIFACT_NAME: setup-symfony-console-${{ matrix.app-id }}
           ENABLE_SSL: 'true'
           INSTALL_AUTO: 'false'
@@ -111,8 +116,8 @@ jobs:
       # Retest the console after shop install
       - name: Check bin/console and cache:clear can run after shop install
         run: |
-          docker exec prestashop-prestashop-git-1 php ./bin/console --app-id=${{ matrix.app-id }}
-          docker exec prestashop-prestashop-git-1 php -d memory_limit=-1 ./bin/console cache:clear --env=dev --app-id=${{ matrix.app-id }}
-          docker exec prestashop-prestashop-git-1 php -d memory_limit=-1 ./bin/console cache:clear --env=prod --app-id=${{ matrix.app-id }}
-          docker exec prestashop-prestashop-git-1 php ./bin/console cache:clear --env=dev --no-warmup --app-id=${{ matrix.app-id }}
-          docker exec prestashop-prestashop-git-1 php ./bin/console cache:clear --env=prod --no-warmup --app-id=${{ matrix.app-id }}
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php ./bin/console --app-id=${{ matrix.app-id }}
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php -d memory_limit=-1 ./bin/console cache:clear --env=dev --app-id=${{ matrix.app-id }}
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php -d memory_limit=-1 ./bin/console cache:clear --env=prod --app-id=${{ matrix.app-id }}
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php ./bin/console cache:clear --env=dev --no-warmup --app-id=${{ matrix.app-id }}
+          docker exec ${{ env.DOCKER_PREFIX }}-prestashop-git-1 php ./bin/console cache:clear --env=prod --no-warmup --app-id=${{ matrix.app-id }}

--- a/admin-dev/themes/new-theme/js/pages/product/category/category-tree-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/category/category-tree-selector.ts
@@ -71,12 +71,6 @@ export default class CategoryTreeSelector {
   }
 
   public showModal(selectedCategories: Array<Category>, defaultCategoryId: number): void {
-    if (!defaultCategoryId) {
-      console.error('Default category id is invalid.');
-
-      return;
-    }
-
     this.selectedCategories = selectedCategories;
     this.defaultCategoryId = defaultCategoryId;
 

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -816,6 +816,6 @@ abstract class ControllerCore
 
     public function getControllerName(): string
     {
-        return Tools::toCamelCase($this->php_self, true);
+        return str_replace('Core', '', get_class($this));
     }
 }

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -813,4 +813,9 @@ abstract class ControllerCore
     {
         return $this->get(static::SERVICE_MULTISTORE_FEATURE)->isUsed();
     }
+
+    public function getControllerName(): string
+    {
+        return Tools::toCamelCase($this->php_self, true);
+    }
 }

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -816,6 +816,6 @@ abstract class ControllerCore
 
     public function getControllerName(): string
     {
-        return str_replace('Core', '', get_class($this));
+        return get_class($this);
     }
 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -225,6 +225,7 @@ class FrontControllerCore extends Controller
                 'controller' => $this,
             ]
         );
+        Hook::exec('actionFrontController' . $this->getControllerName() . 'InitBefore', ['controller' => $this]);
 
         /*
          * Globals are DEPRECATED as of version 1.5.0.1
@@ -492,6 +493,7 @@ class FrontControllerCore extends Controller
                 'controller' => $this,
             ]
         );
+        Hook::exec('actionFrontController' . $this->getControllerName() . 'InitAfter', ['controller' => $this]);
     }
 
     /**
@@ -506,6 +508,8 @@ class FrontControllerCore extends Controller
 
     /**
      * Initializes a set of commonly used variables, available for use in the template.
+     *
+     * @throws PrestaShopException
      */
     protected function assignGeneralPurposeVariables()
     {
@@ -514,6 +518,12 @@ class FrontControllerCore extends Controller
 
         Hook::exec(
             'actionFrontControllerSetVariablesBefore',
+            [
+                'templateVars' => &$templateVars,
+                'cart' => $cart,
+            ]
+        );
+        Hook::exec('actionFrontController' . $this->getControllerName() . 'SetVariablesBefore',
             [
                 'templateVars' => &$templateVars,
                 'cart' => $cart,
@@ -549,6 +559,16 @@ class FrontControllerCore extends Controller
             null,
             true
         );
+        $modulesVariables = array_merge(
+            $modulesVariables,
+            Hook::exec('actionFrontController' . $this->getControllerName() . 'SetVariables',
+                [
+                    'templateVars' => &$templateVars,
+                ],
+                null,
+                true
+            )
+        );
 
         if (is_array($modulesVariables)) {
             foreach ($modulesVariables as $moduleName => $variables) {
@@ -581,12 +601,17 @@ class FrontControllerCore extends Controller
         Hook::exec('actionBuildFrontEndObject', [
             'obj' => &$object,
         ]);
+        Hook::exec('actionBuildFront' . $this->getControllerName() . 'EndObject', [
+            'obj' => &$object,
+        ]);
 
         return $object;
     }
 
     /**
      * Initializes common front page content: header, footer and side columns.
+     *
+     * @throws PrestaShopException
      */
     public function initContent()
     {
@@ -594,7 +619,8 @@ class FrontControllerCore extends Controller
         $this->process();
 
         $this->context->smarty->assign([
-            'HOOK_HEADER' => Hook::exec('displayHeader'),
+            'HOOK_HEADER' => Hook::exec('displayHeader')
+                . Hook::exec('display' . $this->getControllerName() . 'Header'),
         ]);
     }
 
@@ -734,6 +760,7 @@ class FrontControllerCore extends Controller
         }
 
         Hook::exec('actionOutputHTMLBefore', ['html' => &$html]);
+        Hook::exec('actionOutput' . $this->getControllerName() . 'HTMLBefore', ['html' => &$html]);
         echo trim($html);
     }
 
@@ -783,7 +810,7 @@ class FrontControllerCore extends Controller
                 $this->context->smarty->assign([
                     'urls' => $this->getTemplateVarUrls(),
                     'shop' => $this->getTemplateVarShop(),
-                    'HOOK_MAINTENANCE' => Hook::exec('displayMaintenance', []),
+                    'HOOK_MAINTENANCE' => Hook::exec('displayMaintenance'),
                     'maintenance_text' => Configuration::get('PS_MAINTENANCE_TEXT', (int) $this->context->language->id),
                     'stylesheets' => $this->getStylesheets(),
                 ]);
@@ -935,6 +962,7 @@ class FrontControllerCore extends Controller
      * Sets controller CSS and JS files.
      *
      * @return bool
+     * @throws PrestaShopException
      */
     public function setMedia()
     {
@@ -962,7 +990,8 @@ class FrontControllerCore extends Controller
         }
 
         // Execute Hook FrontController SetMedia
-        Hook::exec('actionFrontControllerSetMedia', []);
+        Hook::exec('actionFrontControllerSetMedia');
+        Hook::exec('actionFrontController' . $this->getControllerName() . 'SetMedia');
 
         return true;
     }
@@ -2197,5 +2226,10 @@ class FrontControllerCore extends Controller
         }
 
         return Validate::isUrl($data);
+    }
+
+    protected function getControllerName(): string
+    {
+        return Tools::toCamelCase($this->php_self, true);
     }
 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -225,7 +225,7 @@ class FrontControllerCore extends Controller
                 'controller' => $this,
             ]
         );
-        Hook::exec('actionFrontController' . $this->getControllerName() . 'InitBefore', ['controller' => $this]);
+        Hook::exec('action' . $this->getControllerName() . 'InitBefore', ['controller' => $this]);
 
         /*
          * Globals are DEPRECATED as of version 1.5.0.1
@@ -493,7 +493,7 @@ class FrontControllerCore extends Controller
                 'controller' => $this,
             ]
         );
-        Hook::exec('actionFrontController' . $this->getControllerName() . 'InitAfter', ['controller' => $this]);
+        Hook::exec('action' . $this->getControllerName() . 'InitAfter', ['controller' => $this]);
     }
 
     /**
@@ -523,7 +523,7 @@ class FrontControllerCore extends Controller
                 'cart' => $cart,
             ]
         );
-        Hook::exec('actionFrontController' . $this->getControllerName() . 'SetVariablesBefore',
+        Hook::exec('action' . $this->getControllerName() . 'SetVariablesBefore',
             [
                 'templateVars' => &$templateVars,
                 'cart' => $cart,
@@ -561,7 +561,7 @@ class FrontControllerCore extends Controller
         );
         $modulesVariables = array_merge(
             $modulesVariables,
-            Hook::exec('actionFrontController' . $this->getControllerName() . 'SetVariables',
+            Hook::exec('action' . $this->getControllerName() . 'SetVariables',
                 [
                     'templateVars' => &$templateVars,
                 ],
@@ -601,7 +601,7 @@ class FrontControllerCore extends Controller
         Hook::exec('actionBuildFrontEndObject', [
             'obj' => &$object,
         ]);
-        Hook::exec('actionBuildFront' . $this->getControllerName() . 'EndObject', [
+        Hook::exec('actionBuild' . $this->getControllerName() . 'FrontEndObject', [
             'obj' => &$object,
         ]);
 
@@ -992,7 +992,7 @@ class FrontControllerCore extends Controller
 
         // Execute Hook FrontController SetMedia
         Hook::exec('actionFrontControllerSetMedia');
-        Hook::exec('actionFrontController' . $this->getControllerName() . 'SetMedia');
+        Hook::exec('action' . $this->getControllerName() . 'SetMedia');
 
         return true;
     }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -2228,9 +2228,4 @@ class FrontControllerCore extends Controller
 
         return Validate::isUrl($data);
     }
-
-    protected function getControllerName(): string
-    {
-        return Tools::toCamelCase($this->php_self, true);
-    }
 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -962,6 +962,7 @@ class FrontControllerCore extends Controller
      * Sets controller CSS and JS files.
      *
      * @return bool
+     *
      * @throws PrestaShopException
      */
     public function setMedia()

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1171,14 +1171,14 @@ class AdminImportControllerCore extends AdminController
         }
         AdminImportController::setDefaultValues($info);
 
-        if ($force_ids && isset($info['id']) && (int) $info['id']) {
+        if (!$force_ids) {
+            unset($info['id']);
+        }
+
+        if ($force_ids && isset($info['id']) && (int) $info['id'] && Category::existsInDatabase((int) $info['id'], 'category')) {
             $category = new Category((int) $info['id']);
         } else {
-            if (isset($info['id']) && (int) $info['id'] && Category::existsInDatabase((int) $info['id'], 'category')) {
-                $category = new Category((int) $info['id']);
-            } else {
-                $category = new Category();
-            }
+            $category = new Category();
         }
 
         AdminImportController::arrayWalk($info, ['AdminImportController', 'fillInfo'], $category);
@@ -2661,14 +2661,14 @@ class AdminImportControllerCore extends AdminController
     {
         AdminImportController::setDefaultValues($info);
 
-        if ($force_ids && isset($info['id']) && (int) $info['id']) {
+        if (!$force_ids) {
+            unset($info['id']);
+        }
+
+        if ($force_ids && isset($info['id']) && (int) $info['id'] && Customer::customerIdExistsStatic((int) $info['id'])) {
             $customer = new Customer((int) $info['id']);
         } else {
-            if (array_key_exists('id', $info) && (int) $info['id'] && Customer::customerIdExistsStatic((int) $info['id'])) {
-                $customer = new Customer((int) $info['id']);
-            } else {
-                $customer = new Customer();
-            }
+            $customer = new Customer();
         }
 
         $customer_exist = false;
@@ -2920,14 +2920,13 @@ class AdminImportControllerCore extends AdminController
     {
         AdminImportController::setDefaultValues($info);
 
-        if ($force_ids && isset($info['id']) && (int) $info['id']) {
+        if (!$force_ids) {
+            unset($info['id']);
+        }
+        if ($force_ids && isset($info['id']) && (int) $info['id'] && Address::addressExists((int) $info['id'])) {
             $address = new Address((int) $info['id']);
         } else {
-            if (array_key_exists('id', $info) && (int) $info['id'] && Address::addressExists((int) $info['id'])) {
-                $address = new Address((int) $info['id']);
-            } else {
-                $address = new Address();
-            }
+            $address = new Address();
         }
 
         AdminImportController::arrayWalk($info, ['AdminImportController', 'fillInfo'], $address);
@@ -3240,14 +3239,13 @@ class AdminImportControllerCore extends AdminController
     {
         AdminImportController::setDefaultValues($info);
 
-        if ($force_ids && isset($info['id']) && (int) $info['id']) {
+        if (!$force_ids) {
+            unset($info['id']);
+        }
+        if ($force_ids && isset($info['id']) && (int) $info['id'] && Manufacturer::existsInDatabase((int) $info['id'], 'manufacturer')) {
             $manufacturer = new Manufacturer((int) $info['id']);
         } else {
-            if (array_key_exists('id', $info) && (int) $info['id'] && Manufacturer::existsInDatabase((int) $info['id'], 'manufacturer')) {
-                $manufacturer = new Manufacturer((int) $info['id']);
-            } else {
-                $manufacturer = new Manufacturer();
-            }
+            $manufacturer = new Manufacturer();
         }
 
         AdminImportController::arrayWalk($info, ['AdminImportController', 'fillInfo'], $manufacturer);
@@ -3355,14 +3353,13 @@ class AdminImportControllerCore extends AdminController
     {
         AdminImportController::setDefaultValues($info);
 
-        if ($force_ids && isset($info['id']) && (int) $info['id']) {
+        if (!$force_ids) {
+            unset($info['id']);
+        }
+        if ($force_ids && isset($info['id']) && (int) $info['id'] && Supplier::existsInDatabase((int) $info['id'], 'supplier')) {
             $supplier = new Supplier((int) $info['id']);
         } else {
-            if (array_key_exists('id', $info) && (int) $info['id'] && Supplier::existsInDatabase((int) $info['id'], 'supplier')) {
-                $supplier = new Supplier((int) $info['id']);
-            } else {
-                $supplier = new Supplier();
-            }
+            $supplier = new Supplier();
         }
 
         AdminImportController::arrayWalk($info, ['AdminImportController', 'fillInfo'], $supplier);
@@ -3461,14 +3458,13 @@ class AdminImportControllerCore extends AdminController
     {
         AdminImportController::setDefaultValues($info);
 
-        if ($force_ids && isset($info['id']) && (int) $info['id']) {
+        if (!$force_ids) {
+            unset($info['id']);
+        }
+        if ($force_ids && isset($info['id']) && (int) $info['id'] && Alias::existsInDatabase((int) $info['id'], 'alias')) {
             $alias = new Alias((int) $info['id']);
         } else {
-            if (array_key_exists('id', $info) && (int) $info['id'] && Alias::existsInDatabase((int) $info['id'], 'alias')) {
-                $alias = new Alias((int) $info['id']);
-            } else {
-                $alias = new Alias();
-            }
+            $alias = new Alias();
         }
 
         AdminImportController::arrayWalk($info, ['AdminImportController', 'fillInfo'], $alias);
@@ -3541,14 +3537,13 @@ class AdminImportControllerCore extends AdminController
     {
         AdminImportController::setDefaultValues($info);
 
-        if ($force_ids && isset($info['id']) && (int) $info['id']) {
+        if (!$force_ids) {
+            unset($info['id']);
+        }
+        if ($force_ids && isset($info['id']) && (int) $info['id'] && Store::existsInDatabase((int) $info['id'], 'store')) {
             $store = new Store((int) $info['id']);
         } else {
-            if (array_key_exists('id', $info) && (int) $info['id'] && Store::existsInDatabase((int) $info['id'], 'store')) {
-                $store = new Store((int) $info['id']);
-            } else {
-                $store = new Store();
-            }
+            $store = new Store();
         }
 
         AdminImportController::arrayWalk($info, ['AdminImportController', 'fillInfo'], $store);

--- a/docker-compose.mariadb.yml
+++ b/docker-compose.mariadb.yml
@@ -32,6 +32,7 @@ services:
         - GROUP_ID=${GROUP_ID:-1000}
         - NODE_VERSION=${NODE_VERSION:-16.20.1}
         - INSTALL_XDEBUG=${INSTALL_XDEBUG:-false}
+        - TIMEZONE=${TIMEZONE:-UTC}
     environment:
       DISABLE_MAKE: ${DISABLE_MAKE:-0}
       PS_INSTALL_AUTO: ${PS_INSTALL_AUTO:-1}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
         - GROUP_ID=${GROUP_ID:-1000}
         - NODE_VERSION=${NODE_VERSION:-20.17.0}
         - INSTALL_XDEBUG=${INSTALL_XDEBUG:-false}
+        - TIMEZONE=${TIMEZONE:-UTC}
     environment:
       DISABLE_MAKE: ${DISABLE_MAKE:-0}
       PS_INSTALL_AUTO: ${PS_INSTALL_AUTO:-1}

--- a/src/Adapter/Attribute/Repository/AttributeRepository.php
+++ b/src/Adapter/Attribute/Repository/AttributeRepository.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Attribute\Repository;
 
 use Attribute;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\Attribute\Exception\AttributeNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\Attribute\Exception\CannotAddAttributeException;
@@ -346,6 +347,69 @@ class AttributeRepository extends AbstractMultiShopObjectModelRepository
         }
 
         return $attributesInfoByAttributeId;
+    }
+
+    /**
+     * Retrieve attributes with values (id, name).
+     *
+     * @param int $languageId
+     * @param int[] $shopIds
+     *
+     * @return array<int, array{attribute_group_id: int, name: string, values: array<int, array{item_id: int, name: string}>}>
+     */
+    public function getAttributesWithValues(int $languageId, array $shopIds = []): array
+    {
+        $qb = $this->connection->createQueryBuilder()
+            ->select(
+                'DISTINCT a.id_attribute_group AS attribute_group_id',
+                'agl.name AS name',
+                'al.id_attribute AS value_id',
+                'al.name AS value_name'
+            )
+            ->from($this->dbPrefix . 'attribute', 'a')
+            ->leftJoin('a', $this->dbPrefix . 'attribute_lang', 'al',
+                'a.id_attribute = al.id_attribute AND al.id_lang = :language_id AND LENGTH(TRIM(al.name)) > 0'
+            )
+            ->leftJoin('a', $this->dbPrefix . 'attribute_group', 'ag',
+                'ag.id_attribute_group = a.id_attribute_group'
+            )
+            ->leftJoin('ag', $this->dbPrefix . 'attribute_group_lang', 'agl',
+                'ag.id_attribute_group = agl.id_attribute_group AND agl.id_lang = :language_id AND LENGTH(TRIM(agl.name)) > 0'
+            )
+            ->orderBy('a.id_attribute_group')
+            ->addOrderBy('al.id_attribute')
+            ->setParameter('language_id', $languageId);
+
+        if (!empty($shopIds)) {
+            $qb
+                ->join('a', $this->dbPrefix . 'attribute_shop', 'ats',
+                    'ats.id_attribute = a.id_attribute AND ats.id_shop IN (:shop_ids)'
+                )
+                ->join('a', $this->dbPrefix . 'attribute_group_shop', 'ags',
+                    'ags.id_attribute_group = a.id_attribute_group AND ags.id_shop IN (:shop_ids)'
+                )
+                ->setParameter('shop_ids', $shopIds, ArrayParameterType::INTEGER);
+        }
+
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        $attributeGroups = [];
+        foreach ($rows as $row) {
+            $groupId = (int) $row['attribute_group_id'];
+            if (!isset($attributeGroups[$groupId])) {
+                $attributeGroups[$groupId] = [
+                    'attribute_group_id' => (int) $groupId,
+                    'name' => (string) $row['name'],
+                    'values' => [],
+                ];
+            }
+            $attributeGroups[$groupId]['values'][] = [
+                'item_id' => (int) $row['value_id'],
+                'name' => (string) $row['value_name'],
+            ];
+        }
+
+        return array_values($attributeGroups);
     }
 
     /**

--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -137,6 +137,10 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
             $customer->active = $command->isEnabled();
         }
 
+        if (null !== $command->isNewsletterSubscribed()) {
+            $customer->newsletter = $command->isNewsletterSubscribed();
+        }
+
         if (null !== $command->isPartnerOffersSubscribed()) {
             $customer->optin = $command->isPartnerOffersSubscribed();
         }

--- a/src/Adapter/Feature/Repository/FeatureRepository.php
+++ b/src/Adapter/Feature/Repository/FeatureRepository.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Feature\Repository;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Feature;
@@ -168,6 +169,7 @@ class FeatureRepository extends AbstractMultiShopObjectModelRepository
     {
         $qb = $this->getFeaturesQueryBuilder()
             ->select('f.*, fl.*')
+            ->leftJoin('f', $this->dbPrefix . 'feature_lang', 'fl', 'fl.id_feature = f.id_feature')
             ->setFirstResult($offset ?? 0)
             ->addOrderBy('f.position', 'ASC')
             ->setMaxResults($limit)
@@ -266,6 +268,66 @@ class FeatureRepository extends AbstractMultiShopObjectModelRepository
         return array_map(static function (array $result): ShopId {
             return new ShopId((int) $result['id_shop']);
         }, $qb->executeQuery()->fetchAllAssociative());
+    }
+
+    /**
+     * Retrieve features with values (id, name).
+     *
+     * @param int $languageId
+     * @param int[] $shopIds
+     *
+     * @return array<int, array{feature_id: int, name: string, values: array<int, array{item_id: int, name: string}>}>
+     */
+    public function getFeaturesWithValues(int $languageId, array $shopIds = []): array
+    {
+        $qb = $this->getFeaturesQueryBuilder()
+            ->select(
+                'DISTINCT f.id_feature AS feature_id',
+                'fl.name AS name',
+                'fvl.id_feature_value AS value_id',
+                'fvl.value AS value_name'
+            )
+            ->leftJoin('f', $this->dbPrefix . 'feature_lang', 'fl',
+                'f.id_feature = fl.id_feature AND fl.id_lang = :language_id'
+            )
+            ->leftJoin('f', $this->dbPrefix . 'feature_value', 'fv',
+                'f.id_feature = fv.id_feature'
+            )
+            ->leftJoin('fv', $this->dbPrefix . 'feature_value_lang', 'fvl',
+                'fvl.id_lang = :language_id AND fvl.id_feature_value = fv.id_feature_value'
+            )
+            ->where('fv.custom = 0')
+            ->orderBy('f.id_feature')
+            ->addOrderBy('fvl.id_feature_value')
+            ->setParameter('language_id', $languageId);
+
+        if (!empty($shopIds)) {
+            $qb
+                ->innerJoin('f', $this->dbPrefix . 'feature_shop', 'fs',
+                    'fs.id_feature = f.id_feature AND fs.id_shop IN (:shop_ids)'
+                )
+                ->setParameter('shop_ids', $shopIds, ArrayParameterType::INTEGER);
+        }
+
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        $features = [];
+        foreach ($rows as $row) {
+            $featureId = (int) $row['feature_id'];
+            if (!isset($features[$featureId])) {
+                $features[$featureId] = [
+                    'feature_id' => (int) $featureId,
+                    'name' => (string) $row['name'],
+                    'values' => [],
+                ];
+            }
+            $features[$featureId]['values'][] = [
+                'item_id' => (int) $row['value_id'],
+                'name' => (string) $row['value_name'],
+            ];
+        }
+
+        return array_values($features);
     }
 
     /**

--- a/src/Adapter/State/CommandHandler/EditStateHandler.php
+++ b/src/Adapter/State/CommandHandler/EditStateHandler.php
@@ -38,11 +38,11 @@ class EditStateHandler implements EditStateHandlerInterface
         $state = $this->getState($command->getStateId());
 
         try {
-            if (null !== $command->getZoneId()->getValue()) {
+            if (null !== $command->getZoneId()) {
                 $state->id_zone = $command->getZoneId()->getValue();
             }
 
-            if (null !== $command->getCountryId()->getValue()) {
+            if (null !== $command->getCountryId()) {
                 $state->id_country = $command->getCountryId()->getValue();
             }
 

--- a/src/Core/Domain/Address/QueryResult/EditableCustomerAddress.php
+++ b/src/Core/Domain/Address/QueryResult/EditableCustomerAddress.php
@@ -10,7 +10,6 @@ namespace PrestaShop\PrestaShop\Core\Domain\Address\QueryResult;
 use PrestaShop\PrestaShop\Core\Domain\Address\ValueObject\AddressId;
 use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
-use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\StateId;
 use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\StateIdInterface;
 
 /**
@@ -128,7 +127,7 @@ class EditableCustomerAddress
      * @param string $company
      * @param string $vatNumber
      * @param string $address2
-     * @param StateId $stateId
+     * @param StateIdInterface $stateId
      * @param string $homePhone
      * @param string $mobilePhone
      * @param string $other

--- a/src/Core/Domain/Customer/Command/EditCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/EditCustomerCommand.php
@@ -285,10 +285,14 @@ class EditCustomerCommand
 
     /**
      * @param bool $isNewsletterSubscribed
+     *
+     * @return self
      */
     public function setNewsletterSubscribed($isNewsletterSubscribed)
     {
         $this->isNewsletterSubscribed = $isNewsletterSubscribed;
+
+        return $this;
     }
 
     /**

--- a/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
@@ -27,6 +27,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceAttributeProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
@@ -54,12 +55,12 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
 
     /**
      * @param AttributeGroupRepository $attributeGroupRepository
-     * @param int $langId
+     * @param LanguageContext $languageContext
      * @param ShopContext $shopContext
      */
     public function __construct(
         private readonly AttributeGroupRepository $attributeGroupRepository,
-        private readonly int $langId,
+        private readonly LanguageContext $languageContext,
         private ShopContext $shopContext,
     ) {
     }
@@ -98,7 +99,7 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
         if (null === $this->attributeGroupsChoicesAttributes || null === $this->attributeGroupsChoices) {
             if (null === $this->attributeGroups) {
                 $this->attributeGroups = $this->attributeGroupRepository->findByLangForShops(
-                    $this->langId,
+                    $this->languageContext->getId(),
                     $this->shopContext->getAssociatedShopIds()
                 );
             }

--- a/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
@@ -97,14 +97,10 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
     {
         if (null === $this->attributeGroupsChoicesAttributes || null === $this->attributeGroupsChoices) {
             if (null === $this->attributeGroups) {
-                if ($this->shopContext->isSingleShopContext()) {
-                    $this->attributeGroups = $this->attributeGroupRepository->findByLangAndShop(
-                        $this->langId,
-                        $this->shopContext->getShopConstraint()->getShopId()->getValue()
-                    );
-                } else {
-                    $this->attributeGroups = $this->attributeGroupRepository->findByLangForAllShops($this->langId);
-                }
+                $this->attributeGroups = $this->attributeGroupRepository->findByLangForShops(
+                    $this->langId,
+                    $this->shopContext->getAssociatedShopIds()
+                );
             }
 
             $this->attributeGroupsChoices = [];

--- a/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/AttributeGroupChoiceProvider.php
@@ -27,6 +27,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceAttributeProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Entity\Repository\AttributeGroupRepository;
@@ -54,12 +55,12 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
     /**
      * @param AttributeGroupRepository $attributeGroupRepository
      * @param int $langId
-     * @param int $shopId
+     * @param ShopContext $shopContext
      */
     public function __construct(
         private readonly AttributeGroupRepository $attributeGroupRepository,
         private readonly int $langId,
-        private readonly int $shopId,
+        private ShopContext $shopContext,
     ) {
     }
 
@@ -96,7 +97,14 @@ final class AttributeGroupChoiceProvider implements FormChoiceProviderInterface,
     {
         if (null === $this->attributeGroupsChoicesAttributes || null === $this->attributeGroupsChoices) {
             if (null === $this->attributeGroups) {
-                $this->attributeGroups = $this->attributeGroupRepository->findByLangAndShop($this->langId, $this->shopId);
+                if ($this->shopContext->isSingleShopContext()) {
+                    $this->attributeGroups = $this->attributeGroupRepository->findByLangAndShop(
+                        $this->langId,
+                        $this->shopContext->getShopConstraint()->getShopId()->getValue()
+                    );
+                } else {
+                    $this->attributeGroups = $this->attributeGroupRepository->findByLangForAllShops($this->langId);
+                }
             }
 
             $this->attributeGroupsChoices = [];

--- a/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
@@ -162,6 +162,7 @@ final class CustomerFormDataHandler implements FormDataHandlerInterface
             ->setFirstName($data['first_name'])
             ->setLastName($data['last_name'])
             ->setIsEnabled($data['is_enabled'])
+            ->setNewsletterSubscribed($data['is_newsletter_subscribed'])
             ->setIsPartnerOffersSubscribed($data['is_partner_offers_subscribed'])
             ->setDefaultGroupId((int) $data['default_group_id'])
             ->setGroupIds($groupIds)

--- a/src/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProvider.php
@@ -71,6 +71,7 @@ final class CustomerFormDataProvider implements FormDataProviderInterface
             'email' => $editableCustomer->getEmail()->getValue(),
             'birthday' => $birthday->isEmpty() ? null : $birthday->getValue(),
             'is_enabled' => $editableCustomer->isEnabled(),
+            'is_newsletter_subscribed' => $editableCustomer->isNewsletterSubscribed(),
             'is_partner_offers_subscribed' => $editableCustomer->isPartnerOffersSubscribed(),
             'group_ids' => $editableCustomer->getGroupIds(),
             'default_group_id' => $editableCustomer->getDefaultGroupId(),

--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -147,7 +147,7 @@ class LogoUploader
                 }
             }
 
-            $idShop = $this->shop->id;
+            $idShop = null;
             $idShopGroup = null;
 
             // on updating PS_LOGO if the new file is an svg, copy old logo for mail and invoice
@@ -195,7 +195,7 @@ class LogoUploader
             $logoAll = Configuration::get($fieldName);
             Shop::setContext(Shop::CONTEXT_GROUP);
             $logoGroup = Configuration::get($fieldName);
-            Shop::setContext(Shop::CONTEXT_SHOP);
+            Shop::setContext(Shop::CONTEXT_SHOP, $idShop);
             $logoShop = Configuration::get($fieldName);
             if ($logoAll != $logoShop && $logoGroup != $logoShop && $logoShop != false) {
                 @unlink($this->imageDirection . Configuration::get($fieldName));

--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -173,7 +173,7 @@ class LogoUploader
             $idShopGroup = Shop::getContextShopGroupID();
             Shop::setContext(Shop::CONTEXT_ALL);
             $logoAll = Configuration::get($fieldName);
-            Shop::setContext(Shop::CONTEXT_GROUP);
+            Shop::setContext(Shop::CONTEXT_GROUP, $idShopGroup);
             $logoGroup = Configuration::get($fieldName);
             Shop::setContext(Shop::CONTEXT_SHOP, $idShop);
             $logoShop = Configuration::get($fieldName);
@@ -184,7 +184,7 @@ class LogoUploader
             $idShopGroup = Shop::getContextShopGroupID();
             Shop::setContext(Shop::CONTEXT_ALL);
             $logoAll = Configuration::get($fieldName);
-            Shop::setContext(Shop::CONTEXT_GROUP);
+            Shop::setContext(Shop::CONTEXT_GROUP, $idShopGroup);
             if ($logoAll != Configuration::get($fieldName)) {
                 @unlink($this->imageDirection . Configuration::get($fieldName));
             }

--- a/src/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizer.php
+++ b/src/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizer.php
@@ -65,6 +65,15 @@ class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterfac
      */
     protected array $constructorParameter = [];
 
+    /**
+     * The key is the initial class of the NoValueObject (example NoStateId)
+     * The value is the deduced short name of the associated ValueObject with the No part removed (example StateId)
+     * If the array doesn't contain the VO class it means it's not a NoValueObject
+     *
+     * @var array<string, string>
+     */
+    protected array $noValueClasses = [];
+
     public function __construct(
         protected readonly ClassMetadataFactoryInterface $classMetadataFactory
     ) {
@@ -137,9 +146,15 @@ class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterfac
         }
 
         $metadata = $this->classMetadataFactory->getMetadataFor($object);
+        $className = $metadata->getReflectionClass()->getName();
+        if ($this->isNoValueClass($object) && !empty($this->noValueClasses[$className])) {
+            $valueId = lcfirst($this->noValueClasses[$className]);
+        } else {
+            $valueId = lcfirst($metadata->getReflectionClass()->getShortName());
+        }
 
         return [
-            lcfirst($metadata->getReflectionClass()->getShortName()) => $object->getValue(),
+            $valueId => $object->getValue(),
         ];
     }
 
@@ -162,7 +177,10 @@ class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterfac
             && method_exists($data, 'getValue')
             // Check that ValueObject is part of the namespace
             && str_contains(get_class($data), 'ValueObject')
-            && $this->getConstructorParameter($data);
+            && (
+                $this->getConstructorParameter($data)
+                || $this->isNoValueClass($data)
+            );
     }
 
     protected function isValueObjectType(string $type): bool
@@ -171,7 +189,10 @@ class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterfac
             && method_exists($type, 'getValue')
             // Check that ValueObject is part of the namespace
             && str_contains($type, 'ValueObject')
-            && $this->getConstructorParameter($type);
+            && (
+                $this->getConstructorParameter($type)
+                || $this->isNoValueClass($type)
+            );
     }
 
     protected function matchesConstructorParameter(mixed $value, string $type): bool
@@ -238,5 +259,28 @@ class ValueObjectNormalizer implements NormalizerInterface, DenormalizerInterfac
         }
 
         return $this->constructorParameter[$objectType] ?? null;
+    }
+
+    /**
+     * Is the class used for "no values" like NoStateId, NoCombination that always carry the
+     * 0 value.
+     */
+    protected function isNoValueClass(object|string $type): bool
+    {
+        $objectType = is_object($type) ? get_class($type) : $type;
+        if (!array_key_exists($objectType, $this->noValueClasses)) {
+            $metadata = $this->classMetadataFactory->getMetadataFor($objectType);
+            $shortName = $metadata->getReflectionClass()->getShortName();
+            $matches = [];
+            // Check that the class name starts with No, the following part should be the expected ShortName
+            // when value is set
+            if (!preg_match('/No(.+)/', $shortName, $matches)) {
+                $this->noValueClasses[$objectType] = null;
+            } else {
+                $this->noValueClasses[$objectType] = $matches[1];
+            }
+        }
+
+        return !empty($this->noValueClasses[$objectType]);
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
@@ -10,6 +10,7 @@ namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 
 use Exception;
 use PrestaShop\PrestaShop\Adapter\Feature\FeatureFeature;
+use PrestaShop\PrestaShop\Adapter\Feature\Repository\FeatureRepository;
 use PrestaShop\PrestaShop\Core\Domain\Feature\Command\BulkDeleteFeatureCommand;
 use PrestaShop\PrestaShop\Core\Domain\Feature\Command\DeleteFeatureCommand;
 use PrestaShop\PrestaShop\Core\Domain\Feature\Exception\BulkFeatureException;
@@ -26,7 +27,6 @@ use PrestaShop\PrestaShop\Core\Search\Filters\FeatureFilters;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
 use PrestaShopBundle\Controller\BulkActionsTrait;
-use PrestaShopBundle\Entity\Repository\FeatureAttributeRepository;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -41,8 +41,7 @@ class FeatureController extends PrestaShopAdminController
     use BulkActionsTrait;
 
     public function __construct(
-        private readonly FeatureFeature $featureFeature,
-        private readonly FeatureAttributeRepository $featureAttributeRepository
+        private readonly FeatureFeature $featureFeature
     ) {
     }
 
@@ -275,9 +274,9 @@ class FeatureController extends PrestaShopAdminController
     }
 
     #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))")]
-    public function getAllFeatureGroupsAction(?int $shopId): JsonResponse
+    public function getAllFeatureGroupsAction(FeatureRepository $featureRepository): JsonResponse
     {
-        $features = $this->featureAttributeRepository->getFeatures();
+        $features = $featureRepository->getFeaturesWithValues($this->getLanguageContext()->getId(), $this->getShopContext()->getAssociatedShopIds());
 
         return $this->json($this->formatFeatureGroupsForPresentation($features));
     }

--- a/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
@@ -59,22 +59,25 @@ class AttributeGroupRepository extends \Doctrine\ORM\EntityRepository
     }
 
     /**
-     * Finds attribute groups by language and shop.
+     * Finds attribute groups by language and shops.
      *
      * @param int $idLang Language ID
+     * @param int[] $idShops Shop IDs
      *
      * @return \PrestaShopBundle\Entity\AttributeGroup[]
      */
-    public function findByLangForAllShops(int $idLang): array
+    public function findByLangForShops(int $idLang, array $idShops): array
     {
         return $this->createQueryBuilder('ag')
             ->addSelect('agl')
             ->join('ag.shops', 'ags')
             ->join('ag.attributeGroupLangs', 'agl')
             ->andWhere('agl.lang = :idLang')
+            ->andWhere('ags.id IN (:idShops)')
             ->orderBy('ag.position', 'ASC')
             ->setParameters([
                 'idLang' => $idLang,
+                'idShops' => $idShops,
             ])->getQuery()->getResult();
     }
 }

--- a/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AttributeGroupRepository.php
@@ -57,4 +57,24 @@ class AttributeGroupRepository extends \Doctrine\ORM\EntityRepository
                 'idLang' => $idLang,
             ])->getQuery()->getResult();
     }
+
+    /**
+     * Finds attribute groups by language and shop.
+     *
+     * @param int $idLang Language ID
+     *
+     * @return \PrestaShopBundle\Entity\AttributeGroup[]
+     */
+    public function findByLangForAllShops(int $idLang): array
+    {
+        return $this->createQueryBuilder('ag')
+            ->addSelect('agl')
+            ->join('ag.shops', 'ags')
+            ->join('ag.attributeGroupLangs', 'agl')
+            ->andWhere('agl.lang = :idLang')
+            ->orderBy('ag.position', 'ASC')
+            ->setParameters([
+                'idLang' => $idLang,
+            ])->getQuery()->getResult();
+    }
 }

--- a/src/PrestaShopBundle/Entity/Repository/FeatureAttributeRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/FeatureAttributeRepository.php
@@ -6,73 +6,29 @@
 
 namespace PrestaShopBundle\Entity\Repository;
 
-use Doctrine\DBAL\Connection;
-use Employee;
-use PrestaShop\PrestaShop\Adapter\LegacyContext as ContextAdapter;
-use PrestaShopBundle\Exception\NotImplementedException;
-use RuntimeException;
-use Shop;
+use PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository;
+use PrestaShop\PrestaShop\Adapter\Feature\Repository\FeatureRepository;
+use PrestaShop\PrestaShop\Core\Context\LanguageContext;
+use PrestaShop\PrestaShop\Core\Context\ShopContext;
 
+/**
+ * FeatureAttributeRepository
+ *
+ * @deprecated since 9.1 and will be removed in 10.0, this repository don't have to be used anymore. Use instead FeaturesRepository or AttributesRepository directly.
+ */
 class FeatureAttributeRepository
 {
     use NormalizeFieldTrait;
 
     /**
-     * @var Connection
-     */
-    private $connection;
-
-    /**
-     * @var string
-     */
-    private $tablePrefix;
-
-    /**
-     * @var int
-     */
-    private $languageId;
-
-    /**
-     * @var int
-     */
-    private $shopId;
-
-    /**
      * FeatureAttributeRepository constructor.
-     *
-     * @param Connection $connection
-     * @param ContextAdapter $contextAdapter
-     * @param string $tablePrefix
-     *
-     * @throws NotImplementedException
      */
     public function __construct(
-        Connection $connection,
-        ContextAdapter $contextAdapter,
-        $tablePrefix
+        private readonly ShopContext $shopContext,
+        private readonly LanguageContext $languageContext,
+        private readonly FeatureRepository $featureRepository,
+        private readonly AttributeRepository $attributeRepository
     ) {
-        $this->connection = $connection;
-        $this->tablePrefix = $tablePrefix;
-
-        $context = $contextAdapter->getContext();
-
-        if (!$context->employee instanceof Employee) {
-            throw new RuntimeException('Determining the active language requires a contextual employee instance.');
-        }
-
-        $languageId = $context->employee->id_lang;
-        $this->languageId = (int) $languageId;
-
-        if (!$context->shop instanceof Shop) {
-            throw new RuntimeException('Determining the active shop requires a contextual shop instance.');
-        }
-
-        $shop = $context->shop;
-        if ($shop->getContextType() !== $shop::CONTEXT_SHOP) {
-            throw new NotImplementedException('Shop context types other than "single shop" are not supported');
-        }
-
-        $this->shopId = $shop->getContextualShopId();
     }
 
     /**
@@ -80,53 +36,7 @@ class FeatureAttributeRepository
      */
     public function getAttributes()
     {
-        $query = str_replace(
-            '{table_prefix}',
-            $this->tablePrefix,
-            'SELECT
-            a.id_attribute_group AS attribute_group_id,
-            agl.name AS name,
-            GROUP_CONCAT(
-              CONCAT(al.id_attribute, ":", al.name)
-              ORDER BY al.id_attribute
-            ) AS "values"
-            FROM {table_prefix}attribute a
-            LEFT JOIN {table_prefix}attribute_shop ats ON (
-                ats.id_attribute = a.id_attribute AND
-                ats.id_shop = :shop_id
-            )
-            LEFT JOIN {table_prefix}attribute_lang al ON (
-                a.id_attribute = al.id_attribute
-                AND al.id_lang = :language_id
-                AND LENGTH(TRIM(al.name)) > 0
-            )
-            LEFT JOIN {table_prefix}attribute_group ag ON (
-                ag.id_attribute_group = a.id_attribute_group
-            )
-            LEFT JOIN {table_prefix}attribute_group_shop ags ON (
-                ags.id_attribute_group = a.id_attribute_group AND
-                ags.id_shop = :shop_id
-            )
-            LEFT JOIN {table_prefix}attribute_group_lang agl ON (
-                ag.id_attribute_group = agl.id_attribute_group
-                AND agl.id_lang = :language_id
-                AND LENGTH(TRIM(agl.name)) > 0
-            )
-            GROUP BY ag.id_attribute_group
-        '
-        );
-
-        $statement = $this->connection->prepare($query);
-
-        $statement->bindValue('language_id', $this->languageId);
-        $statement->bindValue('shop_id', $this->shopId);
-
-        $result = $statement->executeQuery();
-
-        $rows = $result->fetchAllAssociative();
-        $rows = $this->explodeCollections($rows);
-
-        return $this->castNumericToInt($rows);
+        return $this->attributeRepository->getAttributesWithValues($this->languageContext->getId(), $this->shopContext->getAssociatedShopIds());
     }
 
     /**
@@ -134,77 +44,6 @@ class FeatureAttributeRepository
      */
     public function getFeatures()
     {
-        $query = str_replace(
-            '{table_prefix}',
-            $this->tablePrefix,
-            'SELECT
-            f.id_feature AS feature_id,
-            fl.name AS name,
-            GROUP_CONCAT(
-              CONCAT(fvl.id_feature_value, ":", fvl.value)
-              ORDER BY fvl.id_feature_value
-            ) AS "values"
-            FROM {table_prefix}feature f
-            LEFT JOIN {table_prefix}feature_lang fl ON (
-                f.id_feature = fl.id_feature AND
-                fl.id_lang = :language_id
-            )
-            LEFT JOIN {table_prefix}feature_shop fs ON (
-                fs.id_shop = :shop_id AND
-                fs.id_feature = f.id_feature
-            )
-            LEFT JOIN {table_prefix}feature_value fv ON (
-                f.id_feature = fv.id_feature
-            )
-            LEFT JOIN {table_prefix}feature_value_lang fvl ON (
-                fvl.id_lang = :language_id AND
-                fvl.id_feature_value = fv.id_feature_value
-            )
-            WHERE fv.custom = 0
-            GROUP BY fv.id_feature
-            ORDER BY f.id_feature
-        '
-        );
-
-        $statement = $this->connection->prepare($query);
-
-        $statement->bindValue('language_id', $this->languageId);
-        $statement->bindValue('shop_id', $this->shopId);
-
-        $result = $statement->executeQuery();
-
-        $rows = $result->fetchAllAssociative();
-        $rows = $this->explodeCollections($rows);
-
-        return $this->castNumericToInt($rows);
-    }
-
-    /**
-     * @param array $rows
-     *
-     * @return array
-     */
-    private function explodeCollections($rows)
-    {
-        return array_map(function ($row) {
-            $row['values'] = explode(',', $row['values']);
-
-            $row['values'] = array_map(function ($value) {
-                if (!str_contains($value, ':')) {
-                    return $value;
-                }
-
-                $parts = explode(':', $value);
-
-                return [
-                    'item_id' => $parts[0],
-                    'name' => $parts[1],
-                ];
-            }, $row['values']);
-
-            $row['values'] = $this->castNumericToInt($row['values']);
-
-            return $row;
-        }, $rows);
+        return $this->featureRepository->getFeaturesWithValues($this->languageContext->getId(), $this->shopContext->getAssociatedShopIds());
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -260,6 +260,11 @@ class CustomerType extends TranslatorAwareType
                 ),
                 'required' => false,
             ])
+            ->add('is_newsletter_subscribed', SwitchType::class, [
+                'label' => $this->trans('Newsletter', 'Admin.Orderscustomers.Feature'),
+                'help' => '',
+                'required' => false,
+            ])
             ->add('is_partner_offers_subscribed', SwitchType::class, [
                 'label' => $this->trans('Partner offers', 'Admin.Orderscustomers.Feature'),
                 'help' => $this->trans(

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/features.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/features.yml
@@ -179,7 +179,7 @@ admin_feature_get_feature_values:
     expose: true
 
 admin_all_feature_groups:
-  path: /all-feature-groups/{shopId}
+  path: /all-feature-groups
   methods: [ GET ]
   options:
     expose: true
@@ -188,5 +188,3 @@ admin_all_feature_groups:
     _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\FeatureController::getAllFeatureGroupsAction
     _legacy_controller: AdminFeatures
     _legacy_link: AdminFeatures:getAllFeatureGroups
-  requirements:
-    shopId: \d+

--- a/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
@@ -104,7 +104,6 @@ services:
   PrestaShopBundle\Controller\Admin\Sell\Catalog\FeatureController:
     arguments:
       $featureFeature: "@prestashop.adapter.feature.feature"
-      $featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
     public: false
     autowire: true
     autoconfigure: true

--- a/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
@@ -97,10 +97,10 @@ services:
 
   prestashop.core.api.feature_attribute.repository:
     class: PrestaShopBundle\Entity\Repository\FeatureAttributeRepository
-    arguments:
-      - "@doctrine.dbal.default_connection"
-      - "@prestashop.adapter.legacy.context"
-      - "%database_prefix%"
+    deprecated:
+      package: PrestaShop\PrestaShop
+      version: 9.1
+    autowire: true
 
   prestashop.core.admin.timezone.repository:
     class: PrestaShopBundle\Entity\Repository\TimezoneRepository

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -141,5 +141,3 @@ services:
 
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\AttributeGroupChoiceProvider:
     autowire: true
-    arguments:
-      $shopId: '@=service("prestashop.adapter.shop.context").getContextShopID()'

--- a/tests/Integration/ApiPlatform/Serializer/CQRSApiSerializerTest.php
+++ b/tests/Integration/ApiPlatform/Serializer/CQRSApiSerializerTest.php
@@ -17,12 +17,16 @@ use PrestaShop\Module\APIResources\ApiPlatform\Resources\Product\Product;
 use PrestaShop\PrestaShop\Core\Context\CurrencyContextBuilder;
 use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
 use PrestaShop\PrestaShop\Core\Context\ShopContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Address\QueryResult\EditableCustomerAddress;
+use PrestaShop\PrestaShop\Core\Domain\Address\ValueObject\AddressId;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\ValueObject\CreatedApiClient;
+use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Command\AddCustomerGroupCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Command\EditCustomerGroupCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Query\GetCustomerGroupForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\QueryResult\EditableCustomerGroup;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\ValueObject\GroupId;
+use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\AddDiscountCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\Command\UpdateDiscountCommand;
 use PrestaShop\PrestaShop\Core\Domain\Discount\ProductRule;
@@ -40,6 +44,8 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\QueryResult\VirtualProductFileForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopCollection;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\NoStateId;
+use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\StateId;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 use PrestaShopBundle\ApiPlatform\NormalizationMapper;
@@ -688,6 +694,96 @@ class CQRSApiSerializerTest extends KernelTestCase
             $productId,
             [
                 'productId' => 42,
+            ],
+        ];
+
+        yield 'normalize EditableCustomerAddress with no state ID' => [
+            new EditableCustomerAddress(
+                new AddressId(1),
+                new CustomerId(42),
+                'pub@prestashop.com',
+                'Order Test Address',
+                'John',
+                'Doe',
+                '1 street Example',
+                'Orleans',
+                new CountryId(8),
+                '45000',
+                'dni',
+                'company',
+                'vatNumber',
+                'address2',
+                new NoStateId(),
+                '',
+                '',
+                '',
+                []
+            ),
+            [
+                'addressId' => 1,
+                'customerId' => 42,
+                'customerEmail' => 'pub@prestashop.com',
+                'addressAlias' => 'Order Test Address',
+                'firstName' => 'John',
+                'lastName' => 'Doe',
+                'address' => '1 street Example',
+                'city' => 'Orleans',
+                'countryId' => 8,
+                'postCode' => '45000',
+                'dni' => 'dni',
+                'company' => 'company',
+                'vatNumber' => 'vatNumber',
+                'address2' => 'address2',
+                'stateId' => 0,
+                'homePhone' => '',
+                'mobilePhone' => '',
+                'other' => '',
+                'requiredFields' => [],
+            ],
+        ];
+
+        yield 'normalize EditableCustomerAddress with StateID' => [
+            new EditableCustomerAddress(
+                new AddressId(1),
+                new CustomerId(42),
+                'pub@prestashop.com',
+                'Order Test Address',
+                'John',
+                'Doe',
+                '1 street Example',
+                'Orleans',
+                new CountryId(8),
+                '45000',
+                'dni',
+                'company',
+                'vatNumber',
+                'address2',
+                new StateId(4),
+                '',
+                '',
+                '',
+                []
+            ),
+            [
+                'addressId' => 1,
+                'customerId' => 42,
+                'customerEmail' => 'pub@prestashop.com',
+                'addressAlias' => 'Order Test Address',
+                'firstName' => 'John',
+                'lastName' => 'Doe',
+                'address' => '1 street Example',
+                'city' => 'Orleans',
+                'countryId' => 8,
+                'postCode' => '45000',
+                'dni' => 'dni',
+                'company' => 'company',
+                'vatNumber' => 'vatNumber',
+                'address2' => 'address2',
+                'stateId' => 4,
+                'homePhone' => '',
+                'mobilePhone' => '',
+                'other' => '',
+                'requiredFields' => [],
             ],
         ];
 

--- a/tests/Integration/Behaviour/Features/Scenario/State/state_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/State/state_management.feature
@@ -17,23 +17,53 @@ Feature: Zones management
     Then state "StateNormandy" zone should be "Europe"
     And state "StateNormandy" should be enabled
 
-  Scenario: Editing state
+  Scenario: Partial Editing state
+    ## Name
     When I edit state "StateNormandy" with following properties:
       | name    | Britain       |
-      | enabled | false         |
-      | country | Italy         |
-      | zone    | South America |
+    Then state "StateNormandy" name should be "Britain"
+    Then state "StateNormandy" country should be "United States"
+    Then state "StateNormandy" zone should be "Europe"
+    And state "StateNormandy" should be enabled
+    ## Enabled
+    When I edit state "StateNormandy" with following properties:
+      | enabled | false          |
+    Then state "StateNormandy" name should be "Britain"
+    Then state "StateNormandy" country should be "United States"
+    Then state "StateNormandy" zone should be "Europe"
+    And state "StateNormandy" should be disabled
+    ## Country
+    When I edit state "StateNormandy" with following properties:
+      | country | Italy          |
+    Then state "StateNormandy" name should be "Britain"
+    Then state "StateNormandy" country should be "Italy"
+    Then state "StateNormandy" zone should be "Europe"
+    And state "StateNormandy" should be disabled
+    ## Zone
+    When I edit state "StateNormandy" with following properties:
+      | zone | South America  |
     Then state "StateNormandy" name should be "Britain"
     Then state "StateNormandy" country should be "Italy"
     Then state "StateNormandy" zone should be "South America"
     And state "StateNormandy" should be disabled
 
+  Scenario: Editing state
+    When I edit state "StateNormandy" with following properties:
+      | name    | Tasmania      |
+      | enabled | true          |
+      | country | Australia     |
+      | zone    | Oceania       |
+    Then state "StateNormandy" name should be "Tasmania"
+    Then state "StateNormandy" country should be "Australia"
+    Then state "StateNormandy" zone should be "Oceania"
+    And state "StateNormandy" should be enabled
+
   Scenario: Enable and disable state status
-    Given state "StateNormandy" is disabled
-    When I toggle status of state "StateNormandy"
-    Then state "StateNormandy" should be enabled
+    Given state "StateNormandy" is enabled
     When I toggle status of state "StateNormandy"
     Then state "StateNormandy" should be disabled
+    When I toggle status of state "StateNormandy"
+    Then state "StateNormandy" should be enabled
 
   Scenario: Enabling and disabling multiple states in bulk action
     When I add new state "StateBrittany" with following properties:

--- a/tests/UI/campaigns/audit/BO/14_wallOfFame.ts
+++ b/tests/UI/campaigns/audit/BO/14_wallOfFame.ts
@@ -1,0 +1,63 @@
+import {expect} from 'chai';
+import testContext from '@utils/testContext';
+
+import {
+  boDashboardPage,
+  boLoginPage,
+  boWallOfFamePage,
+  type BrowserContext,
+  type Page,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'audit_BO_wallOfFame';
+
+describe('BO - Wall of Fame', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+
+  before(async function () {
+    utilsPlaywright.setErrorsCaptured(true);
+
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+  });
+
+  beforeEach(async () => {
+    utilsPlaywright.resetJsErrors();
+  });
+
+  it('should login in BO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+    await boLoginPage.goTo(page, global.BO.URL);
+    await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+    const pageTitle = await boDashboardPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+
+    const jsErrors = utilsPlaywright.getJsErrors();
+    expect(jsErrors.length).to.equals(0);
+  });
+
+  it('should go to \'Wall of Fame\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToWallOfFamePage', baseContext);
+
+    await boDashboardPage.goToSubMenu(
+      page,
+      '',
+      boDashboardPage.wallOfFameLink,
+    );
+    await boWallOfFamePage.closeSfToolBar(page);
+
+    const pageTitle = await boWallOfFamePage.getPageTitle(page);
+    expect(pageTitle).to.contains(boWallOfFamePage.pageTitle);
+
+    const jsErrors = utilsPlaywright.getJsErrors();
+    expect(jsErrors.length).to.equals(0);
+  });
+});

--- a/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/03_statusTab.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/03_statusTab.ts
@@ -109,7 +109,6 @@ describe('BO - Orders - View and edit order : Check order status tab', async () 
   // Pre-condition: Create order by default customer
   createOrderByCustomerTest(orderByCustomerData, `${baseContext}_preTest_4`);
 
-  // before and after functions
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
     page = await utilsPlaywright.newTab(browserContext);

--- a/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/04_documentsTab.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/04_documentsTab.ts
@@ -355,7 +355,7 @@ describe('BO - Orders - View and edit order : Check order documents tab', async 
     it('should check if \'Delivery slip\' document is created', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkDeliverySlipDocument', baseContext);
 
-      const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 3);
+      const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 2);
       expect(documentType).to.be.equal('Delivery slip');
     });
 
@@ -382,7 +382,7 @@ describe('BO - Orders - View and edit order : Check order documents tab', async 
       await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocument', baseContext);
 
       // Get document name
-      const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 4);
+      const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 3);
       expect(documentType).to.be.equal('Credit slip');
     });
 

--- a/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/12_checkMultiInvoice.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/12_checkMultiInvoice.ts
@@ -232,7 +232,7 @@ describe('BO - Orders - View and edit order: Check multi invoice', async () => {
     it('should get the second invoice file name', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'getSecondInvoiceNumber', baseContext);
 
-      secondFileName = await boOrdersViewBlockTabListPage.getFileName(page, 3);
+      secondFileName = await boOrdersViewBlockTabListPage.getFileName(page, 2);
       expect(filePath).is.not.equal('');
     });
   });

--- a/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/01_createFilterCreditSlips.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/01_createFilterCreditSlips.ts
@@ -137,12 +137,10 @@ describe('BO - Orders - Credit slips : Create, filter and check credit slips fil
         .and.to.contain('Delivery slip');
     });
 
-    const tests = [
-      {args: {productID: 1, quantity: 1, documentRow: 4}},
-      {args: {productID: 1, quantity: 2, documentRow: 5}},
-    ];
-
-    tests.forEach((test, index: number) => {
+    [
+      {productID: 1, quantity: 1, documentRow: 4},
+      {productID: 1, quantity: 2, documentRow: 5},
+    ].forEach((arg, index: number) => {
       it(`should create the partial refund n°${index + 1}`, async function () {
         await testContext.addContextItem(this, 'testIdentifier', `addPartialRefund${index + 1}`, baseContext);
 
@@ -150,8 +148,8 @@ describe('BO - Orders - Credit slips : Create, filter and check credit slips fil
 
         const textMessage = await boOrdersViewBlockProductsPage.addPartialRefundProduct(
           page,
-          test.args.productID,
-          test.args.quantity,
+          arg.productID,
+          arg.quantity,
         );
         expect(textMessage).to.contains(boOrdersViewBlockProductsPage.partialRefundValidationMessage);
       });
@@ -205,35 +203,27 @@ describe('BO - Orders - Credit slips : Create, filter and check credit slips fil
       expect(numberOfCreditSlips).to.be.above(0);
     });
 
-    const tests = [
+    [
       {
-        args:
-          {
-            testIdentifier: 'filterIdCreditSlip',
-            filterBy: 'id_credit_slip',
-            filterValue: '1',
-            columnName: 'id_order_slip',
-          },
+        testIdentifier: 'filterIdCreditSlip',
+        filterBy: 'id_credit_slip',
+        filterValue: '1',
+        columnName: 'id_order_slip',
       },
       {
-        args:
-          {
-            testIdentifier: 'filterIdOrder',
-            filterBy: 'id_order',
-            filterValue: '4',
-            columnName: 'id_order',
-          },
+        testIdentifier: 'filterIdOrder',
+        filterBy: 'id_order',
+        filterValue: '4',
+        columnName: 'id_order',
       },
-    ];
-
-    tests.forEach((test) => {
-      it(`should filter by ${test.args.filterBy} '${test.args.filterValue}'`, async function () {
-        await testContext.addContextItem(this, 'testIdentifier', test.args.testIdentifier, baseContext);
+    ].forEach((arg) => {
+      it(`should filter by ${arg.filterBy} '${arg.filterValue}'`, async function () {
+        await testContext.addContextItem(this, 'testIdentifier', arg.testIdentifier, baseContext);
 
         await boCreditSlipsPage.filterCreditSlips(
           page,
-          test.args.filterBy,
-          test.args.filterValue,
+          arg.filterBy,
+          arg.filterValue,
         );
 
         // Get number of credit slips
@@ -244,14 +234,14 @@ describe('BO - Orders - Credit slips : Create, filter and check credit slips fil
           const textColumn = await boCreditSlipsPage.getTextColumnFromTableCreditSlips(
             page,
             i,
-            test.args.columnName,
+            arg.columnName,
           );
-          expect(textColumn).to.contains(test.args.filterValue);
+          expect(textColumn).to.contains(arg.filterValue);
         }
       });
 
       it('should reset all filters', async function () {
-        await testContext.addContextItem(this, 'testIdentifier', `${test.args.testIdentifier}Reset`, baseContext);
+        await testContext.addContextItem(this, 'testIdentifier', `${arg.testIdentifier}Reset`, baseContext);
 
         const numberOfCreditSlipsAfterReset = await boCreditSlipsPage.resetAndGetNumberOfLines(page);
         expect(numberOfCreditSlipsAfterReset).to.be.equal(numberOfCreditSlips);

--- a/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/02_sortAndPaginationCreditSlips.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/02_sortAndPaginationCreditSlips.ts
@@ -146,7 +146,7 @@ describe('BO - Orders - Credit slips : Sort (by ID, Date and OrderID) and Pagina
           `${baseContext}_preTest_${i}`,
         );
 
-        const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 4);
+        const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 3);
         expect(documentType).to.be.equal(creditSlipDocumentName);
       });
     });

--- a/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/03_generateCreditSlipsByDate.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/03_generateCreditSlipsByDate.ts
@@ -39,7 +39,6 @@ describe('BO - Orders - Credit slips : Generate Credit slip file by date', async
   let page: Page;
 
   const futureDate: string = utilsDate.getDateFormat('yyyy-mm-dd', 'future');
-  const creditSlipDocumentName: string = 'Credit slip';
   const orderByCustomerData: FakerOrder = new FakerOrder({
     customer: dataCustomers.johnDoe,
     products: [
@@ -54,7 +53,6 @@ describe('BO - Orders - Credit slips : Generate Credit slip file by date', async
   // Pre-condition: Create order in FO
   createOrderByCustomerTest(orderByCustomerData, baseContext);
 
-  // before and after functions
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
     page = await utilsPlaywright.newTab(browserContext);
@@ -97,6 +95,20 @@ describe('BO - Orders - Credit slips : Generate Credit slip file by date', async
       expect(pageTitle).to.contains(boOrdersViewBlockTabListPage.pageTitle);
     });
 
+    it('should check documents', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocumentNameBefore', baseContext);
+
+      const numDocuments = await boOrdersViewBlockTabListPage.getNumberOfDocuments(page);
+      expect(numDocuments).to.be.equals(0);
+
+      const countDocuments = await boOrdersViewBlockTabListPage.countDocumentsType(page);
+      expect(countDocuments).to.be.deep.equal({
+        creditSlips: 0,
+        deliverySlips: 0,
+        invoices: 0,
+      });
+    });
+
     it(`should change the order status to '${dataOrderStatuses.shipped.name}' and check it`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'updateCreatedOrderStatus', baseContext);
 
@@ -114,10 +126,17 @@ describe('BO - Orders - Credit slips : Generate Credit slip file by date', async
     });
 
     it('should check the existence of the Credit slip document', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocumentName', baseContext);
+      await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocumentNameAfter', baseContext);
 
-      const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 4);
-      expect(documentType).to.be.equal(creditSlipDocumentName);
+      const numDocuments = await boOrdersViewBlockTabListPage.getNumberOfDocuments(page);
+      expect(numDocuments).to.be.equals(3);
+
+      const countDocuments = await boOrdersViewBlockTabListPage.countDocumentsType(page);
+      expect(countDocuments).to.be.deep.equal({
+        creditSlips: 1,
+        deliverySlips: 1,
+        invoices: 1,
+      });
     });
   });
 

--- a/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/04_creditSlipOptions.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/04_creditSlipOptions.ts
@@ -185,9 +185,9 @@ describe('BO - Orders - Credit slips: Credit slip options', async () => {
     it(`should check that the credit slip file name contain the prefix '${prefixToEdit}'`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkUpdatedPrefixOnFileName', baseContext);
 
-      // Get file name
-      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 3);
-      expect(fileName).to.contains(prefixToEdit);
+      const document = await boOrdersViewBlockTabListPage.getDocument(page, 1, 'Credit slip');
+      expect(document.type).to.equals('Credit slip')
+      expect(document.number).to.contains(prefixToEdit);
     });
   });
 

--- a/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/04_creditSlipOptions.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/04_creditSlipOptions.ts
@@ -186,7 +186,7 @@ describe('BO - Orders - Credit slips: Credit slip options', async () => {
       await testContext.addContextItem(this, 'testIdentifier', 'checkUpdatedPrefixOnFileName', baseContext);
 
       const document = await boOrdersViewBlockTabListPage.getDocument(page, 1, 'Credit slip');
-      expect(document.type).to.equals('Credit slip')
+      expect(document.type).to.equals('Credit slip');
       expect(document.number).to.contains(prefixToEdit);
     });
   });

--- a/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/04_creditSlipOptions.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/03_creditSlips/04_creditSlipOptions.ts
@@ -138,6 +138,20 @@ describe('BO - Orders - Credit slips: Credit slip options', async () => {
       expect(pageTitle).to.contains(boOrdersViewBlockTabListPage.pageTitle);
     });
 
+    it('should check documents', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocumentNameBefore', baseContext);
+
+      const numDocuments = await boOrdersViewBlockTabListPage.getNumberOfDocuments(page);
+      expect(numDocuments).to.be.equals(0);
+
+      const countDocuments = await boOrdersViewBlockTabListPage.countDocumentsType(page);
+      expect(countDocuments).to.be.deep.equal({
+        creditSlips: 0,
+        deliverySlips: 0,
+        invoices: 0,
+      });
+    });
+
     it(`should change the order status to '${dataOrderStatuses.shipped.name}' and check it`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'updateOrderStatus', baseContext);
 
@@ -155,18 +169,24 @@ describe('BO - Orders - Credit slips: Credit slip options', async () => {
     });
 
     it('should check the existence of the Credit slip document', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocument', baseContext);
+      await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocumentNameAfter', baseContext);
 
-      // Get document name
-      const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 4);
-      expect(documentType).to.be.equal('Credit slip');
+      const numDocuments = await boOrdersViewBlockTabListPage.getNumberOfDocuments(page);
+      expect(numDocuments).to.be.equals(3);
+
+      const countDocuments = await boOrdersViewBlockTabListPage.countDocumentsType(page);
+      expect(countDocuments).to.be.deep.equal({
+        creditSlips: 1,
+        deliverySlips: 1,
+        invoices: 1,
+      });
     });
 
     it(`should check that the credit slip file name contain the prefix '${prefixToEdit}'`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkUpdatedPrefixOnFileName', baseContext);
 
       // Get file name
-      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 4);
+      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 3);
       expect(fileName).to.contains(prefixToEdit);
     });
   });
@@ -221,7 +241,7 @@ describe('BO - Orders - Credit slips: Credit slip options', async () => {
     it('should check the credit slip file name', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkDeletedPrefix', baseContext);
 
-      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 4);
+      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 3);
       expect(fileName, 'Credit slip file name is not changed to default!').to.not.contains(prefixToEdit);
     });
   });

--- a/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/01_generateDeliverySlipByDate.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/01_generateDeliverySlipByDate.ts
@@ -28,7 +28,6 @@ describe('BO - Orders - Delivery slips : Generate Delivery slip file by date', a
 
   const futureDate: string = utilsDate.getDateFormat('yyyy-mm-dd', 'future');
 
-  // before and after functions
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
     page = await utilsPlaywright.newTab(browserContext);
@@ -72,6 +71,20 @@ describe('BO - Orders - Delivery slips : Generate Delivery slip file by date', a
       expect(pageTitle).to.contains(boOrdersViewBlockTabListPage.pageTitle);
     });
 
+    it('should check documents', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkDocumentsBefore', baseContext);
+
+      const numDocuments = await boOrdersViewBlockTabListPage.getNumberOfDocuments(page);
+      expect(numDocuments).to.be.equals(3);
+
+      const countDocuments = await boOrdersViewBlockTabListPage.countDocumentsType(page);
+      expect(countDocuments).to.be.deep.equal({
+        creditSlips: 1,
+        deliverySlips: 1,
+        invoices: 1,
+      });
+    });
+
     it(`should change the order status to '${dataOrderStatuses.shipped.name}' and check it`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'updateOrderStatus', baseContext);
 
@@ -80,10 +93,17 @@ describe('BO - Orders - Delivery slips : Generate Delivery slip file by date', a
     });
 
     it('should check the delivery slip document name', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkDocumentName', baseContext);
+      await testContext.addContextItem(this, 'testIdentifier', 'checkDocumentsAfter', baseContext);
 
-      const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 3);
-      expect(documentType).to.be.equal('Delivery slip');
+      const numDocuments = await boOrdersViewBlockTabListPage.getNumberOfDocuments(page);
+      expect(numDocuments).to.be.equals(3);
+
+      const countDocuments = await boOrdersViewBlockTabListPage.countDocumentsType(page);
+      expect(countDocuments).to.be.deep.equal({
+        creditSlips: 1,
+        deliverySlips: 1,
+        invoices: 1,
+      });
     });
   });
 

--- a/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/02_deliverySlipOptions/01_deliverySlipPrefix.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/02_deliverySlipOptions/01_deliverySlipPrefix.ts
@@ -109,7 +109,7 @@ describe('BO - Orders - Delivery slips : Update delivery slip prefix and check t
       await testContext.addContextItem(this, 'testIdentifier', 'checkDocumentNamePrefix', baseContext);
 
       // Get delivery slips filename
-      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 3);
+      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 2);
       expect(fileName).to.contains(deliverySlipData.prefix.replace('#', '').trim());
     });
   });

--- a/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/02_deliverySlipOptions/01_deliverySlipPrefix.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/02_deliverySlipOptions/01_deliverySlipPrefix.ts
@@ -108,9 +108,9 @@ describe('BO - Orders - Delivery slips : Update delivery slip prefix and check t
     it(`should check that the delivery slip file name contain '${deliverySlipData.prefix}'`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkDocumentNamePrefix', baseContext);
 
-      // Get delivery slips filename
-      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 2);
-      expect(fileName).to.contains(deliverySlipData.prefix.replace('#', '').trim());
+      const document = await boOrdersViewBlockTabListPage.getDocument(page, 1, 'Delivery slip');
+      expect(document.type).to.equals('Credit slip')
+      expect(document.number).to.contains(deliverySlipData.prefix);
     });
   });
 

--- a/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/02_deliverySlipOptions/01_deliverySlipPrefix.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/02_deliverySlipOptions/01_deliverySlipPrefix.ts
@@ -25,12 +25,10 @@ Back to the default delivery slip prefix value
 describe('BO - Orders - Delivery slips : Update delivery slip prefix and check the generated file name', async () => {
   let browserContext: BrowserContext;
   let page: Page;
-  let fileName: string;
 
   const deliverySlipData: FakerOrderDeliverySlipOptions = new FakerOrderDeliverySlipOptions();
   const defaultPrefix: string = '#DE';
 
-  // before and after functions
   before(async function () {
     browserContext = await utilsPlaywright.createBrowserContext(this.browser);
     page = await utilsPlaywright.newTab(browserContext);
@@ -105,11 +103,18 @@ describe('BO - Orders - Delivery slips : Update delivery slip prefix and check t
       expect(result).to.equal(dataOrderStatuses.shipped.name);
     });
 
+    it('should click on \'Documents\' tab', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'displayDocumentsTab', baseContext);
+
+      const isTabOpened = await boOrdersViewBlockTabListPage.goToDocumentsTab(page);
+      expect(isTabOpened).to.eq(true);
+    });
+
     it(`should check that the delivery slip file name contain '${deliverySlipData.prefix}'`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkDocumentNamePrefix', baseContext);
 
       const document = await boOrdersViewBlockTabListPage.getDocument(page, 1, 'Delivery slip');
-      expect(document.type).to.equals('Credit slip')
+      expect(document.type).to.equals('Delivery slip');
       expect(document.number).to.contains(deliverySlipData.prefix);
     });
   });

--- a/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/02_deliverySlipOptions/02_deliverySlipNumber.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/02_deliverySlipOptions/02_deliverySlipNumber.ts
@@ -133,7 +133,7 @@ describe('BO - Orders - Delivery slips : Update \'Delivery slip number\'', async
       await testContext.addContextItem(this, 'testIdentifier', 'checkDeliverySlipsDocumentName', baseContext);
 
       // Get delivery slips filename
-      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 3);
+      fileName = await boOrdersViewBlockTabListPage.getFileName(page, 2);
       expect(fileName).to.contains(deliverySlipData.number);
     });
   });

--- a/tests/UI/campaigns/functional/BO/03_catalog/07_discounts/discountV2/01_minimumPurchaseAmount.ts
+++ b/tests/UI/campaigns/functional/BO/03_catalog/07_discounts/discountV2/01_minimumPurchaseAmount.ts
@@ -1,0 +1,448 @@
+import testContext from '@utils/testContext';
+import {expect} from 'chai';
+
+import setFeatureFlag from '@commonTests/BO/advancedParameters/newFeatures';
+
+import {
+  // BO pages
+  boDiscountsPage,
+  boDiscountsCreatePage,
+  boDashboardPage,
+  boLoginPage,
+  boFeatureFlagPage,
+  // FO pages
+  foHummingbirdHomePage,
+  foHummingbirdSearchResultsPage,
+  foHummingbirdModalQuickViewPage,
+  foHummingbirdModalBlockCartPage,
+  foHummingbirdCartPage,
+  // Data
+  dataProducts,
+  FakerDiscount,
+  type BrowserContext,
+  type Page,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'functional_BO_catalog_discounts_discountV2_minimumPurchaseAmount';
+
+/*
+Pre-condition:
+- Enable discount
+Scenario:
+- Create discount in BO and check it in FO
+- Edit discount in BO and check it in FO
+- Delete discount
+Post-condition:
+- Disable discount
+ */
+describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+
+  const discountWithoutName: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: ' ',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: 20,
+    minimumAmountTax: 'Tax included',
+    discountValue: 10,
+    discountReductionType: '€',
+    discountTax: 'Tax included',
+  });
+
+  const discountPurchaseAmountZero: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: 'Test',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: '0',
+    minimumAmountTax: 'Tax included',
+    discountValue: 10,
+    discountReductionType: '€',
+    discountTax: 'Tax included',
+  });
+  const discountPurchaseAmountNegative: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: 'Test',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: -50,
+    minimumAmountTax: 'Tax included',
+    discountValue: 10,
+    discountReductionType: '€',
+    discountTax: 'Tax included',
+  });
+  const discountPurchaseAmountText: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: 'Test',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: 'asefr',
+    minimumAmountTax: 'Tax included',
+    discountValue: 10,
+    discountReductionType: '€',
+    discountTax: 'Tax included',
+  });
+
+  const discountValueNegative: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: 'Test',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: 50,
+    minimumAmountTax: 'Tax included',
+    discountValue: -20,
+    discountReductionType: '€',
+    discountTax: 'Tax included',
+  });
+
+  const discountValueZero: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: 'Test',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: 50,
+    minimumAmountTax: 'Tax included',
+    discountValue: '0',
+    discountReductionType: '€',
+    discountTax: 'Tax included',
+  });
+
+  const discountData: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: 'Test',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: 50,
+    minimumAmountTax: 'Tax included',
+    discountValue: 10,
+    discountReductionType: '€',
+    discountTax: 'Tax included',
+    generateDiscountCode: true,
+    discountCode: 'test',
+  });
+  const editDiscountData: FakerDiscount = new FakerDiscount({
+    discountType: 'On cart amount',
+    name: 'Test',
+    noProductCondition: true,
+    minimumPurchaseAmount: true,
+    minimumAmountValue: 50,
+    minimumAmountTax: 'Tax excluded',
+    discountValue: 10,
+    discountReductionType: '€',
+    discountTax: 'Tax excluded',
+    generateDiscountCode: false,
+  });
+
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+  });
+
+  // 1 - Pre-condition: Enable discount
+  setFeatureFlag(boFeatureFlagPage.featureFlagDiscount, true, `${baseContext}_preTest`);
+
+  describe('Create discount and check it in FO', async () => {
+    it('should login in BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+      await boLoginPage.goTo(page, global.BO.URL);
+      await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+      const pageTitle = await boDashboardPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+    });
+
+    it('should go to \'Catalog > Discounts\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToDiscountsPage', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.catalogParentLink,
+        boDashboardPage.discountsLink,
+      );
+
+      const pageTitle = await boDiscountsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDiscountsPage.pageTitle);
+    });
+
+    it('should click on create discount button and choose the type \'On cart amount\'', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'chooseDiscountType', baseContext);
+
+      await boDiscountsPage.clickOnCreateDiscountButton(page);
+      await boDiscountsPage.selectDiscountType(page, discountWithoutName.discountType!);
+
+      const pageTitle = await boDiscountsCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDiscountsCreatePage.pageTitle);
+    });
+
+    it('should create a discount without name and check the error', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createDiscount_1', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, discountWithoutName);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.errorMessageNameRequired);
+    });
+
+    it('should create a discount with a minimum purchase value = 0 euro and check the error', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createDiscount_2', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, discountPurchaseAmountZero);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.errorMessageMinPurchaseAmount);
+    });
+
+    it('should create a discount with a minimum purchase value < 0 and check the error', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createDiscount_3', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, discountPurchaseAmountNegative);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.errorMessageMinPurchaseAmount);
+    });
+
+    it('should create a discount with a minimum purchase value = asefr and check the error', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createDiscount_4', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, discountPurchaseAmountText);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.errorMessageMinPurchaseAmountNotnumber);
+    });
+
+    it('should create a discount with a discount value < 0 and check the error', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createDiscount_5', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, discountValueNegative);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.errorMessageDiscountValue(
+        discountValueNegative.discountValue.toString()));
+    });
+
+    it('should create a discount with a discount value = 0 and check the error', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createDiscount_6', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, discountValueZero);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.errorMessageDiscountValue('0'));
+    });
+
+    it('should create a discount with code', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'createDiscountWithCode', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, discountData);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.successfulCreationMessage);
+    });
+
+    it('should view my shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'viewMyShop', baseContext);
+
+      page = await boDiscountsCreatePage.viewMyShop(page);
+      await foHummingbirdHomePage.changeLanguage(page, 'en');
+
+      const isHomePage = await foHummingbirdHomePage.isHomePage(page);
+      expect(isHomePage, 'Home page is not displayed').to.equal(true);
+    });
+
+    it(`should search for the product '${dataProducts.demo_3.name}'`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'searchProduct_1', baseContext);
+
+      await foHummingbirdHomePage.searchProduct(page, dataProducts.demo_3.name);
+
+      const pageTitle = await foHummingbirdSearchResultsPage.getPageTitle(page);
+      expect(pageTitle).to.equal(foHummingbirdSearchResultsPage.pageTitle);
+    });
+
+    it(`should add the product '${dataProducts.demo_3.name}' to the cart`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'addProductToCart_1', baseContext);
+
+      await foHummingbirdSearchResultsPage.quickViewProduct(page, 1);
+      await foHummingbirdModalQuickViewPage.addToCartByQuickView(page);
+      await foHummingbirdModalBlockCartPage.proceedToCheckout(page);
+
+      const shoppingCarts = await foHummingbirdCartPage.getCartNotificationsNumber(page);
+      expect(shoppingCarts).to.equal(1);
+    });
+
+    it('should add the promo code and check the error message', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'addPromoCode_1', baseContext);
+
+      await foHummingbirdCartPage.addPromoCode(page, discountData.discountCode);
+
+      const voucherErrorText = await foHummingbirdCartPage.getCartRuleErrorMessage(page);
+      expect(voucherErrorText).to.equal(`${foHummingbirdCartPage.minimumAmountErrorMessage
+      } €${parseFloat(discountData.minimumAmountValue.toString()).toFixed(2)}.`);
+    });
+
+    it('should go to home page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToHomePage', baseContext);
+
+      await foHummingbirdCartPage.goToHomePage(page);
+
+      const result = await foHummingbirdHomePage.isHomePage(page);
+      expect(result).to.equal(true);
+    });
+
+    it(`should search for the product '${dataProducts.demo_5.name}'`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'searchProduct_2', baseContext);
+
+      await foHummingbirdHomePage.searchProduct(page, dataProducts.demo_5.name);
+
+      const pageTitle = await foHummingbirdSearchResultsPage.getPageTitle(page);
+      expect(pageTitle).to.equal(foHummingbirdSearchResultsPage.pageTitle);
+    });
+
+    it(`should add the product '${dataProducts.demo_5.name}' to cart`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'addProductToCart_2', baseContext);
+
+      await foHummingbirdSearchResultsPage.quickViewProduct(page, 1);
+      await foHummingbirdModalQuickViewPage.addToCartByQuickView(page);
+      await foHummingbirdModalBlockCartPage.proceedToCheckout(page);
+
+      const shoppingCarts = await foHummingbirdCartPage.getCartNotificationsNumber(page);
+      expect(shoppingCarts).to.equal(2);
+    });
+
+    it('should add the promo code and check the discount name', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'addPromoCode_2', baseContext);
+
+      await foHummingbirdCartPage.addPromoCode(page, discountData.discountCode);
+
+      const cartRuleName = await foHummingbirdCartPage.getCartRuleName(page, 1);
+      expect(cartRuleName).to.contains(discountData.name);
+    });
+
+    it('should check the discount value', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkDiscountValue1', baseContext);
+
+      const discount = parseFloat(discountData.discountValue.toString()).toFixed(2);
+
+      const discountValue = await foHummingbirdCartPage.getCartRuleValue(page);
+      expect(discountValue).to.contains(`-€${discount}`);
+
+      const subTotalDiscount = await foHummingbirdCartPage.getSubtotalDiscountValue(page);
+      expect(subTotalDiscount.toString()).to.equal(`-${discountData.discountValue}`);
+    });
+
+    it('should check the shipping cost', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkShippingCost_2', baseContext);
+
+      const subTotalShipping = await foHummingbirdCartPage.getSubtotalShippingValue(page);
+      expect(subTotalShipping).to.equal('Free');
+    });
+
+    it('should check the Total (tax incl.) after the discount', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkTotalAfterDiscount1', baseContext);
+
+      const discount = parseFloat(discountData.discountValue.toString());
+
+      const totalBeforeDiscount = dataProducts.demo_3.finalPrice + dataProducts.demo_5.finalPrice;
+
+      const totalAfterDiscount = await foHummingbirdCartPage.getATIPrice(page);
+      expect(totalAfterDiscount.toString()).to.equal((totalBeforeDiscount - discount).toFixed(2));
+    });
+  });
+
+  describe('Edit discount in BO and check it in FO', async () => {
+    it('should go back to BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goBackToBO', baseContext);
+
+      page = await foHummingbirdCartPage.changePage(browserContext, 0);
+
+      const pageTitle = await boDiscountsCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDiscountsCreatePage.pageTitle);
+    });
+
+    it('should edit the discount', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'editDiscount', baseContext);
+
+      const errorMessage = await boDiscountsCreatePage.createDiscount(page, editDiscountData);
+      expect(errorMessage).to.contains(boDiscountsCreatePage.successfulUpdateMessage);
+    });
+
+    it('should go back to FO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goBackToFO', baseContext);
+
+      page = await boDiscountsCreatePage.changePage(browserContext, 1);
+
+      const pageTitle = await foHummingbirdCartPage.getPageTitle(page);
+      expect(pageTitle).to.contains(foHummingbirdCartPage.pageTitle);
+    });
+
+    it('should check the discount value', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkDiscountValue_2', baseContext);
+
+      await foHummingbirdCartPage.reloadPage(page);
+      const discountValue = await foHummingbirdCartPage.getCartRuleValue(page);
+      expect(discountValue).to.contains('-€12.00');
+
+      const subTotalDiscount = await foHummingbirdCartPage.getSubtotalDiscountValue(page);
+      expect(subTotalDiscount.toString()).to.equal('-12');
+    });
+
+    it('should check the shipping cost', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkShippingCost_3', baseContext);
+
+      const subTotalShipping = await foHummingbirdCartPage.getSubtotalShippingValue(page);
+      expect(subTotalShipping).to.eq('Free');
+    });
+
+    it('should check the Total (tax incl.) after the discount', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkTotalAfterDiscount_2', baseContext);
+
+      const totalAfterDiscount = await foHummingbirdCartPage.getATIPrice(page);
+      expect(totalAfterDiscount.toString()).to.equal('57.26');
+    });
+  });
+
+  describe('Delete discount', async () => {
+    it('should go back to BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goBackToBO_2', baseContext);
+
+      page = await foHummingbirdCartPage.changePage(browserContext, 0);
+
+      const pageTitle = await boDiscountsCreatePage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDiscountsCreatePage.pageTitle);
+    });
+
+    it('should go to \'Catalog > Discounts\' page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToDiscountsPage2', baseContext);
+
+      await boDashboardPage.goToSubMenu(
+        page,
+        boDashboardPage.catalogParentLink,
+        boDashboardPage.discountsLink,
+      );
+
+      const pageTitle = await boDiscountsPage.getPageTitle(page);
+      expect(pageTitle).to.contains(boDiscountsPage.pageTitle);
+    });
+
+    it('should delete the create discount', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'deleteDiscount', baseContext);
+
+      const validationMessage = await boDiscountsPage.deleteDiscount(page, 1);
+      expect(validationMessage).to.contains(boDiscountsPage.successfulDeleteMessage);
+    });
+
+    it('should go back to FO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goBackToFO_3', baseContext);
+
+      page = await boDiscountsCreatePage.changePage(browserContext, 1);
+
+      const pageTitle = await foHummingbirdCartPage.getPageTitle(page);
+      expect(pageTitle).to.contains(foHummingbirdCartPage.pageTitle);
+    });
+
+    it('should check the Total (tax incl.) after the discount', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkTotalAfterDiscount_3', baseContext);
+
+      await foHummingbirdCartPage.reloadPage(page);
+      const total = dataProducts.demo_3.finalPrice + dataProducts.demo_5.finalPrice;
+
+      const totalAfterDiscount = await foHummingbirdCartPage.getATIPrice(page);
+      expect(totalAfterDiscount.toString()).to.equal(total.toFixed(2));
+    });
+  });
+
+  // 1 - Post-condition: Disable discount
+  setFeatureFlag(boFeatureFlagPage.featureFlagDiscount, false, `${baseContext}_postTest`);
+});

--- a/tests/UI/campaigns/functional/BO/03_catalog/07_discounts/discountV2/01_minimumPurchaseAmount.ts
+++ b/tests/UI/campaigns/functional/BO/03_catalog/07_discounts/discountV2/01_minimumPurchaseAmount.ts
@@ -370,14 +370,14 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
 
       await foHummingbirdCartPage.reloadPage(page);
 
-      const discountTaxExcluded = utilsCore.percentage(parseFloat(editDiscountData.discountValue.toString()),
-        20) + editDiscountData.discountValue;
+      const discount = utilsCore.percentage(parseFloat(editDiscountData.discountValue.toString()),
+        20) + parseFloat(editDiscountData.discountValue.toString());
 
       const discountValue = await foHummingbirdCartPage.getCartRuleValue(page);
-      expect(discountValue).to.contains(`-€${discountTaxExcluded.toFixed(2)}`);
+      expect(discountValue).to.contains(`-€${discount.toFixed(2)}`);
 
       const subTotalDiscount = await foHummingbirdCartPage.getSubtotalDiscountValue(page);
-      expect(subTotalDiscount.toString()).to.equal(`-${discountTaxExcluded}`);
+      expect(subTotalDiscount.toString()).to.equal(`-${discount}`);
     });
 
     it('should check the shipping cost', async function () {
@@ -392,7 +392,7 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
 
       const total = dataProducts.demo_3.finalPrice + dataProducts.demo_5.price;
       const discount = utilsCore.percentage(parseFloat(editDiscountData.discountValue.toString()),
-        20) + editDiscountData.discountValue;
+        20) + parseFloat(editDiscountData.discountValue.toString());
 
       const totalAfterDiscount = await foHummingbirdCartPage.getATIPrice(page);
       expect(totalAfterDiscount.toString()).to.equal((total - discount).toFixed(2));

--- a/tests/UI/campaigns/functional/BO/03_catalog/07_discounts/discountV2/01_minimumPurchaseAmount.ts
+++ b/tests/UI/campaigns/functional/BO/03_catalog/07_discounts/discountV2/01_minimumPurchaseAmount.ts
@@ -19,6 +19,7 @@ import {
   // Data
   dataProducts,
   FakerDiscount,
+  utilsCore,
   type BrowserContext,
   type Page,
   utilsPlaywright,
@@ -51,7 +52,6 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
     discountReductionType: '€',
     discountTax: 'Tax included',
   });
-
   const discountPurchaseAmountZero: FakerDiscount = new FakerDiscount({
     discountType: 'On cart amount',
     name: 'Test',
@@ -85,7 +85,6 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
     discountReductionType: '€',
     discountTax: 'Tax included',
   });
-
   const discountValueNegative: FakerDiscount = new FakerDiscount({
     discountType: 'On cart amount',
     name: 'Test',
@@ -97,7 +96,6 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
     discountReductionType: '€',
     discountTax: 'Tax included',
   });
-
   const discountValueZero: FakerDiscount = new FakerDiscount({
     discountType: 'On cart amount',
     name: 'Test',
@@ -172,7 +170,7 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
       expect(pageTitle).to.contains(boDiscountsPage.pageTitle);
     });
 
-    it('should click on create discount button and choose the type \'On cart amount\'', async function () {
+    it(`should click on create discount button and choose the type '${discountData.discountType}'`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'chooseDiscountType', baseContext);
 
       await boDiscountsPage.clickOnCreateDiscountButton(page);
@@ -371,11 +369,15 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
       await testContext.addContextItem(this, 'testIdentifier', 'checkDiscountValue_2', baseContext);
 
       await foHummingbirdCartPage.reloadPage(page);
+
+      const discountTaxExcluded = utilsCore.percentage(parseFloat(editDiscountData.discountValue.toString()),
+        20) + editDiscountData.discountValue;
+
       const discountValue = await foHummingbirdCartPage.getCartRuleValue(page);
-      expect(discountValue).to.contains('-€12.00');
+      expect(discountValue).to.contains(`-€${discountTaxExcluded.toFixed(2)}`);
 
       const subTotalDiscount = await foHummingbirdCartPage.getSubtotalDiscountValue(page);
-      expect(subTotalDiscount.toString()).to.equal('-12');
+      expect(subTotalDiscount.toString()).to.equal(`-${discountTaxExcluded}`);
     });
 
     it('should check the shipping cost', async function () {
@@ -388,8 +390,12 @@ describe('BO - Catalog - Discounts : Minimum purchase amount (On cart amount)', 
     it('should check the Total (tax incl.) after the discount', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'checkTotalAfterDiscount_2', baseContext);
 
+      const total = dataProducts.demo_3.finalPrice + dataProducts.demo_5.price;
+      const discount = utilsCore.percentage(parseFloat(editDiscountData.discountValue.toString()),
+        20) + editDiscountData.discountValue;
+
       const totalAfterDiscount = await foHummingbirdCartPage.getATIPrice(page);
-      expect(totalAfterDiscount.toString()).to.equal('57.26');
+      expect(totalAfterDiscount.toString()).to.equal((total - discount).toFixed(2));
     });
   });
 

--- a/tests/UI/campaigns/functional/BO/13_shopParameters/07_search/02_tags/01_CRUDTag.ts
+++ b/tests/UI/campaigns/functional/BO/13_shopParameters/07_search/02_tags/01_CRUDTag.ts
@@ -102,7 +102,7 @@ describe('BO - Shop Parameters - Search : Create, update and delete tag in BO', 
       await boTagsPage.gotoEditTagPage(page, 1);
 
       const pageTitle = await boTagsCreatePage.getPageTitle(page);
-      expect(pageTitle).to.contains(boTagsCreatePage.pageTitleEdit);
+      expect(pageTitle).to.contains(boTagsCreatePage.pageTitleEdit(createTagData.name));
     });
 
     it('should update tag', async function () {

--- a/tests/UI/campaigns/functional/FO/classic/03_userAccount/01_creditSlips/01_consultCreditSlip.ts
+++ b/tests/UI/campaigns/functional/FO/classic/03_userAccount/01_creditSlips/01_consultCreditSlip.ts
@@ -230,7 +230,7 @@ describe('FO - Consult credit slip list & View PDF Credit slip & View order', as
         await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocument', baseContext);
 
         // Get document name
-        const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 3);
+        const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 2);
         expect(documentType).to.be.equal('Credit slip');
       });
 
@@ -246,11 +246,11 @@ describe('FO - Consult credit slip list & View PDF Credit slip & View order', as
         await testContext.addContextItem(this, 'testIdentifier', 'getIdentifierDateIssued', baseContext);
 
         // Get Credit Slip ID
-        creditSlipID = await boOrdersViewBlockTabListPage.getFileName(page, 3);
+        creditSlipID = await boOrdersViewBlockTabListPage.getFileName(page, 2);
         expect(creditSlipID).is.not.equal('');
 
         // Get Date Issued
-        dateIssued = await boOrdersViewBlockTabListPage.getDocumentDate(page, 3);
+        dateIssued = await boOrdersViewBlockTabListPage.getDocumentDate(page, 2);
         expect(dateIssued).is.not.equal('');
       });
     });

--- a/tests/UI/campaigns/functional/FO/hummingbird/03_userAccount/01_creditSlips/01_consultCreditSlip.ts
+++ b/tests/UI/campaigns/functional/FO/hummingbird/03_userAccount/01_creditSlips/01_consultCreditSlip.ts
@@ -235,7 +235,7 @@ describe('FO - Consult credit slip list & View PDF Credit slip & View order', as
         await testContext.addContextItem(this, 'testIdentifier', 'checkCreditSlipDocument', baseContext);
 
         // Get document name
-        const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 3);
+        const documentType = await boOrdersViewBlockTabListPage.getDocumentType(page, 2);
         expect(documentType).to.be.equal('Credit slip');
       });
 
@@ -251,11 +251,11 @@ describe('FO - Consult credit slip list & View PDF Credit slip & View order', as
         await testContext.addContextItem(this, 'testIdentifier', 'getIdentifierDateIssued', baseContext);
 
         // Get Credit Slip ID
-        creditSlipID = await boOrdersViewBlockTabListPage.getFileName(page, 3);
+        creditSlipID = await boOrdersViewBlockTabListPage.getFileName(page, 2);
         expect(creditSlipID).is.not.equal('');
 
         // Get Date Issued
-        dateIssued = await boOrdersViewBlockTabListPage.getDocumentDate(page, 3);
+        dateIssued = await boOrdersViewBlockTabListPage.getDocumentDate(page, 2);
         expect(dateIssued).is.not.equal('');
       });
     });

--- a/tests/UI/commonTests/BO/advancedParameters/newFeatures.ts
+++ b/tests/UI/commonTests/BO/advancedParameters/newFeatures.ts
@@ -26,6 +26,9 @@ function setFeatureFlag(featureFlag: string, expectedStatus: boolean, baseContex
     case boFeatureFlagPage.featureFlagImprovedShipment:
       title = 'Improved shipment';
       break;
+    case boFeatureFlagPage.featureFlagDiscount:
+      title = 'Discount';
+      break;
     default:
       throw new Error(`The feature flag ${featureFlag} is not defined`);
   }

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -418,7 +418,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#6c83be94ce863e3515307e939d666344076d352d",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#bc1cc93405133e86673432b82994bbd33f2cc20e",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -7779,7 +7779,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#6c83be94ce863e3515307e939d666344076d352d",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#bc1cc93405133e86673432b82994bbd33f2cc20e",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^10.1.0",

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -534,7 +534,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#6c83be94ce863e3515307e939d666344076d352d",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#fdcd24f0c875e089691637e7a4ce935feed63842",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -8710,7 +8710,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#6c83be94ce863e3515307e939d666344076d352d",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#fdcd24f0c875e089691637e7a4ce935feed63842",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^10.1.0",

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -418,7 +418,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#bc1cc93405133e86673432b82994bbd33f2cc20e",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#ac440421950d8dedfc22b38ba9003cfdf0b90344",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -7779,7 +7779,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#bc1cc93405133e86673432b82994bbd33f2cc20e",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#ac440421950d8dedfc22b38ba9003cfdf0b90344",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^10.1.0",

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -418,7 +418,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#ac440421950d8dedfc22b38ba9003cfdf0b90344",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#22556918441cbac1aee3e129a327c61b7b57e992",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -7779,7 +7779,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#ac440421950d8dedfc22b38ba9003cfdf0b90344",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#22556918441cbac1aee3e129a327c61b7b57e992",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^10.1.0",

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -418,7 +418,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#22556918441cbac1aee3e129a327c61b7b57e992",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#d24e59b4a3013aa20d66fc97d83cd0ad8ae4ac35",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -7779,7 +7779,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#22556918441cbac1aee3e129a327c61b7b57e992",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#d24e59b4a3013aa20d66fc97d83cd0ad8ae4ac35",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^10.1.0",

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -418,7 +418,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#d24e59b4a3013aa20d66fc97d83cd0ad8ae4ac35",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#a012dc440fb006b7499666ee9750ebd8a3208377",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -7779,7 +7779,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#d24e59b4a3013aa20d66fc97d83cd0ad8ae4ac35",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#a012dc440fb006b7499666ee9750ebd8a3208377",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^10.1.0",

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
@@ -115,6 +115,7 @@ class CustomerFormDataProviderTest extends TestCase
             'group_ids' => [1, 2, 3],
             'default_group_id' => 3,
             'is_guest' => false,
+            'is_newsletter_subscribed' => true,
         ], $customerFormDataProvider->getData(1));
     }
 
@@ -145,6 +146,7 @@ class CustomerFormDataProviderTest extends TestCase
             'max_payment_days' => 10,
             'risk_id' => 1,
             'is_guest' => false,
+            'is_newsletter_subscribed' => true,
         ], $customerFormDataProvider->getData(1));
     }
 

--- a/tests/Unit/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizerTest.php
+++ b/tests/Unit/PrestaShopBundle/ApiPlatform/Normalizer/ValueObjectNormalizerTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\EditApiClientCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use PrestaShop\PrestaShop\Core\Domain\State\ValueObject\NoStateId;
 use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ContactTypeChoiceProvider;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
@@ -37,6 +38,7 @@ class ValueObjectNormalizerTest extends TestCase
         yield 'real value object based on string' => [new ProductType(ProductType::TYPE_STANDARD), true];
         yield 'object with getValue but not ValueObject namespace' => [new DbMySQLi('localhost', 'root', 'root', 'prestashop', false), false];
         yield 'object without getValue method' => [new ContactTypeChoiceProvider(1), false];
+        yield 'no state id' => [new NoStateId(), true];
     }
 
     /**
@@ -61,6 +63,9 @@ class ValueObjectNormalizerTest extends TestCase
 
         yield 'VO integer as scalar' => [new ProductId(1), 1, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
         yield 'VO string as scalar' => [new ProductType(ProductType::TYPE_STANDARD), ProductType::TYPE_STANDARD, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+
+        yield 'no state id' => [new NoStateId(), ['stateId' => NoStateId::NO_STATE_ID_VALUE]];
+        yield 'no state id as scalar' => [new NoStateId(), NoStateId::NO_STATE_ID_VALUE, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
     }
 
     /**
@@ -92,6 +97,13 @@ class ValueObjectNormalizerTest extends TestCase
         yield 'product type value' => [['value' => ProductType::TYPE_COMBINATIONS], ProductType::class, true];
         yield 'product type string' => [ProductType::TYPE_COMBINATIONS, ProductType::class, true];
         yield 'product type integer' => [42, ProductType::class, false];
+
+        yield 'no state id, stateId' => [['stateId' => 0], NoStateId::class, true];
+        yield 'no state id, noStateId' => [['noStateId' => 0], NoStateId::class, true];
+        yield 'no state id, state_id' => [['state_id' => 0], NoStateId::class, true];
+        yield 'no state id, value' => [['value' => 0], NoStateId::class, true];
+        yield 'no state id, integer' => [0, NoStateId::class, true];
+        yield 'no state id, string' => ['0', NoStateId::class, true];
     }
 
     /**
@@ -131,5 +143,11 @@ class ValueObjectNormalizerTest extends TestCase
         yield 'product type snake case as scalar' => [['product_type' => ProductType::TYPE_COMBINATIONS], ProductType::class, ProductType::TYPE_COMBINATIONS, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
         yield 'product type value as scalar' => [['value' => ProductType::TYPE_COMBINATIONS], ProductType::class, ProductType::TYPE_COMBINATIONS, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
         yield 'product type string as scalar' => [ProductType::TYPE_COMBINATIONS, ProductType::class, ProductType::TYPE_COMBINATIONS, [ValueObjectNormalizer::VALUE_OBJECT_RETURNED_AS_SCALAR => true]];
+
+        yield 'no state id, stateId' => [['stateId' => 0], NoStateId::class, new NoStateId()];
+        yield 'no state id, noStateId' => [['noStateId' => 0], NoStateId::class, new NoStateId()];
+        yield 'no state id, state_id' => [['state_id' => 0], NoStateId::class, new NoStateId()];
+        yield 'no state id, value' => [['value' => 0], NoStateId::class, new NoStateId()];
+        yield 'no state id, integer' => [0, NoStateId::class, new NoStateId()];
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x 
| Description?      | `Shop::setContext(CONTEXT_GROUP)` was called without `$idShopGroup` in `LogoUploader`, causing incorrect logo comparison across shop contexts and wrong file deletions during logo upload in multi-shop mode.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | cf https://github.com/PrestaShop/PrestaShop/issues/40659
| UI Tests          | **In progress**
| Fixed issue or discussion?     | Fixes [#40659](https://github.com/PrestaShop/PrestaShop/issues/40659)
| Related PRs       | No
| Sponsor company   | https://github.com/PrestaShopCorp
