### PR TITLE
Migration - Add KPI strip and listing statistics to migrated Customer Service page

### DIFF
--- a/src/Adapter/CustomerService/QueryHandler/GetCustomerServiceListingStatisticsHandler.php
+++ b/src/Adapter/CustomerService/QueryHandler/GetCustomerServiceListingStatisticsHandler.php
@@ -8,12 +8,13 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\CustomerService\QueryHandler;
 
-use CustomerMessage;
-use CustomerThread;
+use Db;
 use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerServiceListingStatistics;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryHandler\GetCustomerServiceListingStatisticsHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerServiceListingStatistics;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\ValueObject\CustomerThreadStatus;
+use Shop;
 
 /**
  * @internal
@@ -23,13 +24,66 @@ final class GetCustomerServiceListingStatisticsHandler implements GetCustomerSer
 {
     public function handle(GetCustomerServiceListingStatistics $query): CustomerServiceListingStatistics
     {
+        $threadsByStatus = $this->countThreadsGroupedByStatus();
+        $messagesByAuthor = $this->countMessagesGroupedByAuthor();
+
         return new CustomerServiceListingStatistics(
-            CustomerThread::getTotalCustomerThreads(),
-            CustomerThread::getTotalCustomerThreads('status = "open"'),
-            CustomerThread::getTotalCustomerThreads('status IN ("pending1", "pending2")'),
-            CustomerThread::getTotalCustomerThreads('status = "closed"'),
-            CustomerMessage::getTotalCustomerMessages('id_employee = 0'),
-            CustomerMessage::getTotalCustomerMessages('id_employee != 0'),
+            array_sum($threadsByStatus),
+            $threadsByStatus[CustomerThreadStatus::OPEN] ?? 0,
+            ($threadsByStatus[CustomerThreadStatus::PENDING_1] ?? 0)
+                + ($threadsByStatus[CustomerThreadStatus::PENDING_2] ?? 0),
+            $threadsByStatus[CustomerThreadStatus::CLOSED] ?? 0,
+            $messagesByAuthor['customer'] ?? 0,
+            $messagesByAuthor['employee'] ?? 0,
         );
+    }
+
+    /**
+     * Aggregates customer threads by status with a single GROUP BY query so
+     * the page does not pay for one COUNT per status value.
+     *
+     * @return array<string, int>
+     */
+    private function countThreadsGroupedByStatus(): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT status, COUNT(*) AS count
+                FROM ' . _DB_PREFIX_ . 'customer_thread
+                WHERE 1' . Shop::addSqlRestriction() . '
+                GROUP BY status'
+        );
+
+        $counts = [];
+        foreach ($rows ?: [] as $row) {
+            $counts[(string) $row['status']] = (int) $row['count'];
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Aggregates customer messages by author kind (customer vs employee) in
+     * a single grouped query, joined to customer_thread so multi-shop
+     * scoping is preserved.
+     *
+     * @return array<string, int>
+     */
+    private function countMessagesGroupedByAuthor(): array
+    {
+        $rows = Db::getInstance()->executeS(
+            'SELECT IF(cm.id_employee = 0, "customer", "employee") AS author, COUNT(*) AS count
+                FROM ' . _DB_PREFIX_ . 'customer_message cm
+                LEFT JOIN ' . _DB_PREFIX_ . 'customer_thread ct
+                    ON cm.id_customer_thread = ct.id_customer_thread
+                WHERE 1' . Shop::addSqlRestriction() . '
+                GROUP BY author'
+        );
+
+        $counts = [];
+        foreach ($rows ?: [] as $row) {
+            $counts[(string) $row['author']] = (int) $row['count'];
+        }
+
+        return $counts;
     }
 }

--- a/src/Adapter/CustomerService/QueryHandler/GetCustomerServiceListingStatisticsHandler.php
+++ b/src/Adapter/CustomerService/QueryHandler/GetCustomerServiceListingStatisticsHandler.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\CustomerService\QueryHandler;
+
+use CustomerMessage;
+use CustomerThread;
+use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsQueryHandler;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerServiceListingStatistics;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryHandler\GetCustomerServiceListingStatisticsHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerServiceListingStatistics;
+
+/**
+ * @internal
+ */
+#[AsQueryHandler]
+final class GetCustomerServiceListingStatisticsHandler implements GetCustomerServiceListingStatisticsHandlerInterface
+{
+    public function handle(GetCustomerServiceListingStatistics $query): CustomerServiceListingStatistics
+    {
+        $total = CustomerThread::getTotalCustomerThreads();
+        $open = CustomerThread::getTotalCustomerThreads('status = "open"');
+        $pending = CustomerThread::getTotalCustomerThreads('status LIKE "%pending%"');
+
+        return new CustomerServiceListingStatistics(
+            $total,
+            $open,
+            $pending,
+            max(0, $total - $open - $pending),
+            CustomerMessage::getTotalCustomerMessages('id_employee = 0'),
+            CustomerMessage::getTotalCustomerMessages('id_employee != 0'),
+        );
+    }
+}

