### PR TITLE
Fix address state selection after country states reload

### DIFF
--- a/admin-dev/themes/new-theme/js/components/country-state-selection-toggler.ts
+++ b/admin-dev/themes/new-theme/js/components/country-state-selection-toggler.ts
@@ -53,6 +53,7 @@ export default class CountryStateSelectionToggler {
    */
   private onChange(): void {
     const countryId = this.$countryInput.val();
+    const selectedStateId = this.$countryStateSelector.val();
 
     if (countryId === '') {
       return;
@@ -71,6 +72,7 @@ export default class CountryStateSelectionToggler {
           this.$countryStateSelector.append(
             $('<option></option>')
               .attr('value', response.states[value])
+              .prop('selected', String(selectedStateId) === String(response.states[value]))
               .text(value),
           );
         });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.1.x
| Description?      | <br/>Previously, the state select was emptied and repopulated after fetching the states for the selected country, causing the current selected state to be lost. The selected value is now stored before rebuilding the options and restored afterward.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to Customers > Addresses<br/>2. Edit an address<br/>3. The **State** select field must be correctly pre-selected with the address’s state
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/24707219259
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41284 https://github.com/PrestaShop/PrestaShop/issues/40667
| Related PRs       | 
| Sponsor company   | Codencode snc
