### PR TITLE
Prevent fatal error on invalid sort order

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -3,6 +3,8 @@
  * For the full copyright and license information, please view the
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
+
+use PrestaShop\PrestaShop\Core\Product\Search\Exception\InvalidSortOrderException;
 use PrestaShop\PrestaShop\Core\Product\Search\Facet;
 use PrestaShop\PrestaShop\Core\Product\Search\FacetsRendererInterface;
 use PrestaShop\PrestaShop\Core\Product\Search\Pagination;
@@ -306,9 +308,23 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
 
         // set the sort order if provided in the URL
         if ($encodedSortOrder = Tools::getValue('order')) {
-            $query->setSortOrder(SortOrder::newFromString(
-                $encodedSortOrder
-            ));
+            try {
+                $query->setSortOrder(SortOrder::newFromString(
+                    $encodedSortOrder
+                ));
+            } catch (InvalidSortOrderException $exception) {
+                // Don't send any cookie
+                Context::getContext()->cookie->disallowWriting();
+                if (defined('_PS_MODE_DEV_') && _PS_MODE_DEV_ && $_SERVER['REQUEST_URI'] != __PS_BASE_URI__) {
+                    die('[Debug] Sort order is invalid: ' . $exception->getMessage());
+                }
+
+                if (!$this->ajax) {
+                    header('HTTP/1.0 301 Moved');
+                    header('Cache-Control: no-cache');
+                    Tools::redirect($this->getCanonicalURL());
+                }
+            }
         }
 
         // get the parameters containing the encoded facets from the URL

--- a/src/Core/Product/Search/Exception/InvalidSortOrderDirectionException.php
+++ b/src/Core/Product/Search/Exception/InvalidSortOrderDirectionException.php
@@ -4,25 +4,25 @@
  * docs/licenses/LICENSE.txt file that was distributed with this source code.
  */
 
-namespace PrestaShop\PrestaShop\Core\Product\Search\Exception;
+declare(strict_types=1);
 
-use PrestaShop\PrestaShop\Core\Exception\CoreException;
+namespace PrestaShop\PrestaShop\Core\Product\Search\Exception;
 
 /**
  * Thrown when sort order direction is not valid
  */
-class InvalidSortOrderDirectionException extends CoreException
+class InvalidSortOrderDirectionException extends InvalidSortOrderException
 {
     /**
      * @param string $direction the invalid direction
      */
-    public function __construct($direction)
+    public function __construct(string $direction)
     {
         $message = sprintf(
             'Invalid SortOrder direction `%s`. Expecting one of: `ASC`, `DESC`, or `RANDOM`.',
             $direction
         );
 
-        parent::__construct($message, 0, null);
+        parent::__construct($message);
     }
 }

--- a/src/Core/Product/Search/Exception/InvalidSortOrderException.php
+++ b/src/Core/Product/Search/Exception/InvalidSortOrderException.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * For the full copyright and license information, please view the
+ * docs/licenses/LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Product\Search\Exception;
+
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+
+/**
+ * Thrown when sort order format is not valid
+ */
+class InvalidSortOrderException extends CoreException
+{
+    public function __construct(string $message = '')
+    {
+        parent::__construct($message ?: 'Invalid SortOrder format, expection {entity}.{field}.{direction}');
+    }
+}

--- a/src/Core/Product/Search/SortOrder.php
+++ b/src/Core/Product/Search/SortOrder.php
@@ -6,8 +6,8 @@
 
 namespace PrestaShop\PrestaShop\Core\Product\Search;
 
-use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Product\Search\Exception\InvalidSortOrderDirectionException;
+use PrestaShop\PrestaShop\Core\Product\Search\Exception\InvalidSortOrderException;
 
 /**
  * This class define in which order the list of products will be sorted.
@@ -97,14 +97,14 @@ class SortOrder
      *
      * @return SortOrder
      *
-     * @throws InvalidSortOrderDirectionException
+     * @throws InvalidSortOrderException|InvalidSortOrderDirectionException
      */
     public static function newFromString($sortOrderConfiguration)
     {
         $sortParams = explode('.', $sortOrderConfiguration);
 
         if (count($sortParams) < 3) {
-            throw new CoreException('Invalid argument');
+            throw new InvalidSortOrderException();
         }
 
         [$entity, $field, $direction] = $sortParams;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Invalid sort order on product list used to trigger a PHP Fatal error, this PR implements a friendly way to deal with an invalid URL by redirecting to the canonical one. When triggered in debug mode, error will be displayed in a similar fashion with canonical redirects 
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to a product listing, change the sorting order, manually change the order value with an invalid sort direction: `desc'` or remove part of the sort parameter: `product.desc`
| UI Tests          | No UI change
| Fixed issue or discussion?     | Fixes #34819
| Related PRs       | 
| Sponsor company   | Novius
