### PR TITLE
Merge add shipment in existing command

### DIFF
--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -29,6 +29,8 @@ use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;
 use PrestaShop\PrestaShop\Adapter\Order\OrderDetailUpdater;
 use PrestaShop\PrestaShop\Adapter\Order\OrderProductQuantityUpdater;
+use PrestaShop\PrestaShop\Adapter\Order\Repository\OrderDetailRepository;
+use PrestaShop\PrestaShop\Adapter\Shipment\ShipmentProductAssigner;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DuplicateProductInOrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DuplicateProductInOrderInvoiceException;
@@ -36,6 +38,8 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\AddProductToOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\CommandHandler\AddProductToOrderHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductOutOfStockException;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 use PrestaShopDatabaseException;
 use PrestaShopException;
 use Product;
@@ -88,19 +92,15 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
      */
     private $orderDetailUpdater;
 
-    /**
-     * @param TranslatorInterface $translator
-     * @param ContextStateManager $contextStateManager
-     * @param OrderAmountUpdater $orderAmountUpdater
-     * @param OrderProductQuantityUpdater $orderProductQuantityUpdater
-     * @param OrderDetailUpdater $orderDetailUpdater
-     */
     public function __construct(
         TranslatorInterface $translator,
         ContextStateManager $contextStateManager,
         OrderAmountUpdater $orderAmountUpdater,
         OrderProductQuantityUpdater $orderProductQuantityUpdater,
-        OrderDetailUpdater $orderDetailUpdater
+        OrderDetailUpdater $orderDetailUpdater,
+        private ?OrderDetailRepository $orderDetailRepository = null,
+        private ?FeatureFlagStateCheckerInterface $featureFlagStateCheckerInterface = null,
+        private ?ShipmentProductAssigner $shipmentProductAssigner = null,
     ) {
         $this->context = Context::getContext();
         $this->translator = $translator;
@@ -202,6 +202,28 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
 
             // Update totals amount of order
             $this->orderAmountUpdater->update($order, $cart, null !== $invoice ? (int) $invoice->id : null);
+
+            if (
+                $this->featureFlagStateCheckerInterface !== null
+                && $this->featureFlagStateCheckerInterface->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT)
+                && $command->isVirtual() !== true
+                && $this->shipmentProductAssigner !== null
+                && $this->orderDetailRepository !== null
+            ) {
+                $orderDetail = $this->orderDetailRepository->findByOrderIdAndProductId(
+                    $command->getOrderId(),
+                    $command->getProductId(),
+                    $command->getCombinationId()
+                );
+
+                $this->shipmentProductAssigner->assign(
+                    $command->getShipmentId(),
+                    $order,
+                    $orderDetail,
+                    $command->getCarrierId()
+                );
+            }
+
             Hook::exec('actionOrderEdited', ['order' => $order]);
         } finally {
             $this->contextStateManager->restorePreviousContext();

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -205,7 +205,7 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
 
             if (
                 $this->featureFlagStateCheckerInterface->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT)
-                && !empty($command->isVirtual()) && $command->isVirtual() === false
+                && $command->isVirtual() !== null && $command->isVirtual() === false
             ) {
                 $orderDetail = $this->orderDetailRepository->findByOrderIdAndProductId(
                     $command->getOrderId(),

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -98,9 +98,9 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
         OrderAmountUpdater $orderAmountUpdater,
         OrderProductQuantityUpdater $orderProductQuantityUpdater,
         OrderDetailUpdater $orderDetailUpdater,
-        private ?OrderDetailRepository $orderDetailRepository = null,
-        private ?FeatureFlagStateCheckerInterface $featureFlagStateCheckerInterface = null,
-        private ?ShipmentProductAssigner $shipmentProductAssigner = null,
+        private OrderDetailRepository $orderDetailRepository,
+        private FeatureFlagStateCheckerInterface $featureFlagStateCheckerInterface,
+        private ShipmentProductAssigner $shipmentProductAssigner,
     ) {
         $this->context = Context::getContext();
         $this->translator = $translator;
@@ -204,11 +204,8 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             $this->orderAmountUpdater->update($order, $cart, null !== $invoice ? (int) $invoice->id : null);
 
             if (
-                $this->featureFlagStateCheckerInterface !== null
-                && $this->featureFlagStateCheckerInterface->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT)
-                && $command->isVirtual() !== true
-                && $this->shipmentProductAssigner !== null
-                && $this->orderDetailRepository !== null
+                $this->featureFlagStateCheckerInterface->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT)
+                && !empty($command->isVirtual()) && $command->isVirtual() === false
             ) {
                 $orderDetail = $this->orderDetailRepository->findByOrderIdAndProductId(
                     $command->getOrderId(),

--- a/src/Adapter/Shipment/ShipmentProductAssigner.php
+++ b/src/Adapter/Shipment/ShipmentProductAssigner.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Shipment;
 
+use Exception;
 use Order;
 use OrderDetail;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\ShipmentNotFoundException;
@@ -25,11 +26,14 @@ class ShipmentProductAssigner
      * @param int|null $shipmentId
      * @param Order $order
      * @param OrderDetail
-     * @param int $carrierId
+     * @param int|null $carrierId
      */
-    public function assign(?int $shipmentId, Order $order, OrderDetail $orderDetail, int $carrierId): void
+    public function assign(?int $shipmentId, Order $order, OrderDetail $orderDetail, ?int $carrierId = null): void
     {
         if (empty($shipmentId)) {
+            if (empty($carrierId)) {
+                throw new Exception('A carrier ID is required to create a new shipment');
+            }
             $shipment = new Shipment();
             $shipment->setOrderId((int) $order->id);
             $shipment->setCarrierId($carrierId);

--- a/src/Adapter/Shipment/ShipmentProductAssigner.php
+++ b/src/Adapter/Shipment/ShipmentProductAssigner.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Shipment;
+
+use Order;
+use OrderDetail;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\ShipmentNotFoundException;
+use PrestaShopBundle\Entity\Repository\ShipmentRepository;
+use PrestaShopBundle\Entity\Shipment;
+use PrestaShopBundle\Entity\ShipmentProduct;
+
+class ShipmentProductAssigner
+{
+    public function __construct(private ShipmentRepository $shipmentRepository)
+    {
+    }
+
+    /**
+     * @param int|null $shipmentId
+     * @param Order $order
+     * @param OrderDetail
+     * @param int $carrierId
+     */
+    public function assign(?int $shipmentId, Order $order, OrderDetail $orderDetail, int $carrierId): void
+    {
+        if (empty($shipmentId)) {
+            $shipment = new Shipment();
+            $shipment->setOrderId((int) $order->id);
+            $shipment->setCarrierId($carrierId);
+            $shipment->setAddressId((int) $order->id_address_delivery);
+            $shipment->setTrackingNumber(null);
+            $shipment->setShippingCostTaxExcluded(0.00);
+            $shipment->setShippingCostTaxIncluded(0.00);
+            $shipment->setDeliveredAt(null);
+            $shipment->setShippedAt(null);
+            $shipment->setCancelledAt(null);
+        } else {
+            $shipment = $this->shipmentRepository->findById($shipmentId);
+
+            if ($shipment === null) {
+                throw new ShipmentNotFoundException(sprintf('No shipment with id %d found', $shipmentId));
+            }
+        }
+
+        $shipmentProduct = new ShipmentProduct();
+        $shipmentProduct->setOrderDetailId((int) $orderDetail->id_order_detail);
+        $shipmentProduct->setQuantity((int) $orderDetail->product_quantity);
+        $shipment->addShipmentProduct($shipmentProduct);
+
+        $this->shipmentRepository->save($shipment);
+    }
+}

--- a/src/Adapter/Shipment/ShipmentProductAssigner.php
+++ b/src/Adapter/Shipment/ShipmentProductAssigner.php
@@ -25,7 +25,7 @@ class ShipmentProductAssigner
     /**
      * @param int|null $shipmentId
      * @param Order $order
-     * @param OrderDetail
+     * @param OrderDetail $orderDetail
      * @param int|null $carrierId
      */
     public function assign(?int $shipmentId, Order $order, OrderDetail $orderDetail, ?int $carrierId = null): void

--- a/src/Adapter/Shipment/ShipmentProductAssigner.php
+++ b/src/Adapter/Shipment/ShipmentProductAssigner.php
@@ -22,12 +22,6 @@ class ShipmentProductAssigner
     {
     }
 
-    /**
-     * @param int|null $shipmentId
-     * @param Order $order
-     * @param OrderDetail $orderDetail
-     * @param int|null $carrierId
-     */
     public function assign(?int $shipmentId, Order $order, OrderDetail $orderDetail, ?int $carrierId = null): void
     {
         if (empty($shipmentId)) {

--- a/src/Core/Domain/Order/Product/Command/AddProductToOrderCommand.php
+++ b/src/Core/Domain/Order/Product/Command/AddProductToOrderCommand.php
@@ -61,6 +61,21 @@ class AddProductToOrderCommand
     private $hasFreeShipping;
 
     /**
+     * @var int|null
+     */
+    private ?int $shipmentId = null;
+
+    /**
+     * @var int|null
+     */
+    private ?int $carrierId = null;
+
+    /**
+     * @var bool|null
+     */
+    private ?bool $isVirtual = null;
+
+    /**
      * Add product to an order with new invoice. It applies to orders that were already paid and waiting for payment.
      *
      * @param int $orderId
@@ -70,6 +85,9 @@ class AddProductToOrderCommand
      * @param string $productPriceTaxExcluded
      * @param int $productQuantity
      * @param bool|null $hasFreeShipping
+     * @param int|null $shipmentId
+     * @param int|null $carrierId
+     * @param bool|null $isVirtual
      *
      * @return self
      *
@@ -84,7 +102,10 @@ class AddProductToOrderCommand
         string $productPriceTaxIncluded,
         string $productPriceTaxExcluded,
         int $productQuantity,
-        ?bool $hasFreeShipping = null
+        ?bool $hasFreeShipping = null,
+        ?int $shipmentId = null,
+        ?int $carrierId = null,
+        ?bool $isVirtual = null
     ) {
         $command = new self(
             $orderId,
@@ -96,6 +117,9 @@ class AddProductToOrderCommand
         );
 
         $command->hasFreeShipping = $hasFreeShipping;
+        $command->shipmentId = $shipmentId;
+        $command->carrierId = $carrierId;
+        $command->isVirtual = $isVirtual;
 
         return $command;
     }
@@ -110,6 +134,9 @@ class AddProductToOrderCommand
      * @param string $productPriceTaxIncluded
      * @param string $productPriceTaxExcluded
      * @param int $productQuantity
+     * @param int|null $shipmentId
+     * @param int|null $carrierId
+     * @param bool|null $isVirtual
      *
      * @return self
      *
@@ -124,7 +151,10 @@ class AddProductToOrderCommand
         int $combinationId,
         string $productPriceTaxIncluded,
         string $productPriceTaxExcluded,
-        int $productQuantity
+        int $productQuantity,
+        ?int $shipmentId = null,
+        ?int $carrierId = null,
+        ?bool $isVirtual = null
     ) {
         $command = new self(
             $orderId,
@@ -136,6 +166,9 @@ class AddProductToOrderCommand
         );
 
         $command->orderInvoiceId = $orderInvoiceId;
+        $command->shipmentId = $shipmentId;
+        $command->carrierId = $carrierId;
+        $command->isVirtual = $isVirtual;
 
         return $command;
     }
@@ -234,6 +267,30 @@ class AddProductToOrderCommand
     public function hasFreeShipping(): ?bool
     {
         return $this->hasFreeShipping;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getShipmentId(): ?int
+    {
+        return $this->shipmentId;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getCarrierId(): ?int
+    {
+        return $this->carrierId;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function isVirtual(): ?bool
+    {
+        return $this->isVirtual;
     }
 
     /**

--- a/src/Core/Domain/Order/Product/Command/AddProductToOrderCommand.php
+++ b/src/Core/Domain/Order/Product/Command/AddProductToOrderCommand.php
@@ -60,19 +60,10 @@ class AddProductToOrderCommand
      */
     private $hasFreeShipping;
 
-    /**
-     * @var int|null
-     */
     private ?int $shipmentId = null;
 
-    /**
-     * @var int|null
-     */
     private ?int $carrierId = null;
 
-    /**
-     * @var bool|null
-     */
     private ?bool $isVirtual = null;
 
     /**
@@ -269,25 +260,16 @@ class AddProductToOrderCommand
         return $this->hasFreeShipping;
     }
 
-    /**
-     * @return int|null
-     */
     public function getShipmentId(): ?int
     {
         return $this->shipmentId;
     }
 
-    /**
-     * @return int|null
-     */
     public function getCarrierId(): ?int
     {
         return $this->carrierId;
     }
 
-    /**
-     * @return bool|null
-     */
     public function isVirtual(): ?bool
     {
         return $this->isVirtual;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -65,8 +65,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductOutOfStockExcepti
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductSearchEmptyPhraseException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\FoundProduct;
-use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\AddProductToShipment;
-use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\CreateShipment;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\EditShipment;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\MergeProductsToShipment;
 use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\SplitShipment;
@@ -1016,6 +1014,9 @@ class OrderController extends PrestaShopAdminController
         $invoiceId = (int) $request->get('invoice_id');
         $productId = (int) $request->get('product_id');
         $combinationId = (int) $request->get('combination_id');
+        $shipmentId = (int) $request->get('shipment_id', null);
+        $carrierId = (int) $request->get('carrier_id', null);
+        $isVirtual = (bool) $request->get('virtual', false);
 
         try {
             if ($invoiceId > 0) {
@@ -1026,7 +1027,10 @@ class OrderController extends PrestaShopAdminController
                     $combinationId,
                     $request->get('price_tax_incl'),
                     $request->get('price_tax_excl'),
-                    (int) $request->get('quantity')
+                    (int) $request->get('quantity'),
+                    $shipmentId,
+                    $carrierId,
+                    $isVirtual
                 );
             } else {
                 $hasFreeShipping = null;
@@ -1040,23 +1044,14 @@ class OrderController extends PrestaShopAdminController
                     $request->get('price_tax_incl'),
                     $request->get('price_tax_excl'),
                     (int) $request->get('quantity'),
-                    $hasFreeShipping
+                    $hasFreeShipping,
+                    $shipmentId,
+                    $carrierId,
+                    $isVirtual
                 );
             }
 
             $this->dispatchCommand($addProductCommand);
-            if ($featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT) && $this->orderHasShipment($orderForViewing->getId()) === true) {
-                $shipmentId = (int) $request->get('shipment_id');
-                $isVirtual = (bool) $request->get('virtual');
-
-                if ($shipmentId === 0 && !$isVirtual) {
-                    $carrierId = (int) $request->get('carrier_id');
-                    $shipmentId = $this->dispatchCommand(new CreateShipment($orderId, $carrierId, $productId, (int) $request->get('quantity'), $combinationId));
-                }
-                if (!$isVirtual) {
-                    $this->dispatchCommand(new AddProductToShipment($shipmentId, $productId, $orderId, $combinationId));
-                }
-            }
         } catch (Exception $e) {
             return $this->json(
                 ['message' => $this->getErrorMessageForException($e, $this->getErrorMessages($e))],

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -23,6 +23,9 @@ services:
       - '@prestashop.adapter.order.amount.updater'
       - '@prestashop.adapter.order.product_quantity.updater'
       - '@prestashop.adapter.order.order_detail.updater'
+      - '@PrestaShop\PrestaShop\Adapter\Order\Repository\OrderDetailRepository'
+      - '@PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface'
+      - '@PrestaShop\PrestaShop\Adapter\Shipment\ShipmentProductAssigner'
 
   PrestaShop\PrestaShop\Adapter\Order\CommandHandler\UpdateOrderStatusHandler:
     autowire: true

--- a/src/PrestaShopBundle/Resources/config/services/core/shipment.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/shipment.yml
@@ -10,3 +10,5 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Shipment\ShipmentMerger
 
   PrestaShop\PrestaShop\Adapter\Shipment\ShipmentProductQuantityUpdater:
+
+  PrestaShop\PrestaShop\Adapter\Shipment\ShipmentProductAssigner:

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -206,6 +206,14 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
             if (isset($data['free_shipping'])) {
                 $hasFreeShipping = PrimitiveUtils::castStringBooleanIntoBoolean($data['free_shipping']);
             }
+            $shipmentId = null;
+            if (!empty($data['shipment_id'])) {
+                $shipmentId = (int) SharedStorage::getStorage()->get($data['shipment_id']);
+            }
+            $carrierId = null;
+            if (!empty($data['carrier_id'])) {
+                $carrierId = (int) SharedStorage::getStorage()->get($data['carrier_id']);
+            }
             $this->getCommandBus()->handle(
                 AddProductToOrderCommand::withNewInvoice(
                     $orderId,
@@ -214,7 +222,9 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
                     $data['price_tax_incl'],
                     $data['price'],
                     (int) $data['amount'],
-                    $hasFreeShipping
+                    $hasFreeShipping,
+                    $shipmentId,
+                    $carrierId
                 )
             );
         } catch (InvalidProductQuantityException $e) {

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -214,6 +214,10 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
             if (!empty($data['carrier_id'])) {
                 $carrierId = (int) SharedStorage::getStorage()->get($data['carrier_id']);
             }
+            $isVirtual = null;
+            if (isset($data['is_virtual'])) {
+                $isVirtual = PrimitiveUtils::castStringBooleanIntoBoolean($data['is_virtual']);
+            }
             $this->getCommandBus()->handle(
                 AddProductToOrderCommand::withNewInvoice(
                     $orderId,
@@ -224,7 +228,8 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
                     (int) $data['amount'],
                     $hasFreeShipping,
                     $shipmentId,
-                    $carrierId
+                    $carrierId,
+                    $isVirtual
                 )
             );
         } catch (InvalidProductQuantityException $e) {

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/order_products_add.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/order_products_add.feature
@@ -1,0 +1,107 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s shipment --tags order_products_add
+@restore-all-tables-before-feature
+@clear-cache-before-feature
+@order-products-add-with-shipments
+@order_products_add
+Feature: Add order products with shipments
+  As a BO users
+  I want to add order products with shipments
+
+  Background:
+    Given I enable feature flag "improved_shipment"
+    And the current currency is "USD"
+    And country "US" is enabled
+    And the module "dummy_payment" is installed
+    And I am logged in as "test@prestashop.com" employee
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And a carrier "default_carrier" with name "My carrier" exists
+    And I create an empty cart "dummy_cart" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And I add 1 products "Mug The best is yet to come" to the cart "dummy_cart"
+    And I add 2 products "Mug Today is a good day" to the cart "dummy_cart"
+
+  Scenario: Add product to order assigned to an existing shipment
+    Given I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+    And I reference order "bo_order1" delivery address as "US"
+    And the order "bo_order1" should have the following shipments:
+      | shipment  | carrier         | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
+      | shipment1 | default_carrier |                 | US      |                    7.0 |                   7.42 |
+    And the shipment "shipment1" should have the following products:
+      | product_name                | quantity |
+      | Mug The best is yet to come |        1 |
+      | Mug Today is a good day     |        2 |
+    And I create carrier "pickup_carrier" with specified properties:
+      | name | Pickup |
+    And I split the shipment "shipment1" to create a new shipment with "pickup_carrier" with following products:
+      | product_name             | quantity |
+      | Mug Today is a good day  | 1        |
+    And the shipment "shipment1" should have the following products:
+      | product_name                | quantity |
+      | Mug The best is yet to come | 1        |
+      | Mug Today is a good day     | 1        |
+    And the order "bo_order1" should have "2" shipments:
+    And the shipment "shipment2" should have the following products:
+      | product_name               | quantity |
+      | Mug Today is a good day    | 1        |
+    And there is a product in the catalog named "Test Added Product" with a price of 15.0 and 100 items in stock
+    And order with reference "bo_order1" does not contain product "Test Added Product"
+    And the available stock for product "Test Added Product" should be 100
+    When I add products to order "bo_order1" without invoice and the following products details:
+      | name          | Test Added Product |
+      | amount        | 3                  |
+      | price         | 15                 |
+      | shipment_id   | shipment2          |
+    Then order "bo_order1" should contain 3 products "Test Added Product"
+    And the available stock for product "Test Added Product" should be 97
+    And product "Test Added Product" in order "bo_order1" has following details:
+      | product_quantity            | 3     |
+    Then the shipment "shipment1" should have the following products:
+      | product_name                | quantity |
+      | Mug The best is yet to come | 1        |
+      | Mug Today is a good day     | 1        |
+    Then the shipment "shipment2" should have the following products:
+      | product_name               | quantity |
+      | Mug Today is a good day    | 1        |
+      | Test Added Product         | 3        |
+
+  Scenario: Add product to order creating a new shipment
+    Given I add order "bo_order2" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+    And I reference order "bo_order2" delivery address as "US"
+    And the order "bo_order2" should have the following shipments:
+      | shipment  | carrier         | tracking_number | address | shipping_cost_tax_excl | shipping_cost_tax_incl |
+      | shipment3 | default_carrier |                 | US      |                    7.0 |                   7.42 |
+    And the shipment "shipment3" should have the following products:
+      | product_name                | quantity |
+      | Mug The best is yet to come |        1 |
+      | Mug Today is a good day     |        2 |
+    And I create carrier "pickup_carrier2" with specified properties:
+      | name | Pickup Express |
+    And there is a product in the catalog named "Test Added Product" with a price of 15.0 and 100 items in stock
+    And order with reference "bo_order2" does not contain product "Test Added Product"
+    And the available stock for product "Test Added Product" should be 100
+    When I add products to order "bo_order2" without invoice and the following products details:
+      | name          | Test Added Product |
+      | amount        | 2                  |
+      | price         | 15                 |
+      | carrier_id    | pickup_carrier2    |
+    Then order "bo_order2" should contain 2 products "Test Added Product"
+    And the available stock for product "Test Added Product" should be 98
+    And product "Test Added Product" in order "bo_order2" has following details:
+      | product_quantity            | 2     |
+    And the order "bo_order2" should have "2" shipments:
+    Then the shipment "shipment3" should have the following products:
+      | product_name                | quantity |
+      | Mug The best is yet to come | 1        |
+      | Mug Today is a good day     | 2        |
+    Then the shipment "shipment4" should have the following products:
+      | product_name               | quantity |
+      | Test Added Product         | 2        |

--- a/tests/Integration/Behaviour/Features/Scenario/Shipment/order_products_add.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shipment/order_products_add.feature
@@ -56,6 +56,7 @@ Feature: Add order products with shipments
       | amount        | 3                  |
       | price         | 15                 |
       | shipment_id   | shipment2          |
+      | is_virtual    | false              |
     Then order "bo_order1" should contain 3 products "Test Added Product"
     And the available stock for product "Test Added Product" should be 97
     And product "Test Added Product" in order "bo_order1" has following details:
@@ -93,6 +94,7 @@ Feature: Add order products with shipments
       | amount        | 2                  |
       | price         | 15                 |
       | carrier_id    | pickup_carrier2    |
+      | is_virtual    | false              |
     Then order "bo_order2" should contain 2 products "Test Added Product"
     And the available stock for product "Test Added Product" should be 98
     And product "Test Added Product" in order "bo_order2" has following details:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Actually when you want to add a new product for a existing order, the form is display inside the product table. Now it's displayed inside a modale with shipment inputs. we just merge the shipment stuff on the existing command instead of create new command
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| UI Tests          | https://github.com/Poulinhoo/ga.tests.ui.pr/actions/runs/24072213205