--- a/src/Adapter/CustomerService/QueryHandler/GetCustomerServiceListingStatisticsHandler.php
+++ b/src/Adapter/CustomerService/QueryHandler/GetCustomerServiceListingStatisticsHandler.php
@@ -23,15 +23,11 @@ final class GetCustomerServiceListingStatisticsHandler implements GetCustomerSer
 {
     public function handle(GetCustomerServiceListingStatistics $query): CustomerServiceListingStatistics
     {
-        $total = CustomerThread::getTotalCustomerThreads();
-        $open = CustomerThread::getTotalCustomerThreads('status = "open"');
-        $pending = CustomerThread::getTotalCustomerThreads('status LIKE "%pending%"');
-
         return new CustomerServiceListingStatistics(
-            $total,
-            $open,
-            $pending,
-            max(0, $total - $open - $pending),
+            CustomerThread::getTotalCustomerThreads(),
+            CustomerThread::getTotalCustomerThreads('status = "open"'),
+            CustomerThread::getTotalCustomerThreads('status IN ("pending1", "pending2")'),
+            CustomerThread::getTotalCustomerThreads('status = "closed"'),
             CustomerMessage::getTotalCustomerMessages('id_employee = 0'),
             CustomerMessage::getTotalCustomerMessages('id_employee != 0'),
         );

--- a/src/Adapter/Kpi/AbstractAdminStatsKpi.php
+++ b/src/Adapter/Kpi/AbstractAdminStatsKpi.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Kpi;
+
+use HelperKpi;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Base class for KPI tiles whose value is computed by the legacy
+ * `AdminStatsController` ajax endpoint and cached in `ConfigurationKPI`.
+ *
+ * Concrete subclasses only describe the tile (id, icon, color, translation
+ * keys, configuration keys); the common HelperKpi wiring lives here so the
+ * subclasses do not duplicate `render()`.
+ */
+abstract class AbstractAdminStatsKpi implements KpiInterface
+{
+    public function __construct(
+        protected readonly TranslatorInterface $translator,
+        protected readonly ConfigurationInterface $kpiConfiguration,
+        protected readonly string $sourceUrl,
+    ) {
+    }
+
+    public function render(): string
+    {
+        $helper = new HelperKpi();
+        $helper->id = $this->getId();
+        $helper->icon = $this->getIcon();
+        $helper->color = $this->getColor();
+        $helper->title = $this->getTitle();
+
+        $subtitle = $this->getSubtitle();
+        if (null !== $subtitle) {
+            $helper->subtitle = $subtitle;
+        }
+
+        $value = $this->kpiConfiguration->get($this->getValueConfigurationKey());
+        if (false !== $value) {
+            $helper->value = $value;
+        }
+
+        $helper->source = $this->sourceUrl;
+
+        $expireTimestamp = $this->kpiConfiguration->get($this->getExpireConfigurationKey());
+        $helper->refresh = false === $expireTimestamp || (int) $expireTimestamp < time();
+
+        return $helper->generate();
+    }
+
+    abstract protected function getId(): string;
+
+    abstract protected function getIcon(): string;
+
+    abstract protected function getColor(): string;
+
+    abstract protected function getTitle(): string;
+
+    abstract protected function getValueConfigurationKey(): string;
+
+    abstract protected function getExpireConfigurationKey(): string;
+
+    /**
+     * Optional subtitle (e.g. "30 days"). Override when the KPI needs one.
+     */
+    protected function getSubtitle(): ?string
+    {
+        return null;
+    }
+}

--- a/src/Adapter/Kpi/AverageMessageResponseTimeKpi.php
+++ b/src/Adapter/Kpi/AverageMessageResponseTimeKpi.php
@@ -39,7 +39,8 @@ final class AverageMessageResponseTimeKpi implements KpiInterface
         }
 
         $helper->source = $this->sourceUrl;
-        $helper->refresh = $this->kpiConfiguration->get('AVG_MSG_RESPONSE_TIME_EXPIRE') < time();
+        $expireTimestamp = $this->kpiConfiguration->get('AVG_MSG_RESPONSE_TIME_EXPIRE');
+        $helper->refresh = false === $expireTimestamp || (int) $expireTimestamp < time();
 
         return $helper->generate();
     }

--- a/src/Adapter/Kpi/AverageMessageResponseTimeKpi.php
+++ b/src/Adapter/Kpi/AverageMessageResponseTimeKpi.php
@@ -8,40 +8,43 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Kpi;
 
-use HelperKpi;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
-use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
-
 /**
  * Renders the average time elapsed between customer messages and employee replies over the last 30 days.
  */
