### PR TITLE
Fix missing shipment feature flag in order product update

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -1337,7 +1337,8 @@ class OrderController extends PrestaShopAdminController
         int $orderDetailId,
         Request $request,
         #[Autowire(service: 'prestashop.core.form.identifiable_object.builder.cancel_product_form_builder')] FormBuilderInterface $formBuilder,
-        CurrencyDataProvider $currencyDataProvider
+        CurrencyDataProvider $currencyDataProvider,
+        FeatureFlagStateCheckerInterface $featureFlagStateChecker
     ): Response {
         try {
             $this->dispatchCommand(
@@ -1379,6 +1380,7 @@ class OrderController extends PrestaShopAdminController
             'isColumnLocationDisplayed' => $product->getLocation() !== '',
             'isColumnRefundedDisplayed' => $product->getQuantityRefunded() > 0,
             'isAvailableQuantityDisplayed' => (bool) $this->getConfiguration()->get('PS_STOCK_MANAGEMENT'),
+            'isImprovedShipmentFeatureFlagEnabled' => $featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_IMPROVED_SHIPMENT),
             'orderCurrency' => $orderCurrency,
             'orderForViewing' => $orderForViewing,
             'product' => $product,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | This PR fixes an error that occurs in the Back Office when editing the price of a product inside an order with debug mode enabled.<br/>The template expects the `isImprovedShipmentFeatureFlagEnabled` variable, but this variable was not provided by `OrderController::updateProductAction()`.
| Type?             | bug fix
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |1. Enable debug mode.<br/>2. Go to the Back Office.<br/>3. Open an existing order.<br/>4. Edit the price of one of the products in the order.<br/>5.You should not see any error in the console, and the product row should be reloaded correctly.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/25327726601
| Fixed issue or discussion?     | Fixes #41328
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/40944
| Sponsor company   | Codencode snc