### PR TITLE
Add getOrder() method to order-related classes

### DIFF
--- a/classes/order/OrderCartRule.php
+++ b/classes/order/OrderCartRule.php
@@ -32,6 +32,9 @@ class OrderCartRuleCore extends ObjectModel
     /** @var bool value : deleted from order */
     public $deleted = false;
 
+    /** @var Order * */
+    protected $order;
+
     /**
      * @see ObjectModel::$definition
      */
@@ -55,4 +58,13 @@ class OrderCartRuleCore extends ObjectModel
             'id_order' => ['xlink_resource' => 'orders'],
         ],
     ];
+
+    public function getOrder()
+    {
+        if (!$this->order) {
+            $this->order = new Order($this->id_order);
+        }
+
+        return $this->order;
+    }
 }

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -170,6 +170,9 @@ class OrderDetailCore extends ObjectModel
     /** @var float */
     public $total_refunded_tax_incl;
 
+    /** @var Order * */
+    protected $order;
+
     /**
      * @see ObjectModel::$definition
      */
@@ -296,6 +299,15 @@ class OrderDetailCore extends ObjectModel
         if ($this->context->shop->id != $id_shop) {
             $this->context->shop = new Shop((int) $id_shop);
         }
+    }
+
+    public function getOrder()
+    {
+        if (!$this->order) {
+            $this->order = new Order($this->id_order);
+        }
+
+        return $this->order;
     }
 
     public static function getDownloadFromHash($hash)

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -24,6 +24,9 @@ class OrderHistoryCore extends ObjectModel
     /** @var string Object last modification date */
     public $date_upd;
 
+    /** @var Order * */
+    protected $order;
+
     /**
      * @see ObjectModel::$definition
      */
@@ -52,6 +55,15 @@ class OrderHistoryCore extends ObjectModel
             'add' => 'addWs',
         ],
     ];
+
+    public function getOrder()
+    {
+        if (!$this->order) {
+            $this->order = new Order($this->id_order);
+        }
+
+        return $this->order;
+    }
 
     /**
      * Sets the new state of the given order.

--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -29,6 +29,9 @@ class OrderReturnCore extends ObjectModel
     /** @var string Object last modification date */
     public $date_upd;
 
+    /** @var Order * */
+    protected $order;
+
     /**
      * @see ObjectModel::$definition
      */
@@ -113,6 +116,15 @@ class OrderReturnCore extends ObjectModel
         }
 
         return (int) $data['total'];
+    }
+
+    public function getOrder()
+    {
+        if (!$this->order) {
+            $this->order = new Order($this->id_order);
+        }
+
+        return $this->order;
     }
 
     public static function getOrdersReturn($customer_id, $order_id = false, $no_denied = false, ?Context $context = null, ?int $idOrderReturn = null)

--- a/classes/order/OrderSlip.php
+++ b/classes/order/OrderSlip.php
@@ -50,6 +50,9 @@ class OrderSlipCore extends ObjectModel
     /** @var int */
     public $order_slip_type = 0;
 
+    /** @var Order * */
+    protected $order;
+
     /**
      * @see ObjectModel::$definition
      */
@@ -239,6 +242,15 @@ class OrderSlipCore extends ObjectModel
         }
 
         return $slips;
+    }
+
+    public function getOrder()
+    {
+        if (!$this->order) {
+            $this->order = new Order($this->id_order);
+        }
+
+        return $this->order;
     }
 
     public static function create(Order $order, $product_list, $shipping_cost = false, $amount = 0, $amount_choosen = false, $add_tax = true)


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add a lazy-loading `getOrder()` method (and protected `$order` property) to `OrderCartRule`, `OrderDetail`, `OrderHistory`, `OrderReturn`, and `OrderSlip`, following the same pattern already established in `OrderInvoice`.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Instantiate any of the modified classes (e.g. `new OrderHistory($id)`) and call `->getOrder()` — verify it returns the correct `Order` object. Call it twice to verify the result is cached and no extra DB query is made.
| UI Tests          | N/A
| Fixed issue or discussion?     | Closes #41265, Closes #41267, Closes #41268, Closes #41269, Closes #41270
| Related PRs       | Replaces #41265, #41267, #41268, #41269, #41270, #41453
| Sponsor company   |