### PR TITLE
Fix wrong state saved when country is changed quickly before AJAX completes

### DIFF
--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -112,6 +112,17 @@ class CustomerAddressFormCore extends AbstractForm
             }
         }
 
+        $stateField = $this->getField('id_state');
+        if ($stateField && $stateField->getValue() && !empty($stateField->getAvailableValues())
+            && !array_key_exists($stateField->getValue(), $stateField->getAvailableValues())) {
+            $stateField->addError($this->translator->trans(
+                'This state is not valid for the selected country.',
+                [],
+                'Shop.Forms.Errors'
+            ));
+            $is_valid = false;
+        }
+
         if ($is_valid && Hook::exec('actionValidateCustomerAddressForm', ['form' => $this]) === false) {
             $is_valid = false;
         }

--- a/themes/_core/js/address.js
+++ b/themes/_core/js/address.js
@@ -21,6 +21,9 @@ function handleCountryChange(selectors) {
     const formFieldsSelector = `${selectors.address} input`;
     const target = $(event.target);
 
+    const submitButton = $(`${selectors.address} [type="submit"]`);
+    submitButton.prop('disabled', true);
+
     $.post(getFormViewUrl, requestData).then((resp) => {
       const inputs = [];
 
@@ -38,6 +41,7 @@ function handleCountryChange(selectors) {
 
       prestashop.emit('updatedAddressForm', {target: $(selectors.address), resp});
     }).fail((resp) => {
+      submitButton.prop('disabled', false);
       prestashop.emit('handleError', {eventType: 'updateAddressForm', resp});
     });
   });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions                      | Answers
| ------------------------------ | -------------------------------------------------------
| Branch?                        | 9.1.x
| Description?                   | When a customer changes the country on an address form and submits the form very quickly (before the AJAX request refreshing the state list completes), the form is saved with a state that does not belong to the selected country (e.g. a Canadian province on a US address). Two complementary fixes: (1) disable the submit button during the AJAX refresh so the user cannot submit mid-reload, (2) add server-side validation to reject a state that does not belong to the submitted country.
| Type?                          | bug fix
| Category?                      | FO
| BC breaks?                     | no
| Deprecations?                  | no
| How to test?                   | 1. Go to the address form (customer account → add/edit address). 2. Select a country with states (e.g. Canada) and pick any state. 3. Change the country select to another country with states (e.g. United States) and immediately click **Save** before the state dropdown has reloaded. 4. **Before fix**: address is saved with the wrong state. **After fix**: the submit button is disabled during reload so the action is blocked; if the button is somehow bypassed, the server-side validation rejects the mismatched state with an error message.
| UI Tests                       | https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/25171828393
| Fixed issue or discussion?     | Fixes #36611
| Related PRs                    | ~
| Sponsor company                | PrestaShop SA