### PR TITLE
Fix PDF downloads using Symfony responses

### DIFF
--- a/src/Adapter/PDF/CreditSlipPdfGenerator.php
+++ b/src/Adapter/PDF/CreditSlipPdfGenerator.php
@@ -14,6 +14,7 @@ use PDF;
 use PrestaShop\PrestaShop\Core\Domain\CreditSlip\ValueObject\CreditSlipId;
 use PrestaShop\PrestaShop\Core\PDF\Exception\MissingDataException;
 use PrestaShop\PrestaShop\Core\PDF\Exception\PdfException;
+use PrestaShop\PrestaShop\Core\PDF\GeneratedPdf;
 use PrestaShop\PrestaShop\Core\PDF\PDFGeneratorInterface;
 use PrestaShopException;
 
@@ -53,21 +54,38 @@ final class CreditSlipPdfGenerator implements PDFGeneratorInterface
      */
     public function generatePDF(array $creditSlipIds): string
     {
+        try {
+            return $this->createPdf($creditSlipIds)->render(true);
+        } catch (PrestaShopException $e) {
+            throw new PdfException('Something went wrong when trying to generate pdf', 0, $e);
+        }
+    }
+
+    public function generatePDFForResponse(array $creditSlipIds): GeneratedPdf
+    {
+        try {
+            $pdf = $this->createPdf($creditSlipIds);
+
+            return new GeneratedPdf(
+                $pdf->render(false),
+                $pdf->getFilename()
+            );
+        } catch (PrestaShopException $e) {
+            throw new PdfException('Something went wrong when trying to generate pdf', 0, $e);
+        }
+    }
+
+    private function createPdf(array $creditSlipIds): PDF
+    {
         $ids = [];
         foreach ($creditSlipIds as $creditSlipId) {
             $ids[] = $creditSlipId->getValue();
         }
 
-        try {
-            $slipsList = $this->getCreditSlipsList($ids);
-            $slipsCollection = ObjectModel::hydrateCollection('OrderSlip', $slipsList);
+        $slipsList = $this->getCreditSlipsList($ids);
+        $slipsCollection = ObjectModel::hydrateCollection('OrderSlip', $slipsList);
 
-            $pdf = new PDF($slipsCollection, PDF::TEMPLATE_ORDER_SLIP, Context::getContext()->smarty);
-
-            return $pdf->render(true);
-        } catch (PrestaShopException $e) {
-            throw new PdfException('Something went wrong when trying to generate pdf', 0, $e);
-        }
+        return new PDF($slipsCollection, PDF::TEMPLATE_ORDER_SLIP, Context::getContext()->smarty);
     }
 
     /**

--- a/src/Adapter/PDF/DeliverySlipPdfGenerator.php
+++ b/src/Adapter/PDF/DeliverySlipPdfGenerator.php
@@ -10,6 +10,7 @@ use Context;
 use Order;
 use PDF;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Core\PDF\GeneratedPdf;
 use PrestaShop\PrestaShop\Core\PDF\PDFGeneratorInterface;
 use RuntimeException;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -40,6 +41,21 @@ final class DeliverySlipPdfGenerator implements PDFGeneratorInterface
      */
     public function generatePDF(array $orderId): string
     {
+        return $this->createPdf($orderId)->render(true);
+    }
+
+    public function generatePDFForResponse(array $orderId): GeneratedPdf
+    {
+        $pdf = $this->createPdf($orderId);
+
+        return new GeneratedPdf(
+            $pdf->render(false),
+            $pdf->getFilename()
+        );
+    }
+
+    private function createPdf(array $orderId): PDF
+    {
         if (count($orderId) !== 1) {
             throw new CoreException(sprintf('"%s" supports generating delivery slip for single order only.', self::class));
         }
@@ -53,8 +69,6 @@ final class DeliverySlipPdfGenerator implements PDFGeneratorInterface
 
         $order_invoice_collection = $order->getInvoicesCollection();
 
-        $pdf = new PDF($order_invoice_collection, PDF::TEMPLATE_DELIVERY_SLIP, Context::getContext()->smarty);
-
-        return $pdf->render(true);
+        return new PDF($order_invoice_collection, PDF::TEMPLATE_DELIVERY_SLIP, Context::getContext()->smarty);
     }
 }

