### PR TITLE
Fix multistore shop unreachable due to missing currency association

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -698,14 +698,16 @@ class ToolsCore
             return $currency;
         } else {
             // Get currency from context
-            $currency = Shop::getEntityIds('currency', Context::getContext()->shop->id, true, true);
-            if (isset($currency[0]) && $currency[0]['id_currency']) {
-                $cookie->id_currency = $currency[0]['id_currency'];
+            $shopCurrencies = Shop::getEntityIds('currency', Context::getContext()->shop->id, true, true);
+            if (isset($shopCurrencies[0]) && $shopCurrencies[0]['id_currency']) {
+                $cookie->id_currency = $shopCurrencies[0]['id_currency'];
 
                 return Currency::getCurrencyInstance((int) $cookie->id_currency);
             }
         }
 
+        // Fallback: return the default currency object even if not associated to this shop.
+        // This prevents returning an array when a newly created shop has no currency configured yet.
         return $currency;
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When a new shop is created in multistore mode, no currency is associated to it yet. `Tools::setCurrency()` was overwriting the `Currency` object with the result of `Shop::getEntityIds()` (an array), and returning that array as a fallback when no shop currency was found. This caused fatal errors and warnings in the front office: property access on array in `FrontController::getTemplateVarCurrency()`, and a `TypeError` in `ComputingPrecision::getPrecision()` because `$this->currency->precision` resolved to `null`. Fix: use a separate variable `$shopCurrencies` so the `Currency` object is never overwritten and the fallback always returns a valid object.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable multistore mode. 2. Create a new shop. 3. Assign a URL to the new shop. 4. Access the new shop front office → no more PHP errors or warnings, default currency is used.
| UI Tests          | Please run UI tests from https://github.com/sullivan-monteiro/ga.tests.ui.pr
| Fixed issue or discussion?     | Fixes #39764
| Related PRs       |
| Sponsor company   |