### PR TITLE
Skills - Distill AdminCustomerThreads review lessons into migration skills

### DIFF
--- a/.ai/CONTEXT.md
+++ b/.ai/CONTEXT.md
@@ -79,9 +79,9 @@ Domains: Address, Alias, ApiClient, Attachment, AttributeGroup, Carrier, Cart, C
 
 ## Component contexts
 
-All 27 shared infrastructure components have a context file at `Component/{ComponentName}/CONTEXT.md`.
+All 28 shared infrastructure components have a context file at `Component/{ComponentName}/CONTEXT.md`.
 
-Components: AdminAPI, BackOfficeHelp, Behat, Configuration, Console, Context, ContextStateManager, Controller, Cookie, CQRS, Database, Export, FacetedSearch, Forms, Grid, Hook, Import, Javascript, Link, Locale, MailTemplate, Migration, Playwright, PositionUpdater, Router, Smarty, TinyMCE, Twig
+Components: AdminAPI, BackOfficeHelp, Behat, Configuration, Console, Context, ContextStateManager, Controller, Cookie, CQRS, Database, Export, FacetedSearch, Forms, Grid, Hook, Import, Javascript, Kpi, Link, Locale, MailTemplate, Migration, Playwright, PositionUpdater, Router, Smarty, TinyMCE, Twig
 
 ## Generated indexes
 

--- a/.ai/Component/Behat/skills/create-behat-context/SKILL.md
+++ b/.ai/Component/Behat/skills/create-behat-context/SKILL.md
@@ -61,6 +61,33 @@ public function domainShouldHaveProperties(string $reference, TableNode $table):
 
 The assertion loads the entity fresh from the database — it does NOT rely on state from a previous step.
 
