### PR TITLE
Fix attribute and attribute group position ordering in core methods

### DIFF
--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -184,7 +184,7 @@ class PackCore extends Product
 					LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group_lang` agl ON (ag.`id_attribute_group` = agl.`id_attribute_group` AND agl.`id_lang` = ' . (int) Context::getContext()->language->id . ')
 					WHERE pa.`id_product_attribute` = ' . $row['id_product_attribute_item'] . '
 					GROUP BY pa.`id_product_attribute`, ag.`id_attribute_group`
-					ORDER BY pa.`id_product_attribute`';
+					ORDER BY ag.`position`, a.`position`';
 
                 $combinations = Db::getInstance()->executeS($sql);
                 foreach ($combinations as $k => $combination) {
@@ -382,7 +382,7 @@ class PackCore extends Product
 				LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_image` pai ON (' . $line['id_product_attribute_item'] . ' = pai.`id_product_attribute`)
 				WHERE pa.`id_product` = ' . (int) $line['id_product'] . ' AND pa.`id_product_attribute` = ' . $line['id_product_attribute_item'] . '
 				GROUP BY pa.`id_product_attribute`, ag.`id_attribute_group`
-				ORDER BY pa.`id_product_attribute`';
+				ORDER BY ag.`position`, a.`position`';
 
                 $attr_name = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2481,7 +2481,7 @@ class ProductCore extends ObjectModel
 
         $combinationIds = array_keys($combinations);
 
