### PR TITLE
Allow use of theme's parent translation dictionary

### DIFF
--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -63,7 +63,7 @@ class Theme implements AddonInterface
             $yamlParser = new YamlParser($configurationCacheDirectory);
             $parentAttributes = $yamlParser->parse($themesDirectory . '/' . $attributes['parent'] . '/config/theme.yml');
             $parentAttributes['preview'] = 'themes/' . $attributes['parent'] . '/preview.png';
-            $parentAttributes['parent_directory'] = rtrim($attributes['directory'], '/') . '/';
+            $parentAttributes['parent_directory'] = rtrim($themesDirectory . '/' . $attributes['parent'], '/') . '/';
             $attributes = array_merge($parentAttributes, $attributes);
         }
 

--- a/src/PrestaShopBundle/Translation/TranslatorLanguageLoader.php
+++ b/src/PrestaShopBundle/Translation/TranslatorLanguageLoader.php
@@ -13,6 +13,7 @@ use PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\ExtraPropertyTransl
 use PrestaShop\PrestaShop\Core\Translation\Storage\Normalizer\DomainNormalizer;
 use PrestaShop\TranslationToolsBundle\Translation\Helper\DomainHelper;
 use PrestaShopBundle\Translation\Loader\SqlTranslationLoader;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
 use Symfony\Component\Translation\TranslatorBagInterface;
@@ -174,7 +175,7 @@ class TranslatorLanguageLoader
         string $locale,
         bool $withDB = true
     ): void {
-        $translationDir = sprintf('%s/translations/%s', $modulePath, $locale);
+        $translationDir = Path::join($modulePath, 'translations', $locale);
         if (!is_dir($translationDir)) {
             return;
         }
@@ -215,13 +216,13 @@ class TranslatorLanguageLoader
 
         if (null !== $theme) {
             if ($theme->has('parent_directory')) {
-                $parentThemeLocation = $theme->get('parent_directory') . '/translations';
+                $parentThemeLocation = Path::join($theme->get('parent_directory'), 'translations');
                 if (is_dir($parentThemeLocation)) {
                     $locations['parent_theme'] = $parentThemeLocation;
                 }
             }
 
-            $activeThemeLocation = $theme->getDirectory() . '/translations';
+            $activeThemeLocation = Path::join($theme->getDirectory(), 'translations');
             if (is_dir($activeThemeLocation)) {
                 $locations['theme'] = $activeThemeLocation;
             }

--- a/src/PrestaShopBundle/Translation/TranslatorLanguageLoader.php
+++ b/src/PrestaShopBundle/Translation/TranslatorLanguageLoader.php
@@ -214,6 +214,13 @@ class TranslatorLanguageLoader
         $locations = ['core' => self::TRANSLATION_DIR];
 
         if (null !== $theme) {
+            if ($theme->has('parent_directory')) {
+                $parentThemeLocation = $theme->get('parent_directory') . '/translations';
+                if (is_dir($parentThemeLocation)) {
+                    $locations['parent_theme'] = $parentThemeLocation;
+                }
+            }
+
             $activeThemeLocation = $theme->getDirectory() . '/translations';
             if (is_dir($activeThemeLocation)) {
                 $locations['theme'] = $activeThemeLocation;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Fix error in config and allow the use of parent theme default translations
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Make a copy of your hummingbird/classic theme and add a custom translation to it. Create a child theme base on this new theme and a another custom theme translation. Export translations for both, translation in the xlf files, empty the cache. Both should be translated. (Files provided below, copy your `hummingbird` as `hummingbird_clone`)
| UI Tests          | No UI changes
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | Novius

Without patch:
<img width="277" height="313" alt="Screenshot 2026-05-18 at 16-14-53 PrestaShop" src="https://github.com/user-attachments/assets/49ed6d6d-bb73-442b-830a-5135fa0fb3fb" />

With patch:
<img width="306" height="331" alt="Screenshot 2026-05-18 at 16-15-18 PrestaShop" src="https://github.com/user-attachments/assets/9dcc5ce7-4dff-41fc-9edd-02b04b8f1254" />

### Test artifacts
Child theme example: [child_test.tar.gz](https://github.com/user-attachments/files/27964164/child_test.tar.gz)
Translations to unpack in the `hummingbird_clone` folder: [translations.tar.gz](https://github.com/user-attachments/files/27964156/translations.tar.gz)

In the `humminbird_clone` `templates/index.tpl` file, replace:
```smarty
{block name='page_content_top'}{/block}
```
with:
```smarty
{block name='page_content_top'}
  <p>{l s="Hello, I'm the parent theme!" d="Shop.Hummingbirdclone"}</p>
{/block}
```

**You maybe required to delete the cached theme config in `config/theme/your_theme` because the `parent_directory` field content was wrong.**