### PR TITLE
Fix: Fatal error in hookActionCartSave after account creation when FrontController auto-assigns cart addresses and module calls Product::getPriceStatic() or Cart::getProducts()

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -417,14 +417,24 @@ class FrontControllerCore extends Controller
             ) {
                 $to_update = false;
                 if ($this->automaticallyAllocateDeliveryAddress && (!isset($cart->id_address_delivery) || $cart->id_address_delivery == 0)) {
-                    $to_update = true;
-                    $cart->id_address_delivery = (int) Address::getFirstCustomerAddressId($cart->id_customer);
+                    $deliveryAddressId = (int) Address::getFirstCustomerAddressId($cart->id_customer);
+                    // Skip save when the customer has no address yet.
+                    if ($deliveryAddressId > 0) {
+                        $to_update = true;
+                        $cart->id_address_delivery = $deliveryAddressId;
+                    }
                 }
                 if ($this->automaticallyAllocateInvoiceAddress && (!isset($cart->id_address_invoice) || $cart->id_address_invoice == 0)) {
-                    $to_update = true;
-                    $cart->id_address_invoice = (int) Address::getFirstCustomerAddressId($cart->id_customer);
+                    $invoiceAddressId = (int) Address::getFirstCustomerAddressId($cart->id_customer);
+                    // Skip save when the customer has no address yet.
+                    if ($invoiceAddressId > 0) {
+                        $to_update = true;
+                        $cart->id_address_invoice = $invoiceAddressId;
+                    }
                 }
                 if ($to_update) {
+                    // Keep context cart in sync before triggering actionCartSave.
+                    $this->context->cart = $cart;
                     $cart->update();
                 }
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.1.x
| Description?      |This PR avoids an unnecessary cart save when automatic address allocation resolves to 0, and synchronizes `context->cart` before `actionCartSave` is triggered. This prevents inconsistent cart state during front office refreshes after account creation.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | 1. Install the [issue40794.zip](https://github.com/user-attachments/files/26898017/issue40794.zip)  module<br/>2. Create a new customer account in front office<br/>3. Add one product to the cart<br/>3. The article must be added to the cart without any issues.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/24670069431
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41300
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/40795
| Sponsor company   | @Codencode 
