### PR TITLE
Add a console command to list modules: prestashop:module:list

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1101,6 +1101,16 @@ parameters:
 			path: src/PrestaShopBundle/Command/ModuleCommand.php
 
 		-
+			message: "#^Class Employee is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/PrestaShopBundle/Command/ModuleListCommand.php
+
+		-
+			message: "#^Namespace Employee is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
+			count: 1
+			path: src/PrestaShopBundle/Command/ModuleListCommand.php
+
+		-
 			message: "#^Class ImageManager is forbidden, No legacy calls inside the prestashop bundle\\. Please create an interface and an adapter if you need to\\.$#"
 			count: 2
 			path: src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php

--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -18,6 +18,7 @@ use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Context\LanguageContext;
 use PrestaShop\PrestaShop\Core\Domain\Module\Exception\ModuleNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\ValueObject\ModulePermission;
+use PrestaShop\PrestaShop\Core\Util\PHPCli;
 use Symfony\Component\Finder\Finder;
 use Throwable;
 
@@ -363,10 +364,18 @@ class ModuleRepository implements ModuleRepositoryInterface
     }
 
     /**
-     * Filter modules if the current employee has the right to see it
+     * Filter modules if the current employee has the right to see it.
+     *
+     * Skipped when running in CLI: there is no logged-in employee in that
+     * context, so the per-employee permission check has no meaning and would
+     * otherwise hide every installed module from console commands.
      */
     protected function filterModulesByPermissions(ModuleCollection $modules): ModuleCollection
     {
+        if (PHPCli::isPHPCli()) {
+            return $modules;
+        }
+
         foreach ($modules as $key => $module) {
             $moduleName = $module->getAttributes()->get('name');
             if ($this->moduleDataProvider->isInstalled($moduleName)

--- a/src/PrestaShopBundle/Command/ModuleCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleCommand.php
@@ -204,6 +204,10 @@ class ModuleCommand extends Command
                     if (isset($rows[$name]) || isset($installed[$name])) {
                         continue;
                     }
+                    // A directory only counts as a module if it contains a {name}/{name}.php class file.
+                    if (!is_file($dir->getPathname() . '/' . $name . '.php')) {
+                        continue;
+                    }
                     $rows[$name] = [$name, '-', 'Not installed'];
                 }
             }

--- a/src/PrestaShopBundle/Command/ModuleCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleCommand.php
@@ -11,14 +11,17 @@ use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Configuration\ModuleSelfConfigurator;
+use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Context\ContextBuilderPreparer;
 use PrestaShop\PrestaShop\Core\Module\ModuleManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\FormatterHelper;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ModuleCommand extends Command
@@ -32,6 +35,7 @@ class ModuleCommand extends Command
         'upgrade',
         'configure',
         'delete',
+        'list',
     ];
 
     /**
@@ -51,6 +55,7 @@ class ModuleCommand extends Command
         protected readonly ModuleManager $moduleManager,
         protected readonly ContextBuilderPreparer $contextBuilderPreparer,
         protected readonly Configuration $configuration,
+        protected readonly ModuleDataProvider $moduleDataProvider,
     ) {
         parent::__construct();
     }
@@ -61,9 +66,13 @@ class ModuleCommand extends Command
             ->setName('prestashop:module')
             ->setDescription('Manage your modules via command line')
             ->addArgument('action', InputArgument::REQUIRED, sprintf('Action to execute (Allowed actions: %s).', implode(' / ', $this->allowedActions)))
-            ->addArgument('module name', InputArgument::REQUIRED, 'Module on which the action will be executed')
+            ->addArgument('module name', InputArgument::OPTIONAL, 'Module on which the action will be executed (not required for the "list" action)')
             ->addArgument('file path', InputArgument::OPTIONAL, 'YML file path for configuration')
-            ->addOption('skip-overrides', null, InputOption::VALUE_NONE, 'Skip installing/uninstalling module overrides');
+            ->addOption('skip-overrides', null, InputOption::VALUE_NONE, 'Skip installing/uninstalling module overrides')
+            ->addOption('all', null, InputOption::VALUE_NONE, 'When used with the "list" action, include uninstalled modules.')
+            ->addOption('active', null, InputOption::VALUE_NONE, 'When used with the "list" action, show only installed and enabled modules.')
+            ->addOption('disabled', null, InputOption::VALUE_NONE, 'When used with the "list" action, show only installed but disabled modules.')
+            ->addOption('not-installed', null, InputOption::VALUE_NONE, 'When used with the "list" action, show only modules present on disk but not installed.');
     }
 
     protected function init(InputInterface $input, OutputInterface $output)
@@ -104,6 +113,42 @@ class ModuleCommand extends Command
             return 1;
         }
 
+        if ($action === 'list') {
+            $filterFlags = [
+                'all' => (bool) $input->getOption('all'),
+                'active' => (bool) $input->getOption('active'),
+                'disabled' => (bool) $input->getOption('disabled'),
+                'not-installed' => (bool) $input->getOption('not-installed'),
+            ];
+
+            $enabledFilters = array_keys(array_filter($filterFlags));
+            if (count($enabledFilters) > 1) {
+                $this->displayMessage(
+                    sprintf(
+                        'The --%s options are mutually exclusive; only one may be passed at a time.',
+                        implode(', --', $enabledFilters)
+                    ),
+                    'error'
+                );
+
+                return 1;
+            }
+
+            $filter = $enabledFilters[0] ?? 'installed';
+            $this->executeListAction($output, $filter);
+
+            return 0;
+        }
+
+        if (empty($moduleName)) {
+            $this->displayMessage(
+                sprintf('A module name is required for the "%s" action.', $action),
+                'error'
+            );
+
+            return 1;
+        }
+
         if ($skipOverrides) {
             $disableModuleOriginaleValue = $this->configuration->get('PS_DISABLE_MODULE_OVERRIDES');
             $this->configuration->setTemporary('PS_DISABLE_MODULE_OVERRIDES', 1);
@@ -122,6 +167,55 @@ class ModuleCommand extends Command
         }
 
         return 0;
+    }
+
+    protected function executeListAction(OutputInterface $output, string $filter): void
+    {
+        $installed = $this->moduleDataProvider->getInstalled();
+        $rows = [];
+
+        if ($filter !== 'not-installed') {
+            foreach ($installed as $module) {
+                $isActive = !empty($module['active']);
+                if ($filter === 'active' && !$isActive) {
+                    continue;
+                }
+                if ($filter === 'disabled' && $isActive) {
+                    continue;
+                }
+                $rows[$module['name']] = [
+                    $module['name'],
+                    (string) $module['version'],
+                    $isActive ? 'Enabled' : 'Disabled',
+                ];
+            }
+        }
+
+        if (in_array($filter, ['all', 'not-installed'], true)) {
+            $moduleDir = $this->configuration->get('_PS_MODULE_DIR_');
+            if (is_string($moduleDir) && is_dir($moduleDir)) {
+                $directories = (new Finder())->directories()
+                    ->in($moduleDir)
+                    ->depth('== 0')
+                    ->exclude(['__MACOSX'])
+                    ->ignoreVCS(true);
+                foreach ($directories as $dir) {
+                    $name = $dir->getFilename();
+                    if (isset($rows[$name]) || isset($installed[$name])) {
+                        continue;
+                    }
+                    $rows[$name] = [$name, '-', 'Not installed'];
+                }
+            }
+        }
+
+        $rows = array_values($rows);
+        usort($rows, static fn (array $a, array $b) => strcasecmp($a[0], $b[0]));
+
+        $table = new Table($output);
+        $table->setHeaders(['Name', 'Version', 'Status']);
+        $table->setRows($rows);
+        $table->render();
     }
 
     protected function executeConfigureModuleAction($moduleName, $file = null)

--- a/src/PrestaShopBundle/Command/ModuleCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleCommand.php
@@ -11,13 +11,10 @@ use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Configuration\ModuleSelfConfigurator;
-use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Core\Context\ContextBuilderPreparer;
 use PrestaShop\PrestaShop\Core\Module\ModuleManager;
-use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\FormatterHelper;
-use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -35,7 +32,6 @@ class ModuleCommand extends Command
         'upgrade',
         'configure',
         'delete',
-        'list',
     ];
 
     /**
@@ -55,7 +51,6 @@ class ModuleCommand extends Command
         protected readonly ModuleManager $moduleManager,
         protected readonly ContextBuilderPreparer $contextBuilderPreparer,
         protected readonly Configuration $configuration,
-        protected readonly ModuleRepository $moduleRepository,
     ) {
         parent::__construct();
     }
@@ -66,13 +61,9 @@ class ModuleCommand extends Command
             ->setName('prestashop:module')
             ->setDescription('Manage your modules via command line')
             ->addArgument('action', InputArgument::REQUIRED, sprintf('Action to execute (Allowed actions: %s).', implode(' / ', $this->allowedActions)))
-            ->addArgument('module name', InputArgument::OPTIONAL, 'Module on which the action will be executed (not required for the "list" action)')
+            ->addArgument('module name', InputArgument::REQUIRED, 'Module on which the action will be executed')
             ->addArgument('file path', InputArgument::OPTIONAL, 'YML file path for configuration')
-            ->addOption('skip-overrides', null, InputOption::VALUE_NONE, 'Skip installing/uninstalling module overrides')
-            ->addOption('all', null, InputOption::VALUE_NONE, 'When used with the "list" action, include uninstalled modules.')
-            ->addOption('active', null, InputOption::VALUE_NONE, 'When used with the "list" action, show only installed and enabled modules.')
-            ->addOption('disabled', null, InputOption::VALUE_NONE, 'When used with the "list" action, show only installed but disabled modules.')
-            ->addOption('not-installed', null, InputOption::VALUE_NONE, 'When used with the "list" action, show only modules present on disk but not installed.');
+            ->addOption('skip-overrides', null, InputOption::VALUE_NONE, 'Skip installing/uninstalling module overrides');
     }
 
     protected function init(InputInterface $input, OutputInterface $output)
@@ -113,42 +104,6 @@ class ModuleCommand extends Command
             return 1;
         }
 
-        if ($action === 'list') {
-            $filterFlags = [
-                'all' => (bool) $input->getOption('all'),
-                'active' => (bool) $input->getOption('active'),
-                'disabled' => (bool) $input->getOption('disabled'),
-                'not-installed' => (bool) $input->getOption('not-installed'),
-            ];
-
-            $enabledFilters = array_keys(array_filter($filterFlags));
-            if (count($enabledFilters) > 1) {
-                $this->displayMessage(
-                    sprintf(
-                        'The --%s options are mutually exclusive; only one may be passed at a time.',
-                        implode(', --', $enabledFilters)
-                    ),
-                    'error'
-                );
-
-                return 1;
-            }
-
-            $filter = $enabledFilters[0] ?? 'installed';
-            $this->executeListAction($output, $filter);
-
-            return 0;
-        }
-
-        if (empty($moduleName)) {
-            $this->displayMessage(
-                sprintf('A module name is required for the "%s" action.', $action),
-                'error'
-            );
-
-            return 1;
-        }
-
         if ($skipOverrides) {
             $disableModuleOriginaleValue = $this->configuration->get('PS_DISABLE_MODULE_OVERRIDES');
             $this->configuration->setTemporary('PS_DISABLE_MODULE_OVERRIDES', 1);
@@ -167,48 +122,6 @@ class ModuleCommand extends Command
         }
 
         return 0;
-    }
-
-    protected function executeListAction(OutputInterface $output, string $filter): void
-    {
-        $modules = match ($filter) {
-            'all' => $this->moduleRepository->getList(),
-            'not-installed' => $this->moduleRepository->getList()->filter(
-                static fn (Module $module) => !$module->isInstalled()
-            ),
-            'active' => $this->moduleRepository->getInstalledModules()->filter(
-                static fn (Module $module) => $module->isActive()
-            ),
-            'disabled' => $this->moduleRepository->getInstalledModules()->filter(
-                static fn (Module $module) => !$module->isActive()
-            ),
-            default => $this->moduleRepository->getInstalledModules(),
-        };
-
-        $rows = [];
-        foreach ($modules as $module) {
-            $rows[] = [
-                (string) $module->get('name'),
-                $module->isInstalled() ? (string) $module->get('version') : '-',
-                $this->describeModuleStatus($module),
-            ];
-        }
-
-        usort($rows, static fn (array $a, array $b) => strcasecmp($a[0], $b[0]));
-
-        $table = new Table($output);
-        $table->setHeaders(['Name', 'Version', 'Status']);
-        $table->setRows($rows);
-        $table->render();
-    }
-
-    private function describeModuleStatus(Module $module): string
-    {
-        if (!$module->isInstalled()) {
-            return 'Not installed';
-        }
-
-        return $module->isActive() ? 'Enabled' : 'Disabled';
     }
 
     protected function executeConfigureModuleAction($moduleName, $file = null)

--- a/src/PrestaShopBundle/Command/ModuleCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleCommand.php
@@ -11,9 +11,10 @@ use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Configuration\ModuleSelfConfigurator;
-use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
+use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Core\Context\ContextBuilderPreparer;
 use PrestaShop\PrestaShop\Core\Module\ModuleManager;
+use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\Table;
@@ -21,7 +22,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Finder\Finder;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ModuleCommand extends Command
@@ -55,7 +55,7 @@ class ModuleCommand extends Command
         protected readonly ModuleManager $moduleManager,
         protected readonly ContextBuilderPreparer $contextBuilderPreparer,
         protected readonly Configuration $configuration,
-        protected readonly ModuleDataProvider $moduleDataProvider,
+        protected readonly ModuleRepository $moduleRepository,
     ) {
         parent::__construct();
     }
@@ -171,55 +171,44 @@ class ModuleCommand extends Command
 
     protected function executeListAction(OutputInterface $output, string $filter): void
     {
-        $installed = $this->moduleDataProvider->getInstalled();
+        $modules = match ($filter) {
+            'all' => $this->moduleRepository->getList(),
+            'not-installed' => $this->moduleRepository->getList()->filter(
+                static fn (Module $module) => !$module->isInstalled()
+            ),
+            'active' => $this->moduleRepository->getInstalledModules()->filter(
+                static fn (Module $module) => $module->isActive()
+            ),
+            'disabled' => $this->moduleRepository->getInstalledModules()->filter(
+                static fn (Module $module) => !$module->isActive()
+            ),
+            default => $this->moduleRepository->getInstalledModules(),
+        };
+
         $rows = [];
-
-        if ($filter !== 'not-installed') {
-            foreach ($installed as $module) {
-                $isActive = !empty($module['active']);
-                if ($filter === 'active' && !$isActive) {
-                    continue;
-                }
-                if ($filter === 'disabled' && $isActive) {
-                    continue;
-                }
-                $rows[$module['name']] = [
-                    $module['name'],
-                    (string) $module['version'],
-                    $isActive ? 'Enabled' : 'Disabled',
-                ];
-            }
+        foreach ($modules as $module) {
+            $rows[] = [
+                (string) $module->get('name'),
+                $module->isInstalled() ? (string) $module->get('version') : '-',
+                $this->describeModuleStatus($module),
+            ];
         }
 
-        if (in_array($filter, ['all', 'not-installed'], true)) {
-            $moduleDir = $this->configuration->get('_PS_MODULE_DIR_');
-            if (is_string($moduleDir) && is_dir($moduleDir)) {
-                $directories = (new Finder())->directories()
-                    ->in($moduleDir)
-                    ->depth('== 0')
-                    ->exclude(['__MACOSX'])
-                    ->ignoreVCS(true);
-                foreach ($directories as $dir) {
-                    $name = $dir->getFilename();
-                    if (isset($rows[$name]) || isset($installed[$name])) {
-                        continue;
-                    }
-                    // A directory only counts as a module if it contains a {name}/{name}.php class file.
-                    if (!is_file($dir->getPathname() . '/' . $name . '.php')) {
-                        continue;
-                    }
-                    $rows[$name] = [$name, '-', 'Not installed'];
-                }
-            }
-        }
-
-        $rows = array_values($rows);
         usort($rows, static fn (array $a, array $b) => strcasecmp($a[0], $b[0]));
 
         $table = new Table($output);
         $table->setHeaders(['Name', 'Version', 'Status']);
         $table->setRows($rows);
         $table->render();
+    }
+
+    private function describeModuleStatus(Module $module): string
+    {
+        if (!$module->isInstalled()) {
+            return 'Not installed';
+        }
+
+        return $module->isActive() ? 'Enabled' : 'Disabled';
     }
 
     protected function executeConfigureModuleAction($moduleName, $file = null)

--- a/src/PrestaShopBundle/Command/ModuleListCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleListCommand.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace PrestaShopBundle\Command;
+
+use Employee;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Adapter\Module\Module;
+use PrestaShop\PrestaShop\Core\Context\ContextBuilderPreparer;
+use PrestaShop\PrestaShop\Core\Module\ModuleCollection;
+use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ModuleListCommand extends Command
+{
+    public function __construct(
+        protected readonly LegacyContext $context,
+        protected readonly ContextBuilderPreparer $contextBuilderPreparer,
+        protected readonly Configuration $configuration,
+        protected readonly ModuleRepository $moduleRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('prestashop:module:list')
+            ->setDescription('List shop modules and their versions')
+            ->addOption('all', null, InputOption::VALUE_NONE, 'Include uninstalled modules.')
+            ->addOption('active', null, InputOption::VALUE_NONE, 'Show only installed and enabled modules.')
+            ->addOption('disabled', null, InputOption::VALUE_NONE, 'Show only installed but disabled modules.')
+            ->addOption('not-installed', null, InputOption::VALUE_NONE, 'Show only modules present on disk or registered via hook but not installed.')
+            ->addOption('simple', null, InputOption::VALUE_NONE, 'Output only technical names, one per line, instead of a table.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->initContext();
+
+        $filterFlags = [
+            'all' => (bool) $input->getOption('all'),
+            'active' => (bool) $input->getOption('active'),
+            'disabled' => (bool) $input->getOption('disabled'),
+            'not-installed' => (bool) $input->getOption('not-installed'),
+        ];
+
+        $enabledFilters = array_keys(array_filter($filterFlags));
+        if (count($enabledFilters) > 1) {
+            $output->writeln(sprintf(
+                '<error>The --%s options are mutually exclusive; only one may be passed at a time.</error>',
+                implode(', --', $enabledFilters)
+            ));
+
+            return 1;
+        }
+
+        $filter = $enabledFilters[0] ?? 'installed';
+        $modules = $this->resolveModules($filter);
+
+        if ($input->getOption('simple')) {
+            $names = [];
+            foreach ($modules as $module) {
+                $names[] = (string) $module->get('name');
+            }
+            usort($names, 'strcasecmp');
+            foreach ($names as $name) {
+                $output->writeln($name);
+            }
+
+            return 0;
+        }
+
+        $rows = [];
+        foreach ($modules as $module) {
+            $rows[] = [
+                (string) $module->get('name'),
+                $module->isInstalled() ? (string) $module->get('version') : '-',
+                $this->describeModuleStatus($module),
+            ];
+        }
+        usort($rows, static fn (array $a, array $b) => strcasecmp($a[0], $b[0]));
+
+        $table = new Table($output);
+        $table->setHeaders(['Name', 'Version', 'Status']);
+        $table->setRows($rows);
+        $table->render();
+
+        return 0;
+    }
+
+    private function initContext(): void
+    {
+        // We need an employee or some legacy module hooks blow up (see LegacyHookSubscriber).
+        // The permission filter on ModuleRepository::filterModulesByPermissions() is
+        // bypassed in CLI by PHPCli::isPHPCli(), so a non-existing employee is harmless.
+        if (!$this->context->getContext()->employee) {
+            $this->context->getContext()->employee = new Employee(42);
+        }
+
+        // ModuleRepository keys its cache by language; the language context must be initialised.
+        $this->contextBuilderPreparer->prepareLanguageId($this->configuration->get('PS_LANG_DEFAULT'));
+    }
+
+    private function resolveModules(string $filter): ModuleCollection
+    {
+        return match ($filter) {
+            'all' => $this->moduleRepository->getList(),
+            'not-installed' => $this->moduleRepository->getList()->filter(
+                static fn (Module $module) => !$module->isInstalled()
+            ),
+            'active' => $this->moduleRepository->getInstalledModules()->filter(
+                static fn (Module $module) => $module->isActive()
+            ),
+            'disabled' => $this->moduleRepository->getInstalledModules()->filter(
+                static fn (Module $module) => !$module->isActive()
+            ),
+            default => $this->moduleRepository->getInstalledModules(),
+        };
+    }
+
+    private function describeModuleStatus(Module $module): string
+    {
+        if (!$module->isInstalled()) {
+            return 'Not installed';
+        }
+
+        return $module->isActive() ? 'Enabled' : 'Disabled';
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/command.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/command.yml
@@ -42,6 +42,11 @@ services:
     tags:
       - 'console.command'
 
+  PrestaShopBundle\Command\ModuleListCommand:
+    autowire: true
+    tags:
+      - 'console.command'
+
   PrestaShopBundle\Command\DebugCommand:
     arguments:
       - '@prestashop.core.command_bus'


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds a new dedicated `prestashop:module:list` console command that enumerates shop modules from the CLI. By default it prints a table (Name / Version / Status) of installed modules. Four mutually-exclusive filter options narrow or widen the scope: `--active` (installed + enabled), `--disabled` (installed + disabled), `--not-installed` (present on disk or registered via the `actionListModules` hook but not installed), and `--all` (installed + not-installed combined). A `--simple` flag drops the table layout and prints only the technical names, one per line — convenient for `grep`/`awk`/`xargs` pipelines. The existing `prestashop:module` command is left **completely untouched**.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. On a shop with several modules installed, run `./bin/console prestashop:module:list` — expect a table of every installed module with its version and `Enabled` / `Disabled` status, sorted alphabetically. <br>2. `./bin/console prestashop:module:list --active` — expect a subset showing only modules whose `Status` is `Enabled`. <br>3. Disable a module (`./bin/console prestashop:module disable ps_emailalerts`) then run `./bin/console prestashop:module:list --disabled` — expect the disabled module to appear. Re-enable it and confirm it disappears from `--disabled`. <br>4. `./bin/console prestashop:module:list --not-installed` — expect only modules that exist on disk **or are registered via the `actionListModules` hook** but are not installed (e.g. `autoupgrade`, declared by `ps_distributionapiclient`), with `-` in the `Version` column. <br>5. `./bin/console prestashop:module:list --all` — expect every installed module *and* every not-installed module (on-disk or hook-registered) in a single table. <br>6. `./bin/console prestashop:module:list --simple` — expect one technical name per line, no table, no version, no status. The flag composes with the scope filters: `--simple --disabled` returns only the disabled modules' names; `--simple --not-installed` returns only the not-installed modules' names. <br>7. Pass two filters at once (e.g. `--active --disabled`) — expect a non-zero exit and an error stating the options are mutually exclusive. <br>8. Existing `prestashop:module` actions are unchanged: `./bin/console prestashop:module install`, `disable <name>`, `enable <name>`, `configure <name> <file>` all behave exactly as before — same arguments, same error messages, same exit codes. <br>9. **BO regression check** — with a non-super-admin employee whose profile lacks `view` permission on at least one module, open the BO Module Manager → the un-viewable module must remain hidden, exactly as before. The CLI permission-skip in `ModuleRepository::filterModulesByPermissions()` is gated by `PHPCli::isPHPCli()` (`defined('STDIN') \|\| (PHP_SAPI === 'cli' && empty($_SERVER['REMOTE_ADDR']))`), so HTTP requests are unaffected.
| UI Tests          | N/A — CLI-only change, no UI surface.
| Fixed issue or discussion?     | https://github.com/PrestaShop/PrestaShop/discussions/41445
| Related PRs       | N/A
| Sponsor company   | creabilis.com

## Why

There was previously no way to enumerate installed modules and their versions from the CLI. This is useful for auditing a shop, scripting deploys, debugging support tickets, or quickly answering "what's enabled here?" without opening the back office.

The PR introduces a **dedicated command** (`prestashop:module:list`) rather than bolting a new action onto `prestashop:module`. Two reasons:

- The existing `prestashop:module <action> <module name>` signature stays untouched (no need to make `module name` optional and re-validate at runtime, no need to cram listing-only flags into a command that's otherwise about mutating a single module).
- A purpose-built command can offer listing-specific affordances (the `--simple` flag, scope filters) without polluting the management command.

## What it looks like

```bash
$ ./bin/console prestashop:module:list
+--------------------------+---------+----------+
| Name                     | Version | Status   |
+--------------------------+---------+----------+
| blockreassurance         | 5.1.4   | Enabled  |
| blockwishlist            | 3.0.2   | Disabled |
| contactform              | 4.4.3   | Enabled  |
| ...                                           |
+--------------------------+---------+----------+

$ ./bin/console prestashop:module:list --simple --disabled
blockwishlist
ps_brandlist
ps_supplierlist
```

Four mutually-exclusive scope filters:

| Flag | Scope |
|------|-------|
| _(none)_ | installed modules (Enabled + Disabled) |
| `--active` | installed **and** enabled |
| `--disabled` | installed **and** disabled |
| `--not-installed` | present on disk or registered via the `actionListModules` hook, but not installed |
| `--all` | installed + not-installed combined |

Plus an orthogonal output flag:

| Flag | Effect |
|------|--------|
| `--simple` | print only technical names, one per line, no table |

## Why it's useful

- **Auditing a shop** — quickly check what's installed and at which versions, e.g. before a migration.
- **Deploy / CI scripting** — `--simple` makes it trivial to pipe into `xargs ./bin/console prestashop:module enable` or assert against a fixed list.
- **Prepare upgrade** — list installed modules to check compatibility with the next version.
- **Debugging** — spot a module that's installed but disabled (or available but never installed) without opening the BO.

## Implementation notes

- New file `src/PrestaShopBundle/Command/ModuleListCommand.php`, registered under `prestashop:module:list` and wired in `services/bundle/command.yml` with `autowire: true`.
- The listing reads from `ModuleRepository::getList()` and `getInstalledModules()`. The repository's `filterModulesByPermissions()` would normally hide every installed module from a CLI caller (no logged-in employee → the per-employee permission check fails for each module), so a `PHPCli::isPHPCli()` guard is added at the top of that method to short-circuit the filter in CLI. The HTTP path is byte-for-byte unchanged.
- Going through the repository surfaces modules registered via the `actionListModules` hook (e.g. `autoupgrade`, declared by `ps_distributionapiclient`) — which a manual filesystem scan would miss.
- The command keeps the same legacy-context preparation as `ModuleCommand` (placeholder `Employee(42)` + `prepareLanguageId`) so the `actionListModules` hook actually fires (`LegacyHookSubscriber` requires a non-null `Context::employee` to register its listeners). Two existing baseline entries are mirrored in `phpstan-baseline.neon` for this new file — consistent with how `ModuleCommand` is handled today.

## Backward compatibility

- **`prestashop:module` is unchanged** — same arguments, same actions, same options, same error messages. No risk of regression for existing scripts.
- **HTTP path unchanged.** `ModuleRepository::filterModulesByPermissions()` only short-circuits when `PHPCli::isPHPCli()` is `true`. Under HTTP that helper returns `false`, so the BO Module Manager keeps its existing permission filtering exactly as before.
