### PR TITLE
Update default carrier name and transit time

### DIFF
--- a/classes/lang/KeysReference/CarrierLang.php
+++ b/classes/lang/KeysReference/CarrierLang.php
@@ -4,7 +4,7 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 // install-dev/langs/en/data/carrier.xml
-trans('Pick up in-store', 'Admin.Shipping.Feature');
+trans('Same day', 'Admin.Shipping.Feature');
 // install-dev/fixtures/fashion/langs/en/data/carrier.xml
 trans('Delivery next day!', 'Admin.Shipping.Feature');
 trans('Buy more to pay less!', 'Admin.Shipping.Feature');

--- a/install-dev/data/xml/carrier.xml
+++ b/install-dev/data/xml/carrier.xml
@@ -19,7 +19,7 @@
   </fields>
   <entities>
     <carrier id="carrier_1" id_reference="1" id_tax_rules_group="0" active="1" shipping_handling="0" range_behavior="0" is_free="1" shipping_external="0" need_range="0" shipping_method="0" max_width="0" max_height="0" max_depth="0" max_weight="0" grade="0">
-      <name>Click and collect</name>
+      <name>Pick up in-store</name>
     </carrier>
   </entities>
 </entity_carrier>

--- a/install-dev/langs/en/data/carrier.xml
+++ b/install-dev/langs/en/data/carrier.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <entity_carrier>
   <carrier id="carrier_1" id_shop="1">
-    <delay>Pick up in-store</delay>
+    <delay>Same day</delay>
   </carrier>
 </entity_carrier>

--- a/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_available.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_available.feature
@@ -31,8 +31,8 @@ Scenario: Carrier available when is deleted
   Then the products "s3_product1" should have the following carriers with address "address1":
     | carrier          | carrier_reference | state     | products  |
     | Deleted Carrier  | s42_carrier       | available | product D |
-    | Click and collect|                   | filtered  | product D |
     | My carrier       |                   | filtered  | product D |
+    | Pick up in-store |                   | filtered  | product D |
 
 Scenario: Get available carriers for existing order
   Given I add product "s0_product1" with following information:
@@ -62,8 +62,8 @@ Scenario: Get available carriers for existing order
   Then the products "s0_product1, s0_product2, s0_product3" should have the following carriers with address "address1":
     | carrier           | state     | products                          |
     | s0_express        | filtered  | bottle of beer, bottle of whiskey |
-    | Click and collect | filtered  | bottle of whiskey                 |
     | My carrier        | filtered  | bottle of whiskey                 |
+    | Pick up in-store  | filtered  | bottle of whiskey                 |
     | s0_standard       | available |                                   |
     | s0_pickup         | available |                                   |
 


### PR DESCRIPTION
| Questions | Answers |
| ----------------- | ------------------------------------------------------- |
| Branch? | develop |
| Description? | Updates the default "Pick up in-store" carrier seeded during installation so the carrier name and transit time texts differ: name stays a pickup label; English delay uses "Same day" instead of reusing the method text. |
| Type? | improvement |
| Category? | IN |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | Install PrestaShop from this branch; confirm seeded default in-store carrier name is "Pick up in-store" and English transit time is "Same day". Existing shops are unaffected because this is installer seed data only. |
| UI Tests | Relevant - not run here. Installer XML / language seed changes only, but qa-automation should revalidate the seeded carrier text. |
| Fixed issue or discussion? | Fixes #13828 |
| Related PRs | none |
| Sponsor company | none |

Updated installer seed data:

- `install-dev/data/xml/carrier.xml` - default carrier display name aligned with pickup wording.
- `install-dev/langs/en/data/carrier.xml` - default English delay string "Same day" replaces ambiguous "Pick up in-store" as transit text.

Follow-up in this branch:

- `classes/lang/KeysReference/CarrierLang.php` - generated translation fixture reference updated for `carrier.xml`.
- `tests/Integration/Behaviour/Features/Scenario/Carrier/carrier_available.feature` - Behat expectations updated for the renamed seeded carrier.
