### PR TITLE
Deprecate getHigherPosition() in favor of getHighestPosition()

### DIFF
--- a/classes/AttributeGroup.php
+++ b/classes/AttributeGroup.php
@@ -69,7 +69,7 @@ class AttributeGroupCore extends ObjectModel
         $this->is_color_group = $this->group_type == 'color';
 
         if ($this->position <= 0) {
-            $this->position = AttributeGroup::getHigherPosition() + 1;
+            $this->position = AttributeGroup::getHighestPosition() + 1;
         }
 
         $return = parent::add($autoDate, true);
@@ -379,13 +379,32 @@ class AttributeGroupCore extends ObjectModel
      * Get the highest AttributeGroup position.
      *
      * @return int $position Position
+     *
+     * @deprecated Since 9.2, use AttributeGroup::getHighestPosition() instead.
      */
     public static function getHigherPosition()
+    {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 9.2. Use %s instead.',
+                __METHOD__,
+                self::class . '::getHighestPosition()'
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return self::getHighestPosition();
+    }
+
+    /**
+     * Get the highest AttributeGroup position.
+     */
+    public static function getHighestPosition(): int
     {
         $sql = 'SELECT MAX(`position`)
 				FROM `' . _DB_PREFIX_ . 'attribute_group`';
         $position = Db::getInstance()->getValue($sql);
 
-        return (is_numeric($position)) ? $position : -1;
+        return (is_numeric($position)) ? (int) $position : -1;
     }
 }

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -223,7 +223,7 @@ class CarrierCore extends ObjectModel
     public function add($autoDate = true, $nullValues = false)
     {
         if ($this->position <= 0) {
-            $this->position = Carrier::getHigherPosition() + 1;
+            $this->position = Carrier::getHighestPosition() + 1;
         }
         if (!parent::add($autoDate, $nullValues) || !Validate::isLoadedObject($this)) {
             return false;
@@ -1485,15 +1485,34 @@ class CarrierCore extends ObjectModel
      * Gets the highest carrier position.
      *
      * @return int $position
+     *
+     * @deprecated Since 9.2, use Carrier::getHighestPosition() instead.
      */
     public static function getHigherPosition()
+    {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 9.2. Use %s instead.',
+                __METHOD__,
+                self::class . '::getHighestPosition()'
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return self::getHighestPosition();
+    }
+
+    /**
+     * Gets the highest carrier position.
+     */
+    public static function getHighestPosition(): int
     {
         $sql = 'SELECT MAX(`position`)
                 FROM `' . _DB_PREFIX_ . 'carrier`
                 WHERE `deleted` = 0';
         $position = Db::getInstance()->getValue($sql);
 
-        return (is_numeric($position)) ? $position : -1;
+        return (is_numeric($position)) ? (int) $position : -1;
     }
 
     /**

--- a/classes/Feature.php
+++ b/classes/Feature.php
@@ -107,7 +107,7 @@ class FeatureCore extends ObjectModel
     public function add($autoDate = true, $nullValues = false)
     {
         if ($this->position <= 0) {
-            $this->position = Feature::getHigherPosition() + 1;
+            $this->position = Feature::getHighestPosition() + 1;
         }
 
         $return = parent::add($autoDate, true);
@@ -246,7 +246,7 @@ class FeatureCore extends ObjectModel
             if ($position) {
                 $feature->position = (int) $position;
             } else {
-                $feature->position = Feature::getHigherPosition() + 1;
+                $feature->position = Feature::getHighestPosition() + 1;
             }
             $feature->add();
 
@@ -337,18 +337,35 @@ class FeatureCore extends ObjectModel
     }
 
     /**
-     * getHigherPosition.
-     *
-     * Get the higher feature position
+     * Get the highest Feature position.
      *
      * @return int $position
+     *
+     * @deprecated Since 9.2, use Feature::getHighestPosition() instead.
      */
     public static function getHigherPosition()
+    {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 9.2. Use %s instead.',
+                __METHOD__,
+                self::class . '::getHighestPosition()'
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return self::getHighestPosition();
+    }
+
+    /**
+     * Get the highest Feature position.
+     */
+    public static function getHighestPosition(): int
     {
         $sql = 'SELECT MAX(`position`)
 				FROM `' . _DB_PREFIX_ . 'feature`';
         $position = Db::getInstance()->getValue($sql);
 
-        return (is_numeric($position)) ? $position : -1;
+        return (is_numeric($position)) ? (int) $position : -1;
     }
 }

--- a/controllers/admin/AdminCarriersController.php
+++ b/controllers/admin/AdminCarriersController.php
@@ -481,7 +481,7 @@ class AdminCarriersControllerCore extends AdminController
                         // Create new Carrier
                         $carrier = new Carrier();
                         $this->copyFromPost($carrier, $this->table);
-                        $carrier->position = Carrier::getHigherPosition() + 1;
+                        $carrier->position = Carrier::getHighestPosition() + 1;
                         if ($carrier->add()) {
                             if (($_POST['id_' . $this->table] = $carrier->id /* voluntary */) && $this->postImage($carrier->id) && $this->_redirect) {
                                 $carrier->setTaxRulesGroup((int) Tools::getValue('id_tax_rules_group'), true);

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -2356,7 +2356,7 @@ class AdminImportControllerCore extends AdminController
                     $obj->group_type = pSQL($type);
                     $obj->name[$default_language] = $group;
                     $obj->public_name[$default_language] = $group;
-                    $obj->position = (!$position) ? AttributeGroup::getHigherPosition() + 1 : $position;
+                    $obj->position = (!$position) ? AttributeGroup::getHighestPosition() + 1 : $position;
 
                     if (($field_error = $obj->validateFields(UNFRIENDLY_ERROR, true)) === true
                         && ($lang_field_error = $obj->validateFieldsLang(UNFRIENDLY_ERROR, true)) === true) {


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR deprecates `getHigherPosition()` in favor of the clearer `getHighestPosition()` for `Carrier`, `AttributeGroup`, and `Feature`, following the same approach previously introduced for `ProductAttribute` in #41435.<br/>It also updates internal core usages to call the new method directly, avoiding deprecated calls inside the core codebase.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Create a new Attribute Group and verify that the position is correct.<br/>2 Create a new Feature and verify that the position is correct.<br/>3. Create a new Carrier and verify that the position is correct.<br/>
| UI Tests          | 🟢  https://github.com/Codencode/ga.tests.ui.pr/actions/runs/25960010564
| Fixed issue or discussion?     | 
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/41435
| Sponsor company   | Codencode snc
