### PR TITLE
Fix: Inconsistent escaping of displayCustomization output

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -494,7 +494,9 @@ abstract class PaymentModuleCore extends Module
                         $customization_text = '';
                         if (isset($customization['datas'][Product::CUSTOMIZE_TEXTFIELD])) {
                             foreach ($customization['datas'][Product::CUSTOMIZE_TEXTFIELD] as $text) {
-                                $customization_text .= '<strong>' . $text['name'] . '</strong>: ' . htmlspecialchars($text['value'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '<br />';
+                                $customization_text .= '<strong>' . $text['name'] . '</strong>: '
+                                    . $this->formatCustomizationValueForEmail($text)
+                                    . '<br />';
                             }
                         }
 
@@ -865,6 +867,21 @@ abstract class PaymentModuleCore extends Module
         }
 
         return Currency::getCurrencyInstance((int) $id_currency);
+    }
+
+    /**
+     * @param array<string, mixed> $customizationText
+     */
+    private function formatCustomizationValueForEmail(array $customizationText): string
+    {
+        if (!empty($customizationText['id_module'])) {
+            $module = Module::getInstanceById((int) $customizationText['id_module']);
+            if (Validate::isLoadedObject($module) && (bool) $module->active) {
+                return (string) $customizationText['value'];
+            }
+        }
+
+        return htmlspecialchars((string) $customizationText['value'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     }
 
     /**

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -897,7 +897,8 @@ abstract class PaymentModuleCore extends Module
                 }
 
                 if ($moduleManager->isEnabled($moduleNames[$moduleId])) {
-                    return (string) $customizationText['value'];
+                    // Allow module-provided HTML in emails only after sanitizing to prevent XSS.
+                    return Tools::purifyHTML((string) $customizationText['value']);
                 }
             }
         }

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -6,6 +6,7 @@
 use PrestaShop\PrestaShop\Adapter\MailTemplate\MailPartialTemplateRenderer;
 use PrestaShop\PrestaShop\Adapter\Shipment\OrderShipmentCreator;
 use PrestaShop\PrestaShop\Adapter\StockManager;
+use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
 
@@ -874,10 +875,30 @@ abstract class PaymentModuleCore extends Module
      */
     private function formatCustomizationValueForEmail(array $customizationText): string
     {
+        static $moduleNames = [];
+        static $moduleManager = null;
+
         if (!empty($customizationText['id_module'])) {
-            $module = Module::getInstanceById((int) $customizationText['id_module']);
-            if (Validate::isLoadedObject($module) && (bool) $module->active) {
-                return (string) $customizationText['value'];
+            $moduleId = (int) $customizationText['id_module'];
+
+            if (!array_key_exists($moduleId, $moduleNames)) {
+                $module = Module::getInstanceById($moduleId);
+
+                if (false === $module) {
+                    $moduleNames[$moduleId] = null;
+                } else {
+                    $moduleNames[$moduleId] = $module->name;
+                }
+            }
+
+            if (!empty($moduleNames[$moduleId])) {
+                if (null === $moduleManager) {
+                    $moduleManager = ModuleManagerBuilder::getInstance()->build();
+                }
+
+                if ($moduleManager->isEnabled($moduleNames[$moduleId])) {
+                    return (string) $customizationText['value'];
+                }
             }
         }
 

--- a/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
@@ -15,6 +15,7 @@ use Gender;
 use Group;
 use Order;
 use PrestaShop\PrestaShop\Adapter\ImageManager;
+use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartForViewing;
@@ -239,9 +240,17 @@ final class GetCartForViewingHandler implements GetCartForViewingHandlerInterfac
                                 }
                             } elseif (Product::CUSTOMIZE_TEXTFIELD === $type) {
                                 foreach ($data as $item) {
+                                    $allowHtml = false;
+                                    if (!empty($item['id_module'])) {
+                                        $moduleAdapter = new Module();
+                                        $module = $moduleAdapter->getInstanceById((int) $item['id_module']);
+                                        $allowHtml = Validate::isLoadedObject($module) && (bool) $module->active;
+                                    }
+
                                     $productCustomization['fields'][] = [
                                         'name' => $item['name'],
                                         'value' => $item['value'],
+                                        'allow_html' => $allowHtml,
                                         'type' => 'customizable_text_field',
                                     ];
                                 }

--- a/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
@@ -15,6 +15,7 @@ use Gender;
 use Group;
 use Order;
 use PrestaShop\PrestaShop\Adapter\ImageManager;
+use PrestaShop\PrestaShop\Adapter\Module\ModuleHtmlAuthorizationChecker;
 use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartNotFoundException;
@@ -22,6 +23,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Cart\QueryHandler\GetCartForViewingHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartView;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
+use PrestaShop\PrestaShop\Core\Module\ModuleManager;
 use PrestaShop\PrestaShop\Core\Util\Sorter;
 use Product;
 use StockAvailable;
@@ -35,7 +37,8 @@ final class GetCartForViewingHandler implements GetCartForViewingHandlerInterfac
 {
     public function __construct(
         private ImageManager $imageManager,
-        private Locale $locale
+        private Locale $locale,
+        private ModuleHtmlAuthorizationChecker $moduleHtmlAuthorizationChecker
     ) {
     }
 
@@ -240,17 +243,10 @@ final class GetCartForViewingHandler implements GetCartForViewingHandlerInterfac
                                 }
                             } elseif (Product::CUSTOMIZE_TEXTFIELD === $type) {
                                 foreach ($data as $item) {
-                                    $allowHtml = false;
-                                    if (!empty($item['id_module'])) {
-                                        $moduleAdapter = new Module();
-                                        $module = $moduleAdapter->getInstanceById((int) $item['id_module']);
-                                        $allowHtml = Validate::isLoadedObject($module) && (bool) $module->active;
-                                    }
-
                                     $productCustomization['fields'][] = [
                                         'name' => $item['name'],
                                         'value' => $item['value'],
-                                        'allow_html' => $allowHtml,
+                                        'allow_html' => $this->isModuleHtmlAllowed((int) ($item['id_module'] ?? 0)),
                                         'type' => 'customizable_text_field',
                                     ];
                                 }

--- a/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
@@ -13,6 +13,7 @@ use Customer;
 use DateTime;
 use Gender;
 use Group;
+use Module as LegacyModule;
 use Order;
 use PrestaShop\PrestaShop\Adapter\ImageManager;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleHtmlAuthorizationChecker;

--- a/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
@@ -13,18 +13,15 @@ use Customer;
 use DateTime;
 use Gender;
 use Group;
-use Module as LegacyModule;
 use Order;
 use PrestaShop\PrestaShop\Adapter\ImageManager;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleHtmlAuthorizationChecker;
-use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Cart\QueryHandler\GetCartForViewingHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartView;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
-use PrestaShop\PrestaShop\Core\Module\ModuleManager;
 use PrestaShop\PrestaShop\Core\Util\Sorter;
 use Product;
 use StockAvailable;
@@ -247,7 +244,7 @@ final class GetCartForViewingHandler implements GetCartForViewingHandlerInterfac
                                     $productCustomization['fields'][] = [
                                         'name' => $item['name'],
                                         'value' => $item['value'],
-                                        'allow_html' => $this->isModuleHtmlAllowed((int) ($item['id_module'] ?? 0)),
+                                        'allow_html' => $this->moduleHtmlAuthorizationChecker->isModuleHtmlAllowed((int) ($item['id_module'] ?? 0)),
                                         'type' => 'customizable_text_field',
                                     ];
                                 }

--- a/src/Adapter/Module/ModuleHtmlAuthorizationChecker.php
+++ b/src/Adapter/Module/ModuleHtmlAuthorizationChecker.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Module;
+
+use Module as LegacyModule;
+use PrestaShop\PrestaShop\Core\Module\ModuleManagerInterface;
+
+final class ModuleHtmlAuthorizationChecker
+{
+    private array $moduleNames = [];
+
+    public function __construct(
+        private readonly Module $moduleAdapter,
+        private readonly ModuleManagerInterface $moduleManager
+    ) {
+    }
+
+    public function isModuleHtmlAllowed(int $moduleId): bool
+    {
+        if ($moduleId <= 0) {
+            return false;
+        }
+
+        if (!array_key_exists($moduleId, $this->moduleNames)) {
+            /** @var LegacyModule|false $module */
+            $module = $this->moduleAdapter->getInstanceById($moduleId);
+            $this->moduleNames[$moduleId] = false === $module ? null : $module->name;
+        }
+
+        return !empty($this->moduleNames[$moduleId])
+            && $this->moduleManager->isEnabled($this->moduleNames[$moduleId]);
+    }
+}

--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -28,12 +28,12 @@ use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderProductsForViewing;
 use PrestaShop\PrestaShop\Core\Image\Parser\ImageTagSourceParserInterface;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
+use PrestaShop\PrestaShop\Core\Module\ModuleManagerInterface;
 use PrestaShop\PrestaShop\Core\Util\Sorter;
 use PrestaShopBundle\Entity\Repository\ShipmentRepository;
 use Product;
 use Shop;
 use StockAvailable;
-use Validate;
 
 /**
  * Handles GetOrderProductsForViewing query using legacy object models
@@ -45,7 +45,8 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
         private readonly ImageTagSourceParserInterface $imageTagSourceParser,
         private readonly int $contextLanguageId,
         private readonly Locale $locale,
-        private readonly ShipmentRepository $shipmentRepository
+        private readonly ShipmentRepository $shipmentRepository,
+        private readonly ModuleManagerInterface $moduleManager
     ) {
     }
 
@@ -81,18 +82,11 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                         $customized_product_quantity += (int) $customization['quantity'];
                         foreach ($customization['datas'] as $datas) {
                             foreach ($datas as $data) {
-                                $allowHtml = false;
-                                if (!empty($data['id_module'])) {
-                                    $moduleAdapter = new Module();
-                                    $module = $moduleAdapter->getInstanceById((int) $data['id_module']);
-                                    $allowHtml = Validate::isLoadedObject($module) && (bool) $module->active;
-                                }
-
                                 $customizations[] = new OrderProductCustomizationForViewing(
                                     (int) $data['type'],
                                     (string) $data['name'],
                                     (string) $data['value'],
-                                    $allowHtml
+                                    $this->isModuleHtmlAllowed((int) ($data['id_module'] ?? 0))
                                 );
                             }
                         }
@@ -292,5 +286,28 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
 
         $pack_item['image'] = $id_image ? new Image((int) $id_image) : null;
         $pack_item['image_size'] = null;
+    }
+
+    private function isModuleHtmlAllowed(int $moduleId): bool
+    {
+        static $moduleNames = [];
+
+        if ($moduleId <= 0) {
+            return false;
+        }
+
+        if (!array_key_exists($moduleId, $moduleNames)) {
+            $moduleAdapter = new Module();
+
+            $module = $moduleAdapter->getInstanceById($moduleId);
+
+            if (false === $module) {
+                $moduleNames[$moduleId] = null;
+            } else {
+                $moduleNames[$moduleId] = $module->name;
+            }
+        }
+
+        return !empty($moduleNames[$moduleId]) && $this->moduleManager->isEnabled($moduleNames[$moduleId]);
     }
 }

--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -16,6 +16,7 @@ use OrderReturn;
 use OrderSlip;
 use Pack;
 use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
 use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderProductsForViewing;
@@ -32,6 +33,7 @@ use PrestaShopBundle\Entity\Repository\ShipmentRepository;
 use Product;
 use Shop;
 use StockAvailable;
+use Validate;
 
 /**
  * Handles GetOrderProductsForViewing query using legacy object models
@@ -79,10 +81,18 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                         $customized_product_quantity += (int) $customization['quantity'];
                         foreach ($customization['datas'] as $datas) {
                             foreach ($datas as $data) {
+                                $allowHtml = false;
+                                if (!empty($data['id_module'])) {
+                                    $moduleAdapter = new Module();
+                                    $module = $moduleAdapter->getInstanceById((int) $data['id_module']);
+                                    $allowHtml = Validate::isLoadedObject($module) && (bool) $module->active;
+                                }
+
                                 $customizations[] = new OrderProductCustomizationForViewing(
                                     (int) $data['type'],
                                     (string) $data['name'],
-                                    $data['value']
+                                    (string) $data['value'],
+                                    $allowHtml
                                 );
                             }
                         }

--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -10,6 +10,7 @@ use Currency;
 use Db;
 use Image;
 use ImageManager;
+use Module as LegacyModule;
 use Order;
 use OrderInvoice;
 use OrderReturn;
@@ -299,6 +300,7 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
         if (!array_key_exists($moduleId, $moduleNames)) {
             $moduleAdapter = new Module();
 
+            /** @var LegacyModule|false $module */
             $module = $moduleAdapter->getInstanceById($moduleId);
 
             if (false === $module) {

--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -10,14 +10,13 @@ use Currency;
 use Db;
 use Image;
 use ImageManager;
-use Module as LegacyModule;
 use Order;
 use OrderInvoice;
 use OrderReturn;
 use OrderSlip;
 use Pack;
 use PrestaShop\Decimal\DecimalNumber;
-use PrestaShop\PrestaShop\Adapter\Module\Module;
+use PrestaShop\PrestaShop\Adapter\Module\ModuleHtmlAuthorizationChecker;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
 use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderProductsForViewing;
@@ -29,7 +28,6 @@ use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderProductsForViewing;
 use PrestaShop\PrestaShop\Core\Image\Parser\ImageTagSourceParserInterface;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
-use PrestaShop\PrestaShop\Core\Module\ModuleManagerInterface;
 use PrestaShop\PrestaShop\Core\Util\Sorter;
 use PrestaShopBundle\Entity\Repository\ShipmentRepository;
 use Product;
@@ -47,7 +45,7 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
         private readonly int $contextLanguageId,
         private readonly Locale $locale,
         private readonly ShipmentRepository $shipmentRepository,
-        private readonly ModuleManagerInterface $moduleManager
+        private readonly ModuleHtmlAuthorizationChecker $moduleHtmlAuthorizationChecker
     ) {
     }
 
@@ -87,7 +85,7 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                                     (int) $data['type'],
                                     (string) $data['name'],
                                     (string) $data['value'],
-                                    $this->isModuleHtmlAllowed((int) ($data['id_module'] ?? 0))
+                                    $this->moduleHtmlAuthorizationChecker->isModuleHtmlAllowed((int) ($data['id_module'] ?? 0))
                                 );
                             }
                         }
