### PR TITLE
Mark Upgrader class as deprecated

### DIFF
--- a/classes/Upgrader.php
+++ b/classes/Upgrader.php
@@ -5,7 +5,7 @@
  */
 
 /**
- * Class UpgraderCore.
+ * @deprecated since 9.2.0, will be removed in 10.0.0
  */
 class UpgraderCore
 {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Mark `classes/Upgrader.php` as deprecated
| Type?             | improvement
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     | yes
| How to test?      | N/A it's a deprecation
| UI Tests          | N/A
| Fixed issue or discussion?     | N/A
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/38870
| Sponsor company   | @PrestaShopCorp