-final class AverageMessageResponseTimeKpi implements KpiInterface
+final class AverageMessageResponseTimeKpi extends AbstractAdminStatsKpi
 {
-    public function __construct(
-        private readonly TranslatorInterface $translator,
-        private readonly ConfigurationInterface $kpiConfiguration,
-        private readonly string $sourceUrl,
-    ) {
+    protected function getId(): string
+    {
+        return 'box-age';
     }
 
-    public function render(): string
+    protected function getIcon(): string
     {
-        $helper = new HelperKpi();
-        $helper->id = 'box-age';
-        $helper->icon = 'access_time';
-        $helper->color = 'color2';
-        $helper->title = $this->translator->trans('Average Response Time', [], 'Admin.Catalog.Feature');
-        $helper->subtitle = $this->translator->trans('30 days', [], 'Admin.Global');
+        return 'access_time';
+    }
 
-        if (false !== $this->kpiConfiguration->get('AVG_MSG_RESPONSE_TIME')) {
-            $helper->value = $this->kpiConfiguration->get('AVG_MSG_RESPONSE_TIME');
-        }
+    protected function getColor(): string
+    {
+        return 'color2';
+    }
 
-        $helper->source = $this->sourceUrl;
-        $expireTimestamp = $this->kpiConfiguration->get('AVG_MSG_RESPONSE_TIME_EXPIRE');
-        $helper->refresh = false === $expireTimestamp || (int) $expireTimestamp < time();
+    protected function getTitle(): string
+    {
+        return $this->translator->trans('Average Response Time', [], 'Admin.Catalog.Feature');
+    }
 
-        return $helper->generate();
+    protected function getSubtitle(): ?string
+    {
+        return $this->translator->trans('30 days', [], 'Admin.Global');
+    }
+
+    protected function getValueConfigurationKey(): string
+    {
+        return 'AVG_MSG_RESPONSE_TIME';
+    }
+
+    protected function getExpireConfigurationKey(): string
+    {
+        return 'AVG_MSG_RESPONSE_TIME_EXPIRE';
     }
 }

--- a/src/Adapter/Kpi/AverageMessageResponseTimeKpi.php
+++ b/src/Adapter/Kpi/AverageMessageResponseTimeKpi.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Kpi;
+
+use HelperKpi;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Renders the average time elapsed between customer messages and employee replies over the last 30 days.
+ */
+final class AverageMessageResponseTimeKpi implements KpiInterface
+{
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+        private readonly ConfigurationInterface $kpiConfiguration,
+        private readonly string $sourceUrl,
+    ) {
+    }
+
+    public function render(): string
+    {
+        $helper = new HelperKpi();
+        $helper->id = 'box-age';
+        $helper->icon = 'access_time';
+        $helper->color = 'color2';
+        $helper->title = $this->translator->trans('Average Response Time', [], 'Admin.Catalog.Feature');
+        $helper->subtitle = $this->translator->trans('30 days', [], 'Admin.Global');
+
+        if (false !== $this->kpiConfiguration->get('AVG_MSG_RESPONSE_TIME')) {
+            $helper->value = $this->kpiConfiguration->get('AVG_MSG_RESPONSE_TIME');
+        }
+
+        $helper->source = $this->sourceUrl;
+        $helper->refresh = $this->kpiConfiguration->get('AVG_MSG_RESPONSE_TIME_EXPIRE') < time();
+
+        return $helper->generate();
+    }
+}

--- a/src/Adapter/Kpi/MessagesPerThreadKpi.php
+++ b/src/Adapter/Kpi/MessagesPerThreadKpi.php
@@ -39,7 +39,8 @@ final class MessagesPerThreadKpi implements KpiInterface
         }
 
         $helper->source = $this->sourceUrl;
-        $helper->refresh = $this->kpiConfiguration->get('MESSAGES_PER_THREAD_EXPIRE') < time();
+        $expireTimestamp = $this->kpiConfiguration->get('MESSAGES_PER_THREAD_EXPIRE');
+        $helper->refresh = false === $expireTimestamp || (int) $expireTimestamp < time();
 
         return $helper->generate();
     }

--- a/src/Adapter/Kpi/MessagesPerThreadKpi.php
+++ b/src/Adapter/Kpi/MessagesPerThreadKpi.php
@@ -8,40 +8,43 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Kpi;
 
-use HelperKpi;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
-use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
-
 /**
  * Renders the average number of messages exchanged per customer service thread over the last 30 days.
  */
