### PR TITLE
Fix child theme translation loading in BO translation API

### DIFF
--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -77,7 +77,7 @@ class TranslationController extends ApiController
             } elseif (
                 !empty($theme)
                 // Core themes are not considered like other themes because their translations belong to the Core
-                && in_array($theme, Theme::CORE_THEMES)
+                && !in_array($theme, Theme::CORE_THEMES)
             ) {
                 $providerDefinition = new ThemeProviderDefinition($theme);
             } else {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR fixes a regression in PrestaShop 9.1.0 where child theme translations were not displayed in the Back Office translation interface. The issue was caused by the API translation controller resolving child themes through the core translation provider instead of the theme translation provider when loading domain content.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Install one of the two attached themes [hummingbird-child.zip](https://github.com/user-attachments/files/26411078/hummingbird-child.zip) - [classic-child.zip](https://github.com/user-attachments/files/26411079/classic-child.zip)<br/> 2. Go to **International > Translations**<br/> - In **Type of translation**, select Front office Translations<br/> - In **Select your theme**, choose classic-child or hummingbird-child<br/> - Select a language to translate<br/> 3. Click "**Modify**" <br/>4. you should see the translation for the string "String ENG"
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/23851693587
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41192
| Related PRs       | 
| Sponsor company   | Codencode snc

cc @jolelievre this seems related to the issue addressed in your PR #40295.
I opened this PR as a possible fix and I’d love to get your feedback on it. Do you think this approach looks good?