### PR TITLE
Change the redirection of combination button learn more

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/core/util/helper_card.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/util/helper_card.yml
@@ -10,88 +10,88 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Util\HelperCard\DocumentationLinkProvider'
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getContext().language ? service("prestashop.adapter.legacy.context").getContext().language.iso_code : "en-US"'
-      - 
-        "team":
-          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/team"
-          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/configurer-boutique/parametres-avances/equipe"
-          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/configurar-tienda/parametros-avanzados/equipo"
-          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/configurare-negozio/parametri-avanzati/squadra"
-          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/team"
-        "meta":
-          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/shop-parameters/traffic/seo-and-urls"
-          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/configurer-boutique/configurer-parametres-boutique/trafic/seo-et-url"
-          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/configurar-tienda/parametros-tienda/trafico/seo-y-urls"
-          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/configurare-negozio/parametri-negozio/traffico/seo-e-url"
-          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/shop-parameters/traffic/seo-and-urls"
-        "customer":
-          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-customers/your-customers"
-          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-clients/vos-clients"
-          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-clientes/tus-clientes"
-          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-clienti/i-tuoi-clienti"
-          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-customers/your-customers"
-        "supplier":
-          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-suppliers"
-          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-fournisseurs"
-          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-proveedores"
-          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-fornitori"
-          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-suppliers"
-        "category":
-          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-categories"
-          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-categories"
-          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-categorias"
-          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-categorie"
-          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-categories"
-        "cms_pages":
-          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/customizing-store-design/pages-managing-static-content"
-          "fr": "https://docs.prestashop-project.org/v.8-documentation/v/french-1/guide-utilisateur/optimiser-boutique/personnaliser-apparence-boutique/pages-gerer-contenu-statique"
-          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/optimizar-tienda/personalizar-diseno-tienda/paginas-gestionar-contenido-estatico"
-          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/migliorare-negozio/personalizzare-design-negozio/pagine-gestione-contenuti-statici"
-          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/customizing-store-design/pages-managing-static-content"
-        "debug_mode":
-          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/performance#performance-debugmode"
-          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/configurer-boutique/parametres-avances/performance#parametresdeperformances-modedebug"
-          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/configurar-tienda/parametros-avanzados/rendimiento#rendimiento-mododepuracion"
-          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/configurare-negozio/parametri-avanzati/performance-prestazioni#modalita-di-debug"
-          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/performance#performance-debugmode"
-        "attribute":
-          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-product-attributes"
-          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-attributs-produits"
-          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-atributos-producto"
-          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-attributi-prodotti"
-          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-product-attributes"
-        "monitoring":
-          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/monitoring-catalog"
-          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/suivi-catalogue"
-          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/monitorear-catalogo"
-          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/monitorare-catalogo"
-          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/monitoring-catalog"
-        "attachment":
-          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-files"
-          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-fichiers"
-          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-archivos"
-          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-files"
-          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-files"
-        "credit_slip":
-          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-orders/credit-slips"
-          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-commandes/avoirs"
-          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-pedidos/facturas-por-abono"
-          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-ordini/note-di-credito"
-          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-orders/credit-slips"
-        "carrier":
-          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/managing-shipping/carriers"
-          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/optimiser-boutique/gerer-livraisons/gerer-transporteurs"
-          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/optimizar-tienda/gestionar-transporte/gestionar-transportistas"
-          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/migliorare-negozio/gestire-spedizioni/corrieri"
-          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/managing-shipping/carriers"
-        "combinations":
-          "en": "https://docs.prestashop-project.org/v.9-documentation/user-guide/selling/managing-catalog/managing-products#managingproducts-addingcombinations"
-          "fr": "https://docs.prestashop-project.org/1.7-documentation/v/french/guide-utilisateur/vendre/gerer-catalogue/gerer-produits#creation-dun-produit-avec-des-declinaisons"
-          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-productos#gestionarlosproductos-crearunproductoconcombinaciones"
-          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-prodotti#gestireprodotti-creareunprodottoconcombinazioni"
-          "_fallback": "https://docs.prestashop-project.org/v.9-documentation/user-guide/selling/managing-catalog/managing-products#managingproducts-addingcombinations"
-        "feature":
-          "en": "https://docs.prestashop-project.org/1.7-documentation/user-guide/selling/managing-catalog/managing-product-features"
-          "fr": "https://docs.prestashop-project.org/1.7-documentation/v/french/guide-utilisateur/vendre/gerer-catalogue/gerer-caracteristiques-produits"
-          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-caracteristicas-producto"
-          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-funzioni-prodotto"
-          "_fallback": "https://docs.prestashop-project.org/1.7-documentation/user-guide/selling/managing-catalog/managing-product-features"
+      -
+        'team':
+          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/team'
+          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/configurer-boutique/parametres-avances/equipe'
+          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/configurar-tienda/parametros-avanzados/equipo'
+          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/configurare-negozio/parametri-avanzati/squadra'
+          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/team'
+        'meta':
+          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/shop-parameters/traffic/seo-and-urls'
+          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/configurer-boutique/configurer-parametres-boutique/trafic/seo-et-url'
+          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/configurar-tienda/parametros-tienda/trafico/seo-y-urls'
+          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/configurare-negozio/parametri-negozio/traffico/seo-e-url'
+          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/shop-parameters/traffic/seo-and-urls'
+        'customer':
+          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-customers/your-customers'
+          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-clients/vos-clients'
+          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-clientes/tus-clientes'
+          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-clienti/i-tuoi-clienti'
+          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-customers/your-customers'
+        'supplier':
+          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-suppliers'
+          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-fournisseurs'
+          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-proveedores'
+          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-fornitori'
+          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-suppliers'
+        'category':
+          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-categories'
+          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-categories'
+          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-categorias'
+          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-categorie'
+          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-categories'
+        'cms_pages':
+          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/customizing-store-design/pages-managing-static-content'
+          'fr': 'https://docs.prestashop-project.org/v.8-documentation/v/french-1/guide-utilisateur/optimiser-boutique/personnaliser-apparence-boutique/pages-gerer-contenu-statique'
+          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/optimizar-tienda/personalizar-diseno-tienda/paginas-gestionar-contenido-estatico'
+          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/migliorare-negozio/personalizzare-design-negozio/pagine-gestione-contenuti-statici'
+          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/customizing-store-design/pages-managing-static-content'
+        'debug_mode':
+          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/performance#performance-debugmode'
+          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/configurer-boutique/parametres-avances/performance#parametresdeperformances-modedebug'
+          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/configurar-tienda/parametros-avanzados/rendimiento#rendimiento-mododepuracion'
+          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/configurare-negozio/parametri-avanzati/performance-prestazioni#modalita-di-debug'
+          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/performance#performance-debugmode'
+        'attribute':
+          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-product-attributes'
+          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-attributs-produits'
+          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-atributos-producto'
+          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-attributi-prodotti'
+          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-product-attributes'
+        'monitoring':
+          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/monitoring-catalog'
+          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/suivi-catalogue'
+          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/monitorear-catalogo'
+          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/monitorare-catalogo'
+          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/monitoring-catalog'
+        'attachment':
+          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-files'
+          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-fichiers'
+          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-archivos'
+          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-files'
+          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-files'
+        'credit_slip':
+          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-orders/credit-slips'
+          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-commandes/avoirs'
+          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-pedidos/facturas-por-abono'
+          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-ordini/note-di-credito'
+          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-orders/credit-slips'
+        'carrier':
+          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/managing-shipping/carriers'
+          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/optimiser-boutique/gerer-livraisons/gerer-transporteurs'
+          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/optimizar-tienda/gestionar-transporte/gestionar-transportistas'
+          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/migliorare-negozio/gestire-spedizioni/corrieri'
+          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/managing-shipping/carriers'
+        'combinations':
+          'en': 'https://docs.prestashop-project.org/v.9-documentation/user-guide/selling/managing-catalog/managing-products#managingproducts-addingcombinations'
+          'fr': 'https://docs.prestashop-project.org/1.7-documentation/v/french/guide-utilisateur/vendre/gerer-catalogue/gerer-produits#creation-dun-produit-avec-des-declinaisons'
+          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-productos#gestionarlosproductos-crearunproductoconcombinaciones'
+          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-prodotti#gestireprodotti-creareunprodottoconcombinazioni'
+          '_fallback': 'https://docs.prestashop-project.org/v.9-documentation/user-guide/selling/managing-catalog/managing-products#managingproducts-addingcombinations'
+        'feature':
+          'en': 'https://docs.prestashop-project.org/1.7-documentation/user-guide/selling/managing-catalog/managing-product-features'
+          'fr': 'https://docs.prestashop-project.org/1.7-documentation/v/french/guide-utilisateur/vendre/gerer-catalogue/gerer-caracteristiques-produits'
+          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-caracteristicas-producto'
+          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-funzioni-prodotto'
+          '_fallback': 'https://docs.prestashop-project.org/1.7-documentation/user-guide/selling/managing-catalog/managing-product-features'