-        $lang = Db::getInstance()->executeS('SELECT pac.id_product_attribute, GROUP_CONCAT(agl.`name`, \'' . pSQL($attribute_value_separator) . '\',al.`name` ORDER BY agl.`id_attribute_group` SEPARATOR \'' . pSQL($attribute_separator) . '\') as attribute_designation
+        $lang = Db::getInstance()->executeS('SELECT pac.id_product_attribute, GROUP_CONCAT(agl.`name`, \'' . pSQL($attribute_value_separator) . '\',al.`name` ORDER BY ag.`position`, a.`position` SEPARATOR \'' . pSQL($attribute_separator) . '\') as attribute_designation
                 FROM `' . _DB_PREFIX_ . 'product_attribute_combination` pac
                 LEFT JOIN `' . _DB_PREFIX_ . 'attribute` a ON a.`id_attribute` = pac.`id_attribute`
                 LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group` ag ON ag.`id_attribute_group` = a.`id_attribute_group`
@@ -2537,7 +2537,7 @@ class ProductCore extends ObjectModel
         }
 
         $sql = 'SELECT pa.*, product_attribute_shop.*, ag.`id_attribute_group`, ag.`is_color_group`, agl.`name` AS group_name, al.`name` AS attribute_name, ' .
-            'a.`id_attribute`, stock.location ' .
+            'a.`id_attribute`, a.`position` AS attribute_position, stock.location ' .
             'FROM `' . _DB_PREFIX_ . 'product_attribute` pa ' .
             Shop::addSqlAssociation('product_attribute', 'pa') . ' ' .
             'LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_combination` pac ON pac.`id_product_attribute` = pa.`id_product_attribute` ' .
@@ -2548,7 +2548,7 @@ class ProductCore extends ObjectModel
             'LEFT JOIN `' . _DB_PREFIX_ . 'stock_available` stock ON (stock.id_product = pa.id_product AND stock.id_product_attribute = IFNULL(pa.`id_product_attribute`, 0)) ' .
             'WHERE pa.`id_product` = ' . (int) $this->id . ' ' .
             'GROUP BY pa.`id_product_attribute`' . ($groupByIdAttributeGroup ? ', ag.`id_attribute_group` ' : '') .
-            'ORDER BY pa.`id_product_attribute`';
+            'ORDER BY pa.`id_product_attribute`, ag.`position`, a.`position`';
 
         $res = Db::getInstance()->executeS($sql);
 
@@ -2595,7 +2595,7 @@ class ProductCore extends ObjectModel
                 WHERE pa.`id_product` = ' . (int) $this->id . '
                 AND pa.`id_product_attribute` = ' . (int) $id_product_attribute . '
                 GROUP BY pa.`id_product_attribute`' . ($groupByIdAttributeGroup ? ',ag.`id_attribute_group`' : '') . '
-                ORDER BY pa.`id_product_attribute`';
+                ORDER BY pa.`id_product_attribute`, ag.`position`, a.`position`';
 
         $res = Db::getInstance()->executeS($sql);
 
@@ -7235,6 +7235,8 @@ class ProductCore extends ObjectModel
         FROM `' . _DB_PREFIX_ . 'attribute` a
         LEFT JOIN `' . _DB_PREFIX_ . 'attribute_lang` al
             ON (a.`id_attribute` = al.`id_attribute` AND al.`id_lang` = ' . (int) Context::getContext()->language->id . ')
+        LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group` ag
+            ON (a.`id_attribute_group` = ag.`id_attribute_group`)
         LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group_lang` agl
             ON (a.`id_attribute_group` = agl.`id_attribute_group` AND agl.`id_lang` = ' . (int) Context::getContext()->language->id . ')
         LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_combination` pac
@@ -7243,7 +7245,8 @@ class ProductCore extends ObjectModel
             ON (pac.`id_product_attribute` = pa.`id_product_attribute`)
         ' . Shop::addSqlAssociation('product_attribute', 'pa') . '
         ' . Shop::addSqlAssociation('attribute', 'pac') . '
-        WHERE pa.`id_product` = ' . (int) $id_product);
+        WHERE pa.`id_product` = ' . (int) $id_product . '
+        ORDER BY ag.`position` ASC, a.`position` ASC');
 
         return $result;
     }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7210,11 +7210,14 @@ class ProductCore extends ObjectModel
             ' . Shop::addSqlAssociation('product_attribute', 'pa') . '
             LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_lang` pal
                 ON (pal.`id_product_attribute` = pac.`id_product_attribute` AND pal.`id_lang` = ' . (int) $id_lang . ')
+            LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group` ag
+                ON (a.`id_attribute_group` = ag.`id_attribute_group`)
             LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group_lang` agl
                 ON (a.`id_attribute_group` = agl.`id_attribute_group` AND agl.`id_lang` = ' . (int) $id_lang . ')
             WHERE pa.`id_product` = ' . (int) $id_product . '
                 AND pac.`id_product_attribute` = ' . (int) $id_product_attribute . '
-                AND agl.`id_lang` = ' . (int) $id_lang);
+                AND agl.`id_lang` = ' . (int) $id_lang . '
+            ORDER BY ag.`position` ASC, a.`position` ASC');
             Cache::store($cache_id, $result);
         } else {
             $result = Cache::retrieve($cache_id);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Several core methods in `Product.php` and `Pack.php` order attribute combinations by `pa.id_product_attribute` (creation order) or have no `ORDER BY` at all, instead of using `a.position` (admin-configured order). This causes attributes to appear in the wrong order on most pages (listings, packs, back-office views), while the product detail page displays them correctly because `getAttributesGroups()` already uses `ORDER BY ag.position, a.position`.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to Catalog > Attributes & Features > Attributes<br>Open the "Color" attribute group<br>Verify attribute positions: "Black" is position 0, "White" is position 1<br>Go to the homepage → "Featured products" block<br>Look at the "Hummingbird printed t-shirt" color swatches<br>Before fix: White appears before Black (wrong order)<br>After fix: Black appears before White (correct order, matching the product detail page)
| UI Tests          | N/A — no UI test covers attribute ordering in listings
| Fixed issue or discussion? | Fixes #41224, Fixes #39386
| Related PRs       | none
| Sponsor company   | 

## Changes

7 methods are fixed to respect `ps_attribute.position` ordering, aligned with the pattern already used by `getAttributesGroups()`, `getAttributesColorList()`, and `Cart::fillAttributesList()`:

### `Product::getAttributeCombinations()` — `classes/Product.php`

- Added `a.position AS attribute_position` to SELECT
- Changed `ORDER BY pa.id_product_attribute` → `ORDER BY pa.id_product_attribute, ag.position, a.position`

### `Product::getAttributeCombinationsById()` — `classes/Product.php`

- Changed `ORDER BY pa.id_product_attribute` → `ORDER BY pa.id_product_attribute, ag.position, a.position`

### `Product::getAttributesResume()` — `classes/Product.php`

- Changed `GROUP_CONCAT(... ORDER BY agl.id_attribute_group ...)` → `GROUP_CONCAT(... ORDER BY ag.position, a.position ...)`

### `Product::getAttributesInformationsByProduct()` — `classes/Product.php`

- Added `LEFT JOIN ps_attribute_group ag` (was missing)
- Added `ORDER BY ag.position ASC, a.position ASC` (had no ORDER BY at all)

### `Product::getAttributesParams()` — `classes/Product.php`

- Added `LEFT JOIN ps_attribute_group ag` (was missing)
- Added `ORDER BY ag.position ASC, a.position ASC` (had no ORDER BY at all)
- This method is used by `getAnchor()` to build combination URL fragments (#39386)

### `Pack::getItems()` — `classes/Pack.php`

- Changed `ORDER BY pa.id_product_attribute` → `ORDER BY ag.position, a.position`

### `Pack::getPackItems()` — `classes/Pack.php`

- Changed `ORDER BY pa.id_product_attribute` → `ORDER BY ag.position, a.position`