### PR TITLE
Fix: cast bool field in get cms page category for editing handler

### DIFF
--- a/src/Adapter/CMS/PageCategory/QueryHandler/GetCmsPageCategoryForEditingHandler.php
+++ b/src/Adapter/CMS/PageCategory/QueryHandler/GetCmsPageCategoryForEditingHandler.php
@@ -44,7 +44,7 @@ final class GetCmsPageCategoryForEditingHandler implements GetCmsPageCategoryFor
 
         return new EditableCmsPageCategory(
             $cmsPageCategory->name,
-            $cmsPageCategory->active,
+            (bool) $cmsPageCategory->active,
             (int) $cmsPageCategory->id_parent,
             $cmsPageCategory->description,
             $cmsPageCategory->meta_description,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fix missing (bool) cast on $cmsPageCategory->active in GetCmsPageCategoryForEditingHandler, causing a NotNormalizableValueException when the API serializer tried to denormalize the legacy string "0"/"1" into a typed bool property.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Using the new endpoint GET /cms-page-categories/{id}, you should not have the following fatal error: The type of the "enabled" attribute must be "bool", "string" given.
| UI Tests          | https://github.com/axel-paillaud/ga.tests.ui.pr/actions/runs/24547340413
| Fixed issue or discussion?     | 
| Related PRs       | CmsPageCategories Endpoint for ps_apiresources WORK IN PROGRESS
| Sponsor company   | axel-paillaud

It is the same issue as #41128 for CmsPage endpoint

Without this fix, we get a 500 error on endpoint GET /cms-page-categories/{id}: The type of the "enabled" attribute must be "bool", "string" given.
