### PR TITLE
Improve countries list Symfony migration

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/country/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/country/index.ts
@@ -15,5 +15,6 @@ $(() => {
   countryGrid.addExtension(new window.prestashop.component.GridExtensions.SubmitRowActionExtension());
   countryGrid.addExtension(new window.prestashop.component.GridExtensions.LinkRowActionExtension());
   countryGrid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
-  countryGrid.addExtension(new window.prestashop.component.GridExtensions.ColumnTogglingExtension());
+  countryGrid.addExtension(new window.prestashop.component.GridExtensions.AsyncToggleColumnExtension());
+  countryGrid.addExtension(new window.prestashop.component.GridExtensions.ModalFormSubmitExtension());
 });

--- a/src/Adapter/Country/CommandHandler/BulkToggleCountriesStatusHandler.php
+++ b/src/Adapter/Country/CommandHandler/BulkToggleCountriesStatusHandler.php
@@ -8,40 +8,61 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Country\CommandHandler;
 
-use Country;
+use PrestaShop\PrestaShop\Adapter\Country\Repository\CountryRepository;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\AbstractBulkCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkToggleCountriesStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Country\CommandHandler\BulkToggleCountriesStatusHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CannotToggleCountryStatusException;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\BulkCountryException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryException;
-use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
-use PrestaShopException;
+use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
+use PrestaShop\PrestaShop\Core\Domain\Exception\BulkCommandExceptionInterface;
 
 #[AsCommandHandler]
