### PR TITLE
Fix sidebar blanking on RTL

### DIFF
--- a/admin-dev/themes/new-theme/scss/rtl.scss
+++ b/admin-dev/themes/new-theme/scss/rtl.scss
@@ -294,7 +294,6 @@ ul {
   }
 }
 
-// CSSJanus flips right: 0 to left: 0, but the quick-nav panel must stay at the right edge
 #right-sidebar {
   right: 0;
   left: auto;

--- a/admin-dev/themes/new-theme/scss/rtl.scss
+++ b/admin-dev/themes/new-theme/scss/rtl.scss
@@ -294,6 +294,13 @@ ul {
   }
 }
 
+// CSSJanus flips right: 0 to left: 0, but the quick-nav panel must stay at the right edge
+#right-sidebar {
+  right: 0;
+  left: auto;
+  float: right;
+}
+
 .material-icons {
   &.rtl-flip {
     transform: scaleX(-1);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fix right sidebar blanking on every BO pages in RTL pages
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Login to BO > International > Localization > Import Iran Pack then Go to your profile and set Persian as default language. The right sidebar blanking is not present anymore.
| UI Tests          | https://github.com/cnavarro-prestashop/ga.tests.ui.pr/actions/runs/22964900598
| Fixed issue or discussion?     | Fixes #40388
| Related PRs       | no
| Sponsor company   | PrestaShop
