### PR TITLE
Add automatic cache busting for CSS and JS assets

### DIFF
--- a/classes/assets/JavascriptManager.php
+++ b/classes/assets/JavascriptManager.php
@@ -82,6 +82,15 @@ class JavascriptManagerCore extends AbstractAssetManager
         $attribute = $this->getSanitizedAttribute($attribute);
 
         $srcPath = $fullPath;
+
+        // Auto-generate version from file modification time for cache busting
+        if ($version === null && $server !== 'remote') {
+            $physicalPath = $this->getPathFromUri($fullPath);
+            if (file_exists($physicalPath)) {
+                $version = (string) filemtime($physicalPath);
+            }
+        }
+
         $fullPath = $version ? $fullPath . '?' . $version : $fullPath;
 
         if ('remote' === $server) {

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -95,6 +95,15 @@ class StylesheetManagerCore extends AbstractAssetManager
         $media = $this->getSanitizedMedia($media);
 
         $srcPath = $fullPath;
+
+        // Auto-generate version from file modification time for cache busting
+        if ($version === null && $server !== 'remote') {
+            $physicalPath = $this->getPathFromUri($fullPath);
+            if (file_exists($physicalPath)) {
+                $version = (string) filemtime($physicalPath);
+            }
+        }
+
         $fullPath = $version ? $fullPath . '?' . $version : $fullPath;
 
         if ('remote' === $server) {

--- a/tests/Integration/Classes/Assets/JavascriptManagerTest.php
+++ b/tests/Integration/Classes/Assets/JavascriptManagerTest.php
@@ -59,4 +59,71 @@ class JavascriptManagerTest extends TestCase
         yield ['corejs-ok-4', true, 'js/core.js'];
         yield ['corejs-fail-4', false, false];
     }
+
+    public function testAutoCacheBustingForLocalAssets(): void
+    {
+        $testsPath = '/tests/Resources/assets_manager/';
+        $configuration = new Configuration();
+
+        $javascriptManager = new JavascriptManager(
+            [$testsPath],
+            $configuration
+        );
+
+        $javascriptManager->register('cache-bust-test', '/core.js', 'bottom', 10, false);
+
+        $list = $javascriptManager->getList();
+        $asset = $list['bottom']['external']['cache-bust-test'];
+
+        // URI should contain a query string with the file modification timestamp
+        $this->assertStringContainsString('?', $asset['uri']);
+
+        // Extract the version from URI
+        $uriParts = explode('?', $asset['uri']);
+        $version = $uriParts[1] ?? '';
+
+        // Version should be a valid timestamp (numeric)
+        $this->assertMatchesRegularExpression('/^\d+$/', $version);
+
+        // Version should match the file's modification time
+        $physicalPath = $configuration->get('_PS_ROOT_DIR_') . $testsPath . 'core.js';
+        $expectedVersion = (string) filemtime($physicalPath);
+        $this->assertSame($expectedVersion, $version);
+    }
+
+    public function testManualVersionOverridesAutoCacheBusting(): void
+    {
+        $testsPath = '/tests/Resources/assets_manager/';
+
+        $javascriptManager = new JavascriptManager(
+            [$testsPath],
+            new Configuration()
+        );
+
+        $manualVersion = 'v1.2.3';
+        $javascriptManager->register('manual-version-test', '/core.js', 'bottom', 10, false, null, 'local', $manualVersion);
+
+        $list = $javascriptManager->getList();
+        $asset = $list['bottom']['external']['manual-version-test'];
+
+        // URI should contain the manual version, not auto-generated timestamp
+        $this->assertStringContainsString('?' . $manualVersion, $asset['uri']);
+    }
+
+    public function testRemoteAssetsDoNotGetAutoCacheBusting(): void
+    {
+        $javascriptManager = new JavascriptManager(
+            [],
+            new Configuration()
+        );
+
+        $remoteUrl = 'https://cdn.example.com/script.js';
+        $javascriptManager->register('remote-test', $remoteUrl, 'bottom', 10, false, null, 'remote');
+
+        $list = $javascriptManager->getList();
+        $asset = $list['bottom']['external']['remote-test'];
+
+        // Remote URI should not have a query string added
+        $this->assertSame($remoteUrl, $asset['uri']);
+    }
 }

