### PR TITLE
Fix KPI cache bypass in admin orders/carts list (autowire + KpiConfiguration::get)

### DIFF
--- a/src/Adapter/Configuration/KpiConfiguration.php
+++ b/src/Adapter/Configuration/KpiConfiguration.php
@@ -1,13 +1,34 @@
 <?php
 /**
- * For the full copyright and license information, please view the
- * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop-project.org/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
 namespace PrestaShop\PrestaShop\Adapter\Configuration;
 
 use ConfigurationKPI;
 use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Class KpiConfiguration provides access to legacy ConfigurationKpi methods.
@@ -15,7 +36,29 @@ use PrestaShop\PrestaShop\Adapter\Configuration;
 class KpiConfiguration extends Configuration
 {
     /**
-     * Changes configuration definition before calling it's methods.
+     * Read KPI configuration values from the ps_configuration_kpi table.
+     *
+     * The parent Configuration::get() targets the standard ps_configuration
+     * table. Because get() is defined in the parent, __call() never intercepts
+     * it, so without this override every KPI cache lookup would fall back to
+     * ps_configuration (which does not store KPI keys) and return null. This
+     * caused $helper->refresh to always evaluate to true in the *Kpi adapters,
+     * defeating the cache and forcing the four KPI AJAX calls (conversion_rate,
+     * abandoned_cart, average_order_value, netprofit_visit) to fire on every
+     * back-office orders/carts list page load.
+     */
+    public function get($key, $default = null, ?ShopConstraint $shopConstraint = null): mixed
+    {
+        ConfigurationKPI::setKpiDefinition();
+        try {
+            return parent::get($key, $default, $shopConstraint);
+        } finally {
+            ConfigurationKPI::unsetKpiDefinition();
+        }
+    }
+
+    /**
+     * Changes configuration definition before calling its methods.
      *
      * @param string $name
      * @param mixed $arguments

--- a/src/Adapter/Configuration/KpiConfiguration.php
+++ b/src/Adapter/Configuration/KpiConfiguration.php
@@ -1,27 +1,7 @@
 <?php
 /**
- * Copyright since 2007 PrestaShop SA and Contributors
- * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.md.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop-project.org/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 
 namespace PrestaShop\PrestaShop\Adapter\Configuration;

--- a/src/PrestaShopBundle/Resources/config/services/adapter/kpi.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/kpi.yml
@@ -89,13 +89,27 @@ services:
       - "@prestashop.core.localization.locale.context_locale"
 
   PrestaShop\PrestaShop\Adapter\Kpi\AbandonedCartKpi:
-    autowire: true
+    arguments:
+      - '@prestashop.adapter.legacy.context'
+      - '@translator'
+      - '@prestashop.adapter.legacy.kpi_configuration'
+      - '@PrestaShop\PrestaShop\Core\Context\LanguageContext'
+      - '@router'
 
   PrestaShop\PrestaShop\Adapter\Kpi\AverageOrderValueKpi:
-    autowire: true
+    arguments:
+      - '@translator'
+      - '@prestashop.adapter.legacy.kpi_configuration'
+      - '@prestashop.adapter.legacy.context'
 
   PrestaShop\PrestaShop\Adapter\Kpi\ConversionRateKpi:
-    autowire: true
+    arguments:
+      - '@translator'
+      - '@prestashop.adapter.legacy.kpi_configuration'
+      - '@prestashop.adapter.legacy.context'
 
   PrestaShop\PrestaShop\Adapter\Kpi\NetProfitPerVisitKpi:
-    autowire: true
+    arguments:
+      - '@translator'
+      - '@prestashop.adapter.legacy.kpi_configuration'
+      - '@prestashop.adapter.legacy.context'

--- a/tests/Integration/Adapter/Kpi/KpiConfigurationTest.php
+++ b/tests/Integration/Adapter/Kpi/KpiConfigurationTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Kpi;
+
+use Db;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\Configuration\KpiConfiguration;
+use PrestaShop\PrestaShop\Adapter\Kpi\AbandonedCartKpi;
+use PrestaShop\PrestaShop\Adapter\Kpi\AverageOrderValueKpi;
+use PrestaShop\PrestaShop\Adapter\Kpi\ConversionRateKpi;
+use PrestaShop\PrestaShop\Adapter\Kpi\NetProfitPerVisitKpi;
+use ReflectionObject;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The KPI widgets read their cache through KpiConfiguration, which is the only configuration adapter
+ * that looks at configuration_kpi. If a KPI adapter is handed the ordinary Configuration, or if that
+ * adapter cannot reach the KPI table, every lookup answers null and the cache is never a hit.
+ */
+class KpiConfigurationTest extends KernelTestCase
+{
+    private const KEY = 'TEST_KPI_CONFIGURATION_KEY';
+    private const VALUE = 'cached';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::deleteKey();
+        Db::getInstance()->insert('configuration_kpi', [
+            'name' => self::KEY,
+            'value' => self::VALUE,
+            'date_add' => date('Y-m-d H:i:s'),
+            'date_upd' => date('Y-m-d H:i:s'),
+        ]);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::deleteKey();
+        parent::tearDownAfterClass();
+    }
+
+    public function testItReadsAKeyThatOnlyExistsInTheKpiTable(): void
+    {
+        self::bootKernel();
+
+        $kpiConfiguration = self::getContainer()->get('prestashop.adapter.legacy.kpi_configuration');
+
+        self::assertSame(
+            self::VALUE,
+            $kpiConfiguration->get(self::KEY),
+            'KpiConfiguration must read configuration_kpi, otherwise every KPI cache lookup is a miss'
+        );
+    }
+
+    /**
+     * @dataProvider provideKpiAdapters
+     */
+    public function testTheKpiAdaptersAreGivenTheKpiConfiguration(string $kpiClass): void
+    {
+        self::bootKernel();
+
+        $kpi = self::getContainer()->get($kpiClass);
+        $configurations = [];
+        foreach ((new ReflectionObject($kpi))->getProperties() as $property) {
+            $property->setAccessible(true);
+            $value = $property->getValue($kpi);
+            if ($value instanceof Configuration) {
+                $configurations[$property->getName()] = $value;
+            }
+        }
+
+        self::assertNotEmpty($configurations, $kpiClass . ' holds no configuration to check');
+        foreach ($configurations as $name => $configuration) {
+            self::assertInstanceOf(
+                KpiConfiguration::class,
+                $configuration,
+                sprintf('%s::$%s must be the KPI configuration, or the cached values are unreachable', $kpiClass, $name)
+            );
+        }
+    }
+
+    public function provideKpiAdapters(): array
+    {
+        return [
+            [ConversionRateKpi::class],
+            [AbandonedCartKpi::class],
+            [AverageOrderValueKpi::class],
+            [NetProfitPerVisitKpi::class],
+        ];
+    }
+
+    private static function deleteKey(): void
+    {
+        Db::getInstance()->delete('configuration_kpi', 'name = "' . pSQL(self::KEY) . '"');
+    }
+}


