### PR TITLE
Add getOrder method to OrderCartRule class

### DIFF
--- a/classes/order/OrderCartRule.php
+++ b/classes/order/OrderCartRule.php
@@ -55,4 +55,13 @@ class OrderCartRuleCore extends ObjectModel
             'id_order' => ['xlink_resource' => 'orders'],
         ],
     ];
+
+    public function getOrder()
+    {
+        if (!$this->order) {
+            $this->order = new Order($this->id_order);
+        }
+
+        return $this->order;
+    }
 }

--- a/classes/order/OrderCartRule.php
+++ b/classes/order/OrderCartRule.php
@@ -32,6 +32,9 @@ class OrderCartRuleCore extends ObjectModel
     /** @var bool value : deleted from order */
     public $deleted = false;
 
+    /** @var Order * */
+    protected $order;
+
     /**
      * @see ObjectModel::$definition
      */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | As OrderInvoice, add a getter to get the Order object.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