--- a/src/Adapter/PDF/InvoicePdfGenerator.php
+++ b/src/Adapter/PDF/InvoicePdfGenerator.php
@@ -13,6 +13,7 @@ use Hook;
 use OrderInvoice;
 use PDF;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Core\PDF\GeneratedPdf;
 use PrestaShop\PrestaShop\Core\PDF\PDFGeneratorInterface;
 use RuntimeException;
 use Validate;
@@ -27,6 +28,21 @@ final class InvoicePdfGenerator implements PDFGeneratorInterface
      */
     public function generatePDF(array $invoiceId): void
     {
+        $this->createPdf($invoiceId)->render();
+    }
+
+    public function generatePDFForResponse(array $invoiceId): GeneratedPdf
+    {
+        $pdf = $this->createPdf($invoiceId);
+
+        return new GeneratedPdf(
+            $pdf->render(false),
+            $pdf->getFilename()
+        );
+    }
+
+    private function createPdf(array $invoiceId): PDF
+    {
         if (count($invoiceId) !== 1) {
             throw new CoreException(sprintf('"%s" supports generating PDF for single invoice only.', self::class));
         }
@@ -39,7 +55,6 @@ final class InvoicePdfGenerator implements PDFGeneratorInterface
 
         Hook::exec('actionPDFInvoiceRender', ['order_invoice_list' => [$orderInvoice]]);
 
-        $pdf = new PDF($orderInvoice, PDF::TEMPLATE_INVOICE, Context::getContext()->smarty);
-        $pdf->render();
+        return new PDF($orderInvoice, PDF::TEMPLATE_INVOICE, Context::getContext()->smarty);
     }
 }

--- a/src/Adapter/PDF/OrderInvoicePdfGenerator.php
+++ b/src/Adapter/PDF/OrderInvoicePdfGenerator.php
@@ -11,6 +11,7 @@ use Hook;
 use Order;
 use PDF;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Core\PDF\GeneratedPdf;
 use PrestaShop\PrestaShop\Core\PDF\PDFGeneratorInterface;
 use RuntimeException;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -39,6 +40,21 @@ final class OrderInvoicePdfGenerator implements PDFGeneratorInterface
      */
     public function generatePDF(array $orderId): string
     {
+        return $this->createPdf($orderId)->render(true);
+    }
+
+    public function generatePDFForResponse(array $orderId): GeneratedPdf
+    {
+        $pdf = $this->createPdf($orderId);
+
+        return new GeneratedPdf(
+            $pdf->render(false),
+            $pdf->getFilename()
+        );
+    }
+
+    private function createPdf(array $orderId): PDF
+    {
         if (count($orderId) !== 1) {
             throw new CoreException(sprintf('"%s" supports generating invoice for single order only.', self::class));
         }
@@ -53,8 +69,6 @@ final class OrderInvoicePdfGenerator implements PDFGeneratorInterface
 
         Hook::exec('actionPDFInvoiceRender', ['order_invoice_list' => $order_invoice_list]);
 
-        $pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, Context::getContext()->smarty);
-
-        return $pdf->render(true);
+        return new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, Context::getContext()->smarty);
     }
 }

