### PR TITLE
Improve AI Forms context (settings vs CRUD) and introduce the sub-context pattern

### DIFF
--- a/.ai/Component/Configuration/CONTEXT.md
+++ b/.ai/Component/Configuration/CONTEXT.md
@@ -26,4 +26,4 @@ Typed, multi-store-aware abstraction over PrestaShop's key-value configuration s
 ## Related
 
 - [Context Component](../Context/CONTEXT.md) — `ShopConstraint` from `ShopContext` scopes config writes
-- [Forms Component](../Forms/CONTEXT.md) — settings pages use `DataConfigurationInterface` instead of `FormDataHandlerInterface`
+- [Forms — settings pattern](../Forms/SETTINGS.md) — settings pages use `DataConfigurationInterface` instead of `FormDataHandlerInterface`

--- a/.ai/Component/Controller/skills/create-controller-form-actions/SKILL.md
+++ b/.ai/Component/Controller/skills/create-controller-form-actions/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: create-controller-form-actions
 description: >
-  Create the form page actions in the admin controller: create (add) and edit,
-  plus any entity-specific actions. Uses FormBuilder/FormHandler pattern — never
-  builds commands directly. Trigger: "create form actions for {Domain}",
-  "create add/edit for {Domain}".
-needs: [create-cqrs-commands, create-cqrs-queries, create-form-type, create-form-data-handling]
-produces: "createAction, editAction, and entity-specific actions in {Domain}Controller.php"
+  Create form page actions in the admin controller. Covers both patterns: CRUD
+  (create/edit via FormBuilder + FormHandler pair) and settings (index + save
+  via the base FormHandler). Never builds commands directly. Trigger: "create
+  form actions for {Domain}", "create add/edit for {Domain}", "create settings
+  save action for {Page}".
+needs: [create-cqrs-commands, create-cqrs-queries, create-crud-form-type, create-crud-form-data-handling]
+produces: "createAction, editAction, and entity-specific actions in {Domain}Controller.php (CRUD); index/save actions for settings blocks"
 ---
 
 # create-controller-form-actions
 
 Read `@.ai/Component/Controller/CONTEXT.md` for controller conventions (base class, DI, security attributes, error mapping).
-Read `@.ai/Component/Forms/CONTEXT.md` for form patterns (FormBuilder, FormHandler, FormDataProvider, FormDataHandler).
+Read `@.ai/Component/Forms/CONTEXT.md` for form patterns (FormBuilder, FormHandler, FormDataProvider, FormDataHandler) and the settings-vs-CRUD decision tree.
+
+> **Two patterns:** CRUD entity forms inject the `FormBuilder` + IdentifiableObject `FormHandler` pair (sections 1–3 below). Settings forms inject the base `Handler` once (section 4 below). For the full settings-form stack (DataConfiguration + FormDataProvider + FormType + 4 YAML entries), the umbrella [`create-settings-form`](../../../Forms/skills/create-settings-form/SKILL.md) skill covers everything.
 
 ## 1. Create action
 