-final class MessagesPerThreadKpi implements KpiInterface
+final class MessagesPerThreadKpi extends AbstractAdminStatsKpi
 {
-    public function __construct(
-        private readonly TranslatorInterface $translator,
-        private readonly ConfigurationInterface $kpiConfiguration,
-        private readonly string $sourceUrl,
-    ) {
+    protected function getId(): string
+    {
+        return 'box-messages-per-thread';
     }
 
-    public function render(): string
+    protected function getIcon(): string
     {
-        $helper = new HelperKpi();
-        $helper->id = 'box-messages-per-thread';
-        $helper->icon = 'content_copy';
-        $helper->color = 'color3';
-        $helper->title = $this->translator->trans('Messages per Thread', [], 'Admin.Catalog.Feature');
-        $helper->subtitle = $this->translator->trans('30 days', [], 'Admin.Global');
+        return 'content_copy';
+    }
 
-        if (false !== $this->kpiConfiguration->get('MESSAGES_PER_THREAD')) {
-            $helper->value = $this->kpiConfiguration->get('MESSAGES_PER_THREAD');
-        }
+    protected function getColor(): string
+    {
+        return 'color3';
+    }
 
-        $helper->source = $this->sourceUrl;
-        $expireTimestamp = $this->kpiConfiguration->get('MESSAGES_PER_THREAD_EXPIRE');
-        $helper->refresh = false === $expireTimestamp || (int) $expireTimestamp < time();
+    protected function getTitle(): string
+    {
+        return $this->translator->trans('Messages per Thread', [], 'Admin.Catalog.Feature');
+    }
 
-        return $helper->generate();
+    protected function getSubtitle(): ?string
+    {
+        return $this->translator->trans('30 days', [], 'Admin.Global');
+    }
+
+    protected function getValueConfigurationKey(): string
+    {
+        return 'MESSAGES_PER_THREAD';
+    }
+
+    protected function getExpireConfigurationKey(): string
+    {
+        return 'MESSAGES_PER_THREAD_EXPIRE';
     }
 }

--- a/src/Adapter/Kpi/MessagesPerThreadKpi.php
+++ b/src/Adapter/Kpi/MessagesPerThreadKpi.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Kpi;
+
+use HelperKpi;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Renders the average number of messages exchanged per customer service thread over the last 30 days.
+ */
+final class MessagesPerThreadKpi implements KpiInterface
+{
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+        private readonly ConfigurationInterface $kpiConfiguration,
+        private readonly string $sourceUrl,
+    ) {
+    }
+
+    public function render(): string
+    {
+        $helper = new HelperKpi();
+        $helper->id = 'box-messages-per-thread';
+        $helper->icon = 'content_copy';
+        $helper->color = 'color3';
+        $helper->title = $this->translator->trans('Messages per Thread', [], 'Admin.Catalog.Feature');
+        $helper->subtitle = $this->translator->trans('30 days', [], 'Admin.Global');
+
+        if (false !== $this->kpiConfiguration->get('MESSAGES_PER_THREAD')) {
+            $helper->value = $this->kpiConfiguration->get('MESSAGES_PER_THREAD');
+        }
+
+        $helper->source = $this->sourceUrl;
+        $helper->refresh = $this->kpiConfiguration->get('MESSAGES_PER_THREAD_EXPIRE') < time();
+
+        return $helper->generate();
+    }
+}

--- a/src/Adapter/Kpi/PendingDiscussionThreadsKpi.php
+++ b/src/Adapter/Kpi/PendingDiscussionThreadsKpi.php
@@ -38,7 +38,8 @@ final class PendingDiscussionThreadsKpi implements KpiInterface
         }
 
         $helper->source = $this->sourceUrl;
-        $helper->refresh = $this->kpiConfiguration->get('PENDING_MESSAGES_EXPIRE') < time();
+        $expireTimestamp = $this->kpiConfiguration->get('PENDING_MESSAGES_EXPIRE');
+        $helper->refresh = false === $expireTimestamp || (int) $expireTimestamp < time();
 
         return $helper->generate();
     }

--- a/src/Adapter/Kpi/PendingDiscussionThreadsKpi.php
+++ b/src/Adapter/Kpi/PendingDiscussionThreadsKpi.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Kpi;
+
+use HelperKpi;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Renders the count of customer service threads still awaiting a reply.
+ */
+final class PendingDiscussionThreadsKpi implements KpiInterface
+{
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+        private readonly ConfigurationInterface $kpiConfiguration,
+        private readonly string $sourceUrl,
+    ) {
+    }
+
+    public function render(): string
+    {
+        $helper = new HelperKpi();
+        $helper->id = 'box-pending-messages';
+        $helper->icon = 'mail';
+        $helper->color = 'color1';
+        $helper->title = $this->translator->trans('Pending Discussion Threads', [], 'Admin.Catalog.Feature');
+
+        if (false !== $this->kpiConfiguration->get('PENDING_MESSAGES')) {
+            $helper->value = $this->kpiConfiguration->get('PENDING_MESSAGES');
+        }
+
+        $helper->source = $this->sourceUrl;
+        $helper->refresh = $this->kpiConfiguration->get('PENDING_MESSAGES_EXPIRE') < time();
+
+        return $helper->generate();
+    }
+}

--- a/src/Adapter/Kpi/PendingDiscussionThreadsKpi.php
+++ b/src/Adapter/Kpi/PendingDiscussionThreadsKpi.php
@@ -8,39 +8,38 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Kpi;
 
-use HelperKpi;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
-use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
-
 /**
  * Renders the count of customer service threads still awaiting a reply.
  */
