### PR TITLE
Fix: CountryQueryBuilder::getCountQueryBuilder() always returns 1 instead of the true total

### DIFF
--- a/src/Core/Grid/Query/CountryQueryBuilder.php
+++ b/src/Core/Grid/Query/CountryQueryBuilder.php
@@ -57,7 +57,8 @@ class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
         $qb = $this->getQueryBuilder($searchCriteria)
-            ->select('c.id_country, c.iso_code, c.call_prefix, c.active, cl.name, z.name as zone_name');
+            ->select('c.id_country, c.iso_code, c.call_prefix, c.active, cl.name, z.name as zone_name')
+            ->groupBy('c.id_country');
 
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
@@ -103,7 +104,6 @@ class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
             )
             ->setParameter('contextLangId', $this->contextLangId)
             ->setParameter('contextShopIds', $this->contextShopIds, Connection::PARAM_INT_ARRAY)
-            ->groupBy('c.id_country')
         ;
 
         $this->applyFilters($qb, $searchCriteria);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR fixes the country grid total count calculation.<br/>`CountryQueryBuilder::getCountQueryBuilder()` was reusing a base query that already contained `GROUP BY c.id_country`, causing the count query to return multiple rows with value `1` instead of a single row with the real total. The `GROUP BY` is now applied only to the search query, while the count query keeps using `COUNT(DISTINCT c.id_country)` without grouping.<br/><br/>This keeps the country list deduplicated in multistore contexts and restores the correct `totalItems` value for the grid.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | 1. Enable the experimental **"Countries"** feature in **Advanced Parameters > New & Experimental Features**.<br/>2. Go to **International > Locations > Countries**.<br/>3. Check that the total displayed in the table header matches the actual number of countries and is **not `1`**.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/23233806466
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41005
| Related PRs       |
| Sponsor company   | Codencode snc
