### PR TITLE
Rollback raw purifier on product page module hook

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/modules-content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/modules-content.html.twig
@@ -56,7 +56,7 @@
 <div class="module-contents d-none">
   {% for module in extraModules %}
     <div id="module_{{ module.id }}" class="module-render-container module-{{ module.attributes.name }}">
-      {{ module.content|raw_purified }}
+      {{ module.content|raw }}
     </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | The security fix on 9.1.0 create a regression
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Hook a module on the product page in the section "modules". HTML should not be removed.
| UI Tests          | Please run UI tests and paste here the link to the run. As we support MySQL and MariaDB in our tests, you have to launch 2 campaigns (by choosing both). [Visit the UI Tests repo and follow instructions](https://github.com/PrestaShop/ga.tests.ui.pr/).
| Fixed issue or discussion?     | Fixes #41259
| Related PRs       | NC
| Sponsor company   | @202ecommerce