-final class PendingDiscussionThreadsKpi implements KpiInterface
+final class PendingDiscussionThreadsKpi extends AbstractAdminStatsKpi
 {
-    public function __construct(
-        private readonly TranslatorInterface $translator,
-        private readonly ConfigurationInterface $kpiConfiguration,
-        private readonly string $sourceUrl,
-    ) {
+    protected function getId(): string
+    {
+        return 'box-pending-messages';
     }
 
-    public function render(): string
+    protected function getIcon(): string
     {
-        $helper = new HelperKpi();
-        $helper->id = 'box-pending-messages';
-        $helper->icon = 'mail';
-        $helper->color = 'color1';
-        $helper->title = $this->translator->trans('Pending Discussion Threads', [], 'Admin.Catalog.Feature');
+        return 'mail';
+    }
 
-        if (false !== $this->kpiConfiguration->get('PENDING_MESSAGES')) {
-            $helper->value = $this->kpiConfiguration->get('PENDING_MESSAGES');
-        }
+    protected function getColor(): string
+    {
+        return 'color1';
+    }
 
-        $helper->source = $this->sourceUrl;
-        $expireTimestamp = $this->kpiConfiguration->get('PENDING_MESSAGES_EXPIRE');
-        $helper->refresh = false === $expireTimestamp || (int) $expireTimestamp < time();
+    protected function getTitle(): string
+    {
+        return $this->translator->trans('Pending Discussion Threads', [], 'Admin.Catalog.Feature');
+    }
 
-        return $helper->generate();
+    protected function getValueConfigurationKey(): string
+    {
+        return 'PENDING_MESSAGES';
+    }
+
+    protected function getExpireConfigurationKey(): string
+    {
+        return 'PENDING_MESSAGES_EXPIRE';
     }
 }

--- a/src/Core/Domain/CustomerService/Query/GetCustomerServiceListingStatistics.php
+++ b/src/Core/Domain/CustomerService/Query/GetCustomerServiceListingStatistics.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\CustomerService\Query;
+
+/**
+ * Aggregates the counters displayed above the customer thread listing:
+ * total threads, threads by status, and message totals split by author type.
+ */
+class GetCustomerServiceListingStatistics
+{
+}

--- a/src/Core/Domain/CustomerService/QueryHandler/GetCustomerServiceListingStatisticsHandlerInterface.php
+++ b/src/Core/Domain/CustomerService/QueryHandler/GetCustomerServiceListingStatisticsHandlerInterface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerServiceListingStatistics;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerServiceListingStatistics;
+
+interface GetCustomerServiceListingStatisticsHandlerInterface
+{
+    public function handle(GetCustomerServiceListingStatistics $query): CustomerServiceListingStatistics;
+}

--- a/src/Core/Domain/CustomerService/QueryResult/CustomerServiceListingStatistics.php
+++ b/src/Core/Domain/CustomerService/QueryResult/CustomerServiceListingStatistics.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult;
+
+final class CustomerServiceListingStatistics
+{
+    public function __construct(
+        private readonly int $totalThreads,
+        private readonly int $openThreads,
+        private readonly int $pendingThreads,
+        private readonly int $closedThreads,
+        private readonly int $customerMessages,
+        private readonly int $employeeMessages,
+    ) {
+    }
+
+    public function getTotalThreads(): int
+    {
+        return $this->totalThreads;
+    }
+
+    public function getOpenThreads(): int
+    {
+        return $this->openThreads;
+    }
+
+    public function getPendingThreads(): int
+    {
+        return $this->pendingThreads;
+    }
+
+    public function getClosedThreads(): int
+    {
+        return $this->closedThreads;
+    }
+
+    public function getCustomerMessages(): int
+    {
+        return $this->customerMessages;
+    }
+
+    public function getEmployeeMessages(): int
+    {
+        return $this->employeeMessages;
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/CustomerThreadController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/CustomerThreadController.php
@@ -16,12 +16,14 @@ use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\UpdateCustomerThre
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CannotDeleteCustomerThreadException;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerServiceException;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerThreadNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerServiceListingStatistics;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerServiceSignature;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerThreadForViewing;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerThreadView;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Query\GetEmployeeEmailById;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
 use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
+use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactoryInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerThreadFilter;
 use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
 use PrestaShopBundle\Form\Admin\CustomerService\CustomerThread\ForwardCustomerThreadType;
@@ -50,6 +52,8 @@ class CustomerThreadController extends PrestaShopAdminController
         Request $request,
         #[Autowire(service: 'prestashop.core.grid.factory.customer_thread')]
         GridFactoryInterface $customerGridFactory,
+        #[Autowire(service: 'prestashop.core.kpi_row.factory.customer_service')]
+        KpiRowFactoryInterface $customerServiceKpiFactory,
         CustomerThreadFilter $filters
     ): Response {
         $customerThreadGrid = $customerGridFactory->getGrid($filters);
@@ -57,6 +61,8 @@ class CustomerThreadController extends PrestaShopAdminController
         return $this->render('@PrestaShop/Admin/Sell/CustomerService/CustomerThread/index.html.twig', [
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'customerThreadGrid' => $this->presentGrid($customerThreadGrid),
+            'customerServiceKpi' => $customerServiceKpiFactory->build(),
+            'customerServiceListingStatistics' => $this->dispatchQuery(new GetCustomerServiceListingStatistics()),
             'enableSidebar' => true,
             'layoutTitle' => $this->trans('Customer service', [], 'Admin.Navigation.Menu'),
         ]);

--- a/src/PrestaShopBundle/Resources/config/services/adapter/kpi.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/kpi.yml
@@ -88,6 +88,27 @@ services:
     arguments:
       - "@prestashop.core.localization.locale.context_locale"
 
+  prestashop.adapter.kpi.pending_discussion_threads:
+    class: 'PrestaShop\PrestaShop\Adapter\Kpi\PendingDiscussionThreadsKpi'
+    arguments:
+      - '@translator'
+      - '@prestashop.adapter.legacy.kpi_configuration'
+      - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "pending_messages"})'
+
+  prestashop.adapter.kpi.average_message_response_time:
+    class: 'PrestaShop\PrestaShop\Adapter\Kpi\AverageMessageResponseTimeKpi'
+    arguments:
+      - '@translator'
+      - '@prestashop.adapter.legacy.kpi_configuration'
+      - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "avg_msg_response_time"})'
+
+  prestashop.adapter.kpi.messages_per_thread:
+    class: 'PrestaShop\PrestaShop\Adapter\Kpi\MessagesPerThreadKpi'
+    arguments:
+      - '@translator'
+      - '@prestashop.adapter.legacy.kpi_configuration'
+      - '@=service("prestashop.adapter.legacy.context").getAdminLink("AdminStats", true, {"ajax": 1, "action": "getKpi", "kpi": "messages_per_thread"})'
+
   PrestaShop\PrestaShop\Adapter\Kpi\AbandonedCartKpi:
     autowire: true
 