--- a/src/PrestaShopBundle/Resources/config/services/core/util/helper_card.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/util/helper_card.yml
@@ -10,88 +10,87 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Util\HelperCard\DocumentationLinkProvider'
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getContext().language ? service("prestashop.adapter.legacy.context").getContext().language.iso_code : "en-US"'
-      -
-        'team':
-          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/team'
-          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/configurer-boutique/parametres-avances/equipe'
-          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/configurar-tienda/parametros-avanzados/equipo'
-          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/configurare-negozio/parametri-avanzati/squadra'
-          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/team'
-        'meta':
-          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/shop-parameters/traffic/seo-and-urls'
-          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/configurer-boutique/configurer-parametres-boutique/trafic/seo-et-url'
-          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/configurar-tienda/parametros-tienda/trafico/seo-y-urls'
-          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/configurare-negozio/parametri-negozio/traffico/seo-e-url'
-          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/shop-parameters/traffic/seo-and-urls'
-        'customer':
-          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-customers/your-customers'
-          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-clients/vos-clients'
-          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-clientes/tus-clientes'
-          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-clienti/i-tuoi-clienti'
-          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-customers/your-customers'
-        'supplier':
-          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-suppliers'
-          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-fournisseurs'
-          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-proveedores'
-          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-fornitori'
-          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-suppliers'
-        'category':
-          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-categories'
-          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-categories'
-          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-categorias'
-          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-categorie'
-          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-categories'
-        'cms_pages':
-          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/customizing-store-design/pages-managing-static-content'
-          'fr': 'https://docs.prestashop-project.org/v.8-documentation/v/french-1/guide-utilisateur/optimiser-boutique/personnaliser-apparence-boutique/pages-gerer-contenu-statique'
-          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/optimizar-tienda/personalizar-diseno-tienda/paginas-gestionar-contenido-estatico'
-          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/migliorare-negozio/personalizzare-design-negozio/pagine-gestione-contenuti-statici'
-          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/customizing-store-design/pages-managing-static-content'
-        'debug_mode':
-          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/performance#performance-debugmode'
-          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/configurer-boutique/parametres-avances/performance#parametresdeperformances-modedebug'
-          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/configurar-tienda/parametros-avanzados/rendimiento#rendimiento-mododepuracion'
-          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/configurare-negozio/parametri-avanzati/performance-prestazioni#modalita-di-debug'
-          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/performance#performance-debugmode'
-        'attribute':
-          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-product-attributes'
-          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-attributs-produits'
-          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-atributos-producto'
-          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-attributi-prodotti'
-          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-product-attributes'
-        'monitoring':
-          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/monitoring-catalog'
-          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/suivi-catalogue'
-          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/monitorear-catalogo'
-          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/monitorare-catalogo'
-          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/monitoring-catalog'
-        'attachment':
-          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-files'
-          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-fichiers'
-          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-archivos'
-          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-files'
-          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-files'
-        'credit_slip':
-          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-orders/credit-slips'
-          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-commandes/avoirs'
-          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-pedidos/facturas-por-abono'
-          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-ordini/note-di-credito'
-          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-orders/credit-slips'
-        'carrier':
-          'en': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/managing-shipping/carriers'
-          'fr': 'https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/optimiser-boutique/gerer-livraisons/gerer-transporteurs'
-          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/optimizar-tienda/gestionar-transporte/gestionar-transportistas'
-          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/migliorare-negozio/gestire-spedizioni/corrieri'
-          '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/managing-shipping/carriers'
-        'combinations':
-          'en': 'https://docs.prestashop-project.org/1.7-documentation/user-guide/selling/managing-catalog/managing-products#managingproducts-creatingaproductwithcombinations'
-          'fr': 'https://docs.prestashop-project.org/1.7-documentation/v/french/guide-utilisateur/vendre/gerer-catalogue/gerer-produits#creation-dun-produit-avec-des-declinaisons'
-          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-productos#gestionarlosproductos-crearunproductoconcombinaciones'
-          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-prodotti#gestireprodotti-creareunprodottoconcombinazioni'
-          '_fallback': 'https://docs.prestashop-project.org/1.7-documentation/user-guide/selling/managing-catalog/managing-products#managingproducts-creatingaproductwithcombinations'
-        'feature':
-          'en': 'https://docs.prestashop-project.org/1.7-documentation/user-guide/selling/managing-catalog/managing-product-features'
-          'fr': 'https://docs.prestashop-project.org/1.7-documentation/v/french/guide-utilisateur/vendre/gerer-catalogue/gerer-caracteristiques-produits'
-          'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-caracteristicas-producto'
-          'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-funzioni-prodotto'
-          '_fallback': 'https://docs.prestashop-project.org/1.7-documentation/user-guide/selling/managing-catalog/managing-product-features'
+      - "team":
+          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/team"
+          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/configurer-boutique/parametres-avances/equipe"
+          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/configurar-tienda/parametros-avanzados/equipo"
+          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/configurare-negozio/parametri-avanzati/squadra"
+          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/team"
+        "meta":
+          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/shop-parameters/traffic/seo-and-urls"
+          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/configurer-boutique/configurer-parametres-boutique/trafic/seo-et-url"
+          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/configurar-tienda/parametros-tienda/trafico/seo-y-urls"
+          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/configurare-negozio/parametri-negozio/traffico/seo-e-url"
+          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/shop-parameters/traffic/seo-and-urls"
+        "customer":
+          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-customers/your-customers"
+          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-clients/vos-clients"
+          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-clientes/tus-clientes"
+          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-clienti/i-tuoi-clienti"
+          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-customers/your-customers"
+        "supplier":
+          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-suppliers"
+          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-fournisseurs"
+          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-proveedores"
+          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-fornitori"
+          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-suppliers"
+        "category":
+          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-categories"
+          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-categories"
+          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-categorias"
+          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-categorie"
+          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-categories"
+        "cms_pages":
+          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/customizing-store-design/pages-managing-static-content"
+          "fr": "https://docs.prestashop-project.org/v.8-documentation/v/french-1/guide-utilisateur/optimiser-boutique/personnaliser-apparence-boutique/pages-gerer-contenu-statique"
+          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/optimizar-tienda/personalizar-diseno-tienda/paginas-gestionar-contenido-estatico"
+          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/migliorare-negozio/personalizzare-design-negozio/pagine-gestione-contenuti-statici"
+          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/customizing-store-design/pages-managing-static-content"
+        "debug_mode":
+          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/performance#performance-debugmode"
+          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/configurer-boutique/parametres-avances/performance#parametresdeperformances-modedebug"
+          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/configurar-tienda/parametros-avanzados/rendimiento#rendimiento-mododepuracion"
+          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/configurare-negozio/parametri-avanzati/performance-prestazioni#modalita-di-debug"
+          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/performance#performance-debugmode"
+        "attribute":
+          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-product-attributes"
+          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-attributs-produits"
+          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-atributos-producto"
+          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-attributi-prodotti"
+          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-product-attributes"
+        "monitoring":
+          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/monitoring-catalog"
+          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/suivi-catalogue"
+          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/monitorear-catalogo"
+          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/monitorare-catalogo"
+          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/monitoring-catalog"
+        "attachment":
+          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-files"
+          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-catalogue/gerer-fichiers"
+          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-archivos"
+          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-files"
+          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-catalog/managing-files"
+        "credit_slip":
+          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-orders/credit-slips"
+          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/vendre/gerer-commandes/avoirs"
+          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-pedidos/facturas-por-abono"
+          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-ordini/note-di-credito"
+          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/selling/managing-orders/credit-slips"
+        "carrier":
+          "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/managing-shipping/carriers"
+          "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/optimiser-boutique/gerer-livraisons/gerer-transporteurs"
+          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/optimizar-tienda/gestionar-transporte/gestionar-transportistas"
+          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/migliorare-negozio/gestire-spedizioni/corrieri"
+          "_fallback": "https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/managing-shipping/carriers"
+        "combinations":
+          "en": "https://docs.prestashop-project.org/v.9-documentation/user-guide/selling/managing-catalog/managing-products#managingproducts-addingcombinations"
+          "fr": "https://docs.prestashop-project.org/1.7-documentation/v/french/guide-utilisateur/vendre/gerer-catalogue/gerer-produits#creation-dun-produit-avec-des-declinaisons"
+          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-productos#gestionarlosproductos-crearunproductoconcombinaciones"
+          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-prodotti#gestireprodotti-creareunprodottoconcombinazioni"
+          "_fallback": "https://docs.prestashop-project.org/v.9-documentation/user-guide/selling/managing-catalog/managing-products#managingproducts-addingcombinations"
+        "feature":
+          "en": "https://docs.prestashop-project.org/1.7-documentation/user-guide/selling/managing-catalog/managing-product-features"
+          "fr": "https://docs.prestashop-project.org/1.7-documentation/v/french/guide-utilisateur/vendre/gerer-catalogue/gerer-caracteristiques-produits"
+          "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-caracteristicas-producto"
+          "it": "https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-funzioni-prodotto"
+          "_fallback": "https://docs.prestashop-project.org/1.7-documentation/user-guide/selling/managing-catalog/managing-product-features"

