### PR TITLE
Fix `customerId` always returning `null` in Cart API responses

### DIFF
--- a/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
@@ -125,14 +125,14 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
 
             $result = new CartForOrderCreation(
                 $cart->id,
-                (int) $cart->id_customer,
                 $products,
                 (int) $currency->id,
                 (int) $language->id,
                 $this->extractCartRulesFromLegacySummary($cart, $legacySummary, $currency, $query->hideDiscounts()),
                 $addresses,
                 $this->extractSummaryFromLegacySummary($legacySummary, $currency, $cart),
-                $addresses ? $this->extractShippingFromLegacySummary($cart, $legacySummary, $query->hideDiscounts()) : null
+                $addresses ? $this->extractShippingFromLegacySummary($cart, $legacySummary, $query->hideDiscounts()) : null,
+                (int) $cart->id_customer
             );
         } finally {
             $this->contextStateManager->restorePreviousContext();

--- a/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
@@ -125,6 +125,7 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
 
             $result = new CartForOrderCreation(
                 $cart->id,
+                (int) $cart->id_customer,
                 $products,
                 (int) $currency->id,
                 (int) $language->id,

--- a/src/Core/Domain/Cart/QueryResult/CartForOrderCreation.php
+++ b/src/Core/Domain/Cart/QueryResult/CartForOrderCreation.php
@@ -64,7 +64,6 @@ class CartForOrderCreation
 
     /**
      * @param int $cartId
-     * @param int $customerId
      * @param array $products
      * @param int $currencyId
      * @param int $langId
@@ -72,17 +71,18 @@ class CartForOrderCreation
      * @param CartAddress[] $addresses
      * @param CartSummary $summary
      * @param CartShipping $shipping
+     * @param int $customerId
      */
     public function __construct(
         int $cartId,
-        int $customerId,
         array $products,
         int $currencyId,
         int $langId,
         array $cartRules,
         array $addresses,
         CartSummary $summary,
-        ?CartShipping $shipping = null
+        ?CartShipping $shipping = null,
+        int $customerId = 0
     ) {
         $this->cartId = $cartId;
         $this->customerId = $customerId;

--- a/src/Core/Domain/Cart/QueryResult/CartForOrderCreation.php
+++ b/src/Core/Domain/Cart/QueryResult/CartForOrderCreation.php
@@ -23,6 +23,11 @@ class CartForOrderCreation
     private $cartId;
 
     /**
+     * @var int
+     */
+    private $customerId;
+
+    /**
      * @var CartProduct[]
      */
     private $products;
@@ -59,6 +64,7 @@ class CartForOrderCreation
 
     /**
      * @param int $cartId
+     * @param int $customerId
      * @param array $products
      * @param int $currencyId
      * @param int $langId
@@ -69,6 +75,7 @@ class CartForOrderCreation
      */
     public function __construct(
         int $cartId,
+        int $customerId,
         array $products,
         int $currencyId,
         int $langId,
@@ -78,6 +85,7 @@ class CartForOrderCreation
         ?CartShipping $shipping = null
     ) {
         $this->cartId = $cartId;
+        $this->customerId = $customerId;
         $this->products = $products;
         $this->currencyId = $currencyId;
         $this->langId = $langId;
@@ -93,6 +101,14 @@ class CartForOrderCreation
     public function getCartId(): int
     {
         return $this->cartId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCustomerId(): int
+    {
+        return $this->customerId;
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -913,6 +913,20 @@ class CartFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Then cart :cartReference should belong to customer :customerReference
+     */
+    public function assertCartBelongsToCustomer(string $cartReference, string $customerReference): void
+    {
+        $cartForOrderCreation = $this->getCartForOrderCreationByReference($cartReference);
+
+        Assert::assertSame(
+            $this->referenceToId($customerReference),
+            $cartForOrderCreation->getCustomerId(),
+            sprintf('Cart "%s" does not belong to customer "%s"', $cartReference, $customerReference)
+        );
+    }
+
+    /**
      * @Given /^I use a voucher "(.+)" which provides a gift product "(.+)" and free shipping on the cart "(.+)"$/
      */
     public function addGiftPlusFreeShippingCartRule(string $voucherCode, string $giftProductName, string $cartReference)

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderCartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderCartFeatureContext.php
@@ -73,6 +73,7 @@ class OrderCartFeatureContext extends AbstractDomainFeatureContext
 
         Assert::assertNotSame($cartForOrderCreation->getCartId(), $duplicatedCartForOrderCreation->getCartId());
 
+        Assert::assertEquals($cartForOrderCreation->getCustomerId(), $duplicatedCartForOrderCreation->getCustomerId());
         Assert::assertEquals($cartForOrderCreation->getCartRules(), $duplicatedCartForOrderCreation->getCartRules());
         Assert::assertEquals($cartForOrderCreation->getAddresses(), $duplicatedCartForOrderCreation->getAddresses());
         Assert::assertEquals($cartForOrderCreation->getCurrencyId(), $duplicatedCartForOrderCreation->getCurrencyId());

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/BackOffice/delete_product_from_cart.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartRule/BackOffice/delete_product_from_cart.feature
@@ -12,6 +12,7 @@ Feature: Delete product from cart in Back Office (BO)
 
   Scenario: Delete standard product from cart
     Given I create an empty cart "dummy_cart" for customer "testCustomer"
+    And cart "dummy_cart" should belong to customer "testCustomer"
     And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart"
     And product "Mug The best is yet to come" quantity in cart "dummy_cart" should be 2 excluding gift products
     When I delete product "Mug The best is yet to come" from cart "dummy_cart"

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -126,6 +126,7 @@ Feature: Order from Back Office (BO)
   Scenario: Duplicate order cart
     When I duplicate order "bo_order1" cart "dummy_cart" with reference "duplicated_dummy_cart"
     Then there is duplicated cart "duplicated_dummy_cart" for cart dummy_cart
+    And cart "duplicated_dummy_cart" should belong to customer "testCustomer"
 
   Scenario: Add product to an existing Order without invoice without free shipping and new invoice
     Given there is a product in the catalog named "Test Added Product" with a price of 15.0 and 100 items in stock


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Fix missing customerId in GetCartForOrderCreation query result
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Call the Cart-POST create endpoint with a customer ID. The response body now correctly returns the customer ID instead of null.
| UI Tests          | https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/33404386376
| Fixed issue or discussion?     | Fix Admin API endpoint Cart response customer id = null (in progress)
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | axel-paillaud


The `Cart` API resource exposes a `customerId` field, but it was always `null` in responses
(`GET /carts/{cartId}` and `POST /carts`).

<img width="886" height="768" alt="Screenshot_2026-04-30_06-13-36" src="https://github.com/user-attachments/assets/18b0ca0d-52e7-4118-9ab5-24c19fdd620e" />


The root cause was in `CartForOrderCreation`, the query result returned by `GetCartForOrderCreation`:
it did not include the customer ID at all. Since API Platform maps query result getters to the
resource properties by name, the field was present in the response but never populated.

The fix adds `customerId` to `CartForOrderCreation` (property, constructor parameter, and getter),
and updates `GetCartForOrderCreationHandler` to pass `$cart->id_customer` when building the result

<img width="886" height="768" alt="Screenshot_2026-04-30_06-12-00" src="https://github.com/user-attachments/assets/f5ca1501-ddba-4752-b995-a7f3ef48f2a8" />

[Cart endpoints available here](https://github.com/PrestaShop/ps_apiresources/pull/201)