### PR TITLE
Add getOrder method to OrderReturn class

### DIFF
--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -29,6 +29,9 @@ class OrderReturnCore extends ObjectModel
     /** @var string Object last modification date */
     public $date_upd;
 
+    /** @var Order * */
+    protected $order;
+
     /**
      * @see ObjectModel::$definition
      */

--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -115,6 +115,15 @@ class OrderReturnCore extends ObjectModel
         return (int) $data['total'];
     }
 
+    public function getOrder()
+    {
+        if (!$this->order) {
+            $this->order = new Order($this->id_order);
+        }
+
+        return $this->order;
+    }
+
     public static function getOrdersReturn($customer_id, $order_id = false, $no_denied = false, ?Context $context = null, ?int $idOrderReturn = null)
     {
         if (!$context) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | As OrderInvoice, add a getter to get the Order object.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
