### PR TITLE
Add Claude Code configuration and PR creation skill

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: create-pr
+description: Creates a PrestaShop pull request with the required metadata table. Triggers when asked to create, open, submit, or push a PR, or when mentioning "pull request" in the context of contributing.
+---
+
+Helps a contributor create a pull request for the PrestaShop open source project.
+
+## PR Description Format
+
+Every PR description **must** start with the metadata table from `.github/PULL_REQUEST_TEMPLATE.md`. Additional context goes **after** the table.
+
+```
+| Questions         | Answers
+| ----------------- | -------------------------------------------------------
+| Branch?           | {branch}
+| Description?      | {description}
+| Type?             | {type}
+| Category?         | {category}
+| BC breaks?        | {bc_breaks}
+| Deprecations?     | {deprecations}
+| How to test?      | {how_to_test}
+| UI Tests          | {ui_tests}
+| Fixed issue or discussion? | {fixed_issue}
+| Related PRs       | {related_prs}
+| Sponsor company   | {sponsor}
+```
+
+## Field Rules
+
+### Required (must always be filled)
+
+- **Branch**: Auto-fill from current git branch (`develop`, `9.1.x`, `9.0.x`, `8.2.x`). Ask if unsure.
+- **Description**: Summarize what the PR does. Be specific (versions, browser/server config, module/theme). Ask if lacking context.
+- **Type**: `bug fix` | `improvement` | `new feature` | `refacto`. Infer from changes, ask otherwise.
+- **Category**: `FO` | `BO` | `CO` | `IN` | `WS` | `TE` | `LO` | `ME` | `PM`. Infer from files changed, ask otherwise. See [category reference](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category).
+- **BC breaks**: `yes` | `no`. Analyze changes. Ask if unsure.
+- **Deprecations**: `yes` | `no`. Check for new deprecations. Ask if unsure.
+
+### Recommended
+
+- **How to test**: Step-by-step verification instructions. Write from the PR context, ask if unclear.
+
+### Optional (fill when known, leave empty otherwise)
+
+- **UI Tests**: Link to test runs. Usually pasted by contributor later.
+- **Fixed issue or discussion**: `Fixes #<number>` format. Auto-fill from conversation context, branch name (e.g. `fix/12345`), or commit messages. Multiple: `Fixes #123, Fixes #456`.
+- **Related PRs**: Links to PRs in other repos (theme, modules, autoupgrade).
+- **Sponsor company**: Contributor's company or customer name.
+
+## Workflow
+
+1. **Auto-fill** what you can: branch (git), type/category (code analysis), BC breaks/deprecations, issues (context).
+2. **Ask before guessing** any required field you cannot confidently determine. Do not guess.
+3. **Create the PR** using GitHub MCP tools or `gh` CLI.

--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,6 @@ docker-compose.override.yml
 
 # config vscode
 .hintrc
+
+# Claude Code - personal settings (commands are shared, settings are not)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# PrestaShop - Claude Code Instructions
+
+> **Keep this file lean.** This file is loaded into the AI context for every conversation in this repository. To avoid wasting context tokens, keep instructions here short and actionable. For detailed workflows, create a skill in `.claude/skills/` instead. Do not duplicate information that can be found in the codebase, git history, or existing documentation.
+
+## Branching & Versioning
+
+PrestaShop follows [SemVer](https://semver.org/). Active branches merge upward: `9.1.x` → `develop`. Target the lowest applicable branch.
+
+- **`9.1.x`**: Current stable (patch releases). Bug fixes and minor improvements only — no new features.
+- **`develop`**: Next minor (9.2.0). New features and improvements go here. No breaking changes.
+- **`8.2.x`**: LTS, security fixes only. Rarely modified.
+
+Breaking changes are only allowed in major versions. See [ADR 0017](https://github.com/PrestaShop/adr/blob/master/0017-backward-compatibility-promise.md) for the backward compatibility promise. More architecture decisions at https://github.com/PrestaShop/adr.


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Adds Claude Code project configuration: a `CLAUDE.md` with lean-file guidelines and branching strategy, a `create-pr` skill in `.claude/skills/` that enforces the PR description template for all contributors using Claude Code, and a `.gitignore` entry for personal Claude settings.
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Clone this branch and open the repo with Claude Code. 2. Ask Claude to "create a PR" — it should automatically use the `create-pr` skill and produce a description with the required metadata table. 3. Verify `CLAUDE.md` is loaded in context (visible in Claude Code's system info). 4. Verify `.claude/settings.local.json` is gitignored.
| UI Tests          |
| Fixed issue or discussion? |
| Related PRs       |
| Sponsor company   |

## Details

This PR introduces Claude Code support for the PrestaShop project:

- **`CLAUDE.md`**: Project-level instructions loaded automatically for every contributor using Claude Code. Kept intentionally lean with a guideline to maintain it that way. Includes branching strategy and links to ADR 0017.
- **`.claude/skills/create-pr/SKILL.md`**: A shared skill that enforces the PR description template (from `.github/PULL_REQUEST_TEMPLATE.md`). It auto-fills fields when possible (branch, type, category, issues) and asks contributors for required fields it cannot determine. Triggered automatically when a contributor asks to create a PR.
- **`.gitignore`**: Ignores `.claude/settings.local.json` (personal settings) while allowing `.claude/skills/` (shared) to be committed.

Contributors using Claude Code benefit immediately after pulling this branch — no per-user setup required.