### PR TITLE
Add AI-agnostic context architecture (.ai/ folder)

### DIFF
--- a/.ai/CONTEXT.md
+++ b/.ai/CONTEXT.md
@@ -1,0 +1,107 @@
+# PrestaShop — AI Context (Root)
+
+> This is the root AI context file for the PrestaShop open-source project.
+> For details on how this `.ai/` folder is organized, see [STRUCTURE.md](STRUCTURE.md).
+
+## Project overview
+
+PrestaShop is an open-source e-commerce platform built on Symfony. It follows a progressive migration from a legacy architecture (ObjectModel, legacy controllers) toward a modern Domain-Driven Design approach (CQRS, Symfony controllers, Doctrine).
+
+## Architecture layers
+
+| Layer | Location | Role |
+|-------|----------|------|
+| **Core Domain** | `src/Core/Domain/` | Business logic: Commands, Queries, Handlers, ValueObjects, Exceptions |
+| **Core Components** | `src/Core/` (non-Domain) | Shared infrastructure: Grid, Form, Hook, Translation, etc. |
+| **Adapter** | `src/Adapter/` | Bridges between Core and legacy code or external systems |
+| **PrestaShopBundle** | `src/PrestaShopBundle/` | Symfony bundle: controllers, form types, Twig extensions, DI config |
+| **Legacy** | `classes/`, `controllers/` | Legacy ObjectModel classes and controllers — do not extend, migrate instead |
+| **Admin front-end** | `admin-dev/themes/new-theme/` | Back-office UI: Vue.js components, JavaScript, SCSS |
+| **Front-office themes** | `themes/` | Customer-facing Smarty templates |
+| **Modules** | `modules/` | Native and third-party modules |
+| **Tests** | `tests/` | PHPUnit (unit/integration), Behat (behavior), Playwright (UI) |
+
+## General coding standards
+
+- **Strict types** — every PHP file must declare `declare(strict_types=1);`
+- **Final classes by default** — use `final` unless inheritance is explicitly needed
+- **Type declarations** — all parameters, return types, and properties must be typed
+- **No ObjectModel in new code** — use Doctrine entities or CQRS commands instead
+- **Symfony services** — all services must be defined in YAML config, no `new` in controllers
+- **English only** — all code, comments, and documentation in English
+
+## CQRS pattern
+
+New back-office features must follow the CQRS pattern:
+- **Commands** — represent write intentions (`AddProductCommand`, `UpdateCartRuleCommand`)
+- **Queries** — represent read intentions (`GetProductForEditing`, `SearchCustomers`)
+- **Handlers** — execute the business logic (`AddProductCommandHandler`)
+- Commands and Queries are dispatched via the `CommandBus` / `QueryBus`
+- Handlers must not call other handlers — compose at the controller level
+
+## Do (project-wide)
+
+- Follow existing patterns in the domain you're working on
+- Use ValueObjects for domain identifiers (e.g., `ProductId`, `CartId`)
+- Throw domain-specific exceptions (e.g., `ProductNotFoundException`)
+- Write unit tests for Handlers, integration tests for Commands/Queries
+- Use Behat for behavior scenarios that cross multiple domains
+
+## Don't (project-wide)
+
+- Don't instantiate services manually — use dependency injection
+- Don't add business logic in controllers — delegate to Handlers
+- Don't use legacy `Db::getInstance()` in new code — use Doctrine repositories
+- Don't catch generic `\Exception` — catch specific domain exceptions
+- Don't modify legacy classes unless fixing a bug — new features go in `src/`
+
+## Testing expectations
+
+| Type | Framework | Location | When to use |
+|------|-----------|----------|-------------|
+| Unit | PHPUnit | `tests/Unit/` | Handlers, ValueObjects, domain logic |
+| Integration | PHPUnit | `tests/Integration/` | Commands, Queries, Doctrine repositories |
+| Behavior | Behat | `tests/Integration/Behaviour/` | Domain scenarios, multi-step workflows |
+| UI | Playwright | `tests/UI/` | End-to-end back-office and front-office flows |
+
+## Domain contexts
+
+These files contain conventions and rules specific to each business domain.
+
+| Domain | Path | Status |
+|--------|------|--------|
+| Cart | [.ai/Domain/Cart/CONTEXT.md](Domain/Cart/CONTEXT.md) | Draft |
+| Product | [.ai/Domain/Product/CONTEXT.md](Domain/Product/CONTEXT.md) | Draft |
+
+> More domains will be added progressively. To add a new one, see [STRUCTURE.md](STRUCTURE.md#adding-context-for-a-new-domain).
+
+## Component contexts
+
+These files contain conventions and usage patterns for shared infrastructure components.
+
+| Component | Path | Status |
+|-----------|------|--------|
+| Back Office Help | [.ai/Component/BackOfficeHelp/CONTEXT.md](Component/BackOfficeHelp/CONTEXT.md) | To be defined |
+| Configuration | [.ai/Component/Configuration/CONTEXT.md](Component/Configuration/CONTEXT.md) | To be defined |
+| Console | [.ai/Component/Console/CONTEXT.md](Component/Console/CONTEXT.md) | To be defined |
+| Context | [.ai/Component/Context/CONTEXT.md](Component/Context/CONTEXT.md) | To be defined |
+| Cookie | [.ai/Component/Cookie/CONTEXT.md](Component/Cookie/CONTEXT.md) | To be defined |
+| CQRS | [.ai/Component/CQRS/CONTEXT.md](Component/CQRS/CONTEXT.md) | To be defined |
+| Database | [.ai/Component/Database/CONTEXT.md](Component/Database/CONTEXT.md) | To be defined |
+| Export | [.ai/Component/Export/CONTEXT.md](Component/Export/CONTEXT.md) | To be defined |
+| Faceted Search | [.ai/Component/FacetedSearch/CONTEXT.md](Component/FacetedSearch/CONTEXT.md) | To be defined |
+| Forms | [.ai/Component/Forms/CONTEXT.md](Component/Forms/CONTEXT.md) | To be defined |
+| Global JS | [.ai/Component/GlobalJS/CONTEXT.md](Component/GlobalJS/CONTEXT.md) | To be defined |
+| Grid | [.ai/Component/Grid/CONTEXT.md](Component/Grid/CONTEXT.md) | To be defined |
+| Hook | [.ai/Component/Hook/CONTEXT.md](Component/Hook/CONTEXT.md) | To be defined |
+| Import | [.ai/Component/Import/CONTEXT.md](Component/Import/CONTEXT.md) | To be defined |
+| Link | [.ai/Component/Link/CONTEXT.md](Component/Link/CONTEXT.md) | To be defined |
+| Locale | [.ai/Component/Locale/CONTEXT.md](Component/Locale/CONTEXT.md) | To be defined |
+| Mail Template | [.ai/Component/MailTemplate/CONTEXT.md](Component/MailTemplate/CONTEXT.md) | To be defined |
+| Position Updater | [.ai/Component/PositionUpdater/CONTEXT.md](Component/PositionUpdater/CONTEXT.md) | To be defined |
+| Router | [.ai/Component/Router/CONTEXT.md](Component/Router/CONTEXT.md) | To be defined |
+| Smarty | [.ai/Component/Smarty/CONTEXT.md](Component/Smarty/CONTEXT.md) | To be defined |
+| TinyMCE | [.ai/Component/TinyMCE/CONTEXT.md](Component/TinyMCE/CONTEXT.md) | To be defined |
+| Twig | [.ai/Component/Twig/CONTEXT.md](Component/Twig/CONTEXT.md) | To be defined |
+
+> To add a new component, see [STRUCTURE.md](STRUCTURE.md#adding-context-for-a-new-component).

--- a/.ai/Component/BackOfficeHelp/CONTEXT.md
+++ b/.ai/Component/BackOfficeHelp/CONTEXT.md
@@ -1,0 +1,35 @@
+# Back Office Help
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/CQRS/CONTEXT.md
+++ b/.ai/Component/CQRS/CONTEXT.md
@@ -1,0 +1,35 @@
+# CQRS
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/Configuration/CONTEXT.md
+++ b/.ai/Component/Configuration/CONTEXT.md
@@ -1,0 +1,35 @@
+# Configuration
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/Console/CONTEXT.md
+++ b/.ai/Component/Console/CONTEXT.md
@@ -1,0 +1,35 @@
+# Console
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/Context/CONTEXT.md
+++ b/.ai/Component/Context/CONTEXT.md
@@ -1,0 +1,35 @@
+# Context
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/Cookie/CONTEXT.md
+++ b/.ai/Component/Cookie/CONTEXT.md
@@ -1,0 +1,35 @@
+# Cookie
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/Database/CONTEXT.md
+++ b/.ai/Component/Database/CONTEXT.md
@@ -1,0 +1,35 @@
+# Database
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/Export/CONTEXT.md
+++ b/.ai/Component/Export/CONTEXT.md
@@ -1,0 +1,35 @@
+# Export
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/FacetedSearch/CONTEXT.md
+++ b/.ai/Component/FacetedSearch/CONTEXT.md
@@ -1,0 +1,35 @@
+# Faceted Search
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/Forms/CONTEXT.md
+++ b/.ai/Component/Forms/CONTEXT.md
@@ -1,0 +1,35 @@
+# Forms
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/GlobalJS/CONTEXT.md
+++ b/.ai/Component/GlobalJS/CONTEXT.md
@@ -1,0 +1,35 @@
+# Global JavaScript Components
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/Grid/CONTEXT.md
+++ b/.ai/Component/Grid/CONTEXT.md
@@ -1,0 +1,35 @@
+# Grid
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/Hook/CONTEXT.md
+++ b/.ai/Component/Hook/CONTEXT.md
@@ -1,0 +1,35 @@
+# Hook
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/Import/CONTEXT.md
+++ b/.ai/Component/Import/CONTEXT.md
@@ -1,0 +1,35 @@
+# Import
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/Link/CONTEXT.md
+++ b/.ai/Component/Link/CONTEXT.md
@@ -1,0 +1,35 @@
+# Link
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/Locale/CONTEXT.md
+++ b/.ai/Component/Locale/CONTEXT.md
@@ -1,0 +1,35 @@
+# Locale
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/MailTemplate/CONTEXT.md
+++ b/.ai/Component/MailTemplate/CONTEXT.md
@@ -1,0 +1,35 @@
+# Mail Template
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/PositionUpdater/CONTEXT.md
+++ b/.ai/Component/PositionUpdater/CONTEXT.md
@@ -1,0 +1,35 @@
+# Position Updater
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/Router/CONTEXT.md
+++ b/.ai/Component/Router/CONTEXT.md
@@ -1,0 +1,35 @@
+# Router
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/Smarty/CONTEXT.md
+++ b/.ai/Component/Smarty/CONTEXT.md
@@ -1,0 +1,35 @@
+# Smarty
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/TinyMCE/CONTEXT.md
+++ b/.ai/Component/TinyMCE/CONTEXT.md
@@ -1,0 +1,35 @@
+# TinyMCE
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Component/Twig/CONTEXT.md
+++ b/.ai/Component/Twig/CONTEXT.md
@@ -1,0 +1,35 @@
+# Twig
+
+> **Status:** To be defined — this context file needs to be written by domain experts.
+
+## Purpose
+
+To be defined.
+
+## Architecture overview
+
+To be defined.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md).
+
+## Do
+
+- To be defined
+
+## Don't
+
+- To be defined
+
+## Testing expectations
+
+To be defined.
+
+## Canonical examples
+
+- To be defined
+
+## Related
+
+- [Root context](../../CONTEXT.md)

--- a/.ai/Domain/Cart/CONTEXT.md
+++ b/.ai/Domain/Cart/CONTEXT.md
@@ -1,0 +1,46 @@
+# Cart Domain
+
+> **Status:** Draft — this context file is a starting point and should be refined by domain experts.
+
+## Purpose
+
+The Cart domain manages shopping cart lifecycle: creation, product additions/removals, quantity updates, cart rule application, and price computation. It is the foundation for the Checkout process but does not handle order creation itself.
+
+## Architecture overview
+
+<!-- TODO: Detail key classes, handlers, and relationships -->
+
+To be completed by domain experts.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md). Domain-specific additions to be documented here.
+
+## Do
+
+<!-- TODO: Document accepted patterns specific to Cart -->
+
+- To be defined
+
+## Don't
+
+<!-- TODO: Document forbidden patterns specific to Cart -->
+
+- To be defined
+
+## Testing expectations
+
+<!-- TODO: Document Cart-specific testing requirements -->
+
+- To be defined
+
+## Canonical examples
+
+<!-- TODO: Link to reference implementations -->
+
+- To be defined
+
+## Related
+
+- [CQRS Component](../../Component/CQRS/CONTEXT.md)
+- [DevDocs: Cart](https://devdocs.prestashop-project.org/9/development/page-reference/back-office/order/orders/)

--- a/.ai/Domain/Product/CONTEXT.md
+++ b/.ai/Domain/Product/CONTEXT.md
@@ -1,0 +1,48 @@
+# Product Domain
+
+> **Status:** Draft — this context file is a starting point and should be refined by domain experts.
+
+## Purpose
+
+The Product domain manages the product catalog: product creation, updates, combinations, images, pricing, stock, categories, and multi-shop behavior. It is one of the most complex domains in PrestaShop with extensive CQRS coverage.
+
+## Architecture overview
+
+<!-- TODO: Detail key classes, handlers, and relationships -->
+
+To be completed by domain experts.
+
+## Coding standards
+
+Follows [project-wide standards](../../CONTEXT.md). Domain-specific additions to be documented here.
+
+## Do
+
+<!-- TODO: Document accepted patterns specific to Product -->
+
+- To be defined
+
+## Don't
+
+<!-- TODO: Document forbidden patterns specific to Product -->
+
+- To be defined
+
+## Testing expectations
+
+<!-- TODO: Document Product-specific testing requirements -->
+
+- To be defined
+
+## Canonical examples
+
+<!-- TODO: Link to reference implementations -->
+
+- To be defined
+
+## Related
+
+- [CQRS Component](../../Component/CQRS/CONTEXT.md)
+- [Grid Component](../../Component/Grid/CONTEXT.md)
+- [Forms Component](../../Component/Forms/CONTEXT.md)
+- [DevDocs: Product](https://devdocs.prestashop-project.org/9/development/page-reference/back-office/catalog/products/)

--- a/.ai/STRUCTURE.md
+++ b/.ai/STRUCTURE.md
@@ -1,0 +1,135 @@
+# .ai/ — AI Context Architecture
+
+## Purpose
+
+This folder is the **single source of truth** for all AI-assisted development context in the PrestaShop project. It provides consistent guidance to every AI coding tool used by contributors — whether that's Claude Code, Cursor, GitHub Copilot, Windsurf, Gemini CLI, or a web-based assistant like ChatGPT or Claude.ai.
+
+## Why centralized?
+
+Each AI tool has its own configuration format (`CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md`, `AGENTS.md`, `GEMINI.md`, `.windsurfrules`…). Maintaining one context file per tool per domain leads to fragmentation and drift. Instead:
+
+- **This `.ai/` folder** holds all the context, organized by domain and component.
+- **Pointer files at the repository root** (`CLAUDE.md`, `AGENTS.md`, `.cursorrules`, etc.) are lightweight bridges that reference this folder. They contain no context themselves — only references.
+- **One place to update** — when conventions change, you update the `.ai/` file. Pointer files never need to change.
+
+## Folder structure
+
+```
+.ai/
+├── CONTEXT.md              # Root context: project-wide rules, architecture, and index of all sub-contexts
+├── STRUCTURE.md            # This file — explains the architecture of the .ai/ folder
+│
+├── Domain/                 # Business domain contexts (maps to src/Core/Domain/)
+│   ├── {DomainName}/
+│   │   ├── CONTEXT.md      # Domain-specific conventions, patterns, do/don't rules
+│   │   └── skills/         # Optional: reusable task templates (e.g., skill.md + script.sh)
+│   │       └── {skill-name}/
+│   │           ├── SKILL.md
+│   │           └── script.sh  # Optional automation script
+│   └── ...
+│
+└── Component/              # Cross-cutting component contexts (maps to shared infrastructure)
+    ├── {ComponentName}/
+    │   ├── CONTEXT.md      # Component-specific conventions, usage patterns, do/don't rules
+    │   └── skills/         # Optional: reusable task templates
+    │       └── {skill-name}/
+    │           └── SKILL.md
+    └── ...
+```
+
+## File conventions
+
+| File | Purpose | Target size |
+|------|---------|-------------|
+| `CONTEXT.md` | Conventions, patterns, do/don't rules for a domain or component | < 200 lines |
+| `SKILL.md` | Step-by-step task template an AI agent can follow to accomplish a recurring task | < 150 lines |
+| `STRUCTURE.md` | This file — architecture documentation | N/A |
+
+### CONTEXT.md template
+
+Every `CONTEXT.md` follows this structure:
+
+```markdown
+# {Domain or Component Name}
+
+## Purpose
+[1-2 sentences: what this domain/component does, what it does NOT do]
+
+## Architecture overview
+[Key classes, patterns, relationships — structural, not exhaustive]
+
+## Coding standards
+[Only rules specific to THIS scope — don't repeat root-level rules]
+
+## Do
+- [Accepted patterns with brief rationale]
+
+## Don't
+- [Forbidden patterns with brief rationale]
+
+## Testing expectations
+[What coverage is expected, which test types, where tests live]
+
+## Canonical examples
+- [Links to reference implementation files]
+
+## Related
+- [Links to related domains, components, or documentation]
+```
+
+### Writing guidelines
+
+- **Be concise** — use bullet points and tables, not paragraphs. AI parses structured content more reliably.
+- **No code dumps** — link to canonical example files, don't inline full class implementations.
+- **Describe patterns, not inventories** — write `Handlers follow Domain/{Action}{Entity}Handler.php` instead of listing every handler file.
+- **Don't repeat parent context** — domain/component files should only contain what's unique to their scope. Project-wide rules live in the root `CONTEXT.md`.
+- **No tool-specific syntax** — CONTEXT.md files must work for any AI tool or human reader.
+
+## How AI tools discover this context
+
+### Automatic loading (via pointer files at repo root)
+
+| Tool | Pointer file | How it works |
+|------|-------------|--------------|
+| **Claude Code** | `CLAUDE.md` | Uses `@.ai/CONTEXT.md` reference — loaded at session start. Agent reads domain/component files on demand. |
+| **Gemini CLI** | `GEMINI.md` | Instructs Gemini to read `.ai/CONTEXT.md` and domain files when relevant. |
+| **Cursor** | `.cursor/rules/*.mdc` | One `.mdc` rule per domain/component with glob patterns to auto-attach. |
+| **GitHub Copilot** | `.github/copilot-instructions.md` + `.github/instructions/*.instructions.md` | Repo-wide instructions reference `.ai/CONTEXT.md`. Path-specific files use `applyTo` globs. |
+| **Windsurf** | `.windsurf/rules/*.md` | Project-wide rules instruct Cascade to read `.ai/` files when working on matching paths. |
+| **AGENTS.md** | `AGENTS.md` | Multi-agent systems reference `.ai/CONTEXT.md`. |
+
+### Web-based assistants (ChatGPT, Claude.ai, Gemini)
+
+Contributors using web-based AI assistants should copy-paste the relevant `CONTEXT.md` file(s) as their initial system prompt:
+1. Always start with `.ai/CONTEXT.md` (project-wide rules)
+2. Add the relevant domain or component `CONTEXT.md` for the area they're working on
+
+### How an AI agent should navigate this structure
+
+1. **Start with `.ai/CONTEXT.md`** — it contains project-wide rules and an index of all domain/component contexts.
+2. **Identify the relevant domain or component** from the index based on the files being worked on.
+3. **Read the specific `CONTEXT.md`** for that domain or component.
+4. **Check for skills** if the task matches a known pattern (e.g., "add a field to a form" → `.ai/Component/Forms/skills/add-field-to-form/SKILL.md`).
+
+## How to contribute
+
+### Adding context for a new domain
+
+1. Create `.ai/Domain/{DomainName}/CONTEXT.md` using the template above.
+2. Add an entry to the index table in `.ai/CONTEXT.md`.
+3. Optionally create `.cursor/rules/{domain}.mdc` and `.github/instructions/{domain}.instructions.md` pointer files.
+
+### Adding context for a new component
+
+1. Create `.ai/Component/{ComponentName}/CONTEXT.md` using the template above.
+2. Add an entry to the index table in `.ai/CONTEXT.md`.
+
+### Adding a skill
+
+1. Create `.ai/{Domain|Component}/{Name}/skills/{skill-name}/SKILL.md`.
+2. Optionally add a `script.sh` for automation.
+3. Reference the skill in the parent `CONTEXT.md` under "Related".
+
+### Updating existing context
+
+Edit the relevant `CONTEXT.md` directly. Pointer files at the repo root should never need modification — they only contain references.

--- a/.cursor/rules/prestashop-context.mdc
+++ b/.cursor/rules/prestashop-context.mdc
@@ -1,0 +1,8 @@
+---
+description: "PrestaShop project-wide conventions and architecture"
+alwaysApply: true
+---
+
+Read and follow all instructions in `.ai/CONTEXT.md` at the project root.
+For the full structure of AI context files, see `.ai/STRUCTURE.md`.
+When working on a specific domain or component, also read the corresponding CONTEXT.md file from the `.ai/` folder — the full index is in `.ai/CONTEXT.md`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,8 @@
+## PrestaShop — Copilot Instructions
+
+This project uses a centralized AI context architecture in the `.ai/` folder.
+
+Read `.ai/CONTEXT.md` for project-wide rules, architecture, and an index of all domain/component contexts.
+Read `.ai/STRUCTURE.md` to understand how the `.ai/` folder is organized.
+
+When working on files in a specific domain or component, also read the corresponding CONTEXT.md file from the `.ai/` folder. The full index is in `.ai/CONTEXT.md`.

--- a/.windsurf/rules/prestashop-context.md
+++ b/.windsurf/rules/prestashop-context.md
@@ -1,0 +1,8 @@
+## PrestaShop — Windsurf Rules
+
+This project uses a centralized AI context architecture in the `.ai/` folder.
+
+Read `.ai/CONTEXT.md` for project-wide rules, architecture, and an index of all domain/component contexts.
+Read `.ai/STRUCTURE.md` to understand how the `.ai/` folder is organized.
+
+When working on files in a specific domain or component, also read the corresponding CONTEXT.md file from the `.ai/` folder. The full index is in `.ai/CONTEXT.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# PrestaShop — AI Agent Instructions
+
+This project uses a centralized AI context architecture. All conventions, patterns, and rules are maintained in the `.ai/` folder.
+
+## Getting started
+
+1. Read [.ai/CONTEXT.md](.ai/CONTEXT.md) for project-wide rules, architecture, and an index of all domain/component contexts.
+2. Read [.ai/STRUCTURE.md](.ai/STRUCTURE.md) to understand how the `.ai/` folder is organized.
+3. When working on a specific domain or component, read the corresponding `CONTEXT.md` file listed in the index.
+
+## Key rules
+
+- Follow the CQRS pattern for all new back-office features
+- No business logic in controllers — delegate to Handlers
+- No legacy ObjectModel in new code — use Doctrine entities
+- All PHP files must use `declare(strict_types=1);`
+- Classes are `final` by default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+@.ai/CONTEXT.md
+@.ai/STRUCTURE.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,6 @@
+# PrestaShop — Gemini Context
+
+Read `.ai/CONTEXT.md` for project-wide rules, architecture, and an index of all domain/component contexts.
+Read `.ai/STRUCTURE.md` to understand how the `.ai/` folder is organized.
+
+When working on files in a specific domain or component, also read the corresponding CONTEXT.md file from the `.ai/` folder. The full index is in `.ai/CONTEXT.md`.


### PR DESCRIPTION
## Summary

- Introduces a centralized `.ai/` folder as the single source of truth for AI-assisted development context
- Adds `.ai/STRUCTURE.md` documenting the full architecture, file conventions, and contribution workflow
- Adds `.ai/CONTEXT.md` as root context with project-wide rules, architecture overview, and index of all domain/component contexts
- Creates draft domain contexts for Cart and Product
- Creates 22 placeholder component contexts matching the [devdocs component list](https://devdocs.prestashop-project.org/9/development/components/)
- Adds lightweight pointer files for all major AI tools: Claude Code (`CLAUDE.md`), Cursor (`.cursor/rules/`), GitHub Copilot (`.github/copilot-instructions.md`), Windsurf (`.windsurf/rules/`), Gemini CLI (`GEMINI.md`), and multi-agent systems (`AGENTS.md`)

## How it works

Every AI tool gets identical context through a two-layer system:

1. **Pointer files at root** (tool-specific, ~5 lines each) reference `.ai/CONTEXT.md`
2. **`.ai/CONTEXT.md`** contains project-wide rules and an index pointing to domain/component `CONTEXT.md` files
3. Agents read the root context first, then fetch the relevant domain/component context on demand

This avoids duplication: when conventions change, only the `.ai/` file is updated — pointer files never need modification.

## Test plan

- [ ] Verify `.ai/STRUCTURE.md` clearly explains the architecture
- [ ] Verify `.ai/CONTEXT.md` contains accurate project-wide rules and a complete index
- [ ] Verify `CLAUDE.md` correctly references `.ai/CONTEXT.md` via `@` syntax
- [ ] Verify `.cursor/rules/prestashop-context.mdc` has valid frontmatter with `alwaysApply: true`
- [ ] Verify `.github/copilot-instructions.md` follows GitHub Copilot format
- [ ] Verify domain drafts (Cart, Product) use the template from STRUCTURE.md
- [ ] Verify all 22 component placeholders exist and are listed in the index