### PR TITLE
Add 'operations-per-run' input to stale issues workflow for API operation limit

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -23,6 +23,10 @@ on:
         required: false
         default: "30"
         type: string
+      operations-per-run:
+        description: "Maximum GitHub API operations per run (optional; default 100 if omitted)"
+        required: false
+        type: string
 
 permissions:
   actions: write
@@ -40,5 +44,6 @@ jobs:
         with:
           days-before-stale: ${{ github.event.inputs.days-before-stale || '547' }}
           days-before-close: ${{ github.event.inputs.days-before-close || '30' }}
+          operations-per-run: ${{ github.event.inputs.operations-per-run || '100' }}
           exempt-issue-labels: "Critical, Security, Major, Good first issue, EPIC, Topwatchers, Blocked, Must-have, Waiting for dev, Waiting for QA, Waiting for QA by Community, Waiting for PM, Waiting for UX, Waiting for rebase, Waiting for wording, Release, Detected by TE, 9.1.x"
           debug-only: ${{ github.event.inputs.debug-only || 'false' }}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | "Mark stale issues" has been running for 5 days now. So far it's marked 456 issues as "Stale" so it's a huge success but to be faster we can give the possibility to increase the operations per run set currently to 100. After checking the latest runs, we had largely  Github API rate remaining (https://github.com/PrestaShop/PrestaShop/actions/runs/23527590474/job/68484206199) so for workflow_dispatch only we can increase this number.
| Type?             |  improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run workflow "Mark stale issues" with a operations-per-run parameter to 500.
| UI Tests          | N/A (only Workflow Github modified)
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/40567
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/41038 https://github.com/PrestaShop/PrestaShop/pull/41034 https://github.com/PrestaShop/PrestaShop/pull/41048
| Sponsor company   | PrestaShop SA