--- a/src/PrestaShopBundle/Resources/config/services/core/util/helper_card.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/util/helper_card.yml
@@ -10,7 +10,8 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Util\HelperCard\DocumentationLinkProvider'
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getContext().language ? service("prestashop.adapter.legacy.context").getContext().language.iso_code : "en-US"'
-      - "team":
+      - 
+        "team":
           "en": "https://docs.prestashop-project.org/v.8-documentation/user-guide/configuring-shop/advanced-parameters/team"
           "fr": "https://docs.prestashop-project.org/v.8-documentation/french-1/guide-utilisateur/configurer-boutique/parametres-avances/equipe"
           "es": "https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/configurar-tienda/parametros-avanzados/equipo"

--- a/src/PrestaShopBundle/Resources/config/services/core/util/helper_card.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/util/helper_card.yml
@@ -84,11 +84,11 @@ services:
           'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/migliorare-negozio/gestire-spedizioni/corrieri'
           '_fallback': 'https://docs.prestashop-project.org/v.8-documentation/user-guide/improving-shop/managing-shipping/carriers'
         'combinations':
-          'en': 'https://docs.prestashop-project.org/v.9-documentation/user-guide/selling/managing-catalog/managing-products#managingproducts-addingcombinations'
+          'en': 'https://docs.prestashop-project.org/v.9-documentation/user-guide/selling/managing-catalog/managing-products#managingproducts-creatingaproductwithcombinations'
           'fr': 'https://docs.prestashop-project.org/1.7-documentation/v/french/guide-utilisateur/vendre/gerer-catalogue/gerer-produits#creation-dun-produit-avec-des-declinaisons'
           'es': 'https://docs.prestashop-project.org/1.7-documentation/v/spanish/guia-usuario/vender/gestionar-catalogo/gestionar-productos#gestionarlosproductos-crearunproductoconcombinaciones'
           'it': 'https://docs.prestashop-project.org/1.7-documentation/v/italian/guida-utente/vendere/gestire-catalogo/gestire-prodotti#gestireprodotti-creareunprodottoconcombinazioni'
-          '_fallback': 'https://docs.prestashop-project.org/v.9-documentation/user-guide/selling/managing-catalog/managing-products#managingproducts-addingcombinations'
+          '_fallback': 'https://docs.prestashop-project.org/v.9-documentation/user-guide/selling/managing-catalog/managing-products#managingproducts-creatingaproductwithcombinations'
         'feature':
           'en': 'https://docs.prestashop-project.org/1.7-documentation/user-guide/selling/managing-catalog/managing-product-features'
           'fr': 'https://docs.prestashop-project.org/1.7-documentation/v/french/guide-utilisateur/vendre/gerer-catalogue/gerer-caracteristiques-produits'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x 
| Description?      | Previously, when we click on Learn more button, we are redirected to v1.7 documentation, we are currently on v9.1
| Type?             | bug fix 
| Category?         |  BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to Catalog > Product, create a new combination product, go to combination tab, click on learn more
| UI Tests          | https://github.com/AureRita/ga.tests.ui.pr/actions/runs/24195964386
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41203
| Related PRs       | None
| Sponsor company   | Prestashop
