### PR TITLE
Fix theme export crash when a custom language is installed

### DIFF
--- a/src/Core/Addon/Theme/ThemeExporter.php
+++ b/src/Core/Addon/Theme/ThemeExporter.php
@@ -6,6 +6,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Addon\Theme;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShopBundle\Entity\Repository\LangRepository;
 use PrestaShopBundle\Translation\Exporter\ThemeExporter as TranslationsExporter;
@@ -117,7 +118,16 @@ class ThemeExporter
         $catalogueDir = '';
         foreach ($languages as $lang) {
             $locale = $lang->getLocale();
-            $catalogueDir = $this->translationsExporter->exportCatalogues($theme->getName(), $locale);
+            try {
+                $catalogueDir = $this->translationsExporter->exportCatalogues($theme->getName(), $locale);
+            } catch (Exception) {
+                // Skip languages whose translation catalogues cannot be exported (e.g. custom languages
+                // without associated translation files).
+            }
+        }
+
+        if (empty($catalogueDir)) {
+            return;
         }
 
         $catalogueDirParts = explode(DIRECTORY_SEPARATOR, $catalogueDir);

--- a/tests/Unit/Core/Addon/Theme/ThemeExporterTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeExporterTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Addon\Theme;
+
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeExporter;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShopBundle\Entity\Lang;
+use PrestaShopBundle\Entity\Repository\LangRepository;
+use PrestaShopBundle\Translation\Exporter\ThemeExporter as TranslationsExporter;
+use Symfony\Component\Filesystem\Filesystem;
+
+class ThemeExporterTest extends TestCase
+{
+    private const THEME_NAME = 'classic';
+    private const CACHE_DIR = '/tmp/ps_cache/';
+    private const THEMES_DIR = '/tmp/ps_themes/';
+
+    /**
+     * @var ConfigurationInterface&MockObject
+     */
+    private $configuration;
+
+    /**
+     * @var Filesystem&MockObject
+     */
+    private $fileSystem;
+
+    /**
+     * @var LangRepository&MockObject
+     */
+    private $langRepository;
+
+    /**
+     * @var TranslationsExporter&MockObject
+     */
+    private $translationsExporter;
+
+    protected function setUp(): void
+    {
+        $this->configuration = $this->createMock(ConfigurationInterface::class);
+        $this->configuration->method('get')->willReturnMap([
+            ['_PS_CACHE_DIR_', null, null, self::CACHE_DIR],
+            ['_PS_ALL_THEMES_DIR_', null, null, self::THEMES_DIR],
+            ['_PS_MODULE_DIR_', null, null, '/tmp/ps_modules/'],
+        ]);
+
+        $this->fileSystem = $this->createMock(Filesystem::class);
+        $this->langRepository = $this->createMock(LangRepository::class);
+        $this->translationsExporter = $this->createMock(TranslationsExporter::class);
+    }
+
+    public function testExportDoesNotThrowWhenAllLanguagesAreCustom(): void
+    {
+        $customLang = $this->createLang('xy_XY');
+
+        $this->langRepository->method('findAll')->willReturn([$customLang]);
+
+        $this->translationsExporter
+            ->method('exportCatalogues')
+            ->willThrowException(new Exception('No translation files found for locale xy_XY'));
+
+        $exporter = $this->buildExporter();
+
+        // copyTranslations must not throw even if exportCatalogues fails for every language
+        $exporter->copyTranslations($this->createTheme(), self::CACHE_DIR);
+
+        // mirror must NOT be called when no catalogue could be exported
+        $this->fileSystem->expects($this->never())->method('mirror');
+
+        $exporter->copyTranslations($this->createTheme(), self::CACHE_DIR);
+    }
+
+    public function testExportSkipsCustomLanguageAndContinues(): void
+    {
+        $standardLang = $this->createLang('fr_FR');
+        $customLang = $this->createLang('xy_XY');
+
+        $this->langRepository->method('findAll')->willReturn([$customLang, $standardLang]);
+
+        $this->translationsExporter
+            ->method('exportCatalogues')
+            ->willReturnCallback(function (string $themeName, string $locale): string {
+                if ($locale === 'xy_XY') {
+                    throw new Exception('No translation files found for locale xy_XY');
+                }
+
+                return '/tmp/export/' . $themeName . '/' . $locale;
+            });
+
+        $this->fileSystem->expects($this->once())->method('mirror');
+
+        $this->buildExporter()->copyTranslations($this->createTheme(), self::CACHE_DIR);
+    }
+
+    public function testExportMirrorsCataloguesWhenAllLanguagesSucceed(): void
+    {
+        $this->langRepository->method('findAll')->willReturn([
+            $this->createLang('en_US'),
+            $this->createLang('fr_FR'),
+        ]);
+
+        $this->translationsExporter
+            ->method('exportCatalogues')
+            ->willReturnCallback(fn (string $themeName, string $locale) => '/tmp/export/' . $themeName . '/' . $locale);
+
+        $this->fileSystem->expects($this->once())->method('mirror');
+
+        $this->buildExporter()->copyTranslations($this->createTheme(), self::CACHE_DIR);
+    }
+
+    public function testExportDoesNotMirrorWhenNoLanguages(): void
+    {
+        $this->langRepository->method('findAll')->willReturn([]);
+
+        $this->translationsExporter->expects($this->never())->method('exportCatalogues');
+        $this->fileSystem->expects($this->never())->method('mirror');
+
+        $this->buildExporter()->copyTranslations($this->createTheme(), self::CACHE_DIR);
+    }
+
+    private function buildExporter(): ThemeExporter
+    {
+        $configuration = $this->configuration;
+        $fileSystem = $this->fileSystem;
+        $langRepository = $this->langRepository;
+        $translationsExporter = $this->translationsExporter;
+
+        return new class($configuration, $fileSystem, $langRepository, $translationsExporter) extends ThemeExporter {
+            public function copyTranslations(Theme $theme, $cacheDir): void
+            {
+                parent::copyTranslations($theme, $cacheDir);
+            }
+        };
+    }
+
+    private function createTheme(): Theme
+    {
+        return new Theme(
+            ['name' => self::THEME_NAME, 'directory' => '/tmp/themes/classic/'],
+            '',
+            ''
+        );
+    }
+
+    private function createLang(string $locale): Lang
+    {
+        $lang = $this->createMock(Lang::class);
+        $lang->method('getLocale')->willReturn($locale);
+
+        return $lang;
+    }
+}