@@ -287,29 +285,5 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
 
         $pack_item['image'] = $id_image ? new Image((int) $id_image) : null;
         $pack_item['image_size'] = null;
-    }
-
-    private function isModuleHtmlAllowed(int $moduleId): bool
-    {
-        static $moduleNames = [];
-
-        if ($moduleId <= 0) {
-            return false;
-        }
-
-        if (!array_key_exists($moduleId, $moduleNames)) {
-            $moduleAdapter = new Module();
-
-            /** @var LegacyModule|false $module */
-            $module = $moduleAdapter->getInstanceById($moduleId);
-
-            if (false === $module) {
-                $moduleNames[$moduleId] = null;
-            } else {
-                $moduleNames[$moduleId] = $module->name;
-            }
-        }
-
-        return !empty($moduleNames[$moduleId]) && $this->moduleManager->isEnabled($moduleNames[$moduleId]);
     }
 }

--- a/src/Core/Domain/Order/QueryResult/OrderProductCustomizationForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderProductCustomizationForViewing.php
@@ -33,15 +33,22 @@ class OrderProductCustomizationForViewing
     private $image;
 
     /**
+     * @var bool
+     */
+    private $allowHtml;
+
+    /**
      * @param int $type
      * @param string $name
      * @param string $value
+     * @param bool $allowHtml
      */