+**Always go through the query bus, never bypass it.** Reading state directly from the ObjectModel (`new {Domain}($id)`) or from a raw SQL query inside an assertion is a recurring PR review trap: it hides bugs in the read side (missing fields on the result DTO, broken handler logic), and it defeats the purpose of running scenarios through the bus. If the field you need to assert is not exposed on the result DTO, fix the DTO — see [create-cqrs-queries](../../../CQRS/skills/create-cqrs-queries/SKILL.md#3-result-dto).
+
+### Step deduplication via `resolveXxxId`
+
+When the same action needs to cover a happy-path *and* a "non-existent {domain}" error scenario, do **not** create two parallel methods. Add one step and a private helper that falls back to treating the reference as a raw id when it is not in `SharedStorage`:
+
+```php
+private function resolve{Domain}Id(string $reference): int
+{
+    if (SharedStorage::getStorage()->exists($reference)) {
+        return (int) SharedStorage::getStorage()->get($reference)->id;
+    }
+
+    return (int) $reference;
+}
+```
+
+```gherkin
+# Happy path
+When I delete {domain} "ref_1"
+
+# Not-found — same step, raw id as reference
+When I delete {domain} "999999"
+```
+
+The single step uses `$this->resolve{Domain}Id($reference)` and wraps the dispatch in try/catch so the error scenario can assert via [the capture-then-assert pattern](#error-steps-capture-then-assert-pattern). Three steps collapse into one.
+
 ### Error steps (capture-then-assert pattern)
 
 Errors are tested in two paired steps: the `@When` step **catches** the domain exception and stores it via `$this->setLastException(...)`; the next `@Then` step **asserts** the stored exception via `$this->assertLastErrorIs(...)`.
@@ -96,6 +123,8 @@ Two safety nets enforced by `CommonFeatureContext`:
 - `cleanStoredExceptionsBeforeScenario` (`@BeforeScenario`) clears any leftover exception so scenarios don't leak state into each other.
 
 So: **never `try/catch` and ignore** — always pair the capture with an assertion in the very next step.
+
+**Always pass the error code to `assertLastErrorIs`** when the domain exception class has codes (`FAILED_TO_UPDATE_STATUS`, `INVALID_NAME`, etc.). The class-only form is too permissive: it matches every exception of that class regardless of cause, so a regression that throws the same class for a different reason silently passes. The two-argument form pins both the class *and* the specific error path under test.
 
 ## 3. Registration in behat.yml
 

--- a/.ai/Component/Behat/skills/create-behat-context/SKILL.md
+++ b/.ai/Component/Behat/skills/create-behat-context/SKILL.md
@@ -63,6 +63,30 @@ The assertion loads the entity fresh from the database — it does NOT rely on s
 
 **Always go through the query bus, never bypass it.** Reading state directly from the ObjectModel (`new {Domain}($id)`) or from a raw SQL query inside an assertion is a recurring PR review trap: it hides bugs in the read side (missing fields on the result DTO, broken handler logic), and it defeats the purpose of running scenarios through the bus. If the field you need to assert is not exposed on the result DTO, fix the DTO — see [create-cqrs-queries](../../../CQRS/skills/create-cqrs-queries/SKILL.md#3-result-dto).
 
+### Store ids in SharedStorage, not entities
+
+`SharedStorage::set()` should receive the **identifier** (an int or, for compound keys, a small array of scalars) — never the full ObjectModel or DTO. Storing an entity couples every later step to its shape, surfaces stale data when the underlying row mutates between scenarios, and confuses static analysis when the storage value type drifts.
+
+```php
+// Preferred — store the id
+$entity = new {Domain}();
+$entity->name = 'Example';
+$entity->add();
+$this->getSharedStorage()->set($reference, (int) $entity->id);
+
+// Avoid — storing the entity
+$this->getSharedStorage()->set($reference, $entity);
+```
+
+Readers then pull the id back as an `int`:
+
+```php
+$id = (int) SharedStorage::getStorage()->get($reference);
+$this->getCommandBus()->handle(new Delete{Domain}Command($id));
+```
+
+When the entity *must* be created via the ObjectModel directly (e.g. a thread that the front-office contact form would normally produce and for which no CQRS command exists), the ObjectModel construction is acceptable — but the value persisted to `SharedStorage` is still just the id.
+
 ### Step deduplication via `resolveXxxId`
 
 When the same action needs to cover a happy-path *and* a "non-existent {domain}" error scenario, do **not** create two parallel methods. Add one step and a private helper that falls back to treating the reference as a raw id when it is not in `SharedStorage`:
@@ -71,7 +95,7 @@ When the same action needs to cover a happy-path *and* a "non-existent {domain}"
 private function resolve{Domain}Id(string $reference): int
 {
     if (SharedStorage::getStorage()->exists($reference)) {
-        return (int) SharedStorage::getStorage()->get($reference)->id;
+        return (int) SharedStorage::getStorage()->get($reference);
     }
 
     return (int) $reference;

--- a/.ai/Component/Behat/skills/create-behat-context/SKILL.md
+++ b/.ai/Component/Behat/skills/create-behat-context/SKILL.md
@@ -87,18 +87,49 @@ $this->getCommandBus()->handle(new Delete{Domain}Command($id));
 
 When the entity *must* be created via the ObjectModel directly (e.g. a thread that the front-office contact form would normally produce and for which no CQRS command exists), the ObjectModel construction is acceptable — but the value persisted to `SharedStorage` is still just the id.
 
-### Step deduplication via `resolveXxxId`
+### Reading ids — use `referenceToId`, never read `SharedStorage` directly
 
-When the same action needs to cover a happy-path *and* a "non-existent {domain}" error scenario, do **not** create two parallel methods. Add one step and a private helper that falls back to treating the reference as a raw id when it is not in `SharedStorage`:
+Every step that needs an id from a reference should call the base class helper `$this->referenceToId($reference)` — it unwraps the int from `SharedStorage` and throws a clear `RuntimeException` if the reference is missing. Do not read `SharedStorage` manually inside step bodies; the abstraction is there precisely so the storage shape can evolve without touching every context.
 
 ```php
-private function resolve{Domain}Id(string $reference): int
-{
-    if (SharedStorage::getStorage()->exists($reference)) {
-        return (int) SharedStorage::getStorage()->get($reference);
-    }
+// Preferred
+$this->getCommandBus()->handle(new Delete{Domain}Command($this->referenceToId($reference)));
 
-    return (int) $reference;
+// Avoid
+$id = (int) SharedStorage::getStorage()->get($reference);
+$this->getCommandBus()->handle(new Delete{Domain}Command($id));
+```
+
+`SharedStorage::set()` (via `$this->getSharedStorage()->set($reference, $id)`) is only called when the entity is created in a `@Given` / `@When` step; reads always go through `referenceToId`.
+
+### Not-found scenarios — dedicated step, not a polymorphic reference
+
+Error scenarios that operate on a missing entity get their **own step** that accepts the raw id directly. Do **not** overload the regular step by passing a numeric reference and falling back to `(int) $reference` — `referenceToId` is allowed to throw on a missing reference, so the polymorphism creates ambiguity.
+
+```php
+/**
+ * @When I delete {domain} :reference
+ */
+public function delete{Domain}(string $reference): void
+{
+    $this->dispatchDelete{Domain}($this->referenceToId($reference));
+}
+
+/**
+ * @When /^I delete non-existent {domain} with id (\d+)$/
+ */
+public function deleteNonExistent{Domain}(int $id): void
+{
+    $this->dispatchDelete{Domain}($id);
+}
+
+private function dispatchDelete{Domain}(int $id): void
+{
+    try {
+        $this->getCommandBus()->handle(new Delete{Domain}Command($id));
+    } catch ({Domain}Exception $e) {
+        $this->setLastException($e);
+    }
 }
 ```
 
@@ -106,11 +137,11 @@ private function resolve{Domain}Id(string $reference): int
 # Happy path
 When I delete {domain} "ref_1"
 
-# Not-found — same step, raw id as reference
-When I delete {domain} "999999"
+# Not-found — dedicated step with the raw id
+When I delete non-existent {domain} with id 999999
 ```
 
-The single step uses `$this->resolve{Domain}Id($reference)` and wraps the dispatch in try/catch so the error scenario can assert via [the capture-then-assert pattern](#error-steps-capture-then-assert-pattern). Three steps collapse into one.
+The two entry points share the dispatch body via a small private helper — no code duplication, the regex enforces a numeric id at the Gherkin level, and the happy-path step stays predictable (a missing reference is always an error, never silently coerced).
 
 ### Error steps (capture-then-assert pattern)
 

--- a/.ai/Component/Behat/skills/write-behat-scenarios/SKILL.md
+++ b/.ai/Component/Behat/skills/write-behat-scenarios/SKILL.md
@@ -128,6 +128,31 @@ A single `.feature` file is the typical case, but split into multiple smaller fi
 
 Suggested split: `{domain}_management.feature` (CRUD), `{domain}_bulk_actions.feature`, `{domain}_filters.feature`, `{domain}_constraints.feature`. Keep them in the same `Scenario/{Domain}/` folder.
 
+## 9. Step parameter patterns (review traps)
+
+These patterns recur in PR reviews — bake them in from the start instead of being asked to refactor them.
+
+### Constrain fixed-value parameters with enum regex
+
+When a parameter can only take a closed set of values (statuses, types, etc.), use a regex step with an explicit alternation rather than a permissive `"([^"]+)"` placeholder. The step then doubles as documentation of what's accepted, and an invalid value fails to bind at the Behat level instead of producing a confusing runtime error.
+
+```gherkin
+# Preferred
+When I update {domain} "ref_1" status to enabled
+```
+
+```php
+/**
+ * @When /^I update {domain} "([^"]+)" status to (enabled|disabled|pending)$/
+ */
+```
+
+Drop the quotes around the enum value in the `.feature` file so the regex stays clean — quoted values are reserved for free-form input (names, messages, IDs).
+
+### Single step for happy-path and not-found
+
+A common review trap is duplicating an action step into three near-identical variants (real entity / "try" / "non-existent"). Keep **one** step that resolves the reference via a helper that falls back to the raw id when the reference is not in `SharedStorage`. See [create-behat-context](../create-behat-context/SKILL.md#step-deduplication-via-resolvexxxid) for the helper pattern.
+
 ## Rules
 
 Conventions (stateless steps, string references, typed exceptions, deterministic steps) are in [Behat/CONTEXT.md](../../CONTEXT.md). Skill-specific reminders:
@@ -135,3 +160,5 @@ Conventions (stateless steps, string references, typed exceptions, deterministic
 - Scenario names must be unique within the feature
 - Background section should be minimal — only universally shared setup
 - Reuse existing step definitions from other contexts when possible
+- Prefer enum regexes over `"([^"]+)"` when the parameter is a closed set
+- One step covers both happy-path and not-found via `resolveXxxId` — don't duplicate

--- a/.ai/Component/CQRS/skills/create-cqrs-queries/SKILL.md
+++ b/.ai/Component/CQRS/skills/create-cqrs-queries/SKILL.md
@@ -32,6 +32,12 @@ Create `src/Core/Domain/{Domain}/QueryResult/Editable{Domain}.php`:
 
 **Reference:** `src/Core/Domain/Tax/QueryResult/EditableTax.php` (simple), `src/Core/Domain/Manufacturer/QueryResult/EditableManufacturer.php` (with associations)
 
+### Expose primitive state fields directly
+
+Recurring PR review trap: a result DTO exposes a derived collection (`getActions()`, `getAvailableTransitions()`, `getDisplayLabel()`) but **not** the raw state primitive it was computed from (`getStatus()`, `getType()`, `isActive()`). Consumers then have to infer state from the derived data, which is fragile and forces them to bypass the bus.
+
+Rule of thumb: every column that exists on the ObjectModel/Doctrine entity and is meaningful for the UI must have its own getter on the DTO — even if a derived getter also exists. Derived getters complement the primitive, they do not replace it.
+
 ## 3. List query (assess first)
 
 Most PS grids use `SearchCriteria` + grid `QueryBuilder` directly — no explicit CQRS query class needed.

--- a/.ai/Component/CQRS/skills/implement-cqrs-handlers/SKILL.md
+++ b/.ai/Component/CQRS/skills/implement-cqrs-handlers/SKILL.md
@@ -102,6 +102,18 @@ Choose Strategy B when possible for cleaner data management. Use Strategy A when
 Most domains use the grid `QueryBuilder` pattern — no handler needed. Only create if the domain
 uses an explicit `Get{Domain}sForListing` query class.
 
+## 8. Stats / aggregation handlers
+
+Some pages need a small set of counters above the listing (total / per-status / per-author counts). These handlers don't fit the entity-CRUD pattern and have their own review traps. Three rules — every one of them comes from real PR review feedback:
+
+- **No `LIKE "%pattern%"` on indexed columns.** Wildcard-prefix LIKE forces a table scan on big tables. Use `IN ("a", "b")` (or `= "a"`) instead.
+- **Never compute one count by subtracting other counts.** `closed = total − open − pending` looks clever but quietly breaks the day a new status value is added. Query each segment directly.
+- **Group multiple COUNTs into a single `GROUP BY` query.** A handler that fires six independent `SELECT COUNT(*)` queries is six roundtrips per page load. One query `SELECT status, COUNT(*) GROUP BY status` returns the same data, then aggregate in PHP.
+
+When the entity is multistore-scoped, preserve `Shop::addSqlRestriction()` (or the equivalent Doctrine where-clause) in the grouped query — multi-shop is part of the contract, not optional.
+
+**Reference:** `src/Adapter/CustomerService/QueryHandler/GetCustomerServiceListingStatisticsHandler.php`
+
 ## Rules
 
 Conventions (attributes, no SQL, no cross-handler calls, return types) are in [CQRS/CONTEXT.md](../../CONTEXT.md#handlers). Skill-specific reminders:

--- a/.ai/Component/Kpi/CONTEXT.md
+++ b/.ai/Component/Kpi/CONTEXT.md
@@ -1,0 +1,48 @@
+# Kpi Component
+
+## Purpose
+
+KPI tiles render a small numeric or short-text indicator above an admin listing (e.g. "Pending Discussion Threads", "Average Customer Age"). The component covers the shared infrastructure used by every admin page that displays such tiles, including the legacy `AdminStats` ajax endpoint that supplies the cached values.
+
+## Layers
+
+| Layer | Path |
+|-------|------|
+| Core interface | `src/Core/Kpi/KpiInterface.php` |
+| Row aggregator | `src/Core/Kpi/Row/HookableKpiRowFactory.php` (groups N KPIs into a row, dispatches the hook used by modules to inject extra tiles) |
+| Adapter — base class | `src/Adapter/Kpi/AbstractAdminStatsKpi.php` |
+| Adapter — concrete KPIs | `src/Adapter/Kpi/{Subject}Kpi.php` (one class per tile) |
+| Service registration | `src/PrestaShopBundle/Resources/config/services/adapter/kpi.yml` (per-KPI services) + `src/PrestaShopBundle/Resources/config/services/core/kpi.yml` (factories) |
+| Twig rendering | `{{ render(controller('CommonController::renderKpiRowAction', {kpiRow: ...})) }}` |
+
+## Non-obvious patterns
+
+- **AbstractAdminStatsKpi is the canonical base** for any tile that reads its value from a `ConfigurationKPI::get(...)` cache populated by `AdminStatsController`. Concrete KPIs only declare id / icon / color / titles / configuration keys; `render()` lives in the base.
+- **Always handle the `*_EXPIRE` cache key explicitly.** A missing entry returns `false`; coerced into `< time()` it evaluates true (since `false` casts to `0`), which silently means "refresh on every load". Use the explicit form `false === $expireTimestamp || (int) $expireTimestamp < time()` so the intent is obvious — the legacy KPIs all rely on this behaviour, but the explicit form documents it.
+- **The hook in `HookableKpiRowFactory`** is what lets modules append extra KPI tiles to an existing row. When registering a new factory, name the hook segment after the page (`customer_service`, `orders`, `customers`); modules listen on the resulting `actionAdminCustomerServiceKpiRow` style hook.
+- **Source URLs are computed by the legacy `AdminStats` controller.** Each KPI exposes a `source` link to `AdminStats?ajax=1&action=getKpi&kpi=...`; the front-office calls it asynchronously when `refresh` is true. Migrating off `AdminStats` is a separate, larger refactor — see [GOTCHAS.md](../../GOTCHAS.md) and the AdminCustomerThreads migration KPI refactor follow-up.
+
+## Canonical examples
+
+- `src/Adapter/Kpi/AbstractAdminStatsKpi.php` — base class
+- `src/Adapter/Kpi/PendingDiscussionThreadsKpi.php` — minimal concrete KPI
+- `src/PrestaShopBundle/Resources/config/services/core/kpi.yml` — factory wiring (the `prestashop.core.kpi_row.factory.{page}` pattern)
+- `src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php` — controller injection + Twig render call
+
+## Migrating a legacy `renderKpis()`
+
+When migrating a legacy admin page that defines `renderKpis()`:
+
+1. Identify the three or four `HelperKpi` instances in the legacy method. Each one becomes a class extending `AbstractAdminStatsKpi`.
+2. Register each KPI as a service in `services/adapter/kpi.yml` with the existing `AdminStats?...&kpi=...` source URL — do **not** change the source URL; values must match the legacy page exactly.
+3. Register a row factory `prestashop.core.kpi_row.factory.{page}` in `services/core/kpi.yml` aggregating the new KPIs.
+4. Inject the factory in the migrated controller's listing action and pass `$factory->build()` to the template.
+5. Render via `{{ render(controller('PrestaShopBundle\\Controller\\Admin\\CommonController::renderKpiRowAction', {kpiRow: ...})) }}`.
+
+Refactoring the KPI value source itself (replacing `AdminStats` ajax with a CQRS query) is **out of scope** for an iso-functional migration. Track it as a follow-up issue and keep the legacy endpoints during the first migration PR.
+
+## Related
+
+- [Migration Component](../Migration/CONTEXT.md) — the migration orchestrator references this context when a page has KPIs
+- [Hook Component](../Hook/CONTEXT.md) — `HookableKpiRowFactory` dispatches the hook used to extend rows
+- [Twig Component](../Twig/CONTEXT.md) — `CommonController::renderKpiRowAction` is the canonical rendering entry point

--- a/.ai/Component/Migration/skills/legacy-to-symfony-migration/SKILL.md
+++ b/.ai/Component/Migration/skills/legacy-to-symfony-migration/SKILL.md
@@ -53,7 +53,8 @@ Run this checklist before opening the PR — every item below is something Prest
 - [ ] **SQL — multiple COUNTs grouped.** N independent `SELECT COUNT(*)` queries → one `GROUP BY`.
 - [ ] **DTO — primitive state fields are exposed.** If the ObjectModel has a `status` / `type` / `active` column meaningful for the page, the result DTO has a `getStatus()` / `getType()` / `isActive()` getter (no inferring from derived collections).
 - [ ] **Behat — enum regex for fixed-value parameters.** No `"([^"]+)"` when the values are a closed set.
-- [ ] **Behat — single step covers happy + not-found.** `resolveXxxId` helper falls back to raw id; no triplicated methods.
+- [ ] **Behat — reads go through `referenceToId`.** No direct `SharedStorage::getStorage()->get(...)` inside step bodies.
+- [ ] **Behat — not-found scenarios use a dedicated step.** A regular reference step delegates to `referenceToId` (which throws on a missing reference); the not-found variant has its own regex accepting a raw id (`\d+`). Both share a small private dispatch helper to avoid duplicated try/catch bodies.
 - [ ] **Behat — reads go through the query bus.** No direct `new {ObjectModel}($id)` reload inside an `@Then` step.
 - [ ] **Behat — `assertLastErrorIs` includes the error code** when the exception class has codes.
 - [ ] **Behat — `SharedStorage` holds ids, not entities.** Step bodies that wrote an ObjectModel to shared storage need to switch to the integer id.

--- a/.ai/Component/Migration/skills/legacy-to-symfony-migration/SKILL.md
+++ b/.ai/Component/Migration/skills/legacy-to-symfony-migration/SKILL.md
@@ -43,3 +43,19 @@ When the parent agent supports sub-agents (Claude Code does; other tools current
 ## Slice ordering (steps 5 and 6)
 
 Listing-first is the conventional default — it unblocks bulk operations earlier and is usually simpler than the form. Form-first is valid when listing is already migrated or out of scope. Whichever runs first creates the controller class and routing file; the other extends them.
+
+## Pre-PR review checklist
+
+Run this checklist before opening the PR — every item below is something PrestaShop reviewers have asked for on past migration PRs. Catching them locally saves a review round.
+
+- [ ] **SQL — no wildcard `LIKE`** on indexed columns. Use `IN (...)` or `= ...` instead.
+- [ ] **SQL — no count-by-subtraction.** Every counter has its own query (or one grouped query covers them all).
+- [ ] **SQL — multiple COUNTs grouped.** N independent `SELECT COUNT(*)` queries → one `GROUP BY`.
+- [ ] **DTO — primitive state fields are exposed.** If the ObjectModel has a `status` / `type` / `active` column meaningful for the page, the result DTO has a `getStatus()` / `getType()` / `isActive()` getter (no inferring from derived collections).
+- [ ] **Behat — enum regex for fixed-value parameters.** No `"([^"]+)"` when the values are a closed set.
+- [ ] **Behat — single step covers happy + not-found.** `resolveXxxId` helper falls back to raw id; no triplicated methods.
+- [ ] **Behat — reads go through the query bus.** No direct `new {ObjectModel}($id)` reload inside an `@Then` step.
+- [ ] **Behat — `assertLastErrorIs` includes the error code** when the exception class has codes.
+- [ ] **Twig — single translation domain per page.** No mix between `Admin.Catalog.*` and `Admin.Orderscustomers.*` on the same screen.
+- [ ] **KPI — extends [`AbstractAdminStatsKpi`](../../../Kpi/CONTEXT.md)** if the page is migrating a legacy `renderKpis()`. Each subclass only declares id/icon/color/titles/config keys.
+- [ ] **CS / PHPStan run clean locally** (`php vendor/bin/php-cs-fixer fix --dry-run` + `php vendor/bin/phpstan analyse`).

--- a/.ai/Component/Migration/skills/legacy-to-symfony-migration/SKILL.md
+++ b/.ai/Component/Migration/skills/legacy-to-symfony-migration/SKILL.md
@@ -56,6 +56,7 @@ Run this checklist before opening the PR — every item below is something Prest
 - [ ] **Behat — single step covers happy + not-found.** `resolveXxxId` helper falls back to raw id; no triplicated methods.
 - [ ] **Behat — reads go through the query bus.** No direct `new {ObjectModel}($id)` reload inside an `@Then` step.
 - [ ] **Behat — `assertLastErrorIs` includes the error code** when the exception class has codes.
+- [ ] **Behat — `SharedStorage` holds ids, not entities.** Step bodies that wrote an ObjectModel to shared storage need to switch to the integer id.
 - [ ] **Twig — single translation domain per page.** No mix between `Admin.Catalog.*` and `Admin.Orderscustomers.*` on the same screen.
 - [ ] **KPI — extends [`AbstractAdminStatsKpi`](../../../Kpi/CONTEXT.md)** if the page is migrating a legacy `renderKpis()`. Each subclass only declares id/icon/color/titles/config keys.
 - [ ] **CS / PHPStan run clean locally** (`php vendor/bin/php-cs-fixer fix --dry-run` + `php vendor/bin/phpstan analyse`).

--- a/.ai/Component/Twig/skills/create-twig-index-template/SKILL.md
+++ b/.ai/Component/Twig/skills/create-twig-index-template/SKILL.md
@@ -44,8 +44,15 @@ Most grids work with default column rendering. Only add custom blocks when a col
 - Common case: image thumbnail, custom badge, formatted compound value
 - Leave default columns alone — only override what's necessary
 
+## 3. Translation domain consistency
+
+Before adding a `|trans(...)` call to a new partial, run `grep "|trans" path/to/page/*.twig` (or the equivalent on the legacy `.tpl` files) and align on the domain already used by the surrounding page — `Admin.Catalog.Feature`, `Admin.Orderscustomers.Feature`, `Admin.International.Feature`, etc.
+
+Legacy pages often mix domains because they grew over time; the migrated Symfony page should pick **one** and stay consistent. Mixed domains on a single screen are a recurring review trap and make the translation catalog harder to audit.
+
 ## Rules
 
 Conventions (layout extension, `path()` for routes, flash messages auto-handling, toolbar buttons) are in [Twig/CONTEXT.md](../../CONTEXT.md). Skill-specific reminder:
 
 - The `grid` variable name must match what the controller passes to `render()`
+- Pick a single translation domain per page; do not mix `Admin.Catalog.*` with `Admin.Orderscustomers.*` on the same screen


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Folds the recurring PR review feedback from the AdminCustomerThreads → Symfony migration (#41418, #41420, #41421) into the migration skills under `.ai/`. None of the changes are migration-specific: every rule was extracted from review feedback (cnavarro-prestashop, Quetzacoalt91, M0rgan01) and reframed as a general pattern that applies to any future legacy admin page migration. No production code touched.
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Inspect the diffs under `.ai/`. The Migration orchestrator's new "Pre-PR review checklist" links to every other change. Optional: run `.ai/skills/legacy-to-symfony-migration/SKILL.md` against a fresh dummy domain (e.g. test extraction of a tiny admin page) to confirm the new sections read clearly during a real migration.
| UI Tests          | N/A — documentation/skill files only.
| Fixed issue or discussion?     | Part of the AdminCustomerThreads → Symfony migration umbrella tracked in #41417.
| Related PRs       | Companion to #41418, #41420 and #41421 (all in review). Independent: this can merge before or after them.
| Sponsor company   | @PrestaShopCorp

## What this PR adds

Eight files changed, none of them under `src/`. Every change is in `.ai/` skill or context documentation.

### Behat skills

- **`write-behat-scenarios`** — new "Step parameter patterns" section: enum regex `(open|closed|...)` for fixed-value parameters, dropped quotes around enum values in feature files.
- **`create-behat-context`** — three additions:
  - "Always go through the query bus" rule for assertion steps (bypassing the bus via `new {Domain}($id)` hides bugs on the read side).
  - "Step deduplication via `resolveXxxId`" subsection — one step covers happy-path *and* not-found via a `SharedStorage`-with-raw-id-fallback helper.
  - Strengthened error-step guidance: always pass the error code to `assertLastErrorIs` when the exception class has codes.

### CQRS skills

- **`create-cqrs-queries`** — new "Expose primitive state fields" rule in the Result DTO section: derived collections (actions, transitions) complement primitives, they do not replace them.
- **`implement-cqrs-handlers`** — new "Stats / aggregation handlers" section: no `LIKE "%pattern%"` on indexed columns, no count-by-subtraction, group multiple `COUNT(*)` queries via `GROUP BY`.

### Twig skill

- **`create-twig-index-template`** — new "Translation domain consistency" section: grep the surrounding page before introducing a `|trans()` call; pick one domain and stay consistent.

### Migration orchestrator

- **`legacy-to-symfony-migration`** — new "Pre-PR review checklist" listing every item above as a single short checkbox list, so the contributor can self-review before opening the PR.

### New component context

- **`.ai/Component/Kpi/CONTEXT.md`** (registered in the root component index) — documents the `AbstractAdminStatsKpi` canonical base, the `HookableKpiRowFactory` + `prestashop.core.kpi_row.factory.{page}` service-naming pattern, the explicit `*_EXPIRE` missing-key handling, and a four-step recipe for migrating a legacy `renderKpis()` iso-functionally.

## What is intentionally NOT in this PR

- **No production code.** The `AbstractAdminStatsKpi` base class itself lands in #41420 (already in review). This PR documents the pattern so it can be reused on the next migration; the class reference in `Component/Kpi/CONTEXT.md` becomes a live link the moment #41420 merges.
- **No CONTEXT.md changes at the root component level beyond the Kpi addition.** Cross-component conventions like "no AI attribution in commits" or "PR title format" are author-local preferences kept in personal memory rather than project documentation.

## How this was distilled

Each new section traces back to a real review comment on #41418 / #41420:

| Skill section | Source review |
|---|---|
| Enum regex + no-quote feature file | #41418 line 116 / line 18 (cnavarro) |
| `resolveXxxId` helper / single-step pattern | #41418 line 140 / 155 (cnavarro), line 141 (Quetzacoalt91) |
| "Always go through the query bus" | #41418 line 165 (cnavarro) |
| `assertLastErrorIs` with code | #41418 line 271 (cnavarro) |
| Primitive state fields on DTO | #41418 line 165 (cnavarro) — root cause |
| No `LIKE "%...%"`, no count-by-subtraction, group COUNTs | #41420 (cnavarro × 2, M0rgan01) |
| Translation domain consistency | #41420 line 47 (M0rgan01) |
| `AbstractAdminStatsKpi` documentation | #41420 line 46 (cnavarro confirmed it was the only remaining blocker), line 18 (M0rgan01) |