### PR TITLE
Fix multilang field fallback to default language for non-required fields

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -355,7 +355,7 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
             if ($type == self::FORMAT_LANG && $id_lang && is_array($value)) {
                 if (!empty($value[$id_lang])) {
                     $value = $value[$id_lang];
-                } elseif (!empty($data['required'])) {
+                } elseif (!empty($value[Configuration::get('PS_LANG_DEFAULT')])) {
                     $value = $value[Configuration::get('PS_LANG_DEFAULT')];
                 } else {
                     $value = '';

--- a/tests/Unit/Classes/ObjectModelTest.php
+++ b/tests/Unit/Classes/ObjectModelTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\Classes;
+
+use Configuration;
+use ObjectModel;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Minimal ObjectModel subclass used to test formatFields behavior.
+ */
+class TestableObjectModel extends ObjectModel
+{
+    /** @var string|array */
+    public $name;
+
+    /** @var array */
+    public static $definition = [
+        'table' => 'testable_object',
+        'primary' => 'id_testable_object',
+        'multilang' => true,
+        'fields' => [
+            'name' => [
+                'type' => self::TYPE_STRING,
+                'lang' => true,
+                'required' => false,
+            ],
+        ],
+    ];
+
+    public function formatFieldsPublic(int $type, ?int $id_lang = null): array
+    {
+        return $this->formatFields($type, $id_lang);
+    }
+}
+
+class ObjectModelTest extends TestCase
+{
+    private const DEFAULT_LANG_ID = 1;
+    private const OTHER_LANG_ID = 2;
+
+    protected function setUp(): void
+    {
+        // Pre-populate Configuration static cache to avoid database calls during testing
+        $reflection = new ReflectionClass(Configuration::class);
+
+        $initialized = $reflection->getProperty('_initialized');
+        $initialized->setAccessible(true);
+        $initialized->setValue(null, true);
+
+        $newCacheGlobal = $reflection->getProperty('_new_cache_global');
+        $newCacheGlobal->setAccessible(true);
+        $newCacheGlobal->setValue(null, [
+            'PS_LANG_DEFAULT' => [0 => (string) self::DEFAULT_LANG_ID],
+        ]);
+
+        $newCacheShop = $reflection->getProperty('_new_cache_shop');
+        $newCacheShop->setAccessible(true);
+        $newCacheShop->setValue(null, null);
+
+        $newCacheGroup = $reflection->getProperty('_new_cache_group');
+        $newCacheGroup->setAccessible(true);
+        $newCacheGroup->setValue(null, null);
+    }
+
+    protected function tearDown(): void
+    {
+        Configuration::clearConfigurationCacheForTesting();
+        ObjectModel::resetStaticCache();
+    }
+
+    /**
+     * Regression test for https://github.com/PrestaShop/PrestaShop/issues/40101
+     *
+     * A non-required multilang field (e.g. cart rule name) must fall back to the
+     * default language value when its value is empty for the requested language.
+     * Previously the fallback was incorrectly gated on the `required` flag.
+     */
+    public function testNonRequiredMultilangFieldFallsBackToDefaultLanguage(): void
+    {
+        $model = new TestableObjectModel();
+        $model->name = [
+            self::DEFAULT_LANG_ID => 'My Discount',
+            self::OTHER_LANG_ID => '',
+        ];
+
+        $fields = $model->formatFieldsPublic(ObjectModel::FORMAT_LANG, self::OTHER_LANG_ID);
+
+        $this->assertSame(
+            'My Discount',
+            $fields['name'],
+            'A non-required multilang field should fall back to the default language value when its value is empty for the requested language.'
+        );
+    }
+
+    public function testMultilangFieldReturnsValueWhenSetForRequestedLanguage(): void
+    {
+        $model = new TestableObjectModel();
+        $model->name = [
+            self::DEFAULT_LANG_ID => 'My Discount',
+            self::OTHER_LANG_ID => 'Mon bon de réduction',
+        ];
+
+        $fields = $model->formatFieldsPublic(ObjectModel::FORMAT_LANG, self::OTHER_LANG_ID);
+
+        $this->assertSame('Mon bon de réduction', $fields['name']);
+    }
+
+    public function testMultilangFieldReturnsEmptyStringWhenBothLanguagesAreEmpty(): void
+    {
+        $model = new TestableObjectModel();
+        $model->name = [
+            self::DEFAULT_LANG_ID => '',
+            self::OTHER_LANG_ID => '',
+        ];
+
+        $fields = $model->formatFieldsPublic(ObjectModel::FORMAT_LANG, self::OTHER_LANG_ID);
+
+        $this->assertSame('', $fields['name']);
+    }
+
+    public function testDefaultLanguageFieldReturnsItsOwnValue(): void
+    {
+        $model = new TestableObjectModel();
+        $model->name = [
+            self::DEFAULT_LANG_ID => 'My Discount',
+            self::OTHER_LANG_ID => '',
+        ];
+
+        $fields = $model->formatFieldsPublic(ObjectModel::FORMAT_LANG, self::DEFAULT_LANG_ID);
+
+        $this->assertSame('My Discount', $fields['name']);
+    }
+}


### PR DESCRIPTION
| Questions                  | Answers
| -------------------------- | -------------------------------------------------------
| Branch?                    | develop
| Description?               | In `ObjectModel::formatFields()`, the fallback to the default language value for empty multilang fields was incorrectly gated on the `required` flag. Any non-required multilang field was stored as an empty string instead of inheriting the default language value. The cart rule `name` field was changed to `required=false` in 9.1.0, triggering the regression.
| Type?                      | bug fix
| Category?                  | CO
| BC breaks?                 | no
| Deprecations?              | no
| How to test?               | 1. Install PrestaShop 9.1.x with two languages. 2. Go to BO > Catalog > Discounts. 3. Create a cart rule: fill in the name **only in the default language**, generate a code, activate it. 4. Save. 5. Go to FO, add a product to cart, apply the promo code. 6. Switch to the second language → name should display correctly (fallback to default language). 7. Complete checkout → no exception. 8. Go to My Account > Orders → order status should be visible.
| UI Tests                   | To be run
| Fixed issue or discussion? | Fixes #40101
| Related PRs                | N/A
| Sponsor company            | N/A

## Context

When a multilang field (e.g. cart rule `name`) is defined with `required => false` in an `ObjectModel` subclass, saving an object with only the default language filled in causes all other languages to be stored as empty strings — instead of falling back to the default language value.

This is a **regression introduced in 9.1.0** when the cart rule `name` field was intentionally made non-required (to allow saving inactive cart rules without a name). The side-effect was that the fallback mechanism in `ObjectModel::formatFields()` silently broke for any non-required multilang field.

## Root cause

In [`ObjectModel::formatFields()`](https://github.com/PrestaShop/PrestaShop/blob/develop/classes/ObjectModel.php), the fallback logic was:

```php
// Get field value, if value is multilang and field is empty, use value from default lang
if (!empty($value[$id_lang])) {
    $value = $value[$id_lang];
} elseif (!empty($data['required'])) {   // ← fallback gated on required
    $value = $value[Configuration::get('PS_LANG_DEFAULT')];
} else {
    $value = '';   // ← non-required field → always empty for non-default languages
}
```

The comment in the source code already described the **intended** behavior ("use value from default lang"), but the condition made it unreachable for non-required fields.

## Solution

Decouple the fallback from the `required` flag. Instead, fall back to the default language whenever the requested language value is empty **and** the default language has a value:

```php
if (!empty($value[$id_lang])) {
    $value = $value[$id_lang];
} elseif (!empty($value[Configuration::get('PS_LANG_DEFAULT')])) {
    $value = $value[Configuration::get('PS_LANG_DEFAULT')];
} else {
    $value = '';
}
```

This restores the behavior described by the existing comment and matches the behavior of PrestaShop 9.0.x.

## Alternatives considered

**Making `name` required again in `CartRule`** — would fix the symptom for cart rules only, without addressing the systemic issue. Any other non-required multilang field across the codebase would remain affected.

**Adding a dedicated `fallback_default_lang` field attribute** — more explicit but adds complexity to the `$definition` API for all ObjectModel subclasses. The current fix is simpler and matches the documented intent of the existing code.

## Tests added

`tests/Unit/Classes/ObjectModelTest.php` — 4 unit tests covering `ObjectModel::formatFields()` for multilang fields:

| Test | Scenario |
| ---- | -------- |
| `testNonRequiredMultilangFieldFallsBackToDefaultLanguage` | Regression test: non-required field with empty value for requested lang → returns default lang value |
| `testMultilangFieldReturnsValueWhenSetForRequestedLanguage` | Nominal case: value exists for requested lang → returns it |
| `testMultilangFieldReturnsEmptyStringWhenBothLanguagesAreEmpty` | Both langs empty → empty string |
| `testDefaultLanguageFieldReturnsItsOwnValue` | Default lang always returns its own value |