### PR TITLE
Fix admin URL construction in Install.php

### DIFF
--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -1233,7 +1233,7 @@ class Install extends AbstractInstall
         // And then, we build url and log this information!
         Context::getContext()->shop = new Shop(1);
         Context::getContext()->link = new Link();
-        $adminUrl = rtrim(Context::getContext()->link->getAdminBaseLink(), '/') . '/' . $adminFolder;
+        $adminUrl = rtrim(Context::getContext()->link->getAdminBaseLink(), '/') . '/' . $adminFolder . '/';
 
         $this->getLogger()->logInfo(sprintf('You can now access your backoffice at %s.', $adminUrl));
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Avoid issue while clicking on link after CLI installation (No route found for "GET https://xxx/admin-dev")
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Issue | https://github.com/PrestaShop/PrestaShop/issues/41264
| How to test?      | Create a shop with the CLI install and click on the link(s) given on the end, to access the dashboard.
