### PR TITLE
Update stale issues workflow configuration: fix inactivity period to 547 days on workflow dispatch and add additional exempt issue labels.

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -16,7 +16,7 @@ on:
       days-before-stale:
         description: "Days of inactivity before marking as stale"
         required: false
-        default: "180"
+        default: "547"
         type: string
       days-before-close:
         description: "Days after stale warning before closing"
@@ -39,5 +39,5 @@ jobs:
         with:
           days-before-stale: ${{ github.event.inputs.days-before-stale || '547' }}
           days-before-close: ${{ github.event.inputs.days-before-close || '30' }}
-          exempt-issue-labels: "Critical, Security, Major, Good first issue, EPIC, Topwatchers, Blocked, Must-have"
+          exempt-issue-labels: "Critical, Security, Major, Good first issue, EPIC, Topwatchers, Blocked, Must-have, Waiting for dev, Waiting for QA, Waiting for QA by Community, Waiting for PM, Waiting for UX, Waiting for rebase, Waiting for wording, Release"
           debug-only: ${{ github.event.inputs.debug-only || 'false' }}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Update stale issues workflow configuration: fix inactivity period to 547 days on workflow dispatch and add additional exempt issue labels.
| Type?             | bug fix 
| Category?         | PM 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Dispatch workflow stale-issues with correct inputs
| UI Tests          | TO COMPLETE
| Fixed issue or discussion?     |  Fixes [https://github.com/PrestaShop/PrestaShop/discussions/ {discussion number here}](https://github.com/PrestaShop/PrestaShop/discussions/40567)
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/41034
| Sponsor company   | PrestaShop SA
