### PR TITLE
Fix/40997 default currency import on shop copy

### DIFF
--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -1204,6 +1204,11 @@ class ShopCore extends ObjectModel
             $old_id = Configuration::get('PS_SHOP_DEFAULT');
         }
 
+        // Default currency import to avoid missing currency data when the option is not explicitly set.
+        if (!isset($tables_import['currency'])) {
+            $tables_import['currency'] = 'on';
+        }
+
         if (isset($tables_import['carrier'])) {
             $tables_import['carrier_tax_rules_group_shop'] = true;
             $tables_import['carrier_lang'] = true;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fixed a missing default value for currency in `ShopCore::copyShopData()`.<br/>When the option is not set in `$tables_import`, currency import is now enabled by default to avoid missing currency data during shop duplication.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | 1. Instal a fresh 9.1.0 rc1<br/>2. Go to BO<br/>3. Go to Shop Parameters > General<br/>4. Click on enable Multistore and save<br/>5. Go to Advanced Parameters > Multistore<br/>6. Click on Add a new Store<br/>7. Set the store name, disabled Import data checkbox and clic on save<br/>8. Click on "Click here to set a URL for this shop." in the tab of shop<br/>9. Set a Virtual url and click on Save<br/> 10. Clic on URL displayed on tab
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/23184280003
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/40997 / https://github.com/PrestaShop/PrestaShop/issues/39764
| Related PRs       | 
| Sponsor company   | Codencode snc
