### PR TITLE
Fix: guard against null employee in associateWithShops()

### DIFF
--- a/src/Adapter/Domain/AbstractObjectModelHandler.php
+++ b/src/Adapter/Domain/AbstractObjectModelHandler.php
@@ -44,8 +44,9 @@ abstract class AbstractObjectModelHandler
 
         // Get list of shop id we want to exclude from asso deletion
         $excludeIds = $shopAssociation;
+        $employee = Context::getContext()->employee;
         foreach (Db::getInstance()->executeS('SELECT id_shop FROM ' . _DB_PREFIX_ . 'shop') as $row) {
-            if (!Context::getContext()->employee->hasAuthOnShop($row['id_shop'])) {
+            if ($employee !== null && !$employee->hasAuthOnShop($row['id_shop'])) {
                 $excludeIds[] = $row['id_shop'];
             }
         }
@@ -61,7 +62,8 @@ abstract class AbstractObjectModelHandler
         $insert = [];
         foreach ($shopAssociation as $shopId) {
             // Check if context employee has access to the shop before inserting shop association.
-            if (Context::getContext()->employee->hasAuthOnShop($shopId)) {
+            // When employee is null (e.g. Admin API context), all requested shops are allowed.
+            if ($employee === null || $employee->hasAuthOnShop($shopId)) {
                 $insert[] = [
                     $primaryKeyName => $primaryKeyValue,
                     'id_shop' => (int) $shopId,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fix fatal error in associateWithShops() when called from Admin API context where legacy employee is null.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Enable multistore, then call `POST /admin-api/zones?shopId=1` with a valid Bearer token and body. Expect `201` before and after the fix (was `500` before).
| UI Tests          | https://github.com/kpodemski/ga.tests.ui.pr/actions/runs/28570024605
| Fixed issue or discussion?     | Fix #41143 
| Related PRs       | [#165 ps_apiresources](https://github.com/PrestaShop/ps_apiresources/pull/165)
| Sponsor company   | axel-paillaud

## Problem

When the Admin API is used with multistore enabled, any write operation on an entity which use legacy `associateWithShops` (e.g. Zones, CmsPage) throws a fatal 500 error:

```
Call to a member function hasAuthOnShop() on null
```

This happens in `AbstractObjectModelHandler::associateWithShops()`, which calls `Context::getContext()->employee->hasAuthOnShop()`. In the Admin API context (OAuth2), no legacy employee is set, `Context::getContext()->employee` is `null`.

The bug affects **all entities** that call `associateWithShops()`, not just one specific handler.

## Fix

Add a null check on `employee` before calling `hasAuthOnShop()`. When `employee` is null (Admin API context), the authorization check is skipped and all requested shops are allowed — consistent with the fact that access is already controlled by OAuth2 scopes.

## How to test

1. Enable multistore in **Shop Parameters > General > Enable Multistore**
2. Obtain a Bearer token from the Admin API (`POST /api/access_token`)
3. Call any write endpoint on an entity with shop association, e.g.:
   ```
   POST /api/categories?shopId=1
   Authorization: Bearer <token>
   Content-Type: application/json

   {
     "names": { "en-US": "Test" },
     "linkRewrites": { "en-US": "test" },
     "parentId": 2,
     "shopIds": [1]
   }
   ```
4. **Before fix**: returns `500 - Call to a member function hasAuthOnShop() on null`
5. **After fix**: returns `201` with the created entity


## Why this is safe

- In the legacy back-office context, `employee` is never null, so existing behavior is unchanged.
- In the Admin API context, shop access is governed by OAuth2 scopes, not by employee shop permissions. Skipping the employee check is the correct behavior.
- When multistore is disabled, `associateWithShops()` returns early before reaching this code, this fix only impacts multistore + API usage.