-    public function __construct(int $type, string $name, string $value)
+    public function __construct(int $type, string $name, string $value, bool $allowHtml = false)
     {
         $this->type = $type;
         $this->name = $name;
         $this->value = $value;
+        $this->allowHtml = $allowHtml;
         if (Product::CUSTOMIZE_FILE === $this->type) {
             $this->image = _THEME_PROD_PIC_DIR_ . $this->value . '_small';
         }
@@ -77,5 +84,13 @@ class OrderProductCustomizationForViewing
     public function getImage(): ?string
     {
         return $this->image;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAllowHtml(): bool
+    {
+        return $this->allowHtml;
     }
 }

--- a/src/Core/Domain/Order/QueryResult/OrderProductCustomizationForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderProductCustomizationForViewing.php
@@ -89,7 +89,7 @@ class OrderProductCustomizationForViewing
     /**
      * @return bool
      */
-    public function isAllowHtml(): bool
+    public function isHtmlAllowed(): bool
     {
         return $this->allowHtml;
     }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/cart.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/cart.yml
@@ -72,7 +72,7 @@ services:
     arguments:
       - '@PrestaShop\PrestaShop\Adapter\ImageManager'
       - "@prestashop.core.localization.locale.context_locale"
-      - '@PrestaShop\PrestaShop\Core\Module\ModuleManager'
+      - '@PrestaShop\PrestaShop\Adapter\Module\ModuleHtmlAuthorizationChecker'
 
   prestashop.adapter.cart.query_handler.get_last_empty_customer_cart_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Cart\QueryHandler\GetLastEmptyCustomerCartHandler'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/cart.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/cart.yml
@@ -72,6 +72,7 @@ services:
     arguments:
       - '@PrestaShop\PrestaShop\Adapter\ImageManager'
       - "@prestashop.core.localization.locale.context_locale"
+      - '@PrestaShop\PrestaShop\Core\Module\ModuleManager'
 
   prestashop.adapter.cart.query_handler.get_last_empty_customer_cart_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Cart\QueryHandler\GetLastEmptyCustomerCartHandler'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -134,3 +134,9 @@ services:
       package: PrestaShop\PrestaShop
       version: 9.0
     public: true
+
+  PrestaShop\PrestaShop\Adapter\Module\ModuleHtmlAuthorizationChecker:
+    public: false
+    arguments:
+      - '@prestashop.adapter.legacy.module'
+      - '@PrestaShop\PrestaShop\Core\Module\ModuleManager'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -176,7 +176,7 @@ services:
       - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
       - "@prestashop.core.localization.locale.context_locale"
       - '@PrestaShopBundle\Entity\Repository\ShipmentRepository'
-      - '@PrestaShop\PrestaShop\Core\Module\ModuleManager'
+      - '@PrestaShop\PrestaShop\Adapter\Module\ModuleHtmlAuthorizationChecker'
 
   prestashop.adapter.order.command_handler.resend_order_email_handler:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\ResendOrderEmailHandler

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -176,6 +176,7 @@ services:
       - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
       - "@prestashop.core.localization.locale.context_locale"
       - '@PrestaShopBundle\Entity\Repository\ShipmentRepository'
+      - '@PrestaShop\PrestaShop\Core\Module\ModuleManager'
 
   prestashop.adapter.order.command_handler.resend_order_email_handler:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\ResendOrderEmailHandler

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/Blocks/View/cart_summary.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/Blocks/View/cart_summary.html.twig
@@ -63,6 +63,8 @@
                     <div class="col-6">
                       {% if customizationField.type == 'customizable_file' %}
                         <img src="{{ customizationField.image }}">
+                      {% elseif customizationField.allow_html|default(false) %}
+                        {{ customizationField.value|raw }}
                       {% else %}
                         {{ customizationField.value }}
                       {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/Blocks/View/cart_summary.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/Blocks/View/cart_summary.html.twig
@@ -64,7 +64,7 @@
                       {% if customizationField.type == 'customizable_file' %}
                         <img src="{{ customizationField.image }}">
                       {% elseif customizationField.allow_html|default(false) %}
-                        {{ customizationField.value|raw }}
+                        {{ customizationField.value|raw_purified }}
                       {% else %}
                         {{ customizationField.value }}
                       {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -162,7 +162,14 @@
         </div>
       {% endif %}
       {% for customization in product.customizations.textCustomizations %}
-        <p><strong>{{ customization.name }} :</strong> {{ customization.value }}</p>
+        <p>
+          <strong>{{ customization.name }} :</strong>
+          {% if customization.allowHtml %}
+            {{ customization.value|raw }}
+          {% else %}
+            {{ customization.value }}
+          {% endif %}
+        </p>
       {% endfor %}
       {% if product.type == constant('PrestaShop\\PrestaShop\\Core\\Domain\\Order\\QueryResult\\OrderProductForViewing::TYPE_PACK') %}
         <div class="btn-product-pack-modal mb-3 d-print-none" data-toggle="modal" data-target="#product-pack-modal" data-pack-items="{{ product.packItems|json_encode }}">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -164,7 +164,7 @@
       {% for customization in product.customizations.textCustomizations %}
         <p>
           <strong>{{ customization.name }} :</strong>
-          {% if customization.allowHtml %}
+          {% if customization.htmlAllowed %}
             {{ customization.value|raw_purified }}
           {% else %}
             {{ customization.value }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -165,7 +165,7 @@
         <p>
           <strong>{{ customization.name }} :</strong>
           {% if customization.allowHtml %}
-            {{ customization.value|raw }}
+            {{ customization.value|raw_purified }}
           {% else %}
             {{ customization.value }}
           {% endif %}


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.1.x
| Description?      | This PR fixes inconsistent handling of HTML returned by the `displayCustomization` hook across different PrestaShop contexts.<br/>Before this change, module-provided customization text could be rendered correctly in some front-office legacy templates, but the same output was escaped or re-escaped in:<br/>- order confirmation email<br/>- back-office cart view<br/>- back-office order view<br/><br/>The rendering logic introduced in this PR follows the behavior already used by the Hummingbird theme for module customizations:<br/>https://github.com/PrestaShop/hummingbird/blob/31fe43e8c68c4703d793dfc69c7f5377ba4bb850/templates/catalog/_partials/product-customization-modal.tpl#L33-L37<br/><br/>In practice, HTML is rendered only for module-owned customization text, while standard customization text remains escaped.<br/>This PR also adds an additional safeguard by checking that the related module actually exists and is active before allowing raw HTML rendering.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no 
| Deprecations?     | no
| How to test?      | 1. Install the [exampleproductcustomization.zip](https://github.com/user-attachments/files/28218603/exampleproductcustomization.zip) module.<br/>2. Open a product page and check that the customization fields are displayed after the **Add to cart** button.<br/>3. Fill in the customization fields and add the product to the cart.<br/>4. Open the front-office cart and check that the submitted customization values are displayed correctly, without escaped HTML tags.<br/>5. Go to `Orders > Shopping Carts` in the Back Office, open the corresponding cart, and check that the customization values are displayed correctly inside the product row.<br/>6. Complete the order and check that the customization values are displayed correctly in the order confirmation email.<br/>7. Go to `Orders > Orders` in the Back Office, open the created order, and check that the customization values are displayed correctly inside the product row.<br/><br/>**Note: This module is provided for demonstration purposes only and is not optimized for production use.**
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/24144134876
| Fixed issue or discussion?     | Fixes #41237
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/36796
| Sponsor company   | @Codencode 

---

**Note**: I added a parameter to the constructor of the class `src\Core\Domain\Order\QueryResult\OrderProductCustomizationForViewing.php` and I don't think this creates a BC break.


