### PR TITLE
Fix deprecated in LanguageList.php

### DIFF
--- a/src/PrestaShopBundle/Install/LanguageList.php
+++ b/src/PrestaShopBundle/Install/LanguageList.php
@@ -96,7 +96,7 @@ class LanguageList
      */
     public function getLanguage($iso = null)
     {
-        if (!isset($this->languages[$iso])) {
+        if (empty($iso) || !isset($this->languages[$iso])) {
             $iso = $this->language;
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix PHP 8.x deprecation "Using null as an array offset is deprecated" in `LanguageList::getLanguage()`. When called without an argument, `$iso` defaults to `null`, which was then used as an array key in `isset($this->languages[$iso])`. The fix adds an `empty($iso)` guard so a `null` (or empty) ISO falls back to the default language without triggering the deprecation.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Run a PrestaShop installation in CLI or any page that calls `LanguageList::getLanguage()` without an ISO argument (e.g. the install wizard language step). <br> 2. Verify no `Deprecated: Using null as an array offset` notice appears in PHP logs. <br> 3. Confirm the correct default language is still returned.
| UI Tests          | https://github.com/jf-viguier/ga.tests.ui.pr/actions/runs/32977002239
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | creabilis.com
