### PR TITLE
Fix: align on the same line inline grid action and regular grid action

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/action.html.twig
@@ -19,7 +19,12 @@
       {% endif %}
     {% endfor %}
 
-    <div class="btn-group-action text-right">
+    {% if (inlineActions|length + regularActions|length) <= 2 %}
+      {% set inlineActions = inlineActions|merge(regularActions) %}
+      {% set regularActions = [] %}
+    {% endif %}
+
+    <div class="btn-group-action text-right d-flex justify-content-end align-items-center">
       {% if inlineActions is not empty %}
         <div class="btn-group btn-group-inline d-flex justify-content-start">
           {% for inlineAction in inlineActions -%}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The issue is well describe in the concerned issue that you can find below
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Quite challenging to test the behaviour. Need to add property "use_inline_display" on some existing grid row action
| UI Tests          | [Click here](https://github.com/Nakahiru/ga.tests.ui.pr/actions/runs/23639105260)
| Fixed issue or discussion?     | #29692
| Related PRs       | -
| Sponsor company   | -
