### PR TITLE
TEST [E2E] update Design Pages page Filter and Quick Edit

### DIFF
--- a/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/01_filterAndQuickEditPages.ts
+++ b/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/01_filterAndQuickEditPages.ts
@@ -135,7 +135,12 @@ describe('BO - Design - Pages : Filter and quick edit pages table', async () => 
       it('should reset all filters', async function () {
         await testContext.addContextItem(this, 'testIdentifier', `reset_${test.args.testIdentifier}`, baseContext);
 
-        const numberOfPagesAfterReset = await boCMSPagesPage.resetAndGetNumberOfLines(page, pagesTableName);
+        // Trigger reset then wait for full navigation before reading the count,
+        // because resetAndGetNumberOfLines reads with waitForSelector=false which
+        // can return a stale count if the page is still navigating.
+        await boCMSPagesPage.resetAndGetNumberOfLines(page, pagesTableName);
+        await page.waitForLoadState('networkidle');
+        const numberOfPagesAfterReset = await boCMSPagesPage.getNumberOfElementInGrid(page, pagesTableName);
         expect(numberOfPagesAfterReset).to.be.equal(numberOfPages);
       });
     });
@@ -188,7 +193,25 @@ describe('BO - Design - Pages : Filter and quick edit pages table', async () => 
     it('should reset all filters', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'quickEditReset', baseContext);
 
-      const numberOfPagesAfterReset = await boCMSPagesPage.resetAndGetNumberOfLines(page, pagesTableName);
+      // The status toggle (setStatus) triggers a full redirect to improve/design/cms-pages/
+      // which loads with the session filter still active. The grid's JS bundle may not yet
+      // be loaded when the next it-block starts, so the reset button's click handler is not
+      // bound. Waiting for networkidle ensures the JS is fully loaded before we attempt to
+      // click the reset button.
+      await page.waitForLoadState('networkidle');
+      await boCMSPagesPage.resetAndGetNumberOfLines(page, pagesTableName);
+      // Poll until the grid reflects the unfiltered count (reset AJAX + redirect complete).
+      await page.waitForFunction(
+        (expected: number) => {
+          const el = document.querySelector('#cms_page_grid_panel h3.card-header-title');
+          if (!el?.textContent) return false;
+          const match = el.textContent.match(/\d+/);
+          return match !== null && parseInt(match[0], 10) >= expected;
+        },
+        numberOfPages,
+        {timeout: 30000},
+      );
+      const numberOfPagesAfterReset = await boCMSPagesPage.getNumberOfElementInGrid(page, pagesTableName);
       expect(numberOfPagesAfterReset).to.be.equal(numberOfPages);
     });
   });

--- a/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/01_filterAndQuickEditPages.ts
+++ b/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/01_filterAndQuickEditPages.ts
@@ -123,9 +123,7 @@ describe('BO - Design - Pages : Filter and quick edit pages table', async () => 
           expect(numberOfPagesAfterFilter).to.be.at.most(numberOfPages);
 
           const allValues = await boCMSPagesPage.getAllRowsColumnContentTableCmsPage(page, test.args.filterBy);
-          for (const textColumn of allValues) {
-            expect(textColumn).to.contains(test.args.filterValue);
-          }
+          allValues.forEach((textColumn: string) => expect(textColumn).to.contains(test.args.filterValue));
         }
       });
 