@@ -86,6 +89,67 @@ public function deleteCoverImageAction(int ${domain}Id): RedirectResponse
 ```
 
 The FormBuilder/FormHandler pair is required for the create/edit form lifecycle — not for every controller action.
+
+## 4. Settings form action
+
+For a **settings form** (options block writing into `ps_configuration`), the controller injects the base `Handler` once and calls `getForm()` / `save()` directly. There is no FormBuilder; there is no FormDataHandler. Both interfaces share the short name `FormHandlerInterface`, so use an `as` alias to disambiguate:
+
+```php
+use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface as ConfigurationFormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface; // unaliased — CRUD on this page
+```
+
+Index action — render the form alongside the rest of the page:
+
+```php
+#[AdminSecurity("is_granted('read', request.get('_legacy_controller'))")]
+public function indexAction(
+    Request $request,
+    #[Autowire(service: 'prestashop.admin.{domain}.{name}.form_handler')]
+    ConfigurationFormHandlerInterface $optionsFormHandler,
+): Response {
+    return $this->render('@PrestaShop/Admin/.../index.html.twig', [
+        'optionsForm' => $optionsFormHandler->getForm()->createView(),
+        // … grid, toolbar buttons, etc.
+    ]);
+}
+```
+
+Save action — POST handler:
+
+```php
+#[DemoRestricted(redirectRoute: 'admin_{page}_index')]
+#[AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute: 'admin_{page}_index')]
+public function saveOptionsAction(
+    Request $request,
+    #[Autowire(service: 'prestashop.admin.{domain}.{name}.form_handler')]
+    ConfigurationFormHandlerInterface $optionsFormHandler,
+): Response {
+    $form = $optionsFormHandler->getForm();
+    $form->handleRequest($request);
+
+    if ($form->isSubmitted() && $form->isValid()) {
+        $errors = $optionsFormHandler->save($form->getData());
+
+        if (0 === count($errors)) {
+            $this->addFlash('success', $this->trans('Update successful', [], 'Admin.Notifications.Success'));
+
+            return $this->redirectToRoute('admin_{page}_index');
+        }
+
+        $this->addFlashErrors($errors);
+    }
+
+    return $this->redirectToRoute('admin_{page}_index');
+}
+```
+
+Key differences from CRUD form actions:
+
+- Single handler injection (not a FormBuilder + FormHandler pair).
+- `$formHandler->save($form->getData())` returns an **array of error messages** (empty = success) — no `Result` object, no `getIdentifiableObjectId()`.
+- Index action passes the form view alongside other page data (grid, etc.); save action only redirects.
+- Reference: `CountryController::indexAction()` and `CountryController::saveOptionsAction()` (PR #41406).
 
 ## Rules
 

--- a/.ai/Component/Controller/skills/create-controller-form-actions/SKILL.md
+++ b/.ai/Component/Controller/skills/create-controller-form-actions/SKILL.md
@@ -6,7 +6,7 @@ description: >
   via the base FormHandler). Never builds commands directly. Trigger: "create
   form actions for {Domain}", "create add/edit for {Domain}", "create settings
   save action for {Page}".
-needs: [create-cqrs-commands, create-cqrs-queries, create-crud-form-type, create-crud-form-data-handling]
+needs: [create-cqrs-commands, create-cqrs-queries, create-crud-form-type, create-crud-form-data-handling, create-settings-form]
 produces: "createAction, editAction, and entity-specific actions in {Domain}Controller.php (CRUD); index/save actions for settings blocks"
 ---
 

--- a/.ai/Component/Controller/skills/create-controller-form-actions/SKILL.md
+++ b/.ai/Component/Controller/skills/create-controller-form-actions/SKILL.md
@@ -13,7 +13,9 @@ produces: "createAction, editAction, and entity-specific actions in {Domain}Cont
 # create-controller-form-actions
 
 Read `@.ai/Component/Controller/CONTEXT.md` for controller conventions (base class, DI, security attributes, error mapping).
-Read `@.ai/Component/Forms/CONTEXT.md` for form patterns (FormBuilder, FormHandler, FormDataProvider, FormDataHandler) and the settings-vs-CRUD decision tree.
+Read `@.ai/Component/Forms/CONTEXT.md` for the settings-vs-CRUD decision tree. Then, depending on which branch this controller serves, load only the relevant pattern detail:
+- CRUD action → `@.ai/Component/Forms/CRUD.md` (FormBuilder + FormHandler pair, IdentifiableObject base classes)
+- Settings action → `@.ai/Component/Forms/SETTINGS.md` (base `Handler`, hooks, allowed exception)
 
 > **Two patterns:** CRUD entity forms inject the `FormBuilder` + IdentifiableObject `FormHandler` pair (sections 1–3 below). Settings forms inject the base `Handler` once (section 4 below). For the full settings-form stack (DataConfiguration + FormDataProvider + FormType + 4 YAML entries), the umbrella [`create-settings-form`](../../../Forms/skills/create-settings-form/SKILL.md) skill covers everything.
 

--- a/.ai/Component/Forms/CONTEXT.md
+++ b/.ai/Component/Forms/CONTEXT.md
@@ -2,60 +2,159 @@
 
 ## Purpose
 
-Infrastructure for building, populating, and handling back-office forms tied to identifiable entities: data providers, data handlers, command builders, and choice providers. Does not contain Symfony form type definitions — those live in `src/PrestaShopBundle/Form/Admin/`.
+Infrastructure for building, populating, and handling back-office forms. PrestaShop has **two distinct form patterns** that share almost no code: settings forms (config blocks) and CRUD forms (entity add/edit). Picking the wrong pattern is the most common AI mistake — see the decision section below.
 
-## Layers
+## Settings forms vs CRUD forms — which one is this page?
 
-| Layer | Path |
-|-------|------|
-| Core contracts (configuration/settings forms) | `src/Core/Form/FormHandlerInterface.php`, `FormDataProviderInterface.php` |
-| IdentifiableObject sub-layer (entity forms) | `src/Core/Form/IdentifiableObject/` |
-| CommandBuilder sub-layer | `src/Core/Form/IdentifiableObject/CommandBuilder/` |
-| Choice providers (Core, 61+) | `src/Core/Form/ChoiceProvider/` |
-| Choice providers (Adapter, 26) | `src/Adapter/Form/ChoiceProvider/` |
-| Symfony form types | `src/PrestaShopBundle/Form/Admin/` |
-| Form extensions | `src/PrestaShopBundle/Form/Extension/` — add custom options (e.g. `external_link`, `modify_all_shops`) to all form types globally |
-| Form utilities | `src/PrestaShopBundle/Form/FormBuilderModifier.php`, `FormCloner.php`, `FormHelper.php` — tools for modifying and cloning form builders at runtime |
+Three yes/no questions, in order:
 
-## Non-obvious patterns
+1. Does the page persist values into `ps_configuration` (or another flat key/value store)? → **settings form**.
+2. Is the data identified by an entity ID and listed in a grid for create/edit/delete? → **CRUD form** (a.k.a. *identifiable* form).
+3. Is there (or should there be) a CQRS `Add{Domain}Command` / `Edit{Domain}Command` for it? → **CRUD form**. Otherwise → **settings form**.
 
-- Two distinct patterns coexist: configuration/settings `FormHandlerInterface` (settings pages, no `CommandBus`) and modern `IdentifiableObject` layer (entity forms, dispatches CQRS commands)
-- Settings pages typically have a pair: one `FormDataProviderInterface` (reads/writes configuration values) + one `FormHandlerInterface` (builds the form and delegates save to the provider). The final `FormHandler` wrapper orchestrates them — you implement the interfaces, not the wrapper.
-- `CommandBuilder` bridges raw form `array` → typed CQRS commands; Product domain has 16 builders, Combination has 6 — one per form section, not one per entity
-- `FormDataHandlerInterface` has two methods: `create(array $data)` and `update($id, array $data)` — both return the entity ID
-- `FormOptionsProviderInterface` supplies **dynamic** form options (carriers, tax rules) evaluated at render time, distinct from static choice providers
-- Form extensions in `src/PrestaShopBundle/Form/Extension/` add custom options to all form types globally — check existing extensions before adding new form options
+A single admin page may carry **both** patterns side-by-side (e.g. *Shop parameters > Contact > Stores* has a CRUD grid for store entities **and** a settings form for global contact details). Treat each block independently.
 
-## Canonical examples
+| Pattern | Use case | Base handler | Skill |
+|---|---|---|---|
+| Settings form | options block, page-level configuration, `fields_options` migration | `PrestaShop\PrestaShop\Core\Form\Handler` (registered as service, never subclassed) | [`create-settings-form`](skills/create-settings-form/SKILL.md) |
+| CRUD form | entity add/edit (with grid listing) | `IdentifiableObject\Builder\FormBuilder` + `IdentifiableObject\Handler\FormHandler` (factory-built, never subclassed) | [`create-crud-form-type`](skills/create-crud-form-type/SKILL.md) + [`create-crud-form-data-handling`](skills/create-crud-form-data-handling/SKILL.md) |
 
-- `src/Core/Form/IdentifiableObject/DataHandler/TaxFormDataHandler.php` — simple entity form data handler (typical use case)
-- `src/Core/Form/IdentifiableObject/DataHandler/ProductFormDataHandler.php` — complex handler delegating to CommandBuilders (advanced use case)
-- `src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Security/FormDataProvider.php` — settings page data provider
+## Settings form pattern
 
-## Conventions
+### Required layers
 
-- **Default form base class:** standard entity forms extend `TranslatorAwareType` or `AbstractType`. `NavigationTabType` is only for complex multi-tab forms (exception, not the default)
-- **Form types define structure only** — no knowledge of commands/queries. Validation via Symfony constraints on fields
-- **IdentifiableObject pattern:** entity forms use `FormDataProviderInterface` (reads data for edit) + `FormDataHandlerInterface` (dispatches commands on create/update). These are encapsulated by two framework services:
-  - `FormBuilder` (`PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder`) — builds the Symfony form. For edit, calls `DataProvider::getData($id)` to pre-fill. For create, calls `DataProvider::getDefaultData()`. The controller calls `$this->getFormBuilder()->getForm(...)`
-  - `FormHandler` (`PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler`) — handles form submission. Validates the form, then calls `DataHandler::create()` or `DataHandler::update()`. The controller calls `$this->getFormHandler()->handle($form)`
-  - The controller never calls DataProvider or DataHandler directly — it goes through FormBuilder and FormHandler
-- **DataProvider contract:** `getData($id): array` dispatches the Get query and maps DTO to form array structure. `getDefaultData(): array` returns defaults for create form — must match the same structure as `getData()`
-- **DataHandler contract:** `create(array $data): mixed` builds Add command from form data and dispatches via command bus, returns new ID. `update($id, array $data): void` builds Edit command with setters for non-null fields. Sub-resource commands are dispatched separately after the main command
-- **Multilingual fields:** use `TranslatableType` wrapping the inner field type (including `TextareaType` and `FormattedTextareaType` for multilingual textareas). Data is an array keyed by language ID
-- **File uploads:** use `FileType` with `'mapped' => false, 'required' => false`. Actual file saving happens in the DataHandler, not the form type. The edit template renders the existing file via a custom Twig block
-- **Money / decimal fields:** PrestaShop stores prices with 6 decimal places. Always set explicit decimal scale. Use `DecimalNumber` in commands — never native `float`
-- **Choice providers:** dynamic select options use `ChoiceProviderInterface` services injected into form types. Keys are labels, values are DB IDs
-- **Service registration:** form types tagged with `form.type`, DataProvider/DataHandler registered with `autowire: true` and `autoconfigure: true`. Service IDs follow `prestashop.core.form.identifiable_object.data_provider.{domain}_form_data_provider` (and `data_handler` equivalently)
-- **Sub-resource dispatch order:** in `DataHandler::create()`/`update()`, dispatch the main entity command first, then sub-resource commands separately
-- **Tab anchor IDs:** when using `NavigationTabType`, tab anchor IDs are derived from tab names and used by JS for error-driven tab navigation
-- **Error handling:** server-side validation via Symfony constraints is the source of truth. JS tab error navigation is enhancement only
+| Layer | Path | Role |
+|---|---|---|
+| DataConfiguration | `src/Adapter/{Domain}/{Name}Configuration.php` | extends `AbstractMultistoreConfiguration`. Reads/writes config rows. Implements `getConfiguration(): array`, `updateConfiguration(array): array` (returns array of errors), and protected `buildResolver(): OptionsResolver` for option validation. |
+| FormDataProvider | `src/PrestaShopBundle/Form/Admin/{Section}/{Name}FormDataProvider.php` | implements `PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface`. Two-line bridge: `getData()` → `dataConfiguration->getConfiguration()`, `setData($data)` → `dataConfiguration->updateConfiguration($data)`. |
+| FormType | `src/PrestaShopBundle/Form/Admin/{Section}/{Name}Type.php` | standard `AbstractType` / `TranslatorAwareType`. **This is the root form** — no `getParent()`, no wrapper, no entity binding. |
+
+### Service definitions (4 YAML entries, no PHP handler class)
+
+| Service | YAML file | Class |
+|---|---|---|
+| DataConfiguration | `src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml` | your `{Name}Configuration` |
+| FormDataProvider | `src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml` | your `{Name}FormDataProvider` |
+| FormHandler | `src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml` | **`PrestaShop\PrestaShop\Core\Form\Handler`** (the base class — never your own) |
+| FormType | `src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml` | empty entry for auto-discovery |
+
+The `Handler` service takes 6 ordered arguments: form factory, hook dispatcher, your FormDataProvider, FormType FQCN, **hook name** (PascalCase, e.g. `CountriesPageOptions`), **form name** (kebab-case, e.g. `country-options`). The hook name drives the two module-facing hooks below.
+
+### Hooks dispatched by the base `Handler`
+
+| Hook | When | Parameters | Use |
+|---|---|---|---|
+| `action{HookName}Form` | inside `Handler::getForm()` | `form_builder` (mutable reference) | modules add/remove/modify fields before render |
+| `action{HookName}Save` | inside `Handler::save()` | `errors` and `form_data` (both passed by reference) | modules inject validation errors or rewrite data before persistence |
+
+These hooks are how external modules extend back-office settings forms. Reimplementing `FormHandlerInterface` from scratch silently removes both hooks — see the "Custom `FormHandlerInterface`" anti-pattern below.
+
+### Allowed exception — extending `Handler` for save-time side effects
+
+A handful of pages need a side effect at save time that does not belong in `DataConfiguration` (cache invalidation, cross-field coercion): `ProductPreferencesFormHandler`, `PreferencesFormHandler`, `CustomerPreferencesFormHandler`, `TranslationsSettingsFormHandler`, `InvoiceByDateFormHandler`, `InvoiceByStatusFormHandler`, `ImportFormHandler`. Rule:
+
+- The class must **`extends Handler`** — never reimplement `FormHandlerInterface` from scratch.
+- Overridden `save()` must call **`parent::save()`** so the hook dispatch still fires.
+- Cache-clearing or similar plumbing dependencies are wired via service `calls:` in the YAML.
+
+### Settings form anti-patterns (named symptoms)
+
+**"Outer wrapper builder"** — symptom: a visible wrapper label, a `label => false` workaround on the only `add()` call, submitted data shaped like `['xxx' => [...real fields...]]`, the FormType ends up nested as a child instead of being the root form.
+
+```php
+// ❌ WRONG — this is what PR #41414 generated:
+$this->formFactory->createBuilder()
+    ->add('contact_details', ContactDetailsType::class, ['label' => false])
+    ->setData(['contact_details' => $this->dataProvider->getData()])
+    ->getForm();
+```
+
+The correct construction is `Handler::getForm()`'s one-liner (see `src/Core/Form/Handler.php:83`):
+
+```php
+$formBuilder = $this->formFactory->createNamedBuilder($this->formName, $this->form);
+```
+
+The FormType IS the root form — there is never an extra outer builder.
+
+**"Custom `FormHandlerInterface` implementation"** — symptom: a file like `XxxFormHandler.php` implementing the interface from scratch, with its own `getForm()`/`save()` body. The module hooks `action{HookName}Form` (dispatched at `Handler.php:87`) and `action{HookName}Save` (dispatched at `Handler.php:107`) never fire. Modules silently lose the ability to extend the form. Fix: delete the class, register a `PrestaShop\PrestaShop\Core\Form\Handler` service in `form_handler.yml` instead.
+
+### Canonical example
+
+PR #41406 — "Migrate country options" — adds a textbook settings-form: `src/Adapter/Country/CountryOptionsConfiguration.php`, `src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryOptionsFormDataProvider.php`, `CountryOptionsType.php`, and four YAML entries. Read these files when in doubt.
+
+## CRUD form pattern
+
+### Required layers
+
+| Layer | Path | Role |
+|---|---|---|
+| FormDataProvider | `src/Core/Form/IdentifiableObject/DataProvider/{Domain}FormDataProvider.php` | `getData($id): array` dispatches `Get{Domain}ForEditing`; `getDefaultData(): array` returns create-form defaults |
+| FormDataHandler | `src/Core/Form/IdentifiableObject/DataHandler/{Domain}FormDataHandler.php` | `create(array $data): mixed` dispatches `Add{Domain}Command`; `update($id, array $data): void` dispatches `Edit{Domain}Command` |
+| FormType | `src/PrestaShopBundle/Form/Admin/{Section}/{Domain}/{Domain}Type.php` | fields, validation constraints. No CQRS knowledge. |
+| Base FormBuilder | `PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder` | **factory-built service — never subclassed**. Controller calls `getForm()` / `getFormFor($id)`. |
+| Base FormHandler | `PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler` | **factory-built service — never subclassed**. Controller calls `handle($form)` / `handleFor($id, $form)`. |
+
+### Service definitions
+
+| Service | YAML file |
+|---|---|
+| FormType | `src/PrestaShopBundle/Resources/config/services/core/form/form_type.yml` (or `bundle/form/form_type.yml`) |
+| FormDataProvider | `src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml` |
+| FormDataHandler | `src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml` |
+| FormBuilder | `src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml` (uses `prestashop.core.form.builder.form_builder_factory` factory) |
+| FormHandler | `src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml` (uses `prestashop.core.form.identifiable_object.handler.form_handler_factory` factory) |
+
+Service-ID convention: `prestashop.core.form.identifiable_object.{builder|handler|data_provider|data_handler}.{domain}_form_{role}`.
+
+### Hooks dispatched by the IdentifiableObject `FormHandler`
+
+- `actionBeforeCreate{FormName}FormHandler`
+- `actionAfterCreate{FormName}FormHandler`
+- `actionBeforeUpdate{FormName}FormHandler`
+- `actionAfterUpdate{FormName}FormHandler`
+- plus the `FormBuilderModifier` extension point for in-flight builder mutation by modules
+
+### CRUD form anti-pattern
+
+**"Custom FormBuilder or FormHandler class"** — symptom: a hand-rolled class extending the IdentifiableObject base. There is no legitimate use case; the factory-built services support every pattern needed (file uploads, multilingual, tabs, sub-resource commands). If a hand-rolled class appears in a PR, it is a sign the AI invented one — delete it and use the factory services.
+
+## Critical YAML folder distinction
+
+`src/PrestaShopBundle/Resources/config/services/bundle/form/` = **settings forms** (use the base `Handler` class).
+`src/PrestaShopBundle/Resources/config/services/core/form/` = **CRUD forms** (use the IdentifiableObject factories).
+
+Easy to mix up. Wrong folder will not raise a hard error — the service simply won't be picked up by the auto-discovery, and the page will fail at runtime with a "service not found" message.
+
+## Shared concerns (both patterns)
+
+| Topic | Note |
+|---|---|
+| Translatable fields | `TranslatableType` wrapping the inner type. Data is an array keyed by language ID. Multilingual textareas wrap `TextareaType` / `FormattedTextareaType`. |
+| Money / decimal | `MoneyType` for static currency, `AmountType` for multi-currency. PrestaShop stores prices with 6 decimal places — always set explicit decimal scale, never round to float. Commands carry `DecimalNumber`, never native `float`. |
+| File uploads | `FileType` with `'mapped' => false, 'required' => false`. Actual file saving happens in the DataHandler (CRUD) or DataConfiguration (settings), not the form type. |
+| Choice providers | `ChoiceProviderInterface` services injected into form types for dynamic select options. `FormOptionsProviderInterface` for options evaluated at render time (e.g. carrier lists). |
+| Form extensions | `src/PrestaShopBundle/Form/Extension/` adds custom options (e.g. `external_link`, `modify_all_shops`) to all form types globally. Check existing extensions before adding new options. |
+| Tab layout | `NavigationTabType` is a generic Symfony composition pattern — applicable in either pattern but used today almost exclusively by complex CRUD forms (Carrier, Product). See [`create-form-tab-layout`](skills/create-form-tab-layout/SKILL.md). |
+| Form utilities | `FormBuilderModifier`, `FormCloner`, `FormHelper` under `src/PrestaShopBundle/Form/` — tools for mutating form builders at runtime (mostly module use). |
+| Choice providers location | `src/Core/Form/ChoiceProvider/` (61+) + `src/Adapter/Form/ChoiceProvider/` (26) |
+
+## Canonical references
+
+| File | Pattern | Use case |
+|---|---|---|
+| `src/Adapter/Country/CountryOptionsConfiguration.php` | settings | minimal `AbstractMultistoreConfiguration` extension |
+| `src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryOptionsFormDataProvider.php` | settings | minimal `FormDataProviderInterface` bridge |
+| `src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php` | settings | typical settings FormType with several fields |
+| `src/Core/Form/IdentifiableObject/DataHandler/TaxFormDataHandler.php` | CRUD | simple DataHandler |
+| `src/Core/Form/IdentifiableObject/DataHandler/ProductFormDataHandler.php` | CRUD | complex DataHandler with `CommandBuilder` delegation |
+| `src/Core/Form/Handler.php` | settings (base class) | source-of-truth for the hook-dispatch contract |
 
 ## Skills
 
 | Skill | Trigger |
 |-------|---------|
-| [`create-form-type`](skills/create-form-type/SKILL.md) | "create form type for {Domain}" |
+| [`create-settings-form`](skills/create-settings-form/SKILL.md) | "create settings form for {Page}" |
+| [`create-crud-form-type`](skills/create-crud-form-type/SKILL.md) | "create CRUD form type for {Domain}" |
+| [`create-crud-form-data-handling`](skills/create-crud-form-data-handling/SKILL.md) | "create CRUD form data handling for {Domain}" |
 | [`create-form-tab-layout`](skills/create-form-tab-layout/SKILL.md) | "create tab layout for {Domain} form" |
-| [`create-form-data-handling`](skills/create-form-data-handling/SKILL.md) | "create form data handling for {Domain}" |
-

--- a/.ai/Component/Forms/CONTEXT.md
+++ b/.ai/Component/Forms/CONTEXT.md
@@ -4,6 +4,10 @@
 
 Infrastructure for building, populating, and handling back-office forms. PrestaShop has **two distinct form patterns** that share almost no code: settings forms (config blocks) and CRUD forms (entity add/edit). Picking the wrong pattern is the most common AI mistake — see the decision section below.
 
+Pattern-specific rules live in companion files. Read them on demand, not preemptively:
+- **Settings forms:** [`SETTINGS.md`](SETTINGS.md) — base `Handler`, hooks, anti-patterns, allowed exception, YAML folder, canonical example.
+- **CRUD forms:** [`CRUD.md`](CRUD.md) — base FormBuilder/FormHandler factories, hooks, anti-pattern, YAML folder.
+
 ## Settings forms vs CRUD forms — which one is this page?
 
 Three yes/no questions, in order:
@@ -14,117 +18,19 @@ Three yes/no questions, in order:
 
 A single admin page may carry **both** patterns side-by-side (e.g. *Shop parameters > Contact > Stores* has a CRUD grid for store entities **and** a settings form for global contact details). Treat each block independently.
 
-| Pattern | Use case | Base handler | Skill |
+| Pattern | Use case | Read | Skill |
 |---|---|---|---|
-| Settings form | options block, page-level configuration, `fields_options` migration | `PrestaShop\PrestaShop\Core\Form\Handler` (registered as service, never subclassed) | [`create-settings-form`](skills/create-settings-form/SKILL.md) |
-| CRUD form | entity add/edit (with grid listing) | `IdentifiableObject\Builder\FormBuilder` + `IdentifiableObject\Handler\FormHandler` (factory-built, never subclassed) | [`create-crud-form-type`](skills/create-crud-form-type/SKILL.md) + [`create-crud-form-data-handling`](skills/create-crud-form-data-handling/SKILL.md) |
-
-## Settings form pattern
-
-### Required layers
-
-| Layer | Path | Role |
-|---|---|---|
-| DataConfiguration | `src/Adapter/{Domain}/{Name}Configuration.php` | extends `AbstractMultistoreConfiguration`. Reads/writes config rows. Implements `getConfiguration(): array`, `updateConfiguration(array): array` (returns array of errors), and protected `buildResolver(): OptionsResolver` for option validation. |
-| FormDataProvider | `src/PrestaShopBundle/Form/Admin/{Section}/{Name}FormDataProvider.php` | implements `PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface`. Two-line bridge: `getData()` → `dataConfiguration->getConfiguration()`, `setData($data)` → `dataConfiguration->updateConfiguration($data)`. |
-| FormType | `src/PrestaShopBundle/Form/Admin/{Section}/{Name}Type.php` | standard `AbstractType` / `TranslatorAwareType`. **This is the root form** — no `getParent()`, no wrapper, no entity binding. |
-
-### Service definitions (4 YAML entries, no PHP handler class)
-
-| Service | YAML file | Class |
-|---|---|---|
-| DataConfiguration | `src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml` | your `{Name}Configuration` |
-| FormDataProvider | `src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml` | your `{Name}FormDataProvider` |
-| FormHandler | `src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml` | **`PrestaShop\PrestaShop\Core\Form\Handler`** (the base class — never your own) |
-| FormType | `src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml` | empty entry for auto-discovery |
-
-The `Handler` service takes 6 ordered arguments: form factory, hook dispatcher, your FormDataProvider, FormType FQCN, **hook name** (PascalCase, e.g. `CountriesPageOptions`), **form name** (kebab-case, e.g. `country-options`). The hook name drives the two module-facing hooks below.
-
-### Hooks dispatched by the base `Handler`
-
-| Hook | When | Parameters | Use |
-|---|---|---|---|
-| `action{HookName}Form` | inside `Handler::getForm()` | `form_builder` (mutable reference) | modules add/remove/modify fields before render |
-| `action{HookName}Save` | inside `Handler::save()` | `errors` and `form_data` (both passed by reference) | modules inject validation errors or rewrite data before persistence |
-
-These hooks are how external modules extend back-office settings forms. Reimplementing `FormHandlerInterface` from scratch silently removes both hooks — see the "Custom `FormHandlerInterface`" anti-pattern below.
-
-### Allowed exception — extending `Handler` for save-time side effects
-
-A handful of pages need a side effect at save time that does not belong in `DataConfiguration` (cache invalidation, cross-field coercion): `ProductPreferencesFormHandler`, `PreferencesFormHandler`, `CustomerPreferencesFormHandler`, `TranslationsSettingsFormHandler`, `InvoiceByDateFormHandler`, `InvoiceByStatusFormHandler`, `ImportFormHandler`. Rule:
-
-- The class must **`extends Handler`** — never reimplement `FormHandlerInterface` from scratch.
-- Overridden `save()` must call **`parent::save()`** so the hook dispatch still fires.
-- Cache-clearing or similar plumbing dependencies are wired via service `calls:` in the YAML.
-
-### Settings form anti-patterns (named symptoms)
-
-**"Outer wrapper builder"** — symptom: a visible wrapper label, a `label => false` workaround on the only `add()` call, submitted data shaped like `['xxx' => [...real fields...]]`, the FormType ends up nested as a child instead of being the root form.
-
-```php
-// ❌ WRONG — this is what PR #41414 generated:
-$this->formFactory->createBuilder()
-    ->add('contact_details', ContactDetailsType::class, ['label' => false])
-    ->setData(['contact_details' => $this->dataProvider->getData()])
-    ->getForm();
-```
-
-The correct construction is `Handler::getForm()`'s one-liner (see `src/Core/Form/Handler.php:83`):
-
-```php
-$formBuilder = $this->formFactory->createNamedBuilder($this->formName, $this->form);
-```
-
-The FormType IS the root form — there is never an extra outer builder.
-
-**"Custom `FormHandlerInterface` implementation"** — symptom: a file like `XxxFormHandler.php` implementing the interface from scratch, with its own `getForm()`/`save()` body. The module hooks `action{HookName}Form` (dispatched at `Handler.php:87`) and `action{HookName}Save` (dispatched at `Handler.php:107`) never fire. Modules silently lose the ability to extend the form. Fix: delete the class, register a `PrestaShop\PrestaShop\Core\Form\Handler` service in `form_handler.yml` instead.
-
-### Canonical example
-
-PR #41406 — "Migrate country options" — adds a textbook settings-form: `src/Adapter/Country/CountryOptionsConfiguration.php`, `src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryOptionsFormDataProvider.php`, `CountryOptionsType.php`, and four YAML entries. Read these files when in doubt.
-
-## CRUD form pattern
-
-### Required layers
-
-| Layer | Path | Role |
-|---|---|---|
-| FormDataProvider | `src/Core/Form/IdentifiableObject/DataProvider/{Domain}FormDataProvider.php` | `getData($id): array` dispatches `Get{Domain}ForEditing`; `getDefaultData(): array` returns create-form defaults |
-| FormDataHandler | `src/Core/Form/IdentifiableObject/DataHandler/{Domain}FormDataHandler.php` | `create(array $data): mixed` dispatches `Add{Domain}Command`; `update($id, array $data): void` dispatches `Edit{Domain}Command` |
-| FormType | `src/PrestaShopBundle/Form/Admin/{Section}/{Domain}/{Domain}Type.php` | fields, validation constraints. No CQRS knowledge. |
-| Base FormBuilder | `PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder` | **factory-built service — never subclassed**. Controller calls `getForm()` / `getFormFor($id)`. |
-| Base FormHandler | `PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler` | **factory-built service — never subclassed**. Controller calls `handle($form)` / `handleFor($id, $form)`. |
-
-### Service definitions
-
-| Service | YAML file |
-|---|---|
-| FormType | `src/PrestaShopBundle/Resources/config/services/core/form/form_type.yml` (or `bundle/form/form_type.yml`) |
-| FormDataProvider | `src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml` |
-| FormDataHandler | `src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml` |
-| FormBuilder | `src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml` (uses `prestashop.core.form.builder.form_builder_factory` factory) |
-| FormHandler | `src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml` (uses `prestashop.core.form.identifiable_object.handler.form_handler_factory` factory) |
-
-Service-ID convention: `prestashop.core.form.identifiable_object.{builder|handler|data_provider|data_handler}.{domain}_form_{role}`.
-
-### Hooks dispatched by the IdentifiableObject `FormHandler`
-
-- `actionBeforeCreate{FormName}FormHandler`
-- `actionAfterCreate{FormName}FormHandler`
-- `actionBeforeUpdate{FormName}FormHandler`
-- `actionAfterUpdate{FormName}FormHandler`
-- plus the `FormBuilderModifier` extension point for in-flight builder mutation by modules
-
-### CRUD form anti-pattern
-
-**"Custom FormBuilder or FormHandler class"** — symptom: a hand-rolled class extending the IdentifiableObject base. There is no legitimate use case; the factory-built services support every pattern needed (file uploads, multilingual, tabs, sub-resource commands). If a hand-rolled class appears in a PR, it is a sign the AI invented one — delete it and use the factory services.
+| Settings form | options block, page-level configuration, `fields_options` migration | [`SETTINGS.md`](SETTINGS.md) | [`create-settings-form`](skills/create-settings-form/SKILL.md) |
+| CRUD form | entity add/edit (with grid listing) | [`CRUD.md`](CRUD.md) | [`create-crud-form-type`](skills/create-crud-form-type/SKILL.md) + [`create-crud-form-data-handling`](skills/create-crud-form-data-handling/SKILL.md) |
 
 ## Critical YAML folder distinction
 
-`src/PrestaShopBundle/Resources/config/services/bundle/form/` = **settings forms** (use the base `Handler` class).
-`src/PrestaShopBundle/Resources/config/services/core/form/` = **CRUD forms** (use the IdentifiableObject factories).
+The two patterns use **different** service-definition folders:
 
-Easy to mix up. Wrong folder will not raise a hard error — the service simply won't be picked up by the auto-discovery, and the page will fail at runtime with a "service not found" message.
+- `src/PrestaShopBundle/Resources/config/services/bundle/form/` → **settings forms** (base `Handler`)
+- `src/PrestaShopBundle/Resources/config/services/core/form/` → **CRUD forms** (IdentifiableObject factories)
+
+Easy to mix up. Wrong folder won't raise a hard error — the service simply isn't picked up by auto-discovery, and the page fails at runtime with "service not found". Details in each pattern's companion file.
 
 ## Shared concerns (both patterns)
 
@@ -133,28 +39,16 @@ Easy to mix up. Wrong folder will not raise a hard error — the service simply 
 | Translatable fields | `TranslatableType` wrapping the inner type. Data is an array keyed by language ID. Multilingual textareas wrap `TextareaType` / `FormattedTextareaType`. |
 | Money / decimal | `MoneyType` for static currency, `AmountType` for multi-currency. PrestaShop stores prices with 6 decimal places — always set explicit decimal scale, never round to float. Commands carry `DecimalNumber`, never native `float`. |
 | File uploads | `FileType` with `'mapped' => false, 'required' => false`. Actual file saving happens in the DataHandler (CRUD) or DataConfiguration (settings), not the form type. |
-| Choice providers | `ChoiceProviderInterface` services injected into form types for dynamic select options. `FormOptionsProviderInterface` for options evaluated at render time (e.g. carrier lists). |
+| Choice providers | `ChoiceProviderInterface` services injected into form types for dynamic select options. `FormOptionsProviderInterface` for options evaluated at render time (e.g. carrier lists). Located under `src/Core/Form/ChoiceProvider/` (61+) + `src/Adapter/Form/ChoiceProvider/` (26). |
 | Form extensions | `src/PrestaShopBundle/Form/Extension/` adds custom options (e.g. `external_link`, `modify_all_shops`) to all form types globally. Check existing extensions before adding new options. |
 | Tab layout | `NavigationTabType` is a generic Symfony composition pattern — applicable in either pattern but used today almost exclusively by complex CRUD forms (Carrier, Product). See [`create-form-tab-layout`](skills/create-form-tab-layout/SKILL.md). |
 | Form utilities | `FormBuilderModifier`, `FormCloner`, `FormHelper` under `src/PrestaShopBundle/Form/` — tools for mutating form builders at runtime (mostly module use). |
-| Choice providers location | `src/Core/Form/ChoiceProvider/` (61+) + `src/Adapter/Form/ChoiceProvider/` (26) |
-
-## Canonical references
-
-| File | Pattern | Use case |
-|---|---|---|
-| `src/Adapter/Country/CountryOptionsConfiguration.php` | settings | minimal `AbstractMultistoreConfiguration` extension |
-| `src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryOptionsFormDataProvider.php` | settings | minimal `FormDataProviderInterface` bridge |
-| `src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php` | settings | typical settings FormType with several fields |
-| `src/Core/Form/IdentifiableObject/DataHandler/TaxFormDataHandler.php` | CRUD | simple DataHandler |
-| `src/Core/Form/IdentifiableObject/DataHandler/ProductFormDataHandler.php` | CRUD | complex DataHandler with `CommandBuilder` delegation |
-| `src/Core/Form/Handler.php` | settings (base class) | source-of-truth for the hook-dispatch contract |
 
 ## Skills
 
-| Skill | Trigger |
-|-------|---------|
-| [`create-settings-form`](skills/create-settings-form/SKILL.md) | "create settings form for {Page}" |
-| [`create-crud-form-type`](skills/create-crud-form-type/SKILL.md) | "create CRUD form type for {Domain}" |
-| [`create-crud-form-data-handling`](skills/create-crud-form-data-handling/SKILL.md) | "create CRUD form data handling for {Domain}" |
-| [`create-form-tab-layout`](skills/create-form-tab-layout/SKILL.md) | "create tab layout for {Domain} form" |
+| Skill | Trigger | Pattern detail to load |
+|-------|---------|------------------------|
+| [`create-settings-form`](skills/create-settings-form/SKILL.md) | "create settings form for {Page}" | [`SETTINGS.md`](SETTINGS.md) |
+| [`create-crud-form-type`](skills/create-crud-form-type/SKILL.md) | "create CRUD form type for {Domain}" | [`CRUD.md`](CRUD.md) |
+| [`create-crud-form-data-handling`](skills/create-crud-form-data-handling/SKILL.md) | "create CRUD form data handling for {Domain}" | [`CRUD.md`](CRUD.md) |
+| [`create-form-tab-layout`](skills/create-form-tab-layout/SKILL.md) | "create tab layout for {Domain} form" | — (generic) |

--- a/.ai/Component/Forms/CONTEXT.md
+++ b/.ai/Component/Forms/CONTEXT.md
@@ -36,11 +36,12 @@ Easy to mix up. Wrong folder won't raise a hard error — the service simply isn
 
 | Topic | Note |
 |---|---|
-| Translatable fields | `TranslatableType` wrapping the inner type. Data is an array keyed by language ID. Multilingual textareas wrap `TextareaType` / `FormattedTextareaType`. |
+| Reusable form types | **`PrestaShopBundle\Form\Admin\Type\`** holds 80+ generic, PrestaShop-specific form types (`SwitchType`, `TranslatableType`, `MoneyType`, `CountryChoiceType`, `CurrencyChoiceType`, `ColorPickerType`, `IpAddressType`, `EmailType`, `MaterialChoiceTreeType`, etc., plus the `Common/` and `Material/` sub-namespaces). **Check this namespace before reinventing a field** — there is almost always a ready-made type. |
+| Form extensions | **`PrestaShopBundle\Form\Extension\`** holds 24+ Symfony `AbstractTypeExtension` classes that add custom options to all form types globally: `help`, `hint`, `external_link`, `modify_all_shops`, `autocomplete`, `multistore_configuration_key`, `download_file`, `disabling_switch`, etc. **Check this namespace before inventing a new field option** — the option you want probably already exists. |
+| Translatable fields | `TranslatableType` (in `Form\Admin\Type\`) wrapping the inner type. Data is an array keyed by language ID. Multilingual textareas wrap `TextareaType` / `FormattedTextareaType`. |
 | Money / decimal | `MoneyType` for static currency, `AmountType` for multi-currency. PrestaShop stores prices with 6 decimal places — always set explicit decimal scale, never round to float. Commands carry `DecimalNumber`, never native `float`. |
 | File uploads | `FileType` with `'mapped' => false, 'required' => false`. Actual file saving happens in the DataHandler (CRUD) or DataConfiguration (settings), not the form type. |
 | Choice providers | `ChoiceProviderInterface` services injected into form types for dynamic select options. `FormOptionsProviderInterface` for options evaluated at render time (e.g. carrier lists). Located under `src/Core/Form/ChoiceProvider/` (61+) + `src/Adapter/Form/ChoiceProvider/` (26). |
-| Form extensions | `src/PrestaShopBundle/Form/Extension/` adds custom options (e.g. `external_link`, `modify_all_shops`) to all form types globally. Check existing extensions before adding new options. |
 | Tab layout | `NavigationTabType` is a generic Symfony composition pattern — applicable in either pattern but used today almost exclusively by complex CRUD forms (Carrier, Product). See [`create-form-tab-layout`](skills/create-form-tab-layout/SKILL.md). |
 | Form utilities | `FormBuilderModifier`, `FormCloner`, `FormHelper` under `src/PrestaShopBundle/Form/` — tools for mutating form builders at runtime (mostly module use). |
 

--- a/.ai/Component/Forms/CRUD.md
+++ b/.ai/Component/Forms/CRUD.md
@@ -1,0 +1,50 @@
+# CRUD forms — pattern detail
+
+> Sub-context of [`Forms/CONTEXT.md`](CONTEXT.md). Read the root first for the decision tree and shared concerns; this file documents only what is CRUD-specific.
+
+CRUD form = a.k.a. *identifiable* form. Entity add/edit page backed by CQRS commands.
+
+## Required layers
+
+| Layer | Path | Role |
+|---|---|---|
+| FormDataProvider | `src/Core/Form/IdentifiableObject/DataProvider/{Domain}FormDataProvider.php` | `getData($id): array` dispatches `Get{Domain}ForEditing`; `getDefaultData(): array` returns create-form defaults |
+| FormDataHandler | `src/Core/Form/IdentifiableObject/DataHandler/{Domain}FormDataHandler.php` | `create(array $data): mixed` dispatches `Add{Domain}Command`; `update($id, array $data): void` dispatches `Edit{Domain}Command` |
+| FormType | `src/PrestaShopBundle/Form/Admin/{Section}/{Domain}/{Domain}Type.php` | fields, validation constraints. No CQRS knowledge. |
+| Base FormBuilder | `PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder` | **factory-built service — never subclassed**. Controller calls `getForm()` / `getFormFor($id)`. |
+| Base FormHandler | `PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler` | **factory-built service — never subclassed**. Controller calls `handle($form)` / `handleFor($id, $form)`. |
+
+## Service definitions
+
+All entries go under `src/PrestaShopBundle/Resources/config/services/core/form/`. Never under `bundle/form/` — that folder is reserved for settings forms.
+
+| Service | YAML file |
+|---|---|
+| FormType | `services/core/form/form_type.yml` (or `bundle/form/form_type.yml`) |
+| FormDataProvider | `services/core/form/form_data_provider.yml` |
+| FormDataHandler | `services/core/form/form_data_handler.yml` |
+| FormBuilder | `services/core/form/form_builder.yml` (uses `prestashop.core.form.builder.form_builder_factory` factory) |
+| FormHandler | `services/core/form/form_handler.yml` (uses `prestashop.core.form.identifiable_object.handler.form_handler_factory` factory) |
+
+Service-ID convention: `prestashop.core.form.identifiable_object.{builder|handler|data_provider|data_handler}.{domain}_form_{role}`.
+
+## Hooks dispatched by the IdentifiableObject `FormHandler`
+
+- `actionBeforeCreate{FormName}FormHandler`
+- `actionAfterCreate{FormName}FormHandler`
+- `actionBeforeUpdate{FormName}FormHandler`
+- `actionAfterUpdate{FormName}FormHandler`
+- plus the `FormBuilderModifier` extension point for in-flight builder mutation by modules
+
+## Anti-pattern
+
+**"Custom FormBuilder or FormHandler class"** — symptom: a hand-rolled class extending the IdentifiableObject base. There is no legitimate use case; the factory-built services support every pattern needed (file uploads, multilingual, tabs, sub-resource commands). If a hand-rolled class appears in a PR, it is a sign the AI invented one — delete it and use the factory services.
+
+## Canonical examples
+
+| File | Use case |
+|---|---|
+| `src/Core/Form/IdentifiableObject/DataHandler/TaxFormDataHandler.php` | simple DataHandler |
+| `src/Core/Form/IdentifiableObject/DataHandler/ProductFormDataHandler.php` | complex DataHandler with `CommandBuilder` delegation |
+| `src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php` | simple FormType |
+| `src/PrestaShopBundle/Form/Admin/Sell/Catalog/Manufacturer/ManufacturerType.php` | FormType with image upload |

--- a/.ai/Component/Forms/SETTINGS.md
+++ b/.ai/Component/Forms/SETTINGS.md
@@ -1,0 +1,74 @@
+# Settings forms — pattern detail
+
+> Sub-context of [`Forms/CONTEXT.md`](CONTEXT.md). Read the root first for the decision tree and shared concerns; this file documents only what is settings-specific.
+
+## Required layers
+
+| Layer | Path | Role |
+|---|---|---|
+| DataConfiguration | `src/Adapter/{Domain}/{Name}Configuration.php` | extends `AbstractMultistoreConfiguration`. Reads/writes config rows. Implements `getConfiguration(): array`, `updateConfiguration(array): array` (returns array of errors), and protected `buildResolver(): OptionsResolver` for option validation. |
+| FormDataProvider | `src/PrestaShopBundle/Form/Admin/{Section}/{Name}FormDataProvider.php` | implements `PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface`. Two-line bridge: `getData()` → `dataConfiguration->getConfiguration()`, `setData($data)` → `dataConfiguration->updateConfiguration($data)`. |
+| FormType | `src/PrestaShopBundle/Form/Admin/{Section}/{Name}Type.php` | standard `AbstractType` / `TranslatorAwareType`. **This is the root form** — no `getParent()`, no wrapper, no entity binding. |
+
+## Service definitions (4 YAML entries, no PHP handler class)
+
+All four entries go under `src/PrestaShopBundle/Resources/config/services/bundle/form/` (or `adapter/` for the DataConfiguration). Never under `core/form/` — that folder is reserved for CRUD.
+
+| Service | YAML file | Class |
+|---|---|---|
+| DataConfiguration | `services/adapter/data_configuration.yml` | your `{Name}Configuration` |
+| FormDataProvider | `services/bundle/form/form_data_provider.yml` | your `{Name}FormDataProvider` |
+| FormHandler | `services/bundle/form/form_handler.yml` | **`PrestaShop\PrestaShop\Core\Form\Handler`** (the base class — never your own) |
+| FormType | `services/bundle/form/form_type.yml` | empty entry for auto-discovery |
+
+The `Handler` service takes 6 ordered arguments: form factory, hook dispatcher, your FormDataProvider, FormType FQCN, **hook name** (PascalCase, e.g. `CountriesPageOptions`), **form name** (kebab-case, e.g. `country-options`). The hook name drives the two module-facing hooks below.
+
+## Hooks dispatched by the base `Handler`
+
+| Hook | When | Parameters | Use |
+|---|---|---|---|
+| `action{HookName}Form` | inside `Handler::getForm()` | `form_builder` (mutable reference) | modules add/remove/modify fields before render |
+| `action{HookName}Save` | inside `Handler::save()` | `errors` and `form_data` (both passed by reference) | modules inject validation errors or rewrite data before persistence |
+
+These hooks are how external modules extend back-office settings forms. Reimplementing `FormHandlerInterface` from scratch silently removes both hooks — see the anti-pattern below.
+
+## Allowed exception — extending `Handler` for save-time side effects
+
+A handful of pages need a side effect at save time that does not belong in `DataConfiguration` (cache invalidation, cross-field coercion): `ProductPreferencesFormHandler`, `PreferencesFormHandler`, `CustomerPreferencesFormHandler`, `TranslationsSettingsFormHandler`, `InvoiceByDateFormHandler`, `InvoiceByStatusFormHandler`, `ImportFormHandler`. Rule:
+
+- The class must **`extends Handler`** — never reimplement `FormHandlerInterface` from scratch.
+- Overridden `save()` must call **`parent::save()`** so the hook dispatch still fires.
+- Cache-clearing or similar plumbing dependencies are wired via service `calls:` in the YAML.
+
+## Anti-patterns (named symptoms)
+
+**"Outer wrapper builder"** — symptom: a visible wrapper label, a `label => false` workaround on the only `add()` call, submitted data shaped like `['xxx' => [...real fields...]]`, the FormType ends up nested as a child instead of being the root form.
+
+```php
+// ❌ WRONG — this is what PR #41414 generated:
+$this->formFactory->createBuilder()
+    ->add('contact_details', ContactDetailsType::class, ['label' => false])
+    ->setData(['contact_details' => $this->dataProvider->getData()])
+    ->getForm();
+```
+
+The correct construction is `Handler::getForm()`'s one-liner (see `src/Core/Form/Handler.php:83`):
+
+```php
+$formBuilder = $this->formFactory->createNamedBuilder($this->formName, $this->form);
+```
+
+The FormType IS the root form — there is never an extra outer builder.
+
+**"Custom `FormHandlerInterface` implementation"** — symptom: a file like `XxxFormHandler.php` implementing the interface from scratch, with its own `getForm()`/`save()` body. The module hooks `action{HookName}Form` (dispatched at `Handler.php:87`) and `action{HookName}Save` (dispatched at `Handler.php:107`) never fire. Modules silently lose the ability to extend the form. Fix: delete the class, register a `PrestaShop\PrestaShop\Core\Form\Handler` service in `form_handler.yml` instead.
+
+## Canonical examples
+
+| File | Use case |
+|---|---|
+| `src/Adapter/Country/CountryOptionsConfiguration.php` | minimal `AbstractMultistoreConfiguration` extension |
+| `src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryOptionsFormDataProvider.php` | minimal `FormDataProviderInterface` bridge |
+| `src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php` | typical settings FormType with several fields |
+| `src/Core/Form/Handler.php` | source-of-truth for the hook-dispatch contract |
+
+PR #41406 — "Migrate country options" — wires all four service entries together and is the textbook example to read end-to-end.

--- a/.ai/Component/Forms/skills/create-crud-form-data-handling/SKILL.md
+++ b/.ai/Component/Forms/skills/create-crud-form-data-handling/SKILL.md
@@ -1,18 +1,22 @@
 ---
-name: create-form-data-handling
+name: create-crud-form-data-handling
 description: >
-  Create the form data flow layer: DataProvider (loads entity data for edit form),
-  DataHandler (dispatches commands on create/update), error handling, and service
-  registration. This bridges the form layer with the CQRS layer. Read
-  Component/Forms/CONTEXT.md for conventions. Trigger: "create form data handling for {Domain}".
-needs: [create-cqrs-commands, create-cqrs-queries, create-form-type]
+  Create the CRUD form data flow layer: DataProvider (loads entity data for edit
+  form), DataHandler (dispatches commands on create/update), error handling, and
+  service registration. This bridges the form layer with the CQRS layer. For
+  settings/configuration forms (a single FormDataProvider over ps_configuration,
+  no DataHandler), use create-settings-form. Trigger: "create CRUD form data
+  handling for {Domain}".
+needs: [create-cqrs-commands, create-cqrs-queries, create-crud-form-type]
 produces: "{Domain}FormDataProvider + {Domain}FormDataHandler + DI registration"
 subagent: optional
 ---
 
-# create-form-data-handling
+# create-crud-form-data-handling
 
-Read `@.ai/Component/Forms/CONTEXT.md` for form conventions (IdentifiableObject pattern, service registration).
+> **Scope:** this skill is for **CRUD (identifiable) forms** — entity add/edit pages backed by CQRS commands. Settings forms do NOT have a DataHandler — they use a single `FormDataProvider` over a `DataConfiguration`. Use [`create-settings-form`](../create-settings-form/SKILL.md) for that pattern.
+
+Read `@.ai/Component/Forms/CONTEXT.md` for form conventions (IdentifiableObject pattern, service registration, settings-vs-CRUD decision tree).
 
 ## 1. DataProvider
 

--- a/.ai/Component/Forms/skills/create-crud-form-data-handling/SKILL.md
+++ b/.ai/Component/Forms/skills/create-crud-form-data-handling/SKILL.md
@@ -16,7 +16,7 @@ subagent: optional
 
 > **Scope:** this skill is for **CRUD (identifiable) forms** — entity add/edit pages backed by CQRS commands. Settings forms do NOT have a DataHandler — they use a single `FormDataProvider` over a `DataConfiguration`. Use [`create-settings-form`](../create-settings-form/SKILL.md) for that pattern.
 
-Read `@.ai/Component/Forms/CONTEXT.md` for form conventions (IdentifiableObject pattern, service registration, settings-vs-CRUD decision tree).
+Read `@.ai/Component/Forms/CONTEXT.md` (decision tree, shared concerns) and `@.ai/Component/Forms/CRUD.md` (IdentifiableObject pattern, service folders, hooks) for the conventions this skill builds on.
 
 ## 1. DataProvider
 

--- a/.ai/Component/Forms/skills/create-crud-form-type/SKILL.md
+++ b/.ai/Component/Forms/skills/create-crud-form-type/SKILL.md
@@ -1,18 +1,21 @@
 ---
-name: create-form-type
+name: create-crud-form-type
 description: >
-  Create the Symfony form type for an entity's add/edit form. Covers standard field
-  types, translatable fields, money fields, file uploads, and choice providers.
-  For multi-tab layout with NavigationTabType, see create-form-tab-layout.
-  Trigger: "create form type for {Domain}".
+  Create the Symfony form type for a CRUD (identifiable) entity's add/edit form.
+  Covers standard field types, translatable fields, money fields, file uploads,
+  and choice providers. For multi-tab layout with NavigationTabType, see
+  create-form-tab-layout. For settings/configuration forms, see create-settings-form.
+  Trigger: "create CRUD form type for {Domain}".
 needs: [create-cqrs-commands, create-cqrs-queries]
-produces: "{Domain}Type.php + choice providers — Symfony form structure for add/edit"
+produces: "{Domain}Type.php + choice providers — Symfony form structure for CRUD add/edit"
 subagent: optional
 ---
 
-# create-form-type
+# create-crud-form-type
 
-Read `@.ai/Component/Forms/CONTEXT.md` for form conventions (base classes, data flow, service registration).
+> **Scope:** this skill builds the FormType for a **CRUD (identifiable) form** — an entity with an ID, a grid listing, and an `Add`/`Edit` CQRS command. For a **settings form** (options block, `ps_configuration` rows), use [`create-settings-form`](../create-settings-form/SKILL.md) instead. Settings FormTypes are flat, have no `getParent()`, no `_id` field, and no entity binding.
+
+Read `@.ai/Component/Forms/CONTEXT.md` for form conventions (base classes, data flow, service registration, settings-vs-CRUD decision tree).
 
 ## 1. Root form type
 
@@ -85,3 +88,4 @@ Conventions (base classes, file uploads, choice providers, NavigationTabType) ar
 
 - Add Symfony validation constraints directly on form fields (`NotBlank`, `Length`, `Regex`)
 - For multi-tab layout, use the `create-form-tab-layout` skill instead
+- If the page persists into `ps_configuration` (and not into an entity table), this is NOT a CRUD form — switch to [`create-settings-form`](../create-settings-form/SKILL.md)

--- a/.ai/Component/Forms/skills/create-crud-form-type/SKILL.md
+++ b/.ai/Component/Forms/skills/create-crud-form-type/SKILL.md
@@ -30,6 +30,8 @@ Create `src/PrestaShopBundle/Form/Admin/{Section}/{Domain}/{Domain}Type.php`:
 
 ## 2. Standard field types
 
+> The table below is a starter, not the full catalogue. Before picking a Symfony native type, **scan `PrestaShopBundle\Form\Admin\Type\` for a PrestaShop-specific equivalent** — there are 80+ purpose-built types (`SwitchType`, `IpAddressType`, `ColorPickerType`, `CountryChoiceType`, `CurrencyMoneyType`, `EmailType`, `MaterialChoiceTreeType`, etc.). And before inventing a new option on a field, **scan `PrestaShopBundle\Form\Extension\`** for an existing extension that already provides it (`help`, `hint`, `external_link`, `modify_all_shops`, `autocomplete`, `disabling_switch`, …).
+
 | PS field concept | Symfony/PS type | Notes |
 |---|---|---|
 | Text | `TextType` | Standard input |

--- a/.ai/Component/Forms/skills/create-crud-form-type/SKILL.md
+++ b/.ai/Component/Forms/skills/create-crud-form-type/SKILL.md
@@ -15,7 +15,7 @@ subagent: optional
 
 > **Scope:** this skill builds the FormType for a **CRUD (identifiable) form** — an entity with an ID, a grid listing, and an `Add`/`Edit` CQRS command. For a **settings form** (options block, `ps_configuration` rows), use [`create-settings-form`](../create-settings-form/SKILL.md) instead. Settings FormTypes are flat, have no `getParent()`, no `_id` field, and no entity binding.
 
-Read `@.ai/Component/Forms/CONTEXT.md` for form conventions (base classes, data flow, service registration, settings-vs-CRUD decision tree).
+Read `@.ai/Component/Forms/CONTEXT.md` (decision tree, shared concerns) and `@.ai/Component/Forms/CRUD.md` (base FormBuilder/FormHandler factories, hooks, anti-pattern) for the conventions this skill builds on.
 
 ## 1. Root form type
 

--- a/.ai/Component/Forms/skills/create-form-tab-layout/SKILL.md
+++ b/.ai/Component/Forms/skills/create-form-tab-layout/SKILL.md
@@ -5,7 +5,7 @@ description: >
   specific pattern for complex forms with many fields organized by tabs — NOT the
   default form layout. Most forms do not need tabs. Trigger: "create tab layout
   for {Domain} form", "add tabs to {Domain} form".
-needs: [create-form-type]
+needs: [create-crud-form-type]
 produces: "NavigationTabType-based tab structure with sub-form types per tab"
 conditional: "only for complex entities with many fields requiring tab organization"
 ---

--- a/.ai/Component/Forms/skills/create-settings-form/SKILL.md
+++ b/.ai/Component/Forms/skills/create-settings-form/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: create-settings-form
+description: >
+  Create a PrestaShop settings form (options block writing to ps_configuration):
+  DataConfiguration + FormDataProvider + FormType + 4 YAML service entries
+  (base Handler reused, never subclassed). For CRUD entity forms, use
+  create-crud-form-type instead. Trigger: "create settings form for {Page}",
+  "add options block for {Page}", "migrate fields_options for {Page}".
+needs: []
+produces: "DataConfiguration + FormDataProvider + FormType + 4 YAML service entries — settings form ready to wire into a controller action"
+subagent: optional
+---
+
+# create-settings-form
+
+Read `@.ai/Component/Forms/CONTEXT.md` first — especially the settings-vs-CRUD decision section, the hooks dispatched by the base `Handler`, the two named anti-patterns, and the allowed-extension exception. This skill assumes those conventions; it does not restate them.
+
+If the page is not a settings form per CONTEXT.md's decision section, stop and use [`create-crud-form-type`](../create-crud-form-type/SKILL.md) + [`create-crud-form-data-handling`](../create-crud-form-data-handling/SKILL.md) instead.
+
+## 1. DataConfiguration
+
+Create `src/Adapter/{Domain}/{Name}Configuration.php`. Extend `AbstractMultistoreConfiguration`. Three responsibilities:
+
+- `getConfiguration(): array` — read each `ps_configuration` row via `$this->configuration->get(...)`, return them keyed by the form field name. Cast types here (`(bool)`, `(int)`).
+- `updateConfiguration(array $configuration): array` — call `$this->validateConfiguration($configuration)` first; on success, call `$this->updateConfigurationValue('PS_KEY', 'form_field_name', $configuration, $shopConstraint)` per field. Return `[]` on success or a list of error messages.
+- protected `buildResolver(): OptionsResolver` — declare every form field with `setDefined()` and `setAllowedTypes()` for option validation.
+
+Use `$this->getShopConstraint()` (provided by `AbstractMultistoreConfiguration`) for the multi-store scope.
+
+**Reference:** `src/Adapter/Country/CountryOptionsConfiguration.php`.
+
+## 2. FormDataProvider
+
+Create `src/PrestaShopBundle/Form/Admin/{Section}/{Name}FormDataProvider.php`. Implements `PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface`. The whole file is a two-method bridge:
+
+```php
+public function getData()
+{
+    return $this->dataConfiguration->getConfiguration();
+}
+
+public function setData(array $data)
+{
+    return $this->dataConfiguration->updateConfiguration($data);
+}
+```
+
+Inject the DataConfiguration via constructor. **Never** add other dependencies (no `Db`, no repository, no command bus). If you need side effects at save time, the side effects belong in `DataConfiguration::updateConfiguration()`, not here.
+
+**Reference:** `src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryOptionsFormDataProvider.php`.
+
+## 3. FormType
+
+Create `src/PrestaShopBundle/Form/Admin/{Section}/{Name}Type.php`. Standard `AbstractType` (or `TranslatorAwareType` for `$this->trans()`).
+
+- **The FormType IS the root form.** No `getParent()`, no nested `add('xxx', ChildType::class)` wrapper to host the real fields. Add fields directly in `buildForm()`.
+- Field keys must match the array keys returned by `DataConfiguration::getConfiguration()`.
+- For multi-store fields, set `'multistore_configuration_key' => 'PS_FOO_BAR'` on the field options — PrestaShop's form extension renders the per-shop override checkbox automatically.
+
+**Reference:** `src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryOptionsType.php`, `src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php`.
+
+## 4. Service definitions (4 YAML entries)
+
+Add one entry to each of these YAML files. See [Forms/CONTEXT.md](../../CONTEXT.md) for the `bundle/form/` vs `core/form/` folder rule — settings services go under `bundle/form/`.
+
+`src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml`:
+```yaml
+prestashop.adapter.{domain}.{name}_configuration:
+  class: 'PrestaShop\PrestaShop\Adapter\{Domain}\{Name}Configuration'
+  arguments:
+    - '@prestashop.adapter.legacy.configuration'
+    - '@prestashop.adapter.shop.context'
+    - '@prestashop.adapter.multistore_feature'
+```
+
+`src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml`:
+```yaml
+prestashop.admin.{domain}.{name}.data_provider:
+  class: 'PrestaShopBundle\Form\Admin\{Section}\{Name}FormDataProvider'
+  arguments:
+    - '@prestashop.adapter.{domain}.{name}_configuration'
+```
+
+`src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml`:
+```yaml
+prestashop.admin.{domain}.{name}.form_handler:
+  class: 'PrestaShop\PrestaShop\Core\Form\Handler'
+  arguments:
+    - '@form.factory'
+    - '@prestashop.core.hook.dispatcher'
+    - '@prestashop.admin.{domain}.{name}.data_provider'
+    - 'PrestaShopBundle\Form\Admin\{Section}\{Name}Type'
+    - '{HookName}'          # PascalCase, e.g. CountriesPageOptions — drives action{HookName}Form / action{HookName}Save
+    - '{form-name}'         # kebab-case form name, e.g. country-options
+```
+
+The `class` line **must** be `PrestaShop\PrestaShop\Core\Form\Handler` — the base class. See [Forms/CONTEXT.md](../../CONTEXT.md) for why custom handler classes break the hook contract.
+
+`src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml` — empty entry for auto-discovery:
+```yaml
+PrestaShopBundle\Form\Admin\{Section}\{Name}Type:
+```
+
+**Reference:** PR #41406 (country options block) wires all four files together.
+
+## 5. Next steps
+
+This skill stops at the YAML entries. To finish the page:
+
+- Controller action — invoke [`create-controller-form-actions`](../../../Controller/skills/create-controller-form-actions/SKILL.md) (section "Settings form action").
+- Save route — invoke [`create-admin-routing`](../../../Controller/skills/create-admin-routing/SKILL.md) to wire the POST endpoint that the controller's save action handles.
+- Twig block — invoke [`create-twig-form-template`](../../../Twig/skills/create-twig-form-template/SKILL.md) (settings block section) to render the form on the page.
+
+## Verification
+
+- `php bin/console debug:container prestashop.admin.{domain}.{name}.form_handler` returns a service whose class is `PrestaShop\PrestaShop\Core\Form\Handler` (not your own).
+- Once the controller and template are wired (see "Next steps"), the page renders the form; submit persists into `ps_configuration`; refresh shows the persisted value.
+- Hook listeners on `action{HookName}Form` and `action{HookName}Save` fire when registered by a test module.

--- a/.ai/Component/Forms/skills/create-settings-form/SKILL.md
+++ b/.ai/Component/Forms/skills/create-settings-form/SKILL.md
@@ -56,6 +56,7 @@ Create `src/PrestaShopBundle/Form/Admin/{Section}/{Name}Type.php`. Standard `Abs
 - **The FormType IS the root form.** No `getParent()`, no nested `add('xxx', ChildType::class)` wrapper to host the real fields. Add fields directly in `buildForm()`.
 - Field keys must match the array keys returned by `DataConfiguration::getConfiguration()`.
 - For multi-store fields, set `'multistore_configuration_key' => 'PS_FOO_BAR'` on the field options — PrestaShop's form extension renders the per-shop override checkbox automatically.