--- a/src/PrestaShopBundle/Resources/config/services/core/domain/customer_service.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/domain/customer_service.yml
@@ -59,3 +59,6 @@ services:
 
   prestashop.core.domain.customer_service.repository.customer_thread_repository:
     class: 'PrestaShop\PrestaShop\Core\Domain\CustomerService\Repository\CustomerThreadRepository'
+
+  PrestaShop\PrestaShop\Adapter\CustomerService\QueryHandler\GetCustomerServiceListingStatisticsHandler:
+    autoconfigure: true

--- a/src/PrestaShopBundle/Resources/config/services/core/kpi.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/kpi.yml
@@ -43,6 +43,15 @@ services:
       - '@prestashop.core.hook.dispatcher'
       - 'customers'
 
+  prestashop.core.kpi_row.factory.customer_service:
+    class: PrestaShop\PrestaShop\Core\Kpi\Row\HookableKpiRowFactory
+    arguments:
+      - - '@prestashop.adapter.kpi.pending_discussion_threads'
+        - '@prestashop.adapter.kpi.average_message_response_time'
+        - '@prestashop.adapter.kpi.messages_per_thread'
+      - '@prestashop.core.hook.dispatcher'
+      - 'customer_service'
+
   prestashop.core.kpi_row.factory.cart:
     class: PrestaShop\PrestaShop\Core\Kpi\Row\HookableKpiRowFactory
     arguments:

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/Block/listing_statistics.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/Block/listing_statistics.html.twig
@@ -7,7 +7,7 @@
   <div class="col-lg-6">
     <div class="card">
       <h3 class="card-header">
-        {{ 'Statistics'|trans({}, 'Admin.Orderscustomers.Feature') }}
+        {{ 'Statistics'|trans({}, 'Admin.Catalog.Feature') }}
       </h3>
       <div class="card-body">
         <ul class="list-unstyled mb-0">
@@ -42,14 +42,14 @@
   <div class="col-lg-6">
     <div class="card">
       <h3 class="card-header">
-        {{ 'Meaning of status'|trans({}, 'Admin.Orderscustomers.Feature') }}
+        {{ 'Meaning of status'|trans({}, 'Admin.Catalog.Feature') }}
       </h3>
       <div class="card-body">
         <ul class="list-unstyled mb-0">
-          <li><span class="text-success">●</span> {{ 'Open'|trans({}, 'Admin.Orderscustomers.Feature') }}</li>
-          <li><span class="text-danger">●</span> {{ 'Closed'|trans({}, 'Admin.Orderscustomers.Feature') }}</li>
-          <li><span class="text-warning">●</span> {{ 'Pending 1'|trans({}, 'Admin.Orderscustomers.Feature') }}</li>
-          <li><span class="text-warning">●</span> {{ 'Pending 2'|trans({}, 'Admin.Orderscustomers.Feature') }}</li>
+          <li><span class="text-success">●</span> {{ 'Open'|trans({}, 'Admin.Catalog.Feature') }}</li>
+          <li><span class="text-danger">●</span> {{ 'Closed'|trans({}, 'Admin.Catalog.Feature') }}</li>
+          <li><span class="text-warning">●</span> {{ 'Pending 1'|trans({}, 'Admin.Catalog.Feature') }}</li>
+          <li><span class="text-warning">●</span> {{ 'Pending 2'|trans({}, 'Admin.Catalog.Feature') }}</li>
         </ul>
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/Block/listing_statistics.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/Block/listing_statistics.html.twig
@@ -1,0 +1,57 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+
+<div class="row mb-3">
+  <div class="col-lg-6">
+    <div class="card">
+      <h3 class="card-header">
+        {{ 'Statistics'|trans({}, 'Admin.Orderscustomers.Feature') }}
+      </h3>
+      <div class="card-body">
+        <ul class="list-unstyled mb-0">
+          <li class="d-flex justify-content-between">
+            <span>{{ 'Total threads'|trans({}, 'Admin.Catalog.Feature') }}</span>
+            <span class="badge badge-primary rounded">{{ statistics.totalThreads }}</span>
+          </li>
+          <li class="d-flex justify-content-between">
+            <span>{{ 'Threads pending'|trans({}, 'Admin.Catalog.Feature') }}</span>
+            <span class="badge badge-warning rounded">{{ statistics.pendingThreads }}</span>
+          </li>
+          <li class="d-flex justify-content-between">
+            <span>{{ 'Total number of customer messages'|trans({}, 'Admin.Catalog.Feature') }}</span>
+            <span class="badge badge-primary rounded">{{ statistics.customerMessages }}</span>
+          </li>
+          <li class="d-flex justify-content-between">
+            <span>{{ 'Total number of employee messages'|trans({}, 'Admin.Catalog.Feature') }}</span>
+            <span class="badge badge-primary rounded">{{ statistics.employeeMessages }}</span>
+          </li>
+          <li class="d-flex justify-content-between">
+            <span>{{ 'Unread threads'|trans({}, 'Admin.Catalog.Feature') }}</span>
+            <span class="badge badge-success rounded">{{ statistics.openThreads }}</span>
+          </li>
+          <li class="d-flex justify-content-between">
+            <span>{{ 'Closed threads'|trans({}, 'Admin.Catalog.Feature') }}</span>
+            <span class="badge badge-secondary rounded">{{ statistics.closedThreads }}</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-6">
+    <div class="card">
+      <h3 class="card-header">
+        {{ 'Meaning of status'|trans({}, 'Admin.Orderscustomers.Feature') }}
+      </h3>
+      <div class="card-body">
+        <ul class="list-unstyled mb-0">
+          <li><span class="text-success">●</span> {{ 'Open'|trans({}, 'Admin.Orderscustomers.Feature') }}</li>
+          <li><span class="text-danger">●</span> {{ 'Closed'|trans({}, 'Admin.Orderscustomers.Feature') }}</li>
+          <li><span class="text-warning">●</span> {{ 'Pending 1'|trans({}, 'Admin.Orderscustomers.Feature') }}</li>
+          <li><span class="text-warning">●</span> {{ 'Pending 2'|trans({}, 'Admin.Orderscustomers.Feature') }}</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/index.html.twig
@@ -10,6 +10,20 @@
 {% endblock %}
 
 {% block content %}
