### PR TITLE
Improvement: add back parameter in FO customer template URLs

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1555,10 +1555,10 @@ class FrontControllerCore extends Controller
             ];
             foreach ($p as $page_name) {
                 $index = str_replace('-', '_', $page_name);
-                $pages[$index] = $this->context->link->getPageLink($page_name);
+                $pages[$index] = $this->getPageLinkForTemplate($page_name);
             }
             $pages['brands'] = $pages['manufacturer'];
-            $pages['register'] = $this->context->link->getPageLink('registration');
+            $pages['register'] = $pages['registration'];
             $pages['order_login'] = $this->context->link->getPageLink('order', null, null, ['login' => '1']);
             $urls['pages'] = $pages;
 
@@ -1575,6 +1575,30 @@ class FrontControllerCore extends Controller
         }
 
         return $this->urls;
+    }
+
+    /**
+     * Provides customer URLs with a validated back parameter so templates do not inject it themselves.
+     *
+     * @param string $pageName
+     *
+     * @return string
+     */
+    protected function getPageLinkForTemplate(string $pageName): string
+    {
+        $params = [];
+        if (
+            in_array($pageName, ['authentication', 'registration', 'password'], true)
+            && ($back = Tools::getValue('back', ''))
+            && is_string($back)
+            && Tools::urlBelongsToShop($back)
+        ) {
+            $params['back'] = $back;
+        }
+
+        return empty($params)
+            ? $this->context->link->getPageLink($pageName)
+            : $this->context->link->getPageLink($pageName, null, null, $params);
     }
 
     /**

--- a/tests/Unit/Classes/controller/FrontControllerTest.php
+++ b/tests/Unit/Classes/controller/FrontControllerTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Classes\Controller;
+
+use Context;
+use FrontControllerCore;
+use Link;
+use PHPUnit\Framework\TestCase;
+use Tools;
+
+class FrontControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_GET = [];
+        $_POST = [];
+        $_SERVER['SERVER_NAME'] = 'shop.example.test';
+        Tools::resetRequest();
+        Tools::setFallbackParameters([]);
+    }
+
+    protected function tearDown(): void
+    {
+        $_GET = [];
+        $_POST = [];
+        Tools::resetRequest();
+        Tools::setFallbackParameters([]);
+    }
+
+    /**
+     * @dataProvider backAwarePageProvider
+     */
+    public function testItAddsBackParameterToBackAwarePageLink(string $pageName): void
+    {
+        $_GET['back'] = 'https://shop.example.test/order';
+
+        $pageLink = $this
+            ->getController($pageName, ['back' => 'https://shop.example.test/order'], $pageName . '?back=https://shop.example.test/order')
+            ->getPageLinkForTemplate($pageName);
+
+        $this->assertSame($pageName . '?back=https://shop.example.test/order', $pageLink);
+    }
+
+    /**
+     * @dataProvider invalidBackProvider
+     */
+    public function testItDoesNotAddBackParameterWhenBackIsNotValid(?string $back): void
+    {
+        if ($back !== null) {
+            $_GET['back'] = $back;
+        }
+
+        $pageLink = $this
+            ->getController('authentication', null, 'authentication')
+            ->getPageLinkForTemplate('authentication');
+
+        $this->assertSame('authentication', $pageLink);
+    }
+
+    public function testItDoesNotAddBackParameterToOtherPageLink(): void
+    {
+        $_GET['back'] = 'https://shop.example.test/order';
+
+        $pageLink = $this
+            ->getController('cart', null, 'cart')
+            ->getPageLinkForTemplate('cart');
+
+        $this->assertSame('cart', $pageLink);
+    }
+
+    public static function backAwarePageProvider(): iterable
+    {
+        yield ['authentication'];
+        yield ['registration'];
+        yield ['password'];
+    }
+
+    public static function invalidBackProvider(): iterable
+    {
+        yield 'empty back' => [''];
+        yield 'missing back' => [null];
+        yield 'external back' => ['https://external.example.test/order'];
+    }
+
+    private function getController(string $expectedPageName, ?array $expectedRequest, string $expectedPageLink): TestFrontController
+    {
+        $context = new Context();
+        $context->link = $this->getLinkMock($expectedPageName, $expectedRequest, $expectedPageLink);
+
+        return new TestFrontController($context);
+    }
+
+    private function getLinkMock(string $expectedPageName, ?array $expectedRequest, string $expectedPageLink): Link
+    {
+        $link = $this->getMockBuilder(Link::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getPageLink'])
+            ->getMock();
+        $link
+            ->expects($this->once())
+            ->method('getPageLink')
+            ->with($expectedPageName, null, null, $expectedRequest, false, null, false)
+            ->willReturn($expectedPageLink);
+
+        return $link;
+    }
+}
+
+class TestFrontController extends FrontControllerCore
+{
+    public function __construct(Context $context)
+    {
+        $this->context = $context;
+    }
+
+    public function getPageLinkForTemplate(string $pageName): string
+    {
+        return parent::getPageLinkForTemplate($pageName);
+    }
+}


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Template page URLs generated by `FrontController` now preserve a validated `back` parameter for customer pages that need it: authentication, registration and password reset.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open a FO page with a valid `back` parameter and check that links to authentication, registration and password reset keep the expected `back` URL.
| UI Tests          | Not run.
| Fixed issue or discussion?     | None
| Related PRs       | None
| Sponsor company   | PrestaShop SA