-class BulkToggleCountriesStatusHandler implements BulkToggleCountriesStatusHandlerInterface
+final class BulkToggleCountriesStatusHandler extends AbstractBulkCommandHandler implements BulkToggleCountriesStatusHandlerInterface
 {
+    public function __construct(
+        private readonly CountryRepository $countryRepository,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function handle(BulkToggleCountriesStatusCommand $command): void
     {
-        foreach ($command->getCountryIds() as $countryId) {
-            $country = new Country($countryId->getValue());
+        $this->handleBulkAction($command->getCountryIds(), CountryException::class, $command);
+    }
 
-            if (0 >= $country->id) {
-                throw new CountryNotFoundException(sprintf('Country object with id "%d" has not been found for status changing', $countryId->getValue()));
-            }
+    /**
+     * @param CountryId $id
+     * @param BulkToggleCountriesStatusCommand $command
+     */
+    protected function handleSingleAction(mixed $id, mixed $command): void
+    {
+        $country = $this->countryRepository->get($id);
+        $country->active = $command->getExpectedStatus();
 
-            $country->active = $command->getExpectedStatus();
+        $this->countryRepository->update($country);
+    }
 
-            try {
-                if (!$country->save()) {
-                    throw new CannotToggleCountryStatusException(sprintf('Unable to toggle status for country with id "%d"', $countryId->getValue()));
-                }
-            } catch (PrestaShopException $e) {
-                throw new CountryException(
-                    sprintf('An error occurred while updating country status with id "%d"', $countryId->getValue()),
-                    0,
-                    $e
-                );
-            }
-        }
+    /**
+     * {@inheritDoc}
+     */
+    protected function buildBulkException(array $caughtExceptions): BulkCommandExceptionInterface
+    {
+        return new BulkCountryException(
+            $caughtExceptions,
+            'Errors occurred during country bulk change status action',
+            BulkCountryException::FAILED_BULK_UPDATE_STATUS
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function supports($id): bool
+    {
+        return $id instanceof CountryId;
     }
 }

--- a/src/Adapter/Country/CommandHandler/BulkToggleCountriesStatusHandler.php
+++ b/src/Adapter/Country/CommandHandler/BulkToggleCountriesStatusHandler.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Country\CommandHandler;
+
+use Country;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkToggleCountriesStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\CommandHandler\BulkToggleCountriesStatusHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CannotToggleCountryStatusException;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryException;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
+use PrestaShopException;
+
+#[AsCommandHandler]
+class BulkToggleCountriesStatusHandler implements BulkToggleCountriesStatusHandlerInterface
+{
+    public function handle(BulkToggleCountriesStatusCommand $command): void
+    {
+        foreach ($command->getCountryIds() as $countryId) {
+            $country = new Country($countryId->getValue());
+
+            if (0 >= $country->id) {
+                throw new CountryNotFoundException(sprintf('Country object with id "%d" has not been found for status changing', $countryId->getValue()));
+            }
+
+            $country->active = $command->getExpectedStatus();
+
+            try {
+                if (!$country->save()) {
+                    throw new CannotToggleCountryStatusException(sprintf('Unable to toggle status for country with id "%d"', $countryId->getValue()));
+                }
+            } catch (PrestaShopException $e) {
+                throw new CountryException(
+                    sprintf('An error occurred while updating country status with id "%d"', $countryId->getValue()),
+                    0,
+                    $e
+                );
+            }
+        }
+    }
+}

--- a/src/Adapter/Country/CommandHandler/BulkUpdateCountryZoneHandler.php
+++ b/src/Adapter/Country/CommandHandler/BulkUpdateCountryZoneHandler.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Country\CommandHandler;
+
+use Country;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkUpdateCountryZoneCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\CommandHandler\BulkUpdateCountryZoneHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CannotEditCountryException;
+use PrestaShop\PrestaShop\Core\Domain\Zone\Exception\ZoneNotFoundException;
+use PrestaShopException;
+use Zone;
+
+#[AsCommandHandler]
+class BulkUpdateCountryZoneHandler implements BulkUpdateCountryZoneHandlerInterface
+{
+    public function handle(BulkUpdateCountryZoneCommand $command): void
+    {
+        $zoneId = $command->getNewZoneId();
+        $countryIds = $command->getCountryIds();
+
+        try {
+            $zone = new Zone($zoneId);
+            if (!$zone->id) {
+                throw new ZoneNotFoundException(sprintf('Zone with id "%d" was not found.', $zoneId));
+            }
+        } catch (PrestaShopException $e) {
+            throw new ZoneNotFoundException(sprintf('Zone with id "%d" was not found.', $zoneId));
+        }
+
+        try {
+            $country = new Country();
+            $result = $country->affectZoneToSelection($countryIds, $zoneId);
+
+            if (!$result) {
+                throw new CannotEditCountryException(
+                    sprintf('Failed to update zone for countries: %s', implode(', ', $countryIds)),
+                    CannotEditCountryException::FAILED_TO_UPDATE_COUNTRY
+                );
+            }
+        } catch (PrestaShopException $e) {
+            throw new CannotEditCountryException(
+                sprintf('An error occurred when updating zone for countries: %s', $e->getMessage()),
+                CannotEditCountryException::UNKNOWN_EXCEPTION,
+                $e
+            );
+        }
+    }
+}

--- a/src/Adapter/Country/CommandHandler/BulkUpdateCountryZoneHandler.php
+++ b/src/Adapter/Country/CommandHandler/BulkUpdateCountryZoneHandler.php
@@ -8,48 +8,64 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Country\CommandHandler;
 
-use Country;
+use PrestaShop\PrestaShop\Adapter\Country\Repository\CountryRepository;
+use PrestaShop\PrestaShop\Adapter\Zone\Repository\ZoneRepository;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\AbstractBulkCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkUpdateCountryZoneCommand;
 use PrestaShop\PrestaShop\Core\Domain\Country\CommandHandler\BulkUpdateCountryZoneHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CannotEditCountryException;
-use PrestaShop\PrestaShop\Core\Domain\Zone\Exception\ZoneNotFoundException;
-use PrestaShopException;
-use Zone;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\BulkCountryException;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryException;
+use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
+use PrestaShop\PrestaShop\Core\Domain\Exception\BulkCommandExceptionInterface;
+use PrestaShop\PrestaShop\Core\Domain\Zone\ValueObject\ZoneId;
 
 #[AsCommandHandler]
-class BulkUpdateCountryZoneHandler implements BulkUpdateCountryZoneHandlerInterface
+final class BulkUpdateCountryZoneHandler extends AbstractBulkCommandHandler implements BulkUpdateCountryZoneHandlerInterface
 {
+    public function __construct(
+        private readonly CountryRepository $countryRepository,
+        private readonly ZoneRepository $zoneRepository,
+    ) {
+    }
+
     public function handle(BulkUpdateCountryZoneCommand $command): void
     {
         $zoneId = $command->getNewZoneId();
-        $countryIds = $command->getCountryIds();
+        $this->zoneRepository->get(new ZoneId($zoneId));
 
-        try {
-            $zone = new Zone($zoneId);
-            if (!$zone->id) {
-                throw new ZoneNotFoundException(sprintf('Zone with id "%d" was not found.', $zoneId));
-            }
-        } catch (PrestaShopException $e) {
-            throw new ZoneNotFoundException(sprintf('Zone with id "%d" was not found.', $zoneId));
-        }
+        $this->handleBulkAction($command->getCountryIds(), CountryException::class, $command);
+    }
 
-        try {
-            $country = new Country();
-            $result = $country->affectZoneToSelection($countryIds, $zoneId);
+    /**
+     * @param CountryId $id
+     * @param BulkUpdateCountryZoneCommand $command
+     */
+    protected function handleSingleAction(mixed $id, mixed $command): void
+    {
+        $countryId = $id->getValue();
+        $zoneId = $command->getNewZoneId();
 
-            if (!$result) {
-                throw new CannotEditCountryException(
-                    sprintf('Failed to update zone for countries: %s', implode(', ', $countryIds)),
-                    CannotEditCountryException::FAILED_TO_UPDATE_COUNTRY
-                );
-            }
-        } catch (PrestaShopException $e) {
-            throw new CannotEditCountryException(
-                sprintf('An error occurred when updating zone for countries: %s', $e->getMessage()),
-                CannotEditCountryException::UNKNOWN_EXCEPTION,
-                $e
-            );
-        }
+        $this->countryRepository->affectCountriesToZone([$countryId], $zoneId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function buildBulkException(array $caughtExceptions): BulkCommandExceptionInterface
+    {
+        return new BulkCountryException(
+            $caughtExceptions,
+            'Errors occurred during country bulk update zone action',
+            BulkCountryException::FAILED_BULK_UPDATE_ZONE
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function supports($id): bool
+    {
+        return $id instanceof CountryId;
     }
 }

--- a/src/Adapter/Country/CommandHandler/ToggleCountryStatusHandler.php
+++ b/src/Adapter/Country/CommandHandler/ToggleCountryStatusHandler.php
@@ -8,36 +8,24 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Country\CommandHandler;
 
-use Country;
+use PrestaShop\PrestaShop\Adapter\Country\Repository\CountryRepository;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\ToggleCountryStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Country\CommandHandler\ToggleCountryStatusHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CannotToggleCountryStatusException;
-use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryException;
-use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
-use PrestaShopException;
 
 #[AsCommandHandler]
 class ToggleCountryStatusHandler implements ToggleCountryStatusHandlerInterface
 {
+    public function __construct(
+        private readonly CountryRepository $countryRepository
+    ) {
+    }
+
     public function handle(ToggleCountryStatusCommand $command): void
     {
-        try {
-            $country = new Country($command->getCountryId()->getValue());
+        $country = $this->countryRepository->get($command->getCountryId());
+        $country->active = !$country->active;
 
-            if (0 >= $country->id) {
-                throw new CountryNotFoundException(sprintf('Country object with id "%d" has not been found for status changing', $command->getCountryId()->getValue()));
-            }
-
-            if (false === $country->toggleStatus()) {
-                throw new CannotToggleCountryStatusException(sprintf('Unable to toggle status of country with id "%d"', $command->getCountryId()->getValue()));
-            }
-        } catch (PrestaShopException $e) {
-            throw new CountryException(
-                sprintf('An error occurred when toggling status for country with id "%d"', $command->getCountryId()->getValue()),
-                0,
-                $e
-            );
-        }
+        $this->countryRepository->update($country);
     }
 }

--- a/src/Adapter/Country/CommandHandler/ToggleCountryStatusHandler.php
+++ b/src/Adapter/Country/CommandHandler/ToggleCountryStatusHandler.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Country\CommandHandler;
+
+use Country;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\ToggleCountryStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\CommandHandler\ToggleCountryStatusHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CannotToggleCountryStatusException;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryException;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
+use PrestaShopException;
+
+#[AsCommandHandler]
+class ToggleCountryStatusHandler implements ToggleCountryStatusHandlerInterface
+{
+    public function handle(ToggleCountryStatusCommand $command): void
+    {
+        try {
+            $country = new Country($command->getCountryId()->getValue());
+
+            if (0 >= $country->id) {
+                throw new CountryNotFoundException(sprintf('Country object with id "%d" has not been found for status changing', $command->getCountryId()->getValue()));
+            }
+
+            if (false === $country->toggleStatus()) {
+                throw new CannotToggleCountryStatusException(sprintf('Unable to toggle status of country with id "%d"', $command->getCountryId()->getValue()));
+            }
+        } catch (PrestaShopException $e) {
+            throw new CountryException(
+                sprintf('An error occurred when toggling status for country with id "%d"', $command->getCountryId()->getValue()),
+                0,
+                $e
+            );
+        }
+    }
+}

--- a/src/Adapter/Country/Repository/CountryRepository.php
+++ b/src/Adapter/Country/Repository/CountryRepository.php
@@ -104,4 +104,17 @@ class CountryRepository extends AbstractObjectModelRepository
     {
         $this->deleteObjectModel($this->get($countryId), CannotDeleteCountryException::class);
     }
+
+    /**
+     * @param int[] $countryIds
+     */
+    public function affectCountriesToZone(array $countryIds, int $zoneId): void
+    {
+        foreach ($countryIds as $countryId) {
+            $country = $this->get(new CountryId((int) $countryId));
+            $country->id_zone = $zoneId;
+
+            $this->update($country);
+        }
+    }
 }

--- a/src/Core/Domain/Country/Command/BulkToggleCountriesStatusCommand.php
+++ b/src/Core/Domain/Country/Command/BulkToggleCountriesStatusCommand.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Country\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
+
+/**
+ * Toggles countries status on bulk action.
+ */
+class BulkToggleCountriesStatusCommand
+{
+    /**
+     * @var bool
+     */
+    private $expectedStatus;
+
+    /**
+     * @var array<int, CountryId>
+     */
+    private $countryIds = [];
+
+    /**
+     * @param array<int, int> $countryIds
+     */
+    public function __construct(bool $expectedStatus, array $countryIds)
+    {
+        $this->setCountryIds($countryIds);
+        $this->expectedStatus = $expectedStatus;
+    }
+
+    public function getExpectedStatus(): bool
+    {
+        return $this->expectedStatus;
+    }
+
+    /**
+     * @return array<int, CountryId>
+     */
+    public function getCountryIds(): array
+    {
+        return $this->countryIds;
+    }
+
+    /**
+     * @param array<int, int> $countryIds
+     */
+    private function setCountryIds(array $countryIds): void
+    {
+        foreach ($countryIds as $countryId) {
+            $this->countryIds[] = new CountryId((int) $countryId);
+        }
+    }
+}

--- a/src/Core/Domain/Country/Command/BulkUpdateCountryZoneCommand.php
+++ b/src/Core/Domain/Country/Command/BulkUpdateCountryZoneCommand.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Country\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryException;
+use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 
 /**
  * Updates zone for given countries.
@@ -16,9 +17,9 @@ use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryException;
 class BulkUpdateCountryZoneCommand
 {
     /**
-     * @var int[]
+     * @var array<int, CountryId>
      */
-    private $countryIds;
+    private $countryIds = [];
 
     /**
      * @var int
@@ -39,7 +40,7 @@ class BulkUpdateCountryZoneCommand
     }
 
     /**
-     * @return int[]
+     * @return array<int, CountryId>
      */
     public function getCountryIds(): array
     {
@@ -61,11 +62,7 @@ class BulkUpdateCountryZoneCommand
         }
 
         foreach ($countryIds as $countryId) {
-            if (!is_int($countryId) || $countryId <= 0) {
-                throw new CountryException(sprintf('Invalid country ID: %s', var_export($countryId, true)));
-            }
+            $this->countryIds[] = new CountryId((int) $countryId);
         }
-
-        $this->countryIds = $countryIds;
     }
 }

--- a/src/Core/Domain/Country/Command/BulkUpdateCountryZoneCommand.php
+++ b/src/Core/Domain/Country/Command/BulkUpdateCountryZoneCommand.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Country\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryException;
+
+/**
+ * Updates zone for given countries.
+ */
+class BulkUpdateCountryZoneCommand
+{
+    /**
+     * @var int[]
+     */
+    private $countryIds;
+
+    /**
+     * @var int
+     */
+    private $newZoneId;
+
+    /**
+     * @param int[] $countryIds
+     */
+    public function __construct(array $countryIds, int $newZoneId)
+    {
+        if ($newZoneId <= 0) {
+            throw new CountryException(sprintf('Zone Id must be integer greater than 0, but %s given.', var_export($newZoneId, true)));
+        }
+
+        $this->newZoneId = $newZoneId;
+        $this->setCountryIds($countryIds);
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getCountryIds(): array
+    {
+        return $this->countryIds;
+    }
+
+    public function getNewZoneId(): int
+    {
+        return $this->newZoneId;
+    }
+
+    /**
+     * @param int[] $countryIds
+     */
+    private function setCountryIds(array $countryIds): void
+    {
+        if (empty($countryIds)) {
+            throw new CountryException('You must select at least one country.');
+        }
+
+        foreach ($countryIds as $countryId) {
+            if (!is_int($countryId) || $countryId <= 0) {
+                throw new CountryException(sprintf('Invalid country ID: %s', var_export($countryId, true)));
+            }
+        }
+
+        $this->countryIds = $countryIds;
+    }
+}

--- a/src/Core/Domain/Country/Command/ToggleCountryStatusCommand.php
+++ b/src/Core/Domain/Country/Command/ToggleCountryStatusCommand.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Country\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
+
+/**
+ * Toggles country status.
+ */
+class ToggleCountryStatusCommand
+{
+    /**
+     * @var CountryId
+     */
+    private $countryId;
+
+    public function __construct(int $countryId)
+    {
+        $this->countryId = new CountryId($countryId);
+    }
+
+    public function getCountryId(): CountryId
+    {
+        return $this->countryId;
+    }
+}

--- a/src/Core/Domain/Country/CommandHandler/BulkToggleCountriesStatusHandlerInterface.php
+++ b/src/Core/Domain/Country/CommandHandler/BulkToggleCountriesStatusHandlerInterface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Country\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkToggleCountriesStatusCommand;
+
+interface BulkToggleCountriesStatusHandlerInterface
+{
+    public function handle(BulkToggleCountriesStatusCommand $command): void;
+}

--- a/src/Core/Domain/Country/CommandHandler/BulkUpdateCountryZoneHandlerInterface.php
+++ b/src/Core/Domain/Country/CommandHandler/BulkUpdateCountryZoneHandlerInterface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Country\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkUpdateCountryZoneCommand;
+
+interface BulkUpdateCountryZoneHandlerInterface
+{
+    public function handle(BulkUpdateCountryZoneCommand $command): void;
+}

--- a/src/Core/Domain/Country/CommandHandler/ToggleCountryStatusHandlerInterface.php
+++ b/src/Core/Domain/Country/CommandHandler/ToggleCountryStatusHandlerInterface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Country\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\ToggleCountryStatusCommand;
+
+interface ToggleCountryStatusHandlerInterface
+{
+    public function handle(ToggleCountryStatusCommand $command): void;
+}

--- a/src/Core/Domain/Country/Exception/BulkCountryException.php
+++ b/src/Core/Domain/Country/Exception/BulkCountryException.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Country\Exception;
+
+use PrestaShop\PrestaShop\Core\Domain\Exception\BulkCommandExceptionInterface;
+use Throwable;
+
+class BulkCountryException extends CountryException implements BulkCommandExceptionInterface
+{
+    public const FAILED_BULK_UPDATE_STATUS = 1;
+    public const FAILED_BULK_UPDATE_ZONE = 2;
+
+    /**
+     * @var Throwable[]
+     */
+    private array $exceptions;
+
+    /**
+     * @param Throwable[] $exceptions
+     * @param string $message
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        array $exceptions,
+        string $message = 'Errors occurred during country bulk action',
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        $this->exceptions = $exceptions;
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExceptions(): array
+    {
+        return $this->exceptions;
+    }
+}

--- a/src/Core/Domain/Country/Exception/CannotToggleCountryStatusException.php
+++ b/src/Core/Domain/Country/Exception/CannotToggleCountryStatusException.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Country\Exception;
+
+class CannotToggleCountryStatusException extends CountryException
+{
+}

--- a/src/Core/Grid/Definition/Factory/CountryGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CountryGridDefinitionFactory.php
@@ -10,6 +10,8 @@ namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\ModalFormSubmitBulkAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
@@ -20,6 +22,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ToggleColumn;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollectionInterface;
@@ -97,12 +100,15 @@ class CountryGridDefinitionFactory extends AbstractGridDefinitionFactory
                         'field' => 'zone_name',
                     ])
             )
-            // todo: change it to ToggleColumn when toggle status route is created
             ->add(
-                (new DataColumn('active'))
+                (new ToggleColumn('active'))
                     ->setName($this->trans('Enabled', [], 'Admin.Global'))
                     ->setOptions([
                         'field' => 'active',
+                        'primary_field' => 'id_country',
+                        'route' => 'admin_countries_toggle_status',
+                        'route_param_name' => 'countryId',
+                        'sortable' => false,
                     ])
             )
             ->add(
@@ -248,7 +254,28 @@ class CountryGridDefinitionFactory extends AbstractGridDefinitionFactory
      */
     protected function getBulkActions(): BulkActionCollectionInterface
     {
-        // todo: need to implement bulk actions
-        return new BulkActionCollection();
+        return (new BulkActionCollection())
+            ->add(
+                (new SubmitBulkAction('enable_selection'))
+                    ->setName($this->trans('Enable selection', [], 'Admin.Actions'))
+                    ->setOptions([
+                        'submit_route' => 'admin_countries_bulk_enable_status',
+                    ])
+            )
+            ->add(
+                (new SubmitBulkAction('disable_selection'))
+                    ->setName($this->trans('Disable selection', [], 'Admin.Actions'))
+                    ->setOptions([
+                        'submit_route' => 'admin_countries_bulk_disable_status',
+                    ])
+            )
+            ->add(
+                (new ModalFormSubmitBulkAction('assign_zone'))
+                    ->setName($this->trans('Assign to a new zone', [], 'Admin.International.Feature'))
+                    ->setOptions([
+                        'submit_route' => 'admin_countries_bulk_update_zone',
+                        'modal_id' => 'changeCountriesZoneModal',
+                    ])
+            );
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
@@ -9,7 +9,11 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Controller\Admin\Improve\International;
 
 use Exception;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkToggleCountriesStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkUpdateCountryZoneCommand;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\DeleteCountryCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\ToggleCountryStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CannotToggleCountryStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CannotEditCountryException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryException;
@@ -22,12 +26,16 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterf
 use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\CountryFilters;
 use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
+use PrestaShopBundle\Form\Admin\Improve\International\Locations\ChangeCountriesZoneType;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
 use PrestaShopBundle\Security\Attribute\DemoRestricted;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use PrestaShop\PrestaShop\Core\Domain\Zone\Exception\ZoneException;
+use PrestaShop\PrestaShop\Core\Domain\Zone\Exception\ZoneNotFoundException;
 
 /**
  * CountryController is responsible for handling "Improve > International > Locations > Countries"
@@ -50,10 +58,12 @@ class CountryController extends PrestaShopAdminController
         GridFactoryInterface $countryGridFactory
     ): Response {
         $countryGrid = $countryGridFactory->getGrid($filters);
+        $changeCountriesZoneForm = $this->createForm(ChangeCountriesZoneType::class);
 
         return $this->render('@PrestaShop/Admin/Improve/International/Country/index.html.twig', [
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'countryGrid' => $this->presentGrid($countryGrid),
+            'changeCountriesZoneForm' => $changeCountriesZoneForm->createView(),
             'enableSidebar' => true,
             'layoutHeaderToolbarBtn' => $this->getCountryToolbarButtons(),
         ]);
@@ -164,6 +174,94 @@ class CountryController extends PrestaShopAdminController
         return $this->redirectToRoute('admin_countries_index');
     }
 
+    #[DemoRestricted(redirectRoute: 'admin_countries_index')]
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_countries_index')]
+    public function toggleStatusAction(int $countryId): JsonResponse
+    {
+        try {
+            $this->dispatchCommand(new ToggleCountryStatusCommand($countryId));
+            $response = [
+                'status' => true,
+                'message' => $this->trans(
+                    'The status has been successfully updated.',
+                    [],
+                    'Admin.Notifications.Success'
+                ),
+            ];
+        } catch (CountryException $e) {
+            $response = [
+                'status' => false,
+                'message' => $this->getErrorMessageForException($e, $this->getErrorMessages($e)),
+            ];
+        }
+
+        return $this->json($response);
+    }
+
+    #[DemoRestricted(redirectRoute: 'admin_countries_index')]
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_countries_index')]
+    public function bulkEnableAction(Request $request): RedirectResponse
+    {
+        $countryIds = $this->getBulkCountriesFromRequest($request);
+
+        try {
+            $this->dispatchCommand(new BulkToggleCountriesStatusCommand(true, $countryIds));
+            $this->addFlash(
+                'success',
+                $this->trans('The status has been successfully updated.', [], 'Admin.Notifications.Success')
+            );
+        } catch (CountryException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        }
+
+        return $this->redirectToRoute('admin_countries_index');
+    }
+
+    #[DemoRestricted(redirectRoute: 'admin_countries_index')]
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_countries_index')]
+    public function bulkDisableAction(Request $request): RedirectResponse
+    {
+        $countryIds = $this->getBulkCountriesFromRequest($request);
+
+        try {
+            $this->dispatchCommand(new BulkToggleCountriesStatusCommand(false, $countryIds));
+            $this->addFlash(
+                'success',
+                $this->trans('The status has been successfully updated.', [], 'Admin.Notifications.Success')
+            );
+        } catch (CountryException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        }
+
+        return $this->redirectToRoute('admin_countries_index');
+    }
+
+    #[DemoRestricted(redirectRoute: 'admin_countries_index')]
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_countries_index')]
+    public function bulkUpdateZoneAction(Request $request): RedirectResponse
+    {
+        $changeCountriesZoneForm = $this->createForm(ChangeCountriesZoneType::class);
+        $changeCountriesZoneForm->handleRequest($request);
+
+        $data = $changeCountriesZoneForm->getData();
+
+        try {
+            $this->dispatchCommand(
+                new BulkUpdateCountryZoneCommand($data['country_ids'], (int) $data['new_zone_id'])
+            );
+
+            $this->addFlash('success', $this->trans('Successful update', [], 'Admin.Notifications.Success'));
+        } catch (CountryException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        } catch (ZoneException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        } catch (Exception $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        }
+
+        return $this->redirectToRoute('admin_countries_index');
+    }
+
     /**
      * @return array
      */
@@ -188,6 +286,11 @@ class CountryController extends PrestaShopAdminController
     protected function getErrorMessages(Exception $e): array
     {
         return [
+            CountryException::class => $this->trans(
+                'An unexpected error occurred.',
+                [],
+                'Admin.Notifications.Error'
+            ),
             CountryNotFoundException::class => $this->trans(
                 'This country does not exist.',
                 [],
@@ -205,6 +308,11 @@ class CountryController extends PrestaShopAdminController
                     'Admin.International.Feature'
                 ),
             ],
+            CannotToggleCountryStatusException::class => $this->trans(
+                'Failed to update country status.',
+                [],
+                'Admin.International.Feature'
+            ),
             CountryConstraintException::class => $this->trans(
                 'Country contains invalid field values.',
                 [],
@@ -215,6 +323,30 @@ class CountryController extends PrestaShopAdminController
                 [],
                 'Admin.International.Feature'
             ),
+            ZoneNotFoundException::class => $this->trans(
+                'The object cannot be loaded (or found).',
+                [],
+                'Admin.Notifications.Error'
+            ),
+            ZoneException::class => $this->trans(
+                'The object cannot be loaded (the identifier is missing or invalid)',
+                [],
+                'Admin.Notifications.Error'
+            ),
         ];
+    }
+
+    /**
+     * @return int[]
+     */
+    private function getBulkCountriesFromRequest(Request $request): array
+    {
+        $countryIds = $request->request->all('country_bulk');
+
+        foreach ($countryIds as $index => $countryId) {
+            $countryIds[$index] = (int) $countryId;
+        }
+
+        return $countryIds;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
@@ -13,14 +13,16 @@ use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkToggleCountriesStatusC
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkUpdateCountryZoneCommand;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\DeleteCountryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\ToggleCountryStatusCommand;
-use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CannotToggleCountryStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CannotEditCountryException;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CannotToggleCountryStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\DeleteCountryException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Query\GetCountryForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Country\QueryResult\CountryForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Zone\Exception\ZoneException;
+use PrestaShop\PrestaShop\Core\Domain\Zone\Exception\ZoneNotFoundException;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
@@ -34,8 +36,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use PrestaShop\PrestaShop\Core\Domain\Zone\Exception\ZoneException;
-use PrestaShop\PrestaShop\Core\Domain\Zone\Exception\ZoneNotFoundException;
 
 /**
  * CountryController is responsible for handling "Improve > International > Locations > Countries"
@@ -251,10 +251,6 @@ class CountryController extends PrestaShopAdminController
             );
 
             $this->addFlash('success', $this->trans('Successful update', [], 'Admin.Notifications.Success'));
-        } catch (CountryException $e) {
-            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
-        } catch (ZoneException $e) {
-            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/ChangeCountriesZoneType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/ChangeCountriesZoneType.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Improve\International\Locations;
+
+use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class ChangeCountriesZoneType extends AbstractType
+{
+    public function __construct(private readonly ConfigurableFormChoiceProviderInterface $zoneChoiceProvider)
+    {
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('new_zone_id', ChoiceType::class, [
+                'choices' => $this->zoneChoiceProvider->getChoices([]),
+                'translation_domain' => false,
+            ])
+            ->add('country_ids', CollectionType::class, [
+                'allow_add' => true,
+                'entry_type' => HiddenType::class,
+                'label' => false,
+            ])
+        ;
+
+        $builder->get('country_ids')
+            ->addModelTransformer(new CallbackTransformer(
+                static function ($countryIds) {
+                    return $countryIds;
+                },
+                static function (array $countryIds) {
+                    return array_map(static function ($countryId) {
+                        return (int) $countryId;
+                    }, $countryIds);
+                }
+            ))
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
@@ -53,3 +53,43 @@ admin_countries_delete:
       id_country: countryId
   requirements:
     countryId: \d+
+
+admin_countries_bulk_enable_status:
+  path: /bulk-status-enable
+  methods: [ POST ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\International\CountryController::bulkEnableAction'
+    _legacy_controller: AdminCountries
+    _legacy_link: AdminCountries:submitBulkenableSelectioncountry
+    _legacy_feature_flag: country
+
+admin_countries_bulk_disable_status:
+  path: /bulk-status-disable
+  methods: [ POST ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\International\CountryController::bulkDisableAction'
+    _legacy_controller: AdminCountries
+    _legacy_link: AdminCountries:submitBulkdisableSelectioncountry
+    _legacy_feature_flag: country
+
+admin_countries_bulk_update_zone:
+  path: /bulk-update-zone
+  methods: [ POST ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\International\CountryController::bulkUpdateZoneAction'
+    _legacy_controller: AdminCountries
+    _legacy_link: AdminCountries:submitBulkAffectZonecountry
+    _legacy_feature_flag: country
+
+admin_countries_toggle_status:
+  path: /{countryId}/toggle-status
+  methods: [ POST ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\International\CountryController::toggleStatusAction'
+    _legacy_controller: AdminCountries
+    _legacy_link: AdminCountries:statuscountry
+    _legacy_feature_flag: country
+    _legacy_parameters:
+      id_country: countryId
+  requirements:
+    countryId: \d+

--- a/src/PrestaShopBundle/Resources/config/services/adapter/country.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/country.yml
@@ -32,6 +32,21 @@ services:
     autowire: true
     autoconfigure: true
 
+  PrestaShop\PrestaShop\Adapter\Country\CommandHandler\ToggleCountryStatusHandler:
+    public: false
+    autowire: true
+    autoconfigure: true
+
+  PrestaShop\PrestaShop\Adapter\Country\CommandHandler\BulkToggleCountriesStatusHandler:
+    public: false
+    autowire: true
+    autoconfigure: true
+
+  PrestaShop\PrestaShop\Adapter\Country\CommandHandler\BulkUpdateCountryZoneHandler:
+    public: false
+    autowire: true
+    autoconfigure: true
+
   PrestaShop\PrestaShop\Adapter\Country\CommandHandler\EditCountryHandler:
     public: false
     autowire: true

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -603,6 +603,10 @@ services:
     arguments:
       $zoneChoiceProvider: '@prestashop.core.form.choice_provider.zone_by_id'
 
+  PrestaShopBundle\Form\Admin\Improve\International\Locations\ChangeCountriesZoneType:
+    arguments:
+      $zoneChoiceProvider: '@prestashop.core.form.choice_provider.zone_by_id'
+
   PrestaShopBundle\Form\Admin\Sell\Product\EventListener\SpecificPriceCombinationListener:
     arguments:
       $combinationRepository: '@PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository'

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Country/Blocks/change_countries_zone_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Country/Blocks/change_countries_zone_modal.html.twig
@@ -1,0 +1,36 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+
+{% embed '@PrestaShop/Admin/Helpers/bootstrap_popup.html.twig' with {
+  id: 'changeCountriesZoneModal',
+  title: 'Choose a zone'|trans({}, 'Admin.International.Feature'),
+  closable: true,
+  actions: [{
+    type: 'button',
+    label: 'Update zone'|trans({}, 'Admin.International.Feature'),
+    class: 'btn btn-primary btn-lg js-submit-modal-form-btn',
+  }],
+} %}
+  {% block content %}
+    <div class="modal-body">
+      {{ form_start(changeCountriesZoneForm, {
+        action: path('admin_countries_bulk_update_zone'),
+        attr: {
+          'data-bulk-inputs-id': changeCountriesZoneForm.country_ids.vars.id
+        }
+      }) }}
+
+      <div class="form-group mb-0">
+        {{ form_widget(changeCountriesZoneForm.new_zone_id) }}
+      </div>
+
+      <div class="d-none">
+        {{ form_widget(changeCountriesZoneForm.country_ids) }}
+      </div>
+
+      {{ form_end(changeCountriesZoneForm) }}
+    </div>
+  {% endblock %}
+{% endembed %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Country/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Country/index.html.twig
@@ -5,6 +5,8 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
+  {{ include('@PrestaShop/Admin/Improve/International/Country/Blocks/change_countries_zone_modal.html.twig') }}
+
   {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {grid: countryGrid}) }}
 {% endblock %}
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/CountryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CountryFeatureContext.php
@@ -8,15 +8,20 @@ declare(strict_types=1);
 namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
 use Behat\Gherkin\Node\TableNode;
-use Country;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\AddCountryCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkToggleCountriesStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkUpdateCountryZoneCommand;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\DeleteCountryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Country\Command\EditCountryCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\ToggleCountryStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\BulkCountryException;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Query\GetCountryForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Country\QueryResult\CountryForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Zone\Exception\ZoneNotFoundException;
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\NoExceptionAlthoughExpectedException;
@@ -44,11 +49,45 @@ class CountryFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Given country :reference has invalid id
+     */
+    public function setInvalidCountryReference(string $reference): void
+    {
+        $this->getSharedStorage()->set($reference, 0);
+    }
+
+    /**
      * @Then I should get error that country was not found
      */
     public function assertCountryNotFound(): void
     {
         $this->assertLastErrorIs(CountryNotFoundException::class);
+    }
+
+    /**
+     * @Then I should get error that country id is invalid
+     */
+    public function assertCountryIdIsInvalid(): void
+    {
+        $this->assertLastErrorIs(CountryConstraintException::class, CountryConstraintException::INVALID_ID);
+    }
+
+    /**
+     * @Then I should get error that zone was not found
+     */
+    public function assertZoneNotFound(): void
+    {
+        $this->assertLastErrorIs(ZoneNotFoundException::class);
+    }
+
+    /**
+     * @Then I should get a bulk country exception containing :expectedErrorsCount errors
+     */
+    public function assertBulkCountryExceptionContainingErrors(int $expectedErrorsCount): void
+    {
+        /** @var BulkCountryException $lastError */
+        $lastError = $this->assertLastErrorIs(BulkCountryException::class);
+        Assert::assertCount($expectedErrorsCount, $lastError->getExceptions());
     }
 
     /**
@@ -147,6 +186,76 @@ class CountryFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @When I toggle country status :countryReference
+     */
+    public function toggleCountryStatus(string $countryReference): void
+    {
+        try {
+            $this->getCommandBus()->handle(new ToggleCountryStatusCommand((int) $this->getSharedStorage()->get($countryReference)));
+        } catch (CountryException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @When I bulk enable countries :countryReferences
+     */
+    public function bulkEnableCountries(string $countryReferences): void
+    {
+        $this->bulkToggleCountriesStatus($countryReferences, true);
+    }
+
+    /**
+     * @When I bulk disable countries :countryReferences
+     */
+    public function bulkDisableCountries(string $countryReferences): void
+    {
+        $this->bulkToggleCountriesStatus($countryReferences, false);
+    }
+
+    /**
+     * @When I bulk update countries :countryReferences to zone :zoneId
+     */
+    public function bulkUpdateCountriesZone(string $countryReferences, int $zoneId): void
+    {
+        try {
+            $this->getCommandBus()->handle(new BulkUpdateCountryZoneCommand(
+                $this->getCountryIdsFromReferences($countryReferences),
+                $zoneId
+            ));
+        } catch (CountryException|ZoneNotFoundException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @Then country :countryReference should be enabled
+     */
+    public function assertCountryIsEnabled(string $countryReference): void
+    {
+        $country = $this->getQueryBus()->handle(new GetCountryForEditing((int) $this->getSharedStorage()->get($countryReference)));
+        Assert::assertTrue($country->isEnabled());
+    }
+
+    /**
+     * @Then country :countryReference should be disabled
+     */
+    public function assertCountryIsDisabled(string $countryReference): void
+    {
+        $country = $this->getQueryBus()->handle(new GetCountryForEditing((int) $this->getSharedStorage()->get($countryReference)));
+        Assert::assertFalse($country->isEnabled());
+    }
+
+    /**
+     * @Then country :countryReference should be assigned to zone :zoneId
+     */
+    public function assertCountryZone(string $countryReference, int $zoneId): void
+    {
+        $country = $this->getQueryBus()->handle(new GetCountryForEditing((int) $this->getSharedStorage()->get($countryReference)));
+        Assert::assertSame($zoneId, $country->getZone());
+    }
+
+    /**
      * @Then /^the country "(.+)" should have the following properties:$/
      */
     public function assertQueryCustomerProperties($countryReference, TableNode $table)
@@ -231,5 +340,29 @@ class CountryFeatureContext extends AbstractDomainFeatureContext
         } catch (CountryNotFoundException $e) {
             SharedStorage::getStorage()->clear($countryReference);
         }
+    }
+
+    private function bulkToggleCountriesStatus(string $countryReferences, bool $expectedStatus): void
+    {
+        try {
+            $this->getCommandBus()->handle(new BulkToggleCountriesStatusCommand(
+                $expectedStatus,
+                $this->getCountryIdsFromReferences($countryReferences)
+            ));
+        } catch (CountryException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @return int[]
+     */
+    private function getCountryIdsFromReferences(string $countryReferences): array
+    {
+        $references = array_map('trim', explode(',', $countryReferences));
+
+        return array_map(function (string $reference): int {
+            return (int) $this->getSharedStorage()->get($reference);
+        }, $references);
     }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Country/bulk_toggle_countries_status.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Country/bulk_toggle_countries_status.feature
@@ -1,0 +1,70 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s country --tags bulk-toggle-countries-status
+@restore-all-tables-before-feature
+@bulk-toggle-countries-status
+Feature: Bulk toggle countries status
+  PrestaShop allows BO users to update multiple countries status at once
+  As a BO user
+  I must be able to update multiple countries status at once
+
+  Scenario: Bulk enable and disable countries
+    Given language "language1" with locale "en-US" exists
+    And I add new country "bulk_country_1" with following properties:
+      | name[en-US]                | Bulk Country 1  |
+      | iso_code                   | QA              |
+      | call_prefix                | 21              |
+      | default_currency           | 1               |
+      | zone                       | 1               |
+      | need_zip_code              | true            |
+      | zip_code_format            | NNNNN           |
+      | address_format             | not implemented |
+      | is_enabled                 | false           |
+      | contains_states            | false           |
+      | need_identification_number | false           |
+      | display_tax_label          | true            |
+      | shop_association           | 1               |
+    And I add new country "bulk_country_2" with following properties:
+      | name[en-US]                | Bulk Country 2  |
+      | iso_code                   | QB              |
+      | call_prefix                | 22              |
+      | default_currency           | 1               |
+      | zone                       | 1               |
+      | need_zip_code              | true            |
+      | zip_code_format            | NNNNN           |
+      | address_format             | not implemented |
+      | is_enabled                 | false           |
+      | contains_states            | false           |
+      | need_identification_number | false           |
+      | display_tax_label          | true            |
+      | shop_association           | 1               |
+    When I bulk enable countries "bulk_country_1, bulk_country_2"
+    Then country "bulk_country_1" should be enabled
+    And country "bulk_country_2" should be enabled
+    When I bulk disable countries "bulk_country_1, bulk_country_2"
+    Then country "bulk_country_1" should be disabled
+    And country "bulk_country_2" should be disabled
+
+  Scenario: Bulk toggle should report invalid country id
+    Given country "invalid_country" has invalid id
+    When I bulk enable countries "invalid_country"
+    Then I should get error that country id is invalid
+
+  Scenario: Bulk toggle should continue on partial failure and aggregate errors
+    Given language "language1" with locale "en-US" exists
+    And I add new country "bulk_partial_country" with following properties:
+      | name[en-US]                | Bulk Partial    |
+      | iso_code                   | QC              |
+      | call_prefix                | 31              |
+      | default_currency           | 1               |
+      | zone                       | 1               |
+      | need_zip_code              | true            |
+      | zip_code_format            | NNNNN           |
+      | address_format             | not implemented |
+      | is_enabled                 | false           |
+      | contains_states            | false           |
+      | need_identification_number | false           |
+      | display_tax_label          | true            |
+      | shop_association           | 1               |
+    And country "bulk_partial_missing" does not exist
+    When I bulk enable countries "bulk_partial_country, bulk_partial_missing"
+    Then I should get a bulk country exception containing 1 errors
+    And country "bulk_partial_country" should be enabled

--- a/tests/Integration/Behaviour/Features/Scenario/Country/bulk_update_country_zone.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Country/bulk_update_country_zone.feature
@@ -1,0 +1,81 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s country --tags bulk-update-country-zone
+@restore-all-tables-before-feature
+@bulk-update-country-zone
+Feature: Bulk update countries zone
+  PrestaShop allows BO users to update zone for multiple countries at once
+  As a BO user
+  I must be able to update zone for multiple countries at once
+
+  Scenario: Bulk update countries zone
+    Given language "language1" with locale "en-US" exists
+    And I add new country "zone_country_1" with following properties:
+      | name[en-US]                | Zone Country 1  |
+      | iso_code                   | QD              |
+      | call_prefix                | 41              |
+      | default_currency           | 1               |
+      | zone                       | 1               |
+      | need_zip_code              | true            |
+      | zip_code_format            | NNNNN           |
+      | address_format             | not implemented |
+      | is_enabled                 | true            |
+      | contains_states            | false           |
+      | need_identification_number | false           |
+      | display_tax_label          | true            |
+      | shop_association           | 1               |
+    And I add new country "zone_country_2" with following properties:
+      | name[en-US]                | Zone Country 2  |
+      | iso_code                   | QE              |
+      | call_prefix                | 42              |
+      | default_currency           | 1               |
+      | zone                       | 1               |
+      | need_zip_code              | true            |
+      | zip_code_format            | NNNNN           |
+      | address_format             | not implemented |
+      | is_enabled                 | true            |
+      | contains_states            | false           |
+      | need_identification_number | false           |
+      | display_tax_label          | true            |
+      | shop_association           | 1               |
+    When I bulk update countries "zone_country_1, zone_country_2" to zone 2
+    Then country "zone_country_1" should be assigned to zone 2
+    And country "zone_country_2" should be assigned to zone 2
+
+  Scenario: Bulk update countries zone should fail when zone does not exist
+    Given language "language1" with locale "en-US" exists
+    And I add new country "zone_missing_country" with following properties:
+      | name[en-US]                | Zone Missing    |
+      | iso_code                   | QF              |
+      | call_prefix                | 51              |
+      | default_currency           | 1               |
+      | zone                       | 1               |
+      | need_zip_code              | true            |
+      | zip_code_format            | NNNNN           |
+      | address_format             | not implemented |
+      | is_enabled                 | true            |
+      | contains_states            | false           |
+      | need_identification_number | false           |
+      | display_tax_label          | true            |
+      | shop_association           | 1               |
+    When I bulk update countries "zone_missing_country" to zone 999999
+    Then I should get error that zone was not found
+
+  Scenario: Bulk update countries zone should continue on partial failure and aggregate errors
+    Given language "language1" with locale "en-US" exists
+    And I add new country "zone_partial_country" with following properties:
+      | name[en-US]                | Zone Partial    |
+      | iso_code                   | QG              |
+      | call_prefix                | 61              |
+      | default_currency           | 1               |
+      | zone                       | 1               |
+      | need_zip_code              | true            |
+      | zip_code_format            | NNNNN           |
+      | address_format             | not implemented |
+      | is_enabled                 | true            |
+      | contains_states            | false           |
+      | need_identification_number | false           |
+      | display_tax_label          | true            |
+      | shop_association           | 1               |
+    And country "zone_partial_missing" does not exist
+    When I bulk update countries "zone_partial_country, zone_partial_missing" to zone 2
+    Then I should get a bulk country exception containing 1 errors
+    And country "zone_partial_country" should be assigned to zone 2

--- a/tests/Integration/Behaviour/Features/Scenario/Country/toggle_country_status.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Country/toggle_country_status.feature
@@ -1,0 +1,31 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s country --tags toggle-country-status
+@restore-all-tables-before-feature
+@toggle-country-status
+Feature: Toggle country status
+  PrestaShop allows BO users to toggle country status
+  As a BO user
+  I must be able to toggle country status
+
+  Scenario: Toggle one country status
+    Given language "language1" with locale "en-US" exists
+    When I add new country "toggle_country" with following properties:
+      | name[en-US]                | Toggle Country  |
+      | iso_code                   | QW              |
+      | call_prefix                | 11              |
+      | default_currency           | 1               |
+      | zone                       | 1               |
+      | need_zip_code              | true            |
+      | zip_code_format            | NNNNN           |
+      | address_format             | not implemented |
+      | is_enabled                 | true            |
+      | contains_states            | false           |
+      | need_identification_number | false           |
+      | display_tax_label          | true            |
+      | shop_association           | 1               |
+    And I toggle country status "toggle_country"
+    Then country "toggle_country" should be disabled
+
+  Scenario: Toggle one country status should fail when country does not exist
+    Given country "missing_country" does not exist
+    When I toggle country status "missing_country"
+    Then I should get error that country was not found


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Finalizes the Symfony migration of the Back Office Countries list page. This PR adds the migrated status toggle in the grid, bulk enable/disable actions, and a bulk action to assign a new zone through a modal form.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to BO > International > Locations > Countries. <br> 2. Click the status toggle of a country and check the status is updated and persisted after refresh. <br> 3. Select multiple countries, run bulk enable, and verify their statuses. <br> 4. Select multiple countries, run bulk disable, and verify their statuses. <br> 5. Select multiple countries, run "Assign to a new zone", choose a zone in the modal, submit, and verify the zone is updated in the grid and persisted after refresh.
| UI Tests          |  In progress
| Fixed issue or discussion?     | Fixes #41325
| Related PRs       | None.
| Sponsor company   | N/A