### PR TITLE
PR to fix new translation other themes core

### DIFF
--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -77,7 +77,7 @@ class TranslationController extends ApiController
             } elseif (
                 !empty($theme)
                 // Core themes are not considered like other themes because their translations belong to the Core
-                && in_array($theme, Theme::CORE_THEMES)
+                && !in_array($theme, Theme::CORE_THEMES)
             ) {
                 $providerDefinition = new ThemeProviderDefinition($theme);
             } else {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR fixes an issue where translation keys defined in a custom theme using a custom domain (e.g. `Shop.Theme.Kiwik`) are not detected by the Back Office translation interface.<br><br>Currently, when a developer adds a translation string in a theme template (Smarty) with a custom domain, the translation extractor does not properly register it. As a result, the string is not available in **International > Translations > Theme**, making it impossible to translate it from the BO.<br><br>This PR ensures that custom theme domains following the `Shop.Theme.*` pattern are correctly detected and included in the translation catalogue.<br><br>Tested on PrestaShop 9.1.0 with a custom theme.<br><br>The issue appears to have been introduced in commit `dbe65f8` (https://github.com/PrestaShop/PrestaShop/commit/dbe65f8d22a92fbdd803ce90ed98471810bf68c8), where a missing negation (`!`) causes custom theme domains to be ignored during the extraction process.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create or use a custom theme<br>2. Add a translation key in a template file:<br>```smarty<br>{l s='Learn more' d='Shop.Theme.Kiwik'}<br>```<br>3. Clear cache<br>4. Go to Back Office > International > Translations<br>5. Expand Shop > Theme<br><br>**Before fix:** the domain `Kiwik` and the string do not appear<br>**After fix:** the domain is available and the string can be translated
| UI Tests          | N/A (no UI impact, only translation extraction logic)
| Fixed issue or discussion?     | Fixes #41256
| Related PRs       | N/A
| Sponsor company   | KIWIK