### PR TITLE
Fix product details overridden when changing attribute in quickview modal

### DIFF
--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -230,7 +230,12 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.additionalInfos)
           .first()
           .replaceWith(data.product_additional_info);
-        if (!$('.modal.quickview.in, .modal.quickview.show').length) {
+        const $quickview = $('.modal.quickview.in, .modal.quickview.show');
+        if ($quickview.length) {
+          $quickview.find(prestashop.selectors.product.details).replaceWith(
+            data.product_details,
+          );
+        } else {
           $(prestashop.selectors.product.details).replaceWith(
             data.product_details,
           );

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -230,9 +230,11 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.additionalInfos)
           .first()
           .replaceWith(data.product_additional_info);
-        $(prestashop.selectors.product.details).replaceWith(
-          data.product_details,
-        );
+        if (!$('.modal.quickview.in, .modal.quickview.show').length) {
+          $(prestashop.selectors.product.details).replaceWith(
+            data.product_details,
+          );
+        }
         $(prestashop.selectors.product.flags)
           .first()
           .replaceWith(data.product_flags);

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -156,8 +156,6 @@ function updateProduct(event, eventType, updateUrl) {
       return;
     }
 
-    const isQuickView = !!$('.modal.quickview.in, .modal.quickview.show').length;
-
     currentRequest = $.ajax({
       url:
         updateUrl
@@ -166,7 +164,7 @@ function updateProduct(event, eventType, updateUrl) {
         + preview,
       method: 'POST',
       data: {
-        quickview: isQuickView ? 1 : 0,
+        quickview: $('.modal.quickview.in, .modal.quickview.show').length,
         ajax: 1,
         action: 'refresh',
         quantity_wanted:
@@ -232,11 +230,9 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.additionalInfos)
           .first()
           .replaceWith(data.product_additional_info);
-        if (!isQuickView) {
-          $(prestashop.selectors.product.details).replaceWith(
-            data.product_details,
-          );
-        }
+        $(prestashop.selectors.product.details).replaceWith(
+          data.product_details,
+        );
         $(prestashop.selectors.product.flags)
           .first()
           .replaceWith(data.product_flags);

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -156,6 +156,8 @@ function updateProduct(event, eventType, updateUrl) {
       return;
     }
 
+    const isQuickView = !!$('.modal.quickview.in, .modal.quickview.show').length;
+
     currentRequest = $.ajax({
       url:
         updateUrl
@@ -164,7 +166,7 @@ function updateProduct(event, eventType, updateUrl) {
         + preview,
       method: 'POST',
       data: {
-        quickview: $('.modal.quickview.in, .modal.quickview.show').length,
+        quickview: isQuickView ? 1 : 0,
         ajax: 1,
         action: 'refresh',
         quantity_wanted:
@@ -230,12 +232,7 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.additionalInfos)
           .first()
           .replaceWith(data.product_additional_info);
-        const $quickview = $('.modal.quickview.in, .modal.quickview.show');
-        if ($quickview.length) {
-          $quickview.find(prestashop.selectors.product.details).replaceWith(
-            data.product_details,
-          );
-        } else {
+        if (!isQuickView) {
           $(prestashop.selectors.product.details).replaceWith(
             data.product_details,
           );

--- a/themes/_core/js/selectors.js
+++ b/themes/_core/js/selectors.js
@@ -33,7 +33,7 @@ prestashop.selectors = {
       '.quickview .product-discounts, .page-product:not(.modal-open) .row .product-discounts, .page-product:not(.modal-open) .product-container .product-discounts, .quickview .js-product-discounts, .page-product:not(.modal-open) .row .js-product-discounts, .page-product:not(.modal-open) .product-container .js-product-discounts',
     additionalInfos:
       '.quickview .product-additional-info, .page-product:not(.modal-open) .row .product-additional-info, .page-product:not(.modal-open) .product-container .product-additional-info, .quickview .js-product-additional-info, .page-product:not(.modal-open) .row .js-product-additional-info, .page-product:not(.modal-open) .js-product-container .js-product-additional-info',
-    details: '.quickview #product-details, #product-details, .quickview .js-product-details, .js-product-details',
+    details: '.quickview #product-details, .page-product:not(.modal-open) #product-details, .quickview .js-product-details, .page-product:not(.modal-open) .js-product-details',
     flags:
       '.quickview .product-flags, .page-product:not(.modal-open) .row .product-flags, .page-product:not(.modal-open) .product-container .product-flags, .quickview .js-product-flags, .page-product:not(.modal-open) .row .js-product-flags, .page-product:not(.modal-open) .js-product-container .js-product-flags',
     /* eslint-enable */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions                      | Answers
| ------------------------------ | -------------------------------------------------------
| Branch?                        | 9.1.x
| Description?                   | When a product page displays other products (related products, same-category module, etc.) with a quickview button, opening the quickview of another product and selecting an attribute triggers an AJAX refresh that replaces the `#product-details` block of the background page with data from the quickview product. The root cause is that the `details` entry in `selectors.js` was missing the `.page-product:not(.modal-open)` guard used by all other product selectors. Bootstrap adds `modal-open` to `body` when a modal is open, so guarded selectors correctly avoid the background page. Adding the guard to `details` fixes the issue without any changes to `product.js`.
| Type?                          | bug fix
| Category?                      | FO
| BC breaks?                     | no
| Deprecations?                  | no
| How to test?                   | 1. Have two products with attributes (e.g. T-shirts with sizes). 2. Add product B as a related product of product A (BO > product A > Associations). 3. Go to the FO page of product A and note the product name/details displayed. 4. Open the quickview of product B (from the related products section). 5. Select a different attribute (e.g. size L) in the quickview modal. 6. Close the modal. 7. **Before fix**: the page now shows product B's details instead of product A's. **After fix**: the page correctly keeps product A's details.
| UI Tests                       | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/25496898838
| Fixed issue or discussion?     | Fixes #36783
| Related PRs                    | ~
| Sponsor company                | PrestaShop SA