### PR TITLE
Fix: Multishop: cache_default_attribute is not reset for all shops when changing a product with combinations to a standard product

### DIFF
--- a/src/Adapter/Product/Update/ProductTypeUpdater.php
+++ b/src/Adapter/Product/Update/ProductTypeUpdater.php
@@ -125,7 +125,7 @@ class ProductTypeUpdater
         $this->productRepository->partialUpdate(
             $product,
             $updatedProperties,
-            ShopConstraint::shop($this->productRepository->getProductDefaultShopId($productId)->getValue()),
+            ShopConstraint::allShops(),
             CannotUpdateProductException::FAILED_UPDATE_TYPE
         );
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.1.x
| Description?      | This PR fixes an issue in a multishop context when changing a product with combinations to a standard product.<br/>Previously, the product type update was applied only to the product default shop. As a result, some product shop data, such as `cache_default_attribute`, could remain inconsistent for the other shops.<br/>The update now uses `ShopConstraint::allShops()` so the product type change is correctly applied to all shops associated with the product.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Enable multishop.<br/>2. Create at least two shops.<br/>3. Create a product assigned to both shops.<br/>4. Set the product as a product with combinations.<br/>5. Create one or more combinations.<br/>6. Set one combination as the default combination.<br/>7. Change the product type to **Standard product**.<br/>8. Save the product.<br/>9. Check the `product_shop` table for the product.<br/>10. Confirm that `cache_default_attribute` is set to `0` for all shops.<br/>11. Open the product page in the front office for each shop.<br/>12. Confirm that the product page is displayed correctly and no deprecated warning is triggered.<br/>
| UI Tests          | 🟢 https://github.com/Codencode/ga.tests.ui.pr/actions/runs/25863621650
| Fixed issue or discussion?     | Fixes #41467
| Related PRs       | 
| Sponsor company   | Codencode snc