+- Before picking a Symfony native type, **scan `PrestaShopBundle\Form\Admin\Type\` for a PrestaShop-specific equivalent** (`SwitchType`, `IpAddressType`, `ColorPickerType`, `CountryChoiceType`, etc. — 80+ types). Before inventing a new field option, **scan `PrestaShopBundle\Form\Extension\`** for an existing extension (`help`, `hint`, `external_link`, `modify_all_shops`, `autocomplete`, …).
 
 **Reference:** `src/PrestaShopBundle/Form/Admin/Improve/International/Locations/CountryOptionsType.php`, `src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php`.
 

--- a/.ai/Component/Forms/skills/create-settings-form/SKILL.md
+++ b/.ai/Component/Forms/skills/create-settings-form/SKILL.md
@@ -13,7 +13,7 @@ subagent: optional
 
 # create-settings-form
 
-Read `@.ai/Component/Forms/CONTEXT.md` first — especially the settings-vs-CRUD decision section, the hooks dispatched by the base `Handler`, the two named anti-patterns, and the allowed-extension exception. This skill assumes those conventions; it does not restate them.
+Read `@.ai/Component/Forms/CONTEXT.md` (decision tree, shared concerns) and `@.ai/Component/Forms/SETTINGS.md` (base `Handler`, hooks, anti-patterns, allowed exception) first. This skill assumes those conventions; it does not restate them.
 
 If the page is not a settings form per CONTEXT.md's decision section, stop and use [`create-crud-form-type`](../create-crud-form-type/SKILL.md) + [`create-crud-form-data-handling`](../create-crud-form-data-handling/SKILL.md) instead.
 
@@ -61,7 +61,7 @@ Create `src/PrestaShopBundle/Form/Admin/{Section}/{Name}Type.php`. Standard `Abs
 
 ## 4. Service definitions (4 YAML entries)
 