--- a/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/01_filterAndQuickEditPages.ts
+++ b/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/01_filterAndQuickEditPages.ts
@@ -14,8 +14,8 @@ import {
 const baseContext: string = 'functional_BO_design_pages_pages_filterAndQuickEditPages';
 
 /*
-Filter pages table by : ID, Link, Meta title, Position and Displayed
-Enable/Disable page status by quick edit
+Filter pages table by : ID, Link, Meta title and Displayed
+Enable/Disable page status by quick edit, then verify with displayed filter
  */
 describe('BO - Design - Pages : Filter and quick edit pages table', async () => {
   let browserContext: BrowserContext;
@@ -65,44 +65,41 @@ describe('BO - Design - Pages : Filter and quick edit pages table', async () => 
     expect(numberOfPages).to.be.above(0);
   });
 
-  // 1 : Filter pages with all inputs and selects in grid table
+  // 1 : Filter pages with all inputs in grid table
   describe('Filter pages table', async () => {
     const tests = [
       {
-        args:
-          {
-            testIdentifier: 'filterById',
-            filterType: 'input',
-            filterBy: 'id_cms',
-            filterValue: dataCMSPages.delivery.id.toString(),
-          },
+        args: {
+          testIdentifier: 'filterById',
+          filterType: 'input',
+          filterBy: 'id_cms',
+          filterValue: dataCMSPages.delivery.id.toString(),
+        },
       },
       {
-        args:
-          {
-            testIdentifier: 'filterByLink',
-            filterType: 'input',
-            filterBy: 'link_rewrite',
-            filterValue: dataCMSPages.aboutUs.url,
-          },
+        args: {
+          testIdentifier: 'filterByLink',
+          filterType: 'input',
+          filterBy: 'link_rewrite',
+          filterValue: dataCMSPages.aboutUs.url,
+        },
       },
       {
-        args:
-          {
-            testIdentifier: 'filterByMetaTitle',
-            filterType: 'input',
-            filterBy: 'meta_title',
-            filterValue: dataCMSPages.termsAndCondition.title,
-          },
+        args: {
+          testIdentifier: 'filterByMetaTitle',
+          filterType: 'input',
+          filterBy: 'meta_title',
+          filterValue: dataCMSPages.termsAndCondition.title,
+        },
       },
       {
-        args:
-          {
-            testIdentifier: 'filterByActive',
-            filterType: 'select',
-            filterBy: 'active',
-            filterValue: dataCMSPages.securePayment.displayed ? '1' : '0',
-          },
+        args: {
+          testIdentifier: 'filterByMetaTitleNoResult',
+          filterType: 'input',
+          filterBy: 'meta_title',
+          filterValue: '123',
+          expectedCount: 0,
+        },
       },
     ];
 
@@ -119,14 +116,12 @@ describe('BO - Design - Pages : Filter and quick edit pages table', async () => 
         );
 
         const numberOfPagesAfterFilter = await boCMSPagesPage.getNumberOfElementInGrid(page, pagesTableName);
-        expect(numberOfPagesAfterFilter).to.be.at.most(numberOfPages);
 
-        if (test.args.filterBy === 'active') {
-          for (let i = 1; i <= numberOfPagesAfterFilter; i++) {
-            const pagesStatus = await boCMSPagesPage.getStatus(page, pagesTableName, i);
-            expect(pagesStatus).to.equal(test.args.filterValue === '1');
-          }
+        if (test.args.expectedCount !== undefined) {
+          expect(numberOfPagesAfterFilter).to.equal(test.args.expectedCount);
         } else {
+          expect(numberOfPagesAfterFilter).to.be.at.most(numberOfPages);
+
           const allValues = await boCMSPagesPage.getAllRowsColumnContentTableCmsPage(page, test.args.filterBy);
           for (const textColumn of allValues) {
             expect(textColumn).to.contains(test.args.filterValue);
@@ -143,48 +138,63 @@ describe('BO - Design - Pages : Filter and quick edit pages table', async () => 
     });
   });
 
-  // 2 : Editing pages from grid table
+  // 2 : Quick edit page status and verify with displayed filter
   describe('Quick edit pages', async () => {
-    it('should filter by Title \'Terms and conditions of use\'', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'quickEditFilter', baseContext);
+    it('should disable page with ID 1', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'disablePage', baseContext);
 
-      await boCMSPagesPage.filterTable(
-        page,
-        pagesTableName,
-        'input',
-        'meta_title',
-        dataCMSPages.termsAndCondition.title,
-      );
+      // Grid is unfiltered, ID=1 (delivery) is at row 1 (default sort by ID asc)
+      const isActionPerformed = await boCMSPagesPage.setStatus(page, pagesTableName, 1, false);
 
-      const numberOfPagesAfterFilter = await boCMSPagesPage.getNumberOfElementInGrid(page, pagesTableName);
-
-      if (numberOfPages === 0) {
-        expect(numberOfPagesAfterFilter).to.be.equal(numberOfPages + 1);
-      } else {
-        expect(numberOfPagesAfterFilter).to.be.at.most(numberOfPages);
+      if (isActionPerformed) {
+        const resultMessage = await boCMSPagesPage.getAlertSuccessBlockParagraphContent(page);
+        expect(resultMessage).to.contains(boCMSPagesPage.successfulUpdateStatusMessage);
       }
 
-      const textColumn = await boCMSPagesPage.getTextColumnFromTableCmsPage(page, 1, 'meta_title');
-      expect(textColumn).to.contains(dataCMSPages.termsAndCondition.title);
+      const currentStatus = await boCMSPagesPage.getStatus(page, pagesTableName, 1);
+      expect(currentStatus).to.be.equal(false);
     });
 
-    [
-      {args: {status: 'disable', enable: false}},
-      {args: {status: 'enable', enable: true}},
-    ].forEach((pageStatus) => {
-      it(`should ${pageStatus.args.status} the page`, async function () {
-        await testContext.addContextItem(this, 'testIdentifier', `${pageStatus.args.status}Page`, baseContext);
+    it('should filter by displayed \'No\' and verify only disabled pages are shown', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'filterByDisplayedNo', baseContext);
 
-        const isActionPerformed = await boCMSPagesPage.setStatus(page, pagesTableName, 1, pageStatus.args.enable);
+      await boCMSPagesPage.filterTable(page, pagesTableName, 'select', 'active', '0');
 
-        if (isActionPerformed) {
-          const resultMessage = await boCMSPagesPage.getAlertSuccessBlockParagraphContent(page);
-          expect(resultMessage).to.contains(boCMSPagesPage.successfulUpdateStatusMessage);
-        }
+      const numberOfPagesAfterFilter = await boCMSPagesPage.getNumberOfElementInGrid(page, pagesTableName);
+      expect(numberOfPagesAfterFilter).to.be.at.most(numberOfPages);
 
-        const currentStatus = await boCMSPagesPage.getStatus(page, pagesTableName, 1);
-        expect(currentStatus).to.be.equal(pageStatus.args.enable);
-      });
+      for (let i = 1; i <= numberOfPagesAfterFilter; i++) {
+        const pagesStatus = await boCMSPagesPage.getStatus(page, pagesTableName, i);
+        expect(pagesStatus).to.equal(false);
+      }
+    });
+
+    it('should enable page with ID 1', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'enablePage', baseContext);
+
+      // After filter by 'No', ID=1 is the only disabled page and sits at row 1
+      const isActionPerformed = await boCMSPagesPage.setStatus(page, pagesTableName, 1, true);
+
+      if (isActionPerformed) {
+        const resultMessage = await boCMSPagesPage.getAlertSuccessBlockParagraphContent(page);
+        expect(resultMessage).to.contains(boCMSPagesPage.successfulUpdateStatusMessage);
+      }
+      // Status verification deferred to the next filter step:
+      // after re-enabling, the 'No' session filter returns 0 rows, so getStatus cannot be used here.
+    });
+
+    it('should filter by displayed \'Yes\' and verify only enabled pages are shown', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'filterByDisplayedYes', baseContext);
+
+      await boCMSPagesPage.filterTable(page, pagesTableName, 'select', 'active', '1');
+
+      const numberOfPagesAfterFilter = await boCMSPagesPage.getNumberOfElementInGrid(page, pagesTableName);
+      expect(numberOfPagesAfterFilter).to.be.at.most(numberOfPages);
+
+      for (let i = 1; i <= numberOfPagesAfterFilter; i++) {
+        const pagesStatus = await boCMSPagesPage.getStatus(page, pagesTableName, i);
+        expect(pagesStatus).to.equal(true);
+      }
     });
 
     it('should reset all filters', async function () {

--- a/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/01_filterAndQuickEditPages.ts
+++ b/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/01_filterAndQuickEditPages.ts
@@ -204,8 +204,10 @@ describe('BO - Design - Pages : Filter and quick edit pages table', async () => 
       await page.waitForFunction(
         (expected: number) => {
           const el = document.querySelector('#cms_page_grid_panel h3.card-header-title');
+
           if (!el?.textContent) return false;
           const match = el.textContent.match(/\d+/);
+
           return match !== null && parseInt(match[0], 10) >= expected;
         },
         numberOfPages,

--- a/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/01_filterAndQuickEditPages.ts
+++ b/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/01_filterAndQuickEditPages.ts
@@ -121,12 +121,14 @@ describe('BO - Design - Pages : Filter and quick edit pages table', async () => 
         const numberOfPagesAfterFilter = await boCMSPagesPage.getNumberOfElementInGrid(page, pagesTableName);
         expect(numberOfPagesAfterFilter).to.be.at.most(numberOfPages);
 
-        for (let i = 1; i <= numberOfPagesAfterFilter; i++) {
-          if (test.args.filterBy === 'active') {
+        if (test.args.filterBy === 'active') {
+          for (let i = 1; i <= numberOfPagesAfterFilter; i++) {
             const pagesStatus = await boCMSPagesPage.getStatus(page, pagesTableName, i);
             expect(pagesStatus).to.equal(test.args.filterValue === '1');
-          } else {
-            const textColumn = await boCMSPagesPage.getTextColumnFromTableCmsPage(page, i, test.args.filterBy);
+          }
+        } else {
+          const allValues = await boCMSPagesPage.getAllRowsColumnContentTableCmsPage(page, test.args.filterBy);
+          for (const textColumn of allValues) {
             expect(textColumn).to.contains(test.args.filterValue);
           }
         }
@@ -135,12 +137,7 @@ describe('BO - Design - Pages : Filter and quick edit pages table', async () => 
       it('should reset all filters', async function () {
         await testContext.addContextItem(this, 'testIdentifier', `reset_${test.args.testIdentifier}`, baseContext);
 
-        // Trigger reset then wait for full navigation before reading the count,
-        // because resetAndGetNumberOfLines reads with waitForSelector=false which
-        // can return a stale count if the page is still navigating.
-        await boCMSPagesPage.resetAndGetNumberOfLines(page, pagesTableName);
-        await page.waitForLoadState('networkidle');
-        const numberOfPagesAfterReset = await boCMSPagesPage.getNumberOfElementInGrid(page, pagesTableName);
+        const numberOfPagesAfterReset = await boCMSPagesPage.resetAndGetNumberOfLines(page, pagesTableName);
         expect(numberOfPagesAfterReset).to.be.equal(numberOfPages);
       });
     });
@@ -193,27 +190,7 @@ describe('BO - Design - Pages : Filter and quick edit pages table', async () => 
     it('should reset all filters', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'quickEditReset', baseContext);
 
-      // The status toggle (setStatus) triggers a full redirect to improve/design/cms-pages/
-      // which loads with the session filter still active. The grid's JS bundle may not yet
-      // be loaded when the next it-block starts, so the reset button's click handler is not
-      // bound. Waiting for networkidle ensures the JS is fully loaded before we attempt to
-      // click the reset button.
-      await page.waitForLoadState('networkidle');
-      await boCMSPagesPage.resetAndGetNumberOfLines(page, pagesTableName);
-      // Poll until the grid reflects the unfiltered count (reset AJAX + redirect complete).
-      await page.waitForFunction(
-        (expected: number) => {
-          const el = document.querySelector('#cms_page_grid_panel h3.card-header-title');
-
-          if (!el?.textContent) return false;
-          const match = el.textContent.match(/\d+/);
-
-          return match !== null && parseInt(match[0], 10) >= expected;
-        },
-        numberOfPages,
-        {timeout: 30000},
-      );
-      const numberOfPagesAfterReset = await boCMSPagesPage.getNumberOfElementInGrid(page, pagesTableName);
+      const numberOfPagesAfterReset = await boCMSPagesPage.resetAndGetNumberOfLines(page, pagesTableName);
       expect(numberOfPagesAfterReset).to.be.equal(numberOfPages);
     });
   });

--- a/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/04_sortPages.ts
+++ b/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/04_sortPages.ts
@@ -14,9 +14,25 @@ import {
 const baseContext: string = 'functional_BO_design_pages_pages_sortPages';
 
 /*
-Sort pages table by id, url, title, position
+Pre-condition:
+- Login in BO
+Scenario:
+- Go to Design > Pages
+- Reset all filters
+- Sort pages by ID asc
+- Sort pages by ID desc
+- Sort pages by URL asc
+- Sort pages by URL desc
+- Sort pages by Title asc
+- Sort pages by Title desc
+- Sort pages by Meta Title asc
+- Sort pages by Meta Title desc
+- Sort pages by Position asc
+- Sort pages by Position desc
+- Sort pages by Status asc
+- Sort pages by Status desc
  */
-describe('BO - design - Pages : Sort Pages table', async () => {
+describe('BO - Design - Pages : Sort pages table', async () => {
   let browserContext: BrowserContext;
   let page: Page;
 
@@ -54,38 +70,71 @@ describe('BO - design - Pages : Sort Pages table', async () => {
     expect(pageTitle).to.contains(boCMSPagesPage.pageTitle);
   });
 
+
   // Sort pages table
   describe('Sort pages table', async () => {
-    const sortTests = [
+    const sortTests: {
+      args: { testIdentifier: string, sortBy: string, sortDirection: string, isFloat?: boolean },
+    }[] = [
       {
-        args:
-          {
-            testIdentifier: 'sortByPositionDesc', sortBy: 'position', sortDirection: 'desc', isFloat: true,
-          },
+        args: {
+          testIdentifier: 'sortByIdAsc', sortBy: 'id_cms', sortDirection: 'asc', isFloat: true,
+        },
       },
       {
-        args:
-          {
-            testIdentifier: 'sortByIdAsc', sortBy: 'id_cms', sortDirection: 'asc', isFloat: true,
-          },
+        args: {
+          testIdentifier: 'sortByIdDesc', sortBy: 'id_cms', sortDirection: 'desc', isFloat: true,
+        },
       },
       {
-        args:
-          {
-            testIdentifier: 'sortByIdDesc', sortBy: 'id_cms', sortDirection: 'desc', isFloat: true,
-          },
+        args: {
+          testIdentifier: 'sortByUrlAsc', sortBy: 'link_rewrite', sortDirection: 'asc',
+        },
       },
-      {args: {testIdentifier: 'sortByUrlAsc', sortBy: 'link_rewrite', sortDirection: 'asc'}},
-      {args: {testIdentifier: 'sortByUrlDesc', sortBy: 'link_rewrite', sortDirection: 'desc'}},
-      {args: {testIdentifier: 'sortByTitleAsc', sortBy: 'meta_title', sortDirection: 'asc'}},
-      {args: {testIdentifier: 'sortByTitleDesc', sortBy: 'meta_title', sortDirection: 'desc'}},
-      {args: {testIdentifier: 'sortByStatusAsc', sortBy: 'active', sortDirection: 'asc'}},
-      {args: {testIdentifier: 'sortByStatusDesc', sortBy: 'active', sortDirection: 'desc'}},
       {
-        args:
-          {
-            testIdentifier: 'sortByPositionAsc', sortBy: 'position', sortDirection: 'asc', isFloat: true,
-          },
+        args: {
+          testIdentifier: 'sortByUrlDesc', sortBy: 'link_rewrite', sortDirection: 'desc',
+        },
+      },
+      {
+        args: {
+          testIdentifier: 'sortByTitleAsc', sortBy: 'meta_title', sortDirection: 'asc',
+        },
+      },
+      {
+        args: {
+          testIdentifier: 'sortByTitleDesc', sortBy: 'meta_title', sortDirection: 'desc',
+        },
+      },
+      {
+        args: {
+          testIdentifier: 'sortByMetaTitleAsc', sortBy: 'head_seo_title', sortDirection: 'asc',
+        },
+      },
+      {
+        args: {
+          testIdentifier: 'sortByMetaTitleDesc', sortBy: 'head_seo_title', sortDirection: 'desc',
+        },
+      },
+      {
+        args: {
+          testIdentifier: 'sortByPositionAsc', sortBy: 'position', sortDirection: 'asc', isFloat: true,
+        },
+      },
+      {
+        args: {
+          testIdentifier: 'sortByPositionDesc', sortBy: 'position', sortDirection: 'desc', isFloat: true,
+        },
+      },
+      {
+        args: {
+          testIdentifier: 'sortByStatusAsc', sortBy: 'active', sortDirection: 'asc',
+        },
+      },
+      {
+        args: {
+          testIdentifier: 'sortByStatusDesc', sortBy: 'active', sortDirection: 'desc',
+        },
       },
     ];
 
@@ -110,7 +159,7 @@ describe('BO - design - Pages : Sort Pages table', async () => {
             expect(sortedTableFloat).to.deep.equal(expectedResult.reverse());
           }
         } else {
-          const expectedResult = await utilsCore.sortArray(nonSortedTable);
+          const expectedResult: string[] = await utilsCore.sortArray(nonSortedTable);
 
           if (test.args.sortDirection === 'asc') {
             expect(sortedTable).to.deep.equal(expectedResult);

--- a/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/04_sortPages.ts
+++ b/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/04_sortPages.ts
@@ -70,7 +70,6 @@ describe('BO - Design - Pages : Sort pages table', async () => {
     expect(pageTitle).to.contains(boCMSPagesPage.pageTitle);
   });
 
-
   // Sort pages table
   describe('Sort pages table', async () => {
     const sortTests: {

--- a/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/04_sortPages.ts
+++ b/tests/UI/campaigns/functional/BO/08_design/04_pages/pages/04_sortPages.ts
@@ -14,25 +14,9 @@ import {
 const baseContext: string = 'functional_BO_design_pages_pages_sortPages';
 
 /*
-Pre-condition:
-- Login in BO
-Scenario:
-- Go to Design > Pages
-- Reset all filters
-- Sort pages by ID asc
-- Sort pages by ID desc
-- Sort pages by URL asc
-- Sort pages by URL desc
-- Sort pages by Title asc
-- Sort pages by Title desc
-- Sort pages by Meta Title asc
-- Sort pages by Meta Title desc
-- Sort pages by Position asc
-- Sort pages by Position desc
-- Sort pages by Status asc
-- Sort pages by Status desc
+Sort pages table by id, url, title, position
  */
-describe('BO - Design - Pages : Sort pages table', async () => {
+describe('BO - design - Pages : Sort Pages table', async () => {
   let browserContext: BrowserContext;
   let page: Page;
 
@@ -72,68 +56,36 @@ describe('BO - Design - Pages : Sort pages table', async () => {
 
   // Sort pages table
   describe('Sort pages table', async () => {
-    const sortTests: {
-      args: { testIdentifier: string, sortBy: string, sortDirection: string, isFloat?: boolean },
-    }[] = [
+    const sortTests = [
       {
-        args: {
-          testIdentifier: 'sortByIdAsc', sortBy: 'id_cms', sortDirection: 'asc', isFloat: true,
-        },
+        args:
+          {
+            testIdentifier: 'sortByPositionDesc', sortBy: 'position', sortDirection: 'desc', isFloat: true,
+          },
       },
       {
-        args: {
-          testIdentifier: 'sortByIdDesc', sortBy: 'id_cms', sortDirection: 'desc', isFloat: true,
-        },
+        args:
+          {
+            testIdentifier: 'sortByIdAsc', sortBy: 'id_cms', sortDirection: 'asc', isFloat: true,
+          },
       },
       {
-        args: {
-          testIdentifier: 'sortByUrlAsc', sortBy: 'link_rewrite', sortDirection: 'asc',
-        },
+        args:
+          {
+            testIdentifier: 'sortByIdDesc', sortBy: 'id_cms', sortDirection: 'desc', isFloat: true,
+          },
       },
+      {args: {testIdentifier: 'sortByUrlAsc', sortBy: 'link_rewrite', sortDirection: 'asc'}},
+      {args: {testIdentifier: 'sortByUrlDesc', sortBy: 'link_rewrite', sortDirection: 'desc'}},
+      {args: {testIdentifier: 'sortByTitleAsc', sortBy: 'meta_title', sortDirection: 'asc'}},
+      {args: {testIdentifier: 'sortByTitleDesc', sortBy: 'meta_title', sortDirection: 'desc'}},
+      {args: {testIdentifier: 'sortByStatusAsc', sortBy: 'active', sortDirection: 'asc'}},
+      {args: {testIdentifier: 'sortByStatusDesc', sortBy: 'active', sortDirection: 'desc'}},
       {
-        args: {
-          testIdentifier: 'sortByUrlDesc', sortBy: 'link_rewrite', sortDirection: 'desc',
-        },
-      },
-      {
-        args: {
-          testIdentifier: 'sortByTitleAsc', sortBy: 'meta_title', sortDirection: 'asc',
-        },
-      },
-      {
-        args: {
-          testIdentifier: 'sortByTitleDesc', sortBy: 'meta_title', sortDirection: 'desc',
-        },
-      },
-      {
-        args: {
-          testIdentifier: 'sortByMetaTitleAsc', sortBy: 'head_seo_title', sortDirection: 'asc',
-        },
-      },
-      {
-        args: {
-          testIdentifier: 'sortByMetaTitleDesc', sortBy: 'head_seo_title', sortDirection: 'desc',
-        },
-      },
-      {
-        args: {
-          testIdentifier: 'sortByPositionAsc', sortBy: 'position', sortDirection: 'asc', isFloat: true,
-        },
-      },
-      {
-        args: {
-          testIdentifier: 'sortByPositionDesc', sortBy: 'position', sortDirection: 'desc', isFloat: true,
-        },
-      },
-      {
-        args: {
-          testIdentifier: 'sortByStatusAsc', sortBy: 'active', sortDirection: 'asc',
-        },
-      },
-      {
-        args: {
-          testIdentifier: 'sortByStatusDesc', sortBy: 'active', sortDirection: 'desc',
-        },
+        args:
+          {
+            testIdentifier: 'sortByPositionAsc', sortBy: 'position', sortDirection: 'asc', isFloat: true,
+          },
       },
     ];
 
@@ -158,7 +110,7 @@ describe('BO - Design - Pages : Sort pages table', async () => {
             expect(sortedTableFloat).to.deep.equal(expectedResult.reverse());
           }
         } else {
-          const expectedResult: string[] = await utilsCore.sortArray(nonSortedTable);
+          const expectedResult = await utilsCore.sortArray(nonSortedTable);
 
           if (test.args.sortDirection === 'asc') {
             expect(sortedTable).to.deep.equal(expectedResult);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | The "Displayed" filter has been removed from the filter section and moved to the Quick Edit section, where it now serves to verify the result after each status change on page ID=1. A new filter case by Meta title with a non-existent value ("123") has also been added to cover the "No records found" case.
| Type?             | refacto
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is green
| UI Tests          | https://github.com/paulnoelcholot/ga.tests.ui.pr/actions/runs/24423534730
| Sponsor company   | Prestashop