### PR TITLE
Add getOrder method to OrderHistory class

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -53,6 +53,15 @@ class OrderHistoryCore extends ObjectModel
         ],
     ];
 
+    public function getOrder()
+    {
+        if (!$this->order) {
+            $this->order = new Order($this->id_order);
+        }
+
+        return $this->order;
+    }
+
     /**
      * Sets the new state of the given order.
      *

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -24,6 +24,9 @@ class OrderHistoryCore extends ObjectModel
     /** @var string Object last modification date */
     public $date_upd;
 
+    /** @var Order * */
+    protected $order;
+
     /**
      * @see ObjectModel::$definition
      */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | As OrderInvoice, add a getter to get the Order object.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
