### PR TITLE
Add GitHub Actions workflow to mark and close stale issues

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,0 +1,43 @@
+# Marks and closes inactive (stale) issues
+# Runs: every 10 minutes from 00:00 to 05:59
+name: Mark stale issues
+
+on:
+  schedule:
+    # Every 10 minutes from 00:00 to 05:59
+    - cron: "*/10 0-5 * * *"
+  workflow_dispatch:
+    inputs:
+      debug-only:
+        description: "Dry run (no changes, logs only)"
+        required: false
+        default: false
+        type: boolean
+      days-before-stale:
+        description: "Days of inactivity before marking as stale"
+        required: false
+        default: "180"
+        type: string
+      days-before-close:
+        description: "Days after stale warning before closing"
+        required: false
+        default: "30"
+        type: string
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  stale:
+    name: Mark and close stale issues
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run stale issues action
+        uses: PrestaShop/.github/.github/actions/stale@master
+        with:
+          days-before-stale: ${{ github.event.inputs.days-before-stale || '547' }}
+          days-before-close: ${{ github.event.inputs.days-before-close || '30' }}
+          exempt-issue-labels: "Critical, Security, Major, Good first issue, EPIC, Topwatchers, Blocked, Must-have"
+          debug-only: ${{ github.event.inputs.debug-only || 'false' }}


### PR DESCRIPTION
| Questions         | Answers                                                                       |
| ----------------- | ----------------------------------------------------------------------------- |
| Branch?           | develop                                                                       |
| Description?      | Add a GitHub Actions workflow to automatically mark and close stale issues     |
| Type?             | improvement                                                                   |
| Category?         | PM                                                                            |
| BC breaks?        | no                                                                            |
| Deprecations?     | no                                                                            |
| How to test?      | See below                                                                     |
| UI Tests          | TO COMPLETE                                                       |
| Fixed issue or discussion? | https://github.com/PrestaShop/PrestaShop/discussions/40567            |
| Related PRs       | PrestaShop/.github#37 (reusable composite action)                             |
| Sponsor company   | @PrestaShopCorp


## Description

This PR introduces a new GitHub Actions workflow (`.github/workflows/stale_issues.yml`) that **automatically detects, labels, and closes inactive issues** in the PrestaShop repository.

### Context

This initiative was originally discussed in [#40567 — [Idea] Keeping the PrestaShop issue tracker useful (and sane)](https://github.com/PrestaShop/PrestaShop/discussions/40567), announced by @kpodemski. The community and maintainers agreed on the need to introduce automated issue lifecycle management to keep the tracker meaningful and actionable.

Following that discussion, I tested the Stale GitHub Action on a personal repository ([see test results and demo videos](https://github.com/PrestaShop/PrestaShop/discussions/40567#discussioncomment-15959574)). The tests confirmed that the action correctly marks issues as stale, posts a warning comment, removes the stale label when an issue receives activity, and auto-closes issues after the grace period.

Based on these results, I created the reusable composite action in [PrestaShop/.github#37](https://github.com/PrestaShop/.github/pull/37), and this PR wires it into the main PrestaShop repository.

### Why?

The PrestaShop issue tracker has accumulated thousands of issues that haven't been touched in months or even years — many of them no longer relevant to current versions. This creates noise that makes it harder for maintainers and contributors to focus on what matters, and can be overwhelming for newcomers.

This workflow brings automated lifecycle management to our issues, following a practice widely adopted by major open-source projects.

### How it works

The workflow leverages the shared **`PrestaShop/.github/.github/actions/stale`** composite action and runs on a scheduled basis (every 10 minutes between 00:00 and 05:59 UTC). This cadence was chosen to stay well within the **GitHub API rate limit of 1,000 requests/hour** imposed when authenticating with the default `GITHUB_TOKEN`, while still processing a large backlog of issues efficiently.

1. **Stale detection** — Issues with no activity for **547 days** (~18 months) are automatically labeled as stale and receive a warning comment.
2. **Auto-close** — If no further activity occurs within **30 days** after the stale warning, the issue is automatically closed.
3. **Exempt labels** — Issues carrying any of the following labels are **never** marked as stale: `Critical`, `Security`, `Major`, `Good first issue`, `EPIC`, `Topwatchers`, `Blocked`, `Must-have`.

### Manual trigger & dry-run

The workflow also supports `workflow_dispatch` with configurable inputs:

- **`debug-only`** (boolean) — Enables dry-run mode: the action logs what it *would* do without making any actual changes. Useful for auditing before enabling in production.
- **`days-before-stale`** (string, default: `547`) — Override the inactivity threshold.
- **`days-before-close`** (string, default: `30`) — Override the grace period after the stale warning.

### How to test

1. Navigate to the **Actions** tab of the repository.
2. Select the **"Mark stale issues"** workflow.
3. Click **"Run workflow"** and enable the **`debug-only`** option.
4. Verify in the workflow logs that stale issues are correctly identified without any actual modifications.
5. Optionally, run again with `debug-only` set to `false` on a test repository to observe the full label + comment + close cycle.
