### PR TITLE
Add multistore support to administration and product settings configuration forms

### DIFF
--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -42,6 +42,7 @@ module.exports = {
   entry: {
     address: './js/pages/address',
     alias_form: './js/pages/alias/form',
+    administration: './js/pages/administration',
     api_client: './js/pages/api-client',
     api_client_form: './js/pages/api-client/form',
     attachment: './js/pages/attachment',

--- a/admin-dev/themes/new-theme/js/pages/administration/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/administration/index.ts
@@ -1,0 +1,12 @@
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+$(() => {
+  window.prestashop.component.initComponents(
+    [
+      'MultistoreConfigField',
+    ],
+  );
+});

--- a/admin-dev/themes/new-theme/js/pages/product-preferences/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product-preferences/index.ts
@@ -12,6 +12,7 @@ const {$} = window;
 $(() => {
   window.prestashop.component.initComponents(
     [
+      'MultistoreConfigField',
       'TranslatableInput',
     ],
   );

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -754,7 +754,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                         }
                     }
                     $id_attributes = Db::getInstance()->executeS('SELECT pac2.`id_attribute` FROM `' . _DB_PREFIX_ . 'product_attribute_combination` pac2' .
-                        ((!Product::isAvailableWhenOutOfStock($this->product->out_of_stock) && 0 == Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) ?
+                        ((!Product::isAvailableWhenOutOfStock($this->product->out_of_stock) && false === (bool) Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) ?
                         ' INNER JOIN `' . _DB_PREFIX_ . 'stock_available` pa ON pa.id_product_attribute = pac2.id_product_attribute
                         WHERE pa.quantity > 0 AND ' :
                         ' WHERE ') .
@@ -791,7 +791,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             }
 
             // wash attributes list (if some attributes are unavailables and if allowed to wash it)
-            if (!Product::isAvailableWhenOutOfStock($this->product->out_of_stock) && Configuration::get('PS_DISP_UNAVAILABLE_ATTR') == 0) {
+            if (!Product::isAvailableWhenOutOfStock($this->product->out_of_stock) && false === (bool) Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) {
                 foreach ($groups as &$group) {
                     foreach ($group['attributes_quantity'] as $key => $quantity) {
                         if ($quantity <= 0) {

--- a/src/Adapter/Admin/NotificationsConfiguration.php
+++ b/src/Adapter/Admin/NotificationsConfiguration.php
@@ -7,21 +7,25 @@
 namespace PrestaShop\PrestaShop\Adapter\Admin;
 
 use PrestaShop\PrestaShop\Adapter\Configuration;
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Manages the configuration data about notifications options.
  */
-class NotificationsConfiguration implements DataConfigurationInterface
+class NotificationsConfiguration extends AbstractMultistoreConfiguration
 {
-    /**
-     * @var Configuration
-     */
-    private $configuration;
+    private const CONFIGURATION_FIELDS = [
+        'show_notifs_new_orders',
+        'show_notifs_new_customers',
+        'show_notifs_new_messages',
+    ];
 
-    public function __construct(Configuration $configuration)
+    public function __construct(Configuration $configuration, Context $shopContext, FeatureInterface $multistoreFeature)
     {
-        $this->configuration = $configuration;
+        parent::__construct($configuration, $shopContext, $multistoreFeature);
     }
 
     /**
@@ -29,10 +33,12 @@ class NotificationsConfiguration implements DataConfigurationInterface
      */
     public function getConfiguration()
     {
+        $shopConstraint = $this->getShopConstraint();
+
         return [
-            'show_notifs_new_orders' => $this->configuration->getBoolean('PS_SHOW_NEW_ORDERS'),
-            'show_notifs_new_customers' => $this->configuration->getBoolean('PS_SHOW_NEW_CUSTOMERS'),
-            'show_notifs_new_messages' => $this->configuration->getBoolean('PS_SHOW_NEW_MESSAGES'),
+            'show_notifs_new_orders' => (bool) $this->configuration->get('PS_SHOW_NEW_ORDERS', false, $shopConstraint),
+            'show_notifs_new_customers' => (bool) $this->configuration->get('PS_SHOW_NEW_CUSTOMERS', false, $shopConstraint),
+            'show_notifs_new_messages' => (bool) $this->configuration->get('PS_SHOW_NEW_MESSAGES', false, $shopConstraint),
         ];
     }
 
@@ -44,9 +50,10 @@ class NotificationsConfiguration implements DataConfigurationInterface
         $errors = [];
 
         if ($this->validateConfiguration($configuration)) {
-            $this->configuration->set('PS_SHOW_NEW_ORDERS', (bool) $configuration['show_notifs_new_orders']);
-            $this->configuration->set('PS_SHOW_NEW_CUSTOMERS', (bool) $configuration['show_notifs_new_customers']);
-            $this->configuration->set('PS_SHOW_NEW_MESSAGES', (bool) $configuration['show_notifs_new_messages']);
+            $shopConstraint = $this->getShopConstraint();
+            $this->updateConfigurationValue('PS_SHOW_NEW_ORDERS', 'show_notifs_new_orders', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_SHOW_NEW_CUSTOMERS', 'show_notifs_new_customers', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_SHOW_NEW_MESSAGES', 'show_notifs_new_messages', $configuration, $shopConstraint);
         }
 
         return $errors;
@@ -55,12 +62,12 @@ class NotificationsConfiguration implements DataConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function validateConfiguration(array $configuration)
+    protected function buildResolver(): OptionsResolver
     {
-        return isset(
-            $configuration['show_notifs_new_orders'],
-            $configuration['show_notifs_new_customers'],
-            $configuration['show_notifs_new_messages']
-        );
+        return (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('show_notifs_new_orders', 'bool')
+            ->setAllowedTypes('show_notifs_new_customers', 'bool')
+            ->setAllowedTypes('show_notifs_new_messages', 'bool');
     }
 }

--- a/src/Adapter/GeneralConfiguration.php
+++ b/src/Adapter/GeneralConfiguration.php
@@ -7,8 +7,8 @@
 namespace PrestaShop\PrestaShop\Adapter;
 
 use Cookie;
-use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShop\PrestaShop\Adapter\Cache\Clearer\SymfonyCacheClearer;
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShop\PrestaShop\Core\Http\CookieOptions;

--- a/src/Adapter/GeneralConfiguration.php
+++ b/src/Adapter/GeneralConfiguration.php
@@ -7,20 +7,36 @@
 namespace PrestaShop\PrestaShop\Adapter;
 
 use Cookie;
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShop\PrestaShop\Adapter\Cache\Clearer\SymfonyCacheClearer;
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShop\PrestaShop\Core\Http\CookieOptions;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Manages the configuration data about general options.
  */
-class GeneralConfiguration implements DataConfigurationInterface
+class GeneralConfiguration extends AbstractMultistoreConfiguration
 {
+    /**
+     * @var array<int, string>
+     */
+    private const CONFIGURATION_FIELDS = [
+        'check_ip_address',
+        'front_cookie_lifetime',
+        'back_cookie_lifetime',
+        'cookie_samesite',
+    ];
+
     public function __construct(
-        private readonly Configuration $configuration,
+        Configuration $configuration,
+        Context $shopContext,
+        FeatureInterface $multistoreFeature,
         private readonly Cookie $cookie,
         private readonly SymfonyCacheClearer $symfonyCacheClearer,
     ) {
+        parent::__construct($configuration, $shopContext, $multistoreFeature);
     }
 
     /**
@@ -28,11 +44,13 @@ class GeneralConfiguration implements DataConfigurationInterface
      */
     public function getConfiguration()
     {
+        $shopConstraint = $this->getShopConstraint();
+
         return [
-            'check_ip_address' => $this->configuration->getBoolean('PS_COOKIE_CHECKIP'),
-            'front_cookie_lifetime' => $this->configuration->get('PS_COOKIE_LIFETIME_FO'),
-            'back_cookie_lifetime' => $this->configuration->get('PS_COOKIE_LIFETIME_BO'),
-            'cookie_samesite' => $this->configuration->get('PS_COOKIE_SAMESITE'),
+            'check_ip_address' => (bool) $this->configuration->get('PS_COOKIE_CHECKIP', false, $shopConstraint),
+            'front_cookie_lifetime' => (int) $this->configuration->get('PS_COOKIE_LIFETIME_FO', 0, $shopConstraint),
+            'back_cookie_lifetime' => (int) $this->configuration->get('PS_COOKIE_LIFETIME_BO', 0, $shopConstraint),
+            'cookie_samesite' => (string) $this->configuration->get('PS_COOKIE_SAMESITE', CookieOptions::SAMESITE_LAX, $shopConstraint),
         ];
     }
 
@@ -44,6 +62,8 @@ class GeneralConfiguration implements DataConfigurationInterface
         $errors = [];
 
         if ($this->validateConfiguration($configuration)) {
+            $shopConstraint = $this->getShopConstraint();
+
             if (!$this->validateSameSite($configuration['cookie_samesite'])) {
                 $errors[] = [
                     'key' => 'The SameSite=None attribute is only available in secure mode.',
@@ -51,10 +71,10 @@ class GeneralConfiguration implements DataConfigurationInterface
                     'parameters' => [],
                 ];
             } else {
-                $this->configuration->set('PS_COOKIE_CHECKIP', (bool) $configuration['check_ip_address']);
-                $this->configuration->set('PS_COOKIE_LIFETIME_FO', (int) $configuration['front_cookie_lifetime']);
-                $this->configuration->set('PS_COOKIE_LIFETIME_BO', (int) $configuration['back_cookie_lifetime']);
-                $this->configuration->set('PS_COOKIE_SAMESITE', $configuration['cookie_samesite']);
+                $this->updateConfigurationValue('PS_COOKIE_CHECKIP', 'check_ip_address', $configuration, $shopConstraint);
+                $this->updateConfigurationValue('PS_COOKIE_LIFETIME_FO', 'front_cookie_lifetime', $configuration, $shopConstraint);
+                $this->updateConfigurationValue('PS_COOKIE_LIFETIME_BO', 'back_cookie_lifetime', $configuration, $shopConstraint);
+                $this->updateConfigurationValue('PS_COOKIE_SAMESITE', 'cookie_samesite', $configuration, $shopConstraint);
                 // Clear checksum to force the refresh
                 $this->cookie->checksum = '';
                 $this->cookie->write();
@@ -70,18 +90,15 @@ class GeneralConfiguration implements DataConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function validateConfiguration(array $configuration)
+    protected function buildResolver(): OptionsResolver
     {
-        $isValid = isset(
-            $configuration['check_ip_address'],
-            $configuration['front_cookie_lifetime'],
-            $configuration['back_cookie_lifetime']
-        ) && in_array(
-            $configuration['cookie_samesite'],
-            CookieOptions::SAMESITE_AVAILABLE_VALUES
-        );
-
-        return (bool) $isValid;
+        return (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('check_ip_address', 'bool')
+            ->setAllowedTypes('front_cookie_lifetime', 'int')
+            ->setAllowedTypes('back_cookie_lifetime', 'int')
+            ->setAllowedTypes('cookie_samesite', 'string')
+            ->setAllowedValues('cookie_samesite', CookieOptions::SAMESITE_AVAILABLE_VALUES);
     }
 
     /**

--- a/src/Adapter/Product/GeneralConfiguration.php
+++ b/src/Adapter/Product/GeneralConfiguration.php
@@ -8,20 +8,31 @@ namespace PrestaShop\PrestaShop\Adapter\Product;
 
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Product\SpecificPrice\Update\SpecificPricePriorityUpdater;
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Product\SpecificPrice\Exception\SpecificPriceConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\SpecificPrice\ValueObject\PriorityList;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * This class loads and saves general configuration for product.
  */
-class GeneralConfiguration implements DataConfigurationInterface
+class GeneralConfiguration extends AbstractMultistoreConfiguration
 {
-    /**
-     * @var Configuration
-     */
-    private $configuration;
+    private const CONFIGURATION_FIELDS = [
+        'catalog_mode',
+        'catalog_mode_with_prices',
+        'new_days_number',
+        'short_description_limit',
+        'quantity_discount',
+        'force_friendly_url',
+        'product_breadcrumb_category',
+        'default_status',
+        'specific_price_priorities',
+        'disabled_products_behavior',
+    ];
 
     /**
      * @var SpecificPricePriorityUpdater
@@ -34,9 +45,11 @@ class GeneralConfiguration implements DataConfigurationInterface
      */
     public function __construct(
         Configuration $configuration,
+        Context $shopContext,
+        FeatureInterface $multistoreFeature,
         SpecificPricePriorityUpdater $specificPricePriorityUpdater
     ) {
-        $this->configuration = $configuration;
+        parent::__construct($configuration, $shopContext, $multistoreFeature);
         $this->specificPricePriorityUpdater = $specificPricePriorityUpdater;
     }
 
@@ -45,17 +58,19 @@ class GeneralConfiguration implements DataConfigurationInterface
      */
     public function getConfiguration()
     {
+        $shopConstraint = $this->getShopConstraint();
+
         return [
-            'catalog_mode' => $this->configuration->getBoolean('PS_CATALOG_MODE'),
-            'catalog_mode_with_prices' => $this->configuration->getBoolean('PS_CATALOG_MODE_WITH_PRICES'),
-            'new_days_number' => $this->configuration->get('PS_NB_DAYS_NEW_PRODUCT'),
-            'short_description_limit' => $this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT'),
-            'quantity_discount' => $this->configuration->get('PS_QTY_DISCOUNT_ON_COMBINATION'),
-            'force_friendly_url' => $this->configuration->getBoolean('PS_FORCE_FRIENDLY_PRODUCT'),
-            'product_breadcrumb_category' => $this->configuration->get('PS_PRODUCT_BREADCRUMB_CATEGORY'),
-            'default_status' => $this->configuration->getBoolean('PS_PRODUCT_ACTIVATION_DEFAULT'),
+            'catalog_mode' => (bool) $this->configuration->get('PS_CATALOG_MODE', false, $shopConstraint),
+            'catalog_mode_with_prices' => (bool) $this->configuration->get('PS_CATALOG_MODE_WITH_PRICES', false, $shopConstraint),
+            'new_days_number' => (int) $this->configuration->get('PS_NB_DAYS_NEW_PRODUCT', 0, $shopConstraint),
+            'short_description_limit' => (int) $this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT', 0, $shopConstraint),
+            'quantity_discount' => (int) $this->configuration->get('PS_QTY_DISCOUNT_ON_COMBINATION', 0, $shopConstraint),
+            'force_friendly_url' => (bool) $this->configuration->get('PS_FORCE_FRIENDLY_PRODUCT', false, $shopConstraint),
+            'product_breadcrumb_category' => (string) $this->configuration->get('PS_PRODUCT_BREADCRUMB_CATEGORY', 'default', $shopConstraint),
+            'default_status' => (bool) $this->configuration->get('PS_PRODUCT_ACTIVATION_DEFAULT', false, $shopConstraint),
             'specific_price_priorities' => $this->getPrioritiesData(),
-            'disabled_products_behavior' => $this->configuration->get('PS_PRODUCT_REDIRECTION_DEFAULT'),
+            'disabled_products_behavior' => (string) $this->configuration->get('PS_PRODUCT_REDIRECTION_DEFAULT', RedirectType::TYPE_NOT_FOUND, $shopConstraint),
         ];
     }
 
@@ -67,16 +82,19 @@ class GeneralConfiguration implements DataConfigurationInterface
         $errors = [];
 
         if ($this->validateConfiguration($config)) {
-            $catalogMode = (int) $config['catalog_mode'];
-            $this->configuration->set('PS_CATALOG_MODE', $catalogMode);
-            $this->configuration->set('PS_CATALOG_MODE_WITH_PRICES', $catalogMode ? (int) $config['catalog_mode_with_prices'] : 0);
-            $this->configuration->set('PS_NB_DAYS_NEW_PRODUCT', (int) $config['new_days_number']);
-            $this->configuration->set('PS_PRODUCT_SHORT_DESC_LIMIT', (int) $config['short_description_limit']);
-            $this->configuration->set('PS_QTY_DISCOUNT_ON_COMBINATION', (int) $config['quantity_discount']);
-            $this->configuration->set('PS_FORCE_FRIENDLY_PRODUCT', (int) $config['force_friendly_url']);
-            $this->configuration->set('PS_PRODUCT_BREADCRUMB_CATEGORY', (string) $config['product_breadcrumb_category']);
-            $this->configuration->set('PS_PRODUCT_ACTIVATION_DEFAULT', (int) $config['default_status']);
-            $this->configuration->set('PS_PRODUCT_REDIRECTION_DEFAULT', (string) $config['disabled_products_behavior']);
+            $shopConstraint = $this->getShopConstraint();
+            $configWithCatalogModePrice = $config;
+            $configWithCatalogModePrice['catalog_mode_with_prices'] = $config['catalog_mode'] ? $config['catalog_mode_with_prices'] : false;
+
+            $this->updateConfigurationValue('PS_CATALOG_MODE', 'catalog_mode', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_CATALOG_MODE_WITH_PRICES', 'catalog_mode_with_prices', $configWithCatalogModePrice, $shopConstraint);
+            $this->updateConfigurationValue('PS_NB_DAYS_NEW_PRODUCT', 'new_days_number', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_PRODUCT_SHORT_DESC_LIMIT', 'short_description_limit', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_QTY_DISCOUNT_ON_COMBINATION', 'quantity_discount', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_FORCE_FRIENDLY_PRODUCT', 'force_friendly_url', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_PRODUCT_BREADCRUMB_CATEGORY', 'product_breadcrumb_category', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_PRODUCT_ACTIVATION_DEFAULT', 'default_status', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_PRODUCT_REDIRECTION_DEFAULT', 'disabled_products_behavior', $config, $shopConstraint);
             try {
                 $this->specificPricePriorityUpdater->updateDefaultPriorities(new PriorityList($config['specific_price_priorities']));
             } catch (SpecificPriceConstraintException $e) {
@@ -98,25 +116,20 @@ class GeneralConfiguration implements DataConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function validateConfiguration(array $configuration)
+    protected function buildResolver(): OptionsResolver
     {
-        $resolver = new OptionsResolver();
-        $resolver->setRequired([
-            'catalog_mode',
-            'catalog_mode_with_prices',
-            'new_days_number',
-            'short_description_limit',
-            'quantity_discount',
-            'force_friendly_url',
-            'product_breadcrumb_category',
-            'default_status',
-            'specific_price_priorities',
-            'disabled_products_behavior',
-        ]);
-
-        $resolver->resolve($configuration);
-
-        return true;
+        return (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('catalog_mode', 'bool')
+            ->setAllowedTypes('catalog_mode_with_prices', 'bool')
+            ->setAllowedTypes('new_days_number', 'int')
+            ->setAllowedTypes('short_description_limit', 'int')
+            ->setAllowedTypes('quantity_discount', 'int')
+            ->setAllowedTypes('force_friendly_url', 'bool')
+            ->setAllowedTypes('product_breadcrumb_category', 'string')
+            ->setAllowedTypes('default_status', 'bool')
+            ->setAllowedTypes('specific_price_priorities', 'array')
+            ->setAllowedTypes('disabled_products_behavior', 'string');
     }
 
     /**

--- a/src/Adapter/Product/PageConfiguration.php
+++ b/src/Adapter/Product/PageConfiguration.php
@@ -7,22 +7,29 @@
 namespace PrestaShop\PrestaShop\Adapter\Product;
 
 use PrestaShop\PrestaShop\Adapter\Configuration;
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class PageConfiguration is responsible for saving & loading product page configuration.
  */
-class PageConfiguration implements DataConfigurationInterface
+class PageConfiguration extends AbstractMultistoreConfiguration
 {
-    /**
-     * @var Configuration
-     */
-    private $configuration;
+    private const CONFIGURATION_FIELDS = [
+        'display_quantities',
+        'allow_add_variant_to_cart_from_listing',
+        'use_combination_image_in_listing',
+        'attribute_anchor_separator',
+        'display_discount_price',
+        'display_amount_in_cart',
+        'feature_values_order',
+    ];
 
-    public function __construct(Configuration $configuration)
+    public function __construct(Configuration $configuration, Context $shopContext, FeatureInterface $multistoreFeature)
     {
-        $this->configuration = $configuration;
+        parent::__construct($configuration, $shopContext, $multistoreFeature);
     }
 
     /**
@@ -30,14 +37,16 @@ class PageConfiguration implements DataConfigurationInterface
      */
     public function getConfiguration()
     {
+        $shopConstraint = $this->getShopConstraint();
+
         return [
-            'display_quantities' => $this->configuration->getBoolean('PS_DISPLAY_QTIES'),
-            'allow_add_variant_to_cart_from_listing' => $this->configuration->getBoolean('PS_ATTRIBUTE_CATEGORY_DISPLAY'),
-            'use_combination_image_in_listing' => $this->configuration->getBoolean('PS_USE_COMBINATION_IMAGE_IN_LISTING'),
-            'attribute_anchor_separator' => $this->configuration->get('PS_ATTRIBUTE_ANCHOR_SEPARATOR'),
-            'display_discount_price' => $this->configuration->getBoolean('PS_DISPLAY_DISCOUNT_PRICE'),
-            'display_amount_in_cart' => $this->configuration->getBoolean('PS_DISPLAY_AMOUNT_IN_CART'),
-            'feature_values_order' => $this->configuration->get('PS_FEATURE_VALUES_ORDER'),
+            'display_quantities' => (bool) $this->configuration->get('PS_DISPLAY_QTIES', false, $shopConstraint),
+            'allow_add_variant_to_cart_from_listing' => (bool) $this->configuration->get('PS_ATTRIBUTE_CATEGORY_DISPLAY', false, $shopConstraint),
+            'use_combination_image_in_listing' => (bool) $this->configuration->get('PS_USE_COMBINATION_IMAGE_IN_LISTING', false, $shopConstraint),
+            'attribute_anchor_separator' => (string) $this->configuration->get('PS_ATTRIBUTE_ANCHOR_SEPARATOR', '-', $shopConstraint),
+            'display_discount_price' => (bool) $this->configuration->get('PS_DISPLAY_DISCOUNT_PRICE', false, $shopConstraint),
+            'display_amount_in_cart' => (bool) $this->configuration->get('PS_DISPLAY_AMOUNT_IN_CART', false, $shopConstraint),
+            'feature_values_order' => (string) $this->configuration->get('PS_FEATURE_VALUES_ORDER', 'name', $shopConstraint),
         ];
     }
 
@@ -49,13 +58,14 @@ class PageConfiguration implements DataConfigurationInterface
         $errors = [];
 
         if ($this->validateConfiguration($config)) {
-            $this->configuration->set('PS_DISPLAY_QTIES', (int) $config['display_quantities']);
-            $this->configuration->set('PS_ATTRIBUTE_CATEGORY_DISPLAY', (int) $config['allow_add_variant_to_cart_from_listing']);
-            $this->configuration->set('PS_USE_COMBINATION_IMAGE_IN_LISTING', (int) $config['use_combination_image_in_listing']);
-            $this->configuration->set('PS_ATTRIBUTE_ANCHOR_SEPARATOR', $config['attribute_anchor_separator']);
-            $this->configuration->set('PS_DISPLAY_DISCOUNT_PRICE', (int) $config['display_discount_price']);
-            $this->configuration->set('PS_DISPLAY_AMOUNT_IN_CART', (int) $config['display_amount_in_cart']);
-            $this->configuration->set('PS_FEATURE_VALUES_ORDER', $config['feature_values_order']);
+            $shopConstraint = $this->getShopConstraint();
+            $this->updateConfigurationValue('PS_DISPLAY_QTIES', 'display_quantities', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_ATTRIBUTE_CATEGORY_DISPLAY', 'allow_add_variant_to_cart_from_listing', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_USE_COMBINATION_IMAGE_IN_LISTING', 'use_combination_image_in_listing', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_ATTRIBUTE_ANCHOR_SEPARATOR', 'attribute_anchor_separator', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_DISPLAY_DISCOUNT_PRICE', 'display_discount_price', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_DISPLAY_AMOUNT_IN_CART', 'display_amount_in_cart', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_FEATURE_VALUES_ORDER', 'feature_values_order', $config, $shopConstraint);
         }
 
         return $errors;
@@ -64,21 +74,16 @@ class PageConfiguration implements DataConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function validateConfiguration(array $config)
+    protected function buildResolver(): OptionsResolver
     {
-        $resolver = new OptionsResolver();
-        $resolver->setRequired([
-            'display_quantities',
-            'allow_add_variant_to_cart_from_listing',
-            'use_combination_image_in_listing',
-            'attribute_anchor_separator',
-            'display_discount_price',
-            'display_amount_in_cart',
-            'feature_values_order',
-        ]);
-
-        $resolver->resolve($config);
-
-        return true;
+        return (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('display_quantities', 'bool')
+            ->setAllowedTypes('allow_add_variant_to_cart_from_listing', 'bool')
+            ->setAllowedTypes('use_combination_image_in_listing', 'bool')
+            ->setAllowedTypes('attribute_anchor_separator', 'string')
+            ->setAllowedTypes('display_discount_price', 'bool')
+            ->setAllowedTypes('display_amount_in_cart', 'bool')
+            ->setAllowedTypes('feature_values_order', 'string');
     }
 }

--- a/src/Adapter/Product/PaginationConfiguration.php
+++ b/src/Adapter/Product/PaginationConfiguration.php
@@ -6,23 +6,26 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Product;
 
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class PaginationConfiguration is responsible for saving & loading pagination configuration for products.
  */
-class PaginationConfiguration implements DataConfigurationInterface
+class PaginationConfiguration extends AbstractMultistoreConfiguration
 {
-    /**
-     * @var ConfigurationInterface
-     */
-    private $configuration;
+    private const CONFIGURATION_FIELDS = [
+        'products_per_page',
+        'default_order_by',
+        'default_order_way',
+    ];
 
-    public function __construct(ConfigurationInterface $configuration)
+    public function __construct(ConfigurationInterface $configuration, Context $shopContext, FeatureInterface $multistoreFeature)
     {
-        $this->configuration = $configuration;
+        parent::__construct($configuration, $shopContext, $multistoreFeature);
     }
 
     /**
@@ -30,10 +33,12 @@ class PaginationConfiguration implements DataConfigurationInterface
      */
     public function getConfiguration()
     {
+        $shopConstraint = $this->getShopConstraint();
+
         return [
-            'products_per_page' => $this->configuration->get('PS_PRODUCTS_PER_PAGE'),
-            'default_order_by' => $this->configuration->get('PS_PRODUCTS_ORDER_BY'),
-            'default_order_way' => $this->configuration->get('PS_PRODUCTS_ORDER_WAY'),
+            'products_per_page' => (int) $this->configuration->get('PS_PRODUCTS_PER_PAGE', 12, $shopConstraint),
+            'default_order_by' => (int) $this->configuration->get('PS_PRODUCTS_ORDER_BY', 0, $shopConstraint),
+            'default_order_way' => (int) $this->configuration->get('PS_PRODUCTS_ORDER_WAY', 0, $shopConstraint),
         ];
     }
 
@@ -45,9 +50,10 @@ class PaginationConfiguration implements DataConfigurationInterface
         $errors = [];
 
         if ($this->validateConfiguration($config)) {
-            $this->configuration->set('PS_PRODUCTS_PER_PAGE', (int) $config['products_per_page']);
-            $this->configuration->set('PS_PRODUCTS_ORDER_BY', (int) $config['default_order_by']);
-            $this->configuration->set('PS_PRODUCTS_ORDER_WAY', (int) $config['default_order_way']);
+            $shopConstraint = $this->getShopConstraint();
+            $this->updateConfigurationValue('PS_PRODUCTS_PER_PAGE', 'products_per_page', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_PRODUCTS_ORDER_BY', 'default_order_by', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_PRODUCTS_ORDER_WAY', 'default_order_way', $config, $shopConstraint);
         }
 
         return $errors;
@@ -56,17 +62,12 @@ class PaginationConfiguration implements DataConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function validateConfiguration(array $configuration)
+    protected function buildResolver(): OptionsResolver
     {
-        $resolver = new OptionsResolver();
-        $resolver->setRequired([
-            'products_per_page',
-            'default_order_by',
-            'default_order_way',
-        ]);
-
-        $resolver->resolve($configuration);
-
-        return true;
+        return (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('products_per_page', 'int')
+            ->setAllowedTypes('default_order_by', 'int')
+            ->setAllowedTypes('default_order_way', 'int');
     }
 }

--- a/src/Adapter/Product/StockConfiguration.php
+++ b/src/Adapter/Product/StockConfiguration.php
@@ -7,22 +7,33 @@
 namespace PrestaShop\PrestaShop\Adapter\Product;
 
 use PrestaShop\PrestaShop\Adapter\Configuration;
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class StockConfiguration is responsible for saving & loading products stock configuration.
  */
-class StockConfiguration implements DataConfigurationInterface
+class StockConfiguration extends AbstractMultistoreConfiguration
 {
-    /**
-     * @var Configuration
-     */
-    private $configuration;
+    private const CONFIGURATION_FIELDS = [
+        'allow_ordering_oos',
+        'stock_management',
+        'in_stock_label',
+        'delivery_time',
+        'oos_allowed_backorders',
+        'oos_delivery_time',
+        'oos_denied_backorders',
+        'pack_stock_management',
+        'oos_show_label_listing_pages',
+        'display_last_quantities',
+        'display_unavailable_attributes',
+    ];
 
-    public function __construct(Configuration $configuration)
+    public function __construct(Configuration $configuration, Context $shopContext, FeatureInterface $multistoreFeature)
     {
-        $this->configuration = $configuration;
+        parent::__construct($configuration, $shopContext, $multistoreFeature);
     }
 
     /**
@@ -30,18 +41,20 @@ class StockConfiguration implements DataConfigurationInterface
      */
     public function getConfiguration()
     {
+        $shopConstraint = $this->getShopConstraint();
+
         return [
-            'allow_ordering_oos' => $this->configuration->getBoolean('PS_ORDER_OUT_OF_STOCK'),
-            'stock_management' => $this->configuration->getBoolean('PS_STOCK_MANAGEMENT'),
-            'in_stock_label' => $this->configuration->get('PS_LABEL_IN_STOCK_PRODUCTS'),
-            'oos_allowed_backorders' => $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOA'),
-            'oos_denied_backorders' => $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOD'),
-            'delivery_time' => (array) $this->configuration->get('PS_LABEL_DELIVERY_TIME_AVAILABLE'),
-            'oos_delivery_time' => (array) $this->configuration->get('PS_LABEL_DELIVERY_TIME_OOSBOA'),
-            'pack_stock_management' => $this->configuration->get('PS_PACK_STOCK_TYPE'),
-            'oos_show_label_listing_pages' => $this->configuration->getBoolean('PS_SHOW_LABEL_OOS_LISTING_PAGES'),
-            'display_last_quantities' => $this->configuration->get('PS_LAST_QTIES'),
-            'display_unavailable_attributes' => $this->configuration->getBoolean('PS_DISP_UNAVAILABLE_ATTR'),
+            'allow_ordering_oos' => (bool) $this->configuration->get('PS_ORDER_OUT_OF_STOCK', false, $shopConstraint),
+            'stock_management' => (bool) $this->configuration->get('PS_STOCK_MANAGEMENT', false, $shopConstraint),
+            'in_stock_label' => (array) $this->configuration->get('PS_LABEL_IN_STOCK_PRODUCTS', [], $shopConstraint),
+            'oos_allowed_backorders' => (array) $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOA', [], $shopConstraint),
+            'oos_denied_backorders' => (array) $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOD', [], $shopConstraint),
+            'delivery_time' => (array) $this->configuration->get('PS_LABEL_DELIVERY_TIME_AVAILABLE', [], $shopConstraint),
+            'oos_delivery_time' => (array) $this->configuration->get('PS_LABEL_DELIVERY_TIME_OOSBOA', [], $shopConstraint),
+            'pack_stock_management' => (int) $this->configuration->get('PS_PACK_STOCK_TYPE', 0, $shopConstraint),
+            'oos_show_label_listing_pages' => (bool) $this->configuration->get('PS_SHOW_LABEL_OOS_LISTING_PAGES', false, $shopConstraint),
+            'display_last_quantities' => (int) $this->configuration->get('PS_LAST_QTIES', 0, $shopConstraint),
+            'display_unavailable_attributes' => (bool) $this->configuration->get('PS_DISP_UNAVAILABLE_ATTR', false, $shopConstraint),
         ];
     }
 
@@ -53,17 +66,18 @@ class StockConfiguration implements DataConfigurationInterface
         $errors = [];
 
         if ($this->validateConfiguration($config)) {
-            $this->configuration->set('PS_ORDER_OUT_OF_STOCK', (int) $config['allow_ordering_oos']);
-            $this->configuration->set('PS_STOCK_MANAGEMENT', (int) $config['stock_management']);
-            $this->configuration->set('PS_LABEL_IN_STOCK_PRODUCTS', $config['in_stock_label']);
-            $this->configuration->set('PS_LABEL_OOS_PRODUCTS_BOA', $config['oos_allowed_backorders']);
-            $this->configuration->set('PS_LABEL_OOS_PRODUCTS_BOD', $config['oos_denied_backorders']);
-            $this->configuration->set('PS_LABEL_DELIVERY_TIME_AVAILABLE', $config['delivery_time']);
-            $this->configuration->set('PS_LABEL_DELIVERY_TIME_OOSBOA', $config['oos_delivery_time']);
-            $this->configuration->set('PS_PACK_STOCK_TYPE', $config['pack_stock_management']);
-            $this->configuration->set('PS_SHOW_LABEL_OOS_LISTING_PAGES', $config['oos_show_label_listing_pages']);
-            $this->configuration->set('PS_LAST_QTIES', (int) $config['display_last_quantities']);
-            $this->configuration->set('PS_DISP_UNAVAILABLE_ATTR', (int) $config['display_unavailable_attributes']);
+            $shopConstraint = $this->getShopConstraint();
+            $this->updateConfigurationValue('PS_ORDER_OUT_OF_STOCK', 'allow_ordering_oos', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_STOCK_MANAGEMENT', 'stock_management', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_LABEL_IN_STOCK_PRODUCTS', 'in_stock_label', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_LABEL_OOS_PRODUCTS_BOA', 'oos_allowed_backorders', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_LABEL_OOS_PRODUCTS_BOD', 'oos_denied_backorders', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_LABEL_DELIVERY_TIME_AVAILABLE', 'delivery_time', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_LABEL_DELIVERY_TIME_OOSBOA', 'oos_delivery_time', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_PACK_STOCK_TYPE', 'pack_stock_management', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_SHOW_LABEL_OOS_LISTING_PAGES', 'oos_show_label_listing_pages', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_LAST_QTIES', 'display_last_quantities', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_DISP_UNAVAILABLE_ATTR', 'display_unavailable_attributes', $config, $shopConstraint);
         }
 
         return $errors;
@@ -72,25 +86,20 @@ class StockConfiguration implements DataConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function validateConfiguration(array $configuration)
+    protected function buildResolver(): OptionsResolver
     {
-        $resolver = new OptionsResolver();
-        $resolver->setRequired([
-            'allow_ordering_oos',
-            'stock_management',
-            'in_stock_label',
-            'delivery_time',
-            'oos_allowed_backorders',
-            'oos_delivery_time',
-            'oos_denied_backorders',
-            'pack_stock_management',
-            'oos_show_label_listing_pages',
-            'display_last_quantities',
-            'display_unavailable_attributes',
-        ]);
-
-        $resolver->resolve($configuration);
-
-        return true;
+        return (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('allow_ordering_oos', 'bool')
+            ->setAllowedTypes('stock_management', 'bool')
+            ->setAllowedTypes('in_stock_label', 'array')
+            ->setAllowedTypes('delivery_time', 'array')
+            ->setAllowedTypes('oos_allowed_backorders', 'array')
+            ->setAllowedTypes('oos_delivery_time', 'array')
+            ->setAllowedTypes('oos_denied_backorders', 'array')
+            ->setAllowedTypes('pack_stock_management', 'int')
+            ->setAllowedTypes('oos_show_label_listing_pages', 'bool')
+            ->setAllowedTypes('display_last_quantities', 'int')
+            ->setAllowedTypes('display_unavailable_attributes', 'bool');
     }
 }

--- a/src/Adapter/Upload/UploadQuotaConfiguration.php
+++ b/src/Adapter/Upload/UploadQuotaConfiguration.php
@@ -8,21 +8,25 @@ namespace PrestaShop\PrestaShop\Adapter\Upload;
 
 use Exception;
 use PrestaShop\PrestaShop\Adapter\Configuration;
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Manages the configuration data about upload quota options.
  */
-class UploadQuotaConfiguration implements DataConfigurationInterface
+class UploadQuotaConfiguration extends AbstractMultistoreConfiguration
 {
-    /**
-     * @var Configuration
-     */
-    private $configuration;
+    private const CONFIGURATION_FIELDS = [
+        'max_size_attached_files',
+        'max_size_downloadable_product',
+        'max_size_product_image',
+    ];
 
-    public function __construct(Configuration $configuration)
+    public function __construct(Configuration $configuration, Context $shopContext, FeatureInterface $multistoreFeature)
     {
-        $this->configuration = $configuration;
+        parent::__construct($configuration, $shopContext, $multistoreFeature);
     }
 
     /**
@@ -30,10 +34,12 @@ class UploadQuotaConfiguration implements DataConfigurationInterface
      */
     public function getConfiguration()
     {
+        $shopConstraint = $this->getShopConstraint();
+
         return [
-            'max_size_attached_files' => $this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE'),
-            'max_size_downloadable_product' => $this->configuration->get('PS_LIMIT_UPLOAD_FILE_VALUE'),
-            'max_size_product_image' => $this->configuration->get('PS_LIMIT_UPLOAD_IMAGE_VALUE'),
+            'max_size_attached_files' => (int) $this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE', 0, $shopConstraint),
+            'max_size_downloadable_product' => (int) $this->configuration->get('PS_LIMIT_UPLOAD_FILE_VALUE', 0, $shopConstraint),
+            'max_size_product_image' => (int) $this->configuration->get('PS_LIMIT_UPLOAD_IMAGE_VALUE', 0, $shopConstraint),
         ];
     }
 
@@ -61,6 +67,7 @@ class UploadQuotaConfiguration implements DataConfigurationInterface
     private function updateFileUploadConfiguration(array $configuration)
     {
         $uploadMaxSize = (int) str_replace('M', '', ini_get('upload_max_filesize'));
+        $shopConstraint = $this->getShopConstraint();
         $sizes = [
             'max_size_attached_files' => $uploadMaxSize,
             'max_size_downloadable_product' => (int) str_replace('M', '', ini_get('post_max_size')),
@@ -78,9 +85,11 @@ class UploadQuotaConfiguration implements DataConfigurationInterface
                     ];
                 }
 
-                $this->configuration->set(
+                $this->updateConfigurationValue(
                     $this->getConfigurationKey($configurationKey),
-                    max((int) $configurationValue, 1)
+                    $configurationKey,
+                    array_map(static fn ($value): int => max((int) $value, 1), $configuration),
+                    $shopConstraint
                 );
             }
         }
@@ -109,12 +118,12 @@ class UploadQuotaConfiguration implements DataConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function validateConfiguration(array $configuration)
+    protected function buildResolver(): OptionsResolver
     {
-        return isset(
-            $configuration['max_size_attached_files'],
-            $configuration['max_size_downloadable_product'],
-            $configuration['max_size_product_image']
-        );
+        return (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('max_size_attached_files', 'int')
+            ->setAllowedTypes('max_size_downloadable_product', 'int')
+            ->setAllowedTypes('max_size_product_image', 'int');
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
@@ -7,8 +7,10 @@
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration;
 
 use PrestaShop\PrestaShop\Core\Http\CookieOptions;
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Form\Extension\MultistoreConfigurationTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -29,21 +31,25 @@ class GeneralType extends TranslatorAwareType
             ->add('check_ip_address', SwitchType::class, [
                 'label' => $this->trans('Check the cookie\'s IP address', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('Check the IP address of the cookie in order to prevent your cookie from being stolen.', 'Admin.Advparameters.Help'),
+                'multistore_configuration_key' => 'PS_COOKIE_CHECKIP',
             ])
             ->add(self::FIELD_FRONT_COOKIE_LIFETIME, IntegerType::class, [
                 'label' => $this->trans('Lifetime of front office cookies', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('Set the amount of hours during which the front office cookies are valid. After that amount of time, the customer will have to log in again.', 'Admin.Advparameters.Help'),
                 'unit' => $this->trans('hours', 'Admin.Shopparameters.Feature'),
+                'multistore_configuration_key' => 'PS_COOKIE_LIFETIME_FO',
             ])
             ->add(self::FIELD_BACK_COOKIE_LIFETIME, IntegerType::class, [
                 'label' => $this->trans('Lifetime of back office cookies', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('When you access your back office and decide to stay logged in, your cookies lifetime defines your browser session. Set here the number of hours during which you want them valid before logging in again.', 'Admin.Advparameters.Help'),
                 'unit' => $this->trans('hours', 'Admin.Shopparameters.Feature'),
+                'multistore_configuration_key' => 'PS_COOKIE_LIFETIME_BO',
             ])
             ->add(self::FIELD_COOKIE_SAMESITE, ChoiceType::class, [
                 'label' => $this->trans('Cookie SameSite', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('Allows you to declare if your cookie should be restricted to a first-party or same-site context.', 'Admin.Advparameters.Help'),
                 'choices' => CookieOptions::SAMESITE_AVAILABLE_VALUES,
+                'multistore_configuration_key' => 'PS_COOKIE_SAMESITE',
             ]);
     }
 
@@ -63,5 +69,15 @@ class GeneralType extends TranslatorAwareType
     public function getBlockPrefix()
     {
         return 'administration_general_block';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/NotificationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/NotificationsType.php
@@ -6,8 +6,10 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration;
 
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Form\Extension\MultistoreConfigurationTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -21,12 +23,15 @@ class NotificationsType extends TranslatorAwareType
         $builder
             ->add('show_notifs_new_orders', SwitchType::class, [
                 'label' => $this->trans('Show notifications for new orders', 'Admin.Advparameters.Feature'),
+                'multistore_configuration_key' => 'PS_SHOW_NEW_ORDERS',
             ])
             ->add('show_notifs_new_customers', SwitchType::class, [
                 'label' => $this->trans('Show notifications for new customers', 'Admin.Advparameters.Feature'),
+                'multistore_configuration_key' => 'PS_SHOW_NEW_CUSTOMERS',
             ])
             ->add('show_notifs_new_messages', SwitchType::class, [
                 'label' => $this->trans('Show notifications for new messages', 'Admin.Advparameters.Feature'),
+                'multistore_configuration_key' => 'PS_SHOW_NEW_MESSAGES',
             ]);
     }
 
@@ -46,5 +51,15 @@ class NotificationsType extends TranslatorAwareType
     public function getBlockPrefix()
     {
         return 'administration_notification_block';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
@@ -8,7 +8,9 @@ namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administratio
 
 use PrestaShop\PrestaShop\Core\Configuration\UploadSizeConfigurationInterface;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Form\Extension\MultistoreConfigurationTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -76,6 +78,7 @@ class UploadQuotaType extends TranslatorAwareType
                             ]
                         ),
                     ],
+                    'multistore_configuration_key' => 'PS_ATTACHMENT_MAXIMUM_SIZE',
                 ]
             )
             ->add(
@@ -108,6 +111,7 @@ class UploadQuotaType extends TranslatorAwareType
                             ]
                         ),
                     ],
+                    'multistore_configuration_key' => 'PS_LIMIT_UPLOAD_FILE_VALUE',
                 ]
             )
             ->add(
@@ -140,6 +144,7 @@ class UploadQuotaType extends TranslatorAwareType
                         ),
                     ],
                     'unit' => $this->trans('megabytes', 'Admin.Advparameters.Feature'),
+                    'multistore_configuration_key' => 'PS_LIMIT_UPLOAD_IMAGE_VALUE',
                 ]
             );
     }
@@ -160,5 +165,15 @@ class UploadQuotaType extends TranslatorAwareType
     public function getBlockPrefix()
     {
         return 'administration_upload_quota_block';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -9,8 +9,10 @@ namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreference
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
 use PrestaShopBundle\Form\Admin\Sell\Product\Pricing\SpecificPricePriorityType;
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Form\Extension\MultistoreConfigurationTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -55,6 +57,7 @@ class GeneralType extends TranslatorAwareType
                     'Admin.Shopparameters.Help'
                 ),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_CATALOG_MODE',
             ])
             ->add('catalog_mode_with_prices', SwitchType::class, [
                 'label' => $this->trans('Show prices', 'Admin.Shopparameters.Feature'),
@@ -76,6 +79,7 @@ class GeneralType extends TranslatorAwareType
                     'class' => 'catalog-mode-option',
                 ],
                 'required' => false,
+                'multistore_configuration_key' => 'PS_CATALOG_MODE_WITH_PRICES',
             ])
             ->add('new_days_number', IntegerType::class, [
                 'label' => $this->trans(
@@ -83,6 +87,7 @@ class GeneralType extends TranslatorAwareType
                     'Admin.Shopparameters.Feature'
                 ),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_NB_DAYS_NEW_PRODUCT',
             ])
             ->add('short_description_limit', IntegerType::class, [
                 'label' => $this->trans(
@@ -91,6 +96,7 @@ class GeneralType extends TranslatorAwareType
                 ),
                 'required' => false,
                 'unit' => $this->trans('characters', 'Admin.Shopparameters.Help'),
+                'multistore_configuration_key' => 'PS_PRODUCT_SHORT_DESC_LIMIT',
             ])
             ->add('quantity_discount', ChoiceType::class, [
                 'label' => $this->trans(
@@ -108,6 +114,7 @@ class GeneralType extends TranslatorAwareType
                 'choice_translation_domain' => 'Admin.Global',
                 'placeholder' => false,
                 'required' => false,
+                'multistore_configuration_key' => 'PS_QTY_DISCOUNT_ON_COMBINATION',
             ])
             ->add('force_friendly_url', SwitchType::class, [
                 'label' => $this->trans(
@@ -119,6 +126,7 @@ class GeneralType extends TranslatorAwareType
                     'Admin.Shopparameters.Help'
                 ),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_FORCE_FRIENDLY_PRODUCT',
             ])
             ->add('product_breadcrumb_category', ChoiceType::class, [
                 'label' => $this->trans(
@@ -136,6 +144,7 @@ class GeneralType extends TranslatorAwareType
                     'Admin.Shopparameters.Help'
                 ),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_PRODUCT_BREADCRUMB_CATEGORY',
             ])
             ->add('default_status', SwitchType::class, [
                 'label' => $this->trans(
@@ -147,6 +156,7 @@ class GeneralType extends TranslatorAwareType
                     'Admin.Shopparameters.Help'
                 ),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_PRODUCT_ACTIVATION_DEFAULT',
             ])
             ->add('specific_price_priorities', SpecificPricePriorityType::class, [
                 'label' => $this->trans(
@@ -178,6 +188,7 @@ class GeneralType extends TranslatorAwareType
                 'choice_translation_domain' => 'Admin.Global',
                 'placeholder' => false,
                 'required' => false,
+                'multistore_configuration_key' => 'PS_PRODUCT_REDIRECTION_DEFAULT',
             ])
         ;
     }
@@ -198,5 +209,15 @@ class GeneralType extends TranslatorAwareType
     public function getBlockPrefix()
     {
         return 'product_preferences_general_block';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -6,8 +6,10 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences;
 
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Form\Extension\MultistoreConfigurationTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -30,6 +32,7 @@ class PageType extends TranslatorAwareType
                     'Admin.Shopparameters.Feature'
                 ),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_DISPLAY_QTIES',
             ])
             ->add('allow_add_variant_to_cart_from_listing', SwitchType::class, [
                 'label' => $this->trans(
@@ -48,6 +51,7 @@ class PageType extends TranslatorAwareType
                     []
                 ),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_ATTRIBUTE_CATEGORY_DISPLAY',
             ])
             ->add('use_combination_image_in_listing', SwitchType::class, [
                 'label' => $this->trans(
@@ -59,6 +63,7 @@ class PageType extends TranslatorAwareType
                     'Admin.Shopparameters.Feature'
                 ),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_USE_COMBINATION_IMAGE_IN_LISTING',
             ])
             ->add('attribute_anchor_separator', ChoiceType::class, [
                 'label' => $this->trans(
@@ -72,6 +77,7 @@ class PageType extends TranslatorAwareType
                 'placeholder' => false,
                 'required' => false,
                 'choice_translation_domain' => 'Admin.Global',
+                'multistore_configuration_key' => 'PS_ATTRIBUTE_ANCHOR_SEPARATOR',
             ])
             ->add('display_discount_price', SwitchType::class, [
                 'label' => $this->trans(
@@ -83,6 +89,7 @@ class PageType extends TranslatorAwareType
                     'Admin.Shopparameters.Help'
                 ),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_DISPLAY_DISCOUNT_PRICE',
             ])
             ->add('display_amount_in_cart', SwitchType::class, [
                 'label' => $this->trans(
@@ -94,6 +101,7 @@ class PageType extends TranslatorAwareType
                     'Admin.Shopparameters.Help'
                 ),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_DISPLAY_AMOUNT_IN_CART',
             ])
             ->add('feature_values_order', ChoiceType::class, [
                 'label' => $this->trans(
@@ -111,6 +119,7 @@ class PageType extends TranslatorAwareType
                 'choice_translation_domain' => 'Admin.Shopparameters.Feature',
                 'placeholder' => false,
                 'required' => false,
+                'multistore_configuration_key' => 'PS_FEATURE_VALUES_ORDER',
             ]);
     }
 
@@ -130,5 +139,15 @@ class PageType extends TranslatorAwareType
     public function getBlockPrefix()
     {
         return 'product_preferences_page_block';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
@@ -6,7 +6,9 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences;
 
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Form\Extension\MultistoreConfigurationTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -31,6 +33,7 @@ class PaginationType extends TranslatorAwareType
                 ),
                 'help' => $this->trans('Number of products displayed per page. Default is 12', 'Admin.Shopparameters.Help'),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_PRODUCTS_PER_PAGE',
             ])
             ->add('default_order_by', ChoiceType::class, [
                 'label' => $this->trans(
@@ -54,6 +57,7 @@ class PaginationType extends TranslatorAwareType
                 ],
                 'required' => false,
                 'placeholder' => false,
+                'multistore_configuration_key' => 'PS_PRODUCTS_ORDER_BY',
             ])
             ->add('default_order_way', ChoiceType::class, [
                 'label' => $this->trans(
@@ -67,6 +71,7 @@ class PaginationType extends TranslatorAwareType
                 'choice_translation_domain' => 'Admin.Global',
                 'required' => false,
                 'placeholder' => false,
+                'multistore_configuration_key' => 'PS_PRODUCTS_ORDER_WAY',
             ]);
     }
 
@@ -86,5 +91,15 @@ class PaginationType extends TranslatorAwareType
     public function getBlockPrefix()
     {
         return 'product_preferences_pagination_block';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/ProductPreferencesFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/ProductPreferencesFormHandler.php
@@ -25,14 +25,14 @@ class ProductPreferencesFormHandler extends Handler
      */
     public function save(array $data)
     {
+        if (isset($data['stock_management']) && !$data['stock_management']) {
+            $data['allow_ordering_oos'] = true;
+        }
+
         $errors = $this->formDataProvider->setData($data);
 
         if (empty($errors)) {
             $this->cacheClearer->clear();
-
-            if (isset($data['stock_management']) && !$data['stock_management']) {
-                $data['allow_ordering_oos'] = 1;
-            }
         }
 
         return parent::save($data);

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/ProductPreferencesFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/ProductPreferencesFormHandler.php
@@ -29,13 +29,13 @@ class ProductPreferencesFormHandler extends Handler
             $data['allow_ordering_oos'] = true;
         }
 
-        $errors = $this->formDataProvider->setData($data);
+        $errors = parent::save($data);
 
         if (empty($errors)) {
             $this->cacheClearer->clear();
         }
 
-        return parent::save($data);
+        return $errors;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
@@ -7,9 +7,11 @@
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackStockType;
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Form\Extension\MultistoreConfigurationTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -34,6 +36,7 @@ class StockType extends TranslatorAwareType
                     'Admin.Shopparameters.Feature'
                 ),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_STOCK_MANAGEMENT',
             ])
             ->add('pack_stock_management', ChoiceType::class, [
                 'label' => $this->trans(
@@ -52,6 +55,7 @@ class StockType extends TranslatorAwareType
                 'choice_translation_domain' => 'Admin.Catalog.Feature',
                 'required' => false,
                 'placeholder' => false,
+                'multistore_configuration_key' => 'PS_PACK_STOCK_TYPE',
             ])
             ->add('display_unavailable_attributes', SwitchType::class, [
                 'label' => $this->trans(
@@ -63,6 +67,7 @@ class StockType extends TranslatorAwareType
                     'Admin.Shopparameters.Help'
                 ),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_DISP_UNAVAILABLE_ATTR',
             ])
             ->add('display_last_quantities', IntegerType::class, [
                 'label' => $this->trans(
@@ -74,6 +79,7 @@ class StockType extends TranslatorAwareType
                     'Admin.Shopparameters.Help'
                 ),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_LAST_QTIES',
             ])
             ->add('allow_ordering_oos', SwitchType::class, [
                 'label' => $this->trans(
@@ -91,6 +97,7 @@ class StockType extends TranslatorAwareType
                     ]
                 ),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_ORDER_OUT_OF_STOCK',
             ])
             ->add('in_stock_label', TranslatableType::class, [
                 'label' => $this->trans(
@@ -106,6 +113,7 @@ class StockType extends TranslatorAwareType
                 ],
                 'required' => false,
                 'help' => $this->trans('This will be the default displayed availability of a product, if there is at least 1 in stock. If you don\'t enter anything, nothing will be displayed. Further customization is possible for each product.', 'Admin.Catalog.Help'),
+                'multistore_configuration_key' => 'PS_LABEL_IN_STOCK_PRODUCTS',
             ])
             ->add('oos_allowed_backorders', TranslatableType::class, [
                 'label' => $this->trans(
@@ -121,6 +129,7 @@ class StockType extends TranslatorAwareType
                 ],
                 'required' => false,
                 'help' => $this->trans('This will be the default displayed availability of a product, if it\'s not in stock and backordering it is enabled. If you don\'t enter anything, nothing will be displayed. Further customization is possible for each product.', 'Admin.Catalog.Help'),
+                'multistore_configuration_key' => 'PS_LABEL_OOS_PRODUCTS_BOA',
             ])
             ->add('oos_denied_backorders', TranslatableType::class, [
                 'label' => $this->trans(
@@ -136,6 +145,7 @@ class StockType extends TranslatorAwareType
                 ],
                 'required' => false,
                 'help' => $this->trans('This will be the default displayed availability of a product, if it\'s not in stock and backordering it is denied. If you don\'t enter anything, nothing will be displayed. Further customization is possible for each product.', 'Admin.Catalog.Help'),
+                'multistore_configuration_key' => 'PS_LABEL_OOS_PRODUCTS_BOD',
             ])
             ->add('delivery_time', TranslatableType::class, [
                 'label' => $this->trans(
@@ -157,6 +167,7 @@ class StockType extends TranslatorAwareType
                     ],
                 ],
                 'required' => false,
+                'multistore_configuration_key' => 'PS_LABEL_DELIVERY_TIME_AVAILABLE',
             ])
             ->add('oos_delivery_time', TranslatableType::class, [
                 'label' => $this->trans(
@@ -178,6 +189,7 @@ class StockType extends TranslatorAwareType
                     ],
                 ],
                 'required' => false,
+                'multistore_configuration_key' => 'PS_LABEL_DELIVERY_TIME_OOSBOA',
             ])
             ->add('oos_show_label_listing_pages', SwitchType::class, [
                 'label' => $this->trans(
@@ -189,6 +201,7 @@ class StockType extends TranslatorAwareType
                     'Admin.Shopparameters.Help'
                 ),
                 'required' => false,
+                'multistore_configuration_key' => 'PS_SHOW_LABEL_OOS_LISTING_PAGES',
             ]);
     }
 
@@ -208,5 +221,15 @@ class StockType extends TranslatorAwareType
     public function getBlockPrefix()
     {
         return 'product_preferences_stock_block';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/administration.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/administration.yml
@@ -8,7 +8,7 @@ admin_administration:
 
 admin_administration_general_save:
   path: /general
-  methods: [ POST ]
+  methods: [ PATCH, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\AdministrationController::processGeneralFormAction'
     _legacy_controller: AdminAdminPreferences
@@ -16,14 +16,14 @@ admin_administration_general_save:
 
 admin_administration_upload_quota_save:
   path: /upload-quota
-  methods: [ POST ]
+  methods: [ PATCH, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\AdministrationController::processUploadQuotaFormAction'
     _legacy_controller: AdminAdminPreferences
 
 admin_administration_notifications_save:
   path: /notifications
-  methods: [ POST ]
+  methods: [ PATCH, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\AdministrationController::processNotificationsFormAction'
     _legacy_controller: AdminAdminPreferences

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/product_preferences.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/product_preferences.yml
@@ -8,7 +8,7 @@ admin_product_preferences:
 
 admin_product_preferences_general_save:
   path: /general
-  methods: [ POST ]
+  methods: [ PATCH, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\ProductPreferencesController::processGeneralFormAction'
     _legacy_controller: AdminPPreferences
@@ -16,7 +16,7 @@ admin_product_preferences_general_save:
 
 admin_product_preferences_pagination_save:
   path: /pagination
-  methods: [ POST ]
+  methods: [ PATCH, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\ProductPreferencesController::processPaginationFormAction'
     _legacy_controller: AdminPPreferences
@@ -24,7 +24,7 @@ admin_product_preferences_pagination_save:
 
 admin_product_preferences_page_save:
   path: /page
-  methods: [ POST ]
+  methods: [ PATCH, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\ProductPreferencesController::processPageFormAction'
     _legacy_controller: AdminPPreferences
@@ -32,7 +32,7 @@ admin_product_preferences_page_save:
 
 admin_product_preferences_stock_save:
   path: /stock
-  methods: [ POST ]
+  methods: [ PATCH, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\ProductPreferencesController::processStockFormAction'
     _legacy_controller: AdminPPreferences

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -88,6 +88,8 @@ services:
     autowire: true
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
       - '@=service("prestashop.adapter.legacy.context").getContext().cookie'
 
   prestashop.adapter.maintenance.configuration:
@@ -103,11 +105,17 @@ services:
 
   prestashop.adapter.upload_quota.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Upload\UploadQuotaConfiguration'
-    arguments: [ '@prestashop.adapter.legacy.configuration' ]
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
 
   prestashop.adapter.notifications.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Admin\NotificationsConfiguration'
-    arguments: [ '@prestashop.adapter.legacy.configuration' ]
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
 
   prestashop.adapter.smarty_cache.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Smarty\SmartyCacheConfiguration'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -6,22 +6,30 @@ services:
     class: 'PrestaShop\PrestaShop\Adapter\Product\GeneralConfiguration'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
       - '@PrestaShop\PrestaShop\Adapter\Product\SpecificPrice\Update\SpecificPricePriorityUpdater'
 
   prestashop.adapter.product_pagination.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Product\PaginationConfiguration'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
 
   prestashop.adapter.product_page.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Product\PageConfiguration'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
 
   prestashop.adapter.product_stock.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Product\StockConfiguration'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
 
   prestashop.adapter.customer.customer_configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Customer\CustomerConfiguration'

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig
@@ -81,3 +81,9 @@
   {% endblock %}
   {{ form_end(notificationsForm) }}
 {% endblock %}
+
+{% block javascripts %}
+  {{ parent() }}
+
+  <script src="{{ asset('themes/new-theme/public/administration.bundle.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.2.x
| Description?      | This PR adds multistore support to two configuration sections:<br/><br/>- Advanced Parameters > Administration<br/>- Shop Parameters > Product Settings<br/><br/>The implementation follows the same multistore pattern already used in Shop Parameters > Order Settings, including form type integration, multistore configuration keys, route compatibility with PATCH, and frontend initialization for multistore fields.<br/><br/>It also fixes the allow_ordering_oosfallback in `ProductPreferencesFormHandler` by applying it before the save flow and forcing it to the boolean valuetruewhen stock management is disabled. This prevents the disabled field from reaching the configuration layer asnull, fixes the related form option type error, and avoids a duplicate save while keeping the existing save hook dispatch.
| Type?             | improvement 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |1. Enable multistore.<br/>2. Open `Advanced Parameters > Administration` in a single shop context and update some configuration values.<br/>3. Open `Shop Parameters > Product Settings` in a single shop context and update some configuration values.<br/>4. Check that multistore checkboxes are available and that the changes are saved only for the selected shop context.<br/><br/> **Note: recompilation of the `new-theme` admin theme assets is required.**
 | UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/29180993981
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | Codencode snc

---
~~**Note:**
The switch to `AbstractMultistoreConfiguration` also exposes a legacy compatibility issue in front office boolean checks. Some code paths still assume disabled configuration values are stored as 0, while the multistore configuration flow may persist false as `NULL`. As a result, comparisons such as `0 == Configuration::get('PS_DISP_UNAVAILABLE_ATTR')` no longer behave as expected. This currently happens in the product front controller:~~ https://github.com/PrestaShop/PrestaShop/blob/cec75f117d1045abfa9ca0c69f6222a9530ccada/controllers/front/ProductController.php#L743-L749<br/>
 ~~Adjusting the controller logic is safer than forcing `0` at storage level, since `NULL` storage matches the default AbstractMultistoreConfiguration behavior. This regression is visible in the failing UI test run: https://github.com/Codencode/ga.tests.ui.pr/actions/runs/25482359105/job/74769371860~~
