### PR TITLE
Add params to addJS method

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2288,7 +2288,7 @@ class AdminControllerCore extends Controller
     {
         // We assign js and css files on the last step before display template, because controller can add many js and css files
         $this->context->smarty->assign('css_files', $this->css_files);
-        $this->context->smarty->assign('js_files', array_unique($this->js_files));
+        $this->context->smarty->assign('js_files', array_unique($this->js_files, SORT_REGULAR));
 
         $this->context->smarty->assign([
             'ps_version' => _PS_VERSION_,

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -502,8 +502,9 @@ abstract class ControllerCore
      *
      * @param string|array $js_uri Path to JS file or an array like: array(uri, ...)
      * @param bool $check_path
+     * @param array $params Optional attributes (e.g., ['type' => 'module', 'defer' => true, 'async' => true])
      */
-    public function addJS($js_uri, $check_path = true)
+    public function addJS($js_uri, $check_path = true, $params = [])
     {
         if (!is_array($js_uri)) {
             $js_uri = [$js_uri];
@@ -520,8 +521,22 @@ abstract class ControllerCore
                 $js_path = Media::getJSPath($js_file);
             }
 
-            if ($js_path && !in_array($js_path, $this->js_files)) {
-                $this->js_files[] = $js_path . ($version ? '?' . $version : '');
+            if ($js_path) {
+                $uri = $js_path . ($version ? '?' . $version : '');
+                $exists = false;
+                foreach ($this->js_files as $existing_file) {
+                    if ((is_array($existing_file) && $existing_file['uri'] === $uri) || (is_string($existing_file) && $existing_file === $uri)) {
+                        $exists = true;
+                        break;
+                    }
+                }
+                if (!$exists) {
+                    // Backwards compatibility requires arrays formatted for the templates
+                    $this->js_files[] = [
+                        'uri' => $uri,
+                        'params' => $params
+                    ];
+                }
             }
         }
     }
@@ -543,8 +558,12 @@ abstract class ControllerCore
                 $js_file = Media::getJSPath($js_file);
             }
 
-            if ($js_file && in_array($js_file, $this->js_files)) {
-                unset($this->js_files[array_search($js_file, $this->js_files)]);
+            if ($js_file) {
+                foreach ($this->js_files as $key => $existing_file) {
+                    if ((is_array($existing_file) && $existing_file['uri'] === $js_file) || (is_string($existing_file) && $existing_file === $js_file)) {
+                        unset($this->js_files[$key]);
+                    }
+                }
             }
         }
     }

--- a/themes/javascript.tpl
+++ b/themes/javascript.tpl
@@ -10,8 +10,14 @@ var {$k} = {$def|json_encode nofilter};
 </script>
 {/if}
 {if isset($js_files) && $js_files|@count}
-{foreach from=$js_files key=k item=js_uri}
-<script type="text/javascript" src="{$js_uri}"></script>
+{foreach from=$js_files key=k item=js_file}
+  {assign var="js_uri" value=$js_file}
+  {assign var="js_params" value=[]}
+  {if is_array($js_file)}
+    {assign var="js_uri" value=$js_file.uri}
+    {assign var="js_params" value=$js_file.params}
+  {/if}
+  <script type="{if isset($js_params.type)}{$js_params.type}{else}text/javascript{/if}" src="{$js_uri|escape:'html':'UTF-8'}"{if isset($js_params.defer) && $js_params.defer} defer{/if}{if isset($js_params.async) && $js_params.async} async{/if}{if isset($js_params.attributes) && $js_params.attributes} {$js_params.attributes}{/if}></script>
 {/foreach}
 {/if}
 {if isset($js_inline) && $js_inline|@count}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add params to addJS method to make possible changing type, defear, etc...
| Type?             |  new feature
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Try to use addJS with a 3nd parameter like `[type=module]`. The script tag need to got this parameter.
| UI Tests          | https://github.com/ga-devfront/ga.tests.ui.pr/actions/runs/23647871040
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp
