### PR TITLE
Add CartId into product search handler when employeeId not provided

### DIFF
--- a/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
+++ b/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\QueryHandler;
 
 use Address;
+use Cart;
 use Configuration;
 use Currency;
 use Order;
@@ -100,6 +101,7 @@ final class SearchProductsHandler extends AbstractOrderHandler implements Search
         if (null !== $query->getOrderId()) {
             $order = $this->getOrder($query->getOrderId());
             $this->contextStateManager
+                ->setCart(new Cart($order->id_cart))
                 ->setShop(new Shop($order->id_shop))
             ;
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add CartId context into product search handler when employeeId not provided
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #34486 
| UI Tests          | https://github.com/boherm/ga.tests.ui.pr/actions/runs/25109627809
| Fixed issue or discussion?     | Fixes #34486
| Related PRs       | ~
| Sponsor company   | @PrestaShopCorp
