### PR TITLE
Update tax rates and names for CH localization

### DIFF
--- a/localization/ch.xml
+++ b/localization/ch.xml
@@ -9,19 +9,19 @@
 		<language iso_code="it" />
 	</languages>
 	<taxes>
-		<tax id="1" name="TVA CH 7.7%" rate="7.7" />
-		<tax id="2" name="TVA CH 3.7%" rate="3.7" />
-		<tax id="3" name="TVA CH 2.5%" rate="2.5" />
+		<tax id="1" name="TVA CH 8.1%" rate="8.1" />
+		<tax id="2" name="TVA CH 3.8%" rate="3.8" />
+		<tax id="3" name="TVA CH 2.6%" rate="2.6" />
 
-		<taxRulesGroup name="CH Standard Rate (7.7%)">
+		<taxRulesGroup name="CH Standard Rate (8.1%)">
 			<taxRule iso_code_country="ch" id_tax="1" />
 		</taxRulesGroup>
 
-		<taxRulesGroup name="CH Reduced Rate (3.7%)">
+		<taxRulesGroup name="CH Reduced Rate (3.8%)">
 			<taxRule iso_code_country="ch" id_tax="2" />
 		</taxRulesGroup>
 
-		<taxRulesGroup name="CH Super Reduced Rate (2.5%)">
+		<taxRulesGroup name="CH Super Reduced Rate (2.6%)">
 			<taxRule iso_code_country="ch" id_tax="3" />
 		</taxRulesGroup>
 	</taxes>


### PR DESCRIPTION
Since January 1, 2024, the VAT rates in Switzerland have been increased to 8.1%, 2.6%, and 3.8%.

Reference: https://www.estv.admin.ch/de/mwst-steuersaetze-schweiz

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Since January 1, 2024, the VAT rates in Switzerland have been increased to 8.1%, 2.6%, and 3.8%.
| Type?             | improvement
| Category?         | LO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |  Install Prestashop by CLI Installer with option --country=ch and go to International > Steuersätze
| UI Tests          | 
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | die.internauten.ch GmbH
