### PR TITLE
Add getHighestPosition alias

### DIFF
--- a/classes/AttributeGroup.php
+++ b/classes/AttributeGroup.php
@@ -69,7 +69,7 @@ class AttributeGroupCore extends ObjectModel
         $this->is_color_group = $this->group_type == 'color';
 
         if ($this->position <= 0) {
-            $this->position = AttributeGroup::getHigherPosition() + 1;
+            $this->position = AttributeGroup::getHighestPosition() + 1;
         }
 
         $return = parent::add($autoDate, true);
@@ -379,13 +379,32 @@ class AttributeGroupCore extends ObjectModel
      * Get the highest AttributeGroup position.
      *
      * @return int $position Position
+     *
+     * @deprecated Since 9.2, use AttributeGroup::getHighestPosition() instead.
      */
     public static function getHigherPosition()
+    {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 9.2. Use %s instead.',
+                __METHOD__,
+                self::class . '::getHighestPosition()'
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return self::getHighestPosition();
+    }
+
+    /**
+     * Get the highest AttributeGroup position.
+     */
+    public static function getHighestPosition(): int
     {
         $sql = 'SELECT MAX(`position`)
 				FROM `' . _DB_PREFIX_ . 'attribute_group`';
         $position = Db::getInstance()->getValue($sql);
 
-        return (is_numeric($position)) ? $position : -1;
+        return (is_numeric($position)) ? (int) $position : -1;
     }
 }

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -223,7 +223,7 @@ class CarrierCore extends ObjectModel
     public function add($autoDate = true, $nullValues = false)
     {
         if ($this->position <= 0) {
-            $this->position = Carrier::getHigherPosition() + 1;
+            $this->position = Carrier::getHighestPosition() + 1;
         }
         if (!parent::add($autoDate, $nullValues) || !Validate::isLoadedObject($this)) {
             return false;
@@ -1485,15 +1485,34 @@ class CarrierCore extends ObjectModel
      * Gets the highest carrier position.
      *
      * @return int $position
+     *
+     * @deprecated Since 9.2, use Carrier::getHighestPosition() instead.
      */
     public static function getHigherPosition()
+    {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 9.2. Use %s instead.',
+                __METHOD__,
+                self::class . '::getHighestPosition()'
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return self::getHighestPosition();
+    }
+
+    /**
+     * Gets the highest carrier position.
+     */
+    public static function getHighestPosition(): int
     {
         $sql = 'SELECT MAX(`position`)
                 FROM `' . _DB_PREFIX_ . 'carrier`
                 WHERE `deleted` = 0';
         $position = Db::getInstance()->getValue($sql);
 
-        return (is_numeric($position)) ? $position : -1;
+        return (is_numeric($position)) ? (int) $position : -1;
     }
 
     /**

--- a/classes/Feature.php
+++ b/classes/Feature.php
@@ -107,7 +107,7 @@ class FeatureCore extends ObjectModel
     public function add($autoDate = true, $nullValues = false)
     {
         if ($this->position <= 0) {
-            $this->position = Feature::getHigherPosition() + 1;
+            $this->position = Feature::getHighestPosition() + 1;
         }
 
         $return = parent::add($autoDate, true);
@@ -246,7 +246,7 @@ class FeatureCore extends ObjectModel
             if ($position) {
                 $feature->position = (int) $position;
             } else {
-                $feature->position = Feature::getHigherPosition() + 1;
+                $feature->position = Feature::getHighestPosition() + 1;
             }
             $feature->add();
 
@@ -337,18 +337,35 @@ class FeatureCore extends ObjectModel
     }
 
     /**
-     * getHigherPosition.
-     *
-     * Get the higher feature position
+     * Get the highest Feature position.
      *
      * @return int $position
+     *
+     * @deprecated Since 9.2, use Feature::getHighestPosition() instead.
      */
     public static function getHigherPosition()
+    {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 9.2. Use %s instead.',
+                __METHOD__,
+                self::class . '::getHighestPosition()'
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return self::getHighestPosition();
+    }
+
+    /**
+     * Get the highest Feature position.
+     */
+    public static function getHighestPosition(): int
     {
         $sql = 'SELECT MAX(`position`)
 				FROM `' . _DB_PREFIX_ . 'feature`';
         $position = Db::getInstance()->getValue($sql);
 
-        return (is_numeric($position)) ? $position : -1;
+        return (is_numeric($position)) ? (int) $position : -1;
     }
 }

--- a/classes/ProductAttribute.php
+++ b/classes/ProductAttribute.php
@@ -383,7 +383,6 @@ class ProductAttributeCore extends ObjectModel
      * @return int $position Position
      *
      * @deprecated Since 9.2, use ProductAttribute::getHighestPosition() instead.
-     *
      */
     public static function getHigherPosition($idAttributeGroup)
     {
@@ -407,10 +406,15 @@ class ProductAttributeCore extends ObjectModel
 
     /**
      * Get the highest attribute position from a group attribute
-     *
      */
     public static function getHighestPosition(int $idAttributeGroup): int
     {
-        return self::getHigherPosition($idAttributeGroup);
+        $sql = 'SELECT MAX(`position`)
+                FROM `' . _DB_PREFIX_ . 'attribute`
+                WHERE id_attribute_group = ' . (int) $idAttributeGroup;
+
+        $position = Db::getInstance()->getValue($sql);
+
+        return (is_numeric($position)) ? (int) $position : -1;
     }
 }

--- a/classes/ProductAttribute.php
+++ b/classes/ProductAttribute.php
@@ -135,7 +135,7 @@ class ProductAttributeCore extends ObjectModel
     public function add($autoDate = true, $nullValues = false)
     {
         if ($this->position <= 0) {
-            $this->position = static::getHigherPosition($this->id_attribute_group) + 1;
+            $this->position = static::getHighestPosition($this->id_attribute_group) + 1;
         }
 
         $return = parent::add($autoDate, $nullValues);

--- a/classes/ProductAttribute.php
+++ b/classes/ProductAttribute.php
@@ -402,7 +402,7 @@ class ProductAttributeCore extends ObjectModel
      * @return int $position Position
      *
      */
-    public static function getHighestPosition($idAttributeGroup)
+    public static function getHighestPosition(int $idAttributeGroup): int
     {
         return self::getHigherPosition($idAttributeGroup);
     }

--- a/classes/ProductAttribute.php
+++ b/classes/ProductAttribute.php
@@ -382,9 +382,20 @@ class ProductAttributeCore extends ObjectModel
      *
      * @return int $position Position
      *
+     * @deprecated Since 9.2, use ProductAttribute::getHighestPosition() instead.
+     *
      */
     public static function getHigherPosition($idAttributeGroup)
     {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 9.2. Use %s instead.',
+                __METHOD__,
+                self::class . '::getHighestPosition()'
+            ),
+            E_USER_DEPRECATED
+        );
+
         $sql = 'SELECT MAX(`position`)
                 FROM `' . _DB_PREFIX_ . 'attribute`
                 WHERE id_attribute_group = ' . (int) $idAttributeGroup;

--- a/classes/ProductAttribute.php
+++ b/classes/ProductAttribute.php
@@ -397,10 +397,6 @@ class ProductAttributeCore extends ObjectModel
     /**
      * Get the highest attribute position from a group attribute
      *
-     * @param int $idAttributeGroup AttributeGroup ID
-     *
-     * @return int $position Position
-     *
      */
     public static function getHighestPosition(int $idAttributeGroup): int
     {

--- a/classes/ProductAttribute.php
+++ b/classes/ProductAttribute.php
@@ -395,13 +395,7 @@ class ProductAttributeCore extends ObjectModel
             E_USER_DEPRECATED
         );
 
-        $sql = 'SELECT MAX(`position`)
-                FROM `' . _DB_PREFIX_ . 'attribute`
-                WHERE id_attribute_group = ' . (int) $idAttributeGroup;
-
-        $position = Db::getInstance()->getValue($sql);
-
-        return (is_numeric($position)) ? $position : -1;
+        return self::getHighestPosition((int) $idAttributeGroup);
     }
 
     /**

--- a/classes/ProductAttribute.php
+++ b/classes/ProductAttribute.php
@@ -376,24 +376,34 @@ class ProductAttributeCore extends ObjectModel
     }
 
     /**
-     * get highest position.
-     *
      * Get the highest attribute position from a group attribute
      *
      * @param int $idAttributeGroup AttributeGroup ID
      *
      * @return int $position Position
      *
-     * @todo: Shouldn't this be called getHighestPosition instead?
      */
     public static function getHigherPosition($idAttributeGroup)
     {
         $sql = 'SELECT MAX(`position`)
-				FROM `' . _DB_PREFIX_ . 'attribute`
-				WHERE id_attribute_group = ' . (int) $idAttributeGroup;
+                FROM `' . _DB_PREFIX_ . 'attribute`
+                WHERE id_attribute_group = ' . (int) $idAttributeGroup;
 
         $position = Db::getInstance()->getValue($sql);
 
         return (is_numeric($position)) ? $position : -1;
+    }
+
+    /**
+     * Get the highest attribute position from a group attribute
+     *
+     * @param int $idAttributeGroup AttributeGroup ID
+     *
+     * @return int $position Position
+     *
+     */
+    public static function getHighestPosition($idAttributeGroup)
+    {
+        return self::getHigherPosition($idAttributeGroup);
     }
 }