-Add one entry to each of these YAML files. See [Forms/CONTEXT.md](../../CONTEXT.md) for the `bundle/form/` vs `core/form/` folder rule — settings services go under `bundle/form/`.
+Add one entry to each of these YAML files. See [Forms/SETTINGS.md](../../SETTINGS.md) for the service-definitions table and the `bundle/form/` vs `core/form/` folder rule — settings services go under `bundle/form/`.
 
 `src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml`:
 ```yaml
@@ -94,7 +94,7 @@ prestashop.admin.{domain}.{name}.form_handler:
     - '{form-name}'         # kebab-case form name, e.g. country-options
 ```
 
-The `class` line **must** be `PrestaShop\PrestaShop\Core\Form\Handler` — the base class. See [Forms/CONTEXT.md](../../CONTEXT.md) for why custom handler classes break the hook contract.
+The `class` line **must** be `PrestaShop\PrestaShop\Core\Form\Handler` — the base class. See [Forms/SETTINGS.md](../../SETTINGS.md) for why custom handler classes break the hook contract.
 
 `src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml` — empty entry for auto-discovery:
 ```yaml

--- a/.ai/Component/Javascript/skills/create-vue-component/SKILL.md
+++ b/.ai/Component/Javascript/skills/create-vue-component/SKILL.md
@@ -6,7 +6,7 @@ description: >
   components. Vue is only needed when a section requires rich interactivity that
   standard form types cannot provide (e.g. combination listing, dynamic range
   tables). Trigger: "add Vue component for {Domain}".
-needs: [create-ts-entry-point, create-form-type]
+needs: [create-ts-entry-point, create-crud-form-type]
 produces: "Vue 3 SFC + initialization function mounted on a specific DOM section"
 conditional: "only for sections with complex UX requiring rich interactivity"
 ---

--- a/.ai/Component/Migration/CONTEXT.md
+++ b/.ai/Component/Migration/CONTEXT.md
@@ -82,14 +82,15 @@ Behat tests (create-behat-context, write-behat-scenarios) — GATE: all green
 ╠══════════════════════════════════════════════════════════════════════════╣
 ║   Listing slice                       Form slice                           ║
 ║   ─────────────                       ──────────                           ║
-║   create-grid-definition              create-form-type                     ║
-║   create-grid-query-builder           create-form-tab-layout (cond.)       ║
-║   create-position-column (cond.)      create-form-data-handling            ║
-║   create-controller-listing           create-controller-form-actions       ║
-║   create-admin-routing (listing)      create-admin-routing (form)          ║
-║   create-twig-index-template          create-twig-form-template            ║
-║   create-ts-entry-point (listing)     create-ts-entry-point (form)         ║
-║   init-grid-extensions                init-js-components                   ║
+║   create-grid-definition              CRUD: create-crud-form-type          ║
+║   create-grid-query-builder                 create-form-tab-layout (cond.) ║
+║   create-position-column (cond.)            create-crud-form-data-handling ║
+║   create-controller-listing           Settings: create-settings-form       ║
+║   create-admin-routing (listing)      create-controller-form-actions       ║
+║   create-twig-index-template          create-admin-routing (form)          ║
+║   create-ts-entry-point (listing)     create-twig-form-template            ║
+║   init-grid-extensions                create-ts-entry-point (form)         ║
+║                                       init-js-components                   ║
 ║                                       create-vue-component (exception)     ║
 ╚══════════════════════════════════════════════════════════════════════════╝
                                     |

--- a/.ai/Component/Migration/skills/legacy-to-symfony-migration/SKILL.md
+++ b/.ai/Component/Migration/skills/legacy-to-symfony-migration/SKILL.md
@@ -35,7 +35,7 @@ When the parent agent supports sub-agents (Claude Code does; other tools current
 | 3 | [step-03-adapter-layer.md](step-03-adapter-layer.md) | Adapter Layer | Repository, Handlers, DI registration |
 | 4 | [step-04-behat-tests.md](step-04-behat-tests.md) | Behat Tests | Integration test coverage for CQRS — gate before UI work |
 | 5 | [step-05-listing-page.md](step-05-listing-page.md) | Listing page (vertical slice) | Working listing page: grid + controller actions + listing routes + index template + listing JS |
-| 6 | [step-06-form-page.md](step-06-form-page.md) | Form page (vertical slice) | Working add/edit page: form type + data handling + controller actions + form routes + form template + form JS |
+| 6 | [step-06-form-page.md](step-06-form-page.md) | Form page (vertical slice) | Working add/edit page (CRUD) and/or options block (settings) — branches on form type per block. See the step file for the settings vs CRUD skill chain. |
 | 7 | [step-07-playwright-tests.md](step-07-playwright-tests.md) | Playwright Tests | UI test campaigns per feature area |
 | 8 | [step-08-general-availability.md](step-08-general-availability.md) | General Availability | Promote flag to stable; optional upgrade SQL handoff |
 | 9 | [step-09-removal.md](step-09-removal.md) | Removal | Track legacy controller removal in next major |

--- a/.ai/Component/Migration/skills/legacy-to-symfony-migration/step-06-form-page.md
+++ b/.ai/Component/Migration/skills/legacy-to-symfony-migration/step-06-form-page.md
@@ -16,21 +16,41 @@ Read `@.ai/Component/Forms/CONTEXT.md`, `@.ai/Component/Controller/CONTEXT.md`, 
 
 If listing (step 5) ran first, the controller class and routing YAML already exist — this slice **extends** them with form actions and form routes. If this slice runs first (rare), it creates the controller class and routing YAML; step 5 then extends them later. Both invocations of `create-controller-*` and `create-admin-routing` are designed to support either case.
 
-## Skills to invoke
+## Settings forms vs CRUD forms
+
+Before picking skills, classify each form block on the page (a single admin page can carry both):
+
+- **Settings form** (a.k.a. options block, `fields_options`): persists into `ps_configuration`. No entity ID. No CQRS Add/Edit command. Use the [`create-settings-form`](../../../Forms/skills/create-settings-form/SKILL.md) umbrella skill — it produces the DataConfiguration + FormDataProvider + FormType + service entries in one go. Do **not** invoke `create-crud-form-*` skills for this block.
+- **CRUD form** (a.k.a. identifiable form): entity add/edit with a grid listing. Use the CRUD chain below.
+
+Pages with **both** patterns (e.g. *Shop parameters > Contact > Stores* has a CRUD grid for store entities and a settings form for global contact details) need both flows — run them independently.
+
+## Skills to invoke — CRUD form
 
 In suggested order:
 
 | Skill | Produces |
 |---|---|
-| `create-form-type` | `{Domain}Type` extending `TranslatorAwareType`, with each field mapped from the manifest |
+| `create-crud-form-type` | `{Domain}Type` extending `TranslatorAwareType`, with each field mapped from the manifest |
 | `create-form-tab-layout` | `NavigationTabType`-based tab structure — **conditional, complex pages only**. Most pages do not use tabs. |
-| `create-form-data-handling` | `DataProvider` (loads `Editable{Domain}` for edit) + `DataHandler` (dispatches Add/Edit + sub-resource commands) + DI registration |
+| `create-crud-form-data-handling` | `DataProvider` (loads `Editable{Domain}` for edit) + `DataHandler` (dispatches Add/Edit + sub-resource commands) + DI registration |
 | `create-controller-form-actions` | `createAction`, `editAction` using `FormBuilder` + `FormHandler` injected as action arguments. Creates the controller class on first slice, extends it on second. |
 | `create-admin-routing` | Form routes (`create`, `edit`, plus any custom action). Carries `_legacy_feature_flag: {domain}` on each route. Creates YAML on first slice, extends on second. |
 | `create-twig-form-template` | `form.html.twig` and any form theme overrides |
 | `create-ts-entry-point` | `js/pages/{domain}/form.ts` + webpack entry for the form |
 | `init-js-components` | `initComponents()` calls for translatable inputs, choice trees, TinyMCE editors, etc. — driven by `data-*` attributes in the form template |
 | `create-vue-component` | Vue SFC for sections that need rich interactivity beyond standard JS components — **exception only**. Most pages do not need Vue. |
+
+## Skills to invoke — settings form
+
+In suggested order:
+
+| Skill | Produces |
+|---|---|
+| `create-settings-form` | DataConfiguration (extends `AbstractMultistoreConfiguration`) + FormDataProvider + FormType + 4 service YAML entries — the entire settings stack in one skill. **Never produces a custom `FormHandler` class**: the base `PrestaShop\PrestaShop\Core\Form\Handler` is registered as a service. |
+| `create-controller-form-actions` | The settings-form action (index passes `$formHandler->getForm()->createView()` to the view, save action calls `$formHandler->save($form->getData())`). Uses the `use ... FormHandlerInterface as ConfigurationFormHandlerInterface;` aliasing trick to disambiguate from the IdentifiableObject handler. |
+| `create-admin-routing` | The save route (POST to `admin_{page}_save_options`). |
+| `create-twig-form-template` | The settings block template (one `form_start`/`form_end` per block, explicit `action: path('...')`, submit button outside `form_widget`). |
 
 ## Orchestration notes
 

--- a/.ai/Component/Twig/skills/create-twig-form-template/SKILL.md
+++ b/.ai/Component/Twig/skills/create-twig-form-template/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: create-twig-form-template
 description: >
-  Create the Twig template for the add/edit form page. Renders the Symfony form,
-  save buttons, and optional form theme overrides for custom field rendering.
-  Trigger: "create form template for {Domain}".
-needs: [create-form-type, create-controller-form-actions, create-admin-routing]
-produces: "form.html.twig — add/edit form page template"
+  Create the Twig template for a form page. Covers CRUD add/edit templates (one
+  form per page) and settings-form block templates (multiple forms per page,
+  each with an explicit action URL). Renders the Symfony form, save buttons,
+  and optional form theme overrides for custom field rendering. Trigger:
+  "create form template for {Domain}".
+needs: [create-crud-form-type, create-controller-form-actions, create-admin-routing]
+produces: "form.html.twig (CRUD) or block template (settings) — Symfony form rendering"
 subagent: optional
 ---
 
 # create-twig-form-template
 
 Read `@.ai/Component/Twig/CONTEXT.md` for template conventions (layout, flash messages, routes, form themes).
+
+> **Two patterns:** CRUD forms render one form per page on a dedicated `form.html.twig`. Settings forms render one or more option blocks on the listing page (or a dedicated config page) — each block is its own `form_start`/`form_end` with an explicit `action` URL. See section 4 below for the settings differences.
 
 ## 1. Form template
 
@@ -61,9 +65,41 @@ If the form needs JavaScript (for `initComponents` or Vue):
 
 The asset path must match the webpack entry name.
 
+## 4. Settings form block templates
+
+Settings forms are different. The template usually lives alongside the index page (or as an included Twig block) and renders **one form per option block**. Multiple blocks per page are common (the *Advanced > Performance* page has six).
+
+```twig
+{{ form_start(optionsForm, {action: path('admin_{page}_save_options'), attr: {class: 'form', id: '{name}_form'}}) }}
+  <div class="card">
+    <h3 class="card-header"><i class="material-icons">settings</i>{{ '{Page} options'|trans }}</h3>
+    <div class="card-body">
+      <div class="form-wrapper">
+        {{ form_widget(optionsForm) }}
+      </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+      </div>
+    </div>
+  </div>
+{{ form_end(optionsForm) }}
+```
+
+Two differences from the CRUD pattern:
+
+- **The `action` URL is explicit.** Settings forms POST to a dedicated save route (e.g. `admin_countries_save_options`) that is distinct from the page route. Without it, the form would POST to the listing route, which is not a save endpoint.
+- **The submit button sits outside `form_widget`**, typically in the card footer. The single-`form_widget(form)` rule still applies (for module hook compatibility) — the button is a sibling, not a child of the form widget call.
+
+For pages that mix a grid and one or more settings blocks (e.g. *Improve > International > Locations > Countries*), the index template renders the grid and each settings block as separate top-level elements; each block is its own `form_start`/`form_end`.
+
+**Reference:** `src/PrestaShopBundle/Resources/views/Admin/Improve/International/Country/Blocks/options.html.twig` + `index.html.twig` (PR #41406).
+
 ## Rules
 
 Conventions (layout, `path()`, single `form_widget(form)`, NavigationTabType auto-rendering, file upload enctype, form theme block naming, JS asset inclusion) are in [Twig/CONTEXT.md](../../CONTEXT.md). Skill-specific reminders:
 
 - Form theme overrides should be minimal — Symfony's default rendering handles most cases
 - CSRF token is included automatically by `form_end(form)`
+- Settings blocks must set an explicit `action: path('...')` — the page route is not the save route

--- a/.ai/Component/Twig/skills/create-twig-form-template/SKILL.md
+++ b/.ai/Component/Twig/skills/create-twig-form-template/SKILL.md
@@ -6,7 +6,7 @@ description: >
   each with an explicit action URL). Renders the Symfony form, save buttons,
   and optional form theme overrides for custom field rendering. Trigger:
   "create form template for {Domain}".
-needs: [create-crud-form-type, create-controller-form-actions, create-admin-routing]
+needs: [create-crud-form-type, create-settings-form, create-controller-form-actions, create-admin-routing]
 produces: "form.html.twig (CRUD) or block template (settings) — Symfony form rendering"
 subagent: optional
 ---

--- a/.ai/Component/Twig/skills/create-twig-form-template/SKILL.md
+++ b/.ai/Component/Twig/skills/create-twig-form-template/SKILL.md
@@ -13,7 +13,9 @@ subagent: optional
 
 # create-twig-form-template
 
-Read `@.ai/Component/Twig/CONTEXT.md` for template conventions (layout, flash messages, routes, form themes).
+Read `@.ai/Component/Twig/CONTEXT.md` for template conventions (layout, flash messages, routes, form themes). When the template renders a specific form pattern, load only the relevant Forms sub-context:
+- CRUD template → `@.ai/Component/Forms/CRUD.md`
+- Settings block → `@.ai/Component/Forms/SETTINGS.md`
 
 > **Two patterns:** CRUD forms render one form per page on a dedicated `form.html.twig`. Settings forms render one or more option blocks on the listing page (or a dedicated config page) — each block is its own `form_start`/`form_end` with an explicit `action` URL. See section 4 below for the settings differences.
 

--- a/.ai/Domain/Combination/CONTEXT.md
+++ b/.ai/Domain/Combination/CONTEXT.md
@@ -31,6 +31,6 @@ Manages product attribute combinations (variants): their creation, update, delet
 ## Related
 
 - [CQRS Component](../../Component/CQRS/CONTEXT.md)
-- [Forms Component](../../Component/Forms/CONTEXT.md) — 5 CombinationCommandBuilders in `src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/`
+- [Forms — CRUD pattern](../../Component/Forms/CRUD.md) — 5 CombinationCommandBuilders in `src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/`
 - [Product Domain](../Product/CONTEXT.md) — Combinations are sub-entities of Product; `CombinationId` is referenced throughout the Product domain
 - `tests/Integration/Behaviour/Features/Scenario/Product/Combination/` — Behat scenarios (single-shop and multi-shop)

--- a/.ai/Domain/Product/CONTEXT.md
+++ b/.ai/Domain/Product/CONTEXT.md
@@ -31,7 +31,7 @@ Manages the full product catalog lifecycle: creation, updates, duplication, comb
 
 - [CQRS Component](../../Component/CQRS/CONTEXT.md)
 - [Cart Domain](../Cart/CONTEXT.md) — references `ProductId` via `AddProductToCartCommand`
-- [Forms Component](../../Component/Forms/CONTEXT.md) — `ProductFormDataHandler`, `ProductCommandsBuilder`
+- [Forms — CRUD pattern](../../Component/Forms/CRUD.md) — `ProductFormDataHandler`, `ProductCommandsBuilder`
 - [Grid Component](../../Component/Grid/CONTEXT.md) — `ProductGridDefinitionFactory`
 - [DevDocs](https://devdocs.prestashop-project.org/9/development/page-reference/back-office/catalog/products/)
 - `tests/Integration/Behaviour/Features/Scenario/Product/` — Behat behavior scenarios

--- a/.ai/skills/component-context-generator/SKILL.md
+++ b/.ai/skills/component-context-generator/SKILL.md
@@ -60,7 +60,7 @@ Components are **not** business domains — they have no CQRS structure. They pr
 
 **Do NOT include:** `## Coding standards`, `## Do`, `## Don't`, `## Testing expectations`, `## Architecture overview` with verbose subsections. These inflate token cost without adding value.
 
