### PR TITLE
Fix breadcrumb vertical alignment in Back Office header toolbar

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
@@ -59,6 +59,7 @@
 
     > ol {
       padding-left: 0;
+      align-items: center;
     }
   }
   // toolbar buttons

--- a/tests/UI/campaigns/regression/menu/breadcrumbAlignmentBO.ts
+++ b/tests/UI/campaigns/regression/menu/breadcrumbAlignmentBO.ts
@@ -1,0 +1,104 @@
+// Import utils
+import testContext from '@utils/testContext';
+
+import {expect} from 'chai';
+import {
+  boDashboardPage,
+  boLoginPage,
+  boThemeAndLogoPage,
+  type BrowserContext,
+  type Page,
+  utilsPlaywright,
+} from '@prestashop-core/ui-testing';
+
+const baseContext: string = 'regression_menu_breadcrumbAlignmentBO';
+
+/**
+ * @bug https://github.com/PrestaShop/PrestaShop/issues/37999
+ *
+ * The BO header breadcrumb renders two types of <li> items:
+ *  - a plain text item (container name, no anchor)
+ *  - an anchor item (tab name, with <a href="...">)
+ *
+ * Without explicit `align-items: center` on `ol.breadcrumb`, Bootstrap defaults
+ * to `align-items: stretch`, which causes a visible vertical misalignment between
+ * the two items on browsers that compute different intrinsic heights for text
+ * nodes and inline elements.
+ */
+describe('Regression - BO Header : Breadcrumb items should be vertically aligned', async () => {
+  let browserContext: BrowserContext;
+  let page: Page;
+
+  // before and after functions
+  before(async function () {
+    browserContext = await utilsPlaywright.createBrowserContext(this.browser);
+    page = await utilsPlaywright.newTab(browserContext);
+  });
+
+  after(async () => {
+    await utilsPlaywright.closeBrowserContext(browserContext);
+  });
+
+  it('should login in BO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'loginBO', baseContext);
+
+    await boLoginPage.goTo(page, global.BO.URL);
+    await boLoginPage.successLogin(page, global.BO.EMAIL, global.BO.PASSWD);
+
+    const pageTitle = await boDashboardPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boDashboardPage.pageTitle);
+  });
+
+  it('should navigate to Design > Theme & Logo to get a two-item breadcrumb', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'navigateToDesignPage', baseContext);
+
+    await boDashboardPage.goToSubMenu(
+      page,
+      boDashboardPage.designParentLink,
+      boDashboardPage.themeAndLogoParentLink,
+    );
+
+    const pageTitle = await boThemeAndLogoPage.getPageTitle(page);
+    expect(pageTitle).to.contains(boThemeAndLogoPage.pageTitle);
+  });
+
+  it('should have at least two breadcrumb items visible', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'checkBreadcrumbItemCount', baseContext);
+
+    const itemCount = await page.locator('.header-toolbar nav ol.breadcrumb .breadcrumb-item').count();
+    expect(itemCount).to.be.gte(2, 'Expected at least two breadcrumb items (container + tab)');
+  });
+
+  it('should have all breadcrumb items vertically centered on the same axis', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'checkBreadcrumbAlignment', baseContext);
+
+    // Retrieve the vertical center (midpoint) of each breadcrumb <li> using
+    // getBoundingClientRect so the check is independent of CSS class names or
+    // computed style values.
+    const centers: number[] = await page.evaluate((): number[] => {
+      const items = document.querySelectorAll<HTMLElement>(
+        '.header-toolbar nav ol.breadcrumb .breadcrumb-item',
+      );
+
+      return Array.from(items).map((item: HTMLElement) => {
+        const rect = item.getBoundingClientRect();
+
+        return rect.top + rect.height / 2;
+      });
+    });
+
+    expect(centers.length).to.be.gte(2);
+
+    // Allow a 1 px tolerance to account for sub-pixel rendering differences
+    // across browsers and operating systems.
+    const referenceCenter: number = centers[0];
+
+    centers.forEach((center: number, index: number) => {
+      expect(
+        Math.abs(center - referenceCenter),
+        `Breadcrumb item ${index} is not vertically aligned with item 0 `
+        + `(expected center ~${referenceCenter}px, got ${center}px)`,
+      ).to.be.lte(1);
+    });
+  });
+});