--- a/controllers/admin/AdminCarriersController.php
+++ b/controllers/admin/AdminCarriersController.php
@@ -481,7 +481,7 @@ class AdminCarriersControllerCore extends AdminController
                         // Create new Carrier
                         $carrier = new Carrier();
                         $this->copyFromPost($carrier, $this->table);
-                        $carrier->position = Carrier::getHigherPosition() + 1;
+                        $carrier->position = Carrier::getHighestPosition() + 1;
                         if ($carrier->add()) {
                             if (($_POST['id_' . $this->table] = $carrier->id /* voluntary */) && $this->postImage($carrier->id) && $this->_redirect) {
                                 $carrier->setTaxRulesGroup((int) Tools::getValue('id_tax_rules_group'), true);

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -2410,7 +2410,7 @@ class AdminImportControllerCore extends AdminController
                         // sets the proper id (corresponding to the right key)
                         $obj->id_attribute_group = $groups_attributes[$key]['id'];
                         $obj->name[$default_language] = str_replace('\n', '', str_replace('\r', '', $attribute));
-                        $obj->position = (!$position && isset($groups[$group])) ? ProductAttribute::getHigherPosition($groups[$group]) + 1 : $position;
+                        $obj->position = (!$position && isset($groups[$group])) ? ProductAttribute::getHighestPosition($groups[$group]) + 1 : $position;
 
                         if (($field_error = $obj->validateFields(UNFRIENDLY_ERROR, true)) === true
                             && ($lang_field_error = $obj->validateFieldsLang(UNFRIENDLY_ERROR, true)) === true) {

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -2356,7 +2356,7 @@ class AdminImportControllerCore extends AdminController
                     $obj->group_type = pSQL($type);
                     $obj->name[$default_language] = $group;
                     $obj->public_name[$default_language] = $group;
-                    $obj->position = (!$position) ? AttributeGroup::getHigherPosition() + 1 : $position;
+                    $obj->position = (!$position) ? AttributeGroup::getHighestPosition() + 1 : $position;
 
                     if (($field_error = $obj->validateFields(UNFRIENDLY_ERROR, true)) === true
                         && ($lang_field_error = $obj->validateFieldsLang(UNFRIENDLY_ERROR, true)) === true) {


### PR DESCRIPTION
Introduce a new getHighestPosition method that delegates to the existing getHigherPosition to provide a clearer API name (addresses a TODO about naming). Keeps backward compatibility and preserves the original behavior/return value. Also includes minor SQL indentation formatting cleanup.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove a todo and add an alias method
| Type?             |  improvement
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no