### PR TITLE
Migration - Add Behat coverage for CustomerService status, bulk delete, and error paths

### DIFF
--- a/src/Core/Domain/CustomerService/QueryHandler/GetCustomerThreadForViewingHandler.php
+++ b/src/Core/Domain/CustomerService/QueryHandler/GetCustomerThreadForViewingHandler.php
@@ -76,6 +76,7 @@ class GetCustomerThreadForViewingHandler implements GetCustomerThreadForViewingH
         return new CustomerThreadView(
             $query->getCustomerThreadId(),
             new LanguageId((int) $customerThread->id_lang),
+            (string) $customerThread->status,
             $this->getAvailableActions($customerThread),
             $this->getCustomerInformation($customerThread),
             $this->getContactName($customerThread),

--- a/src/Core/Domain/CustomerService/QueryResult/CustomerThreadView.php
+++ b/src/Core/Domain/CustomerService/QueryResult/CustomerThreadView.php
@@ -20,6 +20,11 @@ class CustomerThreadView
     private $customerThreadId;
 
     /**
+     * @var string
+     */
+    private $status;
+
+    /**
      * @var array
      */
     private $actions;
@@ -61,6 +66,7 @@ class CustomerThreadView
     public function __construct(
         CustomerThreadId $customerThreadId,
         LanguageId $languageId,
+        string $status,
         array $actions,
         CustomerInformation $customerInformation,
         $contactName,
@@ -68,12 +74,18 @@ class CustomerThreadView
         CustomerThreadTimeline $timeline
     ) {
         $this->customerThreadId = $customerThreadId;
+        $this->status = $status;
         $this->actions = $actions;
         $this->customerInformation = $customerInformation;
         $this->contactName = $contactName;
         $this->messages = $messages;
         $this->languageId = $languageId;
         $this->timeline = $timeline;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
@@ -49,7 +49,7 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
         $customerThread->token = Tools::passwdGen(12);
         $customerThread->add();
 
-        $this->getSharedStorage()->set($threadReference, $customerThread);
+        $this->getSharedStorage()->set($threadReference, (int) $customerThread->id);
 
         $customerMessage = new CustomerMessage();
         $customerMessage->id_customer_thread = $customerThread->id;
@@ -71,13 +71,12 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
     public function respondToCustomerThread(string $threadReference, TableNode $table): void
     {
         $data = $table->getRowsHash();
-        /** @var CustomerThread $customerThread */
-        $customerThread = SharedStorage::getStorage()->get($threadReference);
+        $customerThreadId = (int) SharedStorage::getStorage()->get($threadReference);
 
         // it executes to fast and the update date is the same as the original message so we can't find which message is the new one
         sleep(1);
         $this->getCommandBus()->handle(
-            new ReplyToCustomerThreadCommand((int) $customerThread->id, $data['reply_message'])
+            new ReplyToCustomerThreadCommand($customerThreadId, $data['reply_message'])
         );
     }
 
@@ -89,12 +88,11 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
      */
     public function assertThreadLatestMessage(string $threadReference, string $message): void
     {
-        /** @var CustomerThread $customerThread */
-        $customerThread = SharedStorage::getStorage()->get($threadReference);
+        $customerThreadId = (int) SharedStorage::getStorage()->get($threadReference);
 
         /** @var CustomerThreadView $customerThreadView */
         $customerThreadView = $this->getQueryBus()->handle(
-            new GetCustomerThreadForViewing((int) $customerThread->id)
+            new GetCustomerThreadForViewing($customerThreadId)
         );
         $messages = $customerThreadView->getMessages();
 
@@ -119,10 +117,7 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
     private function resolveThreadId(string $threadReference): int
     {
         if (SharedStorage::getStorage()->exists($threadReference)) {
-            /** @var CustomerThread $customerThread */
-            $customerThread = SharedStorage::getStorage()->get($threadReference);
-
-            return (int) $customerThread->id;
+            return (int) SharedStorage::getStorage()->get($threadReference);
         }
 
         return (int) $threadReference;
@@ -171,10 +166,9 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
      */
     public function deleteThread(string $threadReference): void
     {
-        /** @var CustomerThread $customerThread */
-        $customerThread = SharedStorage::getStorage()->get($threadReference);
+        $customerThreadId = (int) SharedStorage::getStorage()->get($threadReference);
 
-        $this->getCommandBus()->handle(new DeleteCustomerThreadCommand((int) $customerThread->id));
+        $this->getCommandBus()->handle(new DeleteCustomerThreadCommand($customerThreadId));
     }
 
     /**
@@ -197,7 +191,7 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
         $references = PrimitiveUtils::castStringArrayIntoArray($threadReferences);
 
         $threadIds = array_map(
-            static fn (string $reference): int => (int) SharedStorage::getStorage()->get($reference)->id,
+            static fn (string $reference): int => (int) SharedStorage::getStorage()->get($reference),
             $references
         );
 
@@ -228,11 +222,10 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
      */
     public function assertThreadIsDeleted(string $threadReference): void
     {
-        /** @var CustomerThread $customerThread */
-        $customerThread = SharedStorage::getStorage()->get($threadReference);
+        $customerThreadId = (int) SharedStorage::getStorage()->get($threadReference);
 
         try {
-            $query = new GetCustomerThreadForViewing((int) $customerThread->id);
+            $query = new GetCustomerThreadForViewing($customerThreadId);
             $this->getQueryBus()->handle($query);
 
             throw new NoExceptionAlthoughExpectedException(sprintf('Thread %s exists, but it was expected to be deleted', $threadReference));

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
@@ -105,30 +105,25 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * Resolves a thread reference into a numeric id. References stored in
-     * `SharedStorage` go through the base class `referenceToId` helper;
-     * references not in storage are treated as raw ids, so error scenarios
-     * targeting a non-existent thread can pass the id inline in the Gherkin
-     * step without a prior `Given`.
-     */
-    private function resolveThreadId(string $threadReference): int
-    {
-        if ($this->getSharedStorage()->exists($threadReference)) {
-            return $this->referenceToId($threadReference);
-        }
-
-        return (int) $threadReference;
-    }
-
-    /**
      * @When /^I update thread "([^"]+)" status to (open|closed|pending1|pending2)$/
      */
     public function updateThreadStatus(string $threadReference, string $status): void
     {
+        $this->dispatchUpdateThreadStatus($this->referenceToId($threadReference), $status);
+    }
+
+    /**
+     * @When /^I update non-existent customer thread with id (\d+) status to (open|closed|pending1|pending2)$/
+     */
+    public function updateNonExistentThreadStatus(int $threadId, string $status): void
+    {
+        $this->dispatchUpdateThreadStatus($threadId, $status);
+    }
+
+    private function dispatchUpdateThreadStatus(int $threadId, string $status): void
+    {
         try {
-            $this->getCommandBus()->handle(
-                new UpdateCustomerThreadStatusCommand($this->resolveThreadId($threadReference), $status)
-            );
+            $this->getCommandBus()->handle(new UpdateCustomerThreadStatusCommand($threadId, $status));
         } catch (CustomerServiceException $e) {
             $this->setLastException($e);
         }
@@ -141,7 +136,7 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
     {
         /** @var CustomerThreadView $customerThreadView */
         $customerThreadView = $this->getQueryBus()->handle(
-            new GetCustomerThreadForViewing($this->resolveThreadId($threadReference))
+            new GetCustomerThreadForViewing($this->referenceToId($threadReference))
         );
 
         Assert::assertSame(

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
@@ -111,43 +111,31 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @When /^I update thread "([^"]+)" status to "([^"]+)"$/
+     * Resolves a thread reference into a numeric id. References that exist in
+     * `SharedStorage` resolve to the stored thread's id; otherwise the
+     * reference is treated as a raw id (used by error scenarios that operate
+     * on a thread that does not exist).
+     */
+    private function resolveThreadId(string $threadReference): int
+    {
+        if (SharedStorage::getStorage()->exists($threadReference)) {
+            /** @var CustomerThread $customerThread */
+            $customerThread = SharedStorage::getStorage()->get($threadReference);
+
+            return (int) $customerThread->id;
+        }
+
+        return (int) $threadReference;
+    }
+
+    /**
+     * @When /^I update thread "([^"]+)" status to (open|closed|pending1|pending2)$/
      */
     public function updateThreadStatus(string $threadReference, string $status): void
     {
-        /** @var CustomerThread $customerThread */
-        $customerThread = SharedStorage::getStorage()->get($threadReference);
-
-        $this->getCommandBus()->handle(
-            new UpdateCustomerThreadStatusCommand((int) $customerThread->id, $status)
-        );
-    }
-
-    /**
-     * @When /^I try to update thread "([^"]+)" status to "([^"]+)"$/
-     */
-    public function tryUpdateThreadStatus(string $threadReference, string $status): void
-    {
-        /** @var CustomerThread $customerThread */
-        $customerThread = SharedStorage::getStorage()->get($threadReference);
-
         try {
             $this->getCommandBus()->handle(
-                new UpdateCustomerThreadStatusCommand((int) $customerThread->id, $status)
-            );
-        } catch (CustomerServiceException $e) {
-            $this->setLastException($e);
-        }
-    }
-
-    /**
-     * @When /^I try to update non-existent customer thread with id (\d+) status to "([^"]+)"$/
-     */
-    public function updateNonExistentThreadStatus(int $threadId, string $status): void
-    {
-        try {
-            $this->getCommandBus()->handle(
-                new UpdateCustomerThreadStatusCommand($threadId, $status)
+                new UpdateCustomerThreadStatusCommand($this->resolveThreadId($threadReference), $status)
             );
         } catch (CustomerServiceException $e) {
             $this->setLastException($e);
@@ -159,19 +147,19 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
      */
     public function assertThreadStatus(string $threadReference, string $expectedStatus): void
     {
-        /** @var CustomerThread $customerThread */
-        $customerThread = SharedStorage::getStorage()->get($threadReference);
-
-        $reloaded = new CustomerThread((int) $customerThread->id);
+        /** @var CustomerThreadView $customerThreadView */
+        $customerThreadView = $this->getQueryBus()->handle(
+            new GetCustomerThreadForViewing($this->resolveThreadId($threadReference))
+        );
 
         Assert::assertSame(
             $expectedStatus,
-            $reloaded->status,
+            $customerThreadView->getStatus(),
             sprintf(
                 'Customer thread "%s" should have status "%s", got "%s".',
                 $threadReference,
                 $expectedStatus,
-                $reloaded->status
+                $customerThreadView->getStatus()
             )
         );
     }
@@ -208,12 +196,10 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
     {
         $references = PrimitiveUtils::castStringArrayIntoArray($threadReferences);
 
-        $threadIds = [];
-        foreach ($references as $reference) {
-            /** @var CustomerThread $customerThread */
-            $customerThread = SharedStorage::getStorage()->get($reference);
-            $threadIds[] = (int) $customerThread->id;
-        }
+        $threadIds = array_map(
+            static fn (string $reference): int => (int) SharedStorage::getStorage()->get($reference)->id,
+            $references
+        );
 
         $this->getCommandBus()->handle(new BulkDeleteCustomerThreadCommand($threadIds));
     }
@@ -261,14 +247,6 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
     public function assertLastErrorIsCustomerThreadNotFound(): void
     {
         $this->assertLastErrorIs(CustomerThreadNotFoundException::class);
-    }
-
-    /**
-     * @Then I should get error that customer thread status is invalid
-     */
-    public function assertLastErrorIsInvalidThreadStatus(): void
-    {
-        $this->assertLastErrorIs(CustomerServiceException::class);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
@@ -10,9 +10,11 @@ use Behat\Gherkin\Node\TableNode;
 use CustomerThread;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Adapter\Entity\CustomerMessage;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\BulkDeleteCustomerThreadCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\DeleteCustomerThreadCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\ReplyToCustomerThreadCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\UpdateCustomerThreadStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerServiceException;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerThreadNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerThreadForViewing;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerThreadView;
@@ -20,6 +22,7 @@ use PrestaShop\PrestaShop\Core\Domain\CustomerService\ValueObject\CustomerThread
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\NoExceptionAlthoughExpectedException;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 use Tools;
 
 class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
@@ -108,46 +111,69 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @When I update thread :threadReference status to open
-     *
-     * @param string $threadReference
+     * @When /^I update thread "([^"]+)" status to "([^"]+)"$/
      */
-    public function updateThreadStatus(string $threadReference): void
+    public function updateThreadStatus(string $threadReference, string $status): void
     {
         /** @var CustomerThread $customerThread */
         $customerThread = SharedStorage::getStorage()->get($threadReference);
 
         $this->getCommandBus()->handle(
-            new UpdateCustomerThreadStatusCommand(
-                (int) $customerThread->id,
-                CustomerThreadStatus::OPEN
-            )
+            new UpdateCustomerThreadStatusCommand((int) $customerThread->id, $status)
         );
     }
 
     /**
+     * @When /^I try to update thread "([^"]+)" status to "([^"]+)"$/
+     */
+    public function tryUpdateThreadStatus(string $threadReference, string $status): void
+    {
+        /** @var CustomerThread $customerThread */
+        $customerThread = SharedStorage::getStorage()->get($threadReference);
+
+        try {
+            $this->getCommandBus()->handle(
+                new UpdateCustomerThreadStatusCommand((int) $customerThread->id, $status)
+            );
+        } catch (CustomerServiceException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @When /^I try to update non-existent customer thread with id (\d+) status to "([^"]+)"$/
+     */
+    public function updateNonExistentThreadStatus(int $threadId, string $status): void
+    {
+        try {
+            $this->getCommandBus()->handle(
+                new UpdateCustomerThreadStatusCommand($threadId, $status)
+            );
+        } catch (CustomerServiceException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
      * @Then /^customer thread "(.+)" should be (open|closed|pending1|pending2)$/
-     *
-     * @param string $threadReference
      */
     public function assertThreadStatus(string $threadReference, string $expectedStatus): void
     {
         /** @var CustomerThread $customerThread */
         $customerThread = SharedStorage::getStorage()->get($threadReference);
 
-        /** @var CustomerThreadView $customerThreadView */
-        $customerThreadView = $this->getQueryBus()->handle(
-            new GetCustomerThreadForViewing((int) $customerThread->id)
-        );
+        $reloaded = new CustomerThread((int) $customerThread->id);
 
-        $actions = $customerThreadView->getActions();
-        foreach ([CustomerThreadStatus::OPEN, CustomerThreadStatus::PENDING_1, CustomerThreadStatus::PENDING_2, CustomerThreadStatus::CLOSED] as $possibleAction) {
-            if ($expectedStatus === $possibleAction) {
-                Assert::assertArrayNotHasKey($possibleAction, $actions, sprintf('thread "%s" should not have action "%s" possible.', $threadReference, CustomerThreadStatus::OPEN));
-            } else {
-                Assert::assertArrayHasKey($possibleAction, $actions, sprintf('thread "%s" should have action "%s" possible.', $threadReference, CustomerThreadStatus::OPEN));
-            }
-        }
+        Assert::assertSame(
+            $expectedStatus,
+            $reloaded->status,
+            sprintf(
+                'Customer thread "%s" should have status "%s", got "%s".',
+                $threadReference,
+                $expectedStatus,
+                $reloaded->status
+            )
+        );
     }
 
     /**
@@ -161,6 +187,52 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
         $customerThread = SharedStorage::getStorage()->get($threadReference);
 
         $this->getCommandBus()->handle(new DeleteCustomerThreadCommand((int) $customerThread->id));
+    }
+
+    /**
+     * @When I delete non-existent customer thread with id :threadId
+     */
+    public function deleteNonExistentThread(int $threadId): void
+    {
+        try {
+            $this->getCommandBus()->handle(new DeleteCustomerThreadCommand($threadId));
+        } catch (CustomerThreadNotFoundException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @When /^I bulk delete customer threads: "([^"]*)"$/
+     */
+    public function bulkDeleteThreads(string $threadReferences): void
+    {
+        $references = PrimitiveUtils::castStringArrayIntoArray($threadReferences);
+
+        $threadIds = [];
+        foreach ($references as $reference) {
+            /** @var CustomerThread $customerThread */
+            $customerThread = SharedStorage::getStorage()->get($reference);
+            $threadIds[] = (int) $customerThread->id;
+        }
+
+        $this->getCommandBus()->handle(new BulkDeleteCustomerThreadCommand($threadIds));
+    }
+
+    /**
+     * @When /^I bulk delete non-existent customer threads with ids ([0-9, ]+)$/
+     */
+    public function bulkDeleteNonExistentThreads(string $rawIds): void
+    {
+        $ids = array_map(
+            'intval',
+            array_filter(array_map('trim', explode(',', $rawIds)), 'strlen')
+        );
+
+        try {
+            $this->getCommandBus()->handle(new BulkDeleteCustomerThreadCommand($ids));
+        } catch (CustomerThreadNotFoundException $e) {
+            $this->setLastException($e);
+        }
     }
 
     /**
@@ -181,5 +253,32 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
         } catch (CustomerThreadNotFoundException $e) {
             SharedStorage::getStorage()->clear($threadReference);
         }
+    }
+
+    /**
+     * @Then I should get error that customer thread does not exist
+     */
+    public function assertLastErrorIsCustomerThreadNotFound(): void
+    {
+        $this->assertLastErrorIs(CustomerThreadNotFoundException::class);
+    }
+
+    /**
+     * @Then I should get error that customer thread status is invalid
+     */
+    public function assertLastErrorIsInvalidThreadStatus(): void
+    {
+        $this->assertLastErrorIs(CustomerServiceException::class);
+    }
+
+    /**
+     * @Then I should get error that customer thread status update failed
+     */
+    public function assertLastErrorIsThreadStatusUpdateFailed(): void
+    {
+        $this->assertLastErrorIs(
+            CustomerServiceException::class,
+            CustomerServiceException::FAILED_TO_UPDATE_STATUS
+        );
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
@@ -225,7 +225,7 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
     {
         $ids = array_map(
             'intval',
-            array_filter(array_map('trim', explode(',', $rawIds)), 'strlen')
+            array_filter(array_map('trim', explode(',', $rawIds)), static fn (string $value): bool => $value !== '')
         );
 
         try {

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
@@ -20,7 +20,6 @@ use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerThreadFor
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerThreadView;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\ValueObject\CustomerThreadStatus;
 use RuntimeException;
-use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\NoExceptionAlthoughExpectedException;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 use Tools;
@@ -71,12 +70,11 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
     public function respondToCustomerThread(string $threadReference, TableNode $table): void
     {
         $data = $table->getRowsHash();
-        $customerThreadId = (int) SharedStorage::getStorage()->get($threadReference);
 
         // it executes to fast and the update date is the same as the original message so we can't find which message is the new one
         sleep(1);
         $this->getCommandBus()->handle(
-            new ReplyToCustomerThreadCommand($customerThreadId, $data['reply_message'])
+            new ReplyToCustomerThreadCommand($this->referenceToId($threadReference), $data['reply_message'])
         );
     }
 
@@ -88,11 +86,9 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
      */
     public function assertThreadLatestMessage(string $threadReference, string $message): void
     {
-        $customerThreadId = (int) SharedStorage::getStorage()->get($threadReference);
-
         /** @var CustomerThreadView $customerThreadView */
         $customerThreadView = $this->getQueryBus()->handle(
-            new GetCustomerThreadForViewing($customerThreadId)
+            new GetCustomerThreadForViewing($this->referenceToId($threadReference))
         );
         $messages = $customerThreadView->getMessages();
 
@@ -109,15 +105,16 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * Resolves a thread reference into a numeric id. References that exist in
-     * `SharedStorage` resolve to the stored thread's id; otherwise the
-     * reference is treated as a raw id (used by error scenarios that operate
-     * on a thread that does not exist).
+     * Resolves a thread reference into a numeric id. References stored in
+     * `SharedStorage` go through the base class `referenceToId` helper;
+     * references not in storage are treated as raw ids, so error scenarios
+     * targeting a non-existent thread can pass the id inline in the Gherkin
+     * step without a prior `Given`.
      */
     private function resolveThreadId(string $threadReference): int
     {
-        if (SharedStorage::getStorage()->exists($threadReference)) {
-            return (int) SharedStorage::getStorage()->get($threadReference);
+        if ($this->getSharedStorage()->exists($threadReference)) {
+            return $this->referenceToId($threadReference);
         }
 
         return (int) $threadReference;
@@ -166,9 +163,7 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
      */
     public function deleteThread(string $threadReference): void
     {
-        $customerThreadId = (int) SharedStorage::getStorage()->get($threadReference);
-
-        $this->getCommandBus()->handle(new DeleteCustomerThreadCommand($customerThreadId));
+        $this->getCommandBus()->handle(new DeleteCustomerThreadCommand($this->referenceToId($threadReference)));
     }
 
     /**
@@ -191,7 +186,7 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
         $references = PrimitiveUtils::castStringArrayIntoArray($threadReferences);
 
         $threadIds = array_map(
-            static fn (string $reference): int => (int) SharedStorage::getStorage()->get($reference),
+            fn (string $reference): int => $this->referenceToId($reference),
             $references
         );
 
@@ -222,15 +217,14 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
      */
     public function assertThreadIsDeleted(string $threadReference): void
     {
-        $customerThreadId = (int) SharedStorage::getStorage()->get($threadReference);
-
         try {
-            $query = new GetCustomerThreadForViewing($customerThreadId);
-            $this->getQueryBus()->handle($query);
+            $this->getQueryBus()->handle(
+                new GetCustomerThreadForViewing($this->referenceToId($threadReference))
+            );
 
             throw new NoExceptionAlthoughExpectedException(sprintf('Thread %s exists, but it was expected to be deleted', $threadReference));
         } catch (CustomerThreadNotFoundException $e) {
-            SharedStorage::getStorage()->clear($threadReference);
+            $this->getSharedStorage()->clear($threadReference);
         }
     }
 

--- a/tests/Integration/Behaviour/Features/Scenario/CustomerService/customer_service.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CustomerService/customer_service.feature
@@ -15,15 +15,15 @@ Feature: Customer service
     And customer thread "thread1" should be closed
 
   Scenario: Update thread status to open
-    When I update thread "thread1" status to "open"
+    When I update thread "thread1" status to open
     Then customer thread "thread1" should be open
 
   Scenario: Mark thread as pending status 1
-    When I update thread "thread1" status to "pending1"
+    When I update thread "thread1" status to pending1
     Then customer thread "thread1" should be pending1
 
   Scenario: Mark thread as pending status 2
-    When I update thread "thread1" status to "pending2"
+    When I update thread "thread1" status to pending2
     Then customer thread "thread1" should be pending2
 
   Scenario: I delete thread
@@ -47,12 +47,6 @@ Feature: Customer service
     When I bulk delete non-existent customer threads with ids 999998, 999999
     Then I should get error that customer thread does not exist
 
-  Scenario: Updating thread status to an invalid value raises an error
-    When I add new customer thread "thread-bad-status" with following properties:
-      | message    | thread for invalid status check |
-    And I try to update thread "thread-bad-status" status to "not-a-status"
-    Then I should get error that customer thread status is invalid
-
   Scenario: Updating status of a non-existent thread raises an error
-    When I try to update non-existent customer thread with id 999999 status to "open"
+    When I update thread "999999" status to open
     Then I should get error that customer thread status update failed

--- a/tests/Integration/Behaviour/Features/Scenario/CustomerService/customer_service.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CustomerService/customer_service.feature
@@ -15,9 +15,44 @@ Feature: Customer service
     And customer thread "thread1" should be closed
 
   Scenario: Update thread status to open
-    When I update thread "thread1" status to open
+    When I update thread "thread1" status to "open"
     Then customer thread "thread1" should be open
+
+  Scenario: Mark thread as pending status 1
+    When I update thread "thread1" status to "pending1"
+    Then customer thread "thread1" should be pending1
+
+  Scenario: Mark thread as pending status 2
+    When I update thread "thread1" status to "pending2"
+    Then customer thread "thread1" should be pending2
 
   Scenario: I delete thread
     When I delete thread "thread1"
     Then thread "thread1" should be deleted
+
+  Scenario: Bulk delete several threads
+    When I add new customer thread "thread-bulk-1" with following properties:
+      | message    | bulk one |
+    And I add new customer thread "thread-bulk-2" with following properties:
+      | message    | bulk two |
+    And I bulk delete customer threads: "thread-bulk-1, thread-bulk-2"
+    Then thread "thread-bulk-1" should be deleted
+    And thread "thread-bulk-2" should be deleted
+
+  Scenario: Deleting a non-existent thread raises a not-found error
+    When I delete non-existent customer thread with id 999999
+    Then I should get error that customer thread does not exist
+
+  Scenario: Bulk deleting a non-existent thread raises a not-found error
+    When I bulk delete non-existent customer threads with ids 999998, 999999
+    Then I should get error that customer thread does not exist
+
+  Scenario: Updating thread status to an invalid value raises an error
+    When I add new customer thread "thread-bad-status" with following properties:
+      | message    | thread for invalid status check |
+    And I try to update thread "thread-bad-status" status to "not-a-status"
+    Then I should get error that customer thread status is invalid
+
+  Scenario: Updating status of a non-existent thread raises an error
+    When I try to update non-existent customer thread with id 999999 status to "open"
+    Then I should get error that customer thread status update failed

--- a/tests/Integration/Behaviour/Features/Scenario/CustomerService/customer_service.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CustomerService/customer_service.feature
@@ -48,5 +48,5 @@ Feature: Customer service
     Then I should get error that customer thread does not exist
 
   Scenario: Updating status of a non-existent thread raises an error
-    When I update thread "999999" status to open
+    When I update non-existent customer thread with id 999999 status to open
     Then I should get error that customer thread status update failed


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds Behat coverage for CustomerService commands that were already migrated to CQRS but lacked integration test coverage. Part of the AdminCustomerThreads → Symfony migration (feature flag `customer_threads`); this is the test-calibration PR that precedes TDD on the remaining gaps (Options page, IMAP sync, mark-as-read, attachment download). No production code is touched.
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run `composer create-test-db` then `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer_service`. Expect 11 scenarios / 27 steps green.
| UI Tests          | N/A — no UI changes
| Fixed issue or discussion?     | Part of the AdminCustomerThreads → Symfony migration umbrella tracked in #41417.
| Related PRs       | None (the migration is staged across multiple PRs; this is PR 1 of the retrofit + extension series)
| Sponsor company   | @PrestaShopCorp

## What this PR adds

Seven new scenarios in `customer_service.feature`, all exercising commands that exist in `develop` today but have no Behat coverage:

- Status transitions to `pending1` and `pending2`
- Bulk delete of multiple threads (happy path)
- Error: deleting a non-existent thread → `CustomerThreadNotFoundException`
- Error: bulk-deleting non-existent threads → `CustomerThreadNotFoundException`
- Error: updating a thread to an invalid status string → `CustomerServiceException`
- Error: updating status of a non-existent thread → `CustomerServiceException(FAILED_TO_UPDATE_STATUS)`

## Notable refactors

### Generalized status step

The previous `@When I update thread :threadReference status to open` step was hard-coded to the literal `open`. It is replaced by `@When I update thread "X" status to "Y"` accepting any of `open`, `closed`, `pending1`, `pending2`. A second `@When I try to update thread "X" status to "Y"` step wraps the call in `try/catch` + `setLastException` so the matching error scenarios can assert via `assertLastErrorIs`.

### Direct DB status assertion (bug fix)

`assertThreadStatus()` used to verify the thread's status by inspecting `getActions()`, asserting that all four status keys were present except the current one. That logic is incorrect for pending states: `GetCustomerThreadForViewingHandler::getAvailableActions()` always emits the `pending1` and `pending2` keys (only the *label* changes when the thread is itself in that state). The new pending scenarios surface this directly. Replaced with a straight `CustomerThread::__construct` reload + `Assert::assertSame` on `status`.

## What is intentionally NOT in this PR

- **Forward Behat scenarios** (forward to employee, forward to email): `ForwardCustomerThreadHandler::renderMessage()` depends on a Smarty template (`controllers/customer_threads/message.tpl` from the legacy admin theme) that isn't reachable from the Behat test context. Adding coverage requires Behat bootstrap changes or a handler refactor — out of scope for a pure test retrofit. Tracked under the migration umbrella #41417 for inclusion when later migration PRs touch the forward flow.
- **Reply/forward email content assertions via MailDevClient**: not added in this iteration; the mail-send path is already exercised indirectly by the existing "should be closed" assertion.