### PR TITLE
Fix #33306: 404 instead of 500 for non-existing product URLs with fri…

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -145,11 +145,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         if ($this->id_product) {
             $this->product = new Product($this->id_product, true, $this->context->language->id, $this->context->shop->id);
         }
+        // check is product object not loaded and change controller type
         if (!Validate::isLoadedObject($this->product)) {
-            header('HTTP/1.1 404 Not Found');
-            header('Status: 404 Not Found');
-            $this->errors[] = $this->trans('This product is no longer available.', [], 'Shop.Notifications.Error');
+            $this->controller_type = '404'; 
             $this->setTemplate('errors/404');
+            $this->errors[] = $this->trans('This product is no longer available.', [], 'Shop.Notifications.Error');
 
             return;
         }
@@ -311,6 +311,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      */
     public function initContent()
     {
+        // added controller type check
+        if ($this->controller_type == '404') {
+            parent::initContent();
+            return;
+        }
         if (!$this->errors) {
             if (Pack::isPack((int) $this->product->id)
                 && !Pack::isInStock((int) $this->product->id, $this->product->minimal_quantity, $this->context->cart)
@@ -1340,7 +1345,12 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function getBreadcrumbLinks()
     {
         $breadcrumb = parent::getBreadcrumbLinks();
-
+        
+        // added product object check
+        if (!Validate::isLoadedObject($this->product) || $this->controller_type == '404') {
+            return $breadcrumb;
+        }
+        
         $categoryDefault = new Category($this->product->id_category_default, $this->context->language->id);
 
         foreach ($categoryDefault->getAllParents() as $category) {


### PR DESCRIPTION
…endly URLs enabled

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.2.x
| Description?      |  When friendly URLs are enabled in PrestaShop 8.x, accessing a non-existing product URL returns **500 Internal Server Error** instead of a proper **404 Not Found**.<br><br>This PR adds a validation in `ProductController.php` **after loading the product** to return 404 cleanly when the product doesn't exist with friendly URLs active.
| Type?             | bug fix 
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | If you try to access on a Friendly URL that doesn't exist on a system before applying the fix returns **500 Internal Server Error**. After the fix shows up a proper **404 Not Found**
| UI Tests          | NA
| Fixed issue or discussion?     | Fixes #33306 #33257 #33258
| Related PRs       | None
| Sponsor company   | None