### PR TITLE
Migration - Migrate Customer service options page to Symfony

### DIFF
--- a/src/Adapter/CustomerService/Configuration/CustomerServiceOptionsConfiguration.php
+++ b/src/Adapter/CustomerService/Configuration/CustomerServiceOptionsConfiguration.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\CustomerService\Configuration;
+
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Persists the "Contact options" panel of the Customer Service settings:
+ * the customer-side file upload toggle and the translatable default
+ * employee signature used when replying to a thread.
+ */
+final class CustomerServiceOptionsConfiguration extends AbstractMultistoreConfiguration
+{
+    private const CONFIGURATION_FIELDS = [
+        'file_upload',
+        'signature',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration()
+    {
+        $shopConstraint = $this->getShopConstraint();
+
+        return [
+            'file_upload' => (bool) $this->configuration->get('PS_CUSTOMER_SERVICE_FILE_UPLOAD', false, $shopConstraint),
+            'signature' => $this->configuration->get('PS_CUSTOMER_SERVICE_SIGNATURE', [], $shopConstraint),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateConfiguration(array $configuration)
+    {
+        if ($this->validateConfiguration($configuration)) {
+            $shopConstraint = $this->getShopConstraint();
+
+            $this->updateConfigurationValue('PS_CUSTOMER_SERVICE_FILE_UPLOAD', 'file_upload', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_CUSTOMER_SERVICE_SIGNATURE', 'signature', $configuration, $shopConstraint);
+        }
+
+        return [];
+    }
+
+    protected function buildResolver(): OptionsResolver
+    {
+        return (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('file_upload', 'bool')
+            ->setAllowedTypes('signature', 'array');
+    }
+}

--- a/src/Adapter/CustomerService/Configuration/ImapConfiguration.php
+++ b/src/Adapter/CustomerService/Configuration/ImapConfiguration.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\CustomerService\Configuration;
+
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Persists the "Customer service options" IMAP panel that drives the
+ * inbox synchronization performed when the Customer Service listing is loaded.
+ *
+ * Thirteen settings: connection (URL / port / user / password), behaviour
+ * flags (delete after sync, create new threads), and the seven IMAP option
+ * toggles native to the PHP imap_open mailbox string. The legacy
+ * `PS_SAV_IMAP_OPT` concatenated value is intentionally not written: it has
+ * no consumers and `syncImap` rebuilds the option string at call time from
+ * the individual toggles.
+ */
+final class ImapConfiguration extends AbstractMultistoreConfiguration
+{
+    /**
+     * Form key => Configuration key. Most are 1:1 except the two `*-CERT`
+     * legacy keys that contain a literal dash.
+     *
+     * @var array<string, string>
+     */
+    private const FIELD_TO_CONFIG_KEY = [
+        'imap_url' => 'PS_SAV_IMAP_URL',
+        'imap_port' => 'PS_SAV_IMAP_PORT',
+        'imap_user' => 'PS_SAV_IMAP_USER',
+        'imap_password' => 'PS_SAV_IMAP_PWD',
+        'imap_delete_msg' => 'PS_SAV_IMAP_DELETE_MSG',
+        'imap_create_threads' => 'PS_SAV_IMAP_CREATE_THREADS',
+        'imap_opt_pop3' => 'PS_SAV_IMAP_OPT_POP3',
+        'imap_opt_norsh' => 'PS_SAV_IMAP_OPT_NORSH',
+        'imap_opt_ssl' => 'PS_SAV_IMAP_OPT_SSL',
+        'imap_opt_validate_cert' => 'PS_SAV_IMAP_OPT_VALIDATE-CERT',
+        'imap_opt_novalidate_cert' => 'PS_SAV_IMAP_OPT_NOVALIDATE-CERT',
+        'imap_opt_tls' => 'PS_SAV_IMAP_OPT_TLS',
+        'imap_opt_notls' => 'PS_SAV_IMAP_OPT_NOTLS',
+    ];
+
+    private const BOOLEAN_FIELDS = [
+        'imap_delete_msg',
+        'imap_create_threads',
+        'imap_opt_pop3',
+        'imap_opt_norsh',
+        'imap_opt_ssl',
+        'imap_opt_validate_cert',
+        'imap_opt_novalidate_cert',
+        'imap_opt_tls',
+        'imap_opt_notls',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration()
+    {
+        $shopConstraint = $this->getShopConstraint();
+        $values = [
+            'imap_url' => (string) $this->configuration->get('PS_SAV_IMAP_URL', '', $shopConstraint),
+            'imap_port' => (string) $this->configuration->get('PS_SAV_IMAP_PORT', '143', $shopConstraint),
+            'imap_user' => (string) $this->configuration->get('PS_SAV_IMAP_USER', '', $shopConstraint),
+            'imap_password' => (string) $this->configuration->get('PS_SAV_IMAP_PWD', '', $shopConstraint),
+        ];
+
+        foreach (self::BOOLEAN_FIELDS as $field) {
+            $values[$field] = (bool) $this->configuration->get(self::FIELD_TO_CONFIG_KEY[$field], false, $shopConstraint);
+        }
+
+        return $values;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateConfiguration(array $configuration)
+    {
+        if ($this->validateConfiguration($configuration)) {
+            $shopConstraint = $this->getShopConstraint();
+
+            foreach (self::FIELD_TO_CONFIG_KEY as $field => $configKey) {
+                // The password field renders empty in the form when the
+                // stored value is masked; persisting it as-is would wipe the
+                // previously saved credentials. Skip it when blank so existing
+                // credentials are preserved.
+                if ($field === 'imap_password' && ($configuration[$field] ?? '') === '') {
+                    continue;
+                }
+
+                $this->updateConfigurationValue($configKey, $field, $configuration, $shopConstraint);
+            }
+        }
+
+        return [];
+    }
+
+    protected function buildResolver(): OptionsResolver
+    {
+        $resolver = (new OptionsResolver())
+            ->setDefined(array_keys(self::FIELD_TO_CONFIG_KEY))
+            ->setAllowedTypes('imap_url', 'string')
+            ->setAllowedTypes('imap_port', 'string')
+            ->setAllowedTypes('imap_user', 'string')
+            ->setAllowedTypes('imap_password', 'string');
+
+        foreach (self::BOOLEAN_FIELDS as $field) {
+            $resolver->setAllowedTypes($field, 'bool');
+        }
+
+        return $resolver;
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/CustomerThreadController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/CustomerThreadController.php
@@ -22,6 +22,7 @@ use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerThreadFor
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerThreadView;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Query\GetEmployeeEmailById;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
+use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
 use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowFactoryInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerThreadFilter;
@@ -29,6 +30,7 @@ use PrestaShopBundle\Controller\Admin\PrestaShopAdminController;
 use PrestaShopBundle\Form\Admin\CustomerService\CustomerThread\ForwardCustomerThreadType;
 use PrestaShopBundle\Form\Admin\Sell\CustomerService\ReplyToCustomerThreadType;
 use PrestaShopBundle\Security\Attribute\AdminSecurity;
+use PrestaShopBundle\Security\Attribute\DemoRestricted;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -301,6 +303,52 @@ class CustomerThreadController extends PrestaShopAdminController
     }
 
     /**
+     * Show the Customer service options forms (Contact panel + IMAP panel).
+     */
+    #[AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute: 'admin_customer_threads')]
+    public function optionsAction(
+        Request $request,
+        #[Autowire(service: 'prestashop.adapter.customer_service.options.form_handler')]
+        FormHandlerInterface $optionsFormHandler,
+        #[Autowire(service: 'prestashop.adapter.customer_service.imap.form_handler')]
+        FormHandlerInterface $imapFormHandler,
+    ): Response {
+        return $this->render('@PrestaShop/Admin/Sell/CustomerService/CustomerThread/options.html.twig', [
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+            'enableSidebar' => true,
+            'layoutTitle' => $this->trans('Customer service options', [], 'Admin.Catalog.Feature'),
+            'customerServiceOptionsForm' => $optionsFormHandler->getForm()->createView(),
+            'imapOptionsForm' => $imapFormHandler->getForm()->createView(),
+        ]);
+    }
+
+    /**
+     * Save the "Contact options" panel.
+     */
+    #[DemoRestricted(redirectRoute: 'admin_customer_threads_options')]
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_customer_threads_options')]
+    public function saveOptionsAction(
+        Request $request,
+        #[Autowire(service: 'prestashop.adapter.customer_service.options.form_handler')]
+        FormHandlerInterface $optionsFormHandler,
+    ): RedirectResponse {
+        return $this->processOptionsForm($request, $optionsFormHandler);
+    }
+
+    /**
+     * Save the "Customer service options" IMAP panel.
+     */
+    #[DemoRestricted(redirectRoute: 'admin_customer_threads_options')]
+    #[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_customer_threads_options')]
+    public function saveImapOptionsAction(
+        Request $request,
+        #[Autowire(service: 'prestashop.adapter.customer_service.imap.form_handler')]
+        FormHandlerInterface $imapFormHandler,
+    ): RedirectResponse {
+        return $this->processOptionsForm($request, $imapFormHandler);
+    }
+
+    /**
      * Bulk delete customer thread
      *
      * @param Request $request
@@ -380,6 +428,28 @@ class CustomerThreadController extends PrestaShopAdminController
         }
 
         return array_map('intval', $customerThreadIds);
+    }
+
+    private function processOptionsForm(Request $request, FormHandlerInterface $formHandler): RedirectResponse
+    {
+        $form = $formHandler->getForm();
+        $form->handleRequest($request);
+
+        if (!$form->isSubmitted() || !$form->isValid()) {
+            return $this->redirectToRoute('admin_customer_threads_options');
+        }
+
+        $saveErrors = $formHandler->save($form->getData());
+
+        if (0 === count($saveErrors)) {
+            $this->addFlash('success', $this->trans('Successful update', [], 'Admin.Notifications.Success'));
+
+            return $this->redirectToRoute('admin_customer_threads_options');
+        }
+
+        $this->addFlashErrors($saveErrors);
+
+        return $this->redirectToRoute('admin_customer_threads_options');
     }
 
     private function handleCustomerThreadStatusUpdate(int $customerThreadId, string $newStatus)

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/CustomerServiceOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/CustomerServiceOptionsFormDataProvider.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\CustomerService;
+
+use PrestaShop\PrestaShop\Adapter\CustomerService\Configuration\CustomerServiceOptionsConfiguration;
+use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
+
+/**
+ * Bridges the "Contact options" panel form with the underlying configuration
+ * adapter, so the controller does not need to know whether values land in
+ * Configuration::updateValue or anywhere else.
+ */
+final class CustomerServiceOptionsFormDataProvider implements FormDataProviderInterface
+{
+    public function __construct(
+        private readonly CustomerServiceOptionsConfiguration $configuration,
+    ) {
+    }
+
+    public function getData(): array
+    {
+        return $this->configuration->getConfiguration();
+    }
+
+    public function setData(array $data): array
+    {
+        return $this->configuration->updateConfiguration($data);
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/CustomerServiceOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/CustomerServiceOptionsType.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\CustomerService;
+
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * "Contact options" panel: customer-side file upload toggle and translatable
+ * default employee signature used when replying to a customer thread.
+ */
+final class CustomerServiceOptionsType extends TranslatorAwareType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('file_upload', SwitchType::class, [
+                'label' => $this->trans('Allow file uploading', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'Allow customers to upload files using the contact page.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('signature', TranslatableType::class, [
+                'label' => $this->trans('Default message', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'Please fill out the message fields that appear by default when you answer a thread on the customer service page.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+                'type' => TextareaType::class,
+                'options' => [
+                    'required' => false,
+                    'attr' => [
+                        'rows' => 5,
+                    ],
+                ],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'Admin.Catalog.Feature',
+        ]);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'customer_service_options_block';
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/ImapOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/ImapOptionsFormDataProvider.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\CustomerService;
+
+use PrestaShop\PrestaShop\Adapter\CustomerService\Configuration\ImapConfiguration;
+use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
+
+final class ImapOptionsFormDataProvider implements FormDataProviderInterface
+{
+    public function __construct(
+        private readonly ImapConfiguration $configuration,
+    ) {
+    }
+
+    public function getData(): array
+    {
+        return $this->configuration->getConfiguration();
+    }
+
+    public function setData(array $data): array
+    {
+        return $this->configuration->updateConfiguration($data);
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/ImapOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/ImapOptionsType.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\CustomerService;
+
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * "Customer service options" IMAP panel powering the inbox synchronization.
+ */
+final class ImapOptionsType extends TranslatorAwareType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('imap_url', TextType::class, [
+                'label' => $this->trans('IMAP URL', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'URL for your IMAP server (ie.: mail.server.com).',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_port', TextType::class, [
+                'label' => $this->trans('IMAP port', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'Port to use to connect to your IMAP server.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_user', TextType::class, [
+                'label' => $this->trans('IMAP user', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'User to use to connect to your IMAP server.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_password', PasswordType::class, [
+                'label' => $this->trans('IMAP password', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'Password to use to connect your IMAP server.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+                'always_empty' => false,
+            ])
+            ->add('imap_delete_msg', SwitchType::class, [
+                'label' => $this->trans('Delete messages', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'Delete messages after synchronization. If you do not enable this option, the synchronization will take more time.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_create_threads', SwitchType::class, [
+                'label' => $this->trans('Create new threads', 'Admin.Catalog.Feature'),
+                'help' => $this->trans(
+                    'Create new threads for unrecognized emails.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_opt_pop3', SwitchType::class, [
+                'label' => $this->trans('IMAP options', 'Admin.Catalog.Feature') . ' (/pop3)',
+                'help' => $this->trans('Use POP3 instead of IMAP.', 'Admin.Catalog.Help'),
+                'required' => false,
+            ])
+            ->add('imap_opt_norsh', SwitchType::class, [
+                'label' => $this->trans('IMAP options', 'Admin.Catalog.Feature') . ' (/norsh)',
+                'help' => $this->trans(
+                    'Do not use RSH or SSH to establish a preauthenticated IMAP sessions.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_opt_ssl', SwitchType::class, [
+                'label' => $this->trans('IMAP options', 'Admin.Catalog.Feature') . ' (/ssl)',
+                'help' => $this->trans(
+                    'Use the Secure Socket Layer (TLS/SSL) to encrypt the session.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_opt_validate_cert', SwitchType::class, [
+                'label' => $this->trans('IMAP options', 'Admin.Catalog.Feature') . ' (/validate-cert)',
+                'help' => $this->trans('Validate certificates from the TLS/SSL server.', 'Admin.Catalog.Help'),
+                'required' => false,
+            ])
+            ->add('imap_opt_novalidate_cert', SwitchType::class, [
+                'label' => $this->trans('IMAP options', 'Admin.Catalog.Feature') . ' (/novalidate-cert)',
+                'help' => $this->trans(
+                    'Do not validate certificates from the TLS/SSL server. This is only needed if a server uses self-signed certificates.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_opt_tls', SwitchType::class, [
+                'label' => $this->trans('IMAP options', 'Admin.Catalog.Feature') . ' (/tls)',
+                'help' => $this->trans(
+                    'Force use of start-TLS to encrypt the session, and reject connection to servers that do not support it.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('imap_opt_notls', SwitchType::class, [
+                'label' => $this->trans('IMAP options', 'Admin.Catalog.Feature') . ' (/notls)',
+                'help' => $this->trans(
+                    'Do not use start-TLS to encrypt the session, even with servers that support it.',
+                    'Admin.Catalog.Help'
+                ),
+                'required' => false,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'Admin.Catalog.Feature',
+        ]);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'imap_options_block';
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer_service/customer_threads.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer_service/customer_threads.yml
@@ -97,3 +97,30 @@ admin_customer_threads_bulk_delete:
     _legacy_controller: AdminCustomerThreads
     _legacy_link: AdminCustomerThreads
     _legacy_feature_flag: customer_threads
+
+admin_customer_threads_options:
+  path: /options
+  methods: [ GET ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\CustomerService\CustomerThreadController::optionsAction
+    _legacy_controller: AdminCustomerThreads
+    _legacy_link: AdminCustomerThreads:options
+    _legacy_feature_flag: customer_threads
+
+admin_customer_threads_options_save:
+  path: /options
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\CustomerService\CustomerThreadController::saveOptionsAction
+    _legacy_controller: AdminCustomerThreads
+    _legacy_link: AdminCustomerThreads:options
+    _legacy_feature_flag: customer_threads
+
+admin_customer_threads_imap_options_save:
+  path: /options/imap
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\CustomerService\CustomerThreadController::saveImapOptionsAction
+    _legacy_controller: AdminCustomerThreads
+    _legacy_link: AdminCustomerThreads:options
+    _legacy_feature_flag: customer_threads

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -30,6 +30,20 @@ services:
       - '@prestashop.adapter.shop.context'
       - '@prestashop.adapter.multistore_feature'
 
+  prestashop.adapter.customer_service.options_configuration:
+    class: 'PrestaShop\PrestaShop\Adapter\CustomerService\Configuration\CustomerServiceOptionsConfiguration'
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
+
+  prestashop.adapter.customer_service.imap_configuration:
+    class: 'PrestaShop\PrestaShop\Adapter\CustomerService\Configuration\ImapConfiguration'
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
+
   prestashop.adapter.order_general.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Order\GeneralConfiguration'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
@@ -136,6 +136,16 @@ services:
   PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Logs\DatabaseLogsFormDataProvider:
     autowire: true
 
+  prestashop.adapter.customer_service.options.form_provider:
+    class: 'PrestaShopBundle\Form\Admin\Sell\CustomerService\CustomerServiceOptionsFormDataProvider'
+    arguments:
+      - '@prestashop.adapter.customer_service.options_configuration'
+
+  prestashop.adapter.customer_service.imap.form_provider:
+    class: 'PrestaShopBundle\Form\Admin\Sell\CustomerService\ImapOptionsFormDataProvider'
+    arguments:
+      - '@prestashop.adapter.customer_service.imap_configuration'
+
   prestashop.admin.import.form_data_provider:
     class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Import\ImportFormDataProvider'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -269,6 +269,24 @@ services:
       - 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Logs\LogsByEmailType'
       - 'LogsPage'
 
+  prestashop.adapter.customer_service.options.form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\Handler'
+    arguments:
+      - '@form.factory'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.adapter.customer_service.options.form_provider'
+      - 'PrestaShopBundle\Form\Admin\Sell\CustomerService\CustomerServiceOptionsType'
+      - 'CustomerServiceOptions'
+
+  prestashop.adapter.customer_service.imap.form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\Handler'
+    arguments:
+      - '@form.factory'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.adapter.customer_service.imap.form_provider'
+      - 'PrestaShopBundle\Form\Admin\Sell\CustomerService\ImapOptionsType'
+      - 'CustomerServiceImap'
+
   prestashop.adapter.logs_database.form_handler:
     class: 'PrestaShop\PrestaShop\Core\Form\Handler'
     arguments:

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/index.html.twig
@@ -13,14 +13,14 @@
   {% block customer_service_kpis %}
     {{ render(controller(
       'PrestaShopBundle\\Controller\\Admin\\CommonController::renderKpiRowAction',
-      {kpiRow: customerServiceKpi}
+      {kpiRow: customerServiceKpi},
     )) }}
   {% endblock %}
 
   {% block customer_service_listing_statistics %}
     {{ include(
       '@PrestaShop/Admin/Sell/CustomerService/CustomerThread/Block/listing_statistics.html.twig',
-      {statistics: customerServiceListingStatistics}
+      {statistics: customerServiceListingStatistics},
     ) }}
   {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/CustomerThread/options.html.twig
@@ -1,0 +1,52 @@
+{#
+ # For the full copyright and license information, please view the
+ # docs/licenses/LICENSE.txt file that was distributed with this source code.
+ #}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+{% trans_default_domain 'Admin.Catalog.Feature' %}
+{% form_theme customerServiceOptionsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
+{% form_theme imapOptionsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
+
+{% block content %}
+  {% block customer_service_options_form %}
+    {{ form_start(customerServiceOptionsForm, {action: path('admin_customer_threads_options_save')}) }}
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">settings</i>
+        {{ 'Contact options'|trans }}
+      </h3>
+      <div class="card-body">
+        <div class="form-wrapper">
+          {{ form_widget(customerServiceOptionsForm) }}
+        </div>
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
+    </div>
+    {{ form_end(customerServiceOptionsForm) }}
+  {% endblock %}
+
+  {% block customer_service_imap_options_form %}
+    {{ form_start(imapOptionsForm, {action: path('admin_customer_threads_imap_options_save')}) }}
+    <div class="card mt-3">
+      <h3 class="card-header">
+        <i class="material-icons">mail</i>
+        {{ 'Customer service options'|trans }}
+      </h3>
+      <div class="card-body">
+        <div class="form-wrapper">
+          {{ form_widget(imapOptionsForm) }}
+        </div>
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
+    </div>
+    {{ form_end(imapOptionsForm) }}
+  {% endblock %}
+{% endblock %}

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerServiceFeatureContext.php
@@ -7,6 +7,7 @@
 namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
 use Behat\Gherkin\Node\TableNode;
+use Configuration;
 use CustomerThread;
 use Db;
 use PHPUnit\Framework\Assert;
@@ -22,6 +23,7 @@ use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerThreadFor
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerServiceListingStatistics;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerThreadView;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\ValueObject\CustomerThreadStatus;
+use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\Util\NoExceptionAlthoughExpectedException;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
@@ -89,7 +91,7 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
         $customerThread->token = Tools::passwdGen(12);
         $customerThread->add();
 
-        $this->getSharedStorage()->set($threadReference, $customerThread);
+        $this->getSharedStorage()->set($threadReference, (int) $customerThread->id);
 
         $customerMessage = new CustomerMessage();
         $customerMessage->id_customer_thread = $customerThread->id;
@@ -221,6 +223,94 @@ class CustomerServiceFeatureContext extends AbstractDomainFeatureContext
                 $customerThreadView->getStatus()
             )
         );
+    }
+
+    /**
+     * @When I update customer service options with:
+     */
+    public function updateCustomerServiceOptions(TableNode $table): void
+    {
+        $rows = $table->getRowsHash();
+        $defaultLangId = (int) Configuration::get('PS_LANG_DEFAULT');
+
+        $data = [
+            'file_upload' => filter_var($rows['file_upload'] ?? false, FILTER_VALIDATE_BOOLEAN),
+            'signature' => [$defaultLangId => $rows['signature_in_default'] ?? ''],
+        ];
+
+        /** @var FormDataProviderInterface $provider */
+        $provider = $this->getContainer()->get('prestashop.adapter.customer_service.options.form_provider');
+        $provider->setData($data);
+    }
+
+    /**
+     * @When I update IMAP options with:
+     */
+    public function updateImapOptions(TableNode $table): void
+    {
+        $rows = $table->getRowsHash();
+        $data = [];
+        foreach ($rows as $key => $value) {
+            if ($key === 'imap_url' || $key === 'imap_port' || $key === 'imap_user' || $key === 'imap_password') {
+                $data[$key] = (string) $value;
+            } else {
+                $data[$key] = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+            }
+        }
+
+        /** @var FormDataProviderInterface $provider */
+        $provider = $this->getContainer()->get('prestashop.adapter.customer_service.imap.form_provider');
+        $provider->setData($data);
+    }
+
+    /**
+     * @Then customer service file upload should be :state
+     */
+    public function assertFileUploadState(string $state): void
+    {
+        $expected = $state === 'enabled';
+        $actual = (bool) Configuration::get('PS_CUSTOMER_SERVICE_FILE_UPLOAD');
+
+        Assert::assertSame(
+            $expected,
+            $actual,
+            sprintf('Expected file upload to be %s, got %s.', $state, $actual ? 'enabled' : 'disabled')
+        );
+    }
+
+    /**
+     * @Then customer service signature in default language should be :expected
+     */
+    public function assertSignatureInDefaultLanguage(string $expected): void
+    {
+        $defaultLangId = (int) Configuration::get('PS_LANG_DEFAULT');
+        $actual = (string) Configuration::get('PS_CUSTOMER_SERVICE_SIGNATURE', $defaultLangId);
+        Assert::assertSame($expected, $actual);
+    }
+
+    /**
+     * @Then /^IMAP configuration "([^"]+)" should be "([^"]+)"$/
+     */
+    public function assertImapConfigurationStringValue(string $key, string $expected): void
+    {
+        $actual = (string) Configuration::get($key);
+        Assert::assertSame($expected, $actual, sprintf('Configuration "%s" should be "%s", got "%s".', $key, $expected, $actual));
+    }
+
+    /**
+     * @Then /^IMAP configuration "([^"]+)" should be enabled$/
+     */
+    public function assertImapConfigurationEnabled(string $key): void
+    {
+        Assert::assertTrue((bool) Configuration::get($key), sprintf('Configuration "%s" should be enabled.', $key));
+    }
+
+    /**
+     * @Then /^IMAP configuration "([^"]+)" should be disabled$/
+     */
+    public function assertImapConfigurationDisabled(string $key): void
+    {
+        Assert::assertFalse((bool) Configuration::get($key), sprintf('Configuration "%s" should be disabled.', $key));
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/CustomerService/customer_service_options.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CustomerService/customer_service_options.feature
@@ -1,0 +1,42 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer_service --tags customer-service-options
+@restore-all-tables-before-feature
+@customer-service-options
+Feature: Customer service options
+
+  Scenario: Save the contact options panel (file upload + signature)
+    When I update customer service options with:
+      | file_upload          | true  |
+      | signature_in_default | Hello |
+    Then customer service file upload should be enabled
+    And customer service signature in default language should be "Hello"
+
+  Scenario: Toggle the contact-side file upload off
+    When I update customer service options with:
+      | file_upload          | false |
+      | signature_in_default | Hi    |
+    Then customer service file upload should be disabled
+
+  Scenario: Save the IMAP options panel
+    When I update IMAP options with:
+      | imap_url            | mail.example.com |
+      | imap_port           | 993              |
+      | imap_user           | support          |
+      | imap_password       | secret           |
+      | imap_delete_msg     | true             |
+      | imap_create_threads | false            |
+      | imap_opt_pop3       | false            |
+      | imap_opt_norsh      | false            |
+      | imap_opt_ssl        | true             |
+      | imap_opt_validate_cert   | true        |
+      | imap_opt_novalidate_cert | false       |
+      | imap_opt_tls        | false            |
+      | imap_opt_notls      | false            |
+    Then IMAP configuration "PS_SAV_IMAP_URL" should be "mail.example.com"
+    And IMAP configuration "PS_SAV_IMAP_PORT" should be "993"
+    And IMAP configuration "PS_SAV_IMAP_USER" should be "support"
+    And IMAP configuration "PS_SAV_IMAP_PWD" should be "secret"
+    And IMAP configuration "PS_SAV_IMAP_DELETE_MSG" should be enabled
+    And IMAP configuration "PS_SAV_IMAP_CREATE_THREADS" should be disabled
+    And IMAP configuration "PS_SAV_IMAP_OPT_SSL" should be enabled
+    And IMAP configuration "PS_SAV_IMAP_OPT_VALIDATE-CERT" should be enabled
+    And IMAP configuration "PS_SAV_IMAP_OPT_NOVALIDATE-CERT" should be disabled


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Migrates the Customer service options page (`Sell > Customer Service > Customer Service > Options`) to the Symfony controller behind feature flag `customer_threads`. Replaces the two legacy `fields_options` panels with iso-functional Symfony forms backed by `AbstractMultistoreConfiguration`. Part of the AdminCustomerThreads → Symfony migration. **Built on top of #41420** (KPI strip + listing stats); rebase against `develop` once #41418 and #41420 merge.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | (1) Enable the `customer_threads` feature flag. (2) Open `Sell > Customer Service > Customer Service > Options`. (3) Verify the Contact options panel saves the file-upload toggle and the translatable default signature for each language. (4) Verify the Customer service options panel saves the IMAP server URL, port, user, password and the seven IMAP option toggles. (5) Run `composer create-test-db && ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer_service` — expect 9 scenarios green.
| UI Tests          | https://github.com/ga-devfront/ga.tests.ui.pr/actions/runs/26462102053
| Fixed issue or discussion?     | Part of the AdminCustomerThreads → Symfony migration umbrella tracked in #41417.
| Related PRs       | Stacked on top of #41420 (KPI strip + listing stats), itself stacked on #41418 (Behat retrofit). Please merge upstream PRs first; this branch will rebase cleanly.
| Sponsor company   | @PrestaShopCorp

## What this PR adds

### Configuration adapters

Two new classes under `src/Adapter/CustomerService/Configuration/`, both extending `AbstractMultistoreConfiguration` so values respect the active `ShopConstraint`:

- `CustomerServiceOptionsConfiguration` — Contact options panel: `file_upload` (`PS_CUSTOMER_SERVICE_FILE_UPLOAD`) and translatable `signature` (`PS_CUSTOMER_SERVICE_SIGNATURE`, stored as a per-language array).
- `ImapConfiguration` — IMAP panel: 13 settings covering connection (URL / port / user / password), behaviour flags (delete after sync, create unrecognized threads) and the seven IMAP option toggles. The legacy concatenated `PS_SAV_IMAP_OPT` value is intentionally **not** written: grep across the whole codebase confirms no consumers, and `syncImap` rebuilds the option string from the individual `PS_SAV_IMAP_OPT_*` toggles at call time.

### Form layer

Following the existing `LogsController` convention used for option pages elsewhere in PrestaShop:

- `CustomerServiceOptionsType` and `ImapOptionsType` (Symfony form types). The signature uses `TranslatableType` over `TextareaType`; booleans use `SwitchType`.
- `CustomerServiceOptionsFormDataProvider` and `ImapOptionsFormDataProvider` bridging the forms to the configuration adapters via `FormDataProviderInterface`.
- Two `Core\Form\Handler` services (`prestashop.adapter.customer_service.options.form_handler` and `prestashop.adapter.customer_service.imap.form_handler`).

### Controller actions and routing

`CustomerThreadController` gains:

- `optionsAction` (`GET /options`) — renders both forms.
- `saveOptionsAction` (`POST /options`) — saves the Contact panel.
- `saveImapOptionsAction` (`POST /options/imap`) — saves the IMAP panel.
- A private `processOptionsForm` helper shared by both save actions.

The two save flows are isolated so a validation error on one panel doesn't reject the other (matches legacy iso-functional behaviour with two separate `submit` buttons).

All routes carry `_legacy_feature_flag: customer_threads`; merchants on the legacy controller continue to see the old options panels until the flag is enabled.

### Behat coverage

`customer_service_options.feature` exercises both data providers through the DI container and asserts persisted values via the legacy `Configuration::get` adapter:

- Save the Contact options panel (file upload + translatable signature).
- Toggle the file upload off.
- Save the full IMAP panel (URL, port, user, password, behaviour flags, option toggles).

Step regexes are anchored so the boolean-state checks (`should be enabled` / `should be disabled`) don't conflate with string-value checks (`should be "..."`).

## What is intentionally NOT in this PR

- **CQRS commands for options updates** — PrestaShop's option pages traditionally use `DataConfigurationInterface` directly (Logs, Customer preferences, Invoice options, etc.). Introducing CQRS commands here would add boilerplate without benefit and diverge from the surrounding codebase. The Admin API in a later PR will inject the configuration adapters directly, the same way the BO controller does.
- **IMAP connection validation** — the legacy `isValidImapUrl` validator is not yet ported to a Symfony constraint. Will land alongside PR 4 (IMAP sync) which is the only consumer.
- **Playwright additions** — existing `04_contactOptions.ts` and `05_customerServiceOptions.ts` campaigns already exercise the same field labels and DB keys; they will be re-run against the migrated page in the dedicated Playwright PR.