### PR TITLE
Disabled discount when only customer or customer group is deleted

### DIFF
--- a/admin-dev/themes/new-theme/js/components/form/customer-search-input.ts
+++ b/admin-dev/themes/new-theme/js/components/form/customer-search-input.ts
@@ -16,7 +16,11 @@ export default class CustomerSearchInput extends EntitySearchInput {
     shopIdCallback: () => number|null,
     disablingSwitchEvent?: string|undefined,
   ) {
-    super($(customerSearchContainer), {
+    const $container = $(customerSearchContainer);
+    const disabledBadgeLabel: string = $container.data('disabledBadgeLabel') as string;
+    const guestBadgeLabel: string = $container.data('guestBadgeLabel') as string;
+
+    super($container, {
       extraQueryParams: () => ({
         shopId: shopIdCallback(),
       }),
@@ -27,7 +31,16 @@ export default class CustomerSearchInput extends EntitySearchInput {
 
         return Object.values(response.customers);
       },
+      suggestionTemplate: (entity: any) => {
+        const guestBadge = String(entity.is_guest) === '1'
+          ? `<span class="customer-suggestion-guest-badge badge badge-pill badge-secondary">${guestBadgeLabel}</span> `
+          : '';
+        const disabledBadge = String(entity.active) === '0'
+          ? ` <span class="customer-suggestion-disabled-badge badge badge-pill badge-secondary">${disabledBadgeLabel}</span>`
+          : '';
 
+        return `<div class="search-suggestion">${guestBadge}${entity.fullname_and_email}${disabledBadge}</div>`;
+      },
     });
     this.disablingSwitchEvent = disablingSwitchEvent;
     this.customerItemSelector = customerItemSelector;

--- a/admin-dev/themes/new-theme/scss/pages/_discount.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_discount.scss
@@ -22,6 +22,45 @@
   }
 }
 
+.entity-search-widget {
+  .customer-disabled-badge,
+  .customer-guest-badge {
+    display: none;
+    color: $gray-800;
+  }
+
+  .customer-disabled-badge {
+    margin-right: 0.25rem;
+    margin-left: auto;
+  }
+
+  .customer-guest-badge {
+    margin-right: 0.5rem;
+  }
+
+  [data-customer-active="0"] .customer-disabled-badge {
+    display: inline-block;
+  }
+
+  [data-customer-guest="1"] .customer-guest-badge {
+    display: inline-block;
+  }
+
+  .customer-suggestion-disabled-badge,
+  .customer-suggestion-guest-badge {
+    display: none;
+    margin-left: 0.35rem;
+    color: $gray-800;
+  }
+
+  .tt-suggestion {
+    .customer-suggestion-disabled-badge,
+    .customer-suggestion-guest-badge {
+      display: inline-block;
+    }
+  }
+}
+
 .specific-product-item {
   .form-group {
     margin-bottom: 0;

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -458,18 +458,22 @@ class CartRuleCore extends ObjectModel
          * Remove cart rule that does not match the customer groups.
          * Even if empty $id_customer was provided, we will still get
          * a visitor group.
+         * When the groups feature is inactive the restriction is ignored dynamically
+         * (handled in checkValidity), so we keep all rules here.
          */
-        $customerGroups = Customer::getGroupsStatic($id_customer);
+        if (Group::isFeatureActive()) {
+            $customerGroups = Customer::getGroupsStatic($id_customer);
 
-        foreach ($result as $key => $cart_rule) {
-            if ($cart_rule['group_restriction']) {
-                $cartRuleGroups = Db::getInstance()->executeS('SELECT id_group FROM ' . _DB_PREFIX_ . 'cart_rule_group WHERE id_cart_rule = ' . (int) $cart_rule['id_cart_rule']);
-                foreach ($cartRuleGroups as $cartRuleGroup) {
-                    if (in_array($cartRuleGroup['id_group'], $customerGroups)) {
-                        continue 2;
+            foreach ($result as $key => $cart_rule) {
+                if ($cart_rule['group_restriction']) {
+                    $cartRuleGroups = Db::getInstance()->executeS('SELECT id_group FROM ' . _DB_PREFIX_ . 'cart_rule_group WHERE id_cart_rule = ' . (int) $cart_rule['id_cart_rule']);
+                    foreach ($cartRuleGroups as $cartRuleGroup) {
+                        if (in_array($cartRuleGroup['id_group'], $customerGroups)) {
+                            continue 2;
+                        }
                     }
+                    unset($result[$key]);
                 }
-                unset($result[$key]);
             }
         }
 
@@ -834,6 +838,9 @@ class CartRuleCore extends ObjectModel
 
         // Get an intersection of the customer groups and the cart rule groups (if the customer is not logged in, the default group is Visitors)
         if ($this->group_restriction) {
+            if (!Group::isFeatureActive()) {
+                return (!$display_error) ? false : $this->trans('You cannot use this voucher', [], 'Shop.Notifications.Error');
+            }
             $id_cart_rule = (int) Db::getInstance()->getValue('
 			SELECT crg.id_cart_rule
 			FROM ' . _DB_PREFIX_ . 'cart_rule_group crg
@@ -2012,7 +2019,7 @@ class CartRuleCore extends ObjectModel
 		)
 		AND (
 			cr.`group_restriction` = 0
-			' . (Validate::isLoadedObject($context->customer) ? 'OR EXISTS (
+			' . (Group::isFeatureActive() && Validate::isLoadedObject($context->customer) ? 'OR EXISTS (
 				SELECT 1
 				FROM `' . _DB_PREFIX_ . 'customer_group` cg
 				INNER JOIN `' . _DB_PREFIX_ . 'cart_rule_group` crg ON cg.id_group = crg.id_group

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -3,6 +3,9 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
+use PrestaShop\PrestaShop\Adapter\CartRule\CartRuleDisablerService;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+
 class GroupCore extends ObjectModel
 {
     public $id;
@@ -209,6 +212,16 @@ class GroupCore extends ObjectModel
         }
 
         if (parent::delete()) {
+            // Delegate to the disabler service so the legacy AdminGroupsController delete flow
+            // gets the same behavior as the CQRS DeleteCustomerGroupHandler. Must run before
+            // the cart_rule_group cleanup below, since the service uses those rows to find
+            // single-group cart rules.
+            $container = SymfonyContainer::getInstance();
+            if (null !== $container) {
+                $container->get(CartRuleDisablerService::class)
+                    ->disableCartRulesThatHadOnlyGroup((int) $this->id);
+            }
+
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'cart_rule_group` WHERE `id_group` = ' . (int) $this->id);
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'customer_group` WHERE `id_group` = ' . (int) $this->id);
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'category_group` WHERE `id_group` = ' . (int) $this->id);

--- a/src/Adapter/CartRule/CartRuleDisablerService.php
+++ b/src/Adapter/CartRule/CartRuleDisablerService.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\CartRule;
+
+use CartRule;
+use Db;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
+use PrestaShopCollection;
+
+/**
+ * Handles disabling of cart rules when their eligibility conditions are removed
+ * (e.g. a customer or customer group is deleted).
+ */
+class CartRuleDisablerService
+{
+    public function __construct(
+        private readonly FeatureFlagStateCheckerInterface $featureFlagStateChecker,
+    ) {
+    }
+
+    /**
+     * On customer deletion: disable cart rules that were restricted to this customer.
+     * Resets the customer restriction so the discount is no longer tied to the deleted customer,
+     * and disables it so the merchant can review and re-enable it manually.
+     *
+     * @param int $customerId
+     */
+    public function disableCartRulesThatHadCustomer(int $customerId): bool
+    {
+        if (!$this->featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_DISCOUNT)) {
+            return true;
+        }
+
+        if (empty($customerId)) {
+            return false;
+        }
+
+        $cartRules = new PrestaShopCollection('CartRule');
+        $cartRules->where('id_customer', '=', $customerId);
+
+        $result = true;
+        foreach ($cartRules as $cartRule) {
+            $cartRule->id_customer = 0;
+            $cartRule->active = false;
+            $result = $cartRule->update() && $result;
+        }
+
+        return $result;
+    }
+
+    /**
+     * On group deletion: disable cart rules that had only this group as their restriction.
+     * Clears the group restriction and disables the discount so the merchant can review it.
+     * Must be called BEFORE the group rows are removed from the cart_rule_group table.
+     *
+     * @param int $groupId
+     */
+    public function disableCartRulesThatHadOnlyGroup(int $groupId): bool
+    {
+        if (!$this->featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_DISCOUNT)) {
+            return true;
+        }
+
+        if (empty($groupId)) {
+            return false;
+        }
+
+        $prefix = _DB_PREFIX_;
+        $db = Db::getInstance();
+
+        $cartRuleIds = $db->executeS(
+            'SELECT crg.`id_cart_rule`
+            FROM `' . $prefix . 'cart_rule_group` crg
+            INNER JOIN `' . $prefix . 'cart_rule` cr ON cr.`id_cart_rule` = crg.`id_cart_rule` AND cr.`group_restriction` = 1
+            WHERE crg.`id_group` = ' . (int) $groupId . '
+            AND crg.`id_cart_rule` IN (
+                SELECT `id_cart_rule` FROM `' . $prefix . 'cart_rule_group` GROUP BY `id_cart_rule` HAVING COUNT(*) = 1
+            )'
+        );
+
+        if (empty($cartRuleIds)) {
+            return true;
+        }
+
+        $result = true;
+        foreach ($cartRuleIds as $row) {
+            $cartRule = new CartRule((int) $row['id_cart_rule']);
+            $cartRule->group_restriction = false;
+            $cartRule->active = false;
+            $result = $cartRule->update() && $result;
+        }
+
+        return $result;
+    }
+}

--- a/src/Adapter/Customer/CommandHandler/DeleteCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/DeleteCustomerHandler.php
@@ -7,6 +7,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Customer\CommandHandler;
 
 use Customer;
+use PrestaShop\PrestaShop\Adapter\CartRule\CartRuleDisablerService;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\DeleteCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\CommandHandler\DeleteCustomerHandlerInterface;
@@ -19,6 +20,11 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\CommandHandler\DeleteCustomerHand
 #[AsCommandHandler]
 final class DeleteCustomerHandler extends AbstractCustomerHandler implements DeleteCustomerHandlerInterface
 {
+    public function __construct(
+        private readonly CartRuleDisablerService $cartRuleDisablerService,
+    ) {
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -28,6 +34,11 @@ final class DeleteCustomerHandler extends AbstractCustomerHandler implements Del
         $customer = new Customer($customerId->getValue());
 
         $this->assertCustomerWasFound($customerId, $customer);
+
+        // When the discount feature flag is enabled, disable cart rules restricted to this customer
+        // instead of deleting them, so the merchant can review and re-enable them manually.
+        // This runs before both the hard-delete and soft-delete paths.
+        $this->cartRuleDisablerService->disableCartRulesThatHadCustomer($customerId->getValue());
 
         if ($command->getDeleteMethod()->isAllowedToRegisterAfterDelete()) {
             $customer->delete();

--- a/src/Adapter/Customer/Group/CommandHandler/DeleteCustomerGroupHandler.php
+++ b/src/Adapter/Customer/Group/CommandHandler/DeleteCustomerGroupHandler.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Customer\Group\CommandHandler;
 
+use PrestaShop\PrestaShop\Adapter\CartRule\CartRuleDisablerService;
 use PrestaShop\PrestaShop\Adapter\Customer\Group\Repository\GroupRepository;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Command\DeleteCustomerGroupCommand;
@@ -18,11 +19,17 @@ class DeleteCustomerGroupHandler implements DeleteCustomerGroupHandlerInterface
 {
     public function __construct(
         private readonly GroupRepository $customerGroupRepository,
+        private readonly CartRuleDisablerService $cartRuleDisablerService,
     ) {
     }
 
     public function handle(DeleteCustomerGroupCommand $command): void
     {
+        // Disable affected cart rules before removing the group rows from cart_rule_group,
+        // so the query that finds single-group rules can still run.
+        $this->cartRuleDisablerService->disableCartRulesThatHadOnlyGroup(
+            $command->getCustomerGroupId()->getValue()
+        );
         $this->customerGroupRepository->delete($command->getCustomerGroupId());
     }
 }

--- a/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
+++ b/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
@@ -81,10 +81,6 @@ final class SearchCustomersHandler implements SearchCustomersHandlerInterface
             }
 
             foreach ($customersResult as $customerArray) {
-                if (!$customerArray['active']) {
-                    continue;
-                }
-
                 $customerArray['fullname_and_email'] = sprintf(
                     '%s %s - %s',
                     $customerArray['firstname'],

--- a/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/DiscountFormDataProvider.php
@@ -460,6 +460,8 @@ class DiscountFormDataProvider implements FormDataProviderInterface
                     [
                         'id_customer' => $customerId,
                         'fullname_and_email' => $fullnameAndEmail,
+                        'active' => (int) $customer->active,
+                        'is_guest' => (int) $customer->is_guest,
                     ],
                 ];
             } catch (CustomerNotFoundException $e) {

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/SearchedCustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/SearchedCustomerType.php
@@ -26,6 +26,12 @@ class SearchedCustomerType extends CommonAbstractType
             ->add('fullname_and_email', TextPreviewType::class, [
                 'label' => false,
             ])
+            ->add('active', HiddenType::class, [
+                'label' => false,
+            ])
+            ->add('is_guest', HiddenType::class, [
+                'label' => false,
+            ])
         ;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountCustomerEligibilityChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Discount/DiscountCustomerEligibilityChoiceType.php
@@ -71,7 +71,7 @@ class DiscountCustomerEligibilityChoiceType extends TranslatorAwareType
                 'layout' => EntitySearchInputType::LIST_LAYOUT,
                 'required' => false,
                 'disabling_switch' => false,
-                'exclude_guests' => true,
+                'exclude_guests' => false,
                 'constraints' => [
                     new When(
                         expression: sprintf(

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomerSearchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomerSearchType.php
@@ -47,6 +47,10 @@ class CustomerSearchType extends EntitySearchInputType
             'suggestion_field' => 'fullname_and_email',
             'required' => false,
             'exclude_guests' => false,
+            'attr' => [
+                'data-disabled-badge-label' => $this->trans('Disabled', 'Admin.Global'),
+                'data-guest-badge-label' => $this->trans('Guest', 'Admin.Shopparameters.Feature'),
+            ],
         ]);
 
         $resolver->setAllowedTypes('exclude_guests', 'bool');

--- a/src/PrestaShopBundle/Resources/config/services/adapter/cart_rule.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/cart_rule.yml
@@ -7,3 +7,6 @@ services:
     autoconfigure: true
     arguments:
       - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
+
+  PrestaShop\PrestaShop\Adapter\CartRule\CartRuleDisablerService:
+    autowire: true

--- a/src/PrestaShopBundle/Resources/config/services/adapter/customer.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/customer.yml
@@ -56,6 +56,7 @@ services:
 
   prestashop.adapter.customer.command_handler.delete_customer_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Customer\CommandHandler\DeleteCustomerHandler'
+    autowire: true
     autoconfigure: true
 
   prestashop.adapter.customer.command_handler.bulk_delete_customer_handler:

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/EmptyState/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/EmptyState/customer.html.twig
@@ -1,0 +1,17 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+
+<div class="text-center showcase-list-card">
+  <p class="mt-4">
+    {{ 'No customer information available yet.'|trans({}, 'Admin.Orderscustomers.Feature') }}
+  </p>
+
+  <div class="mt-4">
+    <a href="{{ path('admin_customers_create') }}" class="btn btn-primary ml-1">
+      <i class="material-icons">add_circle_outline</i>
+      {{ 'Add new customer'|trans({}, 'Admin.Orderscustomers.Feature') }}
+    </a>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/entity_search_input.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/entity_search_input.html.twig
@@ -136,12 +136,20 @@
 {%- endblock -%}
 
 {% block searched_customer_row %}
-  {% set attr = attr|merge({class: (attr.class|default('') ~ ' media entity-item')|trim}) %}
+  {%- set attr = attr|merge({
+    class: (attr.class|default('') ~ ' media entity-item')|trim,
+    'data-customer-active': form.active.vars.value,
+    'data-customer-guest': form.is_guest.vars.value
+  }) -%}
   <li {{ block('widget_container_attributes') }}>
+    <span class="customer-guest-badge badge badge-pill badge-secondary">{{ 'Guest'|trans({}, 'Admin.Shopparameters.Feature') }}</span>
     <div class="media-body media-middle">
       {{ form_widget(form.fullname_and_email) }}
-      <i class="material-icons entity-item-delete">clear</i>
     </div>
+    <span class="customer-disabled-badge badge badge-pill badge-secondary">{{ 'Disabled'|trans({}, 'Admin.Global') }}</span>
+    <i class="material-icons entity-item-delete">clear</i>
     {{ form_widget(form.id_customer) }}
+    {{ form_widget(form.active) }}
+    {{ form_widget(form.is_guest) }}
   </li>
 {% endblock %}

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -19,6 +19,7 @@ use Exception;
 use PHPUnit\Framework\Assert;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Discount\Repository\DiscountRepository;
+use PrestaShop\PrestaShop\Adapter\Discount\Update\DiscountConditionsUpdater;
 use PrestaShop\PrestaShop\Core\Domain\CartRule\Exception\CartRuleValidityException;
 use PrestaShop\PrestaShop\Core\Domain\Discount\DiscountSettings;
 use PrestaShop\PrestaShop\Core\Domain\Discount\ValueObject\DiscountId;
@@ -160,6 +161,13 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
                 $countryIds = $this->referencesToIds($data['countries']);
                 $this->setCartRuleCountries($cartRule, $countryIds);
             }
+            if (isset($data['customer'])) {
+                $cartRule->id_customer = $this->referenceToId($data['customer']);
+                $cartRule->save();
+            }
+            if (isset($data['groups'])) {
+                $this->setCartRuleGroups($cartRule, $this->referencesToIds($data['groups']));
+            }
         } else {
             Assert::assertEquals($cartRule->name, $data['name'], 'Unexpected cart rule name');
             Assert::assertEquals($cartRule->description, $data['description'] ?? '', 'Unexpected cart rule description');
@@ -219,7 +227,7 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
         unset($data['priority'], $data['total_quantity'], $data['quantity_per_user'], $data['code'], $data['free_shipping'], $data['allow_partial_use'], $data['active']);
         unset($data['valid_from'], $data['valid_to'], $data['apply_to_discounted_products'], $data['gift_product']);
         unset($data['minimum_amount'], $data['minimum_amount_currency'], $data['minimum_amount_tax_included'], $data['minimum_amount_shipping_included'], $data['discount_product']);
-        unset($data['quantity'], $data['cheapest_product'], $data['carriers'], $data['countries']);
+        unset($data['quantity'], $data['cheapest_product'], $data['carriers'], $data['countries'], $data['customer'], $data['groups']);
         if (!empty($data)) {
             throw new RuntimeException(sprintf('There are fields that were not handled in cart rule creation: %s', implode(',', array_keys($data))));
         }
@@ -292,6 +300,14 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
         }
         $cartRule->country_restriction = !empty($countryIds);
         $cartRule->save();
+    }
+
+    protected function setCartRuleGroups(CartRule $cartRule, array $groupIds): void
+    {
+        $cartRule->group_restriction = true;
+        $cartRule->save();
+        $updater = CommonFeatureContext::getContainer()->get(DiscountConditionsUpdater::class);
+        $updater->update(new DiscountId((int) $cartRule->id), null, null, null, $groupIds);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Configuration/CommonConfigurationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Configuration/CommonConfigurationFeatureContext.php
@@ -8,6 +8,9 @@ namespace Tests\Integration\Behaviour\Features\Context\Configuration;
 
 use Configuration;
 use Country;
+use Group;
+use PrestaShop\PrestaShop\Adapter\Feature\GroupFeature;
+use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 use Tools;
@@ -50,6 +53,27 @@ class CommonConfigurationFeatureContext extends AbstractConfigurationFeatureCont
     public function activateGroupFeature()
     {
         Configuration::updateGlobalValue('PS_GROUP_FEATURE_ACTIVE', '1');
+        Group::clearCachedValues();
+    }
+
+    /**
+     * @Given /^groups feature is deactivated$/
+     */
+    public function deactivateGroupFeature(): void
+    {
+        /** @var GroupFeature $groupFeature */
+        $groupFeature = CommonFeatureContext::getContainer()->get('prestashop.adapter.feature.group_feature');
+        $groupFeature->disable();
+        Group::clearCachedValues();
+    }
+
+    /**
+     * @Given the default shop is referenced as :reference
+     */
+    public function defaultShopReferencedAs(string $reference): void
+    {
+        $shopId = (int) Configuration::get('PS_SHOP_DEFAULT') ?: 1;
+        SharedStorage::getStorage()->set($reference, $shopId);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/CustomerManagerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CustomerManagerFeatureContext.php
@@ -111,6 +111,7 @@ class CustomerManagerFeatureContext extends AbstractPrestaShopFeatureContext
 
         $this->latestResult = $id->getValue();
         $this->customerRegistry[$customerReference] = $id->getValue();
+        $this->getSharedStorage()->set($customerReference, $id->getValue());
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
@@ -8,10 +8,12 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
 use Behat\Gherkin\Node\TableNode;
 use Configuration;
+use Customer;
 use Exception;
 use Group;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\AddCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Command\EditCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\SetPrivateNoteAboutCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\SetRequiredFieldsForCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
@@ -244,6 +246,18 @@ class CustomerFeatureContext extends AbstractDomainFeatureContext
     public function transformCustomers(TableNode $customersTable): array
     {
         return $customersTable->getHash();
+    }
+
+    /**
+     * @When I disable customer :customerReference
+     */
+    public function disableCustomer(string $customerReference): void
+    {
+        $command = new EditCustomerCommand($this->getSharedStorage()->get($customerReference));
+        $command->setIsEnabled(false);
+        $this->getCommandBus()->handle($command);
+
+        Customer::resetStaticCache();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Discount/DiscountFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Discount/DiscountFeatureContext.php
@@ -745,6 +745,58 @@ class DiscountFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Then discount :discountReference applies to all customers and is disabled
+     */
+    public function assertDiscountAppliesToAllCustomersAndIsDisabled(string $discountReference): void
+    {
+        $discount = $this->getDiscountForEditing($discountReference);
+        Assert::assertNull(
+            $discount->getCustomerId(),
+            sprintf('Discount "%s" should apply to all customers (no customer restriction)', $discountReference)
+        );
+        Assert::assertFalse(
+            $discount->isActive(),
+            sprintf('Discount "%s" should be disabled', $discountReference)
+        );
+    }
+
+    /**
+     * @Then discount :discountReference is enabled and still applies to customer :customerReference
+     */
+    public function assertDiscountIsEnabledAndStillAppliesToCustomer(string $discountReference, string $customerReference): void
+    {
+        $discount = $this->getDiscountForEditing($discountReference);
+        Assert::assertTrue(
+            $discount->isActive(),
+            sprintf('Discount "%s" should still be enabled', $discountReference)
+        );
+        $expectedCustomerId = $this->referenceToId($customerReference);
+        Assert::assertEquals(
+            $expectedCustomerId,
+            $discount->getCustomerId(),
+            sprintf('Discount "%s" should still apply to customer "%s"', $discountReference, $customerReference)
+        );
+    }
+
+    /**
+     * @Then discount :discountReference is enabled and applies only to group :groupReference
+     */
+    public function assertDiscountIsEnabledAndAppliesOnlyToGroup(string $discountReference, string $groupReference): void
+    {
+        $discount = $this->getDiscountForEditing($discountReference);
+        Assert::assertTrue(
+            $discount->isActive(),
+            sprintf('Discount "%s" should be enabled', $discountReference)
+        );
+        $expectedGroupId = $this->referenceToId($groupReference);
+        Assert::assertEquals(
+            [$expectedGroupId],
+            $discount->getCustomerGroupIds(),
+            sprintf('Discount "%s" should apply only to group "%s"', $discountReference, $groupReference)
+        );
+    }
+
+    /**
      * @Then cart :cartReference should have :count cart rules applied
      *
      * @param string $cartReference

--- a/tests/Integration/Behaviour/Features/Scenario/Discount/BO/disable_discount_when_customer_or_group_removed.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Discount/BO/disable_discount_when_customer_or_group_removed.feature
@@ -1,0 +1,115 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s discount --tags disable-discount-when-customer-or-group-removed
+# See https://github.com/PrestaShop/PrestaShop/issues/40109
+@disable-discount-when-customer-or-group-removed
+@restore-cart-rules-after-scenario
+Feature: Disable discount when the only selected customer or customer group is removed
+  When the only selected customer or the only selected customer group for a discount is removed,
+  the discount must apply to all customers but be disabled so it is no longer applied.
+
+  Background:
+    Given groups feature is activated
+    And I enable feature flag "discount"
+    And shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    And the default shop is referenced as "shop1"
+    And there is a currency named "usd" with iso code "USD" and exchange rate of 1.0
+
+  Scenario: Discount for a single customer is disabled and applies to all when that customer is deleted
+    Given I create a customer "discountCustomer" with following properties:
+      | firstName | Jean   |
+      | lastName  | Dupont |
+      | email     | jean.dupont.discount@prestashop.com |
+      | password  | PrestaShopForever1_! |
+    And I create a "cart_level" discount "discountForCustomer" with following properties:
+      | name[en-US]            | Discount for Jean    |
+      | code                   | CUST_DISCOUNT_40109  |
+      | active                 | true                 |
+      | reduction_amount       | 5                    |
+      | reduction_currency     | usd                  |
+      | reduction_tax_included | false                |
+      | customer               | discountCustomer     |
+    Then discount "discountForCustomer" is enabled and still applies to customer "discountCustomer"
+    When I delete customer "discountCustomer" and allow it to register again
+    Then discount "discountForCustomer" applies to all customers and is disabled
+
+  Scenario: Discount for a single customer stays enabled and still applies to that customer when the customer is disabled
+    Given I create a customer "disabledCustomer" with following properties:
+      | firstName | Marie  |
+      | lastName  | Martin |
+      | email     | marie.martin.discount@prestashop.com |
+      | password  | PrestaShopForever1_! |
+    And I create a "cart_level" discount "discountForDisabledCustomer" with following properties:
+      | name[en-US]            | Discount for Marie   |
+      | code                   | CUST_DISABLED_40109  |
+      | active                 | true                 |
+      | reduction_amount       | 5                    |
+      | reduction_currency     | usd                  |
+      | reduction_tax_included | false                |
+      | customer               | disabledCustomer     |
+    Then discount "discountForDisabledCustomer" is enabled and still applies to customer "disabledCustomer"
+    When I disable customer "disabledCustomer"
+    Then discount "discountForDisabledCustomer" is enabled and still applies to customer "disabledCustomer"
+
+  Scenario: Discount for only one customer group is disabled and applies to all when that group is deleted
+    Given I create a customer group "DiscountGroupA" with the following details:
+      | name[en-US]             | Discount Group A |
+      | reduction               | 0                |
+      | displayPriceTaxExcluded | true             |
+      | showPrice               | true             |
+      | shopIds                 | shop1            |
+    And I create a "cart_level" discount "discountForGroupA" with following properties:
+      | name[en-US]            | Discount for Group A   |
+      | code                   | GROUP_A_DISCOUNT_40109 |
+      | active                 | true                   |
+      | reduction_amount       | 10                     |
+      | reduction_currency     | usd                    |
+      | reduction_tax_included | false                  |
+      | customer_groups        | DiscountGroupA         |
+    Then discount "discountForGroupA" is enabled and applies only to group "DiscountGroupA"
+    When I delete customer group "DiscountGroupA"
+    Then discount "discountForGroupA" applies to all customers and is disabled
+
+  Scenario: Discount for two customer groups stays enabled and applies only to remaining group when one group is deleted
+    Given I create a customer group "DiscountGroupB" with the following details:
+      | name[en-US]             | Discount Group B |
+      | reduction               | 0                |
+      | displayPriceTaxExcluded | true             |
+      | showPrice               | true             |
+      | shopIds                 | shop1            |
+    And I create a customer group "DiscountGroupC" with the following details:
+      | name[en-US]             | Discount Group C |
+      | reduction               | 0                |
+      | displayPriceTaxExcluded | true             |
+      | showPrice               | true             |
+      | shopIds                 | shop1            |
+    And I create a "cart_level" discount "discountForGroupBOrC" with following properties:
+      | name[en-US]            | Discount for Group B or C    |
+      | code                   | GROUP_BC_DISCOUNT_40109      |
+      | active                 | true                         |
+      | reduction_amount       | 15                           |
+      | reduction_currency     | usd                          |
+      | reduction_tax_included | false                        |
+      | customer_groups        | DiscountGroupB,DiscountGroupC |
+    Then discount "discountForGroupBOrC" should have the following properties:
+      | active          | true                          |
+      | customer_groups | DiscountGroupB,DiscountGroupC |
+    When I delete customer group "DiscountGroupB"
+    Then discount "discountForGroupBOrC" is enabled and applies only to group "DiscountGroupC"
+
+  Scenario: Discount for a customer group remains active in BO but is blocked dynamically in FO when Customer groups feature is disabled
+    Given I create a customer group "DiscountGroupD" with the following details:
+      | name[en-US]             | Discount Group D |
+      | reduction               | 0                |
+      | displayPriceTaxExcluded | true             |
+      | showPrice               | true             |
+      | shopIds                 | shop1            |
+    And I create a "cart_level" discount "discountForGroupD" with following properties:
+      | name[en-US]            | Discount for Group D   |
+      | code                   | GROUP_D_DISCOUNT_40109 |
+      | active                 | true                   |
+      | reduction_amount       | 20                     |
+      | reduction_currency     | usd                    |
+      | reduction_tax_included | false                  |
+      | customer_groups        | DiscountGroupD         |
+    Then discount "discountForGroupD" is enabled and applies only to group "DiscountGroupD"
+    When groups feature is deactivated
+    Then discount "discountForGroupD" is enabled and applies only to group "DiscountGroupD"

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -99,6 +99,7 @@ default:
         - Tests\Integration\Behaviour\Features\Context\Domain\Carrier\CarrierRangesFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\ZoneFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\CustomerFeatureContext
+        - Tests\Integration\Behaviour\Features\Context\Domain\CustomerGroupFeatureContext
         - Tests\Integration\Behaviour\Features\Context\CartFeatureContext
         - Tests\Integration\Behaviour\Features\Context\CartRuleFeatureContext
         - Tests\Integration\Behaviour\Features\Context\CategoryFeatureContext
@@ -112,6 +113,7 @@ default:
         - Tests\Integration\Behaviour\Features\Context\CountryFeatureContext
         - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
         - Tests\Integration\Behaviour\Features\Context\CustomerFeatureContext
+        - Tests\Integration\Behaviour\Features\Context\CustomerManagerFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\CartFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\OrderFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
@@ -275,6 +277,7 @@ default:
         - Tests\Integration\Behaviour\Features\Context\CountryFeatureContext
         - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
         - Tests\Integration\Behaviour\Features\Context\CustomerFeatureContext
+        - Tests\Integration\Behaviour\Features\Context\CustomerManagerFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\Carrier\CarrierFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\Carrier\CarrierRangesFeatureContext
         - Tests\Integration\Behaviour\Features\Context\Domain\CartFeatureContext

--- a/tests/Resources/config/services.yml
+++ b/tests/Resources/config/services.yml
@@ -110,10 +110,17 @@ services:
         $connection: '@doctrine.dbal.default_connection'
         $dbPrefix: '%database_prefix%'
 
-    # We need this one public to fetch data for behat tests
+    # We need these public to fetch data for behat tests
     PrestaShop\PrestaShop\Adapter\Discount\Repository\DiscountRepository:
       public: true
       autowire: true
       arguments:
         $connection: '@doctrine.dbal.default_connection'
+        $dbPrefix: '%database_prefix%'
+
+    PrestaShop\PrestaShop\Adapter\Discount\Update\DiscountConditionsUpdater:
+      public: true
+      autowire: true
+      autoconfigure: true
+      arguments:
         $dbPrefix: '%database_prefix%'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See detailed description below.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | See "How to test?" section below.
| UI Tests          | https://github.com/tleon/ga.tests.ui.pr/actions/runs/24787731248
| Fixed issue or discussion?     | Fixes #40109
| Related PRs       | None
| Sponsor company   |PrestaShop SA

---

## Description

Implements the behavior described in #40109: when the only selected customer or the only selected customer group for a discount is removed, the discount is no longer deleted but instead:

- **Applies to all customers** (no customer or group restriction), and  
- **Is disabled** so it is not applied until a merchant re-enables it.


