### PR TITLE
Fix theme import from web throwing PHP warnings on invalid URLs

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1926,11 +1926,11 @@ class ToolsCore
         if (!in_array(strtolower($scheme), ['http', 'https'], true)) {
             return false;
         }
-        $remoteFile = fopen($url, 'rb');
+        $remoteFile = @fopen($url, 'rb');
         if (!$remoteFile) {
             return false;
         }
-        $localFile = fopen(basename($url), 'wb');
+        $localFile = @fopen(basename($url), 'wb');
         if (!$localFile) {
             return false;
         }

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -77,7 +77,14 @@ class ThemeManager implements AddonManagerInterface
     public function install($source)
     {
         if (filter_var($source, FILTER_VALIDATE_URL)) {
-            $source = Tools::createFileFromUrl($source);
+            $downloaded = Tools::createFileFromUrl($source);
+            if (false === $downloaded) {
+                throw new ThemeConstraintException(
+                    sprintf('Cannot download theme from URL "%s".', $source),
+                    ThemeConstraintException::CANNOT_DOWNLOAD_FROM_URL
+                );
+            }
+            $source = $downloaded;
         }
         if (preg_match('/\.zip$/', $source)) {
             $this->installFromZip($source);

--- a/src/Core/Domain/Theme/Exception/ThemeConstraintException.php
+++ b/src/Core/Domain/Theme/Exception/ThemeConstraintException.php
@@ -30,4 +30,9 @@ class ThemeConstraintException extends ThemeException
      * Some mandatory files are missing.
      */
     public const INVALID_DATA = 4;
+
+    /**
+     * When the theme cannot be downloaded from the provided URL.
+     */
+    public const CANNOT_DOWNLOAD_FROM_URL = 5;
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -443,6 +443,11 @@ class ThemeController extends PrestaShopAdminController
                 ThemeConstraintException::INVALID_DATA => $this->trans(
                     'Invalid data', [], 'Admin.Notifications.Error'
                 ),
+                ThemeConstraintException::CANNOT_DOWNLOAD_FROM_URL => $this->trans(
+                    'Cannot download the theme from the given URL. Please check the URL and try again.',
+                    [],
+                    'Admin.Design.Notification'
+                ),
             ],
         ];
     }

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -535,7 +535,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#0338b5748eb345560aa2904cfe6c32d34b08c23f",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#1620acb968f43aa160dd89208aceb34113d98502",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -8882,7 +8882,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#0338b5748eb345560aa2904cfe6c32d34b08c23f",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#1620acb968f43aa160dd89208aceb34113d98502",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^10.1.0",

--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -535,7 +535,7 @@
     },
     "node_modules/@prestashop-core/ui-testing": {
       "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#1620acb968f43aa160dd89208aceb34113d98502",
+      "resolved": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#0338b5748eb345560aa2904cfe6c32d34b08c23f",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",
@@ -8882,7 +8882,7 @@
       }
     },
     "@prestashop-core/ui-testing": {
-      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#1620acb968f43aa160dd89208aceb34113d98502",
+      "version": "git+ssh://git@github.com/PrestaShop/ui-testing-library.git#0338b5748eb345560aa2904cfe6c32d34b08c23f",
       "from": "@prestashop-core/ui-testing@https://github.com/PrestaShop/ui-testing-library#main",
       "requires": {
         "@faker-js/faker": "^10.1.0",


### PR DESCRIPTION
| Questions                      | Answers
| ------------------------------ | -------------------------------------------------------
| Branch?                        | 9.1.x
| Description?                   | When importing a theme via URL in **BO > Design > Theme & Logo > Add new theme**, PHP warnings were thrown directly to the output when the remote server returned HTTP 4xx/5xx errors or when the hostname could not be resolved. These warnings were displayed as unhandled exceptions instead of a proper user-facing error message. This PR suppresses the raw PHP warnings from `fopen()` in `Tools::createFileFromUrl()` and converts the download failure into a `ThemeConstraintException`, which is then caught by the controller and displayed as a clean flash error message.
| Type?                          | bug fix
| Category?                      | BO
| BC breaks?                     | no
| Deprecations?                  | no
| How to test?                   | 1. Go to **BO > Design > Theme & Logo**<br/>2. Click **Add new theme**<br/>3. In **Import from the web**, type `http://example.com/files/theme.zip` (URL returning 500) → should display a flash error, **not** a PHP warning<br/>4. Click **Previous**, type a 404 URL from your shop (e.g. `http://my_shop.com/admin_xxx/inexisting.zip`) → same result<br/>5. Click **Previous**, type an invalid URL with a bad scheme (e.g. `ftp://example.com/theme.zip`) → same result
| UI Tests                       | https://github.com/mattgoud/ga.tests.ui.pr/actions/runs/25156509049 :red_circle: 
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/36587 
| Related PRs                    |
| Sponsor company                | PrestaShop SA