### PR TITLE
Fix performance on cart listing with heavy connections/guest tables

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -948,8 +948,10 @@ class CustomerCore extends ObjectModel
 
     /**
      * Return several useful statistics about customer.
+     *
+     * @return array Stats
      */
-    public function getStats(): array
+    public function getStats()
     {
         if (!Validate::isLoadedObject($this)) {
             return [

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -948,11 +948,18 @@ class CustomerCore extends ObjectModel
 
     /**
      * Return several useful statistics about customer.
-     *
-     * @return array Stats
      */
-    public function getStats()
+    public function getStats(): array
     {
+        if (!Validate::isLoadedObject($this)) {
+            return [
+                'nb_orders' => 0,
+                'total_orders' => null,
+                'last_visit' => null,
+                'age' => '--',
+            ];
+        }
+
         $result = Db::getInstance()->getRow('
         SELECT COUNT(`id_order`) AS nb_orders, SUM(`total_paid` / o.`conversion_rate`) AS total_orders
         FROM `' . _DB_PREFIX_ . 'orders` o

--- a/src/Core/Grid/Query/CartQueryBuilder.php
+++ b/src/Core/Grid/Query/CartQueryBuilder.php
@@ -115,7 +115,7 @@ final class CartQueryBuilder extends AbstractDoctrineQueryBuilder
             ->createQueryBuilder()
             ->select('DISTINCT co.`id_guest`')
             ->from($this->dbPrefix . 'connections', 'co')
-            ->where('TIME_TO_SEC(TIMEDIFF(\'' . pSQL(date('Y-m-d H:i:00', time())) . '\', `date_add`)) < ' . self::CUSTOMER_ONLINE_TIME);
+            ->where('`date_add` >= (CURRENT_DATE - INTERVAL '.self::CUSTOMER_ONLINE_TIME.' SECOND)');
 
         $qb = $this->connection
             ->createQueryBuilder()

--- a/src/Core/Grid/Query/CartQueryBuilder.php
+++ b/src/Core/Grid/Query/CartQueryBuilder.php
@@ -115,7 +115,7 @@ final class CartQueryBuilder extends AbstractDoctrineQueryBuilder
             ->createQueryBuilder()
             ->select('DISTINCT co.`id_guest`')
             ->from($this->dbPrefix . 'connections', 'co')
-            ->where('`date_add` >= (CURRENT_DATE - INTERVAL ' . self::CUSTOMER_ONLINE_TIME . ' SECOND)');
+            ->where('`date_add` >= ("' . date('Y-m-d H:i:s') . '" - INTERVAL ' . self::CUSTOMER_ONLINE_TIME . ' SECOND)');
 
         $qb = $this->connection
             ->createQueryBuilder()

--- a/src/Core/Grid/Query/CartQueryBuilder.php
+++ b/src/Core/Grid/Query/CartQueryBuilder.php
@@ -115,7 +115,7 @@ final class CartQueryBuilder extends AbstractDoctrineQueryBuilder
             ->createQueryBuilder()
             ->select('DISTINCT co.`id_guest`')
             ->from($this->dbPrefix . 'connections', 'co')
-            ->where('`date_add` >= (CURRENT_DATE - INTERVAL '.self::CUSTOMER_ONLINE_TIME.' SECOND)');
+            ->where('`date_add` >= (CURRENT_DATE - INTERVAL ' . self::CUSTOMER_ONLINE_TIME . ' SECOND)');
 
         $qb = $this->connection
             ->createQueryBuilder()


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | Prevent performance pitfall on cart listing in BO with massive connection/guest tables. Leverage the `date_add` index from the connection table and prevent `getStats()` on empty Customer from generating aggressive requests
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open cart listing in BO with millions of lines in connection/guest tables
| UI Tests          | 
| Fixed issue or discussion?     | Fixes #37932
| Related PRs       | None
| Sponsor company   | Novius