-Target size: **20–35 lines**.
+Target size: **aim for ~30–50 lines.** Simple components fit in that range. If a component legitimately needs more (multiple parallel patterns, several layers, substantial non-obvious behaviour), prefer splitting into sub-contexts over inflating a single file — see "When to split into sub-contexts" below. A single CONTEXT.md above ~80–100 lines is a smell.
 
 ---
 
@@ -120,6 +120,54 @@ The whole point of splitting contexts into separate files is to avoid loading ev
 - The link would create a bidirectional reference (A → B and B → A)
 
 When in doubt, omit the link. An agent can always find related contexts via the index in `.ai/CONTEXT.md`.
+
+---
+
+## When to split into sub-contexts
+
+Most components fit comfortably in a single `CONTEXT.md`. A few don't — when the component has **two (or more) parallel patterns that share little code but coexist under the same umbrella**, split the file rather than letting it grow past ~80 lines.
+
+### Trigger conditions (all should hold)
+
+- Two or more usage patterns coexist (e.g. settings forms vs CRUD forms; legacy ObjectModel vs Doctrine repositories within the same Component).
+- Most readers only work on **one pattern at a time** — loading the other pattern's rules wastes tokens.
+- The patterns each have non-trivial pattern-specific rules (base classes, service folders, hooks, anti-patterns) that don't reduce to a few bullets.
+- A meaningful shared surface exists (decision tree, shared concerns, skills table) — otherwise consider splitting into two separate Components instead.
+
+### Recommended layout
+
+```
+.ai/Component/{Name}/
+├── CONTEXT.md            ← lean root: purpose, decision tree, shared concerns,
+│                            skills table, links to each sub-context.
+│                            Pure routing hub — minimal pattern-specific detail.
+├── {PATTERN_A}.md        ← pattern A: required layers, service definitions,
+│                            hooks, anti-patterns, canonical example.
+├── {PATTERN_B}.md        ← pattern B: same shape as PATTERN_A.
+└── skills/
+    ├── {pattern-a skill}/  ← body opens with: Read CONTEXT.md + PATTERN_A.md
+    ├── {pattern-b skill}/  ← body opens with: Read CONTEXT.md + PATTERN_B.md
+    └── {generic skill}/    ← body opens with: Read CONTEXT.md only
+```
+
+Naming: use the existing `STRUCTURE.md` / `GOTCHAS.md` / `MULTISTORE.md` convention for sub-context files — UPPERCASE single noun describing the pattern (e.g. `SETTINGS.md`, `CRUD.md`).
+
+### Rules
+
+- **Root `CONTEXT.md` stays the entry point.** Every external link from other components/domains points at `CONTEXT.md`, not at a sub-context — the decision tree in the root routes the reader to the right sub-context. External links should only specialise to a sub-context when their own surrounding text is unambiguously pattern-specific (saves a hop without confusing readers).
+- **No duplication between root and sub-contexts.** Shared concerns live in the root. Pattern-specific rules live in exactly one sub-context.
+- **Skills load sub-contexts conditionally.** A pattern-specific skill body opens with `Read @.ai/Component/{Name}/CONTEXT.md` *and* `Read @.ai/Component/{Name}/{PATTERN}.md`. A skill that serves both patterns (e.g. a unified controller-actions skill) opens with `Read @.ai/Component/{Name}/CONTEXT.md` and instructs the reader to load the relevant sub-context based on the branch they're working on.
+- **Skills table in the root** includes a "Pattern detail to load" column so the reader sees the load decision upfront.
+
+### Reference
+
+See `.ai/Component/Forms/` for a worked example: `CONTEXT.md` (decision tree + shared concerns) + `SETTINGS.md` + `CRUD.md`, with skills that route to one sub-context or the other.
+
+### When NOT to split
+
+- The component has only one pattern, just lots of layers — solve with a tighter Layers table instead.
+- The sub-contexts would each be under ~20 lines — the split adds ceremony without saving tokens.
+- The "two patterns" are actually one pattern with optional features — keep them in one file with a "Conditional layers" subsection.
 
 ---
 

