### PR TITLE
Fix: [Multishop] Error when updating "Schema of URLs" for a single shop

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsUrlSchemaFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaSettingsUrlSchemaFormDataProvider.php
@@ -87,6 +87,11 @@ final class MetaSettingsUrlSchemaFormDataProvider implements FormDataProviderInt
         $patternErrors = [];
         $fieldErrors = [];
         foreach ($data as $routeId => $rule) {
+            // Skip multistore checkbox helper fields added to the form, they are not route patterns.
+            if (str_starts_with($routeId, 'multistore_') && is_bool($rule)) {
+                continue;
+            }
+
             if (!$this->routeValidator->isRoutePattern($rule)) {
                 $patternErrors[] = $this->translator->trans(
                     'The route %routeRule% is not valid',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | In multishop context, the URL schema form contains additional fields prefixed with `multistore_`.<br/>These fields are boolean values used to determine whether a specific field is being overridden for the current shop. However, they were being passed to the route validator together with the actual URL schema rules.<br/><br/>As a result, `RouteValidator::isRouteValid()` received a boolean value instead of a string, causing a type error.<br/><br/>This PR skips `multistore_*` fields when their value is boolean, since they are not URL schema rules and should not be validated as routes.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable multishop. <br/>2. Select a single shop context. <br/>3. Go to Shop Parameters > Traffic & SEO.<br/> 4. Update one of the values in Schema of URLs. 5. Save the form.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/25327777560
| Fixed issue or discussion?     | Fixes #41393
| Related PRs       | 
| Sponsor company   | Codencode snc
