### PR TITLE
Fix: cast bool fields in GetCmsPageForEditingHandler

### DIFF
--- a/src/Adapter/CMS/Page/QueryHandler/GetCmsPageForEditingHandler.php
+++ b/src/Adapter/CMS/Page/QueryHandler/GetCmsPageForEditingHandler.php
@@ -66,8 +66,8 @@ final class GetCmsPageForEditingHandler extends AbstractCmsPageHandler implement
                 $cms->meta_description,
                 $cms->link_rewrite,
                 $cms->content,
-                $cms->indexation,
-                $cms->active,
+                (bool) $cms->indexation,
+                (bool) $cms->active,
                 $cms->getAssociatedShops(),
                 $this->link->getCMSLink($cms, null, null, $this->langId)
             );


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Cast \$cms->indexation` and `$cms->active` to `bool` in `GetCmsPageForEditingHandler`, as PDO returns TINYINT(1) values as strings, causing a serializer error when building strictly-typed API resources.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Using the new endpoint GET /cms-pages/{id}(), you should not have a fatal error. The type of the "indexedForSearch" attribute must be "bool", "string" given.
| UI Tests          | Did I have to launch all UI test for a "little" fix like this ?
| Fixed issue or discussion?     | Fix #41142 
| Related PRs       | Needed for [#165 api_resources](https://github.com/PrestaShop/ps_apiresources/pull/165)
| Sponsor company   | axel-paillaud

## Why

PDO returns TINYINT(1) database values as strings ("0"/"1") by default.
`GetCmsPageForEditingHandler` was passing `$cms->indexation` and
`$cms->active` without casting them to `bool`, meaning `EditableCmsPage`
stored raw strings for these two fields.

This causes a `NotNormalizableValueException` from the Symfony serializer
whenever `EditableCmsPage` is serialized into a strictly-typed API resource
(e.g. a `public bool $indexedForSearch` property), because the serializer
refuses to coerce a string into a bool for typed properties.

## What

Add explicit `(bool)` casts on `$cms->indexation` and `$cms->active` when
constructing `EditableCmsPage`.

## Precedent

All other query handlers in the codebase already cast their boolean fields
explicitly: `GetZoneForEditingHandler`, `GetCountryForEditingHandler`,
`GetContactForEditingHandler`, `GetSupplierForEditingHandler`, and others.
`GetCmsPageForEditingHandler` was the only one missing these casts.

Additionally, `CmsPageFeatureContext.php` already applies `(bool)` when
reading these same fields (lines 213 and 236), which confirms the cast
was always expected.

## Testing

No new tests required. The functional behavior is unchanged,
`(bool)"1" === true` and `(bool)"0" === false`. Existing Behat scenarios
in `tests/Integration/Behaviour/Features/Scenario/CmsPage/` already cover
these fields implicitly.