### PR TITLE
Guard product page when product is null

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -24,7 +24,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     /** @var int|null */
     protected $id_product_attribute;
 
-    /** @var Product */
+    /** @var Product|null */
     protected $product;
 
     /** @var Category|null */
@@ -131,6 +131,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
         // Otherwise immediately show 404
         if (!Validate::isLoadedObject($this->product)) {
+            $this->product = null;
             header('HTTP/1.1 404 Not Found');
             header('Status: 404 Not Found');
             $this->errors[] = $this->trans('This product is no longer available.', [], 'Shop.Notifications.Error');
@@ -296,102 +297,104 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      */
     public function initContent(): void
     {
-        // Assign template vars related to the category + execute hooks related to the category
-        $this->assignCategory();
+        if ($this->product !== null) {
+            // Assign template vars related to the category + execute hooks related to the category
+            $this->assignCategory();
 
-        // Assign template vars related to manufacturer of the product
-        $this->assignManufacturer();
+            // Assign template vars related to manufacturer of the product
+            $this->assignManufacturer();
 
-        // Assign template vars related to the price and tax
-        $this->assignPriceAndTax();
+            // Assign template vars related to the price and tax
+            $this->assignPriceAndTax();
 
-        // Assign attributes combinations to the template
-        $this->assignAttributesCombinations();
+            // Assign attributes combinations to the template
+            $this->assignAttributesCombinations();
 
-        // Add notification about this product being in cart
-        $this->addCartQuantityNotification();
+            // Add notification about this product being in cart
+            $this->addCartQuantityNotification();
 
-        // Get our product itself
-        // At this phase, it's already a presented lazy array, ready to go
-        $product_for_template = $this->getTemplateVarProduct();
+            // Get our product itself
+            // At this phase, it's already a presented lazy array, ready to go
+            $product_for_template = $this->getTemplateVarProduct();
 
-        // Chained hook call - if multiple modules are hooked here, they will receive the result of the previous one as a parameter
-        $filteredProduct = Hook::exec(
-            'filterProductContent',
-            ['object' => $product_for_template],
-            null,
-            false,
-            true,
-            false,
-            null,
-            true
-        );
-        if (!empty($filteredProduct['object'])) {
-            $product_for_template = $filteredProduct['object'];
-        }
-
-        // Prepare product presenter for related items like packs and accessories
-        $assembler = new ProductAssembler($this->context);
-        $presenter = new ProductListingPresenter(
-            new ImageRetriever(
-                $this->context->link
-            ),
-            $this->context->link,
-            new PriceFormatter(),
-            new ProductColorsRetriever(),
-            $this->getTranslator()
-        );
-        $presentationSettings = $this->getProductPresentationSettings();
-
-        // Presenting pack items
-        $pack_items = $product_for_template['pack'] ? $product_for_template['packItems'] : [];
-        $pack_items = $assembler->assembleProducts($pack_items);
-        $presentedPackItems = [];
-        foreach ($pack_items as $item) {
-            $presentedPackItems[] = $presenter->present(
-                $presentationSettings,
-                $item,
-                $this->context->language
+            // Chained hook call - if multiple modules are hooked here, they will receive the result of the previous one as a parameter
+            $filteredProduct = Hook::exec(
+                'filterProductContent',
+                ['object' => $product_for_template],
+                null,
+                false,
+                true,
+                false,
+                null,
+                true
             );
-        }
+            if (!empty($filteredProduct['object'])) {
+                $product_for_template = $filteredProduct['object'];
+            }
 
-        // Assign accessories
-        $accessories = $this->product->getAccessories($this->context->language->id);
-        if (is_array($accessories)) {
-            $accessories = $assembler->assembleProducts($accessories);
-            foreach ($accessories as &$accessory) {
-                $accessory = $presenter->present(
+            // Prepare product presenter for related items like packs and accessories
+            $assembler = new ProductAssembler($this->context);
+            $presenter = new ProductListingPresenter(
+                new ImageRetriever(
+                    $this->context->link
+                ),
+                $this->context->link,
+                new PriceFormatter(),
+                new ProductColorsRetriever(),
+                $this->getTranslator()
+            );
+            $presentationSettings = $this->getProductPresentationSettings();
+
+            // Presenting pack items
+            $pack_items = $product_for_template['pack'] ? $product_for_template['packItems'] : [];
+            $pack_items = $assembler->assembleProducts($pack_items);
+            $presentedPackItems = [];
+            foreach ($pack_items as $item) {
+                $presentedPackItems[] = $presenter->present(
                     $presentationSettings,
-                    $accessory,
+                    $item,
                     $this->context->language
                 );
             }
-            unset($accessory);
+
+            // Assign accessories
+            $accessories = $this->product->getAccessories($this->context->language->id);
+            if (is_array($accessories)) {
+                $accessories = $assembler->assembleProducts($accessories);
+                foreach ($accessories as &$accessory) {
+                    $accessory = $presenter->present(
+                        $presentationSettings,
+                        $accessory,
+                        $this->context->language
+                    );
+                }
+                unset($accessory);
+            }
+
+            // Assign everything to the template
+            $this->context->smarty->assign([
+                'product' => $product_for_template,
+                // How to display prices, tax or no tax?
+                'priceDisplay' => Product::getTaxCalculationMethod((int) $this->context->cookie->id_customer),
+                // If product is customized but not added to cart, ID of the customization
+                'id_customization' => empty($product_for_template['id_customization']) ? null : $product_for_template['id_customization'],
+                // Related products
+                'accessories' => $accessories,
+                // Should price per unit be displayed?
+                'displayUnitPrice' => !empty($product_for_template['unit_price_tax_excluded']),
+                // If product is a pack, pack contents
+                'packItems' => $presentedPackItems,
+                // Price of the product if it wasn't in the pack (should be migrated to lazy array)
+                'noPackPrice' => $product_for_template['nopackprice_to_display'],
+                // Should display the price of product if it wasn't in the pack?
+                'displayPackPrice' => !empty($product_for_template['pack']) && $product_for_template['price_amount'] < $product_for_template['nopackprice'],
+                // Variable containing information about a pack that this product belongs to
+                'packs' => Pack::getPacksTable($this->product->id, $this->context->language->id, true, 1),
+            ]);
+
+            // Assign attribute groups to the template
+            $this->assignAttributesGroups($product_for_template);
         }
-
-        // Assign everything to the template
-        $this->context->smarty->assign([
-            'product' => $product_for_template,
-            // How to display prices, tax or no tax?
-            'priceDisplay' => Product::getTaxCalculationMethod((int) $this->context->cookie->id_customer),
-            // If product is customized but not added to cart, ID of the customization
-            'id_customization' => empty($product_for_template['id_customization']) ? null : $product_for_template['id_customization'],
-            // Related products
-            'accessories' => $accessories,
-            // Should price per unit be displayed?
-            'displayUnitPrice' => !empty($product_for_template['unit_price_tax_excluded']),
-            // If product is a pack, pack contents
-            'packItems' => $presentedPackItems,
-            // Price of the product if it wasn't in the pack (should be migrated to lazy array)
-            'noPackPrice' => $product_for_template['nopackprice_to_display'],
-            // Should display the price of product if it wasn't in the pack?
-            'displayPackPrice' => !empty($product_for_template['pack']) && $product_for_template['price_amount'] < $product_for_template['nopackprice'],
-            // Variable containing information about a pack that this product belongs to
-            'packs' => Pack::getPacksTable($this->product->id, $this->context->language->id, true, 1),
-        ]);
-
-        // Assign attribute groups to the template
-        $this->assignAttributesGroups($product_for_template);
 
         parent::initContent();
     }
@@ -1379,37 +1382,39 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
-        // $productBreadcrumbCategory can have two possible values
-        // - current : Category the product was accessed from
-        // - default : Product default category
-        if (('current' === Configuration::get('PS_PRODUCT_BREADCRUMB_CATEGORY'))
-            && !empty($this->category)) {
-            $productBreadcrumbCategory = $this->category;
-        } else {
-            $productBreadcrumbCategory = new Category($this->product->id_category_default, $this->context->language->id);
-        }
+        if ($this->product !== null) {
+            // $productBreadcrumbCategory can have two possible values
+            // - current : Category the product was accessed from
+            // - default : Product default category
+            if (('current' === Configuration::get('PS_PRODUCT_BREADCRUMB_CATEGORY'))
+                && !empty($this->category)) {
+                $productBreadcrumbCategory = $this->category;
+            } else {
+                $productBreadcrumbCategory = new Category($this->product->id_category_default, $this->context->language->id);
+            }
 
-        foreach ($productBreadcrumbCategory->getAllParents() as $category) {
-            /** @var Category $category */
-            if ($category->id_parent != 0 && !$category->is_root_category && $category->active) {
+            foreach ($productBreadcrumbCategory->getAllParents() as $category) {
+                /** @var Category $category */
+                if ($category->id_parent != 0 && !$category->is_root_category && $category->active) {
+                    $breadcrumb['links'][] = [
+                        'title' => $category->name,
+                        'url' => $this->context->link->getCategoryLink($category),
+                    ];
+                }
+            }
+
+            if ($productBreadcrumbCategory->id_parent != 0 && !$productBreadcrumbCategory->is_root_category && $productBreadcrumbCategory->active) {
                 $breadcrumb['links'][] = [
-                    'title' => $category->name,
-                    'url' => $this->context->link->getCategoryLink($category),
+                    'title' => $productBreadcrumbCategory->name,
+                    'url' => $this->context->link->getCategoryLink($productBreadcrumbCategory),
                 ];
             }
-        }
 
-        if ($productBreadcrumbCategory->id_parent != 0 && !$productBreadcrumbCategory->is_root_category && $productBreadcrumbCategory->active) {
             $breadcrumb['links'][] = [
-                'title' => $productBreadcrumbCategory->name,
-                'url' => $this->context->link->getCategoryLink($productBreadcrumbCategory),
+                'title' => $this->product->name,
+                'url' => $this->context->link->getProductLink($this->product, null, null, null, null, null, (int) $this->getIdProductAttributeByRequest()),
             ];
         }
-
-        $breadcrumb['links'][] = [
-            'title' => $this->product->name,
-            'url' => $this->context->link->getProductLink($this->product, null, null, null, null, null, (int) $this->getIdProductAttributeByRequest()),
-        ];
 
         return $breadcrumb;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR adds a null guard around product-dependent logic in `ProductController` to avoid errors when the product is not available or not properly initialized.<br/>It ensures methods like `initContent()` and breadcrumb generation do not try to access product data when `$this->product` is `null`, making the product page flow more robust in invalid or edge-case contexts.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In the front office, it tries to access a non-existent article by entering a non-existent product ID.
| UI Tests          | 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41292 https://github.com/PrestaShop/PrestaShop/discussions/36868
| Related PRs       | 
| Sponsor company   | Codencode snc