### PR TITLE
Fix webservice date range filter excluding boundary dates (#10822)

### DIFF
--- a/classes/webservice/SQLUtils.php
+++ b/classes/webservice/SQLUtils.php
@@ -40,6 +40,14 @@ class SQLUtils
                     if (count($matches3) > 0) {
                         sort($matches3);
                         [$first, $last] = array_values($matches3); // reset-keys
+                        // When the upper bound is a date without time (YYYY-MM-DD), append end-of-day
+                        // so that BETWEEN includes the entire last day (fixes #10822)
+                        if (preg_match('/^\s*\d{4}-\d{2}-\d{2}\s*$/', $last)) {
+                            $last = trim($last) . ' 23:59:59';
+                        }
+                        if (preg_match('/^\s*\d{4}-\d{2}-\d{2}\s*$/', $first)) {
+                            $first = trim($first) . ' 00:00:00';
+                        }
                         $ret .= ' AND ' . $tableAlias . '`' . bqSQL($sqlId) . '` BETWEEN "' . pSQL($first) . '" AND "' . pSQL($last) . "\"\n";
                     }
                 } else {

--- a/tests/Integration/Classes/SQLUtilsTest.php
+++ b/tests/Integration/Classes/SQLUtilsTest.php
@@ -56,5 +56,20 @@ class SQLUtilsTest extends TestCase
             ['name', '[19.2|20|25]'],
             ' AND (`name` = "19.2" OR `name` = "20" OR `name` = "25")' . PHP_EOL,
         ];
+        // Date range: date-only bounds should include the full last day (fixes #10822)
+        yield [
+            ['date_add', '[2018-07-01,2018-07-31]'],
+            ' AND `date_add` BETWEEN "2018-07-01 00:00:00" AND "2018-07-31 23:59:59"' . PHP_EOL,
+        ];
+        // Date range with table alias
+        yield [
+            ['date_add', '[2020-01-01,2020-12-31]', 'main.'],
+            ' AND `main`.`date_add` BETWEEN "2020-01-01 00:00:00" AND "2020-12-31 23:59:59"' . PHP_EOL,
+        ];
+        // Date range with full datetime values should remain untouched
+        yield [
+            ['date_add', '[2018-07-01 00:00:00,2018-07-31 14:30:00]'],
+            ' AND `date_add` BETWEEN "2018-07-01 00:00:00" AND "2018-07-31 14:30:00"' . PHP_EOL,
+        ];
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When filtering resources (e.g. orders) by `date_add` or `date_upd` via the Webservice API using a date range like `filter[date_add]=[2018-07-01,2018-07-31]&date=1`, records on the boundary dates (first and last day) are excluded. This is because the `BETWEEN` clause uses date-only strings (e.g. `"2018-07-31"`), which MySQL implicitly casts to `"2018-07-31 00:00:00"`, excluding all records after midnight on that day. This fix appends `00:00:00` to the lower bound and `23:59:59` to the upper bound when they are date-only values (`YYYY-MM-DD`), so the full day is included. Full datetime values are left untouched.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable the Webservice API and create an API key with orders access.<br>2. Create orders on specific dates (e.g. 2025-01-01 and 2025-01-31).<br>3. Query `api/orders/?display=[id]&filter[date_add]=[2025-01-01,2025-01-31]&date=1`<br>4. **Before fix:** Orders created after midnight on the last day (Jan 31) are missing.<br>5. **After fix:** All orders from Jan 1st 00:00:00 through Jan 31st 23:59:59 are returned.
| UI Tests          | N/A — This change only affects the Webservice API SQL filter generation, no UI impact.
| Fixed issue or discussion?     | Fixes #10822
| Related PRs       | None
| Sponsor company   | N/A