### PR DESCRIPTION
| Questions                      | Answers
| ------------------------------ | -------------------------------------------------------
| Branch?                        | develop
| Description?                   | See details below.
| Type?                          | bug fix
| Category?                      | BO
| BC breaks?                     | no
| Deprecations?                  | no
| How to test?                   | 1. Go to BO > International > Localization > Languages. 2. Create a custom language (any name, any ISO code not from an official pack). 3. Go to BO > Design > Theme & Logo. 4. Click **Export current theme**. 5. Verify the ZIP is downloaded without any exception. Before this fix: a 500 error / unhandled exception is displayed. After this fix: the theme is exported normally; the custom language is silently skipped.
| UI Tests                       | https://github.com/hschoenenberger/ga.tests.ui.pr/actions/runs/23140949182
| Fixed issue or discussion?     | Fixes #29508
| Related PRs                    | N/A
| Sponsor company                | N/A

---

## Context

When a custom language is created manually in the back office (BO > International > Localization > Languages) without using an official PrestaShop language pack, it has no associated translation files on disk and no entries in the translation catalogues.

When the merchant then clicks **Export current theme** (BO > Design > Theme & Logo), `ThemeExporter::copyTranslations()` iterates over every installed language and calls `TranslationsExporter::exportCatalogues()` for each one. For a custom locale, this call throws an unhandled `Exception` (originating deep in the translation extraction chain) that propagates all the way up to `ThemeController::exportAction()`, which has no try/catch — resulting in a raw 500 error page instead of a ZIP download.

The bug has been reproduced on 1.7.7.8, 1.7.8.7 and 8.0.0-beta and is confirmed as **Verified** in the issue.

## Root cause

Two problems in `ThemeExporter::copyTranslations()` (`src/Core/Addon/Theme/ThemeExporter.php`):

1. **No per-language exception handling.** `exportCatalogues()` is called inside a bare `foreach` with no try/catch. Any exception thrown for one language aborts the entire export.

2. **Unsafe `mirror()` call when `$catalogueDir` stays empty.** If *every* installed language is custom and every call fails, `$catalogueDir` remains `''`. The subsequent `explode(DIRECTORY_SEPARATOR, '')` + `Filesystem::mirror('', ...)` would produce a second crash.

## Proposed solution

**`src/Core/Addon/Theme/ThemeExporter.php`**

- Wrap `exportCatalogues()` in a per-iteration `try/catch (Exception)`. A language whose catalogue cannot be exported is skipped silently; the loop continues for remaining languages.
- Add an early `return` after the loop when `$catalogueDir` is still empty (all languages failed or no languages were installed), preventing the unsafe `mirror()` call.

```diff
+use Exception;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 ...

         $catalogueDir = '';
         foreach ($languages as $lang) {
             $locale = $lang->getLocale();
-            $catalogueDir = $this->translationsExporter->exportCatalogues($theme->getName(), $locale);
+            try {
+                $catalogueDir = $this->translationsExporter->exportCatalogues($theme->getName(), $locale);
+            } catch (Exception) {
+                // Skip languages whose translation catalogues cannot be exported (e.g. custom languages
+                // without associated translation files).
+            }
         }
+
+        if (empty($catalogueDir)) {
+            return;
+        }
+
         $catalogueDirParts = explode(DIRECTORY_SEPARATOR, $catalogueDir);
```

## Alternatives considered

- **Validate the locale before calling `exportCatalogues()`** — would require querying the filesystem or the translation provider to check whether resources exist for a locale. More complex, tightly coupled to internals, and brittle if the storage strategy changes.
- **Catch the exception in `ThemeController::exportAction()` and show a flash error** — addresses the symptom but not the root cause; the export would still fail entirely. Better to let the export succeed and skip the untranslatable language.
- **Propagate a dedicated checked exception from `exportCatalogues()`** — correct long-term, but a larger refactor outside the scope of a minor bug fix.

## Tests added

New file: `tests/Unit/Core/Addon/Theme/ThemeExporterTest.php`

| Test | Scenario |
|------|----------|
| `testExportDoesNotThrowWhenAllLanguagesAreCustom` | All installed languages throw in `exportCatalogues()` → no exception, `mirror()` never called |
| `testExportSkipsCustomLanguageAndContinues` | One custom language fails, one standard language succeeds → `mirror()` called once |
| `testExportMirrorsCataloguesWhenAllLanguagesSucceed` | All languages succeed → `mirror()` called once (nominal path) |
| `testExportDoesNotMirrorWhenNoLanguages` | No languages installed → neither `exportCatalogues()` nor `mirror()` called |

Run with:
```bash
php vendor/bin/phpunit tests/Unit/Core/Addon/Theme/ThemeExporterTest.php
```

## Contribution checklist

- [x] Branch targets `develop`
- [x] `php-cs-fixer` passes with no violations (`@Symfony` ruleset)
- [x] 4 unit tests added, all green
- [x] No BC break (only internal behaviour change in a `protected` method)
- [x] No deprecations introduced
- [x] Fixes #29508