### PR TITLE
Bugfix: prevent email shortcodes automatically being moved. Fixes #38563 issue

### DIFF
--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
@@ -99,6 +99,7 @@
 							rte_mail_config['editor_selector'] = 'rte-mail-' + rte_mail_selector;
 							rte_mail_config['height'] = '500px';
 							rte_mail_config['plugins'] = 'colorpicker link image paste pagebreak table contextmenu filemanager table code media autoresize textcolor anchor fullpage';
+              rte_mail_config['protect'] = [/\{[a-zA-Z_][a-zA-Z0-9_]*\}/g];
 							// move controls to active panel
 							$('#translation_mails-control-actions').appendTo($(this).find('.panel-collapse.in'));
 							// when user first open email

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
@@ -99,7 +99,7 @@
 							rte_mail_config['editor_selector'] = 'rte-mail-' + rte_mail_selector;
 							rte_mail_config['height'] = '500px';
 							rte_mail_config['plugins'] = 'colorpicker link image paste pagebreak table contextmenu filemanager table code media autoresize textcolor anchor fullpage';
-              rte_mail_config['protect'] = [/\{[a-zA-Z_][a-zA-Z0-9_]*\}/g];
+							rte_mail_config['protect'] = [/\{[a-zA-Z_][a-zA-Z0-9_]*\}/g];
 							// move controls to active panel
 							$('#translation_mails-control-actions').appendTo($(this).find('.panel-collapse.in'));
 							// when user first open email

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
@@ -99,7 +99,7 @@
 							rte_mail_config['editor_selector'] = 'rte-mail-' + rte_mail_selector;
 							rte_mail_config['height'] = '500px';
 							rte_mail_config['plugins'] = 'colorpicker link image paste pagebreak table contextmenu filemanager table code media autoresize textcolor anchor fullpage';
-							rte_mail_config['protect'] = [/\{[a-zA-Z_][a-zA-Z0-9_]*\}/g];
+							rte_mail_config['protect'] = [/(?<=<\/(?:tr|thead|tbody|tfoot)>\s*(?:\{[a-zA-Z_]\w*\}\s*)*)\{[a-zA-Z_]\w*\}/g];
 							// move controls to active panel
 							$('#translation_mails-control-actions').appendTo($(this).find('.panel-collapse.in'));
 							// when user first open email


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | TinyMCE automatically formats table. Shortcodes added between table tags are being automatically placed outside the table. <br> To solve this we need to make TinyMCE formatter ignore email shortcodes. TinyMCE [`protect`](https://www.tiny.cloud/docs/tinymce/latest/content-filtering/#protect) configuration is used for this purpose.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Reproduce: <br>  1. Go to the email translations and change anything in the order_conf email template  <br>   2. Save template  <br>  3. Complete order or trigger order_conf email sending  <br>  4. Products table and discounts table is being displayed in the wrong position.
| UI Tests          |  
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/34057
| Related PRs       | Fixes same issue: https://github.com/PrestaShop/PrestaShop/pull/38563
| Sponsor company   | Your company or customer's name goes here (if applicable).