--- a/src/Core/PDF/GeneratedPdf.php
+++ b/src/Core/PDF/GeneratedPdf.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace PrestaShop\PrestaShop\Core\PDF;
+
+/**
+ * Contains generated PDF content and its download filename.
+ */
+final class GeneratedPdf
+{
+    /**
+     * @param string $content
+     * @param string $fileName
+     */
+    public function __construct(
+        private readonly string $content,
+        private readonly string $fileName
+    ) {
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function getFileName(): string
+    {
+        return $this->fileName;
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/CreditSlipController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/CreditSlipController.php
@@ -20,7 +20,7 @@ use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
 use PrestaShopBundle\Form\Admin\Sell\Order\CreditSlip\GeneratePdfByDateType;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -90,8 +90,17 @@ class CreditSlipController extends PrestaShopAdminController
     ) {
         try {
             $creditSlipId = new CreditSlipId($creditSlipId);
+            $generatedPdf = $creditSlipPdfGenerator->generatePDFForResponse([$creditSlipId]);
 
-            return new BinaryFileResponse($creditSlipPdfGenerator->generatePDF([$creditSlipId]));
+            $response = new Response($generatedPdf->getContent());
+            $disposition = HeaderUtils::makeDisposition(
+                HeaderUtils::DISPOSITION_ATTACHMENT,
+                $generatedPdf->getFileName()
+            );
+            $response->headers->set('Content-Type', 'application/pdf');
+            $response->headers->set('Content-Disposition', $disposition);
+
+            return $response;
         } catch (CoreException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
         }
@@ -121,8 +130,17 @@ class CreditSlipController extends PrestaShopAdminController
                     new DateTime($dateRange['from']),
                     new DateTime($dateRange['to'])
                 ));
+                $generatedPdf = $creditSlipPdfGenerator->generatePDFForResponse($slipIds);
 
-                return new BinaryFileResponse($creditSlipPdfGenerator->generatePDF($slipIds));
+                $response = new Response($generatedPdf->getContent());
+                $disposition = HeaderUtils::makeDisposition(
+                    HeaderUtils::DISPOSITION_ATTACHMENT,
+                    $generatedPdf->getFileName()
+                );
+                $response->headers->set('Content-Type', 'application/pdf');
+                $response->headers->set('Content-Disposition', $disposition);
+
+                return $response;
             } catch (CoreException $e) {
                 $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
             }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/InvoicesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/InvoicesController.php
@@ -6,11 +6,12 @@
 
 namespace PrestaShopBundle\Controller\Admin\Sell\Order;
 
