### PR TITLE
Add attachment route configuration in SEO & URLs

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
@@ -170,6 +170,27 @@ class UrlSchemaType extends TranslatorAwareType
                     ],
                 ],
             ])
+            ->add('attachment_rule', TranslatableType::class, [
+                'label' => $this->trans(
+                    'Route to attachments',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'type' => TextType::class,
+                'only_enabled_locales' => false,
+                'help' => $this->getKeywords('attachment_rule'),
+                'multistore_configuration_key' => 'PS_ROUTE_attachment_rule',
+                'options' => [
+                    'required' => true,
+                    'constraints' => [
+                        new NotBlank([
+                            'message' => $this->trans(
+                                'This field cannot be empty.',
+                                'Admin.Notifications.Error'
+                            ),
+                        ]),
+                    ],
+                ],
+            ])
             ->add('module', TranslatableType::class, [
                 'label' => $this->trans(
                     'Route to modules',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR adds the attachment_rule field to the Back Office page` Shop Parameters > Traffic & SEO > SEO & URLs`, allowing merchants to customize the route used for attachment URLs.<br/><br/>It completes the work introduced in #39949, which added SEO-friendly attachment URLs, by making the attachment route configurable from the administration panel.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Go to Shop Parameters > Traffic & SEO > SEO & URLs.<br/>2. Check that a new Route to attachments field is available in the URL schema form.<br/>3. Enter a custom value for attachment_rule and save the form.<br/>4. Verify that the configuration is saved correctly after page reload.<br/>5. Open an attachment URL in the Front Office and confirm it uses the updated route pattern.<br/>6. Verify that existing attachment links still work after changing the route.
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/30518456430
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/39949
| Sponsor company   | Codencode snc

cc @Hlavtox 
