### PR TITLE
Allow configuring payment restrictions for disabled currencies

### DIFF
--- a/src/Adapter/Currency/CurrencyDataProvider.php
+++ b/src/Adapter/Currency/CurrencyDataProvider.php
@@ -45,7 +45,7 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
      */
     public function getCurrencies($object = false, $active = true, $group_by = false)
     {
-        return Currency::getCurrencies($object = false, $active = true, $group_by = false);
+        return Currency::getCurrencies($object, $active, $group_by);
     }
 
     /**

--- a/src/Core/Form/ChoiceProvider/CurrencyByIdChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/CurrencyByIdChoiceProvider.php
@@ -21,11 +21,18 @@ final class CurrencyByIdChoiceProvider implements FormChoiceProviderInterface, F
     private $currencyDataProvider;
 
     /**
-     * @param CurrencyDataProviderInterface $currencyDataProvider
+     * @var bool
      */
-    public function __construct(CurrencyDataProviderInterface $currencyDataProvider)
+    private $activeOnly;
+
+    /**
+     * @param CurrencyDataProviderInterface $currencyDataProvider
+     * @param bool $activeOnly When false, inactive (but not deleted) currencies are included
+     */
+    public function __construct(CurrencyDataProviderInterface $currencyDataProvider, bool $activeOnly = true)
     {
         $this->currencyDataProvider = $currencyDataProvider;
+        $this->activeOnly = $activeOnly;
     }
 
     /**
@@ -61,6 +68,6 @@ final class CurrencyByIdChoiceProvider implements FormChoiceProviderInterface, F
 
     private function getCurrencies(): array
     {
-        return $this->currencyDataProvider->getCurrencies(false, true, true);
+        return $this->currencyDataProvider->getCurrencies(false, $this->activeOnly, true);
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -145,6 +145,7 @@ services:
       $countryChoices: '@=service("prestashop.core.form.choice_provider.country_by_id").getChoices()'
       $groupChoices: '@=service("prestashop.core.form.choice_provider.group_by_id").getChoices()'
       $carrierChoices: '@=service("prestashop.core.form.choice_provider.carrier_by_reference_id").getChoices()'
+      $currencyChoicesProvider: '@prestashop.core.form.choice_provider.currency_by_id.with_inactive'
       $countryDataProvider: '@prestashop.adapter.data_provider.country'
 
   PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Email\EmailConfigurationType:

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -16,6 +16,11 @@ services:
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider:
     public: true
 
+  prestashop.core.form.choice_provider.currency_by_id.with_inactive:
+    class: PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider
+    arguments:
+      $activeOnly: false
+
   PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageChoiceProvider:
     arguments:
       $languages: '@=service("prestashop.adapter.data_provider.language").getLanguages(false)'

--- a/tests/Unit/Core/Form/ChoiceProvider/CurrencyByIdChoiceProviderTest.php
+++ b/tests/Unit/Core/Form/ChoiceProvider/CurrencyByIdChoiceProviderTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\ChoiceProvider;
+
+use PrestaShop\PrestaShop\Core\Currency\CurrencyDataProviderInterface;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CurrencyByIdChoiceProvider;
+
+class CurrencyByIdChoiceProviderTest extends ChoiceProviderTestCase
+{
+    private const ACTIVE_CURRENCIES = [
+        ['id_currency' => 1, 'name' => 'Euro', 'iso_code' => 'EUR', 'symbol' => '€'],
+        ['id_currency' => 2, 'name' => 'US Dollar', 'iso_code' => 'USD', 'symbol' => '$'],
+    ];
+
+    private const ALL_CURRENCIES = [
+        ['id_currency' => 1, 'name' => 'Euro', 'iso_code' => 'EUR', 'symbol' => '€'],
+        ['id_currency' => 2, 'name' => 'US Dollar', 'iso_code' => 'USD', 'symbol' => '$'],
+        ['id_currency' => 3, 'name' => 'British Pound', 'iso_code' => 'GBP', 'symbol' => '£'],
+    ];
+
+    public function testGetChoicesReturnsOnlyActiveCurrenciesByDefault(): void
+    {
+        $provider = new CurrencyByIdChoiceProvider(
+            $this->buildDataProviderMock(true, self::ACTIVE_CURRENCIES)
+        );
+
+        $this->assertSame(
+            ['Euro (EUR)' => 1, 'US Dollar (USD)' => 2],
+            $provider->getChoices()
+        );
+    }
+
+    public function testGetChoicesIncludesInactiveCurrenciesWhenActiveOnlyIsFalse(): void
+    {
+        $provider = new CurrencyByIdChoiceProvider(
+            $this->buildDataProviderMock(false, self::ALL_CURRENCIES),
+            false
+        );
+
+        $this->assertSame(
+            ['Euro (EUR)' => 1, 'US Dollar (USD)' => 2, 'British Pound (GBP)' => 3],
+            $provider->getChoices()
+        );
+    }
+
+    public function testGetChoicesAttributesReturnsSymbolsForActiveCurrencies(): void
+    {
+        $provider = new CurrencyByIdChoiceProvider(
+            $this->buildDataProviderMock(true, self::ACTIVE_CURRENCIES)
+        );
+
+        $this->assertSame(
+            ['Euro (EUR)' => ['symbol' => '€'], 'US Dollar (USD)' => ['symbol' => '$']],
+            $provider->getChoicesAttributes()
+        );
+    }
+
+    public function testGetChoicesAttributesReturnsSymbolsIncludingInactiveCurrencies(): void
+    {
+        $provider = new CurrencyByIdChoiceProvider(
+            $this->buildDataProviderMock(false, self::ALL_CURRENCIES),
+            false
+        );
+
+        $this->assertSame(
+            [
+                'Euro (EUR)' => ['symbol' => '€'],
+                'US Dollar (USD)' => ['symbol' => '$'],
+                'British Pound (GBP)' => ['symbol' => '£'],
+            ],
+            $provider->getChoicesAttributes()
+        );
+    }
+
+    private function buildDataProviderMock(bool $activeOnly, array $returnedCurrencies): CurrencyDataProviderInterface
+    {
+        $mock = $this->createMock(CurrencyDataProviderInterface::class);
+        $mock->expects($this->once())
+            ->method('getCurrencies')
+            ->with(false, $activeOnly, true)
+            ->willReturn($returnedCurrencies);
+
+        return $mock;
+    }
+}


### PR DESCRIPTION


Fixes #40586

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Previously, CurrencyByIdChoiceProvider always fetched active currencies only (active=1), because CurrencyDataProvider::getCurrencies() ignored its $active parameter and hardcoded true. This prevented merchants from pre-configuring payment module restrictions for a disabled currency.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      |   Steps to test:  1. Go to Back Office > International > Localizations > Currencies and ensure at least one currency is disabled (not deleted). 2. Go to Back Office > Payment > Payment Methods > Preferences. 3. Verify that disabled currencies appear in the currency restrictions table, alongside active ones. 4. Configure a currency restriction for the disabled currency and save. 5. Verify the restriction is saved correctly. 6. Re-enable the currency and verify the restriction still applies.
| UI Tests          | https://github.com/antoinemetifeu/ga.tests.ui.pr/actions/runs/23140818238
| Fixed issue or discussion?     | Fixes #40586
| Related PRs       | 
| Sponsor company   | PrestaShop
