### PR TITLE
Avoid bad URL on invalid media with media servers enabled and CCC disabled

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1104,8 +1104,13 @@ class FrontControllerCore extends Controller
         $params = array_merge($default_params, $params);
 
         if (Tools::hasMediaServer() && !Configuration::get('PS_CSS_THEME_CACHE')) {
-            $relativePath = Tools::getCurrentUrlProtocolPrefix() . Tools::getMediaServer($relativePath)
-                . ($this->stylesheetManager->getFullPath($relativePath) ?? $relativePath);
+            $fullPath = $this->stylesheetManager->getFullPath($relativePath);
+
+            if (!$fullPath) {
+                return;
+            }
+
+            $relativePath = Tools::getCurrentUrlProtocolPrefix() . Tools::getMediaServer($relativePath) . $fullPath;
             $params['server'] = 'remote';
         }
 
@@ -1134,8 +1139,13 @@ class FrontControllerCore extends Controller
         $params = array_merge($default_params, $params);
 
         if (Tools::hasMediaServer() && !Configuration::get('PS_JS_THEME_CACHE')) {
-            $relativePath = Tools::getCurrentUrlProtocolPrefix() . Tools::getMediaServer($relativePath)
-                . ($this->javascriptManager->getFullPath($relativePath) ?? $relativePath);
+            $fullPath = $this->javascriptManager->getFullPath($relativePath);
+
+            if (!$fullPath) {
+                return;
+            }
+
+            $relativePath = Tools::getCurrentUrlProtocolPrefix() . Tools::getMediaServer($relativePath) . $fullPath;
             $params['server'] = 'remote';
         }
         $this->javascriptManager->register($id, $relativePath, $params['position'], $params['priority'], $params['inline'], $params['attributes'], $params['server'], $params['version']);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.1.x
| Description?      | When CCC is disabled and media servers are in use, missing js/css files will generate an invalid URI (as `getFullPath` will return false and ternary condition will produce an empty string as a concatenation result). Result must be tested before to avoid generating an URI known to lead to a 404.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Set up a media server, disable CCC, without the path you'll see `/` being requested on your media server once as a css file, and once a a js file. With the patch both calls are avoided.
| UI Tests          | No UI changes
| Fixed issue or discussion?     | 
| Related PRs       | 
| Sponsor company   | Novius
