### PR TITLE
Fix: hook extra content issues with multi shipment

### DIFF
--- a/src/Adapter/Shipment/DeliveryOptionsProvider.php
+++ b/src/Adapter/Shipment/DeliveryOptionsProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
@@ -139,9 +140,11 @@ class DeliveryOptionsProvider extends DeliveryOptionsFinderCore
             $names[] = $carrier['instance']->name;
             $delays[] = $carrier['instance']->delay[$this->context->language->id];
 
-            // if more than on carrier are in the same delivery options then concatenate
-            // all extracontent
-            $extraContent .= Hook::exec('displayCarrierExtraContent', ['carrier' => $carrier['instance']], Module::getModuleIdByName($carrier['instance']->id));
+            if ($carrier['instance']->is_module) {
+                if ($moduleId = Module::getModuleIdByName($carrier['instance']->external_module_name)) {
+                    $extraContent .= Hook::exec('displayCarrierExtraContent', ['carrier' => (array) $carrier['instance']], $moduleId);
+                }
+            }
         }
 
         return [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | There was multiple issues regarding how the hook `carrierExtraContent` was call. Firstly, the filter on if the carrier belongs to a module was not present. Secondly, the second argument in the exec() method of the hook was wrong. Finally there was also a typing issue. This was causing error in front office from all shipping modules that use the hook `carrierExtraContent`. @Progi1984 This should fix the issue on ui tests with the module `psshipping` 😌
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create multiple carrier with one carrier that was created by a module and it is using the hook carrierExtraContent. Make an order with some products that are handled by those carriers. You should be able to complete the checkout process without any error.
| UI Tests          | [Click here](https://github.com/Nakahiru/ga.tests.ui.pr/actions/runs/24654638600)
| Fixed issue or discussion?     | -
| Related PRs       | -
