### PR TITLE
Enhance invoice filename safety by sanitizing number

### DIFF
--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -474,9 +474,9 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
         $id_lang = Context::getContext()->language->id;
         $id_shop = (int) $this->order->id_shop;
 
-        return sprintf(
-            '%s.pdf',
-            $this->order_invoice->getInvoiceNumberFormatted($id_lang, $id_shop)
-        );
+        $invoiceNumber = $this->order_invoice->getInvoiceNumberFormatted($id_lang, $id_shop);
+        $safeNumber = str_replace(['/', '\\'], '-', $invoiceNumber);
+
+        return sprintf('%s.pdf', $safeNumber);
     }
 }


### PR DESCRIPTION
Replace invoice number formatting to ensure safety by replacing slashes with dashes. For the file name, it is necessary to sanitize the result

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | Fix bug in invoice PDF filename generation when PS_INVOICE_USE_YEAR is enabled. The filename could contain a slash (/), causing the browser/filesystem to keep only the last segment and produce names like 2026.pdf instead of the full invoice code.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable PS_INVOICE_USE_YEAR in invoice settings. 2. Generate an invoice PDF. 3. Verify the downloaded filename contains prefix, invoice number, and year (for example PREFIX000001-2026.pdf) instead of just 2026.pdf. 4. Confirm the invoice number displayed inside the PDF remains correct.
| UI Tests          | Not applicable / not required for this backend PDF filename fix
| Fixed issue or discussion?     | Fixes #41436
| Related PRs       | -
| Sponsor company   | MaoDev
