### PR TITLE
Fix SMTP password with special characters being truncated

### DIFF
--- a/src/Core/Email/EmailDataConfigurator.php
+++ b/src/Core/Email/EmailDataConfigurator.php
@@ -6,8 +6,8 @@
 
 namespace PrestaShop\PrestaShop\Core\Email;
 
+use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 
 /**
  * Class EmailDataConfigurator is responsible for configuring email data.
@@ -15,14 +15,14 @@ use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 final class EmailDataConfigurator implements DataConfigurationInterface
 {
     /**
-     * @var ConfigurationInterface
+     * @var Configuration
      */
     private $configuration;
 
     /**
-     * @param ConfigurationInterface $configuration
+     * @param Configuration $configuration
      */
-    public function __construct(ConfigurationInterface $configuration)
+    public function __construct(Configuration $configuration)
     {
         $this->configuration = $configuration;
     }
@@ -78,7 +78,9 @@ final class EmailDataConfigurator implements DataConfigurationInterface
             $smtpPassword = (string) $config['smtp_config']['password'];
 
             if ('' !== $smtpPassword || !$this->configuration->get('PS_MAIL_PASSWD')) {
-                $this->configuration->set('PS_MAIL_PASSWD', $smtpPassword);
+                // Use html option to prevent strip_tags() from removing special characters like '<'
+                // @see https://github.com/PrestaShop/PrestaShop/issues/22540
+                $this->configuration->set('PS_MAIL_PASSWD', $smtpPassword, null, ['html' => true]);
             }
         }
 

--- a/tests/Integration/Core/Email/EmailDataConfiguratorTest.php
+++ b/tests/Integration/Core/Email/EmailDataConfiguratorTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Email;
+
+use Configuration as LegacyConfiguration;
+use PrestaShop\PrestaShop\Adapter\Configuration as ConfigurationAdapter;
+use PrestaShop\PrestaShop\Core\Email\EmailDataConfigurator;
+use Tests\Resources\DatabaseDump;
+use Tests\TestCase\AbstractConfigurationTestCase;
+
+/**
+ * @group email
+ */
+class EmailDataConfiguratorTest extends AbstractConfigurationTestCase
+{
+    private EmailDataConfigurator $emailDataConfigurator;
+    private ConfigurationAdapter $configuration;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        static::resetConfiguration();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        static::resetConfiguration();
+    }
+
+    protected static function resetConfiguration(): void
+    {
+        DatabaseDump::restoreTables([
+            'configuration',
+            'configuration_lang',
+        ]);
+
+        LegacyConfiguration::resetStaticCache();
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->configuration = new ConfigurationAdapter();
+        $this->emailDataConfigurator = new EmailDataConfigurator($this->configuration);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        // Clean up the test password
+        LegacyConfiguration::deleteByName('PS_MAIL_PASSWD');
+        LegacyConfiguration::resetStaticCache();
+    }
+
+    /**
+     * Test that SMTP password with special characters is saved correctly.
+     *
+     * @dataProvider passwordWithSpecialCharactersProvider
+     *
+     * @see https://github.com/PrestaShop/PrestaShop/issues/22540
+     */
+    public function testSmtpPasswordWithSpecialCharactersIsSavedCorrectly(string $password): void
+    {
+        // Arrange
+        $config = $this->getValidConfiguration($password);
+
+        // Act
+        $this->emailDataConfigurator->updateConfiguration($config);
+
+        // Assert
+        $savedPassword = LegacyConfiguration::get('PS_MAIL_PASSWD');
+        $this->assertSame(
+            $password,
+            $savedPassword,
+            sprintf(
+                'Password should be saved exactly as provided. Expected "%s", got "%s"',
+                $password,
+                $savedPassword
+            )
+        );
+    }
+
+    /**
+     * Data provider for passwords with special characters.
+     */
+    public function passwordWithSpecialCharactersProvider(): array
+    {
+        return [
+            'password with less than sign' => ['abcd<efgh'],
+            'password with greater than sign' => ['abcd>efgh'],
+            'password with both signs' => ['<password>'],
+            'password with HTML-like content' => ['my<script>password'],
+            'password with ampersand' => ['pass&word'],
+            'password with quotes' => ['pass"word\'test'],
+            'complex password' => ['P@ss<w0rd>&"test\'123'],
+            'simple password' => ['simplepassword'],
+            'empty password' => [''],
+        ];
+    }
+
+    /**
+     * Get a valid configuration array for testing.
+     */
+    private function getValidConfiguration(string $password): array
+    {
+        return [
+            'send_emails_to' => 1,
+            'mail_method' => 2,
+            'subject_prefix' => true,
+            'mail_type' => 1,
+            'log_emails' => false,
+            'dkim_enable' => false,
+            'dkim_config' => [
+                'domain' => '',
+                'selector' => '',
+                'key' => '',
+            ],
+            'smtp_config' => [
+                'domain' => 'example.com',
+                'server' => 'smtp.example.com',
+                'username' => 'user@example.com',
+                'password' => $password,
+                'encryption' => 'tls',
+                'port' => '587',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix SMTP password with special characters like `<` being truncated when saved
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See steps below
| Fixed issue or discussion? | Fixes #22540

## Summary

When saving an SMTP password containing special characters like `<`, the password was being truncated because `strip_tags()` was called during the save process.

**Example:**
- Input password: `abcd + less-than sign + efgh`
- Saved in database: `abcd` ❌

## Root cause

In `Db::escape()`, when `$html_ok = false` (default), `strip_tags()` is called which removes anything that looks like an HTML tag.

## Solution

Use `Configuration::updateValue()` with `html=true` flag to prevent `strip_tags()` from being called on the SMTP password value.

## How to test

1. Go to BO "Advanced Parameters > Email"
2. Choose "SMTP" for email options
3. Input password `abcd + less-than sign + efgh`
4. Save
5. Check database content: `SELECT value FROM ps_configuration WHERE name = 'PS_MAIL_PASSWD'`
6. ✅ Value should be `abcd<efgh` (not `abcd`)

## Changes

- `src/Core/Email/EmailDataConfigurator.php`: Use `html=true` flag when saving SMTP password
- Added integration tests for passwords with special characters (`<`, `>`, `&`, quotes, etc.)