--- a/.claude/skills/create-crud-form-data-handling
+++ b/.claude/skills/create-crud-form-data-handling
@@ -1,0 +1,1 @@
+../../.ai/Component/Forms/skills/create-crud-form-data-handling

--- a/.claude/skills/create-crud-form-type
+++ b/.claude/skills/create-crud-form-type
@@ -1,0 +1,1 @@
+../../.ai/Component/Forms/skills/create-crud-form-type

--- a/.claude/skills/create-form-data-handling
+++ b/.claude/skills/create-form-data-handling
@@ -1,1 +1,0 @@
-../../.ai/Component/Forms/skills/create-form-data-handling

--- a/.claude/skills/create-form-type
+++ b/.claude/skills/create-form-type
@@ -1,1 +1,0 @@
-../../.ai/Component/Forms/skills/create-form-type

--- a/.claude/skills/create-settings-form
+++ b/.claude/skills/create-settings-form
@@ -1,0 +1,1 @@
+../../.ai/Component/Forms/skills/create-settings-form


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Documentation-only change to the `.ai/` AI-context tree. Reworks the Forms component context to cover both PrestaShop form patterns (settings forms and CRUD forms), splits it into a routing-hub `CONTEXT.md` + `SETTINGS.md` + `CRUD.md` to keep per-task token cost low, and introduces this split-context pattern as a documented option in `component-context-generator`. See the body of this PR for the full background.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See "How to test" below.
| UI Tests          | N/A (documentation-only change, no runtime code touched)
| Fixed issue or discussion?     | /
| Related PRs       | Inspired by #41414 (issue) and #41406 (canonical positive reference)
| Sponsor company   | /

