### PR TITLE
Migrate country options

### DIFF
--- a/src/Adapter/Country/CountryOptionsConfiguration.php
+++ b/src/Adapter/Country/CountryOptionsConfiguration.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Country;
+
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Loads and saves the "Options" block configuration of the Countries page
+ * (Improve > International > Locations > Countries).
+ */
+class CountryOptionsConfiguration extends AbstractMultistoreConfiguration
+{
+    private const CONFIGURATION_FIELDS = ['restrict_country_to_delivery'];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration()
+    {
+        $shopConstraint = $this->getShopConstraint();
+
+        return [
+            'restrict_country_to_delivery' => (bool) $this->configuration->get('PS_RESTRICT_DELIVERED_COUNTRIES', false, $shopConstraint),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateConfiguration(array $configuration)
+    {
+        if ($this->validateConfiguration($configuration)) {
+            $shopConstraint = $this->getShopConstraint();
+            $this->updateConfigurationValue('PS_RESTRICT_DELIVERED_COUNTRIES', 'restrict_country_to_delivery', $configuration, $shopConstraint);
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function buildResolver(): OptionsResolver
+    {
+        return (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('restrict_country_to_delivery', 'bool');
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
@@ -17,6 +17,7 @@ use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\DeleteCountryException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Query\GetCountryForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Country\QueryResult\CountryForEditing;
+use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface as ConfigurationFormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
@@ -47,16 +48,48 @@ class CountryController extends PrestaShopAdminController
         Request $request,
         CountryFilters $filters,
         #[Autowire(service: 'prestashop.core.grid.factory.country')]
-        GridFactoryInterface $countryGridFactory
+        GridFactoryInterface $countryGridFactory,
+        #[Autowire(service: 'prestashop.admin.country.options.form_handler')]
+        ConfigurationFormHandlerInterface $countryOptionsFormHandler
     ): Response {
         $countryGrid = $countryGridFactory->getGrid($filters);
+        $countryOptionsForm = $countryOptionsFormHandler->getForm();
 
         return $this->render('@PrestaShop/Admin/Improve/International/Country/index.html.twig', [
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'countryGrid' => $this->presentGrid($countryGrid),
+            'countryOptionsForm' => $countryOptionsForm->createView(),
             'enableSidebar' => true,
             'layoutHeaderToolbarBtn' => $this->getCountryToolbarButtons(),
         ]);
+    }
+
+    /**
+     * Persists the "Country options" block configuration.
+     */
+    #[DemoRestricted(redirectRoute: 'admin_countries_index')]
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))", redirectRoute: 'admin_countries_index', message: 'You do not have permission to edit this.')]
+    public function saveOptionsAction(
+        Request $request,
+        #[Autowire(service: 'prestashop.admin.country.options.form_handler')]
+        ConfigurationFormHandlerInterface $countryOptionsFormHandler
+    ): Response {
+        $form = $countryOptionsFormHandler->getForm();
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $saveErrors = $countryOptionsFormHandler->save($form->getData());
+
+            if (0 === count($saveErrors)) {
+                $this->addFlash('success', $this->trans('Update successful', [], 'Admin.Notifications.Success'));
+
+                return $this->redirectToRoute('admin_countries_index');
+            }
+
+            $this->addFlashErrors($saveErrors);
+        }
+
+        return $this->redirectToRoute('admin_countries_index');
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryOptionsFormDataProvider.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Improve\International\Locations;
+
+use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
+
+/**
+ * Bridges the "Country options" form data with the underlying configuration handler.
+ */
+class CountryOptionsFormDataProvider implements FormDataProviderInterface
+{
+    /**
+     * @var DataConfigurationInterface
+     */
+    private $dataConfiguration;
+
+    public function __construct(DataConfigurationInterface $dataConfiguration)
+    {
+        $this->dataConfiguration = $dataConfiguration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData()
+    {
+        return $this->dataConfiguration->getConfiguration();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setData(array $data)
+    {
+        return $this->dataConfiguration->updateConfiguration($data);
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryOptionsFormDataProvider.php
@@ -16,14 +16,8 @@ use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
  */
 class CountryOptionsFormDataProvider implements FormDataProviderInterface
 {
-    /**
-     * @var DataConfigurationInterface
-     */
-    private $dataConfiguration;
-
-    public function __construct(DataConfigurationInterface $dataConfiguration)
+    public function __construct(private readonly DataConfigurationInterface $dataConfiguration)
     {
-        $this->dataConfiguration = $dataConfiguration;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryOptionsType.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Improve\International\Locations;
+
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Form\Extension\MultistoreConfigurationTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Generates the "Country options" block of the
+ * "Improve > International > Locations > Countries" page.
+ */
+class CountryOptionsType extends TranslatorAwareType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('restrict_country_to_delivery', SwitchType::class, [
+            'required' => false,
+            'multistore_configuration_key' => 'PS_RESTRICT_DELIVERED_COUNTRIES',
+            'label' => $this->trans(
+                'Restrict country selections in front office to those covered by active carriers',
+                'Admin.International.Help'
+            ),
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'Admin.International.Feature',
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'country_options_block';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
@@ -53,3 +53,12 @@ admin_countries_delete:
       id_country: countryId
   requirements:
     countryId: \d+
+
+admin_countries_save_options:
+  path: /options
+  methods: [ POST ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\International\CountryController::saveOptionsAction'
+    _legacy_controller: AdminCountries
+    _legacy_link: AdminCountries:submitOptionscountry
+    _legacy_feature_flag: country

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -215,6 +215,13 @@ services:
       - '@prestashop.adapter.shop.context'
       - '@prestashop.adapter.multistore_feature'
 
+  prestashop.adapter.country.country_options_configuration:
+    class: 'PrestaShop\PrestaShop\Adapter\Country\CountryOptionsConfiguration'
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
+
   prestashop.core.email.email_configurator:
     class: 'PrestaShop\PrestaShop\Core\Email\EmailDataConfigurator'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
@@ -12,6 +12,11 @@ services:
     arguments:
       - '@prestashop.adapter.shipping_preferences.carrier_options_configuration'
 
+  prestashop.admin.country.options.data_provider:
+    class: 'PrestaShopBundle\Form\Admin\Improve\International\Locations\CountryOptionsFormDataProvider'
+    arguments:
+      - '@prestashop.adapter.country.country_options_configuration'
+
   prestashop.admin.order.invoices.by_date.data_provider:
     class: 'PrestaShopBundle\Form\Admin\Sell\Order\Invoices\InvoicesByDateDataProvider'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -121,6 +121,16 @@ services:
       - 'ShippingPreferencesPageCarrierOptions'
       - 'carrier-options'
 
+  prestashop.admin.country.options.form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\Handler'
+    arguments:
+      - '@form.factory'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.admin.country.options.data_provider'
+      - 'PrestaShopBundle\Form\Admin\Improve\International\Locations\CountryOptionsType'
+      - 'CountriesPageOptions'
+      - 'country-options'
+
   prestashop.admin.order.invoices.by_date.form_handler:
     class: 'PrestaShopBundle\Form\Admin\Sell\Order\Invoices\InvoiceByDateFormHandler'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -571,6 +571,8 @@ services:
     arguments:
       $zoneChoiceProvider: '@prestashop.core.form.choice_provider.zone_by_id'
 
+  PrestaShopBundle\Form\Admin\Improve\International\Locations\CountryOptionsType:
+
   PrestaShopBundle\Form\Admin\Sell\CustomerService\MerchandiseReturn\MerchandiseReturnOptionsType:
 
   PrestaShopBundle\Form\Admin\Type\CarrierChoiceType:

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Country/Blocks/options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Country/Blocks/options.html.twig
@@ -1,0 +1,26 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+
+{% trans_default_domain 'Admin.International.Feature' %}
+{% form_theme countryOptionsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
+
+{% block country_options %}
+  <div id="country-options" class="card">
+    <h3 class="card-header">
+      <i class="material-icons">settings</i>
+      {{ 'Country options'|trans }}
+    </h3>
+    <div class="card-body">
+      <div class="form-wrapper">
+        {{ form_widget(countryOptionsForm) }}
+      </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary" id="save-country-options-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Country/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Country/index.html.twig
@@ -6,6 +6,10 @@
 
 {% block content %}
   {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {grid: countryGrid}) }}
+
+  {{ form_start(countryOptionsForm, {attr: {class: 'form', id: 'configuration_country_options_form'}, action: path('admin_countries_save_options')}) }}
+    {{ include('@PrestaShop/Admin/Improve/International/Country/Blocks/options.html.twig') }}
+  {{ form_end(countryOptionsForm) }}
 {% endblock %}
 
 {% block javascripts %}


### PR DESCRIPTION
  | Questions         | Answers
  | ----------------- | -------------------------------------------------------
  | Branch?           | develop
  | Description?      | Migrates the "Options" block of the Countries page (Improve > International > Locations > Countries) from the legacy `AdminCountriesController::fields_options` to the modern Symfony architecture, behind the existing `country` feature flag. The block contains a single switch — "Restrict country selections in front office to those covered by active carriers" — backed by the `PS_RESTRICT_DELIVERED_COUNTRIES`
  configuration key.
  | Type?             | improvement
  | Category?         | BO
  | BC breaks?        | no
  | Deprecations?     | no
  | How to test?      | See the "How to test" section below.
  | UI Tests          | https://github.com/tleon/ga.tests.ui.pr/actions/runs/25382618370
  | Fixed issue or discussion?     | Fixes #41326
  | Sponsor company   | PrestaShop SA

  ## What this PR does

  Adds the missing **Options** card to the migrated Symfony Countries page so that the page reaches feature parity with the legacy `AdminCountriesController` once the `country` feature flag is enabled.

  The block follows the project convention for `fields_options`-style configuration panels — same pattern used for Tax, Carrier, Maintenance, Invoice, Merchandise Return options:

  src/Adapter/Country/CountryOptionsConfiguration.php           ← extends AbstractMultistoreConfiguration
  src/PrestaShopBundle/Form/Admin/Improve/International/Locations/
      ├── CountryOptionsType.php                                ← Symfony form (one SwitchType)
      └── CountryOptionsFormDataProvider.php                    ← bridges form ⇄ configuration
  src/PrestaShopBundle/Resources/views/Admin/Improve/International/Country/
      ├── index.html.twig                                       ← renders the form below the grid
      └── Blocks/options.html.twig                              ← the "Country options" card
  src/PrestaShopBundle/Resources/config/services/...            ← service registrations
  src/PrestaShopBundle/Resources/config/routing/...             ← admin_countries_save_options route (POST /options)
  src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
      ├── indexAction()                                         ← now also passes the form view
      └── saveOptionsAction()                                   ← new, DemoRestricted + admin perms

  No CQRS Command/Query was added: the Options block writes a single row to `ps_configuration`, which is exactly what `AbstractMultistoreConfiguration` is meant for. Country entity CRUD already has its own CQRS layer (added
  in earlier migration steps).

  The legacy `AdminCountriesController` is untouched, so merchants with the `country` feature flag **off** keep the legacy options block. Both modes share the same `PS_RESTRICT_DELIVERED_COUNTRIES` key, so the value persists
  consistently across modes.

  ## How to test

  BO — Options block renders and persists

  1. Go to Improve > International > Locations > Countries.
  2. Below the countries grid, a new "Country options" card is visible with a single switch: "Restrict country selections in front office to those covered by active carriers".
  3. Toggle the switch ON, click Save → success flash "Update successful".
  4. Refresh the page → the switch is still ON (value re-loaded from configuration).
  5. Toggle OFF, save → value is now 0, switch state persists across reloads.

  FO — Acceptance criterion from the issue

  ▎ "Only countries covered by carriers" are displayed in the front office when the option is enabled.

  1. In Improve > Shipping > Carriers, edit a carrier and restrict its delivery zones/countries (e.g. only "France"). Disable any other active carrier so this is the only one.
  2. In Improve > International > Locations > Countries, make sure several countries other than France are still active (e.g. enable Afghanistan).
  3. Option ON: enable the new switch, save. In the FO:
    - Log in as a customer (or guest) and open My account → Add new address or go through Checkout → Addresses.
    - The Country dropdown only lists countries covered by an active carrier (i.e. France only here). Afghanistan is absent.
  4. Option OFF: disable the switch, save. Refresh the FO address form.
    - The Country dropdown lists every active country again. Afghanistan is present.

  Regression — flag OFF still works

  1. Disable the country feature flag.
  2. Go to Improve > International > Locations > Countries — the legacy listing renders, with the legacy "Country options" panel at the bottom.
  3. Toggle the legacy option, save → still writes the same PS_RESTRICT_DELIVERED_COUNTRIES key. FO behaviour unchanged.
