### PR TITLE
Fix product quantity calculation for unpersisted carts

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1708,6 +1708,10 @@ class CartCore extends ObjectModel
         // Wipe all product-related caches, because something may just changed and we will need fresh data
         $this->resetProductRelatedStaticCache();
 
+        if (!(int) $this->id && !$this->add()) {
+            return false;
+        }
+
         $data = [
             'cart' => $this,
             'product' => $product,

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -328,7 +328,7 @@ class PackCore extends Product
                     $packQuantity = $nbPackAvailableForItem;
                 }
             }
-        } elseif (!empty($cart)) {
+        } elseif ($cart !== null && (int) $cart->id > 0) {
             $cartProduct = $cart->getProductQuantity($idProduct, $idProductAttribute, $idCustomization);
 
             if (!empty($cartProduct['deep_quantity'])) {

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4173,7 +4173,7 @@ class ProductCore extends ObjectModel
         // has already been updated, this is only useful when the order has not yet been created.
         // @todo This logic should probably be moved somewhere else, this method should not do anything with orders.
         $nbProductInCart = 0;
-        if ($cart && empty(Order::getByCartId($cart->id))) {
+        if ($cart && (int) $cart->id > 0 && empty(Order::getByCartId($cart->id))) {
             /*
              * Now, we get the quantity of the product in cart. This method is clever and in deep_quantity,
              * it will get us the quantity products in all the packs, if there are some in the cart, not just standard products.

--- a/tests/Integration/Classes/ProductGetQuantityTest.php
+++ b/tests/Integration/Classes/ProductGetQuantityTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Cart;
+use Context;
+use Db;
+use Product;
+use StockAvailable;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+class ProductGetQuantityTest extends KernelTestCase
+{
+    private const PRODUCT_ID = 1;
+    private const ORPHAN_QUANTITY = 7;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['cart_product']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['cart_product']);
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        Context::getContext()->container = self::getContainer();
+    }
+
+    /**
+     * Product::getQuantity() must not subtract "quantity in cart" for an in-memory cart
+     * that has not been persisted yet (id = 0). The SQL filter `WHERE id_cart = 0` would
+     * otherwise sum every orphan ps_cart_product row, inflating the subtracted amount and
+     * returning a stock figure below the real StockAvailable value.
+     */
+    public function testGetQuantityIgnoresAnUnsavedCart(): void
+    {
+        $stock = (int) StockAvailable::getQuantityAvailableByProduct(self::PRODUCT_ID, 0);
+
+        // An orphan cart line attached to the non-persisted cart id 0.
+        Db::getInstance()->insert('cart_product', [
+            'id_cart' => 0,
+            'id_product' => self::PRODUCT_ID,
+            'id_address_delivery' => 0,
+            'id_shop' => (int) Context::getContext()->shop->id,
+            'id_product_attribute' => 0,
+            'id_customization' => 0,
+            'quantity' => self::ORPHAN_QUANTITY,
+            'date_add' => date('Y-m-d H:i:s'),
+        ]);
+
+        $unsavedCart = new Cart();
+
+        $quantity = Product::getQuantity(self::PRODUCT_ID, 0, null, $unsavedCart);
+
+        $this->assertSame($stock, $quantity);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Prevent product availability from subtracting cart lines when the provided cart has not been persisted yet. This avoids reading orphan `cart_product` rows stored with `id_cart = 0`, which can incorrectly reduce front-office stock and make products appear out of stock.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Insert or keep orphan rows in `ps_cart_product` with `id_cart = 0` for a product. <br> 2. Open the front-office product page with an unpersisted cart context. <br> 3. Check that `Product::getQuantity()` no longer subtracts those orphan rows from stock. <br> 4. Add a product to a normal cart and check that cart quantities are still subtracted for persisted carts.
| UI Tests          | Not run, no UI change.
| Fixed issue or discussion?     | Fixes #41458
| Related PRs       | N/A
| Sponsor company   | N/A

## Additional information

`Product::getQuantity()` and `Pack::getQuantity()` now only subtract cart quantities when the cart has a valid persisted id. `Cart::updateQty()` also persists the cart before inserting into `cart_product`, so new cart lines are not inserted with `id_cart = 0` through this path.