## Why this change

PR #41414 (Stores migration) was generated by Claude using the existing `.ai/` skills. The CRUD form for the Store entity is fine, but the **settings form** for `ContactDetailsType` broke two project conventions:

1. **A dedicated `ContactDetailsFormHandler` class was created** implementing `FormHandlerInterface` from scratch. It should have reused `PrestaShop\PrestaShop\Core\Form\Handler` (the base class) via a YAML service definition. The bypassed base class dispatches the `action{HookName}Form` and `action{HookName}Save` hooks — module developers rely on these to extend back-office forms. Reimplementing the interface silently removes both hooks.
2. **The `FormType` was wrapped inside an outer empty builder** (`createBuilder()->add('contact_details', ContactDetailsType::class, ['label' => false])`). This nested the real form one level deeper, surfaced a visible "Contact details" wrapper label (patched with `label => false`), and re-keyed the submitted data array. The correct base `Handler::getForm()` uses `createNamedBuilder(\$formName, \$formType)` — the `FormType` IS the root form.

The existing `.ai/Component/Forms/` documentation was written with CRUD/identifiable forms in mind and only briefly mentioned settings forms — no service definitions, no documentation of the base handlers' hook contract, no "do not subclass / do not wrap" rules. This PR adds a parallel, equally detailed track for settings forms so future AI generations stop repeating these mistakes.

