### PR TITLE
Fix fatal error when clearing Symfony cache on Windows/Docker

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3118,7 +3118,11 @@ exit;
 
         register_shutdown_function(function () use ($dir) {
             $fs = new Filesystem();
-            $fs->remove($dir);
+            try {
+                $fs->remove($dir);
+            } catch (\Symfony\Component\Filesystem\Exception\IOException $e) {
+                // Ignore removal errors (e.g. locked files on Windows/Docker volume mounts)
+            }
             Hook::exec('actionClearSf2Cache');
         });
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | On Windows with Docker volume mounts, `Filesystem::remove()` throws an `IOException` during PHP shutdown when clearing the Symfony cache. Symfony renames the directory to a temp name (`.!!MZX`) then tries to `rmdir` it, but some files remain locked by the OS, leaving the directory non-empty. This causes a fatal error: `Failed to remove directory "/var/www/html/var/cache/.!!MZX": Directory not empty`. The fix wraps the removal in a try-catch so the fatal error is silenced and the hook `actionClearSf2Cache` still fires.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | On Windows with Docker, trigger a Symfony cache clear (e.g. modify a container service or call `Tools::clearSf2Cache()`). The request should complete without a fatal error.
| UI Tests          | N/A
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | PrestaShop