### PR TITLE
Update stale issues workflow permissions to allow write access for actions for caching

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -25,6 +25,7 @@ on:
         type: string
 
 permissions:
+  actions: write
   issues: write
   contents: read
 
@@ -39,5 +40,5 @@ jobs:
         with:
           days-before-stale: ${{ github.event.inputs.days-before-stale || '547' }}
           days-before-close: ${{ github.event.inputs.days-before-close || '30' }}
-          exempt-issue-labels: "Critical, Security, Major, Good first issue, EPIC, Topwatchers, Blocked, Must-have, Waiting for dev, Waiting for QA, Waiting for QA by Community, Waiting for PM, Waiting for UX, Waiting for rebase, Waiting for wording, Release"
+          exempt-issue-labels: "Critical, Security, Major, Good first issue, EPIC, Topwatchers, Blocked, Must-have, Waiting for dev, Waiting for QA, Waiting for QA by Community, Waiting for PM, Waiting for UX, Waiting for rebase, Waiting for wording, Release, Detected by TE, 9.1.x"
           debug-only: ${{ github.event.inputs.debug-only || 'false' }}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Workflow "Mark stale issues" was failed because it didn't have actions' permissions for caching issues handled in previous schedule. Example : https://github.com/PrestaShop/PrestaShop/actions/runs/23367853570. According to the [README](https://github.com/actions/stale?tab=readme-ov-file#recommended-permissions) and [this issue](https://github.com/actions/stale/issues/1090#issuecomment-1710940734), `actions: write` is required.
| Type?             | bug fix
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Trigger Workflow "Mak stale issues" or wait for schedule
| UI Tests          | N/A (only Github Workflow modified)
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/40567
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/41034, https://github.com/PrestaShop/PrestaShop/pull/41038
| Sponsor company   | PrestaShop SA
