### PR TITLE
Make the getters of Edit commands nullable for Attachment, Country, Customer and Zone

### DIFF
--- a/src/Core/Domain/Attachment/Command/EditAttachmentCommand.php
+++ b/src/Core/Domain/Attachment/Command/EditAttachmentCommand.php
@@ -111,9 +111,9 @@ class EditAttachmentCommand
     }
 
     /**
-     * @return string[]
+     * @return string[]|null
      */
-    public function getLocalizedNames(): array
+    public function getLocalizedNames(): ?array
     {
         return $this->localizedNames;
     }

--- a/src/Core/Domain/Country/Command/EditCountryCommand.php
+++ b/src/Core/Domain/Country/Command/EditCountryCommand.php
@@ -98,9 +98,9 @@ class EditCountryCommand
     }
 
     /**
-     * @return string[]
+     * @return string[]|null
      */
-    public function getLocalizedNames(): array
+    public function getLocalizedNames(): ?array
     {
         return $this->localizedNames;
     }
@@ -122,7 +122,7 @@ class EditCountryCommand
         return $this->isoCode;
     }
 
-    public function setIsoCode($isoCode)
+    public function setIsoCode(string $isoCode)
     {
         $this->isoCode = $isoCode;
 

--- a/src/Core/Domain/Country/Command/EditCountryCommand.php
+++ b/src/Core/Domain/Country/Command/EditCountryCommand.php
@@ -122,7 +122,7 @@ class EditCountryCommand
         return $this->isoCode;
     }
 
-    public function setIsoCode(string $isoCode)
+    public function setIsoCode(string $isoCode): EditCountryCommand
     {
         $this->isoCode = $isoCode;
 

--- a/src/Core/Domain/Customer/Command/EditCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/EditCustomerCommand.php
@@ -296,7 +296,7 @@ class EditCustomerCommand
     }
 
     /**
-     * @return bool
+     * @return bool|null
      */
     public function isEnabled()
     {

--- a/src/Core/Domain/Zone/Command/EditZoneCommand.php
+++ b/src/Core/Domain/Zone/Command/EditZoneCommand.php
@@ -71,10 +71,7 @@ class EditZoneCommand
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function isEnabled(): bool
+    public function isEnabled(): ?bool
     {
         return $this->enabled;
     }

--- a/src/Core/Domain/Zone/Command/EditZoneCommand.php
+++ b/src/Core/Domain/Zone/Command/EditZoneCommand.php
@@ -52,9 +52,9 @@ class EditZoneCommand
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Update the getters of Edit commands with a nullable return type, so we don't have to always provide specific properties when updating a Country, a Zone or an Attachment (The concerned domains).  My understanding is that updating the signature of the methods is considered as BC, if that's a thing on this part of the project. If anyone can confirm (or not) this assessment, that would be nice.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | No
| How to test?      | Follow the description of https://github.com/PrestaShop/PrestaShop/issues/41469
| UI Tests          | [Enjoy](https://github.com/Quetzacoalt91/ga.tests.ui.pr/actions/runs/26505967307)
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/41469
| Related PRs       | /
| Sponsor company   | @PrestaShopCorp