### PR TITLE
Fix: The help card is not displaying correctly in Aliases Page

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/SearchAliasController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/SearchAliasController.php
@@ -45,6 +45,7 @@ class SearchAliasController extends PrestaShopAdminController
         return $this->render('@PrestaShop/Admin/Configure/ShopParameters/Search/index.html.twig', [
             'aliasGrid' => $this->presentGrid($aliasGrid),
             'help_link' => $this->generateSidebarLink('AdminSearchConf'),
+            'enableSidebar' => true,
             'layoutHeaderToolbarBtn' => [
                 'add' => [
                     'desc' => $this->trans('Add new alias', [], 'Admin.Shopparameters.Feature'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR fixes the missing sidebar in the Search Alias admin page by enabling the sidebar in `SearchAliasController::indexAction()`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |1. BO > Shop Parameters > Search > Aliases tab<br/> 2. Click to help<br/>3. Error
| UI Tests          | https://github.com/Codencode/ga.tests.ui.pr/actions/runs/23192759939
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/40932
| Related PRs       | 
| Sponsor company   | Codencode snc