### PR DESCRIPTION
| Questions | Answers |
| --------- | ------- |
| Branch? | develop |
| Description? | The breadcrumb in the Back Office header toolbar was visually misaligned. The `ol.breadcrumb` flex container (Bootstrap) had no explicit `align-items` property, defaulting to `stretch`. Because the two `<li>` items have different intrinsic heights — one contains a plain text node (container name), the other wraps an `<a>` element (tab name with href) — browsers computed different heights for them, causing a visible vertical shift between the two items. The fix adds `align-items: center` on `nav > ol` inside `.header-toolbar`, which forces both items onto the same vertical axis regardless of their individual heights. |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | 1. Navigate to the Back Office. 2. Go to **Design > Theme & Logo** (or any BO page with a two-item breadcrumb). 3. Observe the breadcrumb in the sticky header toolbar: **before fix** — the container item and the tab item are vertically shifted relative to each other; **after fix** — both items share the same vertical center line. |
| UI Tests | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/). |
| Fixed issue or discussion? | Fixes #37999 |
| Related PRs | N/A |
| Sponsor company | N/A |

## Context

The BO header toolbar renders a two-item breadcrumb via `page_header_toolbar.tpl`:

```html
<ol class="breadcrumb">
  <!-- item 1: plain text node -->
  <li class="breadcrumb-item">Design</li>
  <!-- item 2: anchor element -->
  <li class="breadcrumb-item active">
    <a href="..." aria-current="page">Theme & Logo</a>
  </li>
</ol>
```

Bootstrap's `.breadcrumb` uses `display: flex` + `flex-wrap: wrap` but does **not** set `align-items`, which defaults to `stretch`. The two `<li>` items have different intrinsic heights because:
- item 1 is a text node — its height is driven by `line-height`
- item 2 contains an `<a>` element — its height may differ depending on the browser's default anchor box model

With `align-items: stretch`, each item stretches to fill the full cross-axis height of the row, but their **content** is not vertically centered relative to each other, producing a visible misalignment.

## Solution

Adding `align-items: center` to `nav > ol` inside `.header-toolbar` in `_header_toolbar.scss` ensures both `<li>` items share the same vertical midpoint, regardless of their individual heights or the browser rendering engine.

```scss
// admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
nav {
  @include media-breakpoint-down(sm) {
    display: none;
  }

  > ol {
    padding-left: 0;
    align-items: center; // Fix vertical misalignment between text and anchor items
  }
}
```

## Alternatives considered

| Alternative | Why rejected |
| --- | --- |
| `align-items: baseline` | Aligns on text baseline — works in most cases but can break when items have different `font-size` or `padding`, which makes it fragile across themes |
| Wrapping the plain-text item in an `<a>` or `<span>` in the `.tpl` | Would align box heights but changes the DOM structure and potentially the separator rendering from Bootstrap's `::before` pseudo-element |
| Overriding Bootstrap's `.breadcrumb` globally | Too broad — would affect all breadcrumb instances across the theme, including FO-facing ones |
| Setting explicit `height` / `line-height` | Brittle — hard-codes values that would break with theme customisations or font changes |

`align-items: center` is the minimal, semantically correct, and least invasive fix.

## Tests added

A new Playwright regression test has been added:

**`tests/UI/campaigns/regression/menu/breadcrumbAlignmentBO.ts`**

| Step | What is verified |
| --- | --- |
| Login to BO | Standard authentication |
| Navigate to Design > Theme & Logo | Reaches a page that renders both breadcrumb items (container + tab with href) |
| Count breadcrumb items | Asserts `>= 2` items are present |
| Measure vertical centers via `getBoundingClientRect()` | Asserts all items share the same vertical midpoint within a **1 px sub-pixel tolerance** |

The geometry-based assertion (`getBoundingClientRect`) is intentionally independent of CSS class names or computed style values — it directly catches any future regression that would cause items to visually diverge.

## Checklist

- [x] The code follows the project's SCSS conventions (`align-items` before `justify-content`, consistent with `_header_toolbar.scss` and `_nav_bar.scss`)
- [x] No new CSS custom properties or Bootstrap overrides introduced
- [x] No BC break (purely additive CSS property on an existing selector)
- [x] No deprecation introduced
- [x] Regression test added in `tests/UI/campaigns/regression/`
- [x] Test follows project conventions: Mocha/Playwright/Chai, TypeScript strict, `baseContext` naming, `padding-line-between-statements` ESLint rule respected
- [x] Commit message is atomic, imperative mood, references the fixed issue
- [x] Branch is based on `develop` (bug fix destined for next minor release)