### PR TITLE
AdminAPI: AI context + setup-apiresources-dev / link-apiresources-fork skills + module-skill discovery

### DIFF
--- a/.ai/CONTEXT.md
+++ b/.ai/CONTEXT.md
@@ -79,9 +79,9 @@ Domains: Address, Alias, ApiClient, Attachment, AttributeGroup, Carrier, Cart, C
 
 ## Component contexts
 
-All 26 shared infrastructure components have a context file at `Component/{ComponentName}/CONTEXT.md`.
+All 27 shared infrastructure components have a context file at `Component/{ComponentName}/CONTEXT.md`.
 
-Components: BackOfficeHelp, Behat, Configuration, Console, Context, ContextStateManager, Controller, Cookie, CQRS, Database, Export, FacetedSearch, Forms, Grid, Hook, Import, Javascript, Link, Locale, MailTemplate, Migration, Playwright, PositionUpdater, Router, Smarty, TinyMCE, Twig
+Components: AdminAPI, BackOfficeHelp, Behat, Configuration, Console, Context, ContextStateManager, Controller, Cookie, CQRS, Database, Export, FacetedSearch, Forms, Grid, Hook, Import, Javascript, Link, Locale, MailTemplate, Migration, Playwright, PositionUpdater, Router, Smarty, TinyMCE, Twig
 
 ## Generated indexes
 

