### PR TITLE
Support defines_custom.inc.php in the installer 

### DIFF
--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -69,6 +69,9 @@ if ((!is_dir(_PS_CORE_DIR_ . DIRECTORY_SEPARATOR . 'vendor') ||
 }
 
 require_once _PS_CORE_DIR_ . '/config/defines.inc.php';
+if (file_exists(_PS_CORE_DIR_ . '/config/defines_custom.inc.php')) {
+    require_once _PS_CORE_DIR_ . '/config/defines_custom.inc.php';
+}
 require_once _PS_CORE_DIR_ . '/config/autoload.php';
 
 // Loads .env file from the root of project


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This file was missing in order to correctly support `_PS_INSTALLER_STATIC_DB_PREFIX_` set in the custom defines.inc
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set `_PS_INSTALLER_STATIC_DB_PREFIX_` inside `defines_custom.inc.php`, and see that the prefix is available by default in the installer
| UI Tests          | Not needed
| Fixed issue or discussion?     |n/a
| Related PRs       | n/a
| Sponsor company   | impSolutions
