### PR TITLE
Strip %word% placeholders before counting printf args in PassVsprintfValidator

### DIFF
--- a/src/PrestaShopBundle/Translation/Constraints/PassVsprintfValidator.php
+++ b/src/PrestaShopBundle/Translation/Constraints/PassVsprintfValidator.php
@@ -36,8 +36,12 @@ class PassVsprintfValidator extends ConstraintValidator
         if (empty($property)) {
             return 0;
         }
+        // Strip %word% classic placeholders before counting printf-style specifiers to avoid
+        // false positives where a closing % followed by a letter (e.g. "% o" in "%count% order")
+        // is misidentified as a space-padded printf octal/string specifier.
+        $cleaned = preg_replace(Translator::$regexClassicParams, '', $property);
         $matches = [];
-        if (preg_match_all(Translator::$regexSprintfParams, $property, $matches) === false) {
+        if (preg_match_all(Translator::$regexSprintfParams, $cleaned, $matches) === false) {
             throw new Exception('Preg_match failed');
         }
 

--- a/tests/Unit/PrestaShopBundle/PassVsprintfContraintTest.php
+++ b/tests/Unit/PrestaShopBundle/PassVsprintfContraintTest.php
@@ -51,4 +51,40 @@ class PassVsprintfContraintTest extends ConstraintValidatorTestCase
 
         $this->buildViolation($constraint->message)->assertRaised();
     }
+
+    public function testClassicPlaceholderFollowedByLetterIsNotFalsePositive()
+    {
+        // "%product_count% order" — the closing % of the classic placeholder followed by
+        // " o" was misidentified as a space-padded printf octal specifier (% o).
+        $translation = (new Translation())
+            ->setKey('%product_count% order items')
+            ->setTranslation('%product_count% tilaustuotteita');
+        $this->validator->validate($translation, new PassVsprintf());
+
+        $this->assertNoViolation();
+    }
+
+    public function testClassicPlaceholderFollowedByPrintfSpecifierIsValid()
+    {
+        // A string mixing real classic placeholders and a real printf specifier must still validate.
+        $translation = (new Translation())
+            ->setKey('%name% has %d items')
+            ->setTranslation('%name% hat %d Artikel');
+        $this->validator->validate($translation, new PassVsprintf());
+
+        $this->assertNoViolation();
+    }
+
+    public function testMismatchedPrintfSpecifierAfterClassicPlaceholderIsInvalid()
+    {
+        // Translation drops the real %s — this must still raise a violation.
+        $translation = (new Translation())
+            ->setKey('%label%: %s')
+            ->setTranslation('%label%: missing specifier');
+        $constraint = new PassVsprintf();
+
+        $this->validator->validate($translation, $constraint);
+
+        $this->buildViolation($constraint->message)->assertRaised();
+    }
 }


### PR DESCRIPTION
 
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The $regexSprintfParams regex treats a closing % followed by a space and a printf type letter (e.g. % o in %count% order) as a valid specifier, causing silent save failures. Strip classic %word% params first via $regexClassicParams before the sprintf count.
| Type?             | bug fix
| Category?         | LO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to translate the string `%product_count% order items` run the new unit tests 
| UI Tests          | https://github.com/tswfi/ga.tests.ui.pr/actions/runs/26080752650
| Fixed issue or discussion?     | Fixes #36360
| Related PRs       | There is another open pr from few years back about the same thing: https://github.com/PrestaShop/PrestaShop/pull/36361
| Sponsor company   | 
