### PR TITLE
Avoid specific price rule saved with 0€ discount

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1113,7 +1113,7 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
 
             // isRequiredWhenActive and defaultLanguageRequiredWhenActive validators must be called especially when the value is empty
             $isEmptyValidationMethod = Tools::strtolower($data['validate']) === 'isrequiredwhenactive' || Tools::strtolower($data['validate']) === 'defaultlanguagerequiredwhenactive';
-            if (!empty($value) || $isEmptyValidationMethod) {
+            if (!empty($value) || $value === '0' || $isEmptyValidationMethod) {
                 $res = $this->callValidateMethod($data['validate'], $value, isset($id_lang) ? (int) $id_lang : null);
                 if (!$res) {
                     if ($human_errors) {

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1236,8 +1236,13 @@ abstract class ObjectModelCore implements PrestaShop\PrestaShop\Core\Foundation\
                 throw new PrestaShopException($this->trans('Validation function not found: %s.', [$data['validate']], 'Admin.Notifications.Error'));
             }
 
-            // isRequiredWhenActive and defaultLanguageRequiredWhenActive validators must be called especially when the value is empty
-            $isEmptyValidationMethod = Tools::strtolower($data['validate']) === 'isrequiredwhenactive' || Tools::strtolower($data['validate']) === 'defaultlanguagerequiredwhenactive';
+            // These validators exist precisely to reject an empty or zero value, so skipping them
+            // because the value is empty makes them unreachable. They must run on every value.
+            $isEmptyValidationMethod = in_array(Tools::strtolower($data['validate']), [
+                'isrequiredwhenactive',
+                'defaultlanguagerequiredwhenactive',
+                'ispositiveprice',
+            ], true);
             if (!empty($value) || $isEmptyValidationMethod) {
                 $res = $this->callValidateMethod($data['validate'], $value, isset($id_lang) ? (int) $id_lang : null);
                 if (!$res) {

--- a/classes/SpecificPriceRule.php
+++ b/classes/SpecificPriceRule.php
@@ -34,7 +34,7 @@ class SpecificPriceRuleCore extends ObjectModel
             'id_group' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true],
             'from_quantity' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'required' => true],
             'price' => ['type' => self::TYPE_FLOAT, 'validate' => 'isNegativePrice', 'required' => true],
-            'reduction' => ['type' => self::TYPE_FLOAT, 'validate' => 'isPrice', 'required' => true],
+            'reduction' => ['type' => self::TYPE_FLOAT, 'validate' => 'isPositivePrice', 'required' => true],
             'reduction_tax' => ['type' => self::TYPE_INT, 'validate' => 'isBool', 'required' => true],
             'reduction_type' => ['type' => self::TYPE_STRING, 'validate' => 'isReductionType', 'required' => true],
             'from' => ['type' => self::TYPE_DATE, 'validate' => 'isDateFormat', 'required' => false],

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -298,6 +298,18 @@ class ValidateCore
     }
 
     /**
+     * Check for price validity (including positive price).
+     *
+     * @param string $price Price to validate
+     *
+     * @return bool Validity is ok or not
+     */
+    public static function isPositivePrice($price)
+    {
+        return self::isPrice($price) && (float) $price > 0;
+    }
+
+    /**
      * Check for language code (ISO) validity.
      *
      * @param string $iso_code Language code (ISO) to validate

--- a/tests/Integration/Classes/SpecificPriceRuleValidationTest.php
+++ b/tests/Integration/Classes/SpecificPriceRuleValidationTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Customer;
+use PHPUnit\Framework\TestCase;
+use Product;
+use SpecificPriceRule;
+use Store;
+
+/**
+ * A catalog price rule with no reduction is not a price rule. The validator that says so only runs if
+ * ObjectModel lets it run, and ObjectModel skips validation for any value `empty()` calls empty - which
+ * covers '0', 0 and 0.0. Both halves are tested here: the reduction has to be rejected in every shape a
+ * caller can write it, and the fields of other models that legitimately hold a zero must keep saving.
+ */
+class SpecificPriceRuleValidationTest extends TestCase
+{
+    /**
+     * @dataProvider provideRejectedReductions
+     *
+     * @param mixed $reduction
+     */
+    public function testAReductionOfZeroIsRejectedWhateverTypeItArrivesAs($reduction): void
+    {
+        $rule = new SpecificPriceRule();
+
+        $this->assertNotTrue(
+            $rule->validateField('reduction', $reduction),
+            sprintf('a reduction of %s was accepted', var_export($reduction, true))
+        );
+    }
+
+    public function provideRejectedReductions(): iterable
+    {
+        // the back office form posts a string; a module, an import or the webservice writes a number
+        yield "string '0'" => ['0'];
+        yield "string '0.00'" => ['0.00'];
+        yield "string '0.0'" => ['0.0'];
+        yield 'int 0' => [0];
+        yield 'float 0.0' => [0.0];
+    }
+
+    /**
+     * @dataProvider provideAcceptedReductions
+     *
+     * @param mixed $reduction
+     */
+    public function testAReductionAboveZeroIsStillAccepted($reduction): void
+    {
+        $rule = new SpecificPriceRule();
+
+        $this->assertTrue($rule->validateField('reduction', $reduction));
+    }
+
+    public function provideAcceptedReductions(): iterable
+    {
+        yield "string '5'" => ['5'];
+        yield "string '0.01'" => ['0.01'];
+        yield 'float 5.0' => [5.0];
+        yield 'int 5' => [5];
+    }
+
+    /**
+     * The regression guard. Widening ObjectModel's "is there a value here" test instead of the rule's own
+     * validator reaches every field of every model: a store on the equator, a product with no minimum
+     * quantity and a customer whose name is one character all carry a zero that has always been valid.
+     *
+     * @dataProvider provideZerosThatMustStillBeAccepted
+     */
+    public function testAZeroThatIsValidElsewhereIsStillAccepted(object $model, string $field, $value): void
+    {
+        $this->assertTrue(
+            $model->validateField($field, $value),
+            sprintf('%s->%s rejected %s', get_class($model), $field, var_export($value, true))
+        );
+    }
+
+    public function provideZerosThatMustStillBeAccepted(): iterable
+    {
+        yield 'store on the equator' => [new Store(), 'latitude', '0'];
+        yield 'store on the prime meridian' => [new Store(), 'longitude', '0'];
+        yield 'product with no minimum quantity' => [new Product(), 'minimal_quantity', '0'];
+        yield 'customer named 0' => [new Customer(), 'firstname', '0'];
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | When creating a catalog price rule, it is possible to set a 0€ discount and save the rule without any error message being displayed
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to BO → Catalog → Discounts → Catalog Price Rules<br>Click Add new catalog price rule<br>Fill in all mandatory fields (name, currency, etc.)<br>Set Reduction = 0€<br>Click Save<br>You have an error message saying incorrect price
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #39684 
| Related PRs       | 
| Sponsor company   | Agence Off