### PR TITLE
fix: Ambiguous field selection when sorting in a webservice endpoint …

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -1257,6 +1257,10 @@ class WebserviceRequestCore
                     $assoc = Shop::getAssoTable($this->resourceConfiguration['retrieveData']['table']);
                     if ($assoc !== false && $assoc['type'] == 'shop' && ($object->isMultiShopField($this->resourceConfiguration['fields'][$fieldName]['sqlId']) || $fieldName == 'id')) {
                         $table_alias = 'multi_shop_' . $this->resourceConfiguration['retrieveData']['table'];
+                    }
+                    // for sort on a field that has the same name on two tables (while using linked_tables)
+                    elseif (preg_match('#main\.#', $sql_join)) {
+                        $table_alias = 'main';
                     } else {
                         $table_alias = '';
                     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

Original PR: https://github.com/PrestaShop/PrestaShop/pull/37836

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fixes the SQL query while using a sorting parameter and a filter parameter on a linked table. When doing this, we have to specify to use the `main` table to prevent the usage of an ambiguous column name (would happen if two column had the same name on both tables). 
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | see issue https://github.com/PrestaShop/PrestaShop/issues/37835
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/37835
| Related PRs       | 
| Sponsor company   | 
