### PR TITLE
Fix unable to delete order product when catalog product is deleted

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1684,7 +1684,7 @@ class CartCore extends ObjectModel
             if ($operator === 'down') {
                 PrestaShopLogger::addLog(
                     sprintf('Cart::updateQty - Product with ID "%s" could not be loaded, removing it from cart.', $id_product),
-                    2,
+                    PrestaShopLogger::LOG_SEVERITY_LEVEL_WARNING,
                     null,
                     'Cart',
                     (int) $this->id

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1680,6 +1680,10 @@ class CartCore extends ObjectModel
         }
 
         if (!Validate::isLoadedObject($product)) {
+            // Product may have been deleted from catalog but still exist in a cart/order; deleteProduct only needs IDs.
+            if ($operator === 'down') {
+                return $this->deleteProduct($id_product, $id_product_attribute, (int) $id_customization, 0, $preserveGiftRemoval, $useOrderPrices);
+            }
             throw new PrestaShopException(sprintf('Product with ID "%s" could not be loaded.', $id_product));
         }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1682,6 +1682,14 @@ class CartCore extends ObjectModel
         if (!Validate::isLoadedObject($product)) {
             // Product may have been deleted from catalog but still exist in a cart/order; deleteProduct only needs IDs.
             if ($operator === 'down') {
+                PrestaShopLogger::addLog(
+                    sprintf('Cart::updateQty - Product with ID "%s" could not be loaded, removing it from cart.', $id_product),
+                    2,
+                    null,
+                    'Cart',
+                    (int) $this->id
+                );
+
                 return $this->deleteProduct($id_product, $id_product_attribute, (int) $id_customization, 0, $preserveGiftRemoval, $useOrderPrices);
             }
             throw new PrestaShopException(sprintf('Product with ID "%s" could not be loaded.', $id_product));

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -1062,7 +1062,8 @@ class OrderController extends PrestaShopAdminController
         int $orderId,
         Request $request,
         #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.cancel_product_form_builder')] FormBuilderInterface $formBuilder,
-        CurrencyDataProvider $currencyDataProvider
+        CurrencyDataProvider $currencyDataProvider,
+        FeatureFlagStateCheckerInterface $featureFlagStateChecker,
     ): Response {
         /** @var OrderForViewing $orderForViewing */
         $orderForViewing = $this->dispatchQuery(new GetOrderForViewing($orderId, QuerySorting::DESC));
@@ -1135,6 +1136,7 @@ class OrderController extends PrestaShopAdminController
                 'isAvailableQuantityDisplayed' => (bool) $this->getConfiguration()->get('PS_STOCK_MANAGEMENT'),
                 'cancelProductForm' => $cancelProductForm->createView(),
                 'orderCurrency' => $orderCurrency,
+                'isImprovedShipmentFeatureFlagEnabled' => $featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT),
             ]);
         }
 
@@ -1337,7 +1339,8 @@ class OrderController extends PrestaShopAdminController
         int $orderDetailId,
         Request $request,
         #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.cancel_product_form_builder')] FormBuilderInterface $formBuilder,
-        CurrencyDataProvider $currencyDataProvider
+        CurrencyDataProvider $currencyDataProvider,
+        FeatureFlagStateCheckerInterface $featureFlagStateChecker,
     ): Response {
         try {
             $this->dispatchCommand(
@@ -1382,6 +1385,7 @@ class OrderController extends PrestaShopAdminController
             'orderCurrency' => $orderCurrency,
             'orderForViewing' => $orderForViewing,
             'product' => $product,
+            'isImprovedShipmentFeatureFlagEnabled' => $featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT),
         ]);
     }
 
@@ -1857,7 +1861,8 @@ class OrderController extends PrestaShopAdminController
     public function getProductsListAction(
         int $orderId,
         #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.cancel_product_form_builder')] FormBuilderInterface $formBuilder,
-        CurrencyDataProvider $currencyDataProvider
+        CurrencyDataProvider $currencyDataProvider,
+        FeatureFlagStateCheckerInterface $featureFlagStateChecker,
     ): Response {
         /** @var OrderForViewing $orderForViewing */
         $orderForViewing = $this->dispatchQuery(new GetOrderForViewing($orderId, QuerySorting::DESC));
@@ -1893,6 +1898,7 @@ class OrderController extends PrestaShopAdminController
             'isColumnLocationDisplayed' => $isColumnLocationDisplayed,
             'isColumnRefundedDisplayed' => $isColumnRefundedDisplayed,
             'isAvailableQuantityDisplayed' => (bool) $this->getConfiguration()->get('PS_STOCK_MANAGEMENT'),
+            'isImprovedShipmentFeatureFlagEnabled' => $featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT),
         ]);
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions                      | Answers
| ------------------------------ | -------------------------------------------------------
| Branch?                        | 9.1.x
| Description?                   | When a product is deleted from the catalog, its `product_shop` association is removed. Attempting to then delete an order line containing that product triggered two separate 500 errors: 1) `Cart::updateQty()` threw a `PrestaShopException` ("Product with ID X could not be loaded") before reaching the removal logic, even though `Cart::deleteProduct()` only needs the product IDs. Fixed by allowing `'down'` operations to proceed directly to `deleteProduct()` when the product no longer exists. 2) `getProductsListAction`, `updateProductAction` and `addProductAction` were missing the `isImprovedShipmentFeatureFlagEnabled` Twig variable required by `product.html.twig`, causing a 500 error on the product list refresh after the deletion. Fixed by injecting `FeatureFlagStateCheckerInterface` and passing the variable in all three partial render actions.
| Type?                          | bug fix
| Category?                      | BO
| BC breaks?                     | no
| Deprecations?                  | no
| How to test?                   | 1. Create an order with at least 2 products (e.g. product A and product B). 2. Go to Catalog > Products and permanently delete product A. 3. Go back to the order and click the delete button on the order line for product A. 4. **Before fix**: 500 error — "Product with ID X could not be loaded", then after that fix, a Twig 500 on the list refresh. **After fix**: the order line is removed cleanly and the product list refreshes without error.
| UI Tests                       | https://github.com/SiraDIOP/ga.tests.ui.pr/actions/runs/25496864520
| Fixed issue or discussion?     | Fixes #41149
| Related PRs                    | ~
| Sponsor company                | PrestaShop SA