PR #41406 (country options block) is cited throughout as the canonical positive reference.

## What changed

### New skill — `create-settings-form`
Umbrella skill covering DataConfiguration + FormDataProvider + FormType + 4 YAML service entries. Points to `create-controller-form-actions`, `create-admin-routing`, and `create-twig-form-template` for the downstream wiring.

### Renamed two CRUD-only skills
The `crud-` prefix only goes on skills whose **body** is CRUD-only — `create-form-tab-layout` stays generic because `NavigationTabType` is a generic Symfony pattern:
- `create-form-type` → `create-crud-form-type`
- `create-form-data-handling` → `create-crud-form-data-handling`

`needs:` arrays updated in dependent skills (`create-controller-form-actions`, `create-twig-form-template`, `create-form-tab-layout`, `create-vue-component`). Symlinks under `.claude/skills/` re-pointed. `create-settings-form` is now also listed in the `needs:` of the controller and twig skills that cover both branches.

### Forms component context split into root + sub-contexts
The original \`Forms/CONTEXT.md\` grew to ~160 lines after the rework. Split into three files so each task only loads what it needs:

\`\`\`
.ai/Component/Forms/
├── CONTEXT.md       (54 lines) — purpose, decision tree, shared concerns, skills table, routing
├── SETTINGS.md      (74 lines) — base Handler, hooks, anti-patterns, allowed exception, canonical example
├── CRUD.md          (50 lines) — IdentifiableObject factories, hooks, anti-pattern, canonical examples
└── skills/
    ├── create-settings-form/           → loads CONTEXT.md + SETTINGS.md
    ├── create-crud-form-type/          → loads CONTEXT.md + CRUD.md
    ├── create-crud-form-data-handling/ → loads CONTEXT.md + CRUD.md
    └── create-form-tab-layout/         → loads CONTEXT.md only (generic)
\`\`\`

Per-task load drops 20–35% for sessions that only need one pattern, without duplicating content between the two sub-contexts. Three external Related links whose surrounding text is unambiguously pattern-specific are specialised to the sub-context (Configuration → SETTINGS.md, Combination/Product → CRUD.md); all other external links keep pointing at \`CONTEXT.md\` as the routing hub.

### Split-context pattern documented in \`component-context-generator\`
Softens the lean size target (aim ~30–50 lines, ~80–100 is a smell) and adds a "When to split into sub-contexts" section codifying the Forms pattern: trigger conditions (parallel patterns, mostly-disjoint readers, non-trivial pattern-specific rules, shared surface), recommended layout (root + UPPERCASE pattern files following \`STRUCTURE.md\` naming), rules (no duplication, root stays the entry point, skills load conditionally), and a "When NOT to split" guard against over-application. References \`Component/Forms/\` as the worked example.

### Updated dependent skills
- \`create-controller-form-actions/SKILL.md\` — new "Settings form action" section showing the \`use … FormHandlerInterface as ConfigurationFormHandlerInterface;\` aliasing trick (both interfaces share the short name).
- \`create-twig-form-template/SKILL.md\` — new "Settings form block templates" section covering explicit \`action: path(...)\` and multiple blocks per page.
- \`legacy-to-symfony-migration/step-06-form-page.md\` + \`Migration/CONTEXT.md\` — branch the form-slice flow into a CRUD chain and a settings chain; document that pages can carry both (e.g. _Shop parameters > Contact > Stores_).

### Reusable Form types and extensions surfaced
\`PrestaShopBundle\Form\Admin\Type\\\` (80+ purpose-built form types: \`SwitchType\`, \`IpAddressType\`, \`ColorPickerType\`, \`CountryChoiceType\`, \`CurrencyMoneyType\`, etc.) and \`PrestaShopBundle\Form\Extension\\\` (24+ extensions adding custom field options like \`help\`, \`hint\`, \`external_link\`, \`modify_all_shops\`, \`autocomplete\`, \`disabling_switch\`, …) now have prominent rows in the Forms "Shared concerns" table that lead with **"Check this namespace before reinventing"**. The two FormType-creation skills also point at these namespaces so the AI does not treat the small starter tables in the skills as exhaustive.

### Wording change
"Settings form" replaces "configuration form" throughout, and "CRUD form" / "identifiable form" are documented as synonyms — matches the [devdocs section names](https://devdocs.prestashop-project.org/9/development/architecture/migration-guide/forms/).

## How to test

This is documentation-only — no runtime code is touched, so there is no Behat/Playwright/PHPUnit coverage to extend.

Manual verification:

1. **No stale references in the tree:**
   \`\`\`
   grep -rn "skills/create-form-type\\|skills/create-form-data-handling" .ai/
   \`\`\`
   Should return nothing.
2. **Symlinks resolve:**
   \`\`\`
   ls -la .claude/skills/ | grep -E 'form|crud|settings'
   \`\`\`
   Should list \`create-crud-form-type\`, \`create-crud-form-data-handling\`, \`create-settings-form\`, \`create-form-tab-layout\`, \`create-controller-form-actions\`, \`create-twig-form-template\`.
3. **Sub-context files load only on the relevant branch:** when invoking \`create-settings-form\`, the skill body opens with \`Read @.ai/Component/Forms/CONTEXT.md\` and \`Read @.ai/Component/Forms/SETTINGS.md\` — and never references \`CRUD.md\`. Same in reverse for the two \`create-crud-*\` skills. The two dual-mode skills (\`create-controller-form-actions\`, \`create-twig-form-template\`) instruct the reader to load whichever sub-context matches the branch they're on.
4. **Reproduction prompt (the PR #41414 scenario):** in a fresh Claude Code session, ask _"build the contact details settings form for the Stores page"_ and confirm the output:
   - Does NOT create a \`ContactDetailsFormHandler\` class.
   - Adds a service entry in \`bundle/form/form_handler.yml\` using \`class: 'PrestaShop\\PrestaShop\\Core\\Form\\Handler'\`.
   - Uses \`ContactDetailsType\` as the root form (no \`createBuilder()->add(...)\` wrapper).
   - Uses \`use … FormHandlerInterface as ConfigurationFormHandlerInterface;\` in the controller.
   - Picks a sensible PascalCase hook name (e.g. \`StoresPageContactDetails\`).
   - Reuses an existing type from \`PrestaShopBundle\\Form\\Admin\\Type\\\` rather than inventing one.
5. **Regression check:** same kind of reproduction prompt for an entity (e.g. _"build the form for a Manufacturer"_) — output should still follow the CRUD skill chain unchanged.

## Commit history on this branch

1. \`Improve AI Forms context and skills (settings vs CRUD)\` — initial rework: new skill, renames, parallel CONTEXT sections.
2. \`Add create-settings-form to needs of controller/twig form skills\` — dependency-array fix.
3. \`Split Forms/CONTEXT.md into root + SETTINGS.md + CRUD.md sub-contexts\` — per-task load reduction.
4. \`Specialise three pattern-specific Forms Related links + document the split-context pattern\` — convention update in \`component-context-generator\`.
5. \`Document reusable Form types and Form extensions namespaces\` — Form/Admin/Type and Form/Extension surfaced as reuse points.