+use PrestaShop\PrestaShop\Adapter\PDF\InvoicePdfGenerator;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
-use PrestaShop\PrestaShop\Core\PDF\PDFGeneratorInterface;
 use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -131,12 +132,18 @@ class InvoicesController extends PrestaShopAdminController
     #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message: 'Access denied.')]
     public function generatePdfByIdAction(
         int $invoiceId,
-        #[Autowire(service: 'prestashop.adapter.pdf.generator.single_invoice')] PDFGeneratorInterface $invoicePdfGenerator
-    ) {
-        $invoicePdfGenerator->generatePDF([$invoiceId]);
+        #[Autowire(service: 'prestashop.adapter.pdf.generator.single_invoice')] InvoicePdfGenerator $invoicePdfGenerator
+    ): Response {
+        $generatedPdf = $invoicePdfGenerator->generatePDFForResponse([$invoiceId]);
 
-        // When using legacy generator,
-        // we want to be sure that displaying PDF is the last thing this controller will do
-        die;
+        $response = new Response($generatedPdf->getContent());
+        $disposition = HeaderUtils::makeDisposition(
+            HeaderUtils::DISPOSITION_ATTACHMENT,
+            $generatedPdf->getFileName()
+        );
+        $response->headers->set('Content-Type', 'application/pdf');
+        $response->headers->set('Content-Disposition', $disposition);
+
+        return $response;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
 use PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\Order\Repository\OrderDetailRepository;
+use PrestaShop\PrestaShop\Adapter\PDF\DeliverySlipPdfGenerator;
 use PrestaShop\PrestaShop\Adapter\PDF\OrderInvoicePdfGenerator;
 use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Action\ActionsBarButtonsCollection;
@@ -91,7 +92,6 @@ use PrestaShop\PrestaShop\Core\Grid\GridFactory;
 use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
 use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactoryInterface;
 use PrestaShop\PrestaShop\Core\Order\OrderSiblingProviderInterface;
-use PrestaShop\PrestaShop\Core\PDF\PDFGeneratorInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\OrderFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\ShipmentFilters;
 use PrestaShopBundle\Component\CsvResponse;
@@ -121,6 +121,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -314,8 +315,18 @@ class OrderController extends PrestaShopAdminController
     public function generateInvoicePdfAction(
         int $orderId,
         #[Autowire(service: 'prestashop.adapter.pdf.order_invoice_pdf_generator')] OrderInvoicePdfGenerator $invoicePdfGenerator,
-    ): BinaryFileResponse {
-        return new BinaryFileResponse($invoicePdfGenerator->generatePDF([$orderId]));
+    ): Response {
+        $generatedPdf = $invoicePdfGenerator->generatePDFForResponse([$orderId]);
+
+        $response = new Response($generatedPdf->getContent());
+        $disposition = HeaderUtils::makeDisposition(
+            HeaderUtils::DISPOSITION_ATTACHMENT,
+            $generatedPdf->getFileName()
+        );
+        $response->headers->set('Content-Type', 'application/pdf');
+        $response->headers->set('Content-Disposition', $disposition);
+
+        return $response;
     }
 
     /**
@@ -326,9 +337,19 @@ class OrderController extends PrestaShopAdminController
     #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute: 'admin_orders_index')]
     public function generateDeliverySlipPdfAction(
         int $orderId,
-        #[Autowire(service: 'prestashop.adapter.pdf.delivery_slip_pdf_generator')] PDFGeneratorInterface $deliverySlipPdfGenerator,
-    ): BinaryFileResponse {
-        return new BinaryFileResponse($deliverySlipPdfGenerator->generatePDF([$orderId]));
+        #[Autowire(service: 'prestashop.adapter.pdf.delivery_slip_pdf_generator')] DeliverySlipPdfGenerator $deliverySlipPdfGenerator,
+    ): Response {
+        $generatedPdf = $deliverySlipPdfGenerator->generatePDFForResponse([$orderId]);
+
+        $response = new Response($generatedPdf->getContent());
+        $disposition = HeaderUtils::makeDisposition(
+            HeaderUtils::DISPOSITION_ATTACHMENT,
+            $generatedPdf->getFileName()
+        );
+        $response->headers->set('Content-Type', 'application/pdf');
+        $response->headers->set('Content-Disposition', $disposition);
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fix PDF downloads in Symfony controllers by returning a proper `Response` containing the generated PDF content, instead of passing legacy TCPDF output to `BinaryFileResponse`.<br/> This introduces a `GeneratedPdf` DTO to carry both the PDF content and the expected download filename.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create or use an order with an invoice.<br/>From the order view, download the invoice PDF and check that the file is downloaded with the expected filename.<br/>From the same order view, download the delivery slip PDF and check the same behavior.<br/>Go to Sell > Orders > Invoices, open/download a single invoice PDF by invoice ID and verify the download works.<br/>Go to Sell > Orders > Credit slips, download a single credit slip PDF and generate credit slips by date range, then verify both downloads work.<br/>Check the application logs after each download and make sure there is no `request.CRITICAL` entry with `Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException`, `The file "" does not exist`, or a `BinaryFileResponse` file error.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/25327658460
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41248
| Related PRs       | 
| Sponsor company   | Codencode snc

---
# Technical details

The affected controllers were creating a `BinaryFileResponse` from the return value of the legacy PDF generator:

```php
return new BinaryFileResponse($pdfGenerator->generatePDF(...));
```

However, the legacy PDF generator uses TCPDF in direct output mode. This means it sends the PDF content directly to the browser and does not return a physical file path.

As a result, `BinaryFileResponse::__construct()` receives an empty value and calls:

```php
$this->setFile($file, $contentDisposition, $autoEtag, $autoLastModified);
```

with an invalid `$file`, which triggers a `FileNotFoundException`.

In some environments the download may still appear to work because TCPDF has already started sending the PDF content before Symfony catches the exception in `HttpKernel::handle()`. This behavior is fragile and depends on buffering/error handling.

This PR changes the affected generators to expose a response-oriented method returning `GeneratedPdf`, using TCPDF string output mode. Controllers then build a standard Symfony `Response` with:

- `Content-Type: application/pdf`
- `Content-Disposition` containing the expected filename

This avoids using `BinaryFileResponse` when no physical file exists and makes the PDF download flow explicit and stable.


@tleon @mattgoud @boherm @kpodemski What do you think about this approach?

If you think this should target `develop`, I can rebase the branch and update the PR target accordingly.

An alternative would be to keep relying on the legacy PDF output directly and change the controller return type from `BinaryFileResponse` to `void`. I chose the `Response` + `GeneratedPdf` approach because it avoids direct output from the PDF layer and makes the Symfony controller response explicit.

