### PR TITLE
Add getOrder method to OrderDetail class

### DIFF
--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -298,6 +298,15 @@ class OrderDetailCore extends ObjectModel
         }
     }
 
+    public function getOrder()
+    {
+        if (!$this->order) {
+            $this->order = new Order($this->id_order);
+        }
+
+        return $this->order;
+    }
+
     public static function getDownloadFromHash($hash)
     {
         if ($hash == '') {

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -170,6 +170,9 @@ class OrderDetailCore extends ObjectModel
     /** @var float */
     public $total_refunded_tax_incl;
 
+    /** @var Order * */
+    protected $order;
+
     /**
      * @see ObjectModel::$definition
      */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | As OrderInvoice, add a getter to get the Order object.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