+  {% block customer_service_kpis %}
+    {{ render(controller(
+      'PrestaShopBundle\\Controller\\Admin\\CommonController::renderKpiRowAction',
+      {kpiRow: customerServiceKpi}
+    )) }}
+  {% endblock %}
+
+  {% block customer_service_listing_statistics %}
+    {{ include(
+      '@PrestaShop/Admin/Sell/CustomerService/CustomerThread/Block/listing_statistics.html.twig',
+      {statistics: customerServiceListingStatistics}
+    ) }}
+  {% endblock %}
+
   {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {grid: customerThreadGrid}) }}
 {% endblock %}
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
@@ -8,13 +8,16 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
 use Behat\Gherkin\Node\TableNode;
 use CustomerThread;
+use Db;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Adapter\Entity\CustomerMessage;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\DeleteCustomerThreadCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\ReplyToCustomerThreadCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\UpdateCustomerThreadStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerThreadNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerServiceListingStatistics;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerThreadForViewing;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerServiceListingStatistics;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerThreadView;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\ValueObject\CustomerThreadStatus;
 use RuntimeException;
@@ -57,6 +60,75 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
         $customerMessage->private = false;
         $customerMessage->read = false;
         $customerMessage->add();
+    }
+
+    /**
+     * @Given there are no customer threads
+     */
+    public function clearCustomerThreads(): void
+    {
+        Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'customer_message');
+        Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'customer_thread');
+    }
+
+    /**
+     * @When I add new customer thread :threadReference with status :status and message :message
+     */
+    public function createCustomerThreadWithStatus(string $threadReference, string $status, string $message): void
+    {
+        $customerThread = new CustomerThread();
+        $customerThread->id_contact = 2;
+        $customerThread->id_customer = 1;
+        $customerThread->id_shop = $this->getDefaultShopId();
+        $customerThread->id_order = 0;
+        $customerThread->id_lang = 1;
+        $customerThread->email = 'test@gmail.com';
+        $customerThread->status = $status;
+        $customerThread->token = Tools::passwdGen(12);
+        $customerThread->add();
+
+        $this->getSharedStorage()->set($threadReference, $customerThread);
+
+        $customerMessage = new CustomerMessage();
+        $customerMessage->id_customer_thread = $customerThread->id;
+        $customerMessage->id_employee = 0;
+        $customerMessage->message = $message;
+        $customerMessage->file_name = '';
+        $customerMessage->ip_address = '';
+        $customerMessage->private = false;
+        $customerMessage->read = false;
+        $customerMessage->add();
+    }
+
+    /**
+     * @Then customer service listing statistics should be:
+     */
+    public function assertListingStatistics(TableNode $table): void
+    {
+        $expected = $table->getRowsHash();
+
+        /** @var CustomerServiceListingStatistics $stats */
+        $stats = $this->getQueryBus()->handle(new GetCustomerServiceListingStatistics());
+
+        $actual = [
+            'total_threads' => $stats->getTotalThreads(),
+            'open_threads' => $stats->getOpenThreads(),
+            'pending_threads' => $stats->getPendingThreads(),
+            'closed_threads' => $stats->getClosedThreads(),
+            'customer_messages' => $stats->getCustomerMessages(),
+            'employee_messages' => $stats->getEmployeeMessages(),
+        ];
+
+        foreach ($expected as $key => $value) {
+            if (!array_key_exists($key, $actual)) {
+                throw new RuntimeException(sprintf('Unknown statistic "%s" in expectations.', $key));
+            }
+            Assert::assertSame(
+                (int) $value,
+                $actual[$key],
+                sprintf('Statistic "%s" should be %s, got %s.', $key, $value, $actual[$key])
+            );
+        }
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/CustomerService/customer_service_statistics.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CustomerService/customer_service_statistics.feature
@@ -1,0 +1,29 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer_service --tags customer-service-statistics
+@restore-all-tables-before-feature
+@customer-service-statistics
+Feature: Customer service listing statistics
+
+  Background:
+    Given there are no customer threads
+
+  Scenario: An empty installation reports zero counters
+    Then customer service listing statistics should be:
+      | total_threads     | 0 |
+      | open_threads      | 0 |
+      | pending_threads   | 0 |
+      | closed_threads    | 0 |
+      | customer_messages | 0 |
+      | employee_messages | 0 |
+
+  Scenario: Statistics aggregate threads grouped by status
+    When I add new customer thread "stats-open" with status "open" and message "open thread"
+    And I add new customer thread "stats-pending1" with status "pending1" and message "pending1 thread"
+    And I add new customer thread "stats-pending2" with status "pending2" and message "pending2 thread"
+    And I add new customer thread "stats-closed" with status "closed" and message "closed thread"
+    Then customer service listing statistics should be:
+      | total_threads     | 4 |
+      | open_threads      | 1 |
+      | pending_threads   | 2 |
+      | closed_threads    | 1 |
+      | customer_messages | 4 |
+      | employee_messages | 0 |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds the iso-functional KPI row and statistics panel to the migrated Customer Service page (feature flag `customer_threads`). The legacy page renders three KPIs (pending threads, average response time, messages per thread) and a six-counter statistics panel above the grid; the migrated Symfony page rendered neither. This PR closes that gap. Part of the AdminCustomerThreads → Symfony migration.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | (1) Enable the `customer_threads` feature flag. <br>(2) Open `Sell > Customer Service > Customer Service`. <br>(3) Verify the three KPI boxes (Pending Discussion Threads, Average Response Time, Messages per Thread) render above the grid with the same values as the legacy page when the flag is off. <br>(4) Verify the Statistics panel shows the six counters (total / pending / customer messages / employee messages / unread / closed). <br>(5) Run `composer create-test-db && ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer_service` — expect 6 scenarios green.
| UI Tests          | https://github.com/ga-devfront/ga.tests.ui.pr/actions/runs/26274410049
| Fixed issue or discussion?     | None — part of the AdminCustomerThreads → Symfony migration epic. Refactor of KPIs off `AdminStats` is tracked in #41417.
| Related PRs       | Follow-up to the Behat retrofit PR #41418
| Sponsor company   | @PrestaShopCorp

## What this PR adds

### KPI row

Three new KPI classes under `src/Adapter/Kpi/`:

- `PendingDiscussionThreadsKpi`
- `AverageMessageResponseTimeKpi`
- `MessagesPerThreadKpi`

Each one mirrors the legacy `AdminCustomerThreadsController::renderKpis()` output: same `HelperKpi` settings (id, icon, color), same translation keys, same `ConfigurationKPI` cache values, same `AdminStats&action=getKpi` source URL. No new business logic — values match the legacy page exactly.

A new factory `prestashop.core.kpi_row.factory.customer_service` aggregates the three KPIs through `HookableKpiRowFactory` (so `actionAdminCustomerThreadsKpiRow` style hooks keep firing). The factory is injected into `CustomerThreadController::indexAction` via `Autowire` and rendered through the existing `CommonController::renderKpiRowAction` mechanism — same wiring used by the migrated Customer / Order / Cart pages.

### Listing statistics

New CQRS query under `src/Core/Domain/CustomerService/`:

- `GetCustomerServiceListingStatistics` (no parameters)
- `CustomerServiceListingStatistics` result DTO with six typed getters (total / open / pending / closed threads, customer / employee messages)

Concrete handler `GetCustomerServiceListingStatisticsHandler` lives in `src/Adapter/CustomerService/QueryHandler/` (new directory, follows the convention that ObjectModel-based handlers go to `Adapter`). It delegates to the existing `CustomerThread::getTotalCustomerThreads()` and `CustomerMessage::getTotalCustomerMessages()` static methods so multi-shop scoping via `Shop::addSqlRestriction()` is preserved.

The new partial `Block/listing_statistics.html.twig` renders the six counters in a Bootstrap card alongside the legacy status meaning legend (Open / Closed / Pending 1 / Pending 2).

### Behat coverage

New `customer_service_statistics.feature` with two scenarios driving the query through the bus:

- An empty installation reports zero counters.
- Statistics aggregate threads grouped by status (open / pending1 / pending2 / closed) and customer-vs-employee messages.

A `Given there are no customer threads` background step (new `clearCustomerThreads`) makes counts deterministic regardless of fixture seed data.

## What is intentionally NOT in this PR

- **KPI refactor onto a CQRS query** — tracked in #41417. The migrated KPI partial keeps calling the legacy `AdminStats` ajax endpoints so values match exactly.
- **Contact-by-category navigation cards** (the "tickets per category" panel in legacy `list_header.tpl`) — separate concern, will land with a dedicated query in a follow-up.
- **Playwright assertions for the new KPIs/stats** — will be added when the Playwright suite is extended in a later PR of this migration.