### PR DESCRIPTION
| Questions          | Answers
| ------------------ | -------------------------------------------------------
| Branch?            | 9.1.x
| Description?       | Fixes the always-cold KPI cache in the back-office orders/carts list. Two distinct bugs combine to make the four KPI widgets (`Conversion Rate`, `Abandoned Carts`, `Average Order Value`, `Net Profit per Visit`) fire AJAX calls on every page load despite valid cached values in `ps_configuration_kpi`. **Commit 1** (`KpiConfiguration::__call`): the magic method does not intercept the inherited `Configuration::get()`. Added an explicit `get()` override that wraps `parent::get()` with `ConfigurationKPI::setKpiDefinition()` / `unsetKpiDefinition()`. **Commit 2** (`kpi.yml` — the actual root cause for the orders/carts list): the four KPI services declared `autowire: true`, so Symfony resolved their `ConfigurationInterface` / `ShopConfigurationInterface` argument to `Configuration` (the standard adapter targeting `ps_configuration`) instead of `KpiConfiguration` (targeting `ps_configuration_kpi`). Aligned with the explicit-argument pattern already used by the other 12 KPI services in the same file. Both fixes are needed and complementary: without commit 2, the four KPI widgets never receive a `KpiConfiguration` instance at all, so commit 1 alone has no effect on this flow; without commit 1, `KpiConfiguration::get()` would still read the wrong table. After both fixes, zero `getKpi` AJAX calls fire on a fresh order list load when the cache is valid (verified end-to-end on a PrestaShop 9.1.0 production install).
| Type?              | bug fix
| Category?          | BO
| BC breaks?         | no
| Deprecations?      | no
| How to test?       | 1. Open the back-office orders list and let the 4 `getKpi` AJAX calls complete. 2. Verify with `SELECT name, value FROM ps_configuration_kpi WHERE name LIKE '%\_EXPIRE'` that the four `*_EXPIRE` rows have valid future timestamps. 3. Reload the orders list. 4. **Before this PR**: the 4 `getKpi` AJAX calls fire again every time (visible in DevTools → Network), each taking 3–8 s. 5. **After this PR**: zero `getKpi` AJAX calls are made — the Smarty `kpi.tpl` template inserts the `if (arguments[0] != true) return;` guard because `$helper->refresh` is now correctly `false`. 6. Force-refresh via the manual refresh button (top right of the KPI row) still works as expected. 7. Same applies to the carts list (`/sell/orders/carts/`).
| Fixed ticket?      | Fixes #41473
| Related PRs        | none
| Sponsor company    | none

### Note on a pre-existing latent behaviour

As pointed out during review: `ConfigurationKPI::setKpiDefinition()` loads the
`configuration_kpi` table into the shared static `Configuration::$_cache`, and
`unsetKpiDefinition()` restores only the definition, not the cache. So after any
KPI read, KPI values remain reachable through the ordinary `Configuration` adapter
in the same process. Harmless today (the two tables share no key name), but worth
knowing for future work. This PR does not change that behaviour.