--- a/tests/Integration/Classes/Assets/StylesheetManagerTest.php
+++ b/tests/Integration/Classes/Assets/StylesheetManagerTest.php
@@ -60,4 +60,71 @@ class StylesheetManagerTest extends TestCase
         yield ['theme-ok-4', true, 'css/custom.css'];
         yield ['theme-fail-4', false, false];
     }
+
+    public function testAutoCacheBustingForLocalAssets(): void
+    {
+        $testsPath = '/tests/Resources/assets_manager/';
+        $configuration = new Configuration();
+
+        $stylesheetManager = new StylesheetManager(
+            [$testsPath],
+            $configuration
+        );
+
+        $stylesheetManager->register('cache-bust-test', '/theme.css', 'all', 10, false);
+
+        $list = $stylesheetManager->getList();
+        $asset = $list['external']['cache-bust-test'];
+
+        // URI should contain a query string with the file modification timestamp
+        $this->assertStringContainsString('?', $asset['uri']);
+
+        // Extract the version from URI
+        $uriParts = explode('?', $asset['uri']);
+        $version = $uriParts[1] ?? '';
+
+        // Version should be a valid timestamp (numeric)
+        $this->assertMatchesRegularExpression('/^\d+$/', $version);
+
+        // Version should match the file's modification time
+        $physicalPath = $configuration->get('_PS_ROOT_DIR_') . $testsPath . 'theme.css';
+        $expectedVersion = (string) filemtime($physicalPath);
+        $this->assertSame($expectedVersion, $version);
+    }
+
+    public function testManualVersionOverridesAutoCacheBusting(): void
+    {
+        $testsPath = '/tests/Resources/assets_manager/';
+
+        $stylesheetManager = new StylesheetManager(
+            [$testsPath],
+            new Configuration()
+        );
+
+        $manualVersion = 'v1.2.3';
+        $stylesheetManager->register('manual-version-test', '/theme.css', 'all', 10, false, 'local', true, $manualVersion);
+
+        $list = $stylesheetManager->getList();
+        $asset = $list['external']['manual-version-test'];
+
+        // URI should contain the manual version, not auto-generated timestamp
+        $this->assertStringContainsString('?' . $manualVersion, $asset['uri']);
+    }
+
+    public function testRemoteAssetsDoNotGetAutoCacheBusting(): void
+    {
+        $stylesheetManager = new StylesheetManager(
+            [],
+            new Configuration()
+        );
+
+        $remoteUrl = 'https://cdn.example.com/styles.css';
+        $stylesheetManager->register('remote-test', $remoteUrl, 'all', 10, false, 'remote');
+
+        $list = $stylesheetManager->getList();
+        $asset = $list['external']['remote-test'];
+
+        // Remote URI should not have a query string added
+        $this->assertSame($remoteUrl, $asset['uri']);
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Auto-generate version query string from file modification time for local CSS/JS assets
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| Fixed issue?      | Fixes #27819

## Summary

When registering CSS or JS assets without an explicit version, the asset managers now automatically append the file's modification timestamp as a query string parameter.

**Before:** `style.css`
**After:** `style.css?1711721234`

This enables:
- ✅ Long browser cache times (better performance)
- ✅ Immediate propagation of file changes (no stale assets)
- ✅ CDN-friendly cache invalidation

## Technical changes

- `StylesheetManager::add()` - auto-generates version from `filemtime()` when `$version` is null
- `JavascriptManager::add()` - auto-generates version from `filemtime()` when `$version` is null
- Remote assets (`server = 'remote'`) are not affected
- Manual versions still take precedence over auto-generated ones

## How to test

1. Clear PrestaShop cache
2. Load any front-office page
3. Inspect the HTML source
4. CSS and JS URLs should now include a `?{timestamp}` query parameter
5. Modify a CSS/JS file (e.g., touch a theme file)
6. Reload the page
7. The query parameter should have changed to reflect the new modification time

## Automated tests

Added 6 integration tests covering:
- Auto cache busting for local assets
- Manual version override behavior
- Remote assets exclusion