--- a/.ai/Component/AdminAPI/CONTEXT.md
+++ b/.ai/Component/AdminAPI/CONTEXT.md
@@ -1,0 +1,70 @@
+# AdminAPI Component
+
+## Purpose
+
+The Admin API exposes PrestaShop's back-office over REST, built on API Platform 3 with OAuth2 authorization (server inside the bundle, JWT-based) and per-route scopes. Endpoints don't define their own business logic — they delegate to the existing CQRS layer. Most resource definitions ship in a separate module, `ps_apiresources`, rather than in core.
+
+For endpoint authoring conventions (URI shape, scopes, mappings, do/don't), the authoritative source is the module's own context: [`modules/ps_apiresources/CONTEXT.md`](../../../modules/ps_apiresources/CONTEXT.md). This file is intentionally light on those details and focuses on what's specific to the **core** side of the Admin API.
+
+## Layers
+
+| Layer | Path |
+|-------|------|
+| API Platform integration | `src/PrestaShopBundle/ApiPlatform/` (Provider/, Processor/, Normalizer/, Serializer/, Validator/, OpenApi/, Scopes/, Metadata/, Pagination/, Encoder/) |
+| Core-side API resources (always-available, even without ps_apiresources) | `src/PrestaShopBundle/ApiPlatform/Resources/` (currently `ApiClient.php`, `Language.php`) |
+| Legacy API controllers (pre-API-Platform) | `src/PrestaShopBundle/Controller/Api/` |
+| OAuth2 authorization server | `src/PrestaShopBundle/Security/OAuth2/` (Repository/, Provider/, GrantType/, Entity/) |
+| OAuth2 core interfaces + JWT | `src/Core/Security/OAuth2/` |
+| ApiClient domain (CQRS) | `src/Core/Domain/ApiClient/` (Command/, Query/, Exception/, ValueObject/, QueryResult/) |
+| API routing (Symfony) | `src/PrestaShopBundle/Resources/config/routing/api.yml`, `admin-api.yml`, `routing/api/{domain}.yml` |
+| Service wiring | `src/PrestaShopBundle/Resources/config/services/bundle/api_platform.yml`, `oauth.yml`, `open_api.yml` |
+| Module-provided API resources | `modules/ps_apiresources/src/ApiPlatform/Resources/` |
+| Integration tests (core) | `tests/Integration/ApiPlatform/`, `tests/Integration/PrestaShopBundle/ApiPlatform/`, `tests/Integration/PrestaShopBundle/Controller/Api/`, `tests/Resources/ApiPlatform/Resources/` |
+| Integration tests (module) | `modules/ps_apiresources/tests/Integration/` (uses `phpunit-local.xml` / `phpunit-ci.xml`) |
+
+## Non-obvious patterns
+
+- API Platform resources can live OUTSIDE core, inside installed modules — `ps_apiresources` is the canonical example. The scopes extractor scans installed modules to discover the available scope tree.
+- A handful of resources stay in **core** (`src/PrestaShopBundle/ApiPlatform/Resources/`) for endpoints that must work even when `ps_apiresources` is uninstalled — typically when the core itself depends on them. Current examples: `Language` (`/languages` — every other endpoint relies on the lang ID↔ISO mapping), `ApiClient` (`/api-clients/infos` — lets a token introspect itself; declares `scopes: []` and reads identity from `[_context][apiClientId]`).
+- Endpoints reuse CQRS by indirection: `QueryProvider` / `QueryListProvider` dispatch read operations through the query bus, `CommandProcessor` dispatches write operations through the command bus. There are no API-specific business handlers — all logic comes from the existing CQRS layer.
+- `ExperimentalOperationsMetadataCollectionFactoryDecorator` filters operations marked experimental when not in debug mode, so half-baked endpoints don't leak into production OpenAPI docs.
+- `CQRSNotFoundMetadataCollectionFactoryDecorator` filters out resources whose backing CQRS messages don't exist on the current branch — this matters when a module ships a resource for a domain class that's been renamed or removed.
+- Normalizer chain handles PrestaShop value objects: `CQRSApiNormalizer` (priority -1, runs last), `ValueObjectNormalizer`, `DecimalNumberNormalizer`, `ShopConstraintNormalizer`, `DateTimeImmutableNormalizer`, `UploadedFileNormalizer`, `LocalizedValueUpdater` for multilingual fields.
+- File uploads use a custom `MultipartDecoder` in `src/PrestaShopBundle/ApiPlatform/Encoder/`.
+- Position updates use a dedicated `UpdatePositionProcessor` (`api_platform.state_processor`) backed by `PositionCollectionUpdater`.
+- OAuth2 supports a custom `client_credentials` grant via `CustomClientCredentialsGrant`. Clients are persisted via the `ApiClient` domain (CRUD lives in the back-office UI).
+- Scopes are derived from API Resource metadata, cached via `CachedApiResourceScopesExtractor`.
+
+## Canonical examples
+
+- `src/PrestaShopBundle/ApiPlatform/Provider/QueryProvider.php` — query dispatch via the query bus
+- `src/PrestaShopBundle/ApiPlatform/Processor/CommandProcessor.php` — command dispatch via the command bus
+- `src/PrestaShopBundle/ApiPlatform/Normalizer/CQRSApiNormalizer.php` — main normalizer (priority -1, runs last)
+- `src/PrestaShopBundle/Security/OAuth2/PrestashopAuthorisationServer.php` — OAuth2 server
+- `modules/ps_apiresources/src/ApiPlatform/Resources/` — example resource definitions
+
+## Conventions
+
+- **Where new resources live** — default to `modules/ps_apiresources/src/ApiPlatform/Resources/`. Only put a resource in `src/PrestaShopBundle/ApiPlatform/Resources/` when the core itself depends on the endpoint (e.g. lang ID↔ISO mapping, self-introspection of the current API client). Endpoint authoring details (URI, scopes, mappings, do/don't, testing) live in [`modules/ps_apiresources/CONTEXT.md`](../../../modules/ps_apiresources/CONTEXT.md) — that's the source of truth, don't duplicate it here.
+- **Composer scripts** (core-level, not in the module's CONTEXT.md):
+  - `composer check-test-db` — verify the test DB is provisioned (dump files + DB accessible). Use this to skip needless re-creation.
+  - `composer api-module-tests-local` — full setup (slow): creates the test DB, dumps tables, dumps the module autoload, runs the entire module suite.
+  - `composer run-api-module-tests-local` — fast re-run of the suite (DB already provisioned).
+  - `_PS_ROOT_DIR_=$(pwd) php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c modules/ps_apiresources/tests/Integration/phpunit-local.xml --filter=ClassName` — single test class. `_PS_ROOT_DIR_` MUST be set per-command — PHPUnit can't auto-detect the PrestaShop root when the module is symlinked.
+
+## Skills
+
+| Skill | Owner | Trigger |
+|-------|-------|---------|
+| [`setup-apiresources-dev`](skills/setup-apiresources-dev/SKILL.md) | core (this component) | "set up ps_apiresources for development", "fix the API integration tests" |
+| [`link-apiresources-fork`](skills/link-apiresources-fork/SKILL.md) | core (this component) | "pair core with ps_apiresources branch", "use my ps_apiresources fork in the core PR", "revert ps_apiresources to dev-dev" |
+| [`ps-api-endpoint`](skills/ps-api-endpoint/SKILL.md) | `ps_apiresources` module (chained symlink) | "add a new admin API endpoint", "expose {Entity} on the API" |
+
+`ps-api-endpoint` is module-owned — the link is a chained symlink into `modules/ps_apiresources/.claude/skills/`. See [`STRUCTURE.md` → "Adding a module-owned skill"](../../STRUCTURE.md#adding-a-module-owned-skill) for the discovery pattern.
+
+## Related
+
+- [`modules/ps_apiresources/CONTEXT.md`](../../../modules/ps_apiresources/CONTEXT.md) — endpoint authoring conventions (URI, scopes, mappings, do/don't, testing)
+- `Component/CQRS` — endpoints delegate to commands and queries
+- `Domain/ApiClient` — back-office CRUD for API clients
+- External: <https://devdocs.prestashop-project.org/9/admin-api/> — 8 chapters: Context, OAuth2, Resource Server, Authorization Server, How to Use, Contribute to Core API, Setup Development Environment, Swagger Documentation

--- a/.ai/Component/AdminAPI/skills/link-apiresources-fork/SKILL.md
+++ b/.ai/Component/AdminAPI/skills/link-apiresources-fork/SKILL.md
@@ -1,0 +1,314 @@
+---
+name: link-apiresources-fork
+description: >
+  Pair the core PR with a ps_apiresources fork branch for coordinated review,
+  or revert that pairing to upstream dev-dev once both PRs are merged. Edits
+  composer.json (repository URL + dev-<branch> pin) and refreshes composer.lock.
+  Trigger: "pair core with ps_apiresources branch", "link ps_apiresources fork
+  branch", "use my ps_apiresources fork in the core PR", "revert ps_apiresources
+  to dev-dev", "unlink the ps_apiresources fork".
+needs: []
+produces: "Modified core composer.json + composer.lock pointing at the fork's branch (link mode), or reverted to upstream dev-dev (cleanup mode)."
+---
+
+# link-apiresources-fork
+
+Read @.ai/Component/AdminAPI/CONTEXT.md for the architectural background.
+
+This skill coordinates a core PR with a matching `ps_apiresources` PR — required when a change to PrestaShop core depends on (or breaks the contract of) the API module, so both sides must compile together during review. The sibling [`setup-apiresources-dev`](../setup-apiresources-dev/SKILL.md) skill sets up a local dev environment when needed; this skill works without it (e.g. when integrating an existing module PR into a core PR).
+
+**Workflow recap:** the contributor pushes the module branch to a fork → this skill points the core's `composer.json` at that fork branch and refreshes `composer.lock` → both PRs reference each other → the core PR is the one whose CI must be green (the module PR's CI will be red until the core PR merges) → after the core PR merges, close-reopen the module PR for fresh CI → merge the module PR → run this skill in **cleanup mode** to revert the core back to upstream `dev-dev`.
+
+The skill branches at runtime — every choice is an explicit `AskUserQuestion`. Never auto-decide anything that mutates `composer.json`, `composer.lock`, or `modules/ps_apiresources/`.
+
+## 0. Detect the current state
+
+Inspect the two relevant entries in `composer.json`:
+
+```bash
+grep -nE '"prestashop/ps_apiresources"|"ps_apiresources":[[:space:]]*\{' composer.json
+```
+
+- `repositories.ps_apiresources.url` — upstream `https://github.com/PrestaShop/ps_apiresources`, or a fork URL?
+- `require.prestashop/ps_apiresources` — `dev-dev`, or `dev-<branch>`?
+
+| Detected state | Natural mode |
+|----------------|--------------|
+| Both at upstream defaults | **Link** |
+| Either pointing at a fork / non-`dev-dev` branch | **Cleanup** (or relink to a different fork/branch) |
+
+## 1. Pick the mode (`AskUserQuestion`)
+
+Show the detected state, then ask:
+
+- **Link to a fork branch** — pin `repositories.ps_apiresources` to a contributor fork and pin the dependency to `dev-<branch>`.
+- **Cleanup (revert to upstream dev-dev)** — restore upstream URL + `dev-dev`.
+
+If the user picks the "natural" action for the detected state, proceed. If they pick the inverse (e.g. cleanup when the state is already upstream defaults), confirm — the skill should still no-op gracefully but warn there's nothing to do.
+
+## 2. Local-clone protection (always runs before any `composer update`)
+
+`composer update` will overwrite whatever sits at `modules/ps_apiresources/` with the locked version. Detect the current state and protect accordingly:
+
+```bash
+test -L modules/ps_apiresources && echo SYMLINK
+test -d modules/ps_apiresources/.git && echo IN_PLACE_CLONE
+```
+
+| State | Action |
+|-------|--------|
+| **Symlink to external clone** | Run `readlink modules/ps_apiresources` to record the target path. Composer will replace the symlink with its own checkout — that's fine, the external clone is untouched. Offer at the end (step 3g / 4g) to restore the symlink. |
+| **In-place clone (real `.git/`)** | High-risk. Surface uncommitted/unpushed work first, then offer move-and-symlink. See below. |
+| **Composer-installed plain dir (no `.git/`)** | No protection needed — composer overwrites normally. |
+
+### 2a. In-place clone — safety check
+
+```bash
+git -C modules/ps_apiresources status --short
+git -C modules/ps_apiresources log @{u}..HEAD --oneline 2>/dev/null
+```
+
+If anything appears (uncommitted files, unpushed commits), warn explicitly: "composer update will destroy this work."
+
+### 2b. In-place clone — move-and-symlink offer (recommended)
+
+`AskUserQuestion`:
+
+> Your in-place clone at `modules/ps_apiresources/` will be overwritten by `composer update`. Move it to an external path first and replace it with a symlink? (Recommended — preserves your local commits and uncommitted work.)
+
+If yes, `AskUserQuestion` for the absolute target path. Validate:
+
+```bash
+test -d "<parent of target>"     # parent dir must exist
+test ! -e "<target>"             # target must not exist (or must be empty)
+```
+
+Reject relative paths and unexpanded `~`. Then:
+
+```bash
+mv modules/ps_apiresources <target>
+ln -s <target> modules/ps_apiresources
+```
+
+Record `<target>` so step 3g / 4g can offer to restore the symlink.
+
+If the user declines move-and-symlink AND the working tree is dirty or has unpushed commits, **STOP**. Do not proceed. Tell the user to push their branch first.
+
+If the working tree is clean AND the branch is pushed, accept the overwrite — the local clone can be re-created from the remote later.
+
+## 3. Mode A — Link to a fork branch
+
+### 3a. Gather inputs (`AskUserQuestion`)
+
+**Pre-check** — if `modules/ps_apiresources/` is a git checkout (in-place clone or symlink to one), inspect what's currently checked out so the skill can offer to reuse it:
+
+```bash
+git -C modules/ps_apiresources rev-parse --git-dir > /dev/null 2>&1 \
+    && upstream_ref=$(git -C modules/ps_apiresources rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null) \
+    && local_remote=${upstream_ref%%/*} \
+    && local_branch=$(git -C modules/ps_apiresources branch --show-current) \
+    && local_remote_url=$(git -C modules/ps_apiresources remote get-url "$local_remote" 2>/dev/null)
+```
+
+If `local_remote_url` is set and does NOT contain `PrestaShop/ps_apiresources` (i.e. it's a fork, not the upstream), Path C is available — the local checkout is almost certainly what we want to link.
+
+Ask the user — present detected paths first:
+
+> How will you specify the module PR?
+>
+> - **Use the local checkout** (recommended, when detected) — `<local_remote_url>` / `<local_branch>` from `modules/ps_apiresources/`.
+> - **Module PR URL** — paste the URL of the `ps_apiresources` PR; the skill extracts the fork URL and branch name via `gh`.
+> - **Fork URL + branch name** (manual) — provide them separately.
+
+When the local checkout is upstream PrestaShop, has no remote tracker, or `modules/ps_apiresources/` is composer-installed, omit the first option.
+
+#### Path A — Module PR URL
+
+`AskUserQuestion` for the URL. Validate it matches `https://github.com/<owner>/ps_apiresources/pull/<n>`.
+
+Resolve the fork and branch via `gh`:
+
+```bash
+gh pr view <url> --json headRepositoryOwner,headRepository,headRefName
+```
+
+Build:
+
+- Fork URL = `https://github.com/<headRepositoryOwner.login>/<headRepository.name>`
+- Branch name = `<headRefName>`
+
+Confirm via `AskUserQuestion`:
+
+> Detected fork URL `<fork>` / branch `<branch>` from PR `<url>`. Use these?
+
+Record the PR URL — it's reused in the reminder at the end (step 3f).
+
+If `gh` is not installed, not authenticated, or the PR is not found, fall back to **Path B**.
+
+A PR can't exist without a pushed branch, so no separate push prerequisite is needed in this path.
+
+#### Path B — Fork URL + branch name (manual)
+
+Push prerequisite — `AskUserQuestion`:
+
+> Has the module branch been pushed to your `ps_apiresources` fork on GitHub?
+
+If no, **STOP**. Composer can't resolve `dev-<branch>` if the branch doesn't exist remotely. Tell the user to push first; do not push for them.
+
+Then `AskUserQuestion` (batch):
+
+- **Fork URL** — default to `https://github.com/<user>/ps_apiresources` deduced from the parent project's remotes (read `git -C . remote -v`; if any remote points at `git@github.com:<user>/PrestaShop.git` or `https://github.com/<user>/PrestaShop.git`, propose the matching `ps_apiresources` URL). HTTPS is preferred for `composer.json` because it works without SSH credentials in CI. Always allow override.
+- **Branch name** — e.g. `delete-endpoints-command`. The composer pin becomes `dev-<branch-name>`.
+- **Module PR URL** (optional but recommended) — reused in the reminder at the end.
+
+#### Path C — Use the local checkout (when detected)
+
+The skill already has the fork URL and branch from the pre-check. Convert any SSH URL to HTTPS for `composer.json` compatibility:
+
+- `git@github.com:<user>/<repo>(.git)?` → `https://github.com/<user>/<repo>`
+- `https://github.com/<user>/<repo>(.git)?` → `https://github.com/<user>/<repo>`
+
+Verify the branch is fully pushed — composer.lock will resolve to the remote HEAD, not the local working tree:
+
+```bash
+git -C modules/ps_apiresources fetch <local_remote>
+git -C modules/ps_apiresources status -sb | head -1   # look for "[ahead N]"
+```
+
+If `[ahead N]` appears, warn via `AskUserQuestion`:
+
+> Local branch `<branch>` is ahead of `<remote>` by N commit(s). composer.lock will pin the **remote** HEAD, so your unpushed commits won't be linked. Push first?
+
+If the user pushes, re-fetch and continue. If they decline, proceed but make it clear composer.lock will lag.
+
+Final confirmation via `AskUserQuestion`:
+
+> Use fork URL `<fork-url>` / branch `<branch>` from the local checkout?
+
+If the user declines, fall back to Path A or B by re-prompting the input-method question.
+
+A PR URL isn't required for this path. Optionally ask for one to use in the "Related PR" reminder at the end (step 3f); skip if the user has none yet.
+
+### 3b. Edit `composer.json` (two surgical replacements)
+
+Both target strings are unique in the file as of HEAD:
+
+1. Inside the `repositories.ps_apiresources` entry: replace `"url": "https://github.com/PrestaShop/ps_apiresources"` with `"url": "<fork-url>"`.
+2. Replace `"prestashop/ps_apiresources": "dev-dev"` with `"prestashop/ps_apiresources": "dev-<branch>"`.
+
+Use the `Edit` tool — do **not** use `composer config repositories.ps_apiresources vcs <url>` because it may rewrite key order or strip fields and produce a noisy diff.
+
+### 3c. Run `composer update`
+
+```bash
+composer update prestashop/ps_apiresources 2>&1
+```
+
+If this fails (404 on the fork, branch doesn't exist, auth required), capture the error, **revert `composer.json` to its pre-skill state**, and report. Don't leave a broken composer.json behind.
+
+### 3d. Verify
+
+```bash
+composer show prestashop/ps_apiresources | head -20    # expect dev-<branch> + a fork commit hash
+git diff composer.json                                  # expect exactly the 2 intended edits, nothing else
+git diff --stat composer.lock                           # expect a small diff, only ps_apiresources package fields
+```
+
+If `composer.json` shows changes outside the two intended edits (e.g. composer-normalize reformatted the file), inspect carefully and warn the user before proceeding.
+
+If `composer.lock` shows transitive package movements (other packages updated), warn the user — `composer update prestashop/ps_apiresources` should be surgical.
+
+### 3e. Commit and push (`AskUserQuestion`)
+
+The link only takes effect for CI once GitHub sees the updated `composer.json` + `composer.lock`. Ask:
+
+> Commit `composer.json` + `composer.lock` and push to the core PR branch now?
+
+If yes:
+
+```bash
+git add composer.json composer.lock
+git commit -m "Link ps_apiresources to dev-<branch> for cross-PR review"
+git push
+```
+
+If `git push` fails because the branch has no upstream, use `git push -u <remote> <branch>`. Never force-push from this step — the change is additive.
+
+If the user declines, leave the working tree dirty and remind them that the link won't reach CI until they commit + push manually.
+
+### 3f. Reminders (output to user)
+
+- **Add to the core PR description table:** `Related PR: <module PR URL>` (use the PR URL collected via Path A or Path B; if Path B was used and the user didn't provide one, just point at the fork branch).
+- **Expected CI state during the transitory phase:**
+  - Core PR CI: must be green (it has both sides linked).
+  - Module PR CI: will be red until the core PR merges — that's expected, the core PR is the reference.
+- **After both PRs are merged**, run this skill again in **cleanup mode** to revert.
+
+### 3g. Symlink-restore offer
+
+If step 2 recorded a symlink target (either pre-existing or freshly created via move-and-symlink):
+
+> Restore the symlink `modules/ps_apiresources -> <target>`? (Recommended if you'll continue editing the module locally — composer's checkout in `modules/` will be replaced by your external clone.)
+
+If yes:
+
+```bash
+rm -rf modules/ps_apiresources
+ln -s <target> modules/ps_apiresources
+```
+
+Note: after restoring the symlink, the module's working state in `modules/` is whatever the user has at `<target>`, **not** the version composer just locked. If the user is on the fork branch locally, those should align — but warn that running tests will use the local working state, not the locked commit.
+
+## 4. Mode B — Cleanup (revert to upstream dev-dev)
+
+### 4a. Local-clone protection
+
+Run step 2 again. Same logic: protect any in-place clone with uncommitted/unpushed work; offer move-and-symlink.
+
+### 4b. Edit `composer.json` (inverse of 3b)
+
+Two surgical replacements:
+
+1. Inside the `repositories.ps_apiresources` entry: replace `"url": "<current fork URL>"` with `"url": "https://github.com/PrestaShop/ps_apiresources"`.
+2. Replace `"prestashop/ps_apiresources": "dev-<current branch>"` with `"prestashop/ps_apiresources": "dev-dev"`.
+
+Read the current values from `composer.json` first to compute the exact replacement strings.
+
+### 4c. Run `composer update`
+
+```bash
+composer update prestashop/ps_apiresources 2>&1
+```
+
+Same revert-on-failure handling as 3c.
+
+### 4d. Verify
+
+Mirror of 3d. Bonus check: `composer show prestashop/ps_apiresources` should now report `dev-dev` again.
+
+### 4e. Commit and push (`AskUserQuestion`)
+
+> Commit `composer.json` + `composer.lock` and push to the core PR branch now?
+
+If yes:
+
+```bash
+git add composer.json composer.lock
+git commit -m "Revert ps_apiresources to upstream dev-dev"
+git push
+```
+
+If the user declines, leave the working tree dirty.
+
+### 4f. Reminders
+
+- **Remove** the `Related PR: <module PR URL>` line from the core PR description if both PRs are merged.
+
+### 4g. Symlink-restore offer
+
+Mirror of 3g.
+
+## 5. Next steps / related
+
+- For local module development: invoke `/setup-apiresources-dev`.
+- For new endpoints in the module: invoke `/ps-api-endpoint` (chained symlink to the module's own skill).

--- a/.ai/Component/AdminAPI/skills/ps-api-endpoint
+++ b/.ai/Component/AdminAPI/skills/ps-api-endpoint
@@ -1,0 +1,1 @@
+../../../../modules/ps_apiresources/.claude/skills/ps-api-endpoint

--- a/.ai/Component/AdminAPI/skills/setup-apiresources-dev/SKILL.md
+++ b/.ai/Component/AdminAPI/skills/setup-apiresources-dev/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: setup-apiresources-dev
+description: >
+  Configure modules/ps_apiresources as a development-ready git checkout (symlink
+  to existing local clone or fresh clone with upstream + fork remotes), then
+  provision the local test DB. Trigger: "set up ps_apiresources for development",
+  "develop on the API module", "fix the API integration tests", "work on
+  ps_apiresources locally".
+needs: []
+produces: "modules/ps_apiresources/ as a git checkout (in-place or symlinked) with upstream + fork remotes wired, and a provisioned local test DB ready for `composer run-api-module-tests-local`."
+---
+
+# setup-apiresources-dev
+
+Read @.ai/Component/AdminAPI/CONTEXT.md for the architectural background.
+
+This skill prepares `modules/ps_apiresources/` for local development. Composer ships the module as a read-only dependency, so a contributor wanting to fix and push tests has to wire up an actual git checkout.
+
+The skill branches at runtime — every choice is an explicit `AskUserQuestion`. Do NOT auto-decide anything that touches `modules/ps_apiresources/` without confirmation.
+
+## 1. Detect the current state of `modules/ps_apiresources`
+
+Run from the project root:
+
+```bash
+ls -la modules/ps_apiresources 2>&1 | head -2
+```
+
+Branch on the result:
+
+- **Missing** (no entry): run `composer install` — `ps_apiresources` is a dev dependency. Re-run the detection.
+- **Symlink** (`test -L modules/ps_apiresources`): verify the target is a git directory (`test -d "$(readlink modules/ps_apiresources)/.git"`). If yes and the target already has `upstream` + a personal fork remote, **skip to step 6** — already dev-ready.
+- **Plain directory**: check for a `.git/` entry inside.
+  - **`.git/` present**: it's already a git checkout. If `upstream` + fork remotes are wired, **skip to step 6**. Otherwise, jump to step 4 to wire remotes (skip the clone step).
+  - **`.git/` absent**: composer-installed, NOT dev-ready. Continue to step 2.
+
+If the directory is a non-empty plain folder without `.git/`, run `git -C modules/ps_apiresources status 2>&1` first — composer-installed dirs return an error, which is the safe signal. **Never `rm -rf` a directory until you've confirmed it has no untracked work.**
+
+## 2. Pick the setup mode (`AskUserQuestion`)
+
+Ask the user:
+
+> `modules/ps_apiresources` isn't a development checkout yet. How do you want to set it up?
+
+Three options:
+
+- **Clone into an external folder, then symlink** (recommended) → Branch C. The git checkout lives outside the project tree, safer because `composer install` / `composer update` only ever replace the symlink, never the external clone.
+- **Symlink to a clone I already have elsewhere** → Branch A.
+- **Clone fresh directly under modules/** → Branch B. Simpler but riskier — composer can wipe the in-place checkout.
+
+## 3. Branch A — symlink to an existing local clone
+
+3a. **Ask for the absolute path** via `AskUserQuestion`. Validate before doing anything destructive:
+
+```bash
+test -d "<absolute-path>" || echo "path does not exist"
+test -d "<absolute-path>/.git" || echo "not a git directory"
+```
+
+If either check fails, refuse and re-ask. Reject relative paths and unexpanded `~` — `ln -s` does not expand them.
+
+3b. **Confirm replacement** via `AskUserQuestion`:
+
+> The composer-installed `modules/ps_apiresources/` folder will be deleted and replaced by a symlink to `<absolute-path>`. Proceed?
+
+Only proceed if the existing entry is a directory (not already a symlink).
+
+3c. **Replace**:
+
+```bash
+rm -rf modules/ps_apiresources
+ln -s <absolute-path> modules/ps_apiresources
+```
+
+Skip to **step 6**.
+
+## 4. Branch B — fresh clone
+
+4a. **Pick the protocol** via `AskUserQuestion`:
+
+> Use SSH or HTTPS for the upstream remote?
+
+Defaults to SSH if `~/.ssh/id_*` keys exist OR if the parent project's `origin` matches `git@github.com:`. Run `git -C . remote get-url origin` to check.
+
+4b. **Confirm replacement** via `AskUserQuestion` (same as 3b — only if the existing entry is a composer-installed directory).
+
+4c. **Clone upstream**:
+
+```bash
+rm -rf modules/ps_apiresources
+git clone git@github.com:PrestaShop/ps_apiresources.git modules/ps_apiresources       # SSH
+# or
+git clone https://github.com/PrestaShop/ps_apiresources.git modules/ps_apiresources   # HTTPS
+```
+
+4d. **Deduce the contributor's fork URL.** Read the parent project's remotes:
+
+```bash
+git -C . remote -v
+```
+
+If `origin` (or any remote) points to `git@github.com:<user>/PrestaShop.git`, the natural fork URL is `git@github.com:<user>/ps_apiresources.git` (HTTPS equivalent: `https://github.com/<user>/ps_apiresources.git`). Match the protocol chosen in 4a.
+
+**Confirm via `AskUserQuestion`** — present the deduced URL as the recommended option, but always allow the user to override (e.g. corp fork, fork-of-fork, different account). Never auto-apply.
+
+4e. **Wire the remotes.** Convention used in this skill: `fork` = the contributor's fork, `upstream` = PrestaShop's main repo. The names are explicit on purpose so contributors don't confuse the upstream with their own fork — this differs from the parent project where `origin` = fork, but it makes the two remotes self-documenting.
+
+```bash
+git -C modules/ps_apiresources remote rename origin upstream
+git -C modules/ps_apiresources remote add fork <fork-url>
+git -C modules/ps_apiresources fetch fork || true   # tolerate fork not existing yet
+```
+
+If `git fetch fork` fails because the fork doesn't exist on GitHub yet, treat as a soft warning and tell the user to create it at `https://github.com/<user>/ps_apiresources/fork`. Do NOT block setup — `fork` can be added before the fork exists.
+
+## 5. Branch C — clone into external folder + symlink (recommended)
+
+Same operations as Branch B, but the clone lands at an external path and `modules/ps_apiresources` becomes a symlink to it. Run the Branch B steps with `<external-path>` substituted for `modules/ps_apiresources`, then symlink at the end.
+
+5a. **Ask for the absolute external path** via `AskUserQuestion`:
+
+> Where should the ps_apiresources clone live on disk? Pick a path outside this PrestaShop project tree (e.g. `~/dev/ps_apiresources`).
+
+Validate: reject relative paths and unexpanded `~`; the parent directory must exist; the target itself must NOT exist or must be empty.
+
+5b. **Run Branch B steps 4a, 4c, 4d, 4e** with `<external-path>` substituted for `modules/ps_apiresources`. Note: 4c's `rm -rf modules/ps_apiresources` line does NOT apply here (the external path is empty); only the `git clone <upstream-url> <external-path>` runs.
+
+5c. **Confirm replacement** of `modules/ps_apiresources/` via `AskUserQuestion` — only if the existing entry is a composer-installed plain dir.
+
+5d. **Replace with a symlink**:
+
+```bash
+rm -rf modules/ps_apiresources
+ln -s <external-path> modules/ps_apiresources
+```
+
+Skip to **step 6**.
+
+## 6. Verify the git setup
+
+```bash
+git -C modules/ps_apiresources remote -v        # must show both upstream + fork
+git -C modules/ps_apiresources status           # must be clean / on a known branch
+```
+
+Abort and report if remotes are missing or the working tree isn't clean.
+
+## 7. Pick the work branch
+
+Any new fix or improvement on `ps_apiresources` MUST start from `upstream/dev` HEAD — that's the only way to be in sync with the latest upstream state. `AskUserQuestion`:
+
+> What branch will you work on?
+>
+> - Existing branch — already on my fork; the skill will fetch and check it out.
+> - New branch — the skill will create one from `upstream/dev` HEAD.
+> - Skip — I'll handle the branch myself.
+
+Refuse to proceed in any path if the working tree isn't clean (`git -C modules/ps_apiresources status --porcelain` non-empty). Ask the user to commit or stash first.
+
+**Existing branch path** — `AskUserQuestion` for the branch name, then:
+
+```bash
+git -C modules/ps_apiresources fetch fork
+git -C modules/ps_apiresources switch <branch-name>
+# If no local branch yet: git -C modules/ps_apiresources switch -c <branch-name> fork/<branch-name>
+```
+
+**New branch path** — `AskUserQuestion` for the branch name. Propose the parent core project's current branch name as the default (read via `git -C . branch --show-current`) so the module branch mirrors the core PR's branch; the user can override (e.g. pick a different naming convention or scope).
+
+Then:
+
+```bash
+git -C modules/ps_apiresources fetch upstream
+git -C modules/ps_apiresources switch --no-track -c <branch-name> upstream/dev
+```
+
+`--no-track` is critical: a plain `switch -c <name> upstream/dev` auto-binds the new branch's upstream to `upstream/dev`, so a later `git push` would target the main PrestaShop repository directly. The work branch must stay local-only until the contributor pushes it to their fork (`git push -u fork HEAD`), at which point it tracks `fork/<branch>` — never `upstream`.
+
+## 8. Provision the local test DB
+
+The test DB is shared across all PrestaShop test suites (Integration, Behat, ApiPlatform, ps_apiresources). If the contributor has run any test setup before, it's already there — re-creating it is slow and unnecessary. Always check first:
+
+```bash
+composer check-test-db
+```
+
+- **Exit 0** — `Test environment is ready.` Skip provisioning, but still run `composer dump-autoload --dev --working-dir=modules/ps_apiresources` once to make sure the module's autoload is current after we just rewired its directory. Continue to step 9.
+- **Exit non-zero** — at least one of: dump files missing, per-table dumps missing, or DB unreachable. `AskUserQuestion` to confirm before resetting any existing local test DB, then:
+
+  ```bash
+  composer create-test-db
+  composer dump-autoload --dev --working-dir=modules/ps_apiresources
+  ```
+
+The full suite is NOT run here — it's slow and unnecessary as a setup check. A single test class is enough to confirm the env (next step).
+
+## 9. Verify the dev setup
+
+Run a single test class as a smoke test:
+
+```bash
+_PS_ROOT_DIR_=$(pwd) php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit \
+    -c modules/ps_apiresources/tests/Integration/phpunit-local.xml \
+    --filter=AddressEndpointTest
+```
+
+Look for `OK (...)` in the output. `FAILURES!` or `ERRORS!` means the env isn't ready — capture the error and report. The full suite (`composer run-api-module-tests-local`) is available as a day-to-day command (step 10) but isn't run here.
+
+## 10. Day-to-day commands
+
+After this skill completes, refresh the module autoload once:
+
+```bash
+composer dump-autoload --dev --working-dir=modules/ps_apiresources
+```
+
+For day-to-day test commands (re-run the suite, run a single test class) see [`Component/AdminAPI/CONTEXT.md` → Conventions](../../CONTEXT.md#conventions). The `_PS_ROOT_DIR_` inlining requirement documented there is critical when the module is symlinked — a stale `_PS_ROOT_DIR_` exported from another shell silently misroutes everything.
+
+## 11. Next steps / related
+
+- For new endpoints: invoke `/ps-api-endpoint`, or read [`skills/ps-api-endpoint/SKILL.md`](../ps-api-endpoint/SKILL.md) (chained symlink — the canonical file lives in `modules/ps_apiresources/.claude/skills/ps-api-endpoint/`).
+- For pairing this module with a fork branch in a core PR: invoke `/link-apiresources-fork`.

--- a/.ai/STRUCTURE.md
+++ b/.ai/STRUCTURE.md
@@ -168,6 +168,24 @@ A skill exists to help: use the `create-skill` skill.
 2. Create a symlink in `.claude/skills/` pointing to the skill directory (for Claude Code auto-discovery).
 3. Add a `## Skills` entry to the corresponding `CONTEXT.md`: root `.ai/CONTEXT.md` for cross-cutting skills, or the relevant component/domain `CONTEXT.md` for scoped ones. This table is the agnostic discovery mechanism for all non-Claude tools.
 
+### Adding a module-owned skill
+
+Modules can ship their own AI skills under `<module>/.claude/skills/{skill-name}/SKILL.md` or `<module>/.ai/skills/{skill-name}/SKILL.md`. The skill is owned and maintained by the module, not by this repository — but to be auto-discoverable from the project root it has to be exposed via a chained symlink, because Claude Code does NOT walk into nested `.claude/` directories.
+
+1. **Decide which component the skill belongs to.** This is a human judgment call — the component should be the natural architectural fit (e.g. an API resource skill belongs under `Component/AdminAPI/`). Don't auto-pick.
+2. **Curate the component association** with a single symlink:
+   ```bash
+   ln -s ../../../../modules/<module>/<dotdir>/skills/<skill-name> \
+     .ai/Component/{Name}/skills/<skill-name>
+   ```
+   `<dotdir>` is `.claude` or `.ai` depending on where the module hosts the skill.
+3. **Run the index generator** — `bash .ai/bin/generate-ai-index.sh`. It uses `find -L` so it follows the component-level symlink into the module, then auto-creates the standard `.claude/skills/<skill-name> -> ../../.ai/Component/{Name}/skills/<skill-name>` like every other skill.
+4. **Add a `## Skills` row** to the component's `CONTEXT.md` marking the skill as module-owned, with a link back to this section.
+
+The chain (`.claude/skills/<name>` → `.ai/Component/{N}/skills/<name>` → module skill dir) resolves whenever the module is present — composer-installed, freshly cloned, or locally symlinked — and dangles harmlessly otherwise.
+
+The index generator also runs `discover_module_skills` to scan `modules/*/.claude/skills/` and `modules/*/.ai/skills/`, listing any module skill that has no component association yet. Contributors see those as suggestions; nothing is auto-attached.
+
 ### Updating existing context
 
 Edit the relevant `CONTEXT.md` directly. Pointer files at the repo root should never need modification — they only contain references.

--- a/.ai/bin/generate-ai-index.sh
+++ b/.ai/bin/generate-ai-index.sh
@@ -42,11 +42,32 @@ php_classname() {
         | tr -d '\r' || true
 }
 
+# Replace $final with $tmp atomically only if their content differs modulo the
+# `(generated YYYY-MM-DD)` date line in the header. Avoids pushing date-only diffs.
+finalize_outfile() {
+    local final="$1" tmp="$2" label="$3"
+    local lines
+
+    if [[ -f "$final" ]] && diff -q \
+            <(sed -E 's/\(generated [0-9]{4}-[0-9]{2}-[0-9]{2}\)/(generated DATE)/' "$final") \
+            <(sed -E 's/\(generated [0-9]{4}-[0-9]{2}-[0-9]{2}\)/(generated DATE)/' "$tmp") \
+            > /dev/null 2>&1; then
+        rm -f "$tmp"
+        lines=$(wc -l < "$final" | tr -d ' ')
+        printf "  = %-13s (unchanged, %s lines)\n" "$label" "$lines"
+    else
+        mv -f "$tmp" "$final"
+        lines=$(wc -l < "$final" | tr -d ' ')
+        printf "  ✓ %-13s (%s lines)\n" "$label" "$lines"
+    fi
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # 1. cqrs.md — Commands & Queries grouped by domain
 # ─────────────────────────────────────────────────────────────────────────────
 generate_cqrs() {
-    local outfile="$OUTPUT_DIR/cqrs.md"
+    local final="$OUTPUT_DIR/cqrs.md"
+    local outfile="$final.tmp"
     local domain_dir="$REPO_ROOT/src/Core/Domain"
 
     local cmd_count query_count domain_count
@@ -131,14 +152,15 @@ generate_cqrs() {
         if [[ $wrote_domain -eq 1 ]]; then echo "" >> "$outfile"; fi
     done < <(find "$domain_dir" -maxdepth 1 -mindepth 1 -type d | sort)
 
-    echo "  ✓ cqrs.md        ($(wc -l < "$outfile" | tr -d ' ') lines)"
+    finalize_outfile "$final" "$outfile" "cqrs.md"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 2. routes.md — Symfony routes grouped by routing file
 # ─────────────────────────────────────────────────────────────────────────────
 generate_routes() {
-    local outfile="$OUTPUT_DIR/routes.md"
+    local final="$OUTPUT_DIR/routes.md"
+    local outfile="$final.tmp"
     local routing_dir="$REPO_ROOT/src/PrestaShopBundle/Resources/config/routing"
 
     local total_routes
@@ -220,14 +242,15 @@ generate_routes() {
         done <<< "$area_files"
     done
 
-    echo "  ✓ routes.md      ($(wc -l < "$outfile" | tr -d ' ') lines)"
+    finalize_outfile "$final" "$outfile" "routes.md"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 3. entities.md — Doctrine entity properties & relations
 # ─────────────────────────────────────────────────────────────────────────────
 generate_entities() {
-    local outfile="$OUTPUT_DIR/entities.md"
+    local final="$OUTPUT_DIR/entities.md"
+    local outfile="$final.tmp"
     local entity_dir="$REPO_ROOT/src/PrestaShopBundle/Entity"
 
     local entity_count
@@ -289,14 +312,15 @@ generate_entities() {
         echo "" >> "$outfile"
     done < <(find "$entity_dir" -maxdepth 1 -name "*.php" | sort)
 
-    echo "  ✓ entities.md    ($(wc -l < "$outfile" | tr -d ' ') lines)"
+    finalize_outfile "$final" "$outfile" "entities.md"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 4. hooks.md — Hook names discovered in source
 # ─────────────────────────────────────────────────────────────────────────────
 generate_hooks() {
-    local outfile="$OUTPUT_DIR/hooks.md"
+    local final="$OUTPUT_DIR/hooks.md"
+    local outfile="$final.tmp"
     local src_dir="$REPO_ROOT/src"
 
     # Extract literal hook names passed to dispatch* methods
@@ -362,7 +386,7 @@ generate_hooks() {
         echo "" >> "$outfile"
     fi
 
-    echo "  ✓ hooks.md       ($(wc -l < "$outfile" | tr -d ' ') lines)"
+    finalize_outfile "$final" "$outfile" "hooks.md"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -389,9 +413,49 @@ sync_skill_symlinks() {
             ln -s "$target" "$link"
             created=$((created + 1))
         fi
-    done < <(find "$REPO_ROOT/.ai" -iname "skill.md" | sort)
+    done < <(find -L "$REPO_ROOT/.ai" -iname "skill.md" | sort)
 
     echo "  ✓ skill symlinks ($created created, $already already linked)"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. discover_module_skills — suggest component associations for module-shipped skills
+# ─────────────────────────────────────────────────────────────────────────────
+discover_module_skills() {
+    local modules_dir="$REPO_ROOT/modules"
+    [[ -d "$modules_dir" ]] || return 0
+
+    local total=0 unattached=0
+    local suggestions=""
+
+    while IFS= read -r skill_md; do
+        local skill_dir skill_name module_path module_name
+        skill_dir="$(dirname "$skill_md")"
+        skill_name="$(basename "$skill_dir")"
+        # extract module dir from: modules/<name>/(.claude|.ai)/skills/<skill_name>/SKILL.md
+        module_path="${skill_dir%/.claude/skills/*}"
+        module_path="${module_path%/.ai/skills/*}"
+        module_name="$(basename "$module_path")"
+
+        total=$((total + 1))
+
+        # Already associated under any .ai/Component/*/skills/<skill_name> symlink?
+        if find "$REPO_ROOT/.ai/Component" -maxdepth 3 -name "$skill_name" -type l 2>/dev/null | grep -q .; then
+            continue
+        fi
+
+        unattached=$((unattached + 1))
+        suggestions+="    - $module_name/$skill_name → consider symlinking under .ai/Component/{?}/skills/$skill_name"$'\n'
+    done < <(find "$modules_dir" -mindepth 4 -maxdepth 5 \
+                  \( -path "*/.claude/skills/*/SKILL.md" -o -path "*/.ai/skills/*/SKILL.md" \) \
+                  -iname "skill.md" 2>/dev/null | sort)
+
+    if [[ $unattached -gt 0 ]]; then
+        echo "  ⚠ module skills  ($total found, $unattached unattached):"
+        printf "%s" "$suggestions"
+    else
+        echo "  ✓ module skills  ($total found, all associated)"
+    fi
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -403,6 +467,7 @@ generate_cqrs
 generate_routes
 generate_entities
 generate_hooks
+discover_module_skills
 sync_skill_symlinks
 
 echo ""

--- a/.claude/skills/link-apiresources-fork
+++ b/.claude/skills/link-apiresources-fork
@@ -1,0 +1,1 @@
+../../.ai/Component/AdminAPI/skills/link-apiresources-fork

--- a/.claude/skills/ps-api-endpoint
+++ b/.claude/skills/ps-api-endpoint
@@ -1,0 +1,1 @@
+../../.ai/Component/AdminAPI/skills/ps-api-endpoint

--- a/.claude/skills/setup-apiresources-dev
+++ b/.claude/skills/setup-apiresources-dev
@@ -1,0 +1,1 @@
+../../.ai/Component/AdminAPI/skills/setup-apiresources-dev

--- a/composer.json
+++ b/composer.json
@@ -275,6 +275,9 @@
             "@composer dump-autoload --dev --working-dir=modules/ps_apiresources",
             "@composer run-api-module-tests-local"
         ],
+        "check-test-db": [
+            "@php ./tests/bin/check-test-db.php"
+        ],
         "create-release": "@php tools/build/CreateRelease.php",
         "create-test-db": [
             "@php ./tests/bin/create-test-db.php",
@@ -321,6 +324,7 @@
         ]
     },
     "scripts-descriptions": {
+        "check-test-db": "Check whether the test Database has been initialized (dump files + DB accessible)",
         "create-release": "Create a release of PrestaShop, run the command with -h/--help argument for more information.",
         "create-test-db": "Create a Database for testing purposes",
         "create-test-table-dumps": "Create a dump of each table in the Database for testing purposes",

--- a/tests/bin/check-test-db.php
+++ b/tests/bin/check-test-db.php
@@ -1,0 +1,98 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+use PrestaShop\PrestaShop\Core\Version;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+define('_PS_ROOT_DIR_', dirname(__DIR__, 2));
+const _PS_IN_TEST_ = true;
+const __PS_BASE_URI__ = '/';
+const _PS_MODULE_DIR_ = _PS_ROOT_DIR_ . '/tests/Resources/modules/';
+const _PS_ALL_THEMES_DIR_ = _PS_ROOT_DIR_ . '/tests/Resources/themes/';
+require_once _PS_ROOT_DIR_ . '/install-dev/init.php';
+
+$output = new ConsoleOutput();
+$exitCode = 0;
+
+$dbName = _DB_NAME_;
+$tmpDir = sys_get_temp_dir();
+$globalDump = sprintf('%s/ps_dump_%s_%s.sql', $tmpDir, $dbName, Version::VERSION);
+$tableDumpPattern = sprintf('%s/ps_dump_%s_%s_*.sql', $tmpDir, $dbName, Version::VERSION);
+
+// 1. Global dump file
+if (file_exists($globalDump)) {
+    $output->writeln(sprintf('<info> ✓ Global dump present:</info> %s', $globalDump));
+} else {
+    $output->writeln(sprintf('<error> ✗ Global dump missing:</error> %s', $globalDump));
+    $exitCode = 1;
+}
+
+// 2. Per-table dump files (the global pattern also matches the global dump itself, so we exclude it)
+$tableDumps = array_filter(glob($tableDumpPattern) ?: [], static fn (string $f): bool => $f !== $globalDump);
+$dumpCount = null;
+if (!empty($tableDumps)) {
+    $dumpCount = count($tableDumps);
+    $output->writeln(sprintf('<info> ✓ Per-table dumps present:</info> %d files', $dumpCount));
+} else {
+    $output->writeln(sprintf('<error> ✗ No per-table dumps found at:</error> %s', $tableDumpPattern));
+    $exitCode = 1;
+}
+
+// 3. Test database created and accessible
+$tableCount = null;
+try {
+    $tables = Db::getInstance()->executeS('SHOW TABLES');
+    if (is_array($tables) && count($tables) > 0) {
+        $tableCount = count($tables);
+        $output->writeln(sprintf('<info> ✓ Test database "%s" accessible:</info> %d tables', $dbName, $tableCount));
+    } else {
+        $output->writeln(sprintf('<error> ✗ Test database "%s" exists but has no tables</error>', $dbName));
+        $exitCode = 1;
+    }
+} catch (Throwable $e) {
+    $output->writeln(sprintf('<error> ✗ Cannot access test database "%s":</error> %s', $dbName, $e->getMessage()));
+    $exitCode = 1;
+}
+
+// 4. Per-table dumps and DB tables count must match (content not checked)
+if ($dumpCount !== null && $tableCount !== null) {
+    if ($dumpCount === $tableCount) {
+        $output->writeln(sprintf('<info> ✓ Table counts match:</info> %d dumps = %d tables', $dumpCount, $tableCount));
+    } else {
+        $output->writeln(sprintf('<error> ✗ Table count mismatch:</error> %d per-table dumps vs %d tables in the DB', $dumpCount, $tableCount));
+        $exitCode = 1;
+    }
+}
+
+$output->writeln('');
+if ($exitCode === 0) {
+    $output->writeln('<info>Test environment is ready.</info>');
+} else {
+    $output->writeln('<comment>Run `composer create-test-db` to provision the test database.</comment>');
+}
+
+exit($exitCode);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add an `AdminAPI` component context under `.ai/` plus two cross-cutting skills that streamline contributing to the Admin API: `setup-apiresources-dev` (turns `modules/ps_apiresources/` into a development checkout) and `link-apiresources-fork` (pairs a core PR with a `ps_apiresources` fork branch via `composer.json`). Adds `composer check-test-db` so test-DB provisioning can be skipped when already done, and documents a project-wide pattern for module-owned skills (chained symlinks under `.ai/Component/{Name}/skills/`) so modules can ship their own skills without being forked into core.
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | This PR ships project tooling for AI assistants and contributors — no runtime or UI changes. To verify locally: <br> 1. `bash .ai/bin/generate-ai-index.sh` runs cleanly and reports any module-shipped skills it discovers (look for the `discover_module_skills` summary at the end). Run twice and confirm the second pass produces no diff (the date-only-diff churn fix). <br> 2. `composer check-test-db` exits 0 when your test DB is already provisioned, non-zero with a clear message otherwise. <br> 3. The `setup-apiresources-dev` skill at `.ai/Component/AdminAPI/skills/setup-apiresources-dev/SKILL.md` walks through every branch (existing local clone, fresh clone, in-place vs external) and provisions the test DB. <br> 4. The `link-apiresources-fork` skill at `.ai/Component/AdminAPI/skills/link-apiresources-fork/SKILL.md` toggles `composer.json` + `composer.lock` between upstream `dev-dev` and a fork's `dev-<branch>`, with local-clone protection. <br> 5. The `ps-api-endpoint` skill (module-owned, lives in `modules/ps_apiresources/.claude/skills/`) is auto-discovered via the chained symlink at `.ai/Component/AdminAPI/skills/ps-api-endpoint` → `.claude/skills/ps-api-endpoint`.
| UI Tests          | Out of scope — no runtime change
| Fixed issue or discussion?     | n/a
| Related PRs       |
| Sponsor company   |

## What's in this PR

### `.ai/Component/AdminAPI/CONTEXT.md` (new)
Documents the core Admin API layering: API Platform 3 + OAuth2 (server in-bundle, JWT) + per-route scopes + CQRS delegation. Calls out the small set of resources that must stay in core (rather than `ps_apiresources`) because the core itself depends on them — `Language` (every endpoint relies on the lang ID↔ISO mapping) and `ApiClient` (`/api-clients/infos` self-introspection, `scopes: []`). Endpoint authoring conventions stay in `modules/ps_apiresources/CONTEXT.md` so they live with the module.

### `setup-apiresources-dev` skill (new)
Turns `modules/ps_apiresources/` from a read-only composer dependency into a real git checkout for contributors who want to fix or extend the module. Three setup branches via `AskUserQuestion`:
- symlink to an existing local clone,
- fresh clone in-place under `modules/`,
- fresh clone in an external folder + symlink (recommended — survives `composer update`).

Wires `upstream` + `fork` remotes explicitly (so the upstream PrestaShop repo isn't called `origin`), creates work branches with `--no-track` (so `git push` doesn't accidentally target upstream), and provisions the test DB only when `composer check-test-db` says it isn't ready.

### `link-apiresources-fork` skill (new)
Pairs a core PR with a `ps_apiresources` fork branch by surgically editing `composer.json` (`repositories.ps_apiresources.url` + the `dev-<branch>` pin) and refreshing `composer.lock`. Modes: **link** (point core at a fork branch) and **cleanup** (revert to upstream `dev-dev`). Includes local-clone protection: detects when `modules/ps_apiresources/` is a real git checkout with uncommitted/unpushed work and offers move-and-symlink before `composer update` would overwrite it. Three input paths: module PR URL (resolves fork + branch via `gh`), manual fork URL + branch, or auto-detect from the local checkout.

### `tests/bin/check-test-db.php` + `composer check-test-db` (new)
Verifies the test environment without re-provisioning: global dump present, per-table dumps present, DB accessible, table counts match. Used by `setup-apiresources-dev` to skip the slow `composer create-test-db` when the DB is already there.

### Module-owned skill pattern (`.ai/STRUCTURE.md`)
Documents a project-wide convention for skills that ship with modules. A chained symlink under `.ai/Component/{Name}/skills/<name>` exposes a module's skill (e.g. `ps-api-endpoint` from `modules/ps_apiresources/.claude/skills/`); the project-root `.claude/skills/<name>` link is then auto-created by the index script. This keeps the skill ownership in the module while still making it discoverable from the project root.

### `.ai/bin/generate-ai-index.sh`
- `find -L` on `sync_skill_symlinks` so it follows component-level symlinks into modules.
- New `discover_module_skills` function reports unattached module skills as suggestions (no auto-association — component placement is a human judgment call).
- Generators write to a `.tmp` and only swap in when the content differs **modulo the `(generated YYYY-MM-DD)` header**, so date-only diffs no longer churn the working tree.