### PR TITLE
Fix email HTML previews for module emails

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -3036,10 +3036,24 @@ class AdminTranslationsControllerCore extends AdminController
             $email_file = _PS_ROOT_DIR_ . $email;
         }
 
-        if (strpos(realpath($email_file), _PS_MAIL_DIR_) === 0 && file_exists($email_file)) {
+        if (!file_exists($email_file)) {
+            return '';
+        }
+
+        $realEmailPath = realpath($email_file);
+
+        if (!$realEmailPath) {
+            return '';
+        }
+
+        $isCoreMail = strpos($realEmailPath, _PS_MAIL_DIR_) === 0;
+        $isModuleMail = strpos($realEmailPath, _PS_MODULE_DIR_) === 0
+            && str_contains($realEmailPath, '/mails/');
+
+        $email_html = '';
+
+        if ($isCoreMail || $isModuleMail) {
             $email_html = file_get_contents($email_file);
-        } else {
-            $email_html = '';
         }
 
         return $email_html;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fix email HTML preview for module mail templates in International > Translations by extending the path security check to also allow paths under _PS_MODULE_DIR_/mails/, in addition to the existing _PS_MAIL_DIR_
  check.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to International > Translations, in **Modify Translations** select "Email Translations" - Body - Any theme or language. HTML Preview for module emails should work
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #40855

Before: `getEmailHTML()` only handle Core Emails path `mails/`, for example `/var/www/html/mails/`

But for Emails Modules, path is: `modules/mymodule/mails`, for example `/var/www/html/modules/ps_emailalerts/mails/`

This proposal takes both paths into account, with early returns if the conditions are not met to avoid overly nested else/if statements.

Should work on any branch, code is here for 15+ years.

Generated 90% with my brain and 10% with Claude's.

**Before fix:**

<img width="1313" height="905" alt="555771691-5b0aee74-b58e-481b-9731-e5a855090833" src="https://github.com/user-attachments/assets/243ecdc9-db89-419c-af44-68c51e6fb664" />


**After fix:**

<img width="1655" height="848" alt="Screenshot_2026-03-04_05-31-56" src="https://github.com/user-attachments/assets/1156ca6d-65c5-403b-8cce-ab843f745854" />

(The logo still needs to be corrected; this will be the subject of another PR)

Note : it is the same PR as #40927, but targeting 9.1.x branch this time